### PR TITLE
CASMCMS-7673: First draft of csm-1.0.1 upgrade procedure

### DIFF
--- a/install/install_csm_services.md
+++ b/install/install_csm_services.md
@@ -14,8 +14,7 @@ This procedure will install CSM applications and services into the CSM Kubernete
    1. [Apply Pod Priorities](#apply-pod-priorities)
    1. [Apply After Sysmgmt Manifest Workarounds](#apply-after-sysmgmt-manifest-workarounds)
    1. [Known Issues](#known-issues)
-      * [install.sh known issues](#known-issues-install-sh)
-      * [Setup Nexus known issues](#known-issues-setup-nexus)
+      * [`install.sh` Known Issues](#known-issues-install-sh)
    1. [Next Topic](#next-topic)
 
 
@@ -247,8 +246,8 @@ pit# ./lib/setup-nexus.sh
 setup-nexus.sh: OK
 ```
 
-In the event of an error, consult the [known issues](#known-issues) below to
-resolve potential problems and then try running `setup-nexus.sh` again. Note
+In the event of an error, consult [Troubleshoot Nexus](../operations/package_repository_management/Troubleshoot_Nexus.md)
+to resolve potential problems and then try running `setup-nexus.sh` again. Note
 that subsequent runs of `setup-nexus.sh` may report `FAIL` when uploading
 duplicate assets. This is ok as long as `setup-nexus.sh` outputs
 `setup-nexus.sh: OK` and exits with status code `0`.
@@ -373,7 +372,7 @@ Follow the [workaround instructions](../update_product_stream/index.md#apply-wor
 ### 9. Known Issues
 
 <a name="known-issues-install-sh"></a>
-#### 9.1 install.sh known issues
+#### 9.1 `install.sh` Known Issues
 
 The `install.sh` script changes cluster state and should not simply be rerun
 in the event of a failure without careful consideration of the specific
@@ -413,11 +412,6 @@ The following error may occur when running `./install.sh`:
      ```
   
   4. Running `install.sh` again is expected to succeed.
-
-<a name="known-issues-setup-nexus"></a>
-#### 9.2 Setup Nexus known issues
-
-Known potential issues with suggested fixes are listed in [Troubleshoot Nexus](../operations/package_repository_management/Troubleshoot_Nexus.md).
 
 <a name="next-topic"></a>
 # 10. Next Topic

--- a/update_product_stream/index.md
+++ b/update_product_stream/index.md
@@ -45,8 +45,11 @@ None.
 
       If doing a first time install, this can be done on a Linux system, but for an upgrade, it could be done on one of the NCNs, such as ncn-m001.
 
+      > **`NOTE:`** Use `--no-same-owner` and `--no-same-permissions` options to `tar` when extracting a CSM release
+      > distribution as `root` to ensure the current `umask` value.
+
       ```bash
-      linux# tar -xzvf ${CSM_RELEASE}.tar.gz
+      linux# tar --no-same-owner --no-same-permissions -xzvf ${CSM_RELEASE}.tar.gz
       ```
 
    1. Before using this software release, check for any patches available for it. If patches are available, see [Apply Patch to CSM Release](#patch).

--- a/upgrade/1.0.1/README.md
+++ b/upgrade/1.0.1/README.md
@@ -1,0 +1,135 @@
+# CSM 1.0.1 Patch Installation Instructions
+
+## Steps
+1. [Preparation](#preparation)
+1. [Setup Nexus](#setup-nexus)
+1. [Upgrade Services](#upgrade-services)
+1. [Rollout Deployment Restart](#rollout-deployment-restart)
+1. [Verification](#verification)
+1. [Exit Typescript](#exit-typescript)
+
+<a name="preparation"></a>
+## Preparation
+
+1. Start a typescript on `ncn-m001` to capture the commands and output from this procedure.
+
+    ```bash
+    ncn-m001# script -af csm-update.$(date +%Y-%m-%d).txt
+    ncn-m001# export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
+    ```
+
+1. Download and extract the CSM 1.0.1 release to `ncn-m001`.
+
+    See [Download and Extract CSM Product Release](../../update_product_stream/index.md#download-and-extract).
+
+1. Set `CSM_DISTDIR` to the directory of the extracted files:
+
+    **IMPORTANT**: If necessary, be sure to change this example command to match the actual location of the extracted files.
+
+    ```bash
+    ncn-m001# export CSM_DISTDIR="$(pwd)/csm-1.0.1"
+    ```
+
+1. Set `CSM_RELEASE_VERSION` to the version reported by `${CSM_DISTDIR}/lib/version.sh`:
+
+    ```bash
+    ncn-m001# CSM_RELEASE_VERSION="$(${CSM_DISTDIR}/lib/version.sh --version)"
+    ncn-m001# echo $CSM_RELEASE_VERSION
+    ```
+
+1. Download and install/upgrade the _latest_ documentation and workarounds RPMs on `ncn-m001`.
+
+    See [Check for Latest Workarounds and Documentation Updates](../../update_product_stream/index.md#workarounds).
+
+<a name="setup-nexus"></a>
+## Setup Nexus
+
+Run `lib/setup-nexus.sh` to configure Nexus and upload new CSM RPM
+repositories, container images, and Helm charts:
+
+```bash
+ncn-m001# cd "$CSM_DISTDIR"
+ncn-m001# ./lib/setup-nexus.sh
+```
+
+On success, `setup-nexus.sh` will output `OK` on stderr and exit with status
+code `0`, e.g.:
+
+```bash
++ Nexus setup complete
+setup-nexus.sh: OK
+ncn-m001# echo $?
+0
+```
+
+In the event of an error, consult [Troubleshoot Nexus](../../operations/package_repository_management/Troubleshoot_Nexus.md)
+to resolve potential problems and then try running `setup-nexus.sh` again. Note that subsequent runs of `setup-nexus.sh` may
+report `FAIL` when uploading duplicate assets. This is ok as long as `setup-nexus.sh` outputs `setup-nexus.sh: OK` and exits
+with status code `0`.
+
+<a name="upgrade-services"></a>
+## Upgrade Services
+
+Run `upgrade.sh` to deploy upgraded CSM applications and services:
+
+```bash
+ncn-m001# cd "$CSM_DISTDIR"
+ncn-m001# ./upgrade.sh
+```
+
+<a name="rollout-deployment-restart"></a>
+## Rollout Deployment Restart
+
+Instruct Kubernetes to gracefully restart the Unbound pods:
+
+```text
+ncn-m001:~ # kubectl -n services rollout restart deployment cray-dns-unbound
+deployment.apps/cray-dns-unbound restarted
+ 
+ncn-m001:~ # kubectl -n services rollout status deployment cray-dns-unbound
+Waiting for deployment "cray-dns-unbound" rollout to finish: 0 out of 3 new replicas have been updated...
+Waiting for deployment "cray-dns-unbound" rollout to finish: 3 old replicas are pending termination...
+Waiting for deployment "cray-dns-unbound" rollout to finish: 3 old replicas are pending termination...
+Waiting for deployment "cray-dns-unbound" rollout to finish: 3 old replicas are pending termination...
+Waiting for deployment "cray-dns-unbound" rollout to finish: 2 old replicas are pending termination...
+Waiting for deployment "cray-dns-unbound" rollout to finish: 2 old replicas are pending termination...
+Waiting for deployment "cray-dns-unbound" rollout to finish: 2 old replicas are pending termination...
+Waiting for deployment "cray-dns-unbound" rollout to finish: 1 old replicas are pending termination...
+Waiting for deployment "cray-dns-unbound" rollout to finish: 1 old replicas are pending termination...
+deployment "cray-dns-unbound" successfully rolled out
+```
+
+<a name="verification"></a>
+## Verification
+
+### Verify CSM Version in Product Catalog
+
+1. Verify that the following command includes the new CSM version:
+
+    ```bash
+    ncn-m001# kubectl get cm cray-product-catalog -n services -o jsonpath='{.data.csm}' | yq r -j - | jq -r 'to_entries[] | .key' | sort -V
+    0.9.2
+    0.9.3
+    0.9.4
+    0.9.5
+    0.9.6
+    1.0.0
+    1.0.1
+    ```
+
+1. Confirm the `import_date` reflects the timestamp of the upgrade:
+
+    ```bash
+    ncn-m001# kubectl get cm cray-product-catalog -n services -o jsonpath='{.data.csm}' | yq r  - '"1.0.1".configuration.import_date'
+    ```
+
+<a name="exit-typescript"></a>
+## Exit Typescript
+
+Remember to exit your typescript.
+
+```bash
+ncn-m001# exit
+```
+
+It is recommended to save the typescript file for later reference.

--- a/upgrade/index.md
+++ b/upgrade/index.md
@@ -18,74 +18,74 @@ product streams for the HPE Cray EX system can be installed or upgraded.
 Note: If problems are encountered during the upgrade, some of the topics do have their own troubleshooting
 sections, but there is also a general troubleshooting topic.
 
-## Details
-
 <a name="prepare_for_upgrade"></a>
+## Prepare For Upgrade
 
-1. Prepare for Upgrade
+See [Prepare for Upgrade](prepare_for_upgrade.md)
 
-    See [Prepare for Upgrade](prepare_for_upgrade.md)
+<a name="upgrade_management_nodes_csm_services"></a>
+## Upgrade Management Nodes and CSM Services
 
-   <a name="upgrade_management_nodes_csm_services"></a>
+The procedure you follow depends on the new CSM version to which you are upgrading:
+   
+* Upgrading **to CSM 1.0.0**
 
-1. Upgrade Management Nodes and CSM Services
+    The upgrade of CSM software will do a controlled, rolling reboot of all management nodes before updating the CSM services.
 
-   The upgrade of CSM software will do a controlled, rolling reboot of all management nodes before updating the CSM services.
+    The upgrade is a guided process starting with [Upgrade Management Nodes and CSM Services](1.0/README.md).
 
-   The upgrade is a guided process Starting with [Upgrade Management Nodes and CSM Services](1.0/README.md)
-
-   <a name="update_management_network"></a>
-
-1. Update Management Network
-
-   There are new features and functions with Shasta v1.5. Some of these changes were available as patches and hotfixes
-   for Shasta v1.4, so may already be applied.
-   * Static Lags from the CDU switches to the CMMs (Aruba and Dell).
-   * HPE Apollo node port config, requires a trunk port to the iLO.
-   * BGP TFTP static route removal (Aruba).
-   * BGP passive neighbors (Aruba and Mellanox)
-
-   See [Update Management Network](update_management_network.md)
-
-   <a name="validate_csm_health"></a>
-
-1. Validate CSM Health
-
-     > **`IMPORTANT:`** Wait at least 15 minutes after
-     > [`csm-service-upgrade.sh`](1.0/Stage_4.md) in stage 4 completes to let the various Kubernetes
-     > resources get initialized and started.
+* Upgrading **to CSM 1.0.1**
+   
+    **IMPORTANT**: You must already be at CSM 1.0.0 in order to upgrade to CSM 1.0.1.
   
-     Run the following validation checks to ensure that everything is still working
-     properly after the upgrade:
-  
-     > **`IMPORTANT:`** If your site does not use UAIs, skip UAS and UAI validation. If you do use
-     > UAIs, there are products that configure UAS like Cray Analytics and Cray Programming Environment that
-     > must be working correctly with UAIs and should be validated and corrected (the procedures for this are
-     > beyond the scope of this document) prior to validating UAS and UAI. Failures in UAI creation that result
-     > from incorrect or incomplete installation of these products will generally take the form of UAIs stuck in
-     > waiting state trying to set up volume mounts.
-  
-     1. [Platform Health Checks](../operations/validate_csm_health.md#platform-health-checks)
-     2. [Hardware Management Services Health Checks](../operations/validate_csm_health.md#hms-health-checks)
-     3. [Software Management Services Validation Utility](../operations/validate_csm_health.md#sms-health-checks)
-     4. [Validate UAS and UAI Functionality](../operations/validate_csm_health.md#uas-uai-validate)
-  
-     Booting the barebones image on the compute nodes should be skipped if the compute nodes have been running
-     application workload during the the CSM upgrade.
-  
-     See [Validate CSM Health](../operations/validate_csm_health.md)
-  
-     <a name="update_firmware_with_fas"></a>
+    The upgrade is a guided process starting with [CSM 1.0.1 Patch Installation Instructions](1.0.1/README.md).
 
-1. Update Firmware with FAS
+<a name="update_management_network"></a>
+## Update Management Network
 
-    See [Update Firmware with FAS](../operations/firmware/Update_Firmware_with_FAS.md)
+**IMPORTANT**: Only do this step if upgrading from CSM 0.9 (Shasta 1.4). If upgrading from CSM 1.0 (Shasta 1.5), skip this step.
 
-    <a name="next_topic"></a>
+There are new features and functions with Shasta v1.5. Some of these changes were available as patches and hotfixes
+for Shasta v1.4, so may already be applied.
+* Static Lags from the CDU switches to the CMMs (Aruba and Dell).
+* HPE Apollo node port config, requires a trunk port to the iLO.
+* BGP TFTP static route removal (Aruba).
+* BGP passive neighbors (Aruba and Mellanox)
 
-1. Next Topic
+See [Update Management Network](update_management_network.md)
 
-    After completion of the firmware update with FAS, the CSM product stream has been fully upgraded and
-    configured. Refer to the 1.5 _HPE Cray EX System Software Getting Started Guide S-8000_ 
-    on the HPE Customer Support Center at https://www.hpe.com/support/ex-gsg 
-    more information on other product streams to be upgraded and configured after CSM.
+<a name="validate_csm_health"></a>
+## Validate CSM Health
+
+> **`IMPORTANT:`** Wait at least 15 minutes after completing the previous steps to let the updated
+> CSM Kubernetes resources initialize and start.
+  
+It is always recommended to run all possible CSM health validation procedures. At a minimum, run the
+following validation checks to ensure that everything is still working properly after the upgrade.
+  
+> **`IMPORTANT:`** If your site does not use UAIs, skip UAS and UAI validation. If you do use
+> UAIs, there are products that configure UAS like Cray Analytics and Cray Programming Environment that
+> must be working correctly with UAIs and should be validated and corrected (the procedures for this are
+> beyond the scope of this document) prior to validating UAS and UAI. Failures in UAI creation that result
+> from incorrect or incomplete installation of these products will generally take the form of UAIs stuck in
+> waiting state trying to set up volume mounts.
+  
+1. [Platform Health Checks](../operations/validate_csm_health.md#platform-health-checks)
+2. [Hardware Management Services Health Checks](../operations/validate_csm_health.md#hms-health-checks)
+3. [Software Management Services Validation Utility](../operations/validate_csm_health.md#sms-health-checks)
+4. [Validate UAS and UAI Functionality](../operations/validate_csm_health.md#uas-uai-validate)
+  
+See [Validate CSM Health](../operations/validate_csm_health.md)
+  
+<a name="update_firmware_with_fas"></a>
+## Update Firmware with FAS
+
+See [Update Firmware with FAS](../operations/firmware/Update_Firmware_with_FAS.md)
+
+<a name="next_topic"></a>
+## Next Topic
+
+After completion of the firmware update with FAS, the CSM product stream has been fully upgraded and
+configured. Refer to the 1.5 _HPE Cray EX System Software Getting Started Guide S-8000_ 
+on the HPE Customer Support Center at https://www.hpe.com/support/ex-gsg 
+more information on other product streams to be upgraded and configured after CSM.

--- a/upgrade/prepare_for_upgrade.md
+++ b/upgrade/prepare_for_upgrade.md
@@ -17,35 +17,35 @@ Before beginning an upgrade to a new version of CSM, there are a few things to d
 
 1. Optional system health checks.
 
-    1. Use the System Dump Utility \(SDU\) to capture current state of system before the shutdown.
+   1. Use the System Dump Utility \(SDU\) to capture current state of system before the shutdown.
 
-        **Important:** SDU takes about 15 minutes to run on a small system \(longer for large systems\).
+      **Important:** SDU takes about 15 minutes to run on a small system \(longer for large systems\).
 
-        ```screen
-        ncn-m001# sdu --scenario triage --start_time '-4 hours' \
-        --reason "saving state before powerdown/up"
-        ```
-        Refer to the HPE Cray EX System Dump Utility (SDU) Administration Guide for more information and troubleshooting steps.
+      ```screen
+      ncn-m001# sdu --scenario triage --start_time '-4 hours' \
+      --reason "saving state before powerdown/up"
+      ```
+      Refer to the HPE Cray EX System Dump Utility (SDU) Administration Guide for more information and troubleshooting steps.
 
-    1. Check Ceph status.
+   1. Check Ceph status.
 
-        ```screen
-        ncn-m001# ceph -s > ceph.status
-        ```
+      ```screen
+      ncn-m001# ceph -s > ceph.status
+      ```
 
-    1. Check Kubernetes pod status for all pods.
+   1. Check Kubernetes pod status for all pods.
 
-        ```screen
-        ncn-m001# kubectl get pods -o wide -A > k8s.pods
-        ```
+      ```screen
+      ncn-m001# kubectl get pods -o wide -A > k8s.pods
+      ```
 
-        Additional Kubernetes status check examples :
+      Additional Kubernetes status check examples :
 
-        ```screen
-        ncn-m001# kubectl get pods -o wide -A | egrep "CrashLoopBackOff" > k8s.pods.CLBO
-        ncn-m001# kubectl get pods -o wide -A | egrep "ContainerCreating" > k8s.pods.CC
-        ncn-m001# kubectl get pods -o wide -A | egrep -v "Run|Completed" > k8s.pods.errors
-        ```
+      ```screen
+      ncn-m001# kubectl get pods -o wide -A | egrep "CrashLoopBackOff" > k8s.pods.CLBO
+      ncn-m001# kubectl get pods -o wide -A | egrep "ContainerCreating" > k8s.pods.CC
+      ncn-m001# kubectl get pods -o wide -A | egrep -v "Run|Completed" > k8s.pods.errors
+      ```
 
 1. Check for running sessions.
 
@@ -71,18 +71,20 @@ Before beginning an upgrade to a new version of CSM, there are a few things to d
 
 1. Coordinate with the site to prevent new sessions from starting in the services listed (BOS, CFS, CRUS, FAS, NMD).
 
-    In version Shasta v1.4, there is no method to prevent new sessions from being created as long as the service APIs are accessible on the API gateway.
-
+    There is currently no method to prevent new sessions from being created as long as the service APIs are accessible on the API gateway.
 
 1. Validate CSM Health
 
-   Run the CSM health checks to ensure that everything is working properly before the upgrade starts.
+   Run the CSM health checks to ensure that everything is working properly before the upgrade starts. It is always best to 
+   perform all possible health checks. Be sure to run the validation procedures appropriate for your **current** CSM version.
 
-   Some of the CSM health checks, such as booting the barebones image on the compute nodes, could be skipped.
+   **NOTE**: Booting the barebones image on the compute nodes may be skipped if all compute nodes are currently running
+   application workloads. However, **it is recommended to do this test if possible**, because it validates that boot services
+   are still working properly.
 
-   See the `CSM Install Validation and Health Checks` procedures **`in the CSM 0.9 documentation`**. 
+   * If upgrading **from CSM 1.0 (Shasta 1.5)**, follow the [Validate CSM Health](../operations/validate_csm_health.md) procedures.
 
-   **`IMPORTANT:`** The validation procedures in the CSM 1.0 documentation are not all intended to work on CSM 0.9.
+   * If upgrading **from CSM 0.9 (Shasta 1.4)**, see the [CSM Install Validation and Health Checks](https://github.com/Cray-HPE/docs-csm/blob/release/0.9/008-CSM-VALIDATION.md) procedures **`in the CSM 0.9 documentation`**. The validation procedures in the CSM 1.0 documentation are not all intended to work on CSM 0.9.
 
 1. Validate Lustre Health
 

--- a/upgrade/update_management_network.md
+++ b/upgrade/update_management_network.md
@@ -1,5 +1,7 @@
 # Update management network from 1.4 to 1.5
 
+**IMPORTANT**: These procedures only need to be followed if upgrading from CSM 0.9 (Shasta 1.4). If upgrading from CSM 1.0 (Shasta 1.5), these procedures should already have been done.
+
 ## New Features and Functions for v1.5
 
 - Static Lags from the CDU switches to the CMMs (Aruba and Dell).


### PR DESCRIPTION
This is the first draft of the csm-1.0.1 upgrade procedure. It involved making some small edits to the existing upgrade documents, so that there was a path for users to follow for 1.0.0 upgrades and 1.0.1 upgrades. 

For the 1.0.1 procedure itself, I essentially copied the 0.9.6 update procedure, removing the parts that do not apply to this upgrade. We can of course build off this skeleton if we want to add additional checks or update operations.