### PR TITLE
CASMINST-3384: Shift locaion of link to setting Gigabyte BIOS time in prepare_compute_nodes.md

### DIFF
--- a/install/prepare_compute_nodes.md
+++ b/install/prepare_compute_nodes.md
@@ -5,11 +5,7 @@ These nodes have an additional procedure before they can be booted.
 
 ### Topics:
    1. [Configure HPE Apollo 6500 XL645d Gen10 Plus Compute Nodes](#configure-hpe-apollo-6500-x645d-gen10-plus-compute-nodes)
-
-### Prerequisites
-
-The time for Gigabyte compute nodes is synced with the rest of the system.
-See [Update the Gigabyte Server BIOS Time](../operations/node_management/Update_the_Gigabyte_Server_BIOS_Time.md).
+   1. [Update the BIOS Time on Gigabyte Compute Nodes](#update-the-bios-time-on-gigabyte-compute-nodes)"
 
 ## Details
 
@@ -162,6 +158,11 @@ This procedure needs to be done for each of the HPE Apollo 6500 XL645d nodes to 
    ```
 
    Everything is now configured and the node is ready to be rebooted.
+
+<a name="update-the-bios-time-on-gigabyte-compute-nodes"></a>
+### 1. Update the BIOS Time on Gigabyte Compute Nodes
+The BIOS time for Gigabyte compute nodes must be synced with the rest of the system.
+See [Update the Gigabyte Server BIOS Time](../operations/node_management/Update_the_Gigabyte_Server_BIOS_Time.md).
 
 <a name="next-topic"></a>
 # Next Topic


### PR DESCRIPTION
CASMINST-3384: Shift locaion of link to setting Gigabyte BIOS time in prepare_compute_nodes.md