### PR TITLE
CASMINST-3109: Fix broken commands; restore previous commits that were overwritten; linting

### DIFF
--- a/background/ncn_boot_workflow.md
+++ b/background/ncn_boot_workflow.md
@@ -79,7 +79,7 @@ Setting the boot order with efibootmgr will ensure that the desired network inte
 
 > **`NOTE`** The four digit hex numbers shown in the examples below may be different, even between nodes of the same function and vendor. The first two efibootmgr commands will display the correct hex numbers for the third efibootmgr command to use in setting the proper boot order.
 
-1. Create our boot-bios-selector file(s) based on the manufacturer:
+Follow the section corresponding to the hardware manufacturer of the system:
 
    > <a name="gigabyte-technology"></a>
    > #### Gigabyte Technology
@@ -93,8 +93,9 @@ Setting the boot order with efibootmgr will ensure that the desired network inte
    > ncn-m# efibootmgr | grep cray | tee /tmp/bbs2
    > Boot0000* cray (sda1)
    > Boot0002* cray (sdb1)
-   > ncn-m# efibootmgr -o $(cat /tmp/bbs* | awk '!x[$0]++' | sed 's/^Boot//g' | awk '{print $1}' | tr -t '*' ',' | tr -d '\n' | sed 's/,$//') | grep -i bootorder
+   > ncn-m# efibootmgr -o $(cat /tmp/bbs* | awk '!x[$0]++' | sed 's/^Boot//g' | tr -d '*' | awk '{print $1}' | tr -t '\n' ',' | sed 's/,$//') | grep -i bootorder
    > BootOrder: 0007,0009,0000,0002
+   > ncn-m# cat /tmp/bbs* | awk '!x[$0]++' | sed 's/^Boot//g' | tr -d '*' | awk '{print $1}' | xargs -r -t -i efibootmgr -b {} -a
    > ```
    >
    > ##### Storage
@@ -106,8 +107,9 @@ Setting the boot order with efibootmgr will ensure that the desired network inte
    > ncn-s# efibootmgr | grep cray | tee /tmp/bbs2
    > Boot0000* cray (sda1)
    > Boot0002* cray (sdb1)
-   > ncn-s# efibootmgr -o $(cat /tmp/bbs* | awk '!x[$0]++' | sed 's/^Boot//g' | awk '{print $1}' | tr -t '*' ',' | tr -d '\n' | sed 's/,$//') | grep -i bootorder
+   > ncn-s# efibootmgr -o $(cat /tmp/bbs* | awk '!x[$0]++' | sed 's/^Boot//g' | tr -d '*' | awk '{print $1}' | tr -t '\n' ',' | sed 's/,$//') | grep -i bootorder
    > BootOrder: 0007,0009,0000,0002
+   > ncn-s# cat /tmp/bbs* | awk '!x[$0]++' | sed 's/^Boot//g' | tr -d '*' | awk '{print $1}' | xargs -r -t -i efibootmgr -b {} -a
    > ```
    >
    > ##### Workers
@@ -123,8 +125,9 @@ Setting the boot order with efibootmgr will ensure that the desired network inte
    > ncn-w# efibootmgr | grep cray | tee /tmp/bbs2
    > Boot0000* cray (sda1)
    > Boot0002* cray (sdb1)
-   > ncn-w# efibootmgr -o $(cat /tmp/bbs* | awk '!x[$0]++' | sed 's/^Boot//g' | awk '{print $1}' | tr -t '*' ',' | tr -d '\n' | sed 's/,$//') | grep -i bootorder
+   > ncn-w# efibootmgr -o $(cat /tmp/bbs* | awk '!x[$0]++' | sed 's/^Boot//g' | tr -d '*' | awk '{print $1}' | tr -t '\n' ',' | sed 's/,$//') | grep -i bootorder
    > BootOrder: 0009,0007,000B,0000,0002
+   > ncn-w# cat /tmp/bbs* | awk '!x[$0]++' | sed 's/^Boot//g' | tr -d '*' | awk '{print $1}' | xargs -r -t -i efibootmgr -b {} -a
    > ```
    >
    > <a name="hewlett-packard-enterprise"></a>
@@ -140,8 +143,9 @@ Setting the boot order with efibootmgr will ensure that the desired network inte
    > ncn-m# efibootmgr | grep cray | tee /tmp/bbs2
    > Boot0021* cray (sdb1)
    > Boot0022* cray (sdc1)
-   > ncn-m# efibootmgr -o $(cat /tmp/bbs* | awk '!x[$0]++' | sed 's/^Boot//g' | awk '{print $1}' | tr -t '*' ',' | tr -d '\n' | sed 's/,$//') | grep -i bootorder
+   > ncn-m# efibootmgr -o $(cat /tmp/bbs* | awk '!x[$0]++' | sed 's/^Boot//g' | tr -d '*' | awk '{print $1}' | tr -t '\n' ',' | sed 's/,$//') | grep -i bootorder
    > BootOrder: 0014,0018,0021,0022
+   > ncn-m# cat /tmp/bbs* | awk '!x[$0]++' | sed 's/^Boot//g' | tr -d '*' | awk '{print $1}' | xargs -r -t -i efibootmgr -b {} -a
    > ```
    >
    > ##### Storage
@@ -153,8 +157,9 @@ Setting the boot order with efibootmgr will ensure that the desired network inte
    > ncn-s# efibootmgr | grep cray | tee /tmp/bbs2
    > Boot0002* cray (sdg1)
    > Boot0020* cray (sdh1)
-   > ncn-s# efibootmgr -o $(cat /tmp/bbs* | awk '!x[$0]++' | sed 's/^Boot//g' | awk '{print $1}' | tr -t '*' ',' | tr -d '\n' | sed 's/,$//') | grep -i bootorder
+   > ncn-s# efibootmgr -o $(cat /tmp/bbs* | awk '!x[$0]++' | sed 's/^Boot//g' | tr -d '*' | awk '{print $1}' | tr -t '\n' ',' | sed 's/,$//') | grep -i bootorder
    > BootOrder: 001C,001D,0002,0020
+   > ncn-s# cat /tmp/bbs* | awk '!x[$0]++' | sed 's/^Boot//g' | tr -d '*' | awk '{print $1}' | xargs -r -t -i efibootmgr -b {} -a
    > ```
    >
    > ##### Workers
@@ -166,8 +171,9 @@ Setting the boot order with efibootmgr will ensure that the desired network inte
    > ncn-w# efibootmgr | grep cray | tee /tmp/bbs2
    > Boot0017* cray (sdb1)
    > Boot0018* cray (sdc1)
-   > ncn-w# efibootmgr -o $(cat /tmp/bbs* | awk '!x[$0]++' | sed 's/^Boot//g' | awk '{print $1}' | tr -t '*' ',' | tr -d '\n' | sed 's/,$//') | grep -i bootorder
+   > ncn-w# efibootmgr -o $(cat /tmp/bbs* | awk '!x[$0]++' | sed 's/^Boot//g' | tr -d '*' | awk '{print $1}' | tr -t '\n' ',' | sed 's/,$//') | grep -i bootorder
    > BootOrder: 0012,0017,0018
+   > ncn-w# cat /tmp/bbs* | awk '!x[$0]++' | sed 's/^Boot//g' | tr -d '*' | awk '{print $1}' | xargs -r -t -i efibootmgr -b {} -a
    > ```
    >
    > <a name="intel-corporation"></a>
@@ -181,8 +187,9 @@ Setting the boot order with efibootmgr will ensure that the desired network inte
    > ncn-m# efibootmgr | grep -i 'cray' | tee /tmp/bbs2
    > Boot0011* cray (sda1)
    > Boot0012* cray (sdb1)
-   > ncn-m# efibootmgr -o $(cat /tmp/bbs* | awk '!x[$0]++' | sed 's/^Boot//g' | awk '{print $1}' | tr -t '*' ',' | tr -d '\n' | sed 's/,$//') | grep -i bootorder
+   > ncn-m# efibootmgr -o $(cat /tmp/bbs* | awk '!x[$0]++' | sed 's/^Boot//g' | tr -d '*' | awk '{print $1}' | tr -t '\n' ',' | sed 's/,$//') | grep -i bootorder
    > BootOrder: 000E,0014,0011,0012
+   > ncn-m# cat /tmp/bbs* | awk '!x[$0]++' | sed 's/^Boot//g' | tr -d '*' | awk '{print $1}' | xargs -r -t -i efibootmgr -b {} -a
    >```
    > ##### Storage
    > ```bash
@@ -192,8 +199,9 @@ Setting the boot order with efibootmgr will ensure that the desired network inte
    > ncn-s# efibootmgr | grep -i 'cray' | tee /tmp/bbs2
    > Boot0014* cray (sda1)
    > Boot0015* cray (sdb1)
-   > ncn-s# efibootmgr -o $(cat /tmp/bbs* | awk '!x[$0]++' | sed 's/^Boot//g' | awk '{print $1}' | tr -t '*' ',' | tr -d '\n' | sed 's/,$//') | grep -i bootorder
+   > ncn-s# efibootmgr -o $(cat /tmp/bbs* | awk '!x[$0]++' | sed 's/^Boot//g' | tr -d '*' | awk '{print $1}' | tr -t '\n' ',' | sed 's/,$//') | grep -i bootorder
    > BootOrder: 000E,0012,0014,0015
+   > ncn-s# cat /tmp/bbs* | awk '!x[$0]++' | sed 's/^Boot//g' | tr -d '*' | awk '{print $1}' | xargs -r -t -i efibootmgr -b {} -a
    > ```
    > ##### Workers
    >
@@ -204,8 +212,9 @@ Setting the boot order with efibootmgr will ensure that the desired network inte
    > ncn-w# efibootmgr | grep -i 'cray' | tee /tmp/bbs2
    > Boot0010* cray (sda1)
    > Boot0011* cray (sdb1)
-   > ncn-w# efibootmgr -o $(cat /tmp/bbs* | awk '!x[$0]++' | sed 's/^Boot//g' | awk '{print $1}' | tr -t '*' ',' | tr -d '\n' | sed 's/,$//') | grep -i bootorder
+   > ncn-w# efibootmgr -o $(cat /tmp/bbs* | awk '!x[$0]++' | sed 's/^Boot//g' | tr -d '*' | awk '{print $1}' | tr -t '\n' ',' | sed 's/,$//') | grep -i bootorder
    > BootOrder: 0008,000C,0010,0011
+   > ncn-w# cat /tmp/bbs* | awk '!x[$0]++' | sed 's/^Boot//g' | tr -d '*' | awk '{print $1}' | xargs -r -t -i efibootmgr -b {} -a
    > ```
 
 After following the steps above on a given NCN, that NCN will now use the desired Shasta boot order.
@@ -242,7 +251,7 @@ Simply run the reverse-pattern of the PXE commands from the [setting boot order]
 2. Remove them:
 
    ```bash
-   ncn# cat /tmp/rbbs* | awk '!x[$0]++' | sed 's/^Boot//g' | awk '{print $1}' | tr -d '*' | xargs -t -i efibootmgr -b {} -B
+   ncn# cat /tmp/rbbs* | awk '!x[$0]++' | sed 's/^Boot//g' | awk '{print $1}' | tr -d '*' | xargs -r -t -i efibootmgr -b {} -B
    ```
 
 Your boot menu should be trimmed down to contain only relevant entries.

--- a/install/redeploy_pit_node.md
+++ b/install/redeploy_pit_node.md
@@ -487,7 +487,7 @@ the Kubernetes cluster as the final of three master nodes forming a quorum.
     https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
     ```
 
-1.  **`IN-PLACE WORKAROUND`** Set the wipe safeguard to allow safe net-reboots. **This will set the safeguard on all NCNs**. This is fixed by MTL
+1.  **`IN-PLACE WORKAROUND`** Set the wipe safeguard to allow safe net-reboots. **This will set the safeguard on all NCNs**.
 
     ```bash
     ncn-m001# /tmp/csi handoff bss-update-param --set metal.no-wipe=1

--- a/operations/CSM_product_management/Manage_a_Configuration_with_CFS.md
+++ b/operations/CSM_product_management/Manage_a_Configuration_with_CFS.md
@@ -159,7 +159,7 @@ customization and node personalization for CFS targets.
 
 To replace the private key half:
 ```bash
-ncn# kubectl get secret -n services csm-private-key -o json | jq --arg value "$(cat ~/.ssh/id_rsa | base64)" '.data["value"]=$value' | | kubectl apply -f -
+ncn# kubectl get secret -n services csm-private-key -o json | jq --arg value "$(cat ~/.ssh/id_rsa | base64)" '.data["value"]=$value' | kubectl apply -f -
 ```
 
 In this example, `~/.ssh/id_rsa` is a local file containing a private key in a format specified by the admin.
@@ -249,7 +249,7 @@ Multiple product configuration layers may be created later to apply multiple cha
    }
    EOF
    ncn# sed -i -e "s:@RELEASE@:$RELEASE:g" \
-   -e "s:@COMMIT@:$COMMIT@:g" csm-config-$RELEASE.json
+   -e "s:@COMMIT@:$COMMIT:g" csm-config-$RELEASE.json
    ```
 
 1. If this is a first time install and only the CSM software product has been installed, then this file can become

--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -751,9 +751,9 @@ The session template below can be copied and used as the basis for the BOS Sessi
      "enable_cfs": false,
      "name": "shasta-1.4-csm-bare-bones-image"
    }
+   ```
 
    **NOTE**: Be sure to replace the values of the `etag` and `path` fields with the ones you noted earlier in the `cray ims images list` command.
-
 
 2. Create the BOS session template using the following file as input:
    ```


### PR DESCRIPTION
This PR includes:
* The boot order changes from this PR: https://github.com/Cray-HPE/docs-csm/pull/48
* The CFS configuration management section has two errors which result in broken commands (one of which is particularly bad since it does not cause the command to fail, but causes errors further down the line, after much time has been spent). These were fixed by previous commits, but the most recent commit to that page restored the bugs on accident. This PR restores the fixes.
* Minor linting done on CSM Health Validation and Redeploy Pit Node sections