### PR TITLE
CASM-2565 - DNS deprecation notice

### DIFF
--- a/introduction/PowerDNS_migration.md
+++ b/introduction/PowerDNS_migration.md
@@ -1,6 +1,6 @@
 # PowerDNS Migration Notice
 
-The migration to PowerDNS as the authoratative DNS source and the introduction of Bifurcated CAN (Customer Access Network) will result in some changes to the node and service naming conventions.
+The migration to PowerDNS as the authoritative DNS source and the introduction of Bifurcated CAN (Customer Access Network) will result in some changes to the node and service naming conventions.
 
 ## DNS Record Naming Changes
 

--- a/introduction/PowerDNS_migration.md
+++ b/introduction/PowerDNS_migration.md
@@ -1,0 +1,41 @@
+# PowerDNS Migration Notice
+
+The migration to PowerDNS as the authoratative DNS source and the introduction of Bifurcated CAN (Customer Access Network) will result in some changes to the node and service naming conventions.
+
+## DNS Record Naming Changes
+
+Fully qualified domain names will be introduced for all DNS records.
+
+Canonical name: `hostname`.`network-path`.`system-name`.`tld`
+
+* `hostname` - The hostname of the node or service
+* `network-path` - The network path used to access the node
+  * .nmn - Node Management Network
+  * .hmn - Hardware Management Network
+  * .hsn - High Speed Network (Slingshot)
+  * .can - Customer Access Network
+  * .chn - Customer High Speed network
+  * .cmn - Customer Management Network
+* `system-name` - The customer defined name of the system
+* `tld` - The top-level domain
+
+Kubernetes services present on the Hardware Management Network (HMN) and Node Management Network (NMN) that needed to be referenced by name used names in the `.local` domain which will be deprecated in favour of a fully qualified domain name.
+
+### Examples
+
+The following examples assume the system was configured with a `system-name` of `shasta` and a `site-domain` of `dev.cray.com`
+
+| Old name                  | New name                                                                                  |
+|---------------------------|-------------------------------------------------------------------------------------------|
+| ncn-w001                  | ncn-w001.nmn.shasta.dev.cray.com                                                          |
+| nid000001-nmn             | nid000001.nmn.shasta.dev.cray.com                                                         |
+| x3000c0s2b0               | x3000c0s2b0.hmn.shasta.dev.cray.com                                                       |
+| api-gw-service-nmn.local  | api.nmn.shasta.dev.cray.com                                                               |
+| registry.local            | registry.nmn.shasta.dev.cray.com                                                          |
+| packages.local            | packages.nmn.shasta.dev.cray.com                                                          |
+| nexus.shasta.dev.cray.com | nexus.cmn.shasta.dev.cray.com                                                             |
+| api.shasta.dev.cray.com   | api.cmn.shasta.dev.cray.com<br>api.chn.shasta.dev.cray.com<br>api.can.shasta.dev.cray.com |
+
+## Backwards Compatibility
+
+The old service and node names will not be migrated to PowerDNS however they will be maintained in Unbound as local records for the purpose of backwards compatibility. These records will be removed entirely in a future release when the cray-dns-unbound-manager job is deprecated.

--- a/introduction/differences.md
+++ b/introduction/differences.md
@@ -44,7 +44,9 @@ The most noteworthy changes since the previous release are described here.
         * The `--template-body` option for the Cray CLI `bos` command will be deprecated.
         * Performing a GET on the session status for a boot set (i.e. `/v1/session/{session_id}/status/{boot_set_name}`) currently returns a status code of 201, but instead it should return a status code of 200. This will be corrected to return 200.
    * PowerDNS will replace Unbound as the authoritative DNS source in CSM version 1.2.
-        * The cray-dns-unbound-manager CronJob will be deprecated when all DNS records are migrated to PowerDNS.
+        * The cray-dns-unbound-manager CronJob will be deprecated in a future release once all DNS records are migrated to PowerDNS.
+        * The introduction of PowerDNS and Bifurcated CAN will introduce some node and service naming changes.
+        * Please see the [PowerDNS migration notice](../introduction/PowerDNS_migration.md) for more information.
 
 <a name="deprecated_features"></a>
 ### Deprecated Features


### PR DESCRIPTION
Document introduction of PowerDNS, upcoming DNS record naming changes, and upcoming deprecation of cray-dns-unbound-manager job.