### PR TITLE
CRAYSAT-1206: Add guidance for API timeouts for CAPMC during power off

### DIFF
--- a/operations/power_management/Power_Off_Compute_and_IO_Cabinets.md
+++ b/operations/power_management/Power_Off_Compute_and_IO_Cabinets.md
@@ -41,6 +41,12 @@ When the PDU breakers are switched to OFF, the Chassis Management Modules \(CMMs
 
     This command suspends the hms-discovery cron job and recursively powers off the liquid-cooled cabinet chassis.
 
+    The `sat bootsys shutdown` command may fail to power off some cabinets and indicate that requests to CAPMC have timed out. In this case, the `sat` command may be run with an increased `--api-timeout` option.
+
+    ```bash
+    ncn-m001# sat --api-timeout 180 bootsys shutdown --stage cabinet-power
+    ```
+
 5.  Verify that the hms-discovery cron job has been suspended \(`SUSPEND` column = true\).
 
     ```bash


### PR DESCRIPTION
This change adds a note to the "Power Off Compute and IO Cabinets"
section which describes how to resolve issues which may occur when
running the `sat bootsys shutdown --stage cabinet-power` command. In the
event that the command times out, it is now suggested that the command
be run with a higher value for `--api-timeout`.