### PR TITLE
rescan ssh keys on all storage nodes

### DIFF
--- a/upgrade/1.0/Stage_2.md
+++ b/upgrade/1.0/Stage_2.md
@@ -20,7 +20,7 @@
 
 1. After `ncn-upgrade-ceph-nodes.sh` has successfully run for all storage nodes, rescan ssh keys on all storage nodes
     ```bash
-    ncn-m001# grep -oP "(ncn-s\w+)" /etc/hosts | sort -u | xargs -t -i ssh {} 'rm -rf /root/.ssh/known_hosts'
+    ncn-m001# grep -oP "(ncn-s\w+)" /etc/hosts | sort -u | xargs -t -i ssh {} 'truncate --size=0 ~/.ssh/known_hosts'
 
     ncn-m001# grep -oP "(ncn-s\w+)" /etc/hosts | sort -u | xargs -t -i ssh {} 'grep -oP "(ncn-s\w+|ncn-m\w+|ncn-w\w+)" /etc/hosts | sort -u | xargs -t -i ssh-keyscan -H \{\} >> /root/.ssh/known_hosts'
     ```

--- a/upgrade/1.0/Stage_2.md
+++ b/upgrade/1.0/Stage_2.md
@@ -18,7 +18,14 @@
 
 1. Repeat the previous step for each other storage node, one at a time.
 
-1. After `ncn-upgrade-ceph-nodes.sh` has successfully run for all storage nodes, deploy `node-exporter` and `alertmanager`.
+1. After `ncn-upgrade-ceph-nodes.sh` has successfully run for all storage nodes, rescan ssh keys on all storage nodes
+    ```bash
+    ncn-m001# grep -oP "(ncn-s\w+)" /etc/hosts | sort -u | xargs -t -i ssh {} 'rm -rf /root/.ssh/known_hosts'
+
+    ncn-m001# grep -oP "(ncn-s\w+)" /etc/hosts | sort -u | xargs -t -i ssh {} 'grep -oP "(ncn-s\w+|ncn-m\w+|ncn-w\w+)" /etc/hosts | sort -u | xargs -t -i ssh-keyscan -H \{\} >> /root/.ssh/known_hosts'
+    ```
+
+1. Deploy `node-exporter` and `alertmanager`.
 
     **NOTE:** This process will need to run on a node running `ceph-mon`, which in most cases will be `ncn-s001`, `ncn-s002`, and `ncn-s003`. It only needs to be run once, not on every one of these nodes.
 


### PR DESCRIPTION
## Summary and Scope

rescan ssh keys/fingerprints on all storage nodes after upgrade. It is blocking storage nodes reboot after 0.9 -> 1.0 upgrade

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-3462](https://connect.us.cray.com/jira/browse/CASMINST-3462)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `drax`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?yes
- Were continuous integration tests run? If not, why?no, this is doc only change
- Was upgrade tested? If not, why?yes
- Was downgrade tested? If not, why?no, this is doc only change
- Were new tests (or test issues/Jiras) created for this change?no, this is doc only change

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

