### PR TITLE
CASMINST-3278: Use correct hostname for API gateway

### DIFF
--- a/operations/node_management/Swap_a_Compute_Blade_with_a_Different_System.md
+++ b/operations/node_management/Swap_a_Compute_Blade_with_a_Different_System.md
@@ -58,7 +58,7 @@ Swap an HPE Cray EX liquid-cooled compute blade between two systems.
   To insert an `ethernetInterfaces` entry using curl:
 
   ```bash
-  ncn-m001:# while read  PAYLOAD ; do curl -H "Authorization: Bearer $MY_TOKEN" -L -X POST 'https://api_gw_service.local/apis/smd/hsm/v1/Inventory/EthernetInterfaces' -H 'Content-Type: application/json' --data-raw "$(echo $PAYLOAD | jq -c '{ComponentID: .xname,Description: .Desc,MACAddress: .MAC,IPAddress: .IP}')";sleep 5;  done < x9000c3s1.json
+  ncn-m001:# while read  PAYLOAD ; do curl -H "Authorization: Bearer $MY_TOKEN" -L -X POST 'https://api-gw-service-nmn.local/apis/smd/hsm/v1/Inventory/EthernetInterfaces' -H 'Content-Type: application/json' --data-raw "$(echo $PAYLOAD | jq -c '{ComponentID: .xname,Description: .Desc,MACAddress: .MAC,IPAddress: .IP}')";sleep 5;  done < x9000c3s1.json
   ```
 
 - The blades must have the coolant drained and filled during the swap to minimize cross-contamination of cooling systems.
@@ -395,7 +395,7 @@ The hardware management network NIC MAC addresses for liquid-cooled blades are a
     ```
 
     ```bash
-    ncn-m001# curl -H "Authorization: Bearer ${TOKEN}" -L -X POST 'https://api_gw_service.local/apis/smd/hsm/v1/Inventory/EthernetInterfaces' -H 'Content-Type: application/json' --data-raw '{
+    ncn-m001# curl -H "Authorization: Bearer ${TOKEN}" -L -X POST 'https://api-gw-service-nmn.local/apis/smd/hsm/v1/Inventory/EthernetInterfaces' -H 'Content-Type: application/json' --data-raw '{
             "Description": "Node Maintenance Network",
             "MACAddress": "$MAC",
             "IPAddress": "$IP_ADDRESS",
@@ -415,7 +415,7 @@ The hardware management network NIC MAC addresses for liquid-cooled blades are a
     To change or correct a curl command that has been entered, use a PATCH request, for example:
 
     ```bash
-    ncn-m001# curl -k -H "Authorization: Bearer $TOKEN" -L -X PATCH \ 'https://api_gw_service.local/apis/smd/hsm/v1/Inventory/EthernetInterfaces/0040a68350a4' -H 'Content-Type: application/json'  --data-raw '{"MACAddress":"xx:xx:xx:xx:xx:xx","IPAddress":"10.xxx.xxx.xxx","ComponentID":"XNAME"}'
+    ncn-m001# curl -k -H "Authorization: Bearer $TOKEN" -L -X PATCH \ 'https://api-gw-service-nmn.local/apis/smd/hsm/v1/Inventory/EthernetInterfaces/0040a68350a4' -H 'Content-Type: application/json'  --data-raw '{"MACAddress":"xx:xx:xx:xx:xx:xx","IPAddress":"10.xxx.xxx.xxx","ComponentID":"XNAME"}'
     ```
 
 29. Repeat the preceding command for each node in the blade.

--- a/upgrade/1.0/scripts/ceph/lib/update_bss_metadata.sh
+++ b/upgrade/1.0/scripts/ceph/lib/update_bss_metadata.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Copyright 2021 Hewlett Packard Enterprise Development LP
+
 # Many of our functions do not check return codes because they assume that
 # they are being run with set -e. This file is used in isolation at one
 # point during the upgrade procedure, thus it is important that we verify
@@ -110,20 +112,20 @@ function update_bss_storage() {
 
         echo "update_bss_storage: Putting updated bootparameters for ${storage_node}"
         curl -i -s -k -H "Content-Type: application/json" \
-            -H "Authorization: Bearer ${TOKEN}" "https://api_gw_service.local/apis/bss/boot/v1/bootparameters" \
+            -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters" \
             -X PUT -d @/tmp/$xName > /tmp/put.$xName
         rc=$?
         if [ $rc -ne 0 ]; then
             cat /tmp/put.$xName
             update_bss_storage_cmd_failed curl -i -s -k -H "Content-Type: application/json" \
-                -H "Authorization: Bearer ${TOKEN}" "https://api_gw_service.local/apis/bss/boot/v1/bootparameters" \
+                -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters" \
                 -X PUT -d @/tmp/$xName \> /tmp/put.$xName
             return 1
         elif ! head -1 /tmp/put.$xName | grep -Eq "^HTTP.*[[:space:]]200[[:space:]]*$" ; then
             cat /tmp/put.$xName
             update_bss_storage_error "Expected 200 response but did not receive it from command: " \
                 "curl -i -s -k -H \"Content-Type: application/json\" -H \"Authorization: Bearer ${TOKEN}\" "\
-                "https://api_gw_service.local/apis/bss/boot/v1/bootparameters -X PUT -d @/tmp/$xName"
+                "https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters -X PUT -d @/tmp/$xName"
             return 1
         fi
         echo "update_bss_storage: Successfully updated bootparameters for ${storage_node}"


### PR DESCRIPTION
There are a few places in the docs where the wrong hostname is used for the API gateway. Most notably, one of the upgrade scripts uses the old API gateway hostname, and this can cause the upgrade to fail, reporting malformed JSON errors when trying to upload data into BSS. This PR just replaces all occurrences of the old hostname with the correct one. In the case of the script change, I have tested it during the shandy upgrade and verified that the updated script avoids the problem.