### PR TITLE
CASMINST-2950; change ntp-pool to ntp-pools in all sample commands

### DIFF
--- a/background/cray_site_init_files.md
+++ b/background/cray_site_init_files.md
@@ -61,7 +61,7 @@ ncn-metadata: ncn_metadata.csv
 ncn-mgmt-node-auditing-enabled: false
 nmn-bootstrap-vlan: 2
 nmn-cidr: 10.252.0.0/17
-ntp-pool: time.nist.gov
+ntp-pools: time.nist.gov
 river-cabinets: 1
 rpm-repository: https://packages.nmn/repository/shasta-master
 site-dns: 172.30.84.40

--- a/install/bootstrap_livecd_remote_iso.md
+++ b/install/bootstrap_livecd_remote_iso.md
@@ -379,7 +379,7 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
              --can-dynamic-pool 10.103.11.128/25 \
              --nmn-cidr 10.252.0.0/17 \
              --hmn-cidr 10.254.0.0/17 \
-             --ntp-pool time.nist.gov \
+             --ntp-pools time.nist.gov \
              --site-domain dev.cray.com \
              --site-ip 172.30.53.79/20 \
              --site-gw 172.30.48.1 \
@@ -413,7 +413,7 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
          * An override to default cabinet IPv4 subnets can be made with the `hmn-mtn-cidr` and `nmn-mtn-cidr` parameters.
          * By default, spine switches are used as MetalLB peers. Use `--bgp-peers aggregation` to use aggregation switches instead.
          * Several parameters (`can-gateway`, `can-cidr`, `can-static-pool`, `can-dynamic-pool`) describe the CAN (Customer Access network). The `can-gateway` is the common gateway IP address used for both spine switches and commonly referred to as the Virtual IP address for the CAN. The `can-cidr` is the IP subnet for the CAN assigned to this system. The `can-static-pool` and `can-dynamic-pool` are the MetalLB address static and dynamic pools for the CAN. The `can-external-dns` is the static IP address assigned to the DNS instance running in the cluster to which requests the cluster subdomain will be forwarded. The `can-external-dns` IP address must be within the `can-static-pool` range.
-         * Set `ntp-pool` to a reachable NTP server
+         * Set `ntp-pools` to reachable NTP pools
 
          These warnings from `csi config init` for issues in `hmn_connections.json` can be ignored.
             * The node with the external connection (`ncn-m001`) will have a warning similar to this because its BMC is connected to the site and not the HMN like the other management NCNs. It can be ignored.

--- a/install/bootstrap_livecd_usb.md
+++ b/install/bootstrap_livecd_usb.md
@@ -368,7 +368,7 @@ Some files are needed for generating the configuration payload. See these topics
           --can-dynamic-pool 10.103.11.128/25 \
           --nmn-cidr 10.252.0.0/17 \
           --hmn-cidr 10.254.0.0/17 \
-          --ntp-pool time.nist.gov \
+          --ntp-pools time.nist.gov \
           --site-domain dev.cray.com \
           --site-ip 172.30.53.79/20 \
           --site-gw 172.30.48.1 \
@@ -402,7 +402,7 @@ Some files are needed for generating the configuration payload. See these topics
       * An override to default cabinet IPv4 subnets can be made with the `hmn-mtn-cidr` and `nmn-mtn-cidr` parameters.
       * By default, spine switches are used as MetalLB peers. Use `--bgp-peers aggregation` to use aggregation switches instead.
       * Several parameters (`can-gateway`, `can-cidr`, `can-static-pool`, `can-dynamic-pool`) describe the CAN (Customer Access network). The `can-gateway` is the common gateway IP address used for both spine switches and commonly referred to as the Virtual IP address for the CAN. The `can-cidr` is the IP subnet for the CAN assigned to this system. The `can-static-pool` and `can-dynamic-pool` are the MetalLB address static and dynamic pools for the CAN. The `can-external-dns` is the static IP address assigned to the DNS instance running in the cluster to which requests the cluster subdomain will be forwarded. The `can-external-dns` IP address must be within the `can-static-pool` range.
-      * Set `ntp-pool` to a reachable NTP server
+      * Set `ntp-pools` to reachable NTP pools
 
       These warnings from `csi config init` for issues in `hmn_connections.json` can be ignored.
       * The node with the external connection (`ncn-m001`) will have a warning similar to this because its BMC is connected to the site and not the HMN like the other management NCNs. It can be ignored.

--- a/install/prepare_configuration_payload.md
+++ b/install/prepare_configuration_payload.md
@@ -51,7 +51,7 @@ For more description of these settings and the default values, see [Default IP A
 | --nmn-cidr 10.252.0.0/17 | Override the default cabinet IPv4 subnet for River NMN |
 | --hmn-mtn-cidr 10.104.0.0/17 | Override the default cabinet IPv4 subnet for Mountain HMN |
 | --nmn-mtn-cidr 10.100.0.0/17 | Override the default cabinet IPv4 subnet for Mountain NMN |
-| --ntp-pool time.nist.gov | External NTP server for this system to use |
+| --ntp-pools time.nist.gov | External NTP pool(s) for this system to use |
 | --site-domain dev.cray.com | Domain name for this system |
 | --site-ip 172.30.53.79/20 | IP address and netmask for the PIT node lan0 connection |
 | --site-gw 172.30.48.1 | Gateway for the PIT node to use |
@@ -72,7 +72,7 @@ For more description of these settings and the default values, see [Default IP A
    * The starting cabinet number for each type of cabinet (for example, `starting-mountain-cabinet`) has a default that can be overridden. See the `csi config init --help` output for more information.
    * An override to default cabinet IPv4 subnets can be made with the `hmn-mtn-cidr` and `nmn-mtn-cidr` parameters.
    * Several parameters (`can-gateway`, `can-cidr`, `can-static-pool`, `can-dynamic-pool`) describe the CAN (Customer Access network). The `can-gateway` is the common gateway IP address used for both spine switches and commonly referred to as the Virtual IP address for the CAN. The `can-cidr` is the IP subnet for the CAN assigned to this system. The `can-static-pool` and `can-dynamic-pool` are the MetalLB address static and dynamic pools for the CAN. The `can-external-dns` is the static IP address assigned to the DNS instance running in the cluster to which requests the cluster subdomain will be forwarded. The `can-external-dns` IP address must be within the `can-static-pool` range.
-   * Set `ntp-pool` to a reachable NTP server.
+   * Set `ntp-pools` to reachable NTP pools.
    * The `application_node_config.yaml` file is required. It is used to describe the mapping between prefixes in `hmn_connections.csv` and HSM subroles. This file also defines aliases application nodes. For details, see [Create Application Node YAML](create_application_node_config_yaml.md).
    * For systems that use non-sequential cabinet id numbers, use `cabinets-yaml` to include the `cabinets.yaml` file. This file can include information about the starting ID for each cabinet type and number of cabinets which have separate command line options, but is a way to specify explicitly the id of every cabinet in the system. See [Create Cabinets YAML](create_cabinets_yaml.md).
 

--- a/introduction/differences.md
+++ b/introduction/differences.md
@@ -45,7 +45,7 @@ The most noteworthy changes since the previous release are described here.
 ### Deprecated Features
 
    * cray-conman pod. This has been replaced by cray-console-node.
-   * The `csi config init` command has changed the option from `-ntp-pool` to `ntp-pools` to support a comma-separated list of NTP pools..
+   * The `csi config init` command has changed the option from `-ntp-pool` to `ntp-pools` to support a comma-separated list of NTP pools.
 
 <a name="other_changes"></a>
 ### Other Changes

--- a/introduction/differences.md
+++ b/introduction/differences.md
@@ -45,6 +45,7 @@ The most noteworthy changes since the previous release are described here.
 ### Deprecated Features
 
    * cray-conman pod. This has been replaced by cray-console-node.
+   * The `csi config init` command has changed the option from `-ntp-pool` to `ntp-pools` to support a comma-separated list of NTP pools..
 
 <a name="other_changes"></a>
 ### Other Changes

--- a/operations/network/metallb_bgp/Update_BGP_Neighbors.md
+++ b/operations/network/metallb_bgp/Update_BGP_Neighbors.md
@@ -17,7 +17,7 @@ You will not have BGP peers until CSM `install.sh` has run. This is where MetalL
 CSI CLI arguments with `--bgp-peers aggregation`
 ```bash
 linux# export IPMI_PASSWORD=changeme
-linux# csi config init --bootstrap-ncn-bmc-user root --bootstrap-ncn-bmc-pass $IPMI_PASSWORD --ntp-pool cfntp-4-1.us.cray.com,cfntp-4-2.us.cray.com --can-external-dns 10.103.8.113 --can-gateway 10.103.8.1 --site-ip 172.30.56.2/24 --site-gw 172.30.48.1 --site-dns 172.30.84.40 --site-nic em1 --system-name odin --bgp-peers aggregation
+linux# csi config init --bootstrap-ncn-bmc-user root --bootstrap-ncn-bmc-pass $IPMI_PASSWORD --ntp-pools cfntp-4-1.us.cray.com,cfntp-4-2.us.cray.com --can-external-dns 10.103.8.113 --can-gateway 10.103.8.1 --site-ip 172.30.56.2/24 --site-gw 172.30.48.1 --site-dns 172.30.84.40 --site-nic em1 --system-name odin --bgp-peers aggregation
 ```
 
 ## Automated Process


### PR DESCRIPTION
CASMINST-2950

Changed ntp-pool to ntp-pools in all sample commands for "csi config init -ntp-pools".