### PR TITLE
CASMINST-3554 Update Apollo 6500 iLO prep

### DIFF
--- a/install/prepare_compute_nodes.md
+++ b/install/prepare_compute_nodes.md
@@ -1,12 +1,8 @@
-# Prepare Compute nodes
-
-Some compute nodes types need to have additional procedures performed before
-they can be booted, but most compute nodes are ready to be used now.
+# Prepare Compute Nodes
 
 ### Topics:
    1. [Configure HPE Apollo 6500 XL645d Gen10 Plus Compute Nodes](#configure-hpe-apollo-6500-x645d-gen10-plus-compute-nodes)
-
-      1. [Gather Information](#gather_information)
+      1. [Gather information](#gather_information)
       2. [Configure the iLO to use VLAN 4](#configure_ilo)
       3. [Configure the switch port for the iLO to use VLAN 4](#configure_switch_port)
       4. [Clear bad MAC and IP address out of KEA](#cleanup_kea)
@@ -21,7 +17,7 @@ See [Update the Gigabyte Server BIOS Time](../operations/node_management/Update_
 
 <a name="configure-hpe-apollo-6500-x645d-gen10-plus-compute-nodes"></a>
 
-### 1. Configure HPE Apollo 6500 XL645d Gen10 Plus Compute Nodes
+### Configure HPE Apollo 6500 XL645d Gen10 Plus Compute Nodes
 
 The HPE Apollo 6500 XL645d Gen10 Plus compute node uses a NIC/shared iLO network
 port. The NIC is also referred to as the Embedded LOM (LAN On Motherboard) and
@@ -36,18 +32,20 @@ and it will no longer DHCP an IP address.
 This procedure needs to be done for each of the HPE Apollo 6500 XL645d servers
 that will be managed by CSM software. River compute nodes always index their
 BMCs from 1. For example, the compute BMCs in servers with more than one node
-will have xnames as follows x3000c0s30b1, x3000c0s30b2, x3000c0s30b3, etc...
-The node indicator is always a 0. For example, x3000c0s30b1n0 or x3000c0s30b4n0.
+will have xnames as follows: x3000c0s30b1, x3000c0s30b2, x3000c0s30b3, and so
+on.  The node indicator is always a 0. For example, x3000c0s30b1n0 or
+x3000c0s30b4n0.
 
    <a name="gather_information"></a>
 
-1. Gather Information
+1. Gather information
 
-   Example using x3000c0s30b1n0 as the target compute node xname
+   The following is an example using x3000c0s30b1n0 as the target compute node
+   xname:
 
    ```
-   ncn-m001:~ # XNAME=x3000c0s30b1n0
-   ncn-m001:~ # cray hsm inventory ethernetInterfaces list --component-id \
+   ncn-m001# XNAME=x3000c0s30b1n0
+   ncn-m001# cray hsm inventory ethernetInterfaces list --component-id \
          ${XNAME} --format json | jq '.[]|select((.IPAddresses|length)>0)'
    {
    "ID": "6805cabbc182",
@@ -78,14 +76,14 @@ The node indicator is always a 0. For example, x3000c0s30b1n0 or x3000c0s30b4n0.
    ```
    The second entry is the indication that the NIC is receiving incorrect IP
    addresses. The 10.254.x.y address is for the HMN and should not be associated
-   with the node itself (x3000c0s30b1n0)
+   with the node itself (x3000c0s30b1n0).
 
    Make a note of the ID, MACAddress, and IPAddress of the entry that has the
    10.254 address listed.
    ```
-   ncn-m001:~ # ID="9440c938f7b4"
-   ncn-m001:~ # MAC="94:40:c9:38:f7:b4"
-   ncn-m001:~ # IPADDR="10.254.1.38"
+   ncn-m001# ID="9440c938f7b4"
+   ncn-m001# MAC="94:40:c9:38:f7:b4"
+   ncn-m001# IPADDR="10.254.1.38"
    ```
    These will be used later to clean up KEA and Hardware State Manager (HSM).
    There may not be a 10.254 address associated with the node, that is OK, it
@@ -93,8 +91,8 @@ The node indicator is always a 0. For example, x3000c0s30b1n0 or x3000c0s30b4n0.
 
    <a name="configure_ilo"></a>
 
-2. Configure the iLO to use VLAN 4
-   1. Connect to BMC WebUI and log in with standard root credentials
+2. Configure the iLO to use VLAN 4.
+   1. Connect to BMC WebUI and log in with standard root credentials.
       1. From the administrators own machine create an SSH tunnel (-L creates
          the tunnel, and -N prevents a shell and stubs the connection):
          ```
@@ -103,29 +101,29 @@ The node indicator is always a 0. For example, x3000c0s30b1n0 or x3000c0s30b4n0.
          ```
       1. Opening a web browser to `https://localhost:9443` will give access to
          the BMC's web interface.
-      1. Login with the root credentials
-   2. Click on **iLO Shared Network Port** on left menu
+      1. Login with the root credentials.
+   2. Click on **iLO Shared Network Port** on left menu.
    2. Make a note of the **MAC Address** under the **Information** section,
         that will be needed later.
         ```
-        ncn-m001:~ # ILOMAC="<MAC Address>"
+        ncn-m001# ILOMAC="<MAC Address>"
         ```
         For example
         ```
-        ncn-m001:~ # ILOMAC="94:40:c9:38:08:c7"
+        ncn-m001# ILOMAC="94:40:c9:38:08:c7"
         ```
-   3. Click on **General** on the top menu
-   4. Under **NIC Settings** move slider to **Enable VLAN**
-   5. In the **VLAN Tag** box, enter **4**
-   6. Click **Apply**
-   7. Click **Reset iLO** when it appears
-   8.  Click **Yes, Reset** when it appears on the right
+   3. Click on **General** on the top menu.
+   4. Under **NIC Settings** move slider to **Enable VLAN**.
+   5. In the **VLAN Tag** box, enter **4**.
+   6. Click **Apply**.
+   7. Click **Reset iLO** when it appears.
+   8.  Click **Yes, Reset** when it appears on the right.
    9.  After accepting the BMC restart, connection to the BMC will be lost until
    the switch port reconfiguration is performed.
 
    <a name="configure_switch_port"></a>
 
-2. Configure the switch port for the iLO to use VLAN 4
+2. Configure the switch port for the iLO to use VLAN 4.
    1. Find the port and the switch the iLO is plugged into using the SHCD.
    2. ssh to the switch and log in with standard admin credentials. Refer to
    `/etc/hosts` for exact hostname.
@@ -141,7 +139,7 @@ The node indicator is always a 0. For example, x3000c0s30b1n0 or x3000c0s30b4n0.
       Make sure the MAC address shown for that port matches the ILOMAC address
       noted in step 2.3 from the **Information** section of the WebUI
 
-      **Note:** If the MAC is not correct, double check the server cabling and
+      **NOTE:** If the MAC is not correct, double check the server cabling and
       SHCD for the correct port then start this section over. **Do not** move on
       until the ILOMAC address has been found on the switch at the expected
       port.
@@ -159,7 +157,7 @@ The node indicator is always a 0. For example, x3000c0s30b1n0 or x3000c0s30b4n0.
       sw-leaf01(config-if)# exit
       sw-leaf01(config)# exit
       ```
-   5. Verify the settings
+   5. Verify the settings.
       ```
       sw-leaf01# show running-config interface 1/1/46
       interface 1/1/46
@@ -179,9 +177,9 @@ The node indicator is always a 0. For example, x3000c0s30b1n0 or x3000c0s30b4n0.
 
    <a name="cleanup_kea"></a>
 
-3. Clear bad MAC and IP address out of KEA
+3. Clear bad MAC and IP address out of KEA.
 
-   **Note:** Skip this step if there was no bad MAC and IPADDR found in step 1.
+   **NOTE:** Skip this step if there was no bad MAC and IPADDR found in step 1.
 
    Retrieve a bearer token if you have not done so already.
    ```
@@ -195,27 +193,27 @@ The node indicator is always a 0. For example, x3000c0s30b1n0 or x3000c0s30b4n0.
    gathered in section 1.1.
 
    ```
-   ncn-m001:~ # curl -s -k -H "Authorization: Bearer ${TOKEN}" -X POST -H \
+   ncn-m001# curl -s -k -H "Authorization: Bearer ${TOKEN}" -X POST -H \
    "Content-Type: application/json" -d '{"command": "lease4-del", \
    "service": [ "dhcp4" ], "arguments": {"hw-address": "'${MAC}'", \
    "ip-address": "'${IPADDR}'"}}' https://api-gw-service-nmn.local/apis/dhcp-kea
    ```
-   Expected results
+   Expected results:
    ```
    [ { "result": 0, "text": "IPv4 lease deleted." } ]
    ```
 
    <a name="cleanup_hsm"></a>
 
-4. Clear bad ID out of HSM
+4. Clear bad ID out of HSM.
 
-   **Note:** Skip this step if there was no bad ID found in step 1.
+   **NOTE:** Skip this step if there was no bad ID found in step 1.
 
-   Tell HSM to delete the bad ID out of the Ethernet Interfaces table
+   Tell HSM to delete the bad ID out of the Ethernet Interfaces table.
    ```
-   ncn-m001:~ # cray hsm inventory ethernetInterfaces delete $ID
+   ncn-m001# cray hsm inventory ethernetInterfaces delete $ID
    ```
-   Expected results
+   Expected results:
    ```
    {
    "code": 0,
@@ -233,4 +231,5 @@ to be booted.
    After completing the preparation for compute nodes, the CSM product stream
    has been fully installed and configured. Check the next topic.
 
-   See [Next Topic](index.md#next_topic)
+   See [Next Topic](index.md#next_topic) for more information on other product
+   streams to be installed and configured after CSM.

--- a/install/prepare_compute_nodes.md
+++ b/install/prepare_compute_nodes.md
@@ -1,10 +1,16 @@
 # Prepare Compute nodes
 
-Some compute nodes types have special preparation steps, but most compute nodes are ready to be used now
-These nodes have an additional procedure before they can be booted.
+Some compute nodes types need to have additional procedures performed before
+they can be booted, but most compute nodes are ready to be used now.
 
 ### Topics:
    1. [Configure HPE Apollo 6500 XL645d Gen10 Plus Compute Nodes](#configure-hpe-apollo-6500-x645d-gen10-plus-compute-nodes)
+
+      1. [Gather Information](#gather_information)
+      2. [Configure the iLO to use VLAN 4](#configure_ilo)
+      3. [Configure the switch port for the iLO to use VLAN 4](#configure_switch_port)
+      4. [Clear bad MAC and IP address out of KEA](#cleanup_kea)
+      5. [Clear bad ID out of HSM](#cleanup_hsm)
 
 ### Prerequisites
 
@@ -14,33 +20,41 @@ See [Update the Gigabyte Server BIOS Time](../operations/node_management/Update_
 ## Details
 
 <a name="configure-hpe-apollo-6500-x645d-gen10-plus-compute-nodes"></a>
+
 ### 1. Configure HPE Apollo 6500 XL645d Gen10 Plus Compute Nodes
 
-The HPE Apollo 6500 XL645d Gen10 Plus compute node uses a NIC/shared iLO network port. The NIC is
-also referred to as the Embedded LOM (LAN On Motherboard) and is available to the booted OS. This
-shared port is plugged into a port on the TOR Ethernet switch designated for the
-Hardware Management Network (HMN) causing the NIC to get an IP address assigned
-to it from the wrong pool. To prevent this from happening, the iLO VLAN tag
-needs to be configured for VLAN 4 and the switch port the NIC/shared iLO is
-plugged into needs to be configured to allow only VLAN 4 traffic. This prevents
-the NIC from communicating over the switch, and it will no longer DHCP an IP
-address.
+The HPE Apollo 6500 XL645d Gen10 Plus compute node uses a NIC/shared iLO network
+port. The NIC is also referred to as the Embedded LOM (LAN On Motherboard) and
+is available to the booted OS. This shared port is plugged into a port on the
+TOR Ethernet switch designated for the Hardware Management Network (HMN) causing
+the NIC to get an IP address assigned to it from the wrong pool. To prevent this
+from happening, the iLO VLAN tag needs to be configured for VLAN 4 and the
+switch port the NIC/shared iLO is plugged into needs to be configured to allow
+only VLAN 4 traffic. This prevents the NIC from communicating over the switch
+and it will no longer DHCP an IP address.
 
-This procedure needs to be done for each HPE Apollo 6500 XL645d node managed by CSM software.
+This procedure needs to be done for each of the HPE Apollo 6500 XL645d servers
+that will be managed by CSM software. River compute nodes always index their
+BMCs from 1. For example, the compute BMCs in servers with more than one node
+will have xnames as follows x3000c0s30b1, x3000c0s30b2, x3000c0s30b3, etc...
+The node indicator is always a 0. For example, x3000c0s30b1n0 or x3000c0s30b4n0.
+
+   <a name="gather_information"></a>
 
 1. Gather Information
 
-   Example using x3000c0s30b0n0 as the target component xname
+   Example using x3000c0s30b1n0 as the target compute node xname
 
    ```
+   ncn-m001:~ # XNAME=x3000c0s30b1n0
    ncn-m001:~ # cray hsm inventory ethernetInterfaces list --component-id \
-           x3000c0s30b0n0 --format json | jq '.[]|select((.IPAddresses|length)>0)'
+         ${XNAME} --format json | jq '.[]|select((.IPAddresses|length)>0)'
    {
    "ID": "6805cabbc182",
    "Description": "",
    "MACAddress": "68:05:ca:bb:c1:82",
    "LastUpdate": "2021-04-19T22:15:00.523621Z",
-   "ComponentID": "x3000c0s30b0n0",
+   "ComponentID": "x3000c0s30b1n0",
    "Type": "Node",
    "IPAddresses": [
        {
@@ -53,7 +67,7 @@ This procedure needs to be done for each HPE Apollo 6500 XL645d node managed by 
    "Description": "",
    "MACAddress": "94:40:c9:38:f7:b4",
    "LastUpdate": "2021-05-07T18:37:59.239924Z",
-   "ComponentID": "x3000c0s30b0n0",
+   "ComponentID": "x3000c0s30b1n0",
    "Type": "Node",
    "IPAddresses": [
        {
@@ -62,34 +76,60 @@ This procedure needs to be done for each HPE Apollo 6500 XL645d node managed by 
    ]
    }
    ```
-   *NOTE:* the data might not exist in HSM for the node which is fine because if it is not there then the data is not needed to clean up KEA later.
+   The second entry is the indication that the NIC is receiving incorrect IP
+   addresses. The 10.254.x.y address is for the HMN and should not be associated
+   with the node itself (x3000c0s30b1n0)
 
    Make a note of the ID, MACAddress, and IPAddress of the entry that has the
-   10.254 address listed. Those will be used later to clean up kea and
-   Hardware State Manager (HSM). There may not be a 10.254 address list, that
-   is fine, continue on to the next step.
+   10.254 address listed.
+   ```
+   ncn-m001:~ # ID="9440c938f7b4"
+   ncn-m001:~ # MAC="94:40:c9:38:f7:b4"
+   ncn-m001:~ # IPADDR="10.254.1.38"
+   ```
+   These will be used later to clean up KEA and Hardware State Manager (HSM).
+   There may not be a 10.254 address associated with the node, that is OK, it
+   will enable skipping of several steps later on.
 
    <a name="configure_ilo"></a>
 
-1. Configure the iLO to use VLAN 4
+2. Configure the iLO to use VLAN 4
    1. Connect to BMC WebUI and log in with standard root credentials
-   1. Click on **iLO Shared Network Port** on left menu
-   1. Make a note of the **MAC Address** under the **Information** section,
+      1. From the administrators own machine create an SSH tunnel (-L creates
+         the tunnel, and -N prevents a shell and stubs the connection):
+         ```
+         linux# BMC=x3000c0s30b1
+         linux# ssh -L 9443:$BMC:443 -N root@example-ncn-m001
+         ```
+      1. Opening a web browser to `https://localhost:9443` will give access to
+         the BMC's web interface.
+      1. Login with the root credentials
+   2. Click on **iLO Shared Network Port** on left menu
+   2. Make a note of the **MAC Address** under the **Information** section,
         that will be needed later.
-   1. Click on **General** on the top menu
-   1. Under **NIC Settings** move slider to **Enable VLAN**
-   1. In the **VLAN Tag** box, enter **4**
-   1. Click **Apply**
-   1. Click **Reset iLO** when it appears
-   1. Click **Yes, Reset** when it appears on the right
-   1. After accepting the BMC restart, connection to the BMC will be lost
-        until the switch port reconfiguration is performed.
+        ```
+        ncn-m001:~ # ILOMAC="<MAC Address>"
+        ```
+        For example
+        ```
+        ncn-m001:~ # ILOMAC="94:40:c9:38:08:c7"
+        ```
+   3. Click on **General** on the top menu
+   4. Under **NIC Settings** move slider to **Enable VLAN**
+   5. In the **VLAN Tag** box, enter **4**
+   6. Click **Apply**
+   7. Click **Reset iLO** when it appears
+   8.  Click **Yes, Reset** when it appears on the right
+   9.  After accepting the BMC restart, connection to the BMC will be lost until
+   the switch port reconfiguration is performed.
 
-1. Configure the switch port for the iLO to use VLAN 4
+   <a name="configure_switch_port"></a>
+
+2. Configure the switch port for the iLO to use VLAN 4
    1. Find the port and the switch the iLO is plugged into using the SHCD.
-   1. ssh to the switch and log in with standard admin credentials. Refer to
-        /etc/hosts for exact hostname.
-   1. Verify the MAC on the port.
+   2. ssh to the switch and log in with standard admin credentials. Refer to
+   `/etc/hosts` for exact hostname.
+   3. Verify the MAC on the port.
 
       Example using port number 46.
 
@@ -98,13 +138,15 @@ This procedure needs to be done for each HPE Apollo 6500 XL645d node managed by 
       94:40:c9:38:08:c7    4        dynamic                   1/1/46
       ```
 
-      Make sure MAC address returned for that port matches the MAC address
+      Make sure the MAC address shown for that port matches the ILOMAC address
       noted in step 2.3 from the **Information** section of the WebUI
 
-      If the MAC is not correct, double check the server cabling and SHCD
-      then start this section over.
+      **Note:** If the MAC is not correct, double check the server cabling and
+      SHCD for the correct port then start this section over. **Do not** move on
+      until the ILOMAC address has been found on the switch at the expected
+      port.
 
-   1. Configure the port if the MAC is correct.
+   4. Configure the port if the MAC is correct.
 
       Example using port number 46.
 
@@ -116,6 +158,9 @@ This procedure needs to be done for each HPE Apollo 6500 XL645d node managed by 
       Copying configuration: [Success]
       sw-leaf01(config-if)# exit
       sw-leaf01(config)# exit
+      ```
+   5. Verify the settings
+      ```
       sw-leaf01# show running-config interface 1/1/46
       interface 1/1/46
           no shutdown
@@ -132,41 +177,60 @@ This procedure needs to be done for each HPE Apollo 6500 XL645d node managed by 
       After a few minutes the switch will be configured and access to the
       WebUI will be regained.
 
-1. Clear bad MAC and IP address out of kea
+   <a name="cleanup_kea"></a>
 
-   Skip this step if there was no MAC and IP address found in step 1.
+3. Clear bad MAC and IP address out of KEA
 
-   Example using the MAC and IP address from step 1.
+   **Note:** Skip this step if there was no bad MAC and IPADDR found in step 1.
+
+   Retrieve a bearer token if you have not done so already.
+   ```
+   export TOKEN=$(curl -s -S -d grant_type=client_credentials \
+      -d client_id=admin-client \
+      -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
+      https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
+   ```
+
+   Remove the entry from KEA that is associated with the MAC and IPADDRESS
+   gathered in section 1.1.
 
    ```
    ncn-m001:~ # curl -s -k -H "Authorization: Bearer ${TOKEN}" -X POST -H \
    "Content-Type: application/json" -d '{"command": "lease4-del", \
-   "service": [ "dhcp4" ], "arguments": {"hw-address": "94:40:c9:38:f7:b4", \
-   "ip-address": "10.254.1.38"}}' https://api-gw-service-nmn.local/apis/dhcp-kea
-
+   "service": [ "dhcp4" ], "arguments": {"hw-address": "'${MAC}'", \
+   "ip-address": "'${IPADDR}'"}}' https://api-gw-service-nmn.local/apis/dhcp-kea
+   ```
+   Expected results
+   ```
    [ { "result": 0, "text": "IPv4 lease deleted." } ]
    ```
 
-1. Clear bad ID out of HSM
+   <a name="cleanup_hsm"></a>
 
-   Skip this step if there was no ID found in step 1.
+4. Clear bad ID out of HSM
 
-   Example using the ID from step 1.
+   **Note:** Skip this step if there was no bad ID found in step 1.
 
+   Tell HSM to delete the bad ID out of the Ethernet Interfaces table
    ```
-   ncn-m001:~ # cray hsm inventory ethernetInterfaces delete 9440c938f7b4
+   ncn-m001:~ # cray hsm inventory ethernetInterfaces delete $ID
+   ```
+   Expected results
+   ```
    {
    "code": 0,
    "message": "deleted 1 entry"
    }
    ```
-
-   Everything is now configured and the node is ready to be rebooted.
+Everything is now configured and the CSM software will automatically discover
+the node after several minutes. After it has been discovered, the node is ready
+to be booted.
 
 <a name="next-topic"></a>
+
 # Next Topic
 
-   After completing the preparation for compute management nodes, the CSM product stream has
-   been fully installed and configured. Check the next topic.
+   After completing the preparation for compute nodes, the CSM product stream
+   has been fully installed and configured. Check the next topic.
 
    See [Next Topic](index.md#next_topic)


### PR DESCRIPTION
## Summary and Scope

Improves documentation for configuring Apollo 6500 iLO and the switch port it is connected to.

## Issues and Related PRs

* Resolves [CASMINST-3554](https://connect.us.cray.com/jira/browse/CASMINST-3554)

## Testing

NA

### Tested on:

NA

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable