### PR TITLE
CASMINST-3437: Add note to correct message printed by prerequisites.sh

### DIFF
--- a/upgrade/1.0/Stage_0_Prerequisites.md
+++ b/upgrade/1.0/Stage_0_Prerequisites.md
@@ -106,6 +106,8 @@ Perform these steps to update `customizations.yaml`:
 
 1. Run check script:
 
+    **NOTE** The `prerequisites.sh` script will warn that it will unmount `/mnt/pitdata`, but this is not accurate. The script will only unmount it if the script itself mounts it. That is, if it is mounted when the script begins, the script will not unmount it.
+
     * Option 1 - Internet Connected Environment
 
         1. Set the `ENDPOINT` variable to the URL of the directory containing the CSM release tarball.

--- a/upgrade/1.0/Stage_3.md
+++ b/upgrade/1.0/Stage_3.md
@@ -52,6 +52,8 @@ For `ncn-m001`, use `ncn-m002` as the stable NCN. Use `vlan007`/CAN IP address t
 
 1. Install document RPM and run check script on `ncn-m002`
 
+    **NOTE** The `prerequisites.sh` script will warn that it will unmount `/mnt/pitdata`, but this is not accurate. The script will only unmount it if the script itself mounts it. That is, if it is mounted when the script begins, the script will not unmount it.
+
     * Option 1 - Internet Connected Environment
 
         1. Install document RPM package:


### PR DESCRIPTION
The prerequisites.sh script prints a warning about unmounting /mnt/pitdata, but that warning is no longer accurate after some script changes. This adds a note to the upgrade documentation that clarifies what the script actually does.