### PR TITLE
[Backport release/1.0] CASMPET-5109 1.0 : DOCS : Minor Postgres doc cleanup

### DIFF
--- a/operations/kubernetes/Disaster_Recovery_Postgres.md
+++ b/operations/kubernetes/Disaster_Recovery_Postgres.md
@@ -8,7 +8,10 @@ Disaster Recovery Procedures by Service:
 
 - [Restore HSM (Hardware State Manger) Postgres without a Backup](../hardware_state_manager/Restore_HSM_Postgres_without_a_Backup.md)
 - [Restore SLS (System Layout Service) Postgres without a Backup](../system_layout_service/Restore_SLS_Postgres_without_an_Existing_Backup.md)
+- [Restore Spire Postgres without a Backup](../spire/Restore_Spire_Postgres_without_a_Backup.md)
+- [Restore Keycloak Postgres without a Backup](#restore-keycloak-postgres)
 
+<a name="restore-keycloak-postgres"> </a>
 ### Keycloak
 
 The following procedures are required to rebuild the automatically populated
@@ -78,4 +81,3 @@ recreated.
 Any other changes made to Keycloak, such as local users that have been created,
 will have to be manually re-applied.
 
-- [Restore Spire Postgres without a Backup](../spire/Restore_Spire_Postgres_without_a_Backup.md)

--- a/operations/kubernetes/Restore_Postgres.md
+++ b/operations/kubernetes/Restore_Postgres.md
@@ -150,7 +150,7 @@ In the event that the spire Postgres cluster is in a state that the cluster must
     root@spire-postgres-0:/home/postgres# /usr/bin/psql postgres postgres
     postgres=# ALTER USER postgres WITH PASSWORD 'ABCXYZ';
     ALTER ROLE
-    postgres=# ALTER USER service-account WITH PASSWORD 'ABC123';
+    postgres=# ALTER USER service_account WITH PASSWORD 'ABC123';
     ALTER ROLE
     postgres=#ALTER USER spire WITH PASSWORD 'XYZ123';
     ALTER ROLE
@@ -352,7 +352,7 @@ In the event that the keycloak Postgres cluster is in a state that the cluster m
     root@keycloak-postgres-0:/home/postgres# /usr/bin/psql postgres postgres
     postgres=# ALTER USER postgres WITH PASSWORD 'ABCXYZ';
     ALTER ROLE
-    postgres=# ALTER USER service-account WITH PASSWORD 'ABC123';
+    postgres=# ALTER USER service_account WITH PASSWORD 'ABC123';
     ALTER ROLE
     postgres=#ALTER USER standby WITH PASSWORD '123456';
     ALTER ROLE
@@ -599,7 +599,7 @@ In the event that the VCS Postgres cluster is in a state that the cluster must b
     root@gitea-vcs-postgres-0:/home/postgres# /usr/bin/psql postgres postgres
     postgres=# ALTER USER postgres WITH PASSWORD 'ABCXYZ';
     ALTER ROLE
-    postgres=# ALTER USER service-account WITH PASSWORD 'ABC123';
+    postgres=# ALTER USER service_account WITH PASSWORD 'ABC123';
     ALTER ROLE
     postgres=#ALTER USER gitea WITH PASSWORD 'XYZ123';
     ALTER ROLE


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/docs-csm/pull/388. Cherry-picked from  for branch release/1.0.