### PR TITLE
CASMINST-3215: Add retries and skip capability to postgres lag check

### DIFF
--- a/upgrade/1.0/scripts/upgrade/ncn-upgrade-k8s-worker.sh
+++ b/upgrade/1.0/scripts/upgrade/ncn-upgrade-k8s-worker.sh
@@ -65,11 +65,38 @@ else
     echo "====> ${state_name} has been completed"
 fi
 
+# The UPGRADE_POSTGRES_MAX_LAG may be exported by the user to control
+# the maximum lag value permitted by this script. Setting its value to
+# a negative number or a non-integer value has the effect of skipping the
+# maximum lag check. In other words, if one wishes to skip this check,
+# one could:
+# export UPGRADE_POSTGRES_MAX_LAG=skip
+UPGRADE_POSTGRES_MAX_LAG=${UPGRADE_POSTGRES_MAX_LAG:-'0'}
+
+# UPGRADE_POSTGRES_MAX_ATTEMPTS specifies the maximum number of times the
+# postgres check will be performed on a given cluster before failing. Note that
+# failures other than due to maximum lag are always fatal and are not retried.
+# If unset or set to a non-positive integer, default to 10
+if [[ ! $UPGRADE_POSTGRES_MAX_ATTEMPTS =~ ^[1-9][0-9]*$ ]]; then
+    UPGRADE_POSTGRES_MAX_ATTEMPTS=10
+fi
+
+# UPGRADE_POSTGRES_WAIT_SECONDS_BETWEEN_ATTEMPTS specifies the time (in seconds)
+# between postgres checks on a given cluster.
+# If unset or set to a non-positive integer, default to 10
+if [[ ! $UPGRADE_POSTGRES_WAIT_SECONDS_BETWEEN_ATTEMPTS =~ ^[1-9][0-9]*$ ]]; then
+    UPGRADE_POSTGRES_WAIT_SECONDS_BETWEEN_ATTEMPTS=10
+fi
+
 state_name="ENSURE_POSTGRES_HEALTHY"
 state_recorded=$(is_state_recorded "${state_name}" ${upgrade_ncn})
 if [[ $state_recorded == "0" ]]; then
     echo "====> ${state_name} ..."
-
+    if [[ ! $UPGRADE_POSTGRES_MAX_LAG =~ ^[0-9][0-9]*$ ]]; then
+        echo "Skipping postgres cluster max lag checks because of UPGRADE_POSTGRES_MAX_LAG setting"
+    else
+        echo "Postgres cluster checks may take several minutes, depending on latency"
+    fi
     if [[ ! -z $(kubectl get postgresql -A -o json | jq '.items[].status | select(.PostgresClusterStatus != "Running")') ]]; then
         echo "--- ERROR --- not all Postgresql Clusters have a status of 'Running'"
         exit 1
@@ -81,42 +108,70 @@ if [[ $state_recorded == "0" ]]; then
         # NameSpace and postgres cluster name
         c_ns="$(echo $c | awk -F, '{print $1;}')"
         c_name="$(echo $c | awk -F, '{print $2;}')"
-        c_cluster_details=$(kubectl exec "${c_name}-1" -c postgres -it -n ${c_ns} -- curl -s http://localhost:8008/cluster)
-        c_num_of_members=$(echo $c_cluster_details | jq '.members | length' )
-        c_num_of_leader=$(echo $c_cluster_details | jq '.members[] | .role' | grep "leader" | wc -l)
-        c_max_lag=$(echo $c_cluster_details | jq '[.members[] | .lag] | max')
-        c_unknown_lag=$(echo $c_cluster_details | jq '[.members[] | .lag]' | grep "unknown" | wc -l)
+        echo -n "Checking postgres cluster ${c_name} in namespace ${c_ns} ..."
+        c_attempt=0
+        c_lag_history=""
+        while [ true ]; do
+            # Normally I would use let for arithmetic, but if the let expression evaluates to 0,
+            # the return code is non-0, which breaks us because we are operating under set -e.
+            # Therefore, in this function, arithmetic is performed in the following fashion:
+            c_attempt=$((${c_attempt} + 1))
 
-        # check number of members
-        if [[ $c_name == "sma-postgres-cluster" ]]; then
-            if [[ $c_num_of_members -ne 2 ]]; then
-                echo "--- ERROR --- $c cluster only has $c_num_of_members/2 cluster members"
+            echo -n "."
+            if [[ $c_attempt -gt 1 ]]; then
+                # Sleep before re-attempting
+                sleep $UPGRADE_POSTGRES_WAIT_SECONDS_BETWEEN_ATTEMPTS
+            fi
+            c_cluster_details=$(kubectl exec "${c_name}-1" -c postgres -it -n ${c_ns} -- curl -s http://localhost:8008/cluster)
+            c_num_of_members=$(echo $c_cluster_details | jq '.members | length' )
+            c_num_of_leader=$(echo $c_cluster_details | jq '.members[] | .role' | grep "leader" | wc -l)
+            c_max_lag=$(echo $c_cluster_details | jq '[.members[] | .lag] | max')
+            if [[ -n $c_lag_history ]]; then
+                c_lag_history+=", $c_max_lag"
+            else
+                c_lag_history="$c_max_lag"
+            fi
+            c_unknown_lag=$(echo $c_cluster_details | jq '[.members[] | .lag]' | grep "unknown" | wc -l)
+
+            # check number of members
+            if [[ $c_name == "sma-postgres-cluster" ]]; then
+                if [[ $c_num_of_members -ne 2 ]]; then
+                    echo -e "\n--- ERROR --- $c cluster only has $c_num_of_members/2 cluster members"
+                    exit 1
+                fi
+            else
+                if [[ $c_num_of_members -ne 3 ]]; then
+                    echo -e "\n--- ERROR --- $c cluster only has $c_num_of_members/3 cluster members"
+                    exit 1
+                fi
+            fi
+
+            #check number of leader
+            if [[ $c_num_of_leader -ne 1 ]]; then
+                echo -e "\n--- ERROR --- $c cluster does not have a leader"
                 exit 1
             fi
-        else
-            if [[ $c_num_of_members -ne 3 ]]; then
-                echo "--- ERROR --- $c cluster only has $c_num_of_members/3 cluster members"
+
+            #check lag:unknown
+            if [[ $c_unknown_lag -gt 0 ]]; then
+                echo -e "\n--- ERROR --- $c cluster has lag: unknown"
                 exit 1
             fi
-        fi
 
-        #check number of leader
-        if [[ $c_num_of_leader -ne 1 ]]; then
-            echo "--- ERROR --- $c cluster does not have a leader"
-            exit 1
-        fi
-        #check number of lag
-        if [[ $c_max_lag -gt 0 ]]; then
-            echo "--- ERROR --- $c cluster has lag: $c_max_lag"
-            exit 1
-        fi
-        #check lag:unknown
-        if [[ $c_unknown_lag -gt 0 ]]; then
-            echo "--- ERROR --- $c cluster has lag: unknown"
-            exit 1
-        fi
+            if [[ $UPGRADE_POSTGRES_MAX_LAG =~ ^[0-9][0-9]*$ ]]; then
+                #check max_lag is <= $UPGRADE_POSTGRES_MAX_LAG
+                if [[ $c_max_lag -gt $UPGRADE_POSTGRES_MAX_LAG ]]; then
+                    # If we have not exhausted our number of attempts, retry
+                    [[ $c_attempt -ge $UPGRADE_POSTGRES_MAX_ATTEMPTS ]] || continue
+                    
+                    echo -e "\n--- ERROR --- $c cluster has lag: $c_lag_history"
+                    exit 1
+                fi
+            fi
+            echo " OK"
+            break
+        done
     done
-
 
     record_state "${state_name}" ${upgrade_ncn}
 else


### PR DESCRIPTION
Before upgrading worker NCNs, the upgrade script checks all of the postgres clusters. Among other things, it checks the maximum lag values they report, and fails if any of them are reporting any lag. Often a lag value will be temporarily non-0 not because of any real problem. In this case, the upgrade script fails, but a retry may succeed. On some systems, multiple retries may be required, since every postgres cluster is checked on every attempt.

This PR modifies the previous behavior as follows:
1) If the maximum lag value for a cluster is non-0, this does not result in immediate failure. The script will now sleep for 10 seconds and then check again. The script only fails if the lag is non-0 for 10 attempts.

2) The lag check (but not the overall postgres check) can be skipped by exporting an environment variable before running the upgrade script:
_export UPGRADE_POSTGRES_MAX_LAG=skip_

3) Before the postgres checks are performed, a message is printed warning that they may take several minutes.

4) Progress during the retries is conveyed by printing "." to the screen before each attempt.

I tested just this check code on pepsi, which had no lag and passed. I also ran it on hela, where it did need to retry a few times to work on some of the clusters, and where even 10 retries was not enough for it to work on one of the clusters. I verified that setting the environment variable listed above allowed me to skip the lag check and proceed.