### PR TITLE
CASMPET-5080 main : DOCS - Add a note to the postgres health check validation indicating that the DCS communication errors can be benign

### DIFF
--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -194,6 +194,9 @@ Execute ncnPostgresHealthChecks script and analyze the output of each individual
          - **ERROR: failed to update leader lock** 
          - **ERROR: Exception when working with master via replication connection**
          
+         Errors reported after rebooting worker NCNs should be re-checked in 15 minutes by re-running the ncnPostgresHealthChecks script - for example errors that start with the following:
+         - **ERROR: Error communicating with DCS**
+
          If there is no Leader, refer to [Troubleshoot Postgres Database](./kubernetes/Troubleshoot_Postgres_Database.md#leader).
 
       - Verify the State of each cluster member is 'running'.


### PR DESCRIPTION
Resolve for main
* CASMPET-5080 main : DOCS - Add a note to the postgres health check validation indicating that the DCS communication errors can be benign