### PR TITLE
CASMINST-3490: Added tarball expansion estimate and standardized path…

### DIFF
--- a/install/bootstrap_livecd_remote_iso.md
+++ b/install/bootstrap_livecd_remote_iso.md
@@ -97,8 +97,7 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
 
 
    ```bash
-   pit# mkdir -pv /var/www/ephemeral/prep/admin
-   pit# pushd !$
+   pit# cd ~
    pit# script -af csm-install-remoteiso.$(date +%Y-%m-%d).txt
    pit# export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
    ```
@@ -138,7 +137,7 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
    1. (recommended) After reconnecting, resume the typescript (the `-a` appends to an existing script).
 
        ```bash
-      pit# pushd /var/www/ephemeral/prep/admin
+      pit# cd ~
       pit# script -af $(ls -tr csm-install-remoteiso* | head -n 1)
       pit# export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
       ```
@@ -164,6 +163,18 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
     pit# mount -v -L PITDATA
     pit# pushd /var/www/ephemeral
     pit/var/www/ephemeral# mkdir -v prep configs data
+    ```
+
+1. Quit the typescript session with the `exit` command, copy the file (csm-install-remoteis.<date>.txt) from its initial location to the newly created directory, and restart the typescript.
+
+    ```bash
+    pit# mkdir -pv /mnt/pitdata/prep/admin
+    pit# exit # The typescript
+    pit# cp ~/csm-install-remoteiso.*.txt /mnt/pitdata/prep/admin
+    pit# cd /mnt/pitdata/prep/admin
+    pit# script -af $(ls -tr csm-install-remoteiso* | head -n 1)
+    pit# export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
+    pit# pushd /var/www/ephemeral
     ```
 
 1. Download the CSM software release to the PIT node.
@@ -194,6 +205,9 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
       ```
 
    1. Expand the tarball on the PIT node.
+
+      > Note: Expansion of the tarball may take more than 45 minutes.
+
 
       ```bash
       pit:/var/www/ephemeral# tar -zxvf ${CSM_RELEASE}.tar.gz

--- a/install/bootstrap_livecd_usb.md
+++ b/install/bootstrap_livecd_usb.md
@@ -41,6 +41,8 @@ Fetch the base installation CSM tarball and extract it, installing the contained
 
    **Important:** Download to a location that has sufficient space for both the tarball and the expanded tarball.
 
+   > Note: Expansion of the tarball may take more than 45 minutes.
+
    The rest of this procedure will use the CSM_RELEASE variable and expect to have the
    contents of the CSM software release tarball plus any patches, workarounds, or hotfixes.
 
@@ -549,9 +551,9 @@ This will enable SSH, and other services when the LiveCD starts.
 1. Quit the typescript session with the `exit` command and copy the file (csm-install-usb.<date>.txt) to the data partition on the USB drive.
 
     ```bash
-    linux# mkdir -pv /mnt/pitdata/prep/logs
+    linux# mkdir -pv /mnt/pitdata/prep/admin
     linux# exit
-    linux# cp ~/csm-install-usb.*.txt /mnt/pitdata/prep/logs
+    linux# cp ~/csm-install-usb.*.txt /mnt/pitdata/prep/admin
     ```
 
 1. Unmount the data partition:
@@ -663,8 +665,8 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
 1. Start a typescript to record this section of activities done on ncn-m001 while booted from the LiveCD.
 
    ```bash
-   pit# mkdir -pv /var/www/ephemeral/prep/logs
-   pit# script -af /var/www/ephemeral/prep/logs/booted-csm-livecd.$(date +%Y-%m-%d).txt
+   pit# mkdir -pv /var/www/ephemeral/prep/admin
+   pit# script -af /var/www/ephemeral/prep/admin/booted-csm-livecd.$(date +%Y-%m-%d).txt
    pit# export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
    ```
 

--- a/install/create_hmn_connections_json.md
+++ b/install/create_hmn_connections_json.md
@@ -25,7 +25,7 @@ The [SHCD/HMN Connections Rules document](shcd_hmn_connections_rules.md) explain
     
     > The `CSM_RELEASE` environment variable is expected to to be set from the [Bootstrap PIT Node from LiveCD USB](bootstrap_livecd_usb.md) or [Bootstrap Pit Node from LiveCD Remote ISO](bootstrap_livecd_remote_iso.md) procedures.
     >
-    > It is expected that current directory contains the directory of the extracted CSM release tarball.
+    > It is expected that the current directory contains the directory of the extracted CSM release tarball.
 
     Determine the version of the `hms-shcd-parser` container image:
 


### PR DESCRIPTION
## Summary and Scope

CASMINST-3490: 
* Added tarball expansion estimate
* standardized path to store typescripts
* Corrected problem in bootstrap_livecd_remote_iso where the directory containing the typescript was obscured by mounting the PITDATA device on top of it.

## Issues and Related PRs

## Testing


### Tested on:


### Test description:



## Risks and Mitigations



## Pull Request Checklist

