### PR TITLE
CASMINST-3489 fix ntp config on ncn-m001

### DIFF
--- a/install/redeploy_pit_node.md
+++ b/install/redeploy_pit_node.md
@@ -16,6 +16,7 @@ Topics:
       * [Start Hand-Off](#start-hand-off)
    * [Reboot](#reboot)
    * [Enable NCN Disk Wiping Safeguard](#enable-ncn-disk-wiping-safeguard)
+   * [Fix NTP on ncn-m001](#fix-ntp-config-on-ncn-m001)
    * [Configure DNS and NTP on each BMC](#configure-dns-and-ntp-on-each-bmc)
    * [Validate `BOOTRAID` artifacts](#validate-bootraid-artifacts)
    * [Next Topic](#next-topic)
@@ -506,8 +507,19 @@ the Kubernetes cluster as the final of three master nodes forming a quorum.
 
 > **`CSI NOTE`** `/tmp/csi` will delete itself on the next reboot. The `/tmp` directory is `tmpfs` and runs in memory, it normally will not persist on restarts.
 
+<a name="fix-ntp-config-on-ncn-m001"></a>
+### 6. Fix the NTP Config on ncn-m001
+
+Run the following commands on ncn-m001 **only**:
+
+```bash
+wget -O /usr/lib/python3.6/site-packages/cloudinit/config/cc_ntp.py https://raw.githubusercontent.com/Cray-HPE/metal-cloud-init/main/cloudinit/config/cc_ntp.py
+wget -O /etc/cloud/templates/chrony.conf.cray.tmpl https://raw.githubusercontent.com/Cray-HPE/metal-cloud-init/main/config/cray.conf.j2
+cloud-init single --name ntp --frequency always
+```
+
 <a name="configure-dns-and-ntp-on-each-bmc"></a>
-### 6. Configure DNS and NTP on each BMC
+### 7. Configure DNS and NTP on each BMC
 
  > **`NOTE`** If the system uses Gigabyte or Intel hardware, skip this section.
 


### PR DESCRIPTION
Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>

## Summary and Scope

Adds a step to correct a bug in 1.0 NTP setup.

## Issues and Related PRs

* Resolves CASMINST-3489
* Merge after https://github.com/Cray-HPE/metal-cloud-init/pull/10
* Merge after https://github.com/Cray-HPE/metal-cloud-init/pull/11
* Merge after https://github.com/Cray-HPE/metal-cloud-init/pull/12

## Testing

### Tested on:

  * `#mug` ncn-m001 and ncn-w004

## Risks and Mitigations

Low.  The module can still run as normal and this fixes up the NTP config.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

