### PR TITLE
CASMCMS-7342: Minor updates to cmsdev section of CSM health checks

### DIFF
--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -713,7 +713,7 @@ If one or more checks failed:
         1
         ```
 
-Additional test execution details can be found in `/opt/cray/tests/cmsdev.log`.
+Additional test execution details can be found in `/opt/cray/tests/cmsdev.log` on the node where the test was run.
 
 <a name="booting-csm-barebones-image"></a>
 ## 4. Booting CSM Barebones Image


### PR DESCRIPTION
Add a minor clarification on where to find the cmsdev test logs in the CSM health check.

This is ready for merge pending approval.