### PR TITLE
CASMCMS-7342: Do not run VCS test in csm-1.1 health checks

### DIFF
--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -633,7 +633,7 @@ The Software Management Services health checks are run using `/usr/local/bin/cms
 The following test can be run on any Kubernetes node (any master or worker node, but **not** the PIT node).
 
 ```bash
-ncn# /usr/local/bin/cmsdev test -q all
+ncn# /usr/local/bin/cmsdev test -q bos cfs conman crus ims ipxe
 ```
 
 <a name="cmsdev-results"></a>
@@ -644,9 +644,9 @@ If all checks passed:
    * The final line of output will begin with `SUCCESS`
    * For example:
         ```bash
-        ncn# /usr/local/bin/cmsdev test -q all
+        ncn# /usr/local/bin/cmsdev test -q bos cfs conman crus ims ipxe
         ...
-        SUCCESS: All 7 service tests passed: bos, cfs, conman, crus, ims, tftp, vcs
+        SUCCESS: All 6 service tests passed: bos, cfs, conman, crus, ims, ipxe
         ncn# echo $?
         0
         ```
@@ -656,14 +656,14 @@ If one or more checks failed:
    * The final line of output will begin with `FAILURE` and will list which checks failed
    * For example:
         ```bash
-        ncn# /usr/local/bin/cmsdev test -q all
+        ncn# /usr/local/bin/cmsdev test -q bos cfs conman crus ims ipxe
         ...
-        FAILURE: 2 service tests FAILED (conman, ims), 5 passed (bos, cfs, crus, tftp, vcs)
+        FAILURE: 2 service tests FAILED (conman, ims), 4 passed (bos, cfs, crus, ipxe)
         ncn# echo $?
         1
         ```
 
-Additional test execution details can be found in `/opt/cray/tests/cmsdev.log`.
+Additional test execution details can be found in `/opt/cray/tests/cmsdev.log` on the node where the test was run.
 
 <a name="booting-csm-barebones-image"></a>
 ## 4. Booting CSM Barebones Image


### PR DESCRIPTION
Because the cmsdev tests are not being updated for csm-1.1, this PR changes the health check docs so that the VCS test is not run (as it will fail). It also makes a minor clarification to the instructions for finding the test log. This is ready to merge, pending approvals.