### PR TITLE
MTL-1545 1.2.bootfixes

### DIFF
--- a/upgrade/1.0.1/README.md
+++ b/upgrade/1.0.1/README.md
@@ -67,6 +67,22 @@ to resolve potential problems and then try running `setup-nexus.sh` again. Note 
 report `FAIL` when uploading duplicate assets. This is ok as long as `setup-nexus.sh` outputs `setup-nexus.sh: OK` and exits
 with status code `0`.
 
+<a name="run-validation-checks-pre-upgrade"></a>
+## Run Validation Checks (Pre-Upgrade)
+
+_Pre-upgrades must run after nexus is setup in order to ensure any and all necessary RPMs are available_.
+
+1. Invoke the 1.2 NCN boot order backport
+
+   > **`NOTE`** This presumes all NCNs are still online, and their BMCs are reachable. If some NCNs are not reachable over SSH then the EFI boot menus will not be corrected. If some BMCs are not reachable over IPMI then vendor specific tweaks will not be applied.
+
+   ```bash
+   ncn-m001# export IPMI_PASSWORD=changeme
+   ncn-m001# export CI=1
+   ncn-m001# /usr/share/doc/csm/upgrade/lib/validation/CASMREL-776-CSM12-NCN-boot-order-backport/install-hotfix.sh
+   ```
+
+
 <a name="upgrade-services"></a>
 ## Upgrade Services
 

--- a/upgrade/lib/validation/CASMREL-776-CSM12-NCN-boot-order-backport/README.md
+++ b/upgrade/lib/validation/CASMREL-776-CSM12-NCN-boot-order-backport/README.md
@@ -1,0 +1,34 @@
+# NCN Boot Order Hot-fix/Backport
+
+This hot-fix applies the CSM 1.2 boot order tooling to the non-compute nodes.
+
+## Requirments
+
+All dependencies and necessities are included in this directory.
+
+The RPMs and scripts may be installed and run in either:
+- PIT : Install or Recovery context
+- NCN : Runtime context
+
+Ideally, invoke this hot-fix from ncn-m001 (e.g. any NCN that is reachable over SSH).
+
+> **`CLARIFICATION:`** [] **The intent of this hotfix is executing in runtime, **this** hotfix must run from a node with passwordless-ssh between all the NCNs. **However**, the scripts and RPMs in this hotfix are runnable on a PIT node. The PIT node by default is not configured with passwordless-SSH, the PIT can run this hotfix if and only if the user done the extra step to configure it. This is valuable information for recovery and re-deploy contexts such as; customer wants to use this on a fresh install, or has a problem during an upgrade.
+
+## Usage
+
+1. Just run `install-hotfix.sh` to invoke the hot-fix, and export your BMC password to the shell environment.
+
+    ```bash
+    ncn# export IPMI_PASSWORD=opensesame
+    ncn# ./install-hotfix.sh
+    ```
+
+The NCNs are now configured, and will have deterministic boot ordering.
+
+
+## Triage
+
+If the boot order is out-of-spec following this hot-fix _and_ a single reboot of the NCN (a single reboot is needed to ensure all BIOS changes were taken, and no new unknowns appeared on during POST), then plaese provide the following information to CRAY-HPE in the bug-submission:
+
+- `efibootmgr` output of the afflicted node(s)
+- `node=ncn-m002 && ilorest login $node -u $(whoami) -p $IPMI_PASSWORD && ilorest --nologo list --selector=BIOS.` dump the BIOS settings of the afflicted node(s)

--- a/upgrade/lib/validation/CASMREL-776-CSM12-NCN-boot-order-backport/install-hotfix.sh
+++ b/upgrade/lib/validation/CASMREL-776-CSM12-NCN-boot-order-backport/install-hotfix.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Copyright 2021 Hewlett Packard Enterprise Development LP
+
+set -o errexit
+set -o pipefail
+
+WORKING_DIR=$(dirname $0)
+pitinit_ver='1.2.11-1'
+ilorest_ver='3.2.3-1'
+# Installs RPMs, or fetches them if possible.
+function install_rpms {
+    zypper --no-gpg-checks \
+        --plus-repo https://packages.local/repository/csm-sles-15sp2 \
+        -n in -y \
+        "ilorest=$ilorest_ver" \
+        "pit-init=$pitinit_ver"
+}
+
+# Copies files into place.
+function copy {
+    if [ -f /etc/pit-release ]; then
+        read -r -p "this requires passwordless-SSH; please run this on an NCN or configure the PIT with passwordless-SSH otherwise password prompts will occur. Continue? [y/n]: " response
+        case "$response" in
+            [yY][eE][sS]|[yY])
+                :
+                ;;
+            *)
+                echo 'exiting ...'
+                exit 1
+                ;;
+        esac
+    fi
+    echo "Copying ${WORKING_DIR}/mini-install.sh and ${WORKING_DIR}/metal-lib.sh ${WORKING_DIR}/lib.sh to ..."
+    for ncn in $(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u); do
+        echo "$ncn:/srv/cray/scripts/metal/mini-install.sh"
+        scp ${WORKING_DIR}/scripts/mini-install.sh ${ncn}:/srv/cray/scripts/metal/ >/dev/null
+        echo "$ncn:/srv/cray/scripts/metal/metal-lib.sh"
+        scp ${WORKING_DIR}/scripts/metal-lib.sh ${ncn}:/srv/cray/scripts/metal/ >/dev/null
+        echo "$ncn:/srv/cray/scripts/common/lib.sh"
+        scp ${WORKING_DIR}/scripts/lib.sh ${ncn}:/srv/cray/scripts/common/ >/dev/null
+    done
+
+}
+
+# Runs the scripts
+function run {
+    if [ -z "$IPMI_PASSWORD" ] ; then
+        echo >&2 'Need IPMI_PASSWORD exported to the environment.'
+    fi
+    echo 'Adjusting BIOS facilitating network booting ... (/root/bin/bios-baseline.sh)'
+    export CI='yes' && /root/bin/bios-baseline.sh
+    unset CI
+    echo 'Adjusting UEFI Boot Order ... '
+    for ncn in $(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u); do
+        echo "$ncn - starting mini-install.sh"
+        ssh -o StrictHostKeyChecking=no $ncn /srv/cray/scripts/metal/mini-install.sh
+        echo "$ncn - done"
+    done
+}
+
+function main {
+    rpm -q ilorest pit-init || install_rpms
+    copy
+    run
+    echo 'Done'
+}
+
+main

--- a/upgrade/lib/validation/CASMREL-776-CSM12-NCN-boot-order-backport/scripts/lib.sh
+++ b/upgrade/lib/validation/CASMREL-776-CSM12-NCN-boot-order-backport/scripts/lib.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Permalink to original lib: https://github.com/Cray-HPE/node-image-build/blob/8ec558f712bd894792758058fbdabdb6c2addf38/boxes/ncn-common/files/scripts/common/lib.sh
+function mprint {
+    printf '[% -25s] %s\n' "$0" "$1"
+}

--- a/upgrade/lib/validation/CASMREL-776-CSM12-NCN-boot-order-backport/scripts/metal-lib.sh
+++ b/upgrade/lib/validation/CASMREL-776-CSM12-NCN-boot-order-backport/scripts/metal-lib.sh
@@ -1,0 +1,449 @@
+#!/bin/bash
+# Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# (MIT License)
+# Permalink to original lib: https://github.com/Cray-HPE/node-image-build/blob/cfad25b84431cfc5c3b8935df78a7ce68d4a8be4/boxes/ncn-common/files/scripts/metal/metal-lib.sh
+fslabel=BOOTRAID
+type mprint >/dev/null 2>&1 || . /srv/cray/scripts/common/lib.sh
+
+set -e
+
+# initrd - fetched from /proc/cmdline ; grab the horse we rode in on, not what the API aliens say.
+export initrd=$(grep -Po 'initrd=([\w\.]+)' /proc/cmdline | cut -d '=' -f2)
+[ -z "$initrd" ] && initrd=initrd.img.xz
+
+trim() {
+    local var="$*"
+    var="${var#${var%%[![:space:]]*}}"   # remove leading whitespace characters
+    printf "%s" "$var"
+}
+
+install_grub2() {
+    local working_path=${1:-/metal/recovery}
+    mount -v -L $fslabel $working_path 2>/dev/null || echo 'continuing ...'
+    # Remove all existing ones; this script installs the only bootloader.
+    for entry in $(efibootmgr | awk -F '*' '/CRAY/ {print $1}'); do
+         efibootmgr -q -b ${entry:4:8} -B
+    done
+
+    # Install grub2.
+    local name=$(grep PRETTY_NAME /etc/*release* | cut -d '=' -f2 | tr -d '"')
+    local index=0
+    [ -z "$name" ] && name='CRAY Linux'
+    for disk in $(mdadm --detail $(blkid -L $fslabel) | grep /dev/sd | awk '{print $NF}'); do
+        # Add '--suse-enable-tpm' to grub2-install once we need TPM.
+        grub2-install --no-rs-codes --suse-force-signed --root-directory $working_path --removable "$disk"
+        efibootmgr -c -D -d "$disk" -p 1 -L "CRAY UEFI OS $index" -l '\efi\boot\bootx64.efi' | grep CRAY
+        index=$(($index + 1))
+    done
+
+    # Get the kernel command we used to boot.
+    local init_cmdline=$(cat /proc/cmdline)
+    local disk_cmdline=''
+    for cmd in $init_cmdline; do
+        # cleans up first argument when running this script on a disk-booted system
+        if [[ $cmd =~ kernel$ ]]; then
+            cmd=$(basename "$(echo $cmd  | awk '{print $1}')")
+        fi
+        if [[ $cmd =~ ^rd.live.overlay.reset ]] ; then :
+        elif [[ $cmd =~ ^rd.debug ]] ; then :
+        # removes all metal vars, and escapes anything that iPXE was escaping
+        # metal vars are used for customizing nodes on deployment, they don't need
+        # to stick around for runtime.
+        # (i.e. ds=nocloud-net;s=http://$url will get the ; escaped)
+        # removes netboot vars
+        elif [[ ! $cmd =~ ^metal. ]] && [[ ! $cmd =~ ^ip=.*:dhcp ]] && [[ ! $cmd =~ ^bootdev= ]]; then
+            disk_cmdline="$(trim $disk_cmdline) ${cmd//;/\\;}"
+        fi
+    done
+
+    # ensure no-wipe is now set for disk-boots.
+    disk_cmdline="$disk_cmdline metal.no-wipe=1"
+
+    # Make our grub.cfg file.
+    # TODO: Add disk-rebuild option
+    cat << EOF > $working_path/boot/grub2/grub.cfg
+set timeout=10
+set default=0 # Set the default menu entry
+menuentry "$name" --class sles --class gnu-linux --class gnu {
+    set gfxpayload=keep
+    # needed for compression
+    insmod gzio
+    # needed for partition manipulation
+    insmod part_gpt
+    # needed for block device handles
+    insmod diskfilter
+    # needed for RAID (this does not always load despite this entry)
+    insmod mdraid1x
+    # verbosely define accepted formats (ext2/3/4 & xfs)
+    insmod ext2
+    insmod xfs
+    echo    'Loading kernel ...'
+    linuxefi \$prefix/../$disk_cmdline
+    echo    'Loading initial ramdisk ...'
+    initrdefi \$prefix/../$initrd
+}
+EOF
+}
+
+function update_auxiliary_fstab {
+    local working_path=${1:-/metal/recovery}
+
+    # Mount at boot
+    if [ -f /etc/fstab.metal ] && grep -q "${fslabel^^}" /etc/fstab.metal; then :
+    else
+        mkdir -pv $working_path
+        printf '# \nLABEL=%s\t%s\t%s\t%s\t%d\t%d\n' "${fslabel^^}" $working_path vfat defaults 0 0 >> /etc/fstab.metal
+    fi
+}
+
+function get_boot_artifacts {
+    local squashfs_storage
+    local base_dir
+    local live_dir
+    local working_path=${1:-/metal/recovery}
+    local artifact_error=0
+
+    mount -L BOOTRAID -T /etc/fstab.metal && echo 'continuing ...'
+    mkdir -pv $working_path/boot
+
+    squashfs_storage=$(grep -Po 'root=\w+:?\w+=\w+' /proc/cmdline | cut -d '=' -f3)
+    [ -z "$squashfs_storage" ] && squashfs_storage=SQFSRAID
+
+    # rd.live.dir - fetched from /proc/cmdline ; grab any customization or deviation from the default preference, aling with dracut.
+    live_dir=$(grep -Eo 'rd.live.dir=.* ' /proc/cmdline | cut -d '=' -f2 | sed 's![^/]$!&/!')
+    [ -z "$live_dir" ] && live_dir=LiveOS/
+
+    # pull the loaded items from the mounted squashFS storage into the fallback bootloader
+    base_dir="$(lsblk $(blkid -L $squashfs_storage) -o MOUNTPOINT -n)/$live_dir"
+    [ -d $base_dir ] || echo >&2 'SQFSRAID was not mounted!' return 1
+    cp -pv "${base_dir}kernel" "$working_path/boot/" || echo >&2 "Kernel file NOT found in $base_dir!" || artifact_error=1
+    cp -pv "${base_dir}${initrd}" "$working_path/boot/" || echo >&2 "${initrd} file NOT found in $base_dir!" || artifact_error=1
+
+    [ "$artifact_error" = 0 ] && return 0 || return 1
+}
+
+function configure_lldp() {
+    local interfaces
+    interfaces=`ls /sys/class/net/ | grep mgmt`
+    for i in $interfaces; do
+      echo "enabling and configuring LLDP for interface: $i"
+      lldptool set-lldp -i $i adminStatus=rxtx
+      lldptool -T -i $i -V  sysName enableTx=yes
+      lldptool -T -i $i -V  portDesc enableTx=yes
+      lldptool -T -i $i -V  sysDesc enableTx=yes
+      lldptool -T -i $i -V sysCap enableTx=yes
+      lldptool -T -i $i -V mngAddr enableTx=yes
+    done
+    echo 'enabling and configuring of LLDP is complete'
+}
+
+function set_static_fallback() {
+
+    #
+    ## Set static IP; assign the current IP as static.
+    #
+
+    local defgw
+    local ipaddr
+    local lan
+    local netmask
+    local netconf=/tmp/netconf
+
+    # BMCs either run dedicated on lan3 (last LAN channel as is the case with Intel's),
+    # or lan1 (when there's only one channel).
+    if ipmi_output_3=$(ipmitool lan print 3 2>/dev/null); then
+        lan=3
+        echo "$ipmi_output_3" > $netconf
+    elif [ -z $lan ] && ipmi_output_1=$(ipmitool lan print 1 2>/dev/null); then
+        lan=1
+        echo "$ipmi_output_1" > $netconf
+    elif [ -z $lan ]; then
+        echo "Failed to determine which LAN channel to use!"
+    fi
+
+    ipaddr=$(grep -Ei 'IP Address\s+\:' $netconf | awk '{print $NF}')
+    netmask=$(grep -Ei 'Subnet Mask\s+\:' $netconf | awk '{print $NF}')
+    defgw=$(grep -Ei 'Default Gateway IP\s+\:' $netconf | awk '{print $NF}')
+    ipmitool lan set $lan ipsrc static || :
+    ipmitool lan set $lan ipaddr $ipaddr || :
+    ipmitool lan set $lan netmask $netmask || :
+    ipmitool lan set $lan defgw ipaddr $defgw || :
+    ipmitool lan print $lan || :
+    rm -f $netconf
+}
+
+function reset_bmc() {
+    local reset=${1:-'cold'}
+    ipmitool mc reset "$reset"
+    sleep 5 # Allow the BMC to go offline to prevent false-positive for connectivity checks.
+}
+
+function enable_amsd() {
+    if ! rpm -qi amsd >/dev/null 2>&1 ; then
+        echo 'amsd is not installed, ignoring amsd services'
+        return 0
+    fi
+    echo scanning vendor ... && vendor=$(ipmitool fru | grep -i 'board mfg' | tail -n 1 | cut -d ':' -f2 | tr -d ' ')
+    case $vendor in
+        *Marvell*|HP|HPE)
+            echo Enabling iLO services for detected vendor: $vendor
+            systemctl enable ahslog
+            systemctl enable amsd
+            systemctl enable smad
+
+            # Not needed; SCSI, IDE, nor FCA are used
+            # systemctl enable cpqFca
+            # systemctl enable cpqIde
+            # systemctl enable cpqScsi
+
+            systemctl start ahslog
+            systemctl start amsd
+            systemctl start smad
+
+            # Not needed; SCSI, IDE, nor FCA are used
+            # systemctl start cpqFca
+            # systemctl start cpqIde
+            # systemctl start cpqScsi
+            ;;
+        *)
+        echo >&2 not enabling iLO services for detected vendor: $vendor
+        ;;
+    esac
+}
+
+function clean_bogies {
+    # removing eth0 configs
+    # ALWAYS DO THIS; THESE SHOULD NOT EXIST IN METAL
+    # Any interface file that exists is tracked by wicked, if the interface does
+    # not actually exist in reality then wicked will complain. Remove the needless files.
+    rm -rfv /etc/sysconfig/network/*eth*
+}
+
+function drop_metal_tcp_ip {
+    local nic=$1
+    [ -z "$nic" ] && return 0
+    local ip4addr
+    local ip6addr
+    ip4addr=$(ip a s $nic | grep 'inet '| head -n 1 | awk '{print $2}')
+    ip6addr=$(ip a s $nic | grep inet6 | head -n 1 | awk '{print $2}')
+    if [ -n "$ip4addr" ]; then
+        echo "Deleting ephemeral bootstrap IP $ip4addr from $nic"
+        ip a d $ip4addr dev $nic
+    fi
+    if [ -n "$ip6addr" ]; then
+        echo "Deleting ephemeral bootstrap IP $ip6addr from $nic"
+        ip a d $ip6addr dev $nic
+    fi
+}
+
+function write_default_route {
+    # Setup the route
+    # ALWAYS CLOBBER; ROUTE SHOULD ALWAYS BE THE SAME
+    # CLOBBER=UPDATE; ALWAYS UPDATE.
+    local gw
+    local nic=bond0.cmn0
+    gw=$(craysys metadata get --level node ipam | jq .cmn.gateway | tr -d '"')
+    echo "default ${gw} - $nic" >/etc/sysconfig/network/ifroute-$nic && wicked ifreload all || systemctl restart wickedd && sleep 3
+}
+
+# This will let the order fall into however the BIOS wants it; grouping netboot, disk, and removable options.
+
+# Set to 1 to skip enforcing the order, but still cleanup the boot menu.
+[ -z "$no_enforce" ] && export no_enforce=0
+[ -z "$efibootmgr_prefix" ] && export efibootmgr_prefix=''
+
+function efi_fail_host {
+    echo >&2 "no prefix-driver for hostname: $hostname"
+    return 1
+}
+
+function efi_trim {
+    echo disabling undesired boot entries $(cat /tmp/rbbs*) && cat /tmp/rbbs* | sort | sed 's/^Boot//g' | awk '{print $1}' | tr -d '*' | xargs -r -i efibootmgr -b {} -A
+}
+
+function efi_remove {
+    echo removing undesired boot entries $(cat /tmp/sbbs*) && cat /tmp/sbbs* | sort | sed 's/^Boot//g' | awk '{print $1}' | tr -d '*' | xargs -r -i efibootmgr -b {} -B
+}
+
+function efi_enforce {
+    # IMPORTANT: The ENTIRE list of entries needs to exist, otherwise iLO/HPE servers will undo any changes.
+    # both /tmp/bbs* and /tmp/rbbs* are concatenated together; the ordinal order of the /tmp/bbsNUM files
+    # will enforce NICs first.
+    echo enforcing boot order $(cat /tmp/bbs*) && efibootmgr -o $efibootmgr_prefix$(cat /tmp/bbs* | sed 's/^Boot//g' | awk '{print $1} ' | tr -d '*' | tr -d '\n' | sed -r 's/(.{4})/\1,/g;s/,$//'),$(cat /tmp/rbbs* | sed 's/^Boot//g' | awk '{print $1} ' | tr -d '*' | tr -d '\n' | sed -r 's/(.{4})/\1,/g;s/,$//') | grep -i bootorder
+    echo activating boot entries && cat /tmp/bbs* | awk '!x[$0]++' | sed 's/^Boot//g' | tr -d '*' | awk '{print $1}' | xargs -r -i efibootmgr -b {} -a
+}
+
+# uses /tmp/rbbs99
+function efi_specials {
+    # TODO: If Marvell; then ensure PXE retries only once per NIC.
+    echo 'removing Shasta V1.3 items' && efibootmgr | grep -iP '(crayinstall|sles-secureboot)' | tee /tmp/sbbs
+}
+
+function setup_uefi_bootorder() {
+cat << EOM
+Configuring UEFI boot-order...
+these use the same commands from the manual page:
+    https://github.com/Cray-HPE/docs-csm/blob/main/background/ncn_boot_workflow.md#setting-order
+EOM
+    echo scanning vendor ... && vendor=$(ipmitool fru | grep -i 'board mfg' | tail -n 1 | cut -d ':' -f2 | tr -d ' ')
+    hostname=${hostname:-$(hostname)}
+    # Add vendors here; add like-vendors on the same case statement.
+    # "like-vendors" means their efibootmgr outboot matches
+
+    # formatting:
+    # if another vendor is identical then it should live with another.
+    # vendors may have differing hostnames, depending where this script runs
+    # vendor)
+    #   hostname_prefix_1)
+    #     file1)
+    #     fileN)
+    #   hostname_prefix_2)
+    #     file1)
+    #     fileN)
+    #   hostname_prefix_N)
+    #     file1)
+    #     fileN)
+    #   error)
+    #   remove_file_1
+    #   remove_file_N
+    # done
+    case $vendor in
+        *GIGABYTE*)
+            # Removal file(s) ...
+            efibootmgr | grep -ivP '(pxe ipv?4.*)' | grep -iP '(adapter|connection|nvme|sata)' | tee /tmp/rbbs1
+            efibootmgr | grep -iP '(pxe ipv?4.*)' | grep -i connection | tee /tmp/rbbs2
+            efibootmgr_prefix=''
+            efi_trim
+            efi_specials
+            efi_remove
+            case $hostname in
+                ncn-m*)
+                    efibootmgr | grep -iP '(pxe ipv?(4|6).*adapter)' | tee /tmp/bbs1
+                    efibootmgr | grep cray | tee /tmp/bbs2
+                    efibootmgr | grep 'UEFI OS' | tee /tmp/bbs3
+                    ;;
+                ncn-s*)
+                    efibootmgr | grep -iP '(pxe ipv?(4|6).*adapter)' | tee /tmp/bbs1
+                    efibootmgr | grep cray | tee /tmp/bbs2
+                    efibootmgr | grep 'UEFI OS' | tee /tmp/bbs3
+                    ;;
+                ncn-w*)
+                    efibootmgr | grep -iP '(pxe ipv?(4|6).*adapter)' | tee /tmp/bbs1
+                    efibootmgr | grep cray | tee /tmp/bbs2
+                    efibootmgr | grep 'UEFI OS' | tee /tmp/bbs3
+                    ;;
+                *)
+                    efi_fail_host
+                    ;;
+            esac
+            ;;
+        *Marvell*|HP|HPE)
+            # Removal file(s) ...
+            efibootmgr | grep -vi 'pxe ipv4' | grep -i adapter |tee /tmp/rbbs1
+            efibootmgr | grep -iP '(sata|nvme)' | tee /tmp/rbbs2
+            efibootmgr_prefix='0000,'
+            efi_trim
+            efi_specials
+            efi_remove
+            case $hostname in
+                ncn-m*)
+                    efibootmgr | grep -i 'port 1' | grep -i 'pxe ipv4' | tee /tmp/bbs1
+                    efibootmgr | grep cray | tee /tmp/bbs2
+                    ;;
+                ncn-s*)
+                    efibootmgr | grep -i 'port 1' | grep -i 'pxe ipv4' | tee /tmp/bbs1
+                    efibootmgr | grep cray | tee /tmp/bbs2
+                    ;;
+                ncn-w*)
+                    efibootmgr | grep -i 'port 1' | grep -i 'pxe ipv4' | tee /tmp/bbs1
+                    efibootmgr | grep cray | tee /tmp/bbs2
+                    ;;
+                *)
+                    efi_fail_host
+                    ;;
+            esac
+            ;;
+        *'Intel'*'Corporation'*)
+            # Removal file(s) ...
+            efibootmgr | grep -vi 'ipv4' | grep -iP '(sata|nvme|uefi)' | tee /tmp/rbbs1
+            efibootmgr | grep -i baseboard | tee /tmp/rbbs2
+            efibootmgr_prefix=''
+            efi_trim
+            efi_specials
+            efi_remove
+            case $hostname in
+                ncn-m*)
+                    efibootmgr | grep -i 'ipv4' | grep -iv 'baseboard' | tee /tmp/bbs1
+                    efibootmgr | grep -i 'cray' | tee /tmp/bbs2
+                    ;;
+                ncn-s*)
+                    efibootmgr | grep -i 'ipv4' | grep -iv 'baseboard' | tee /tmp/bbs1
+                    efibootmgr | grep -i 'cray' | tee /tmp/bbs2
+                    ;;
+                ncn-w*)
+                    efibootmgr | grep -i 'ipv4' | grep -iv 'baseboard' | tee /tmp/bbs1
+                    efibootmgr | grep -i 'cray' | tee /tmp/bbs2
+                    ;;
+                *)
+                    echo >&2 $0 Unsupported node name $hostname
+                    return 1
+                    ;;
+            esac
+            ;;
+        *)
+            echo >&2 not modifying unknown vendor: $vendor
+            return 1
+            ;;
+    esac
+
+    [ "$no_enforce" = 0 ] && efi_enforce
+
+    mprint "log file located at $0.log"
+}
+
+function paginate() {
+    local url="$1"
+    local token
+    { token="$(curl -sSk "$url" | tee /dev/fd/3 | jq -r '.continuationToken // null')"; } 3>&1
+    until [[ "$token" == "null" ]]; do
+        {
+            token="$(curl -sSk "$url&continuationToken=${token}" | tee /dev/fd/3 | jq -r '.continuationToken // null')";
+        } 3>&1
+    done
+}
+
+function install_csm_rpms() {
+
+    # Verify nexus is available.  It's expected to *not* be available during initial install of the NCNs.
+    if ! curl -sSf https://packages.local/service/rest/v1/components?repository=csm-sle-15sp3 >& /dev/null; then
+        echo "unable to contact nexus, bailing"
+        return 0
+    fi
+
+    # Retreive the packages from nexus
+    goss_servers_url=$(paginate "https://packages.local/service/rest/v1/components?repository=csm-sle-15sp2" \
+        | jq -r  '.items[] | .assets[] | .downloadUrl' | grep goss-servers | sort -V | tail -1)
+    csm_testing_url=$(paginate "https://packages.local/service/rest/v1/components?repository=csm-sle-15sp2" \
+        | jq -r  '.items[] | .assets[] | .downloadUrl' | grep csm-testing | sort -V | tail -1)
+    platform_utils_url=$(paginate "https://packages.local/service/rest/v1/components?repository=csm-sle-15sp2" \
+        | jq -r  '.items[] | .assets[] | .downloadUrl' | grep platform-utils | sort -V | tail -1)
+    zypper install -y $goss_servers_url $csm_testing_url $platform_utils_url && systemctl enable goss-servers && systemctl restart goss-servers
+}

--- a/upgrade/lib/validation/CASMREL-776-CSM12-NCN-boot-order-backport/scripts/mini-install.sh
+++ b/upgrade/lib/validation/CASMREL-776-CSM12-NCN-boot-order-backport/scripts/mini-install.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Author: Russell Bunch <doomslayer@hpe.com>
+# Permalink to original script: https://github.com/Cray-HPE/node-image-build/blob/8ec558f712bd894792758058fbdabdb6c2addf38/boxes/ncn-common/files/scripts/metal/install.sh
+trap "printf >&2 'Metal Install: [ % -20s ]' 'failed'" ERR TERM HUP INT
+trap "echo 'See logfile at: /var/log/cloud-init-metal.log'" EXIT
+set -e
+
+# Echo that we're the original, but stripped down script.
+echo "Running stripped CSM 1.2 install.sh script, $0"
+# See the original "install.sh" here: https://raw.githubusercontent.com/Cray-HPE/node-image-build/develop/boxes/ncn-common/files/scripts/metal/install.sh?token=AB3JQE4CBRQKCKMZ5UAKHH3BL4264'
+
+# Load the metal library.
+printf 'Metal Install: [ % -20s ]\n' 'loading ...' && . /srv/cray/scripts/metal/metal-lib.sh && printf 'Metal Install: [ % -20s ]\n' 'loading done' && sleep 2
+
+# 1. Run this first; disable bootstrap info to level the playing field for configuration.
+breakaway() {
+    # clean bootstrap/ephemeral TCP/IP information
+    (
+        set -x
+        clean_bogies
+        drop_metal_tcp_ip bond0
+        write_default_route
+    ) 2>/var/log/cloud-init-metal-breakaway.error
+}
+
+# 2. After detaching bootstrap, setup our bootloader..
+bootloader() {
+    (
+        set -x
+        local working_path=/metal/recovery
+        update_auxiliary_fstab $working_path
+        get_boot_artifacts $working_path
+        install_grub2 $working_path
+    ) 2>/var/log/cloud-init-metal-bootloader.error
+}
+
+# 3. Metal configuration for servers and networks.
+hardware() {
+    (
+        set -x
+        setup_uefi_bootorder
+#         configure_lldp
+#         set_static_fallback
+#         enable_amsd
+    ) 2>/var/log/cloud-init-metal-hardware.error
+}
+
+# 4. CSM Testing and dependencies
+csm() {
+    (
+        set -x
+        install_csm_rpms
+    ) 2>/var/log/cloud-init-metal-csm.error
+}
+
+# MAIN
+(
+    # 1.
+#     printf 'Metal Install: [ % -20s ]\n' 'running: breakaway' >&2
+#     [ -n "$METAL_TIME" ] && time breakaway || breakaway
+
+    # 2.
+    printf 'Metal Install: [ % -20s ]\n' 'running: fallback' >&2
+    [ -n "$METAL_TIME" ] && time bootloader || bootloader
+
+    # 3.
+    printf 'Metal Install: [ % -20s ]\n' 'running: hardware' >&2
+    [ -n "$METAL_TIME" ] && time hardware || hardware
+
+    # 4.
+#     printf 'Metal Install: [ % -20s ]\n' 'running: CSM layer' >&2
+#     [ -n "$METAL_TIME" ] && time csm || csm
+
+) >/var/log/cloud-init-metal.log
+
+printf 'Metal Install: [ % -20s ]\n' 'done and complete'

--- a/upgrade/lib/validation/README.md
+++ b/upgrade/lib/validation/README.md
@@ -1,0 +1,4 @@
+# Pre-Upgrade Scripts
+
+These scripts **must** be invoked before an upgrade.
+


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

This change brings the updated CSM 1.2 bootcode from MTL-1535 into 1.0.1 upgrades.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

Yes; 0.9, 1.0, and forwards compatible with 1.2.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [MTL-1545](https://connect.us.cray.com/jira/browse/MTL-1545)
* Merge with/after https://github.com/Cray-HPE/csm/pull/84

## Testing

_List the environments in which these changes were tested._

Testing of the new content was already done, testing of this hotfix in the context of this repo was not done.

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_

This must be invoked before deploying NCNs, the new settings applied to any NCN requires a reboot. This reboot comes for free during deployment.

The changes here do not mandate a reboot, as they do fix aspects of the bootorder prior to reboot. The BIOS tweaks for HPE servers (none exist for GB and Intel at this time) require a reboot to apply.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

