### PR TITLE
Upgrade to backport-action v2

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -1,14 +1,23 @@
 name: Backport
-
+ 
 on:
   pull_request:
     types:
       - closed
       - labeled
-
+      - unlabeled
+ 
 jobs:
   backport:
+    if: ${{ github.event.pull_request.labels != '[]' && github.event.pull_request.labels != '' }}
+    strategy:
+      matrix:
+        label: ${{github.event.pull_request.labels.*.name}}
+      fail-fast: false
     runs-on: self-hosted
-    name: Backport closed pull request
     steps:
-    - uses: Cray-HPE/backport-action@v1
+    - name: ${{ matrix.label }}
+      env:
+        BACKPORT_LABEL: ${{ matrix.label }}
+        BACKPORT_REPORT_FAILURE: ${{ github.event_name == 'pull_request' && github.event.action == 'closed' }}
+      uses: Cray-HPE/backport-action@v2


### PR DESCRIPTION
Backport action v2 features:
* dry-run on unmerged PR - notify about merge conflicts prior to merge
* support for "Rebase" PR merge strategy - previously action was only cherry-picking last commit
* better resiliency on static runner - added checkout/clone if failed logic