### PR TITLE
CASMINST-3134 1.0: DOCS: Postgres health check failed with one error message for gitea-vcs-postgres pod.

### DIFF
--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -191,7 +191,11 @@ Execute ncnPostgresHealthChecks script and analyze the output of each individual
             INFO: running post_bootstrap
             INFO: trying to bootstrap a new cluster
          ```
-         Errors reported prior to the lock status, such as **ERROR: get_cluster** or **ERROR: ObjectCache.run ProtocolError('Connection broken: IncompleteRead(0 bytes read)', IncompleteRead(0 bytes read))** can be ignored.
+         Errors reported prior to the lock status can be ignored:
+         - **ERROR: get_cluster**
+         - **ERROR: ObjectCache.run ProtocolError('Connection broken: IncompleteRead(0 bytes read)', IncompleteRead(0 bytes read))**
+         - **ERROR: failed to update leader lock** 
+         
          If there is no Leader, refer to [Troubleshoot Postgres Database](./kubernetes/Troubleshoot_Postgres_Database.md#leader).
 
       - Verify the State of each cluster member is 'running'.


### PR DESCRIPTION
Add additional postgres error that can be ignore to the validate csm health md
Resolves
* CASMINST-3134 : DOCS: Postgres health check failed with one error message for gitea-vcs-postgres pod. (for csm-1.0)