### PR TITLE
add a note to upgrade doc that we unset CRAY_FORMAT

### DIFF
--- a/upgrade/1.0/Stage_0_Prerequisites.md
+++ b/upgrade/1.0/Stage_0_Prerequisites.md
@@ -83,7 +83,7 @@ Perform these steps to update `customizations.yaml`:
 > Run below command to make sure cray cli output format is reset to default
 > 
 >```
-> ncn-m# unset CRAY_OUTPUT
+> ncn-m# unset CRAY_FORMAT
 >```
 
 Run check script:


### PR DESCRIPTION
I am not sure if this is the only way a customer could change the default output format, in creek, they have CRAY_FORMAT set to json in .bash_profile. if there is another way to change cray cli's default output format, we should add here.