### PR TITLE
CASMNET-1000 - cray-externaldns is not populating the cmn and can DNS zones

### DIFF
--- a/upgrade/1.2/scripts/upgrade/update-customizations.sh
+++ b/upgrade/1.2/scripts/upgrade/update-customizations.sh
@@ -94,8 +94,13 @@ if [[ -z "$(yq r "$c" 'spec.kubernetes.sealed_secrets.dnssec')" ]]; then
   yq w -i "$c" 'spec.kubernetes.sealed_secrets.dnssec.generate.data[0].args.value' ZHVtbXkK
 fi
 
-# Delete unused externaldns configuraation
+# Remove unused cray-externaldns configuration and add domain filters required for bifurcated CAN.
 yq d -i "$c" 'spec.kubernetes.services.cray-externaldns'
+yq w -i --style=single "$c" 'spec.kubernetes.services.cray-externaldns.external-dns.domainFilters[+]' 'cmn.{{ network.dns.external }}'
+yq w -i --style=single "$c" 'spec.kubernetes.services.cray-externaldns.external-dns.domainFilters[+]' 'can.{{ network.dns.external }}'
+yq w -i --style=single "$c" 'spec.kubernetes.services.cray-externaldns.external-dns.domainFilters[+]' 'chn.{{ network.dns.external }}'
+yq w -i --style=single "$c" 'spec.kubernetes.services.cray-externaldns.external-dns.domainFilters[+]' 'nmn.{{ network.dns.external }}'
+yq w -i --style=single "$c" 'spec.kubernetes.services.cray-externaldns.external-dns.domainFilters[+]' 'hmn.{{ network.dns.external }}'
 
 # Add required PowerDNS and Unbound configuration
 yq w -i "$c" 'spec.kubernetes.services.cray-dns-unbound.domain_name' '{{ network.dns.external }}'


### PR DESCRIPTION
### Summary and Scope

Bifurcated CAN breaks the system domain out into multiple subdomains (cmn.<system_domain>, can.<system_domain>, chn.<system_domain>, nmn.<system_domain>, hmn.<system_domain>)

In order to have External DNS populate these zones correctly rather than just populating the top level <system_domain>, domain filters need to be specified via the External DNS `--domain-filter` command line option.

### Issues and Related PRs

* Resolves CASMNET-1000

### Testing

Tested on:

* Fresh install tested on wasp

### Risks and Mitigations

Requires:

* Upgrade testing