### PR TITLE
Fixes for 0.9.6 patch install

### DIFF
--- a/upgrade/0.9/csm-0.9.6/README.md
+++ b/upgrade/0.9/csm-0.9.6/README.md
@@ -29,6 +29,7 @@
 - [Apply cray-hms-hmcollector scale changes](#apply-cray-hms-hmcollector-scale-changes)
 - [Setup Nexus](#setup-nexus)
 - [Update NCNs](#update-ncns)
+- [Update BSS metadata](#update-bss)
 - [Upgrade Services](#upgrade-services)
 - [Rollout Deployment Restart](#rollout-deployment-restart)
 - [Verification](#verification)
@@ -130,6 +131,16 @@ report `FAIL` when uploading duplicate assets. This is ok as long as
    ```bash
    ncn-m001# cd "$CSM_SCRIPTDIR"
    ncn-m001# ./update-ncns.sh
+   ```
+
+<a name="update-bss"></a>
+## Update BSS metadata
+
+1. Execute the following script from the scripts directory determined above to update BSS metadata.
+
+   ```bash
+   ncn-m001# cd "$CSM_SCRIPTDIR"
+   ncn-m001# ./update-bss-metadata.sh
    ```
 
 <a name="upgrade-services"></a>
@@ -265,7 +276,7 @@ deployment "cray-dns-unbound" successfully rolled out
        "/srv/cray/scripts/metal/set-bmc-bbs.sh",
        "/srv/cray/scripts/metal/disable-cloud-init.sh",
        "/srv/cray/scripts/common/update_ca_certs.py",
-       "zypper --no-gpg-checks in -y https://packages.local/repository/casmrel-755/cray-node-exporter-1.2.2.1-1.x86_64.rpm"
+       "zypper --no-gpg-checks in -y https://packages.local/repository/csm-sle-15sp2/x86_64/cray-node-exporter-1.2.2.1-1.x86_64.rpm"
      ]
    }
    ```

--- a/upgrade/0.9/csm-0.9.6/scripts/update-bss-metadata.sh
+++ b/upgrade/0.9/csm-0.9.6/scripts/update-bss-metadata.sh
@@ -22,15 +22,22 @@ function update_bss_storage() {
     xName=$(ssh -q -o StrictHostKeyChecking=no $storage_node 'cat /etc/cray/xname')
     cray bss bootparameters list --name $xName --format=json | jq '.[]' > /tmp/$xName
     if ! grep -q "cray-node-exporter-1.2.2.1-1.x86_64.rpm" /tmp/$xName; then
-      sed -i '/"\/srv\/cray\/scripts\/common\/update_ca_certs.py"/a \        "zypper --no-gpg-checks in -y https://packages.local/repository/csm-sle-15sp2/cray-node-exporter-1.2.2.1-1.x86_64.rpm"' /tmp/$xName
+      sed -i '/"\/srv\/cray\/scripts\/common\/update_ca_certs.py"/a \        "zypper --no-gpg-checks in -y https://packages.local/repository/csm-sle-15sp2/x86_64/cray-node-exporter-1.2.2.1-1.x86_64.rpm"' /tmp/$xName
+      if [[ "$storage_node" =~ "ncn-s001" ]]
+      then
+        sed -i '/storage-ceph-cloudinit.sh/d' /tmp/$xName
+      else
+        sed -i 's/update_ca_certs.py\"/update_ca_certs.py\",/' /tmp/$xName
+      fi
+      echo "putting config"
+      curl -i -s -k -H "Content-Type: application/json" -H "Authorization: Bearer ${TOKEN}" "https://api_gw_service.local/apis/bss/boot/v1/bootparameters" -X PUT -d @/tmp/$xName
     fi
-    if [[ "$storage_node" =~ "ncn-s001" ]]
-    then
-      sed -i '/storage-ceph-cloudinit.sh/d' /tmp/$xName
-    else
-      sed -i 's/update_ca_certs.py\"/update_ca_certs.py\",/' /tmp/$xName
-    fi
-    echo "putting config"
-    curl -i -s -k -H "Content-Type: application/json" -H "Authorization: Bearer ${TOKEN}" "https://api_gw_service.local/apis/bss/boot/v1/bootparameters" -X PUT -d @/tmp/$xName
   done
 }
+
+TOKEN=`curl -k -s -S -d grant_type=client_credentials -d client_id=admin-client -d client_secret=\`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d\` https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token'`
+
+update_bss_storage
+update_bss_masters
+
+echo "Done!"

--- a/upgrade/0.9/csm-0.9.6/scripts/update-ncns.sh
+++ b/upgrade/0.9/csm-0.9.6/scripts/update-ncns.sh
@@ -16,7 +16,7 @@ masters=$(kubectl get node --selector='node-role.kubernetes.io/master' -o name |
 export PDSH_SSH_ARGS_APPEND="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
 export IFS=","
 for master in $masters; do
-  scp ${ROOTDIR}/scripts/patch-manifests.sh $master:/tmp
+  scp ./patch-manifests.sh $master:/tmp
   pdsh -w $master "/tmp/patch-manifests.sh"
   # Give K8S a chance to spin up pods for this node
   sleep 10
@@ -39,5 +39,5 @@ for node_num in $(seq $num_storage_nodes); do
   if [ "$status" == "active" ]; then
     pdsh -w $storage_node "systemctl stop node_exporter; zypper rm -y golang-github-prometheus-node_exporter"
   fi
-  pdsh -w $storage_node "zypper --no-gpg-checks in -y https://packages.local/repository/csm-sle-15sp2/cray-node-exporter-1.2.2.1-1.x86_64.rpm"
+  pdsh -w $storage_node "zypper --no-gpg-checks in -y https://packages.local/repository/csm-sle-15sp2/x86_64/cray-node-exporter-1.2.2.1-1.x86_64.rpm"
 done


### PR DESCRIPTION
This PR addresses:

CASMINST-3193: 0.9.6 patch instructions don't make call to update bss metadata
CASMINST-3194: update-ncns.sh script in 0.9.6 patch has several issues