### PR TITLE
CASMCMS-7255: Describe how to modify fault BOA re-run command

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,5 @@
+# Cray System Management (CSM) - Release Notes
+## What’s new
+## Bug Fixes
+## Known Issues
+- Incorrect_output_for_bos_command_rerun: When a Boot Orchestration Service (BOS) session fails, it may output a message in the Boot Orchestration Agent (BOA) log associated with that session. This output contains a command that instructs the user how to re-run the failed session. It will only contain the nodes that failed during that session. The command is faulty, and this issue addresses correcting it.

--- a/troubleshooting/index.md
+++ b/troubleshooting/index.md
@@ -7,6 +7,7 @@ This document provides troubleshooting information for services and functionalit
     * [Hardware Discovery](#known-issues-hardware-discovery)
     * [initrd.img.xz not found](#initrd-not-found)
     * [SAT/HSM/CAPMC Component Power State Mismatch](known_issues/component_power_state_mismatch.md)
+    * [BOS/BOA Incorrect command is output to rerun a failed operation.](known_issues/incorrect_output_for_bos_command_rerun.md)
  * Kubernetes troubleshooting
     * [General Kubernetes Commands for Troubleshooting](./kubernetes/Kubernetes_Troubleshooting_Information.md)
     * [Kubernetes Log File Locations](./kubernetes/Kubernetes_Log_File_Locations.md)

--- a/troubleshooting/known_issues/incorrect_output_for_bos_command_rerun.md
+++ b/troubleshooting/known_issues/incorrect_output_for_bos_command_rerun.md
@@ -1,0 +1,27 @@
+# BOS/BOA Incorrect command is output to rerun a failed operation.
+When the Boot Orchestration Agent (BOA), an agent of the Boot Orchestration Service (BOS), encounters a failure, it issues a command to rerun the operation for any nodes that experienced the failure. However, the syntax of this command is faulty.
+
+The faulty command includes squiggly braces around a comma separated list of quoted nodes. These squiggly braces, single quotes, and the spaces separating the individual nodes all need to be removed. Then, this reformatted command can be run.
+
+Example of a faulty command in the BOA log:
+```
+ERROR   - cray.boa.agent - You can attempt to boot these nodes by issuing the command:
+cray bos v1 session create --template-uuid shasta-1.4-csm-bare-bones-image --operation boot --limit {'x3000c0s25b3n0', 'x3000c0s23b4n0', 'x3000c0s20b4n0', 'x3000c0s37b2n0', 'x1000c0s7b0n0', 'x1000c3s3b0n0', 'x1000c1s1b1n1', 'x1000c0s7b1n0', 'x1000c2s3b1n1', 'x3000c0s20b3n0', 'x3000c0s25b1n0', 'x3000c0s20b1n0', 'x3000c0s20b2n0', 'x3000c0s25b2n0', 'x3000c0s23b3n0', 'x3000c0s25b4n0', 'x1000c1s1b1n0', 'x3000c0s37b1n0', 'x3000c0s37b4n0', 'x1000c2s3b1n0', 'x3000c0s23b2n0', 'x3000c0s23b1n0', 'x1000c0s7b1n1', 'x3000c0s37b3n0', 'x1000c0s7b0n1'}
+```
+
+Example of the correct command:
+```
+cray bos v1 session create --template-uuid shasta-1.4-csm-bare-bones-image --operation boot --limit x3000c0s25b3n0,x3000c0s23b4n0,x3000c0s20b4n0,x3000c0s37b2n0,x1000c0s7b0n0,x1000c3s3b0n0,x1000c1s1b1n1,x1000c0s7b1n0,x1000c2s3b1n1,x3000c0s20b3n0,x3000c0s25b1n0,x3000c0s20b1n0,x3000c0s20b2n0,x3000c0s25b2n0,x3000c0s23b3n0,x3000c0s25b4n0,x1000c1s1b1n0,x3000c0s37b1n0,x3000c0s37b4n0,x1000c2s3b1n0,x3000c0s23b2n0,x3000c0s23b1n0,x1000c0s7b1n1,x3000c0s37b3n0,x1000c0s7b0n1
+```
+
+Cut and paste the faulty command and assign to an environment variable.
+```
+# CMD="cray bos v1 session create --template-uuid shasta-1.4-csm-bare-bones-image --operation boot --limit {'x3000c0s25b3n0', 'x3000c0s23b4n0', 'x3000c0s20b4n0', 'x3000c0s37b2n0', 'x1000c0s7b0n0', 'x1000c3s3b0n0', 'x1000c1s1b1n1', 'x1000c0s7b1n0', 'x1000c2s3b1n1', 'x3000c0s20\
+b3n0', 'x3000c0s25b1n0', 'x3000c0s20b1n0', 'x3000c0s20b2n0', 'x3000c0s25b2n0', 'x3000c0s23b3n0', 'x3000c0s25b4n0', 'x1000c1s1b1n0', 'x3000c0s37b1n0', 'x3000c0s37b4n0', 'x1000c2s3b1n0', 'x3000c0s23b2n0', 'x3000c0s23b1n0', 'x1000c0s7b1n1', 'x3000c0s37b3n0', 'x1000c0s7b0n\
+1'}"
+```
+
+Then, paste this command to get the corrected output.
+```
+# echo $CMD |sed s/,\ /,/g|sed s/{//g|sed s/}//g|sed s/\'//g
+```


### PR DESCRIPTION
The command BOA outputs to re-run a failed operation is faulty. This
describes how to correct the faulty command to make it runnable. It
provides cut and paste instructions to fix the command.