### PR TITLE
CASMPET-5066 - Drive location doc

### DIFF
--- a/operations/node_management/NCN_Identify_Drives_Using_ledctl.md
+++ b/operations/node_management/NCN_Identify_Drives_Using_ledctl.md
@@ -1,0 +1,17 @@
+# NCN Drive Identification
+
+Basic usage for the ledmon/ledctl software for drive indentification via the drive leds.
+
+## Usage
+
+Turn on led locator beacon
+
+```bash
+ledctl locate=/dev/<drive>
+```
+
+Turn off led locator beacon
+
+```bash
+ledctl locate_off=/dev/<drive>
+```


### PR DESCRIPTION
## Summary and Scope
- utilizes ledmon/ledctl for drive led beacon

## Issues and Related PRs

* Resolves CASMPET-5066

## Testing

### Tested on:

  * mug

### Test description:

Enabled and disabled the LED locator beacon on drives in the mug environment.  DHCW confirmed the drive beacons were turned on and off.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? n/a
- Were continuous integration tests run? If not, why? n/a
- Was upgrade tested? If not, why? n/a
- Was downgrade tested? If not, why? n/a
- Were new tests (or test issues/Jiras) created for this change? n/a

## Risks and Mitigations

n/a


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

