### PR TITLE
CASMCMS-7473: Add documentation on automatically applying csm config

### DIFF
--- a/operations/CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md
+++ b/operations/CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md
@@ -45,7 +45,15 @@ with CFS.
 ### Option 2: Provide Custom SSH Keys
 
 Administrators may elect to replace the CSM-provided keys with their own custom
-keys.
+keys. The `replace_ssh_keys.sh` script can be used to replace the keys from
+files.
+
+```bash
+ncn-m001# /usr/share/doc/csm/scripts/install/configuration/replace_ssh_keys.sh \
+--public-key-file ./id_rsa.pub --private-key-file ./id_rsa
+```
+
+Alternatively, the keys stored in Kubernetes can be updated directly. 
 
 1. Replace the private key half:
    ```bash
@@ -90,11 +98,19 @@ associated with the product.
 > Use this procedure if switching from custom keys to the default CSM SSH keys
 > only, otherwise it can be skipped.
 
+To restore the default CSM keys, administrators can run the
+`restore_ssh_keys.sh` script.
+
+```bash
+ncn-m001# /usr/share/doc/csm/scripts/install/configuration/restore_ssh_keys.sh
+```
+
+Alternatively, the keys can be deleted from Kubernetes directly.
 The `csm-ssh-keys` Kubernetes deployment provided by CSM periodically checks the
 ConfigMap and secret containing the key information. If these entries do not
-exist, it will recreate them from the default CSM keys. In this case, deleting
-the associated ConfigMap and secrets will republish them with the default
-CSM-provided keys.
+exist, it will recreate them from the default CSM keys. To manually restore
+keys, delete the associated ConfigMap and secret, and the default CSM-provided
+keys will be republished.
 
 1. Delete the `csm-private-key` Kubernetes secret.
    ```bash
@@ -125,8 +141,15 @@ and managed in Vault.
 
 After completing the previous procedures, apply the configuration to the NCNs
 by running NCN personalization with [CFS](../configuration_management/Configuration_Management.md).
+This can be accomplished by running the `apply_csm_configuration.sh` script, or
+running the steps manually. For more information on the script, see
+[Automatically Apply CSM Configuration to NCNs](#auto_apply_csm_config).
 
-Prior to running NCN personalization, gather the following information: 
+```bash
+ncn-m001# /usr/share/doc/csm/scripts/install/configuration/apply_csm_configuration.sh
+```
+
+To manually run NCN personalization, first gather the following information: 
 
 * HTTP clone URL for the configuration repository in [VCS](../configuration_management/Version_Control_Service_VCS.md)
 * Path to the Ansible play to run in the repository
@@ -183,3 +206,38 @@ Prior to running NCN personalization, gather the following information:
 
 > **NOTE:** The CSM configuration layer _MUST_ be the first layer in the
 > NCN personalization CFS configuration.
+
+<a name="auto_apply_csm_config"></a>
+## Automatically Apply CSM Configuration to NCNs
+
+CSM configuration can automatically be applied to NCNs by running the
+`apply_csm_configuration.sh` script.
+
+```bash
+ncn-m001# /usr/share/doc/csm/scripts/install/configuration/apply_csm_configuration.sh
+```
+
+### Automatic CSM Configuration Steps
+ 
+By default the script will perform the following steps:
+1. Finds the latest installed release version of the CSM product stream.
+1. Finds the latest commit on the release branch of the `csm-config-management` repo.
+1. Creates or updates the `ncn-personalization.json` configuration file.
+1. Finds all nodes in HSM with the `Management` role.
+1. Disables configuration for all NCNs.
+1. Updates the `ncn-personalization` configuration in CFS from the `ncn-personalization.json` file.
+1. Enables configuration for all NCN nodes, and sets their desired configuration to `ncn-personalization`.
+1. Monitors CFS until all NCN nodes have successfully completed, or failed, configuration.
+
+### Automatic CSM Configuration Overrides
+
+The script also supports several flags to override these behaviors:
+- csm-release: Overrides the version of the CSM release that is used. Defaults to the latest version.
+- git-commit: Overrides the git commit cloned for the configuration content. Defaults to the latest
+commit on the csm-release branch.
+- git-clone-url: Overrides the source of the configuration content. Defaults to `https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git`
+- ncn-config-file: Sets a file other than `ncn-personalization.json` to be used for the configuration.
+- xnames: A comma-separated list xnames to deploy to. Defaults to all `Management` nodes in HSM.
+- clear-state: Clears existing state from components to ensure CFS runs. This can be used if
+configuration needs to be re-run on successful nodes with no change to the git content since the previous
+run. For examples, if the ssh keys have changed. 

--- a/scripts/operations/configuration/apply_csm_configuration.sh
+++ b/scripts/operations/configuration/apply_csm_configuration.sh
@@ -1,0 +1,196 @@
+# Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# (MIT License)
+
+#!/bin/bash
+
+usage()
+{
+   # Display Help
+   echo "Runs CFS to setup passwordless ssh"
+   echo "All parameters are optional and the values will be determined automatically if not set."
+   echo
+   echo "Usage: deploy_ssh_keys.sh [ --csm-release version ] [ --git-commit hash ]"
+   echo "                            [ --git-clone-url url ] [ --ncn-config-file file ]"
+   echo "                            [ --xnames xname1,xname2... ] [ --clear-state ]"
+   echo
+   echo "Options:"
+   echo "csm-release          The version of the CSM release to use. (e.g. 1.6.11)"
+   echo "git-commit           The git commit hash for CFS to use."
+   echo "git-clone-url        The git clone url for CFS to use."
+   echo "ncn-config-file      A file containing the NCN CFS configuration."
+   echo "xnames               A comma seperated list xnames to deploy to. All management nodes will be included if not set."
+   echo "clear-state          Clears existing state from components to ensure CFS runs."
+   echo
+}
+
+if [[ $# -eq 0 ]]; then
+  usage
+fi
+
+while [[ $# -gt 0 ]]; do
+  key="$1"
+
+  case $key in
+    --csm-release)
+      RELEASE="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --git-commit)
+      COMMIT="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --git-clone-url)
+      CLONE_URL="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --ncn-config-file)
+      NCN_CONFIG_FILE="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --xnames)
+      XNAMES="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --clear-state)
+      CLEAR_STATE="true"
+      shift # past argument
+      ;;
+    -h|--help) # help option
+      usage
+      exit 0
+      ;;
+    *) # unknown option
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+## CONFIGURATION SETUP ##
+if [[ -z "${RELEASE}" ]]; then
+    RELEASE=$(kubectl -n services get cm cray-product-catalog -o jsonpath='{.data.csm}' 2>/dev/null\
+        | yq r -j - 2>/dev/null | jq -r ' to_entries | .[0].value.configuration.import_branch' 2>/dev/null\
+        | awk -F'/' '{ print $NF }')
+    echo "Found release version ${RELEASE}"
+fi
+
+CSM_CONFIG_FILE="csm-config-$RELEASE.json"
+if [[ -z "${NCN_CONFIG_FILE}" ]]; then
+    NCN_CONFIG_FILE="ncn-personalization.json"
+fi
+if [[ -z "${CLONE_URL}" ]]; then
+    CLONE_URL="https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git"
+fi
+
+if [[ -z "${COMMIT}" ]]; then
+    VCS_USER=$(kubectl get secret -n services vcs-user-credentials --template={{.data.vcs_username}} | base64 --decode)
+    VCS_PASSWORD=$(kubectl get secret -n services vcs-user-credentials --template={{.data.vcs_password}} | base64 --decode)
+    echo "https://${VCS_USER}:${VCS_PASSWORD}@api-gw-service-nmn.local/vcs/cray/csm-config-management.git" > .git-credentials
+    echo "${CLONE_URL/\/\//\/\/${VCS_USER}:${VCS_PASSWORD}@}" > .git-credentials
+    git config --file .gitconfig credential.helper store
+    COMMIT=$(git ls-remote $CLONE_URL refs/heads/cray/csm/${RELEASE} | awk '{print $1}')
+    if [[ -n $COMMIT ]]; then
+        echo "Found git commit ${COMMIT}"
+    else
+        echo "No git commit found"
+        exit 1
+    fi
+fi
+
+CONFIG="{
+  \"layers\": [
+    {
+      \"name\": \"csm-${RELEASE}\",
+      \"cloneUrl\": \"$CLONE_URL\",
+      \"commit\": \"${COMMIT}\",
+      \"playbook\": \"site.yml\"
+    }
+  ]
+}"
+
+if [[ ! -f $CSM_CONFIG_FILE ]]; then
+    echo "Creating the configuration file ${CSM_CONFIG_FILE}"
+else
+    echo "Replacing the configuration file ${CSM_CONFIG_FILE}"
+fi
+echo $CONFIG | jq > $CSM_CONFIG_FILE
+
+if [ ! -f $NCN_CONFIG_FILE ]; then
+    echo "Creating the configuration file ${NCN_CONFIG_FILE}"
+    cp -p $CSM_CONFIG_FILE $NCN_CONFIG_FILE
+else
+    echo "Making a backup of old ${NCN_CONFIG_FILE}"
+    cp -p $NCN_CONFIG_FILE ${NCN_CONFIG_FILE}.backup
+    echo "Updating the configuration file ${NCN_CONFIG_FILE}"
+    jq -n --slurpfile new $CSM_CONFIG_FILE --slurpfile old $NCN_CONFIG_FILE \
+        '{"layers": ($new[0].layers + ($old[0].layers | del(.[] | select(.cloneUrl == $new[0].layers[0].cloneUrl and .playbook == $new[0].layers[0].playbook))))}'\
+        > ${NCN_CONFIG_FILE}.new
+    mv ${NCN_CONFIG_FILE}.new $NCN_CONFIG_FILE
+fi
+
+## RUNNING CFS ##
+if [[ -z $XNAMES ]]; then
+    echo "Retrieving a list of all management node xnames"
+    XNAMES=$(cray hsm state components list --role Management | jq -r '.Components | map(.ID) | join(",")')
+fi
+XNAME_LIST=${XNAMES//,/ }
+
+echo "Disabling configuration for all listed components"
+for xname in $XNAME_LIST; do
+    cray cfs components update $xname --enabled false
+done
+
+echo "Updating ncn-personalization configuration"
+cray cfs configurations update ncn-personalization --file $NCN_CONFIG_FILE
+
+if [[ -n $CLEAR_STATE ]]; then
+    echo "Clearing state from all listed components"
+    for xname in $XNAME_LIST; do
+        cray cfs components update $xname --state []
+    done
+fi
+
+echo "Setting desired configuration and enabling all listed components"
+for xname in $XNAME_LIST; do
+    cray cfs components update $xname --enabled true --error-count 0 --desired-config ncn-personalization
+done
+
+while true; do
+  RESULT=$(cray cfs components list --status pending --ids ${XNAMES} | jq length)
+  if [[ "$RESULT" -eq 0 ]]; then
+    break
+  fi
+  echo "Waiting for configuration to complete.  ${RESULT} components remaining."
+  sleep 60
+done
+
+CONFIGURED=$(cray cfs components list --status configured --ids ${XNAMES} | jq length)
+FAILED=$(cray cfs components list --status failed --ids ${XNAMES} | jq length)
+echo "Configuration complete. $CONFIGURED component(s) completed successfully.  $FAILED component(s) failed."
+if [ "$FAILED" -ne "0" ]; then
+   echo "The following components failed: $(cray cfs components list --status failed --ids ${XNAMES} | jq -r '. | map(.id) | join(",")')"
+fi

--- a/scripts/operations/configuration/replace_ssh_keys.sh
+++ b/scripts/operations/configuration/replace_ssh_keys.sh
@@ -1,0 +1,99 @@
+# Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# (MIT License)
+
+# !/bin/bash
+
+usage()
+{
+   # Display Help
+   echo "Replaces the ssh keys in Kubernetes"
+   echo "At least one option must be specified"
+   echo "NOTE: This does not update deployed keys"
+   echo
+   echo "Usage: replace_ssh_keys.sh [ --public-key-file file ]"
+   echo "                           [ --private-key-file file ]"
+   echo
+   echo "Options:"
+   echo "public-key-file      File path for a public key."
+   echo "private-key-file     File path for a private key."
+   echo
+}
+
+if [[ $# -eq 0 ]]; then
+  usage
+fi
+
+while [[ $# -gt 0 ]]; do
+  key="$1"
+
+  case $key in
+    --public-key-file)
+      PUBLIC_KEY_FILE="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --private-key-file)
+      PRIVATE_KEY_FILE="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    -h|--help) # help option
+      usage
+      exit 0
+      ;;
+    *) # unknown option
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -n "${PUBLIC_KEY_FILE}" ]]; then
+  PUBLIC_KEY=$(cat $PUBLIC_KEY_FILE)
+  if [[ -z "${PUBLIC_KEY}" ]]; then
+    echo "Public key not found in specified file"
+    exit 1
+  fi
+fi
+
+if [[ -n "${PRIVATE_KEY_FILE}" ]]; then
+  PRIVATE_KEY=$(cat $PRIVATE_KEY_FILE)
+  if [[ -z "${PRIVATE_KEY}" ]]; then
+    echo "Private key not found in specified file"
+    exit 1
+  fi
+fi
+
+if [[ -n "${PUBLIC_KEY}" ]]; then
+  echo "Updating public key..."
+  kubectl delete configmap -n services csm-public-key
+  cat ${PUBLIC_KEY_FILE} | \
+    base64 > ./value && kubectl create configmap --from-file \
+    value csm-public-key --namespace services && rm ./value
+fi
+
+if [[ -n "${PRIVATE_KEY}" ]]; then
+  echo "Updatating private key..."
+  kubectl get secret -n services csm-private-key -o json | \
+    jq --arg value "$(cat ${PRIVATE_KEY_FILE} | base64)" \
+    '.data["value"]=$value' | kubectl apply -f -
+fi

--- a/scripts/operations/configuration/restore_ssh_keys.sh
+++ b/scripts/operations/configuration/restore_ssh_keys.sh
@@ -1,0 +1,63 @@
+# Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# (MIT License)
+
+#!/bin/bash
+
+usage()
+{
+   # Display Help
+   echo "Removes the ssh keys in Kubernetes to restore their value from vault"
+   echo "NOTE: This does not update deployed keys"
+   echo
+   echo "Usage: restore_ssh_keys.sh"
+   echo
+}
+
+while [[ $# -gt 0 ]]; do
+  key="$1"
+
+  case $key in
+    -h|--help) # help option
+      usage
+      exit 0
+      ;;
+    *) # unknown option
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+
+kubectl delete configmap -n services csm-public-key
+kubectl delete secret -n services csm-private-key
+echo "Keys removed.  Waiting for defaults to be populated."
+echo "csm-ssh-keys will be restarted to force the keys to be restored sooner."
+kubectl -n services rollout restart deployment csm-ssh-keys
+
+until kubectl get configmap -n services csm-public-key >/dev/null 2>&1 && \
+      kubectl get secret -n services csm-private-key >/dev/null 2>&1; do
+  echo "Waiting for defaults to be populated..."
+  sleep 10
+done
+
+echo "Defaults have been restored"


### PR DESCRIPTION
### Summary and Scope

Adds documentation for scripts to automate parts of the installation.  The three scripts allow admins to modify keys and deploy keys for passwordless ssh.

(Scripts PR can be found here: https://stash.us.cray.com/projects/CSM/repos/scripts/pull-requests/64/overview)

### Issues and Related PRs

* Resolves CASMCMS-7473

### Testing

Tested on:

* Mug

Tested each script with all parameter options

### Risks and Mitigations

None