### PR TITLE
FAS documentation changes for gigabyte - Minor wording changes.

### DIFF
--- a/operations/firmware/FAS_Recipes.md
+++ b/operations/firmware/FAS_Recipes.md
@@ -259,14 +259,21 @@ See [Configure DNS and NTP on Each BMC](../../install/redeploy_pit_node.md#confi
     "tag": "default",
     "overrideDryrun": false,
     "restoreNotPossibleOverride": true,
-    "timeLimit": 2000,
+    "timeLimit": 4000,
     "description": "Dryrun upgrade of Gigabyte node BMCs"
   }
 }
 ```
 
-**NOTE:** The timeLimit is `2000` because the Gigabytes can take a lot longer to update.
+**NOTE:** The timeLimit is `4000` because the Gigabytes can take a lot longer to update.
 
+You may receive a node failed to update with the output:
+`stateHelper = "Firmware Update Information Returned Downloading – See /redfish/v1/UpdateService"`
+FAS has incorrectly marked this node as failed.
+It most likely will complete the update successfully.
+You can check the update status by looking at the redfish `FirmwareInvetnory (/redfish/v1/UpdateService/FirmwareInventory/BMC)`
+or rerunning FAS to verify that the BMC firmware was updated.
+Make sure you have waited for the current firmware to be updated before starting a new FAS action on the same node.
 
 <a name="gb-device-type-nodebmc-target-bios"></a>
 
@@ -293,7 +300,7 @@ See [Configure DNS and NTP on Each BMC](../../install/redeploy_pit_node.md#confi
     "tag": "default",
     "overrideDryrun": false,
     "restoreNotPossibleOverride": true,
-    "timeLimit": 2000,
+    "timeLimit": 4000,
     "description": "Dryrun upgrade of Gigabyte node BIOS"
   }
 }

--- a/operations/firmware/FAS_Use_Cases.md
+++ b/operations/firmware/FAS_Use_Cases.md
@@ -459,13 +459,21 @@ See [Lock and Unlock Management Nodes](../hardware_state_manager/Lock_and_Unlock
     "tag": "default",
     "overrideDryrun": false,
     "restoreNotPossibleOverride": true,
-    "timeLimit": 2000,
+    "timeLimit": 4000,
     "description": "Dryrun upgrade of Gigabyte node BMCs"
   }
 }
 ```
 
-**IMPORTANT**: The *timeLimit* is `2000` because the gigabytes can take a lot longer to update.
+**IMPORTANT**: The *timeLimit* is `4000` because the gigabytes can take a lot longer to update.
+
+You may receive a node failed to update with the output:
+`stateHelper = "Firmware Update Information Returned Downloading – See /redfish/v1/UpdateService"`
+FAS has incorrectly marked this node as failed.
+It most likely will complete the update successfully.
+You can check the update status by looking at the redfish `FirmwareInvetnory (/redfish/v1/UpdateService/FirmwareInventory/BMC)`
+or rerunning FAS to verify that the BMC firmware was updated.
+Make sure you have waited for the current firmware to be updated before starting a new FAS action on the same node.
 
 **Device Type: NodeBMC | Target: BIOS**
 ```json
@@ -492,11 +500,13 @@ See [Lock and Unlock Management Nodes](../hardware_state_manager/Lock_and_Unlock
     "tag": "default",
     "overrideDryrun": false,
     "restoreNotPossibleOverride": true,
-    "timeLimit": 2000,
+    "timeLimit": 4000,
     "description": "Dryrun upgrade of Gigabyte node BIOS"
   }
 }
 ```
+
+**IMPORTANT**: The *timeLimit* is `4000` because the gigabytes can take a lot longer to update.
 
 #### HPE
 
@@ -602,11 +612,13 @@ Use this procedure to update compute node BIOS firmware using FAS. There are two
     "tag": "default",
     "overrideDryrun": false,
     "restoreNotPossibleOverride": true,
-    "timeLimit": 2000,
+    "timeLimit": 4000,
     "description": "Dryrun upgrade of Gigabyte node BIOS"
   }
 }
 ```
+
+**IMPORTANT**: The *timeLimit* is `4000` because the gigabytes can take a lot longer to update.
 
 **Manufacturer: HPE | Device Type: NodeBMC | Target: `System ROM` aka BIOS**
 

--- a/operations/firmware/Update_Firmware_with_FAS.md
+++ b/operations/firmware/Update_Firmware_with_FAS.md
@@ -125,7 +125,7 @@ After identifying which hardware is in the system, start with the top most item 
 There are several use cases for using the FAS to update firmware on the system. These use cases are intended to be run by system administrators with a good understanding of firmware. Under no circumstances should non-administrator users attempt to use FAS or perform a firmware update.
 
 -   Perform a firmware update: Update the firmware of an xname's target to the latest, earliest, or an explicit version.
--   Determine what hardware can be updated by performing a dry-run: The easiest was to determine what can be updated is to perform a dry-run of the update.
+-   Determine what hardware can be updated by performing a dry-run: This is the easiest way to determine what can be updated.
 -   Take a snapshot of the system: Record the firmware versions present on each target for the identified xnames. If the firmware version corresponds to an image available in the images repository, link the `imageID` to the record.
 -   Restore the snapshot of the system: Take the previously recorded snapshot and use the related `imageIDs` to put the xname/targets back to the firmware version they were at, at the time of the snapshot.
 -   Provide firmware for updating: FAS can only update an xname/target if it has an image record that is applicable. Most administrators will not encounter this use case.
@@ -157,10 +157,10 @@ FAS operations will have one of the following states:
 - blocked - Only one operation can be performed on a node at a time. If more than one update is required for a xname, operations will be blocked. This will have a message of "blocked by sibling".
 - inProgress - Update is in progress, but not completed.
 - verifying - Waiting for update to complete.
-- failed - An update was attempted, but could FAS is unable to tell that the update succeeded in the time allowed.
+- failed - An update was attempted, but FAS is unable to tell that the update succeeded in the allotted time.
 - noOperation - Firmware is at the correct version according to the images loaded into FAS.
 - noSolution - FAS does not have a suitable image for an update.
-- aborted - The operation was aborted before it could determine if it was successful. If aborted after the update command was sent to the node, the node may still have updated.
+- aborted - the operation was aborted before it could determine if it was successful.  If aborted after the update command was sent to the node, the node may still have updated.
 
 <a name="firmware-images"></a>
 


### PR DESCRIPTION
FAS Documentation update for Gigabyte BMC and BIOS procedures increasing the run time limit to 4000 and warning about a possible false detection of an update failure.
Some minor wording changes taken from the 1.1 branch documents
CASMHMS-5201
CASMHMS-5202