### PR TITLE
CASMINST-3460: Remove reference to CAN vrf in BGP from csm-1.0 docs

### DIFF
--- a/upgrade/update_management_network.md
+++ b/upgrade/update_management_network.md
@@ -54,11 +54,9 @@ router bgp 65533
 ```bash
 sw-spine-001 [standalone: master] # show run | include bgp
    protocol bgp
-   router bgp 65533 vrf CAN
    router bgp 65533 vrf default
    router bgp 65533 vrf default router-id 10.252.0.2 force
    router bgp 65533 vrf default maximum-paths ibgp 32
-   router bgp 65533 vrf CAN maximum-paths 32
 ```
 
 ### Aruba BGP updates


### PR DESCRIPTION
Per Sean Lynn, this was mistakenly pulled into the csm-1.0 docs but should only be in the csm-1.2 docs. We ran into this during the creek csm-1.0 RC 3 upgrade. This PR just removes the mistakenly added lines from the update management network document.