### PR TITLE
CASMINST-3430 - DOCS: If sdu fails, direct to SDU documentation

### DIFF
--- a/upgrade/prepare_for_upgrade.md
+++ b/upgrade/prepare_for_upgrade.md
@@ -25,6 +25,7 @@ Before beginning an upgrade to a new version of CSM, there are a few things to d
         ncn-m001# sdu --scenario triage --start_time '-4 hours' \
         --reason "saving state before powerdown/up"
         ```
+        Refer to the HPE Cray EX System Dump Utility (SDU) Administration Guide for more information and troubleshooting steps.
 
     1. Check Ceph status.
 


### PR DESCRIPTION
The `upgrade/prepare_for_upgrade.md` doc directs an admin to run an SDU command to test behaviour.

Added a pointer to the SDU documentation for further information and troubleshooting.