### PR TITLE
CASMINST-2999 1.1 : DOCS: 1.0 : Update the ignorable error message for postgres health check script

### DIFF
--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -191,10 +191,11 @@ Execute ncnPostgresHealthChecks script and analyze the output of each individual
             INFO: running post_bootstrap
             INFO: trying to bootstrap a new cluster
          ```
-         Errors reported prior to the lock status can be ignored:
+         Errors reported prior to the lock status can be ignored - for example:
          - **ERROR: get_cluster**
          - **ERROR: ObjectCache.run ProtocolError('Connection broken: IncompleteRead(0 bytes read)', IncompleteRead(0 bytes read))**
          - **ERROR: failed to update leader lock** 
+         - **ERROR: Exception when working with master via replication connection**
          
          If there is no Leader, refer to [Troubleshoot Postgres Database](./kubernetes/Troubleshoot_Postgres_Database.md#leader).
 


### PR DESCRIPTION
Resolves for release/1.1
* CASMINST : Update the ignorable error message for postgres health check script
Adds another postgres error that can be ignored.

