### PR TITLE
CASMTRIAGE-1847: Show how to list installed products

### DIFF
--- a/upgrade/1.0/README.md
+++ b/upgrade/1.0/README.md
@@ -20,6 +20,18 @@ upgrade that node.
 
 > NOTE: CSM-0.9.4 is the version of CSM required in order to upgrade to CSM-1.0.0 (available with Shasta v1.5).
 
+> NOTE: Installed CSM versions may be listed from the product catalog using the following command. This will sort a semantic version without a hyphenated suffix after the same semantic version with a hyphenated suffix, e.g. 1.0.0 > 1.0.0-beta.19. 
+>
+> ```bash
+> ncn-m001# kubectl -n services get cm cray-product-catalog -o jsonpath='{.data.csm}' | yq r -j - | jq -r 'keys[]' | sed '/-/!{s/$/_/}' | sort -V | sed 's/_$//'
+> ```
+>
+> NOTE: The latest installed CSM version may be listed from the product catalog using the following command. This will sort a semantic version without a hyphenated suffix after the same semantic version with a hyphenated suffix, e.g. 1.0.0 > 1.0.0-beta.19. 
+>
+> ```bash
+> ncn-m001# kubectl -n services get cm cray-product-catalog -o jsonpath='{.data.csm}' | yq r -j - | jq -r 'keys[]' | sed '/-/!{s/$/_/}' | sort -V | sed 's/_$// | tail -n 1'
+> ```
+
 The following command can be used to check the CSM version on the system:
 
 ```bash


### PR DESCRIPTION
The document has been updated to show how to just list the product
versions without the entire contents of each product. It was also
updated to show how to list just the newest product installation.