### PR TITLE
CASMINST-3450 : Update the file name to get the BMCs for the NCNs

### DIFF
--- a/background/ncn_boot_workflow.md
+++ b/background/ncn_boot_workflow.md
@@ -76,7 +76,7 @@ If you are reinstalling a system, the BMCs for the NCNs may be set to static. We
 ```bash
 ncn# export USERNAME=root
 ncn# export IPMI_PASSWORD=changeme
-ncn# for h in $( grep mgmt /etc/dnsmasq.d/statics.conf | grep -v m001 | awk -F ',' '{print $2}' )
+ncn# for h in $( grep mgmt /etc/hosts | grep -v m001 | awk -F ',' '{print $2}' )
 do
 ipmitool -U $USERNAME -I lanplus -H $h -E lan set 1 ipsrc dhcp
 done
@@ -87,7 +87,7 @@ Some BMCs need a cold reset in order to pick up this change fully:
 ```bash
 ncn# export USERNAME=root
 ncn# export IPMI_PASSWORD=changeme
-ncn# for h in $( grep mgmt /etc/dnsmasq.d/statics.conf | grep -v m001 | awk -F ',' '{print $2}' )
+ncn# for h in $( grep mgmt /etc/hosts | grep -v m001 | awk -F ',' '{print $2}' )
 do
 ipmitool -U $USERNAME -I lanplus -H $h -E mc reset cold
 done


### PR DESCRIPTION
## Summary and Scope

In the document to get the BMCs for the NCNs "/etc/dnsmasq.d/statics.conf" file has mentioned which infact is not working when the system is in NCN mode . This will work when the system is in PIT . 

Since the Command is running from NCNs , Updated the file name as /etc/hosts in stead of "/etc/dnsmasq.d/statics.conf". 