### PR TITLE
MTL-1558 reference HFP firmware location

### DIFF
--- a/install/clear_gigabyte_cmos.md
+++ b/install/clear_gigabyte_cmos.md
@@ -4,6 +4,8 @@ Because of a bug in the Gigabyte firmware, the Shasta 1.5 install may negatively
 
 A patched firmware release (newer than C20 BIOS) is expected to be available for a future release of Shasta. It is recommended that Gigabyte users wait for this new firmware before attempting an installation of Shasta 1.5. The procedure to recover the boards is included below.
 
+> All firmware can be found with HFP package provided with the Shasta release.
+
 ## Clear BIOS settings by jumper
 
 1. Pull the power cables or blade server from the chassis, and open the system top cover.

--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -179,6 +179,8 @@ proceed to step 2.
 <a name="update_management_node_firmware"></a>
 ### 2. Update Management Node Firmware
 
+> All firmware can be found in the HFP package provided with the Shasta release.
+
 The management nodes are expected to have certain minimum firmware installed for BMC, node BIOS, and PCIe card
 firmware. Where possible, the firmware should be updated prior to install. It is good to meet the minimum NCN
 firmware requirement before starting.
@@ -202,6 +204,8 @@ firmware requirement before starting.
    It will be possible to extract the files from the product tarball, but the install.sh script from that product 
    will be unable to load the firmware versions into the Firmware Action Services (FAS) because the management nodes
    are not booted and running Kubernetes and FAS cannot be used until Kubernetes is running.
+
+   If booted into the PIT node, the firmware can be found with HFP package provided with the Shasta release.
 
 1. (optional) Check these BIOS settings on management nodes [NCN BIOS](../background/ncn_bios.md).
 

--- a/install/set_gigabyte_node_bmc_to_factory_defaults.md
+++ b/install/set_gigabyte_node_bmc_to_factory_defaults.md
@@ -9,8 +9,9 @@ Use the management scripts and text files to reset Gigabyte BMC to factory defau
 - When BIOS or BMC flash procedures fail using Redfish
   - Run the `do_bmc_factory_default.sh` script
   - Run `ipmitool -I lanplus -U admin -P password -H BMC_or_CMC_IP mc reset cold` and flash it again after 5 minutes seconds
-- If booted from the PIT node, the required scripts are located in
-   `/var/www/fw/river/sh-svr-scripts`
+- If booted from the PIT node:
+  - the firmware packages are located in the HFP package provided with the Shasta release
+  - the required scripts are located in `/var/www/fw/river/sh-svr-scripts`
 
 ### Procedure
 

--- a/operations/network/management_network/update_management_network_firmware.md
+++ b/operations/network/management_network/update_management_network_firmware.md
@@ -8,18 +8,7 @@ Access to the switches from the LiveCD/ncn-m001.
 
 ## Configuration
 
-All firmware will be located at `/var/www/fw/network` on the LiveCD. It should contain the following files:
-
-```
-ncn-m001-pit:/var/www/network/firmware # ls -lh
-total 2.7G
--rw-rw-r--+ 1 root root 658353828 Jan  7  2021 ArubaOS-CX_6400-6300_10_06_0010.stable.swi
--rw-rw-r--+ 1 root root 384156519 May  3 22:18 ArubaOS-CX_8320_10_06_0110.stable.swi
--rw-rw-r--+ 1 root root 444610797 Jan  7  2021 ArubaOS-CX_8325_10_06_0010.stable.swi
--rw-rw-r--+ 1 root root 431371873 Apr 30 20:55 ArubaOS-CX_8360_10_06_0110.stable.swi
--rw-rw-r--+ 1 root root 763636433 Aug 26  2020 onyx-X86_64-3.9.1014.stable.img
--rw-rw-r--+ 1 root root 604119040 Oct 28  2020 OS10_Enterprise_10.5.1.4.stable.tar
-```
+All firmware can be found in the HFP package provided with the Shasta release.
 
 ## Switch Firmware
 


### PR DESCRIPTION
Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>

## Summary and Scope

De-references bundled PIT firmware and points users to the HFP package included with a Shasta release.

## Issues and Related PRs


* Resolves MTL-1558

## Testing

### Tested on:

n/a 

### Test description:

n/a

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
