### PR TITLE
CASMTRIAGE-2690: Clarify NCN Password Update Procedures

### DIFF
--- a/operations/CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md
+++ b/operations/CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md
@@ -109,19 +109,16 @@ CSM-provided keys.
    ```
 
 <a name="set_root_password"></a>
-## Set the Root Password
+## Configure the Root Password in Vault
 
-This procedure should be run during CSM installation and afterwards whenever
-the password needs to be changed per site requirements.
-
-The root password is managed on NCNs by using the `csm.password` Ansible role
+The root password is applied to NCNs by using the `csm.password` Ansible role
 located in the CSM configuration management repository. Root passwords are set
 and managed in Vault.
 
-1. Set the password in Vault by following steps 1-3 in the
-   [Update NCN Passwords](../security_and_authentication/Update_NCN_Passwords.md)
-   procedure.
-1. Run [NCN personalization](#run_ncn_personalization).
+1. Set the password in Vault by following the _Configure Root Password in Vault_
+   procedure in [Update NCN Passwords](../security_and_authentication/Update_NCN_Passwords.md).
+1. Apply the Vault password to the NCNs in the
+   [NCN personalization](#run_ncn_personalization) procedure.
 
 <a name="run_ncn_personalization"></a>
 ## Run NCN Personalization

--- a/operations/security_and_authentication/Update_NCN_Passwords.md
+++ b/operations/security_and_authentication/Update_NCN_Passwords.md
@@ -34,11 +34,12 @@ applied with the `csm.password` Ansible role via a CFS session.
 
    ```bash
    ncn# kubectl exec -itn vault cray-vault-0 -- sh
-   export VAULT_ADDR=http://cray-vault:8200
-   vault login
-   vault write secret/csm/management_nodes root_password='HASH'
-   vault read secret/csm/management_nodes
-   exit
+
+   cray-vault-0# export VAULT_ADDR=http://cray-vault:8200
+   cray-vault-0# vault login
+   cray-vault-0# vault write secret/csm/management_nodes root_password='HASH'
+   cray-vault-0# vault read secret/csm/management_nodes
+   cray-vault-0# exit
    ```
 
 ### Procedure: Apply Root Password to NCNs (Standalone)


### PR DESCRIPTION
## Summary and Scope

Clarify the NCN password change procedure by splitting the Vault password update into a different section than the CFS session creation sections (either standalone password changes or through NCN personalization).

Also, add pod shell prompts to the commands run in a pod to set NCN passwords in Vault.

## Issues and Related PRs

* Resolves [CASMTRIAGE-2690](https://connect.us.cray.com/jira/browse/CASMTRIAGE-2690)
* Also requires changes to `release/1.2` and `main` branches.

## Testing

N/A


## Risks and Mitigations

N/A


## Pull Request Checklist

- [ x ] Version number(s) incremented, if applicable
- [ x ] Copyrights updated
- [ x ] License file intact
- [ x ] Target branch correct
- [ x ] CHANGELOG.md updated
- [ x ] Testing is appropriate and complete, if applicable
- [ x ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

