### PR TITLE
CASMTRIAGE-2299: add calls to remove service repos

### DIFF
--- a/upgrade/0.9/csm-0.9.4/README.md
+++ b/upgrade/0.9/csm-0.9.4/README.md
@@ -14,6 +14,7 @@ Procedures:
 - [Run Validation Checks (Pre-Upgrade)](#run-validation-checks-pre-upgrade)
 - [Update /etc/hosts on Workers](#update-hosts-on-workers)
 - [Check For Manually Created Unbound PSP](#check-unbound-psp)
+- [Remove zypper RIS services repositories](rm-zypper-services)
 - [Setup Nexus](#setup-nexus)
 - [Backup VCS Content](#backup-vcs-content)
 - [Upgrade Services](#upgrade-services)
@@ -157,6 +158,14 @@ Check for manually created unbound-psp and delete the psp. Helm will manage the 
    ```bash
    ncn-m001# ${CSM_SCRIPTDIR}/check-unbound-psp.sh
    ```
+<a name="rm-zypper-services"></a>
+## Remove zypper RIS services repositories
+Run `lib/remove-service-repos.sh` to remove repositories that are external to the system.
+
+```bash
+ncn-m001# ${CSM_SCRIPTDIR}/remove-service-repos.sh
+```
+
 <a name="setup-nexus"></a>
 ## Setup Nexus
 

--- a/upgrade/0.9/csm-0.9.4/scripts/remove-service-repos.sh
+++ b/upgrade/0.9/csm-0.9.4/scripts/remove-service-repos.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+NCNS=$("$CSM_DISTDIR"/lib/list-ncns.sh | paste -sd,)
+
+pdsh -w "$NCNS" 'zypper ms -d Basesystem_Module_15_SP2_x86_64'
+pdsh -w "$NCNS" 'zypper ms -d Public_Cloud_Module_15_SP2_x86_64'
+pdsh -w "$NCNS" 'zypper ms -d SUSE_Linux_Enterprise_Server_15_SP2_x86_64'
+pdsh -w "$NCNS" 'zypper ms -d Server_Applications_Module_15_SP2_x86_64'

--- a/upgrade/0.9/csm-0.9.5/README.md
+++ b/upgrade/0.9/csm-0.9.5/README.md
@@ -14,6 +14,7 @@ Procedures:
 
 - [Preparation](#preparation)
 - [Run Validation Checks (Pre-Upgrade)](#run-validation-checks-pre-upgrade)
+- [Remove zypper RIS services repositories](rm-zypper-services)
 - [Run CVE Patch Script](#run-cve-patch)
 - [Reboot NCNs](#reboot-ncns)
 - [Validate NCNs Running Patched Kernel](#validate-new-kernel)
@@ -90,6 +91,14 @@ It is important to first verify a healthy starting state. To do this, run the
 [CSM validation checks](../../../008-CSM-VALIDATION.md). If any problems are
 found, correct them and verify the appropriate validation checks before
 proceeding.
+
+<a name="rm-zypper-services"></a>
+## Remove zypper RIS services repositories
+Run `lib/remove-service-repos.sh` to remove repositories that are external to the system.
+
+```bash
+ncn-m001# ${CSM_SCRIPTDIR}/remove-service-repos.sh
+```
 
 <a name="run-cve-patch"></a>
 ## Run CVE Patch Script

--- a/upgrade/0.9/csm-0.9.5/scripts/remove-service-repos.sh
+++ b/upgrade/0.9/csm-0.9.5/scripts/remove-service-repos.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+NCNS=$("$CSM_DISTDIR"/lib/list-ncns.sh | paste -sd,)
+
+pdsh -w "$NCNS" 'zypper ms -d Basesystem_Module_15_SP2_x86_64'
+pdsh -w "$NCNS" 'zypper ms -d Public_Cloud_Module_15_SP2_x86_64'
+pdsh -w "$NCNS" 'zypper ms -d SUSE_Linux_Enterprise_Server_15_SP2_x86_64'
+pdsh -w "$NCNS" 'zypper ms -d Server_Applications_Module_15_SP2_x86_64'

--- a/upgrade/0.9/csm-0.9.6/README.md
+++ b/upgrade/0.9/csm-0.9.6/README.md
@@ -125,7 +125,7 @@ report `FAIL` when uploading duplicate assets. This is ok as long as
    ncn-m001# CSM_SCRIPTDIR=/usr/share/doc/metal/upgrade/0.9/csm-0.9.6/scripts
    ```
 
-2. Execute the following script from the scripts directory determined in the previous step to update master and storage nodes:
+2. Execute the following script from the scripts directory determined in the previous step to update NCN.
 
    ```bash
    ncn-m001# cd "$CSM_SCRIPTDIR"

--- a/upgrade/0.9/csm-0.9.6/scripts/update-ncns.sh
+++ b/upgrade/0.9/csm-0.9.6/scripts/update-ncns.sh
@@ -1,11 +1,21 @@
 #!/bin/bash
 
+NCNS=$("$CSM_DISTDIR"/lib/list-ncns.sh | paste -sd,)
+
+for node in $NCNS; do
+  ssh-keyscan -H "$node" 2> /dev/null >> ~/.ssh/known_hosts
+done
+
+pdsh -w "$NCNS" 'zypper ms -d Basesystem_Module_15_SP2_x86_64'
+pdsh -w "$NCNS" 'zypper ms -d Public_Cloud_Module_15_SP2_x86_64'
+pdsh -w "$NCNS" 'zypper ms -d SUSE_Linux_Enterprise_Server_15_SP2_x86_64'
+pdsh -w "$NCNS" 'zypper ms -d Server_Applications_Module_15_SP2_x86_64'
+
 # Distribute and run script to patch kube-system manifests to master nodes
 masters=$(kubectl get node --selector='node-role.kubernetes.io/master' -o name | sed -e 's,^node/,,' | paste -sd,)
 export PDSH_SSH_ARGS_APPEND="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
 export IFS=","
 for master in $masters; do
-  ssh-keyscan -H "$master" 2> /dev/null >> ~/.ssh/known_hosts
   scp ${ROOTDIR}/scripts/patch-manifests.sh $master:/tmp
   pdsh -w $master "/tmp/patch-manifests.sh"
   # Give K8S a chance to spin up pods for this node
@@ -25,7 +35,6 @@ fi
 num_storage_nodes=$(craysys metadata get num-storage-nodes)
 for node_num in $(seq $num_storage_nodes); do
   storage_node=$(printf "ncn-s%03d" "$node_num")
-  ssh-keyscan -H "$storage_node" 2> /dev/null >> ~/.ssh/known_hosts
   status=$(pdsh -N -w $storage_node "systemctl is-active node_exporter")
   if [ "$status" == "active" ]; then
     pdsh -w $storage_node "systemctl stop node_exporter; zypper rm -y golang-github-prometheus-node_exporter"


### PR DESCRIPTION
We had this logic in csm-9.2 and csm-9.3.  It was missing in
csm-9.4, csm-9.5, and csm-9.6