### PR TITLE
CASMINST-3267: Add info on broken CFS feature to release notes (1.0)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,3 +4,4 @@
 ## Known Issues
 - Incorrect_output_for_bos_command_rerun: When a Boot Orchestration Service (BOS) session fails, it may output a message in the Boot Orchestration Agent (BOA) log associated with that session. This output contains a command that instructs the user how to re-run the failed session. It will only contain the nodes that failed during that session. The command is faulty, and this issue addresses correcting it.
 - Cfs_session_stuck_in_pending: Under some circumstances CFS sessions can get stuck in a pending state, never completing and potentially blocking other sessions.  This addresses cleaning up those sessions.
+- The "branch" parameter in CFS configurations may not work, and setting it will instead return an error.  Continue setting the commit id instead.


### PR DESCRIPTION
### Summary and Scope

Adds information on the broken "branch" parameters in CFS configurations to the known issues in the release notes.

### Issues and Related PRs

* Resolves CASMINST-3267
### Testing

Tested on:

* NA, docs only

### Risks and Mitigations

None