### PR TITLE
STP-3061 (1.0): Commands missing --format option

### DIFF
--- a/operations/node_management/Find_Node_Type_and_Manufacturer.md
+++ b/operations/node_management/Find_Node_Type_and_Manufacturer.md
@@ -5,21 +5,21 @@ There are three different vendors providing nodes for air-cooled cabinets, which
 HPE nodes contain the /redfish/v1/Systems/1 endpoint:
 
 ```
-ncn-m001# cray hsm inventory componentEndpoints describe XNAME | jq '.RedfishURL'
+ncn-m001# cray hsm inventory componentEndpoints describe XNAME --format json | jq '.RedfishURL'
 "x3000c0s18b0/redfish/v1/Systems/1"
 ```
 
 Gigabyte nodes contain the /redfish/v1/Systems/Self endpoint:
 
 ```
-ncn-m001# cray hsm inventory componentEndpoints describe XNAME | jq '.RedfishURL'
+ncn-m001# cray hsm inventory componentEndpoints describe XNAME --format json | jq '.RedfishURL'
 "x3000c0s7b0/redfish/v1/Systems/Self"
 ```
 
 Intel nodes contain the /redfish/v1/Systems/SERIAL\_NUMBER endpoint:
 
 ```
-ncn-m001# cray hsm inventory componentEndpoints describe XNAME | jq '.RedfishURL'
+ncn-m001# cray hsm inventory componentEndpoints describe XNAME --format json | jq '.RedfishURL'
 "x3000c0s15b0/redfish/v1/Systems/BQWT92000021"
 ```
 


### PR DESCRIPTION
## Summary and Scope

Several commands were missing the `--format` option, causing the commands to fail.

## Issues and Related PRs

* Resolves [STP-3061](https://connect.us.cray.com/jira/browse/STP-3061)

## Testing

N/A

### Tested on:

Gamora

### Test description:

N/A

## Risks and Mitigations

None.
