### PR TITLE
CASMHMS-5244 Add known Mountain BMC Warning flag issue to HMS health check documentation csm-1.0

### DIFF
--- a/troubleshooting/interpreting_hms_health_check_results.md
+++ b/troubleshooting/interpreting_hms_health_check_results.md
@@ -249,7 +249,7 @@ This section outlines known issues that cause HMS Health Check failures.
 
 #### SDEVICE-3319 - Warning flags incorrectly set in HSM for Mountain BMCs
 
-The HMS functional tests include a check for unexpected flags that may be set in Hardware State Manager (HSM) for the BMCs on the system. There is a known issue [SDEVICE-3319](https://connect.us.cray.com/jira/browse/SDEVICE-3319) that can cause Warning flags to be incorrectly set in HSM for Mountain BMCs and result in test failures. If _test_smd_components_ncn-functional_remote-functional.tavern.yaml_ fails during the HMS functional test run with error messages about Warning flags being set on one or more BMCs:
+The HMS functional tests include a check for unexpected flags that may be set in Hardware State Manager (HSM) for the BMCs on the system. There is a known issue [SDEVICE-3319](https://connect.us.cray.com/jira/browse/SDEVICE-3319) that can cause Warning flags to be incorrectly set in HSM for Mountain BMCs and result in test failures. If _test_smd_components_ncn-functional_remote-functional.tavern.yaml_ fails with error messages about Warning flags being set on one or more BMCs:
 
 ```
 =================================== FAILURES ===================================

--- a/troubleshooting/interpreting_hms_health_check_results.md
+++ b/troubleshooting/interpreting_hms_health_check_results.md
@@ -247,7 +247,7 @@ ncn# cray hsm inventory redfishEndpoints describe <xname>
 
 This section outlines known issues that cause HMS Health Check failures.
 
-#### SDEVICE-3319 - Warning flags set in HSM for Mountain BMCs
+#### SDEVICE-3319 - Warning flags incorrectly set in HSM for Mountain BMCs
 
 The HMS functional tests include a check for unexpected flags that may be set in Hardware State Manager (HSM) for the BMCs on the system. There is a known issue [SDEVICE-3319](https://connect.us.cray.com/jira/browse/SDEVICE-3319) that can cause Warning flags to be incorrectly set in HSM for Mountain BMCs and result in test failures. If _test_smd_components_ncn-functional_remote-functional.tavern.yaml_ fails during the HMS functional test run with error messages about Warning flags being set on one or more BMCs:
 


### PR DESCRIPTION
### Summary and Scope

Add known Mountain BMC Warning flag issue SDEVICE-3319 to HMS health check documentation for csm-1.0. This section was previously removed since SDEVICE-3319 is fixed in the Mountain BMC firmware version included with csm-1.0, however this issue may still cause test failures during upgrades to csm-1.0 from csm-0.9 if BMC firmware isn't also updated.

### Issues and Related PRs

* Resolves CASMHMS-5244 in csm-1.0.

### Testing

Verified that the Markdown documentation changes rendered successfully in StackEdit.

### Risks and Mitigations

No risks.