### PR TITLE
STP-2903: Updated scsd config in procedure

### DIFF
--- a/operations/node_management/Enable_Passwordless_Connections_to_Liquid_Cooled_Node_BMCs.md
+++ b/operations/node_management/Enable_Passwordless_Connections_to_Liquid_Cooled_Node_BMCs.md
@@ -44,7 +44,7 @@ Setting up SSH keys enables administrators to view recent console messages and i
     {
        "Force":false,
        "Targets":
-    $(cray hsm inventory redfishEndpoints list --format=json | jq '[.RedfishEndpoints[] | .ID]' | sed 's/^/   /'),
+    $(cray hsm state components list --class mountain --type nodebmc --format json | jq '[.Components[] | select((.State == "On") or (.State == "Ready")) | .ID]')
        "Params":{
           "SSHKey":"$(echo $SCSD_SSH_KEY)",
           "SSHConsoleKey":"$(echo $SCSD_SSH_CONSOLE_KEY)"


### PR DESCRIPTION
Minor update to how to generate the System Configuration Service configuration in the "Enable Passwordless Connections to Liquid Cooled Node BMCs" procedure.