### PR TITLE
CASMCMS-7606: Add docs for stuck CFS sessions (1.1)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,3 +3,4 @@
 ## Bug Fixes
 ## Known Issues
 - Incorrect_output_for_bos_command_rerun: When a Boot Orchestration Service (BOS) session fails, it may output a message in the Boot Orchestration Agent (BOA) log associated with that session. This output contains a command that instructs the user how to re-run the failed session. It will only contain the nodes that failed during that session. The command is faulty, and this issue addresses correcting it.
+- Cfs_session_stuck_in_pending: Under some circumstances CFS sessions can get stuck in a pending state, never completing and potentially blocking other sessions.  This addresses cleaning up those sessions.

--- a/troubleshooting/index.md
+++ b/troubleshooting/index.md
@@ -8,6 +8,7 @@ This document provides troubleshooting information for services and functionalit
     * [initrd.img.xz not found](#initrd-not-found)
     * [SAT/HSM/CAPMC Component Power State Mismatch](known_issues/component_power_state_mismatch.md)
     * [BOS/BOA Incorrect command is output to rerun a failed operation.](known_issues/incorrect_output_for_bos_command_rerun.md)
+    * [CFS Sessions are Stuck in a Pending State](known_issues/cfs_sessions_stuck_in_pending.md)
  * Kubernetes troubleshooting
     * [General Kubernetes Commands for Troubleshooting](./kubernetes/Kubernetes_Troubleshooting_Information.md)
     * [Kubernetes Log File Locations](./kubernetes/Kubernetes_Log_File_Locations.md)

--- a/troubleshooting/known_issues/cfs_sessions_stuck_in_pending.md
+++ b/troubleshooting/known_issues/cfs_sessions_stuck_in_pending.md
@@ -1,0 +1,9 @@
+# CFS Sessions are Stuck in Pending State
+In rare cases it is possible that a CFS session can be stuck in a `pending` state.  Sessions should only enter the `pending` state briefly, for no more than a few seconds while the corresponding Kubernetes job is being scheduled.  If any sessions are in this state for more than a minute, they can safely be deleted.  If the sessions were created automatically and retires are enabled, the sessions should be recreated automatically.
+
+Pending sessions can be found with the following command:
+```
+cray cfs sessions list --status pending
+```
+
+Stuck sessions that were created by the cfs-batcher can block further sessions from being scheduled against the same components.  In the event that sessions are not being scheduled against some components, check the list of pending sessions to see if any are stuck and targeting the same component.  


### PR DESCRIPTION
### Summary and Scope

This adds documentation detailing how to check for and recover from CFS sessions that are stuck in a pending state.

### Issues and Related PRs

* Resolves CASMCMS-7606

### Testing

Tested on:

* NA, docs

### Risks and Mitigations

None