### PR TITLE
Added patching of data.json to remove storage-ceph-cloudinit.sh from runcmd of s001.

### DIFF
--- a/007-CSM-INSTALL-REBOOT.md
+++ b/007-CSM-INSTALL-REBOOT.md
@@ -95,13 +95,13 @@ all been run by the administrator before starting this stage.
       https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
     ```
 
-1. Patch the `data.json` file to prevent running a CEPH script that should only ever be run on initial installation. __If you have made any changes__ to this file as a result of any customizations or workarounds use the path to that file instead.
+1. Patch the `data.json` file to prevent re-running a CEPH script that should only ever be run on initial installation. __If you have made any changes__ to this file as a result of any customizations or workarounds use the path to that file instead.
 
-```bash
-pit# sed -i.bak 's/storage-ceph-cloudinit.sh/ceph-enable-services.sh/g' /var/www/ephemeral/configs/data.json
-```    
+    ```bash
+    pit# sed -i.bak 's/storage-ceph-cloudinit.sh/ceph-enable-services.sh/g' /var/www/ephemeral/configs/data.json
+    ```    
 
-1. Upload the same `data.json` file we used to BSS, our Kubernetes cloud-init DataSource. The patch to `data.json` should be the same as the one used in the last step. This step will prompt for the root password of the NCNs.
+1. Upload the same `data.json` file we used to BSS, our Kubernetes cloud-init DataSource. **The path to `data.json` should be the same as the one used in the last step** (i.e., the file you just patched). This step will prompt for the root password of the NCNs.
     
     ```bash
     pit# csi handoff bss-metadata --data-file /var/www/ephemeral/configs/data.json

--- a/007-CSM-INSTALL-REBOOT.md
+++ b/007-CSM-INSTALL-REBOOT.md
@@ -94,8 +94,14 @@ all been run by the administrator before starting this stage.
       -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
       https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
     ```
-    
-1. Upload the same `data.json` file we used to BSS, our Kubernetes cloud-init DataSource. __If you have made any changes__ to this file as a result of any customizations or workarounds use the path to that file instead. This step will prompt for the root password of the NCNs.
+
+1. Patch the `data.json` file to prevent running a CEPH script that should only ever be run on initial installation. __If you have made any changes__ to this file as a result of any customizations or workarounds use the path to that file instead.
+
+```bash
+pit# sed -i.bak 's/storage-ceph-cloudinit.sh/ceph-enable-services.sh/g' /var/www/ephemeral/configs/data.json
+```    
+
+1. Upload the same `data.json` file we used to BSS, our Kubernetes cloud-init DataSource. The patch to `data.json` should be the same as the one used in the last step. This step will prompt for the root password of the NCNs.
     
     ```bash
     pit# csi handoff bss-metadata --data-file /var/www/ephemeral/configs/data.json

--- a/007-CSM-INSTALL-REBOOT.md
+++ b/007-CSM-INSTALL-REBOOT.md
@@ -95,16 +95,16 @@ all been run by the administrator before starting this stage.
       https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
     ```
 
-1. Patch the `data.json` file to prevent re-running a CEPH script that should only ever be run on initial installation. __If you have made any changes__ to this file as a result of any customizations or workarounds use the path to that file instead.
-
-    ```bash
-    pit# sed -i.bak 's/storage-ceph-cloudinit.sh/ceph-enable-services.sh/g' /var/www/ephemeral/configs/data.json
-    ```    
-
-1. Upload the same `data.json` file we used to BSS, our Kubernetes cloud-init DataSource. **The path to `data.json` should be the same as the one used in the last step** (i.e., the file you just patched). This step will prompt for the root password of the NCNs.
+1. Upload the same `data.json` file we used to BSS, our Kubernetes cloud-init DataSource. __If you have made any changes__ to this file as a result of any customizations or workarounds use the path to that file instead. This step will prompt for the root password of the NCNs.
     
     ```bash
     pit# csi handoff bss-metadata --data-file /var/www/ephemeral/configs/data.json
+    ```
+
+1. Patch the metadata for the CEPH nodes to have the correct run commands:
+
+    ```bash
+    pit# python3 /usr/share/doc/metal/scripts/patch-ceph-runcmd.py
     ```
     
 1. <a name="ncn-boot-artifacts-hand-off"></a>Perform csi handoff, uploading NCN boot artifacts into S3.

--- a/scripts/patch-ceph-runcmd.py
+++ b/scripts/patch-ceph-runcmd.py
@@ -1,0 +1,62 @@
+import argparse
+import http
+import sys
+import requests
+import json
+import os
+import urllib3
+
+urllib3.disable_warnings()
+
+# Check to make sure we have a token.
+token = os.environ.get('TOKEN')
+if token is None:
+    print("TOKEN environment variable must be set!")
+    sys.exit(1)
+
+parser = argparse.ArgumentParser(description='CEPH runcmd utility.')
+parser.add_argument('--api_gateway_address', action='store', default='api-gw-service-nmn.local',
+                    help='Address of the API gateway.')
+
+args = parser.parse_args()
+
+session = requests.Session()
+session.verify = False
+
+# Get the storage nodes.
+components_response = session.get('https://{}/apis/smd/hsm/v2/State/Components?role=Management&subrole=Storage'.format(
+        args.api_gateway_address),
+        headers={'Authorization': 'Bearer {}'.format(token)})
+components_json = components_response.json()
+
+for storage_component in components_json['Components']:
+    body = {'hosts': [storage_component['ID']]}
+    bss_response = session.get('https://{}/apis/bss/boot/v1/bootparameters'.format(args.api_gateway_address),
+                               headers={'Authorization': 'Bearer {}'.format(token),
+                                        "Content-Type": "application/json"},
+                               data=json.dumps(body))
+    bss_json = bss_response.json()[0]
+
+    run_cmd = bss_json['cloud-init']['user-data']['runcmd']
+
+    # Out with the old (if it exists)...
+    cloudinit_script = "/srv/cray/scripts/common/storage-ceph-cloudinit.sh"
+    if cloudinit_script in run_cmd:
+        run_cmd.remove(cloudinit_script)
+
+    # ...and in with the new (if it's not already there)
+    enable_script = "/srv/cray/scripts/common/ceph-enable-services.sh"
+    if enable_script not in run_cmd:
+        run_cmd.append(enable_script)
+
+    # Now patch BSS.
+    patch_response = session.patch('https://{}/apis/bss/boot/v1/bootparameters'.format(args.api_gateway_address),
+                               headers={'Authorization': 'Bearer {}'.format(token),
+                                        "Content-Type": "application/json"},
+                               data=json.dumps(bss_json))
+    if patch_response.status_code != http.HTTPStatus.OK:
+        print('Failed to patch BSS entry for {}/{}!'.format(storage_component['ID'],
+                                                            bss_json['cloud-init']['user-data']['hostname']))
+    else:
+        print('BSS entry for {}/{} patched.'.format(storage_component['ID'],
+                                                    bss_json['cloud-init']['user-data']['hostname']))


### PR DESCRIPTION
Resolves CASMINST-3351.

Testing:

```
ncn-m001:~/swallace # cray bss bootparameters list --hosts $(ssh ncn-s001 cat /etc/cray/xname) --format json > ncn-s001.json
Warning: Permanently added 'ncn-s001,10.252.1.10' (ECDSA) to the list of known hosts.
ncn-m001:~/swallace # cray bss bootparameters list --hosts $(ssh ncn-s002 cat /etc/cray/xname) --format json > ncn-s002.json
Warning: Permanently added 'ncn-s002,10.252.1.11' (ECDSA) to the list of known hosts.
ncn-m001:~/swallace # cray bss bootparameters list --hosts $(ssh ncn-s003 cat /etc/cray/xname) --format json > ncn-s003.json
Warning: Permanently added 'ncn-s003,10.252.1.12' (ECDSA) to the list of known hosts.

ncn-m001:~/swallace # python3 /usr/share/doc/metal/scripts/patch-ceph-runcmd.py
BSS entry for x3000c0s26b0n0/ncn-s003 patched.
BSS entry for x3000c0s22b0n0/ncn-s001 patched.
BSS entry for x3000c0s24b0n0/ncn-s002 patched.

ncn-m001:~/swallace # cray bss bootparameters list --hosts $(ssh ncn-s001 cat /etc/cray/xname) --format json > ncn-s001.new.json
Warning: Permanently added 'ncn-s001,10.252.1.10' (ECDSA) to the list of known hosts.
ncn-m001:~/swallace # cray bss bootparameters list --hosts $(ssh ncn-s002 cat /etc/cray/xname) --format json > ncn-s002.new.json
Warning: Permanently added 'ncn-s002,10.252.1.11' (ECDSA) to the list of known hosts.
ncn-m001:~/swallace # cray bss bootparameters list --hosts $(ssh ncn-s003 cat /etc/cray/xname) --format json > ncn-s003.new.json
Warning: Permanently added 'ncn-s003,10.252.1.12' (ECDSA) to the list of known hosts.

ncn-m001:~/swallace # diff ncn-s001.json ncn-s001.new.json
35c35
<           "/srv/cray/scripts/common/storage-ceph-cloudinit.sh"
---
>           "/srv/cray/scripts/common/ceph-enable-services.sh"
ncn-m001:~/swallace # diff ncn-s002.json ncn-s002.new.json
34c34,35
<           "/srv/cray/scripts/common/update_ca_certs.py"
---
>           "/srv/cray/scripts/common/update_ca_certs.py",
>           "/srv/cray/scripts/common/ceph-enable-services.sh"
ncn-m001:~/swallace # diff ncn-s004.json ncn-s003.new.json
diff: ncn-s004.json: No such file or directory
ncn-m001:~/swallace # diff ncn-s003.json ncn-s003.new.json
34c34,35
<           "/srv/cray/scripts/common/update_ca_certs.py"
---
>           "/srv/cray/scripts/common/update_ca_certs.py",
>           "/srv/cray/scripts/common/ceph-enable-services.sh"
```