### PR TITLE
[Backport release/1.2] Upgrade to backport-action v2

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -1,14 +1,23 @@
 name: Backport
-
+ 
 on:
   pull_request:
     types:
       - closed
       - labeled
-
+      - unlabeled
+ 
 jobs:
   backport:
+    if: ${{ github.event.pull_request.labels != '[]' && github.event.pull_request.labels != '' }}
+    strategy:
+      matrix:
+        label: ${{github.event.pull_request.labels.*.name}}
+      fail-fast: false
     runs-on: self-hosted
-    name: Backport closed pull request
     steps:
-    - uses: Cray-HPE/backport-action@v1
+    - name: ${{ matrix.label }}
+      env:
+        BACKPORT_LABEL: ${{ matrix.label }}
+        BACKPORT_REPORT_FAILURE: ${{ github.event_name == 'pull_request' && github.event.action == 'closed' }}
+      uses: Cray-HPE/backport-action@v2


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/docs-csm/pull/361. Cherry-picked from c172bac8a14598900cdae52b325f61b9eb45d1f5 for branch release/1.2.