### PR TITLE
Add note about how to get ceph status when ncn-s001 is down

### DIFF
--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -131,6 +131,8 @@ If in doubt, validate the CRUS service using the [CMS Validation Tool](#sms-heal
 
 Additionally, hmn-discovery and unbound manager cronjob pods may be in a 'NotReady' state. This is expected as these pods are periodically started and transition to the completed state.
 
+**IMPORTANT:** If `ncn-s001` is down when running the ncnHealthChecks script, status from the `ceph -s` command  will be unavailable. In this case, the `ceph -s` command can be executed on any available master or storage node to determine the status of the Ceph cluster.
+
 <a name="pet-ncnpostgreshealthchecks"></a>
 ### 1.2 ncnPostgresHealthChecks
 


### PR DESCRIPTION
## Summary and Scope

Add note about how to get ceph status if ncn-s001 is down.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-2693](https://connect.us.cray.com/jira/browse/CASMTRIAGE-2693)

## Testing

N/A

### Tested on:

N/A

### Test description:

N/A

## Risks and Mitigations

N/A


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

