### PR TITLE
CASMINST-2324: Clarify cabinets.yaml example for non-contiguous cabinets and VLAN IDs

### DIFF
--- a/install/create_cabinets_yaml.md
+++ b/install/create_cabinets_yaml.md
@@ -1,6 +1,6 @@
 # Create Cabinets YAML
 
-This page provides directions on constructing the `cabinets.yaml` file. This file lists cabinet IDs for any systems with non-contiguous cabinet ID numbers as well as VLAN overrides and controls how the `csi config init` command treats cabinet IDs.
+This page provides directions on constructing the `cabinets.yaml` file. This file lists cabinet IDs for any systems with non-contiguous cabinet ID numbers, as well as VLAN overrides, and controls how the `csi config init` command treats cabinet IDs.
 
 The following example file is manually created and follows this format. Each "type" of cabinet can have several fields: `total_number` of cabinets of this type, `starting_id` for this cabinet type, and a list of the IDs.
 
@@ -31,7 +31,7 @@ cabinets:
   starting_id: 3000
 ```
 
-In this example file, there are two Hill cabinets that will be automatically numbered as 9000 and 9001. The Mountain cabinets appear in two groups as 1000 and 1001 and then another area in 1100 and 1101 with VLAN ids related to the cabinet number. This is one way to provide space in the cabinet IDs to allow for future expansion of the system or to identify location of a row of cabinets.  The River cabinets are contiguous in four separated IDs as 3000, 3001, 3002, and 30003..
+In this example file, there are two Hill cabinets that will be automatically numbered as 9000 and 9001. The Mountain cabinets appear in two groups as 1000 and 1001, and then another area in 1100 and 1101, with VLAN ids related to the cabinet number. This is one way to provide space in the cabinet IDs to allow for future expansion of the system or to identify location of a row of cabinets.  The River cabinets are contiguous in four separated IDs as 3000, 3001, 3002, and 30003..
 
 A system with Hill cabinets can have one to four cabinet IDs. There is no limit on the number of Mountain or River cabinets.
 


### PR DESCRIPTION
CASMINST-2324: Clarify cabinets.yaml example for non-contiguous cabinets and VLAN IDs