### PR TITLE
(CSM 1.2) CASMINST-3249/3247

### DIFF
--- a/install/install_csm_services.md
+++ b/install/install_csm_services.md
@@ -14,9 +14,8 @@ This procedure will install CSM applications and services into the CSM Kubernete
    1. [Apply Pod Priorities](#apply-pod-priorities)
    1. [Apply After Sysmgmt Manifest Workarounds](#apply-after-sysmgmt-manifest-workarounds)
    1. [Known Issues](#known-issues)
-      * [Error: not ready: https://packages.local](#error-not-ready)
-      * [Error initiating layer upload ... in registry.local: received unexpected HTTP status: 200 OK](#error-initiating-layer-upload)
-      * [Error lookup registry.local: no such host](#error-registry-local-no-such-host)
+      * [install.sh known issues](#known-issues-install-sh)
+      * [Setup Nexus known issues](#known-issues-setup-nexus)
    1. [Next Topic](#next-topic)
 
 
@@ -374,6 +373,9 @@ Follow the [workaround instructions](../update_product_stream/index.md#apply-wor
 <a name="known-issues"></a>
 ### 9. Known Issues
 
+<a name="known-issues-install-sh"></a>
+#### 9.1 install.sh known issues
+
 The `install.sh` script changes cluster state and should not simply be rerun
 in the event of a failure without careful consideration of the specific
 error. It may be possible to resume installation from the last successful
@@ -381,11 +383,45 @@ command executed by `install.sh`, but administrators will need to appropriately
 modify `install.sh` to pick up where the previous run left off. (Note: The
 `install.sh` script runs with `set -x`, so each command will be printed to
 stderr prefixed with the expanded value of PS4, namely, `+ `.)
+ 
+The following error may occur when running `./install.sh`:
+  ```
+  + csi upload-sls-file --sls-file /var/www/ephemeral/prep/eniac/sls_input_file.json
+  2021/10/05 18:42:58 Retrieving S3 credentials ( sls-s3-credentials ) for SLS
+  2021/10/05 18:42:58 Unable to SLS S3 secret from k8s:secrets "sls-s3-credentials" not found
+  ```
+
+  1. Verify the `sls-s3-credentials` secret exists in the `default` namespace:
+     ```bash
+     pit# kubectl get secret sls-s3-credentials
+     NAME                 TYPE     DATA   AGE
+     sls-s3-credentials   Opaque   7      28d
+     ```
+
+  2. Check for running sonar-sync jobs. If there are no sonar-sync jobs, then wait for one to complete. The sonar-sync cronjob is responsible for copying the `sls-s3-credentials` secret from the `default` to `services` namespaces.
+     ```bash
+     pit# kubectl -n services get pods -l cronjob-name=sonar-sync
+     NAME                          READY   STATUS      RESTARTS   AGE
+     sonar-sync-1634322840-4fckz   0/1     Completed   0          73s
+     sonar-sync-1634322900-pnvl6   1/1     Running     0          13s
+     ```
+
+  3. Verify the `sls-s3-credentials` secret now exists in the `services` namespaces.
+     ```bash
+     pit# kubectl -n services get secret sls-s3-credentials
+     NAME                 TYPE     DATA   AGE
+     sls-s3-credentials   Opaque   7      20s
+     ```
+  
+  4. Running `install.sh` again is expected to succeed.
+
+<a name="known-issues-setup-nexus"></a>
+#### 9.2 Setup Nexus known issues
 
 Known potential issues with suggested fixes are listed in [Troubleshoot Nexus](../operations/package_repository_management/Troubleshoot_Nexus.md).
 
 <a name="next-topic"></a>
-# 9. Next Topic
+# 10. Next Topic
 
    After completing this procedure the next step is to redeploy the PIT node.
 

--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -614,6 +614,19 @@ BMC can be safely ignored, or if there is a legitimate issue with the BMC.
 
 * The node BMC of 'ncn-m001' will not typically be present in HSM component data, as it is typically connected to the site network instead of the HMN network.
 
+* The node BMCs for HPE Apollo XL645D nodes may report as a mismatch depedning on the state of the system when the `verify_hsm_discovery.py` script is ran. If the system is currently going through the process of installation, then this is an expected mistmatch as the [Preapre Compute Nodes](../install/prepare_compute_nodes.md) procedure required to configure the BMC of the HPE Apollo 6500 XL645D node may not have been completed yet. 
+   > For more information refer to [Configure HPE Apollo 6500 XL645d Gen10 Plus Compute Nodes](../install/prepare_compute_nodes.md#configure-hpe-apollo-6500-x645d-gen10-plus-compute-nodes) for additional required configuration for this type of BMC.
+
+   Example mistmatch for the BMC of a HPE Apollo XL654D:
+```bash
+...
+  Nodes: FAIL
+    - x3000c0s30b1n0 (Compute, NID 5) - Not found in HSM Components.
+  NodeBMCs: FAIL
+    - x3000c0s19b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
+...
+```
+
 * Chassis Management Controllers (CMC) may show up as not being present in HSM. CMCs for Intel server blades can be ignored. Gigabyte server blade CMCs not found in HSM is not normal and should be investigated. If a Gigabyte CMC is expected to not be connected to the HMN network, then it can be ignored.
    > CMCs have xnames in the form of `xXc0sSb999`, where `X` is the cabinet and `S` is the rack U of the compute node chassis.
 


### PR DESCRIPTION
CASMINST-3249 - Added an item underneath the hms_discovery_verify.sh interpreting results section in the Validate CSM health document. The BMC for an Apollo XL645D may not be discovered when the hms_discovery_verify.sh is ran during an install, as it requires an operational task to be completed near the end of the CSM Install process.

CASMINST-3247 - Added a known issue for the install.sh script were it may fail due to the sls-s3-credentials secret is not present in the services namespace.