### PR TITLE
[Backport release/1.2] CASMPET-5080 main : DOCS - Add a note to the postgres health check validation indicating that the DCS communication errors can be benign

### DIFF
--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -194,6 +194,9 @@ Execute ncnPostgresHealthChecks script and analyze the output of each individual
          - **ERROR: failed to update leader lock** 
          - **ERROR: Exception when working with master via replication connection** 
          
+         Errors reported after rebooting worker NCNs should be re-checked in 15 minutes by re-running the ncnPostgresHealthChecks script - for example errors that start with the following:
+         - **ERROR: Error communicating with DCS**
+
          If there is no Leader, refer to [Troubleshoot Postgres Database](./kubernetes/Troubleshoot_Postgres_Database.md#leader).
 
       - Verify the State of each cluster member is 'running'.


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/docs-csm/pull/302. Cherry-picked from f20bc338cf59f26a023aea0db1bddf7579d5618f for branch release/1.2.