### PR TITLE
CASMINST-3116 Automatic backport of closed PRs to selected branches (0.9)

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -1,0 +1,14 @@
+name: Backport
+
+on:
+  pull_request:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    runs-on: self-hosted
+    name: Backport closed pull request
+    steps:
+    - uses: syndesisio/backport-action@master

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -11,4 +11,4 @@ jobs:
     runs-on: self-hosted
     name: Backport closed pull request
     steps:
-    - uses: syndesisio/backport-action@master
+    - uses: Cray-HPE/backport-action@v1


### PR DESCRIPTION
Cherry-pick of https://github.com/Cray-HPE/docs-csm/pull/212 to release/0.9 branch.