### PR TITLE
CASMPET-5088: Remove references to Istio Prometheus

### DIFF
--- a/operations/network/customer_access_network/Externally_Exposed_Services.md
+++ b/operations/network/customer_access_network/Externally_Exposed_Services.md
@@ -19,7 +19,6 @@ See [External DNS](../external_dns/External_DNS.md) for more information.
 | Sysmgmt-health Prometheus |prometheus|| |No| Uses the IP of<br/>Keycloak<br/>Gatekeeper<br/>Ingress |
 | Sysmgmt-health Alert Manager |alertmanager|| |No| Uses the IP of<br/>Keycloak<br/>Gatekeeper<br/>Ingress |
 | Sysmgmt-health Grafana |grafana|| |No| Uses the IP of<br/>Keycloak<br/>Gatekeeper<br/>Ingress |
-| Istio Prometheus |prometheus-istio|| |No| Uses the IP of<br/>Keycloak<br/>Gatekeeper<br/>Ingress |
 | Istio Kiali | kiali-istio      || |No| Uses the IP of<br/>Keycloak<br/>Gatekeeper<br/>Ingress |
 | Istio Jaeger |jaeger-istio|| |No| Uses the IP of<br/>Keycloak<br/>Gatekeeper<br/>Ingress |
 | VCS |vcs|| |No| Uses the IP of<br/>Keycloak<br/>Gatekeeper<br/>Ingress |

--- a/operations/network/external_dns/External_DNS_Failing_to_Discover_Services_Workaround.md
+++ b/operations/network/external_dns/External_DNS_Failing_to_Discover_Services_Workaround.md
@@ -20,7 +20,6 @@ This procedure requires administrative privileges.
     ncn-w001# kubectl get vs -A | grep -v '[*]'
     NAMESPACE        NAME                              GATEWAYS                       HOSTS                                                      AGE
     istio-system     kiali                             [services/services-gateway]    [kiali-istio.SYSTEM_DOMAIN_NAME]                           2d16h
-    istio-system     prometheus                        [services/services-gateway]    [prometheus-istio.SYSTEM_DOMAIN_NAME]                      2d16h
     istio-system     tracing                           [services/services-gateway]    [jaeger-istio.SYSTEM_DOMAIN_NAME]                          2d16h
     nexus            nexus                             [services/services-gateway]    [packages.local registry.local nexus.SYSTEM_DOMAIN_NAME]   2d16h
     services         gitea-vcs-external                [services/services-gateway]    [vcs.SYSTEM_DOMAIN_NAME]                                   2d16h

--- a/operations/network/external_dns/Troubleshoot_DNS_Configuration_Issues.md
+++ b/operations/network/external_dns/Troubleshoot_DNS_Configuration_Issues.md
@@ -63,7 +63,7 @@ The Domain Name Service \(DNS\) is not configured properly.
     {{ printf "%s\t%s\n" .ip $hostnames }}{{ end }}{{ end }}
     {{ end }}{{ end }}{{ end }}' | sort -u | tr , ' '
 
-    10.101.5.128    opa-gpm.SYSTEM_DOMAIN_NAME nexus.SYSTEM_DOMAIN_NAME grafana-istio.SYSTEM_DOMAIN_NAME jaeger-istio.SYSTEM_DOMAIN_NAME prometheus-istio.SYSTEM_DOMAIN_NAME kiali-istio.SYSTEM_DOMAIN_NAME prometheus.SYSTEM_DOMAIN_NAME alertmanager.SYSTEM_DOMAIN_NAME grafana.SYSTEM_DOMAIN_NAME vcs.SYSTEM_DOMAIN_NAME sma-grafana.SYSTEM_DOMAIN_NAME sma-kibana.SYSTEM_DOMAIN_NAME csms.SYSTEM_DOMAIN_NAME
+    10.101.5.128    opa-gpm.SYSTEM_DOMAIN_NAME nexus.SYSTEM_DOMAIN_NAME jaeger-istio.SYSTEM_DOMAIN_NAME kiali-istio.SYSTEM_DOMAIN_NAME prometheus.SYSTEM_DOMAIN_NAME alertmanager.SYSTEM_DOMAIN_NAME grafana.SYSTEM_DOMAIN_NAME vcs.SYSTEM_DOMAIN_NAME sma-grafana.SYSTEM_DOMAIN_NAME sma-kibana.SYSTEM_DOMAIN_NAME csms.SYSTEM_DOMAIN_NAME
     10.101.5.129    api.SYSTEM_DOMAIN_NAME auth.SYSTEM_DOMAIN_NAME
     10.101.5.130    s3.SYSTEM_DOMAIN_NAME
     10.92.100.222   cray-dhcp-kea

--- a/operations/network/external_dns/Troubleshoot_Systems_Not_Provisioned_with_External_IP_Addresses.md
+++ b/operations/network/external_dns/Troubleshoot_Systems_Not_Provisioned_with_External_IP_Addresses.md
@@ -22,7 +22,6 @@ The Customer Access Network \(CAN\) is not supported on the system.
     ncn-w001# kubectl get vs -A | grep -v '[*]'
     NAMESPACE        NAME                              GATEWAYS                       HOSTS                                                      AGE
     istio-system     kiali                             [services/services-gateway]    [kiali-istio.SYSTEM_DOMAIN_NAME]                           2d16h
-    istio-system     prometheus                        [services/services-gateway]    [prometheus-istio.SYSTEM_DOMAIN_NAME]                      2d16h
     istio-system     tracing                           [services/services-gateway]    [jaeger-istio.SYSTEM_DOMAIN_NAME]                          2d16h
     nexus            nexus                             [services/services-gateway]    [packages.local registry.local nexus.SYSTEM_DOMAIN_NAME]   2d16h
     services         gitea-vcs-external                [services/services-gateway]    [vcs.SYSTEM_DOMAIN_NAME]                                   2d16h

--- a/operations/system_management_health/Access_System_Management_Health_Services.md
+++ b/operations/system_management_health/Access_System_Management_Health_Services.md
@@ -59,13 +59,3 @@ This procedure enables administrators to set up the service and access its compo
         Jaeger provides distributed tracing of requests across micro-services based on headers automatically injected by Envoy.
 
         For more information regarding the `jaeger-istio` front end/UI configuration, refer to the online documentation \([https://www.jaegertracing.io/](https://www.jaegertracing.io/)\). Click on the 'Docs' section to get more information around the Jaeger Frontend/UI.
-
-    Additional components are also exposed, though only for convenience. Do not rely on these components to always be available:
-
-    -   **https://prometheus-istio.\{\{shasta\_domain\}\}/**
-
-        Prometheus instance that collects Istio metrics \(included as part of `istio` Helm chart\).
-
-        For more information regarding the use of the Prometheus interface, see [https://prometheus.io/docs/alerting/overview/](https://prometheus.io/docs/alerting/overview/).
-
-


### PR DESCRIPTION
Starting in CSM 1.2 there will no longer be an Istio Prometheus
instance. References to this Prometheus are removed from the docs.