### PR TITLE
CASMINST-3270: Clarify when to run goss tests, how to run manual LVM test

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -43,7 +43,7 @@ pipeline {
           steps {
             script {
                 if(env.RELEASE_BRANCH_VERSION){
-                    RELEASE_FOLDER = "/" + env.RELEASE_BRANCH_VERSION 
+                    RELEASE_FOLDER = "/" + env.RELEASE_BRANCH_VERSION
                 } else {
                     RELEASE_FOLDER = ""
                 }

--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -266,7 +266,7 @@ The configuration workflow described here is intended to help understand the exp
     pit# /root/bin/bios-baseline.sh
     ```
 
-1. Set each node to always UEFI Network Boot, and ensure they are powered off
+1. <a name="set-uefi-and-power-off"></a>Set each node to always UEFI Network Boot, and ensure they are powered off
 
     ```bash
     pit# grep -oP "($mtoken|$stoken|$wtoken)" /etc/dnsmasq.d/statics.conf | sort -u | xargs -t -i ipmitool -I lanplus -U $USERNAME -E -H {} chassis bootdev pxe options=efiboot,persistent
@@ -487,27 +487,31 @@ If needed, the LVM checks can be performed manually on the master and worker nod
 * Manual check on worker nodes:
     ```bash
     ncn-w# blkid -L CONLIB
-    /dev/sdc
-   ncn-w# blkid -L CONRUN
-   /dev/sdc
-   ncn-w# blkid -L K8SLET
-   /dev/sdc
-   ```
+    /dev/sdb2
+    ncn-w# blkid -L CONRUN
+    /dev/sdb1
+    ncn-w# blkid -L K8SLET
+    /dev/sdb3
+    ```
 
 The manual checks are considered successful if all of the `blkid` commands report a disk device (such as `/dev/sdc` -- the particular device is unimportant). If any of the `lsblk` commands return no output, then the check is a failure. **Any failures must be resolved before continuing.** See the following section for details on how to do so.
 
 <a name="lvm-check-failure-recovery"></a>
 #### 3.3.3 LVM Check Failure Recovery
 
-If there are LVM check failures, then the problem must be resolved before continuing to the next step.
+If there are LVM check failures, then the problem must be resolved before continuing with the install.
 
-* If a **master node** has the problem then it is best to wipe and redeploy all of the management nodes before continuing the installation.
-    1. Wipe the each of the worker and master nodes (except `ncn-m001` because it is the PIT node) using the 'Basic Wipe' section of [Wipe NCN Disks for Reinstallation](wipe_ncn_disks_for_reinstallation.md#basic-wipe) and then wipe each of the storage nodes using the 'Full Wipe' section of [Wipe NCN Disks for Reinstallation](wipe_ncn_disks_for_reinstallation.md#full-wipe).
-    1. Return to the [Boot the **Storage Nodes**](#boot-the-storage-nodes) step of [Deploy Management Nodes](#deploy_management_nodes) section above.
+* If **any master node** has the problem, then you must wipe and redeploy **all** of the NCNs before continuing the installation:
+    1. Wipe each worker node using the 'Basic Wipe' section of [Wipe NCN Disks for Reinstallation](wipe_ncn_disks_for_reinstallation.md#basic-wipe).
+    1. Wipe each master node (**except** `ncn-m001` because it is the PIT node) using the 'Basic Wipe' section of [Wipe NCN Disks for Reinstallation](wipe_ncn_disks_for_reinstallation.md#basic-wipe).
+    1. Wipe each storage node using the 'Full Wipe' section of [Wipe NCN Disks for Reinstallation](wipe_ncn_disks_for_reinstallation.md#full-wipe).
+    1. Return to the [Set each node to always UEFI Network Boot, and ensure they are powered off](#set-uefi-and-power-off) step of the [Deploy Management Nodes](#deploy_management_nodes) section above.
 
-* If a **worker node** has the problem then it is best to wipe and redeploy that worker node before continuing the installation.
-    1. Wipe this  worker node using the 'Basic Wipe' section of [Wipe NCN Disks for Reinstallation](wipe_ncn_disks_for_reinstallation.md#basic-wipe).
-    1. Return to the [Boot the Master and Worker Nodes**](#boot-master-and-worker-nodes) step of [Deploy Management Nodes](#deploy_management_nodes) section above.
+* If **only worker nodes** have the problem, then you must wipe and redeploy the affected worker nodes before continuing the installation:
+    1. Wipe each affected worker node using the 'Basic Wipe' section of [Wipe NCN Disks for Reinstallation](wipe_ncn_disks_for_reinstallation.md#basic-wipe).
+    1. Power off each affected worker node.
+    1. Return to the [Boot the Master and Worker Nodes](#boot-master-and-worker-nodes) step of the [Deploy Management Nodes](#deploy_management_nodes) section above.
+        * Note: The `ipmitool` command will give errors trying to power on the unaffected nodes, since they are already powered on -- this is expected and not a problem.
 
 <a name="check-for-unused-drives-on-utility-storage-nodes"></a>
 ### 3.4 Check for Unused Drives on Utility Storage Nodes

--- a/install/prepare_management_nodes.md
+++ b/install/prepare_management_nodes.md
@@ -181,14 +181,13 @@ Set the BMCs on the management nodes to DHCP.
 <a name="wipe_usb_device_on_pit_node"></a>
 ## Wipe USB Device on PIT Node
 
-    If intending to boot the PIT node from the Remote ISO and there is a USB device which was previously used with LiveCD data, it should be wiped to avoid having two devices with disk labels claiming to be the LiveCD.
+If intending to boot the PIT node from the Remote ISO and there is a USB device which was previously used with LiveCD data, it should be wiped to avoid having two devices with disk labels claiming to be the LiveCD. Alternatively, the USB device could be removed from the PIT node.
 
-    Alternately, the USB device could be removed from the PIT node.
-
-    1.  Wipe USB storage on `ncn-m001`.
-        ```bash
-        ncn-m001# wipefs --all --force /dev/disk/by-label/cow /dev/disk/by-label/PITDATA /dev/disk/by-label/BOOT /dev/disk/by-label/CRAYLIVE
-        ```
+1. If not removing the USB device from `ncn-m001`, then wipe its USB storage with the following command:
+    
+    ```bash
+    ncn-m001# wipefs --all --force /dev/disk/by-label/cow /dev/disk/by-label/PITDATA /dev/disk/by-label/BOOT /dev/disk/by-label/CRAYLIVE
+    ```
 
 <a name="power_off_pit_node"></a>
 ## Power Off PIT Node

--- a/install/wipe_ncn_disks_for_reinstallation.md
+++ b/install/wipe_ncn_disks_for_reinstallation.md
@@ -72,7 +72,7 @@ wiping the disks and RAIDs.
 
     ```bash
     ncn-s# ls -1 /dev/sd* /dev/disk/by-label/*
-    ncn-s# vgremove -f --select 'vg_name=~ceph*'
+    ncn-s# vgremove -f -v --select 'vg_name=~ceph*'
     ```
 
 1. List the disks for verification.
@@ -99,12 +99,14 @@ RAIDs, zeroing the disks, and then wiping the disks and RAIDs.
 
 1. Reset Kubernetes on each master and worker node.
 
-    ***NOTE:*** Our recommended order is to do this first on the workers, then on the master nodes.
+   This will stop kubelet, underlying containers, and remove the contents of `/var/lib/kubelet`.
+
+   **NOTE:** The recommended order is to do this on the worker nodes, and then the master nodes.
 
     1. For each worker node, run the following:
 
         ```bash
-        ncn-w# kubeadm reset --force
+        ncn-mw# kubeadm reset --force
         ```
 
     1. List any containers running in `containerd`.
@@ -125,11 +127,11 @@ RAIDs, zeroing the disks, and then wiping the disks and RAIDs.
         ncn-mw# crictl stop <container id from the CONTAINER column>
         ```
 
-    This will stop `kubelet`, underlying containers, and remove the contents of `/var/lib/kubelet`.
+    1. After performing the previous steps for the worker nodes to be wiped, then perform them for the master nodes to be wiped.
 
-1. Delete CEPH volumes ***on Utility Storage Nodes ONLY***.
+1. Delete Ceph Volumes **on storage nodes ONLY**.
 
-    For each Storage node:
+    For each storage node:
 
     1. Stop Ceph.
 
@@ -165,7 +167,7 @@ RAIDs, zeroing the disks, and then wiping the disks and RAIDs.
 
         ```bash
         ncn-s# ls -1 /dev/sd* /dev/disk/by-label/*
-        ncn-s# vgremove -f --select 'vg_name=~ceph*'
+        ncn-s# vgremove -f -v --select 'vg_name=~ceph*'
         ```
 
 1. Unmount volumes.
@@ -219,7 +221,7 @@ RAIDs, zeroing the disks, and then wiping the disks and RAIDs.
         7741d5096625  registry.local/sdu-docker-stable-local/cray-sdu-rda:1.1.1  /bin/sh -c /usr/s...  6 weeks ago  Up 6 weeks ago          cray-sdu-rda
         ```
 
-        If there is a running `cray-sdu-rda` container in the above output, stop it using the container id:
+    1. If there is a running `cray-sdu-rda` container in the above output, stop it using the container ID:
 
         ```bash
         ncn# podman stop 7741d5096625
@@ -229,7 +231,7 @@ RAIDs, zeroing the disks, and then wiping the disks and RAIDs.
     1. Remove metal LVM.
 
         ```bash
-        ncn# vgremove -f --select 'vg_name=~metal*'
+        ncn# vgremove -f -v --select 'vg_name=~metal*'
         ```
 
         > **`NOTE`** Optionally you can run the `pvs` command and if any drives are still listed, you can remove them with `pvremove`, but this is rarely needed. Also, if the above command fails or returns a warning about the filesystem being in use, you should ignore the error and proceed to the next step, as this will not inhibit the wipe process.
@@ -237,7 +239,7 @@ RAIDs, zeroing the disks, and then wiping the disks and RAIDs.
 1. Stop the RAIDs.
 
     ```bash
-    ncn# for md in /dev/md/*; do mdadm -S $md || echo nope ; done
+    ncn# for md in /dev/md/*; do mdadm -S -v $md || echo nope ; done
     ```
 
 1. List the disks for verification.

--- a/operations/hmcollector/adjust_hmcollector_resource_limits_requests.md
+++ b/operations/hmcollector/adjust_hmcollector_resource_limits_requests.md
@@ -12,16 +12,16 @@
 View resource usage of the containers in the cray-hms-hmcollector pod:
 ```bash
 ncn-m001# kubectl -n services top pod -l app.kubernetes.io/name=cray-hms-hmcollector --containers
-POD                                     NAME                   CPU(cores)   MEMORY(bytes)   
-cray-hms-hmcollector-7c5b797c5c-zxt67   istio-proxy            187m         275Mi           
-cray-hms-hmcollector-7c5b797c5c-zxt67   cray-hms-hmcollector   4398m        296Mi   
+POD                                     NAME                   CPU(cores)   MEMORY(bytes)
+cray-hms-hmcollector-7c5b797c5c-zxt67   istio-proxy            187m         275Mi
+cray-hms-hmcollector-7c5b797c5c-zxt67   cray-hms-hmcollector   4398m        296Mi
 ```
 
 The default resource limits for the cray-hms-hmcollector container are:
    * CPU: `4` or `4000m`
    * Memory: `5Gi`
 
-The default resource limits for the istio-proxy container are: 
+The default resource limits for the istio-proxy container are:
    * CPU: `2` or `2000m`
    * Memory: `1Gi`
 
@@ -32,7 +32,7 @@ Describe the collector-hms-hmcollector pod to determine if it has been OOMKilled
 ncn-m001# kubectl -n services describe pod -l app.kubernetes.io/name=cray-hms-hmcollector
 ```
 
-Look for the `cray-hms-hmcollector` container and check its `Last State` (if present) to see if the container has been perviously terminated due to it running out of memory: 
+Look for the `cray-hms-hmcollector` container and check its `Last State` (if present) to see if the container has been perviously terminated due to it running out of memory:
 ```
 ...
 Containers:
@@ -53,7 +53,7 @@ Containers:
 ```
 > In the above example output the `cray-hms-hmcollector` container was perviously OOMKilled, but the container is currently running.
 
-Look for the `isitio-proxy` container and check its `Last State` (if present) to see if the container has been perviously terminated due to it running out of memory: 
+Look for the `isitio-proxy` container and check its `Last State` (if present) to see if the container has been perviously terminated due to it running out of memory:
 ```
 ...
  istio-proxy:
@@ -86,7 +86,7 @@ Look for the `isitio-proxy` container and check its `Last State` (if present) to
 > In the above example output the `istio-proxy` container was perviously OOMKilled, but the container is currently running.
 
 ### How to adjust CPU and Memory limits
-If the `cray-hms-hmcollector` container is hitting its CPU limit and memory usage is steadily increasing till it gets OOMKilled, then the CPU limit for the `cray-hms-hmcollector` should be increased. It can be increased in increments of `8` or `8000m` This is a situation were the collector is unable to process events fast enough and they start to collect build up inside of it.  
+If the `cray-hms-hmcollector` container is hitting its CPU limit and memory usage is steadily increasing till it gets OOMKilled, then the CPU limit for the `cray-hms-hmcollector` should be increased. It can be increased in increments of `8` or `8000m` This is a situation were the collector is unable to process events fast enough and they start to collect build up inside of it.
 
 If the `cray-hms-hmcollector` container is consistency hitting its CPU limit, then its CPU limit should be increased. It can be increased in increments of `8` or `8000m`.
 
@@ -96,7 +96,7 @@ If the `istio-proxy` container is getting OOMKilled, then its memory limit shoul
 
 Otherwise, if the `cray-hms-hmcollector` and `istio-proxy` containers are not hitting their CPU or memory limits
 
-For reference, on a system with 4 fully populated liquid cooled cabinets the cray-hms-hmcollector was consuming `~5` or `~5000m` of CPU and `~300Mi` of memory. 
+For reference, on a system with 4 fully populated liquid cooled cabinets the cray-hms-hmcollector was consuming `~5` or `~5000m` of CPU and `~300Mi` of memory.
 
 <a name="customize-resource-limits"></a>
 ## Customize cray-hms-hmcollector resource limits and requests in customizations.yaml
@@ -234,7 +234,7 @@ For reference, on a system with 4 fully populated liquid cooled cabinets the cra
 
 2. Create `hmcollector-manifest.yaml`:
     ```bash
-    ncn-m001# cat > hmcollector-manifest.yaml << EOF 
+    ncn-m001# cat > hmcollector-manifest.yaml << EOF
     apiVersion: manifests/v1beta1
     metadata:
         name: hmcollector

--- a/operations/kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md
+++ b/operations/kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md
@@ -8,7 +8,7 @@ As part of the installation, Kubernetes generates certificates for the required 
 
 **`IMPORTANT:`** When you pick your master node to renew the certificatess on, that is the node that will be referenced in this document as `ncn-m`.
 
-**`IMPORTANT:`** This document is based off a base hardware configuration of 3 masters and 3 workers (We are leaving off utility storage since they are not running Kubernetes). Please make sure to update any commands that run on multiple nodes accordingly.  
+**`IMPORTANT:`** This document is based off a base hardware configuration of 3 masters and 3 workers (We are leaving off utility storage since they are not running Kubernetes). Please make sure to update any commands that run on multiple nodes accordingly.
 
 ## File locations
 
@@ -185,7 +185,7 @@ Check the expiration of the certificates.
     -rw-r--r-- 1 root root 1139 Sep 22 17:13 peer.crt
     -rw------- 1 root root 1679 Sep 22 17:13 peer.key
     -rw-r--r-- 1 root root 1139 Sep 22 17:13 server.crt
-    -rw------- 1 root root 1675 Sep 22 17:13 server.key   
+    -rw------- 1 root root 1675 Sep 22 17:13 server.key
     ```
 
    As we can see not all the certificate files were updated.
@@ -235,7 +235,7 @@ Check the expiration of the certificates.
    /var/lib/kubelet/pki/kubelet-client-2021-09-07-17-06-36.pem
    notAfter=Sep  4 17:01:38 2022 GMT
    /var/lib/kubelet/pki/kubelet-client-current.pem
-   notAfter=Sep  4 17:01:38 2022 GMT   
+   notAfter=Sep  4 17:01:38 2022 GMT
    ```
 
    **`IMPORTANT:`** DO NOT forget to verify certificates in /etc/kubernetes/pki/etcd.
@@ -324,7 +324,7 @@ Check the expiration of the certificates.
 
    This will generate a new `kubelet.conf` file in the `/root/` directory. There should be a new file per node running Kubernetes.
 
-3. Copy each file to the corresponding node shown in the filename. 
+3. Copy each file to the corresponding node shown in the filename.
 
    **`NOTE:`** Please update the below command with the appropriate amount of master and worker nodes.
 
@@ -360,9 +360,8 @@ Check the expiration of the certificates.
 
    1. Follow the [Reboot_NCNs](../node_management/Reboot_NCNs.md) process.
 
-      **IMPORTANT:** Please ensure you are verifying pods are running on the master node that was rebooted before proceeding to the next node.
+   **IMPORTANT:** Please ensure you are verifying pods are running on the master node that was rebooted before proceeding to the next node.
 
 7. Perform a rolling reboot of worker nodes.
 
    1. Follow the [Reboot_NCNs](../node_management/Reboot_NCNs.md) process.
-

--- a/operations/node_management/Reboot_NCNs.md
+++ b/operations/node_management/Reboot_NCNs.md
@@ -241,7 +241,8 @@ Before rebooting NCNs:
 
     10. Repeat all of the sub-steps above for the remaining storage nodes, going from the highest to lowest number until all storage nodes have successfully rebooted.
 
-         **Important:** Ensure `ceph -s` shows that Ceph is healthy BEFORE MOVING ON to reboot the next storage node. Once Ceph has recovered the downed mon, it may take a several minutes for Ceph to resolve clock skew.
+    **Important:** Ensure `ceph -s` shows that Ceph is healthy (`HEALTH_OK`) **BEFORE MOVING ON** to reboot the next storage node. Once Ceph has recovered the downed mon,
+    it may take a several minutes for Ceph to resolve clock skew.
 
 #### NCN Worker Nodes
 

--- a/operations/security_and_authentication/Add_LDAP_User_Federation.md
+++ b/operations/security_and_authentication/Add_LDAP_User_Federation.md
@@ -51,7 +51,7 @@ LDAP user federation is not currently configured in Keycloak. For example, if it
 
 2. Repopulate the keycloak_users_localize and cray-keycloak Sealed Secrets in the customizations.yaml file with the desired configuration.
 
-   Update the LDAP settings with the desired configuration. LDAP connection information 
+   Update the LDAP settings with the desired configuration. LDAP connection information
    is stored in the keycloak-users-localize Secret in the customizations.yaml file.
 
    -   The ldap_connection_url key is required and is set to an LDAP URL.
@@ -91,7 +91,7 @@ LDAP user federation is not currently configured in Keycloak. For example, if it
      The example above puts an empty certs.jks in the cray-keycloak Sealed Secret.
      The next step will generate certs.jks.
 
-     Other LDAP configuration settings are set in the spec.kubernetes.services.cray-keycloak-users-localize field in the customizations.yaml file. 
+     Other LDAP configuration settings are set in the spec.kubernetes.services.cray-keycloak-users-localize field in the customizations.yaml file.
         
      The fields are as follows:
 
@@ -263,7 +263,7 @@ LDAP user federation is not currently configured in Keycloak. For example, if it
 
 3. (Optional) Add the LDAP CA certificate in the certs.jks section of customizations.yaml.
    
-   If LDAP requires TLS (recommended), update the `cray-keycloak` Sealed 
+   If LDAP requires TLS (recommended), update the `cray-keycloak` Sealed
    Secret value by supplying a base64 encoded Java KeyStore (JKS) that
    contains the CA certificate that signed the LDAP server's host key. The
    password for the JKS file must be `password`.
@@ -280,7 +280,7 @@ LDAP user federation is not currently configured in Keycloak. For example, if it
         ncn-m001# ${CSM_DISTDIR}/hack/load-container-image.sh dtr.dev.cray.com/library/openjdk:11-jre-slim
         ```
 
-        **Troubleshooting:** 
+        **Troubleshooting:**
         
         * If the output shows the skopeo.tar file cannot be found, ensure that the $CSM_DISTDIR directory looks correct, and contains the `dtr.dev.cray.com` directory that includes the originally installed docker images.
 
@@ -347,7 +347,7 @@ LDAP user federation is not currently configured in Keycloak. For example, if it
         > from the output of the above `openssl s_client` example if the
         > following commands are unsuccessful.
 
-        Observe the issuer's DN. 
+        Observe the issuer's DN.
         
         For example:
 
@@ -438,7 +438,7 @@ LDAP user federation is not currently configured in Keycloak. For example, if it
 
 4. Prepare to generate Sealed Secrets.
    
-   Secrets are stored in customizations.yaml as `SealedSecret` resources 
+   Secrets are stored in customizations.yaml as `SealedSecret` resources
    (encrypted secrets), which are deployed by specific charts and decrypted by the
    Sealed Secrets operator. But first, those Secrets must be seeded, generated, and
    encrypted.

--- a/operations/security_and_authentication/Change_EX_Cabinet_Global_Default_Password.md
+++ b/operations/security_and_authentication/Change_EX_Cabinet_Global_Default_Password.md
@@ -2,7 +2,7 @@
 
 ## Change Cray EX Cabinet Global Default Password
 
-This procedure changes the global default credential on HPE Cray EX liquid-cooled cabinet embedded controllers (BMCs). The chassis management module (CMM) controller (cC), node controller (nC), and Slingshot switch controller (sC) are generically referred to as "BMCs" in these procedures.  
+This procedure changes the global default credential on HPE Cray EX liquid-cooled cabinet embedded controllers (BMCs). The chassis management module (CMM) controller (cC), node controller (nC), and Slingshot switch controller (sC) are generically referred to as "BMCs" in these procedures.
 
 ### Prerequisites
 
@@ -14,7 +14,7 @@ This procedure changes the global default credential on HPE Cray EX liquid-coole
 
 1. Perform procedures in ["Provisioning a Liquid-Cooled EX Cabinet CEC with Default Credentials."](Provisioning_a_Liquid-Cooled_EX_Cabinet_CEC_with_Default_Credentials.md)
 
-2. Perform procedures in ["Updating the Liquid-Cooled EX Cabinet Default Credentials after a CEC Password Change."](Updating_the_Liquid-Cooled_EX_Cabinet_Default_Credentials_after_a_CEC_Password_Change.md) 
+2. Perform procedures in ["Updating the Liquid-Cooled EX Cabinet Default Credentials after a CEC Password Change."](Updating_the_Liquid-Cooled_EX_Cabinet_Default_Credentials_after_a_CEC_Password_Change.md)
 
-3. To update Slingshot switch BMCs, refer to "Change Rosetta Login and Redfish API Credentials" in the *Slingshot Operations Guide* (1.6.0). 
+3. To update Slingshot switch BMCs, refer to "Change Rosetta Login and Redfish API Credentials" in the *Slingshot Operations Guide* (1.6.0).
 

--- a/operations/security_and_authentication/Provisioning_a_Liquid-Cooled_EX_Cabinet_CEC_with_Default_Credentials.md
+++ b/operations/security_and_authentication/Provisioning_a_Liquid-Cooled_EX_Cabinet_CEC_with_Default_Credentials.md
@@ -1,14 +1,12 @@
-
-
 ## Provisioning a Liquid-Cooled EX Cabinet CEC with Default Credentials
 
-This procedure provisions a Glibc compatible SHA-512 administrative password hash to a cabinet environmental controller (CEC). This password becomes the Redfish default global credential to access the CMM controllers and node controllers (BMCs). 
+This procedure provisions a Glibc compatible SHA-512 administrative password hash to a cabinet environmental controller (CEC). This password becomes the Redfish default global credential to access the CMM controllers and node controllers (BMCs).
 
-This procedure does not provision Slingshot switch BMCs. Slingshot switch BMC default credentials must be changed using the procedures in the Slingshot product documentation. Refer to "Change Switch BMC Passwords" in the Slingshot product documentation for more information. 
+This procedure does not provision Slingshot switch BMCs. Slingshot switch BMC default credentials must be changed using the procedures in the Slingshot product documentation. Refer to "Change Switch BMC Passwords" in the Slingshot product documentation for more information.
 
 ### Prerequisites
 
-- The administrator must have physical access to the CEC LCD panel to enable privileged command mode. The CEC does not enable users to set, display, or clear the password hash in restricted command mode. 
+- The administrator must have physical access to the CEC LCD panel to enable privileged command mode. The CEC does not enable users to set, display, or clear the password hash in restricted command mode.
 
 - An Apple Mac or Linux laptop that supports 10/100 IPv6 Ethernet connectivity to the CEC Ethernet port is recommended. A Windows system running a Linux emulation package may have difficulties establishing a stable network connection to the CEC.
 
@@ -46,7 +44,7 @@ This procedure does not provision Slingshot switch BMCs. Slingshot switch BMC de
 
    - Enter return a few times to start the connection.
 
-   - **NOTE**: If the network connection to the CEC is lost, or if a CEC command does not return to the prompt, it may be necessary to reboot the CEC.  Use the Right Arrow on the CEC control panel to display the Action menu, select Reset CEC, and press the green checkmark button to reboot the CEC. Then re-establish the `nc` or `telnet` connection. 
+   - **NOTE**: If the network connection to the CEC is lost, or if a CEC command does not return to the prompt, it may be necessary to reboot the CEC. Use the Right Arrow on the CEC control panel to display the Action menu, select Reset CEC, and press the green checkmark button to reboot the CEC. Then re-establish the `nc` or `telnet` connection.
 
      ![CEC Front Panel Controls](../../img//CEC_Display_Controls_CEC_Actions.svg)
 
@@ -99,13 +97,13 @@ This procedure does not provision Slingshot switch BMCs. Slingshot switch BMC de
 
 11. Use the front panel Right Arrow to select the CEC Action menu.
 
-12. Reset the CMMs 3, 2, 1, and 0. 
+12. Reset the CMMs 3, 2, 1, and 0.
 
     The Reset CMM commands reboot either the even numbered, or odd numbered CMMs in the cabinet, depending on which CEC is issuing the commands.
 
     ![Front Panel Controls](../../img//CEC_Display_Controls_CEC_Actions.svg)
 
-13. To test the password, connect to the CMM serial console though the CEC. The IPv6 address is the same, but the port numbers are different as described below. 
+13. To test the password, connect to the CMM serial console though the CEC. The IPv6 address is the same, but the port numbers are different as described below.
 
       ```screen
       #!/bin/bash
@@ -114,8 +112,8 @@ This procedure does not provision Slingshot switch BMCs. Slingshot switch BMC de
       nc -6 'fe80::a1:2328:0%en14' 50000
       ```
 
-      - The even numbered CEC manages the CMM serial console for chassis 0, 2, 4, 6 on TCP port numbers 50000-50003 respectively. 
-      - The odd numbered CEC manages the CMM serial console for chassis 1, 3, 5, 7 on TCP port numbers 50000-50003 respectively. 
+      - The even numbered CEC manages the CMM serial console for chassis 0, 2, 4, 6 on TCP port numbers 50000-50003 respectively.
+      - The odd numbered CEC manages the CMM serial console for chassis 1, 3, 5, 7 on TCP port numbers 50000-50003 respectively.
       - If using the script shown in the example to connect to the CMM console, type `exit` to return to the CMM login prompt and enter ctrl-c to close the console connection.
 
 14. Perform this procedure for each CEC in all system cabinets.

--- a/operations/security_and_authentication/Updating_the_Liquid-Cooled_EX_Cabinet_Default_Credentials_after_a_CEC_Password_Change.md
+++ b/operations/security_and_authentication/Updating_the_Liquid-Cooled_EX_Cabinet_Default_Credentials_after_a_CEC_Password_Change.md
@@ -1,14 +1,14 @@
 ## Updating the Liquid-Cooled EX Cabinet CEC with Default Credentials after a CEC Password Change
 
-This procedure changes the credential for liquid-cooled EX cabinet chassis controllers and node controller (BMCs) used by CSM services after the CECs have been set to a new global default credential. 
+This procedure changes the credential for liquid-cooled EX cabinet chassis controllers and node controller (BMCs) used by CSM services after the CECs have been set to a new global default credential.
 
-**NOTE:** This procedure does not provision Slingshot switch BMCs (RouterBMCs). Slingshot switch BMC default credentials must be changed using the procedures in the Slingshot product documentation. To update Slingshot switch BMCs, refer to "Change Rosetta Login and Redfish API Credentials" in the *Slingshot Operations Guide* (1.6.0).  
+**NOTE:** This procedure does not provision Slingshot switch BMCs (RouterBMCs). Slingshot switch BMC default credentials must be changed using the procedures in the Slingshot product documentation. To update Slingshot switch BMCs, refer to "Change Rosetta Login and Redfish API Credentials" in the *Slingshot Operations Guide* (1.6.0).
 
 This procedure provisions only the default Redfish root account passwords. It does not modify Redfish accounts that have been added after an initial system installation.
 
 ### Prerequisites
 
-- Perform procedures in [Provisioning a Liquid-Cooled EX Cabinet CEC with Default Credentials](Provisioning_a_Liquid-Cooled_EX_Cabinet_CEC_with_Default_Credentials.md) on all CECs in the system.  
+- Perform procedures in [Provisioning a Liquid-Cooled EX Cabinet CEC with Default Credentials](Provisioning_a_Liquid-Cooled_EX_Cabinet_CEC_with_Default_Credentials.md) on all CECs in the system.
 - All of the CECs must be configured with the __same__ global credential.
 - The previous default global credential for liquid-cooled BMCs needs to be known.
 
@@ -37,8 +37,8 @@ Before redeploying MEDS, update the `customizations.yaml` file in the `site-init
 
    > **`NOTE:`** If `site-init` was cloned from a remote repository in step 1,
    > there may not be any differences and hence nothing to commit. This is
-   > okay. If there are differences between what's in the repository and what
-   > was stored in the `site-init`, then it suggests settings were changed at some 
+   > okay. If there are differences between what is in the repository and what
+   > was stored in the `site-init`, then it suggests settings were changed at some
    > point.
 
    ```bash
@@ -130,7 +130,7 @@ Before redeploying MEDS, update the `customizations.yaml` file in the `site-init
 
 2. Create `meds-manifest.yaml`:
     ```bash
-    ncn-m001# cat > meds-manifest.yaml << EOF 
+    ncn-m001# cat > meds-manifest.yaml << EOF
     apiVersion: manifests/v1beta1
     metadata:
         name: meds
@@ -238,7 +238,7 @@ Before redeploying MEDS, update the `customizations.yaml` file in the `site-init
 
     For each Redfish endpoint that is reported use the following to troubleshoot why it is not `DiscoverOK` or `DiscoveryStarted`:
     - If the Redfish endpoint is `DiscoveryStarted`, then that BMC is currently in the process of being inventoried by HSM. Wait a few minutes and re-try the bash script above to re-check the current discovery status of the RedfishEndpoints.
-        > The hms-discovery cronjob (if enabled) will trigger a discover on BMCs that are not currently in `DiscoverOK` or `DiscoveryStarted` every 3 minutes.  
+        > The hms-discovery cronjob (if enabled) will trigger a discover on BMCs that are not currently in `DiscoverOK` or `DiscoveryStarted` every 3 minutes.
     - If the Redfish endpoint is `HTTPsGetFailed`, then HSM had issues contacting BMC.
     
         1. Verify that the BMC xname is resolvable and pingable:
@@ -267,7 +267,7 @@ Before redeploying MEDS, update the `customizations.yaml` file in the `site-init
             > <!-- In CSM 1.0 the hostname for a ChassisBMC matches its xname -->
             ```bash
             ncn-m001# curl -k -u root:$CRED_PASSWORD https://BMC_HOSTNAME/redfish/v1/Managers | jq
-            ``` 
+            ```
 
             If the error message below is returned, then the BMC needs to be have a StatefulReset action performed on it. The StatefulReset action will clear out any previously user defined credentials that are taking precedence over the CEC supplied credential. It will also clear out NTP, Syslog, and SSH Key configurations on the BMC.
     
@@ -363,7 +363,7 @@ This section only needs to be performed if any liquid-cooled Node or Chassis BMC
     ncn-m001# kubectl -n services rollout status deployment cray-conman
     ```
 
-6. Restore passwordless SSH connections to the liquid-cooled Node BMCs that have had the StatefulReset applied to them by following the procedure `30.23 Enable Passwordless Connections to Liquid Cooled Node BMCs` of the _HPE Cray EX System Administration Guide 1.4 S-80001_. 
+6. Restore passwordless SSH connections to the liquid-cooled Node BMCs that have had the StatefulReset applied to them by following the procedure `30.23 Enable Passwordless Connections to Liquid Cooled Node BMCs` of the _HPE Cray EX System Administration Guide 1.4 S-80001_.
     > __WARNING__: If an admin uses SCSD to update the SSHConsoleKey value outside of ConMan, it will disrupt the ConMan connection to the console and collection of console logs.
     > Refer to "About the ConMan Containerized Service" in the _HPE Cray EX System Administration Guide 1.4 S-8001_.
 
@@ -374,14 +374,14 @@ This section only needs to be performed if any liquid-cooled Node or Chassis BMC
         ncn-m001# export SSH_PUBLIC_KEY=$(cat /root/.ssh/id_rsa.pub | sed 's/[[:space:]]*$//')
         ```
 
-    2. Enable passwordless SSH to the root user of the BMCs. Skip this step if passwordless SSH to the root user is not desired. Replace `BMC_HOSTNAME` with the hostname name of the Chassis BMC. The hostname of a ChassisBMC is its xname with the ending `b0` removed. 
+    2. Enable passwordless SSH to the root user of the BMCs. Skip this step if passwordless SSH to the root user is not desired. Replace `BMC_HOSTNAME` with the hostname name of the Chassis BMC. The hostname of a ChassisBMC is its xname with the ending `b0` removed.
         ```bash
         ncn-m001# curl -k -u root:$CRED_PASSWORD -X PATCH https://BMC_HOSTNAME/redfish/v1/Managers/BMC/NetworkProtocol \
             -H 'Content-Type: application/json' \
             -d "{\"Oem\":{\"SSHAdmin\":{\"AuthorizedKeys\":\"ssh-rsa $SSH_PUBLIC_KEY\"}}}"
         ```
 
-    3. Enable passwordless SSH to the consoles on the BMCs. Skip this step if passwordless SSH to the root user is not desired. Replace `BMC_HOSTNAME` with the hostname name of the Chassis BMC. The hostname of a ChassisBMC is its xname with the ending `b0` removed. 
+    3. Enable passwordless SSH to the consoles on the BMCs. Skip this step if passwordless SSH to the root user is not desired. Replace `BMC_HOSTNAME` with the hostname name of the Chassis BMC. The hostname of a ChassisBMC is its xname with the ending `b0` removed.
         ```bash
         ncn-m001# curl -k -u root:$CRED_PASSWORD -X PATCH https://BMC_HOSTNAME/redfish/v1/Managers/BMC/NetworkProtocol \
             -H 'Content-Type: application/json' \

--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -453,7 +453,7 @@ There are multiple [Goss](https://github.com/aelsabbahy/goss) test suites availa
 
 Run the NCN health checks against the three different types of nodes with the following commands:
 
-**IMPORTANT:** These tests may only be successful while booted into the PIT node. Do not run these as part of upgrade testing. This includes the Kubernetes check in the next block.
+**IMPORTANT:** These tests should only be run while booted into the PIT node. Do not run these as part of upgrade testing. This includes the Kubernetes check in the next block.
 
 
 ```bash
@@ -476,7 +476,6 @@ pit# /opt/cray/tests/install/ncn/automated/ncn-kubernetes-checks
   - May fail immediately after platform install. Should pass after the TrustedCerts Operator has updated BSS (Global cloud-init meta) with CA certificates.
 * K8S Test: Kubernetes Velero No Failed Backups
   - Because of a [known issue](https://github.com/vmware-tanzu/velero/issues/1980) with Velero, a backup may be attempted immediately upon the deployment of a backup schedule (for example, vault). It may be necessary to use the `velero` command to delete backups from a Kubernetes node to clear this situation.
-
 
 <a name="optional-check-of-system-management-monitoring-tools"></a>
 ### 1.9 Optional Check of System Management Monitoring Tools


### PR DESCRIPTION
1. Tries to make it more obvious that the automated goss tests are only to be run from the PIT node.
2. Tries to make it more obvious what manual procedure should be carried out in the case that an automated test fails with "/dev/sdc" errors
3. Minor improvements to the recovery steps in the case that the manual checks show a problem

I also pulled in my linting commit for CASMINST-3344