### PR TITLE
CASMCMS-7632: Fix docs for updating VCS password (1.1)

### DIFF
--- a/operations/configuration_management/Version_Control_Service_VCS.md
+++ b/operations/configuration_management/Version_Control_Service_VCS.md
@@ -33,9 +33,9 @@ To change the password in the `vcs-user-credentials` Kubernetes secret, use the 
 
 ```bash
 ncn# kubectl create secret generic vcs-user-credentials --save-config \
---from-literal=vcs_username="crayvcs"
+--from-literal=vcs_username="crayvcs" \
 --from-literal=vcs_password="NEW_PASSWORD" \
---dry-run -o yaml | kubectl apply -f -
+--dry-run=client -o yaml | kubectl apply -f -
 ```
 
 The `NEW_PASSWORD` value must be replaced with the updated password.


### PR DESCRIPTION
### Summary and Scope

Fixes the command for updating the VCS password secret.  Adds a missing "\" for line continuation as well as fixing a deprecated usage of --dry-run so that the command works in more recent kubernetes versions.

### Issues and Related PRs

* Resolves CASMCMS-7632

### Testing

Tested on:

* Mug

Updated the VCS password

### Risks and Mitigations

None