### PR TITLE
CASMCMS-7606: Add docs for stuck CFS sessions (0.9)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,5 @@
+# Cray System Management (CSM) - Release Notes
+## What’s new
+## Bug Fixes
+## Known Issues
+- Cfs_session_stuck_in_pending: Under some circumstances CFS sessions can get stuck in a pending state, never completing and potentially blocking other sessions.  This addresses cleaning up those sessions.

--- a/troubleshooting/index.md
+++ b/troubleshooting/index.md
@@ -1,0 +1,12 @@
+# CSM Troubleshooting Information
+
+This document provides troubleshooting information for services and functionality provided by CSM.
+
+### Topics
+ * [Known Issues](#known-issues)
+    * [CFS Sessions are Stuck in a Pending State](known_issues/cfs_sessions_stuck_in_pending.md)
+
+<a name="known-issues"></a>
+
+## Known Issues
+Listing of known issues and procedures to workaround them in this CSM release.

--- a/troubleshooting/known_issues/cfs_sessions_stuck_in_pending.md
+++ b/troubleshooting/known_issues/cfs_sessions_stuck_in_pending.md
@@ -1,0 +1,9 @@
+# CFS Sessions are Stuck in Pending State
+In rare cases it is possible that a CFS session can be stuck in a `pending` state.  Sessions should only enter the `pending` state briefly, for no more than a few seconds while the corresponding Kubernetes job is being scheduled.  If any sessions are in this state for more than a minute, they can safely be deleted.  If the sessions were created automatically and retires are enabled, the sessions should be recreated automatically.
+
+Pending sessions can be found with the following command:
+```
+cray cfs sessions list --format json | jq '.[] | select(.status.session.status=="pending") | {name}'
+```
+
+Stuck sessions that were created by the cfs-batcher can block further sessions from being scheduled against the same components.  In the event that sessions are not being scheduled against some components, check the list of pending sessions to see if any are stuck and targeting the same component.  


### PR DESCRIPTION
### Summary and Scope

This adds documentation detailing how to check for and recover from CFS sessions that are stuck in a pending state.

### Issues and Related PRs

* Resolves CASMCMS-7606

### Testing

Tested on:

* NA, docs

### Risks and Mitigations

None