### PR TITLE
CASMINST-3416 change vlan00* names to bond0.*mn0 names

### DIFF
--- a/operations/UAS_user_and_admin_topics/UAI_Network_Attachments.md
+++ b/operations/UAS_user_and_admin_topics/UAI_Network_Attachments.md
@@ -9,7 +9,7 @@ This section describes the data at each of those stages to show how the final ne
 
 The details of CSI localization are beyond the scope of this guide, but here are the important settings, and the values used in the following examples:
 
-- The interface name on which the Kubernetes worker nodes reach their NMN subnet: `vlan002`
+- The interface name on which the Kubernetes worker nodes reach their NMN subnet: `bond0.nmn0`
 - The network and CIDR configured on that interface: `10.252.0.0/17`
 - The IP address of the gateway to other NMN subnets found on that network: `10.252.0.1`
 - The subnets where compute nodes reside on this system:
@@ -34,7 +34,7 @@ spec:
       nmn_subnet: 10.252.2.0/23
       nmn_supernet: 10.252.0.0/17
       nmn_supernet_gateway: 10.252.0.1
-      nmn_vlan: vlan002
+      nmn_vlan: bond0.nmn0
       # NOTE: the term DHCP here is misleading, this is merely
       #       a range of reserved IPs for UAIs that should not
       #       be handed out to others because the network
@@ -116,7 +116,7 @@ items:
     config: '{
       "cniVersion": "0.3.0",
       "type": "macvlan",
-      "master": "vlan002",
+      "master": "bond0.nmn0",
       "mode": "bridge",
       "ipam": {
         "type": "host-local",

--- a/operations/boot_orchestration/Compute_Node_Boot_Issue_Symptom_Duplicate_Address_Warnings_and_Declined_DHCP_Offers_in_Logs.md
+++ b/operations/boot_orchestration/Compute_Node_Boot_Issue_Symptom_Duplicate_Address_Warnings_and_Declined_DHCP_Offers_in_Logs.md
@@ -47,7 +47,7 @@ There are multiple ways to check if this problem exists:
     ```bash
     ncn-m001# arp
     Address                  HWtype  HWaddress           Flags Mask            Iface
-    ncn-w002.local           ether   98:03:9b:b4:f1:fe   C                     vlan002
+    ncn-w002.local           ether   98:03:9b:b4:f1:fe   C                     bond0.nmn0
     10.46.11.201             ether   ca:d3:dc:33:29:e7   C                     weave
     10.46.12.7               ether   7e:7e:7f:f0:0d:2d   C                     weave
     10.46.11.197             ether   62:4c:91:91:ec:9f   C                     weave
@@ -60,10 +60,10 @@ There are multiple ways to check if this problem exists:
     10.48.15.0               ether   da:c2:40:ed:f4:ec   CM                    flannel.2
     10.46.11.183             ether   a2:f2:0d:34:cc:8b   C                     weave
     10.46.11.246             ether   7e:42:c4:0f:59:97   C                     weave
-    nid000003-nmn.local      ether   a4:bf:01:3e:f9:cd   C                     vlan002
+    nid000003-nmn.local      ether   a4:bf:01:3e:f9:cd   C                     bond0.nmn0
     10.46.11.242             ether   4e:06:ef:eb:5c:ba   C                     weave
     10.46.11.234             ether   f2:76:9d:1a:68:00   C                     weave
-    sw-spine01-nmn.local     ether   b8:59:9f:68:97:48   C                     vlan002
+    sw-spine01-nmn.local     ether   b8:59:9f:68:97:48   C                     bond0.nmn0
     10.46.11.230             ether   6a:a3:65:5c:37:ba   C                     weave
     10.46.12.28              ether   06:0e:54:02:a7:c4   C                     weave
     10.46.11.226             ether   5a:5b:55:77:97:b7   C                     weave
@@ -73,13 +73,13 @@ There are multiple ways to check if this problem exists:
     10.46.11.218             ether   66:81:68:6e:2e:38   C                     weave
     10.46.11.214             ether   ea:91:c2:b7:de:a2   C                     weave
     10.46.12.12              ether   5a:dd:d2:8b:20:66   C                     weave
-    ncn-m002.local           ether   b8:59:9f:1d:da:26   C                     vlan002
+    ncn-m002.local           ether   b8:59:9f:1d:da:26   C                     bond0.nmn0
     10.46.11.210             ether   2e:9f:17:a6:d7:d4   C                     weave
     10.48.52.0               ether   e2:9e:26:a4:d3:ba   CM                    flannel.2
-    ncn-s003.local           ether   98:03:9b:bb:a9:48   C                     vlan002
+    ncn-s003.local           ether   98:03:9b:bb:a9:48   C                     bond0.nmn0
     10.38.1.73               ether   46:67:08:21:f1:fc   C                     weave
     10.46.11.206             ether   36:b9:47:ad:69:8d   C                     weave
-    ncn-s002.local           ether   b8:59:9f:34:88:ca   C                     vlan002
+    ncn-s002.local           ether   b8:59:9f:34:88:ca   C                     bond0.nmn0
     10.46.12.0               ether   36:cb:f8:3c:b4:05   C                     weave
     10.46.11.194             ether   e2:7d:57:7e:9c:9e   C                     weave
     10.32.0.6                ether   46:e2:fe:29:1d:02   C                     weave
@@ -87,7 +87,7 @@ There are multiple ways to check if this problem exists:
     10.46.11.255             ether   3a:e6:e4:91:7a:ec   C                     weave
     10.48.16.0               ether   1a:fa:2e:8f:80:5c   CM                    flannel.2
     10.46.11.247             ether   c2:af:c4:53:ba:ff   C                     weave
-    nid000002-nmn.local      ether   a4:bf:01:3e:ef:d7   C                     vlan002
+    nid000002-nmn.local      ether   a4:bf:01:3e:ef:d7   C                     bond0.nmn0
     10.46.11.243             ether   de:5c:cc:47:db:55   C                     weave
     10.46.11.235             ether   c6:bb:07:55:8a:4d   C                     weave
     10.46.11.231             ether   6a:73:3c:fe:3f:95   C                     weave
@@ -97,7 +97,7 @@ There are multiple ways to check if this problem exists:
     10.46.11.219             ether   8a:47:b1:71:05:f9   C                     weave
     10.46.11.215             ether   ce:b1:cb:48:c7:e3   C                     weave
     10.46.12.13              ether   e2:34:38:f3:ce:3f   C                     weave
-    ncn-m001.local           ether   b8:59:9f:1d:d8:4a   C                     vlan002
+    ncn-m001.local           ether   b8:59:9f:1d:d8:4a   C                     bond0.nmn0
     10.46.11.211             ether   7e:ad:22:04:9b:32   C                     weave
     10.46.11.203             ether   16:23:a2:96:d4:d2   C                     weave
     10.46.12.1               ether   8e:51:2a:b6:f1:cc   C                     weave
@@ -109,25 +109,25 @@ There are multiple ways to check if this problem exists:
     10.46.11.248             ether   ea:ff:53:cd:27:36   C                     weave
     10.46.11.240             ether   6a:33:63:3a:50:0a   C                     weave
     cfgw-48-vrrp.us.cray.com  ether   00:00:5e:00:01:30   C                     em1
-    10.252.120.2             ether   b8:59:9f:1d:da:26   C                     vlan002
-    sw-leaf-001-can.local      ether   3c:2c:30:5e:6d:b5   C                     vlan007
-    nid000001-nmn.local      ether   a4:bf:01:3e:e0:93   C                     vlan002
+    10.252.120.2             ether   b8:59:9f:1d:da:26   C                     bond0.nmn0
+    sw-leaf-001-can.local      ether   3c:2c:30:5e:6d:b5   C                     bond0.cmn0
+    nid000001-nmn.local      ether   a4:bf:01:3e:e0:93   C                     bond0.nmn0
     10.46.11.232             ether   3a:69:e4:d9:7f:1f   C                     weave
     10.45.1.166              ether   9a:86:9c:c0:53:c5   C                     weave
     10.46.11.224             ether   d6:ec:f3:eb:6a:cb   C                     weave
     10.46.12.30              ether   a2:e1:8e:f5:65:64   C                     weave
     10.46.11.220             ether   1e:37:ab:42:15:24   C                     weave
     10.46.11.212             ether   16:82:52:f6:ca:de   C                     weave
-    sw-leaf-001-hmn.local      ether   3c:2c:30:5e:6d:b5   C                     vlan004
+    sw-leaf-001-hmn.local      ether   3c:2c:30:5e:6d:b5   C                     bond0.hmn0
     sw-leaf-001-mtl.local      ether   3c:2c:30:5e:6d:b5   C                     p1p1
     10.46.11.208             ether   0e:cf:3d:df:ea:21   C                     weave
     10.46.12.14              ether   92:73:ff:8d:8a:07   C                     weave
     10.46.12.10              ether   32:19:b3:75:3c:f7   C                     weave
-    ncn-w003.local           ether   98:03:9b:bb:a8:8c   C                     vlan002
+    ncn-w003.local           ether   98:03:9b:bb:a8:8c   C                     bond0.nmn0
     10.46.11.200             ether   1a:c3:46:0f:a0:b9   C                     weave
     10.48.3.0                ether   16:78:89:dd:ae:7c   CM                    flannel.2
     10.46.12.6               ether   c6:3d:da:ef:d8:a5   C                     weave
-    ncn-s001.local           ether   b8:59:9f:1d:d9:1e   C                     vlan002
+    ncn-s001.local           ether   b8:59:9f:1d:d9:1e   C                     bond0.nmn0
     10.46.11.196             ether   96:88:fc:f4:15:ac   C                     weave
     10.46.12.2               ether   d2:ac:dd:44:2c:0a   C                     weave
     10.46.11.192             ether   e6:aa:51:79:ee:83   C                     weave
@@ -136,7 +136,7 @@ There are multiple ways to check if this problem exists:
     10.46.11.249             ether   fa:37:7f:0a:ed:73   C                     weave
     10.46.11.186             ether   aa:d9:05:39:cd:77   C                     weave
     10.46.11.241             ether   36:a7:00:8a:8a:9e   C                     weave
-    nid000004-nmn.local      ether   a4:bf:01:3e:ca:61   C                     vlan002
+    nid000004-nmn.local      ether   a4:bf:01:3e:ca:61   C                     bond0.nmn0
     172.17.0.2               ether   02:42:ac:11:00:02   C                     docker0
     10.46.11.233             ether   3a:5f:0f:9f:ce:e1   C                     weave
     10.46.12.35              ether   9e:6d:fa:63:5e:2c   C                     weave
@@ -146,9 +146,9 @@ There are multiple ways to check if this problem exists:
     10.46.12.27              ether   1a:42:25:07:ee:0d   C                     weave
     10.46.11.213             ether   06:b8:de:1d:b2:99   C                     weave
     10.46.12.19              ether   82:61:83:18:fc:b7   C                     weave
-    sw-spine-001-hmn.local     ether   b8:59:9f:68:97:48   C                     vlan004
+    sw-spine-001-hmn.local     ether   b8:59:9f:68:97:48   C                     bond0.hmn0
     10.46.12.15              ether   ce:92:74:c6:4b:b3   C                     weave
-    ncn-m003.local           ether   b8:59:9f:1d:d9:f2   C                     vlan002
+    ncn-m003.local           ether   b8:59:9f:1d:d9:f2   C                     bond0.nmn0
     10.46.11.205             ether   16:e7:2e:6d:a3:e2   C                     weave
     10.46.12.11              ether   22:33:f7:4f:be:80   C                     weave
     ```

--- a/operations/network/customer_access_network/CAN_with_Dual-Spine_Configuration.md
+++ b/operations/network/customer_access_network/CAN_with_Dual-Spine_Configuration.md
@@ -128,7 +128,7 @@ Default route on the NCN \(configured by the can-network role\):
 
 ```screen
 ncn-m001# ip route
-default via 10.102.5.27 dev vlan007
+default via 10.102.5.27 dev bond0.cmn0
 ```
 
 

--- a/operations/network/customer_access_network/Troubleshoot_CAN_Issues.md
+++ b/operations/network/customer_access_network/Troubleshoot_CAN_Issues.md
@@ -6,15 +6,15 @@ The most frequent issue with the Customer Access Network \(CAN\) is trouble acce
 
 The best way to resolve this issue is to try to ping an outside IP address from one of the NCNs other than `ncn-m001`, which has a direct connection that it can use instead of the Customer Access Network \(CAN\). The following are some things to check to make sure CAN is configured correctly:
 
-### Does the NCN have an IP Address Configured on the vlan007 Interface?
+### Does the NCN have an IP Address Configured on the bond0.cmn0 Interface?
 
-Check the status of the vlan007 interface. Make sure it has an address specified.
+Check the status of the bond0.cmn0 interface. Make sure it has an address specified.
 
 ```screen
-ncn-w002# ip addr show vlan007
-534: vlan007@bond0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
+ncn-w002# ip addr show bond0.cmn0
+534: bond0.cmn0@bond0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
     link/ether 98:03:9b:b4:27:62 brd ff:ff:ff:ff:ff:ff
-    inet 10.102.5.5/26 brd 10.101.8.255 scope global vlan007
+    inet 10.102.5.5/26 brd 10.101.8.255 scope global bond0.cmn0
        valid_lft forever preferred_lft forever
     inet6 fe80::9a03:9bff:feb4:2762/64 scope link
        valid_lft forever preferred_lft forever
@@ -28,7 +28,7 @@ Check the default route on an NCN other than `ncn-m001`. There should be a defau
 
 ```screen
 ncn-w002# ip route | grep default
-default via 10.102.5.27 dev vlan007
+default via 10.102.5.27 dev bond0.cmn0
 ```
 
 If there is not an address specified, make sure the can- values have been defined in csi config init input.
@@ -73,7 +73,7 @@ If the outside IP address cannot be reached, check the spine switch configuratio
 
 ### Can the Spines Reach the NCN?
 
-Check that each of the spines can ping one or more of the NCNs at its vlan007 IP address. If there is only one spine being used on the system, only `spine-001` needs to be checked.
+Check that each of the spines can ping one or more of the NCNs at its bond0.cmn0 IP address. If there is only one spine being used on the system, only `spine-001` needs to be checked.
 
 ```screen
 sw-spine-001 [standalone: master] # ping 10.102.5.5

--- a/operations/network/network_management_install_guide/aruba/management_network_configuration_example.md
+++ b/operations/network/network_management_install_guide/aruba/management_network_configuration_example.md
@@ -262,7 +262,7 @@ Configure default routes on Workers
 
 * To make it persistent we'll need to create a ifcfg file for hsn0 and remove the old vlan7 default route.
 
-> ncn-w001:/ # mv /etc/sysconfig/network/ifroute-vlan007 /etc/sysconfig/network/ifroute-vlan007.old
+> ncn-w001:/ # mv /etc/sysconfig/network/ifroute-bond0.cmn0 /etc/sysconfig/network/ifroute-bond0.cmn0.old
 > 
 > ncn-w001:/ # echo "default 10.101.10.1 - -" > /etc/sysconfig/network/ifroute-hsn0
 

--- a/operations/network/network_management_install_guide/aruba/ncn_tcpdump.md
+++ b/operations/network/network_management_install_guide/aruba/ncn_tcpdump.md
@@ -5,10 +5,10 @@ If your host is not getting an IP address you can run a packet capture to see if
 On ncn-w001 or a worker/manager with kubectl, run:
 
 ```
-tcpdump -w dhcp.pcap -envli vlan002 port 67 or port 68
+tcpdump -w dhcp.pcap -envli bond0.nmn0 port 67 or port 68
 ```
 
-This will make a .pcap file named dhcp in your current directory. It will collect all DHCP traffic on the port you specify, in this example we are looking for DHCP traffic on interface vlan002 (10.252.0.0/17)
+This will make a .pcap file named dhcp in your current directory. It will collect all DHCP traffic on the port you specify, in this example we are looking for DHCP traffic on interface bond0.nmn0 (10.252.0.0/17)
 
 To view the DHCP traffic, run:
 

--- a/operations/network/network_management_install_guide/aruba/reboot_pxe_fail.md
+++ b/operations/network/network_management_install_guide/aruba/reboot_pxe_fail.md
@@ -29,7 +29,7 @@ PING 10.1.0.1 (10.1.0.1) 56(84) bytes of data.
 If this fails you may have a misconfigured CAN or need to add a route to the MTL network.
 
 ```
-ncn-w001:~ # ip route add 10.1.0.0/16 via 10.252.0.1 dev vlan002
+ncn-w001:~ # ip route add 10.1.0.0/16 via 10.252.0.1 dev bond0.nmn0
 ```
 
 [Back to Index](./index.md)

--- a/operations/network/network_management_install_guide/mellanox/management_network_configuration_example.md
+++ b/operations/network/network_management_install_guide/mellanox/management_network_configuration_example.md
@@ -262,7 +262,7 @@ Configure default routes on Workers
 
 * To make it persistent we'll need to create a ifcfg file for hsn0 and remove the old vlan7 default route.
 
-> ncn-w001:/ # mv /etc/sysconfig/network/ifroute-vlan007 /etc/sysconfig/network/ifroute-vlan007.old
+> ncn-w001:/ # mv /etc/sysconfig/network/ifroute-bond0.cmn0 /etc/sysconfig/network/ifroute-bond0.cmn0.old
 > 
 > ncn-w001:/ # echo "default 10.101.10.1 - -" > /etc/sysconfig/network/ifroute-hsn0
 

--- a/operations/network/network_management_install_guide/mellanox/ncn_tcpdump.md
+++ b/operations/network/network_management_install_guide/mellanox/ncn_tcpdump.md
@@ -5,10 +5,10 @@ If your host is not getting an IP address you can run a packet capture to see if
 On ncn-w001 or a worker/manager with kubectl, run:
 
 ```
-tcpdump -w dhcp.pcap -envli vlan002 port 67 or port 68
+tcpdump -w dhcp.pcap -envli bond0.nmn0 port 67 or port 68
 ```
 
-This will make a .pcap file named dhcp in your current directory. It will collect all DHCP traffic on the port you specify, in this example we are looking for DHCP traffic on interface vlan002 (10.252.0.0/17)
+This will make a .pcap file named dhcp in your current directory. It will collect all DHCP traffic on the port you specify, in this example we are looking for DHCP traffic on interface bond0.nmn0 (10.252.0.0/17)
 
 To view the DHCP traffic, run:
 

--- a/operations/network/network_management_install_guide/mellanox/reboot_pxe_fail.md
+++ b/operations/network/network_management_install_guide/mellanox/reboot_pxe_fail.md
@@ -29,7 +29,7 @@ PING 10.1.0.1 (10.1.0.1) 56(84) bytes of data.
 If this fails you may have a misconfigured CAN or need to add a route to the MTL network.
 
 ```
-ncn-w001:~ # ip route add 10.1.0.0/16 via 10.252.0.1 dev vlan002
+ncn-w001:~ # ip route add 10.1.0.0/16 via 10.252.0.1 dev bond0.nmn0
 ```
 
 [Back to Index](./index.md)

--- a/operations/node_management/Configuration_of_NCN_Bonding.md
+++ b/operations/node_management/Configuration_of_NCN_Bonding.md
@@ -49,20 +49,20 @@ To view a system wide interface network configuration:
 ncn-w001# wicked ifstatus all
 ```
 
-Use the following command to view information about a specific interface. In this example, vlan007 is used.
+Use the following command to view information about a specific interface. In this example, bond0.cmn0 is used.
 
 ```bash
-ncn-w001# wicked ifstatus --verbose vlan007
-vlan007         up
+ncn-w001# wicked ifstatus --verbose bond0.cmn0
+bond0.cmn0         up
       link:     #4603, state up, mtu 1500
       type:     vlan bond0[7], hwaddr b8:59:9f:c7:11:12
       control:  none
-      config:   compat:suse:/etc/sysconfig/network/ifcfg-vlan007,
+      config:   compat:suse:/etc/sysconfig/network/ifcfg-bond0.cmn0,
                 uuid: 5cce4d33-8d99-50a2-b6c0-b4b3d101c557
       leases:   ipv4 static granted
       addr:     ipv6 fe80::ba59:9fff:fec7:1112/64 scope link
-      addr:     ipv4 10.102.3.4/24 brd 10.102.3.4 scope universe label vlan007 [static]
-      route:    ipv4 0.0.0.0/0 via 10.102.3.20 dev vlan007 type unicast table 3 scope universe protocol boot
+      addr:     ipv4 10.102.3.4/24 brd 10.102.3.4 scope universe label bond0.cmn0 [static]
+      route:    ipv4 0.0.0.0/0 via 10.102.3.20 dev bond0.cmn0 type unicast table 3 scope universe protocol boot
       route:    ipv4 10.102.3.0/24 type unicast table main scope link protocol kernel pref-src 10.102.3.4
       route:    ipv6 fe80::/64 type unicast table main scope universe protocol kernel priority 256
 ```

--- a/operations/node_management/Rebuild_NCNs.md
+++ b/operations/node_management/Rebuild_NCNs.md
@@ -683,7 +683,7 @@ This section applies to all node types. The commands in this section assume you 
     ncn-m# cloud-init clean; cloud-init init --local; cloud-init init
     ```
 
-1. Confirm `vlan004` is up with the correct IP address on the rebuilt node.
+1. Confirm `bond0.hmn0` is up with the correct IP address on the rebuilt node.
 
     Run these commands on the rebuilt node.
 
@@ -701,19 +701,19 @@ This section applies to all node types. The commands in this section assume you 
         If the IP addresses match, proceed to the next step. If they do not match, continue with the following sub-steps.
 
         ```bash
-        ncn# ip addr show vlan004
-        14: vlan004@bond0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
+        ncn# ip addr show bond0.hmn0
+        14: bond0.hmn0@bond0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
             link/ether b8:59:9f:2b:2f:9e brd ff:ff:ff:ff:ff:ff
-            inet 10.254.1.16/17 brd 10.254.127.255 scope global vlan004
+            inet 10.254.1.16/17 brd 10.254.127.255 scope global bond0.hmn0
                valid_lft forever preferred_lft forever
             inet6 fe80::ba59:9fff:fe2b:2f9e/64 scope link
                valid_lft forever preferred_lft forever
         ```
 
-        1. Change the IP address for `vlan004` if necessary.
+        1. Change the IP address for `bond0.hmn0` if necessary.
 
             ```bash
-            ncn# vim /etc/sysconfig/network/ifcfg-vlan004
+            ncn# vim /etc/sysconfig/network/ifcfg-bond0.hmn0
             ```
 
             Set the `IPADDR` line to the correct IP address with a `/17` mask. For example, if the correct IP address is `10.254.1.16`, the line should be:
@@ -722,19 +722,19 @@ This section applies to all node types. The commands in this section assume you 
             IPADDR='10.254.1.16/17'
             ```
 
-        1. Restart the `vlan004` network interface.
+        1. Restart the `bond0.hmn0` network interface.
 
             ```bash
-            ncn# wicked ifreload vlan004
+            ncn# wicked ifreload bond0.hmn0
             ```
 
         1. Confirm the output from the dig command matches the interface.
 
             ```bash
-            ncn# ip addr show vlan004
+            ncn# ip addr show bond0.hmn0
             ```
 
-1. Confirm that `vlan007` is up with the correct IP address on the rebuilt node.
+1. Confirm that `bond0.cmn0` is up with the correct IP address on the rebuilt node.
 
     Run these commands on the rebuilt node.
 
@@ -752,19 +752,19 @@ This section applies to all node types. The commands in this section assume you 
         If the IP addresses match, proceed to the next step. If they do not match, continue with the following sub-steps.
 
         ```bash
-        ncn# ip addr show vlan007
-        15: vlan007@bond0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
+        ncn# ip addr show bond0.cmn0
+        15: bond0.cmn0@bond0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
             link/ether b8:59:9f:2b:2f:9e brd ff:ff:ff:ff:ff:ff
-            inet 10.103.8.11/24 brd 10.103.8.255 scope global vlan007
+            inet 10.103.8.11/24 brd 10.103.8.255 scope global bond0.cmn0
                valid_lft forever preferred_lft forever
             inet6 fe80::ba59:9fff:fe2b:2f9e/64 scope link
                valid_lft forever preferred_lft forever
         ```
 
-        1. Change the IP address for `vlan007` if necessary.
+        1. Change the IP address for `bond0.cmn0` if necessary.
 
             ```bash
-            ncn# vim /etc/sysconfig/network/ifcfg-vlan007
+            ncn# vim /etc/sysconfig/network/ifcfg-bond0.cmn0
             ```
 
             Set the `IPADDR` line to the correct IP address with a `/24` mask. For example, if the correct IP address is `10.103.8.11`, the line should be:
@@ -773,16 +773,16 @@ This section applies to all node types. The commands in this section assume you 
             IPADDR='10.103.8.11/24'
             ```
 
-        1. Restart the `vlan007` network interface.
+        1. Restart the `bond0.cmn0` network interface.
 
             ```bash
-            ncn# wicked ifreload vlan007
+            ncn# wicked ifreload bond0.cmn0
             ```
 
         1. Confirm the output from the dig command matches the interface.
 
             ```bash
-            ncn# ip addr show vlan007
+            ncn# ip addr show bond0.cmn0
             ```
 
 1. Set the wipe flag back so it will not wipe the disk when the node is rebooted.

--- a/operations/package_repository_management/Troubleshoot_Nexus.md
+++ b/operations/package_repository_management/Troubleshoot_Nexus.md
@@ -68,7 +68,7 @@ If packages.local resolves to the correct addresses, verify basic
 connectivity using ping. If `ping packages.local` is unsuccessful, verify the
 IP routes from the PIT node to the NMN load balancer network. The
 typical `ip route` configuration is `10.92.100.0/24 via 10.252.0.1 dev
-vlan002`. If pings are successful, try checking the status of Nexus by
+bond0.nmn0`. If pings are successful, try checking the status of Nexus by
 running `curl -sS https://packages.local/service/rest/v1/status/writable`. If
 the connection times out, it indicates there is a more complex connection
 issue. Verify switches are configured properly and BGP peering is operating

--- a/operations/utility_storage/Troubleshoot_an_Unresponsive_S3_Endpoint.md
+++ b/operations/utility_storage/Troubleshoot_an_Unresponsive_S3_Endpoint.md
@@ -49,8 +49,8 @@ Expected Responses: 2xx, 3xx
     ```bash
     ncn-s# journalctl -u keepalived.service --no-pager |grep -i gratuitous
     Aug 25 19:33:12 ncn-s001 Keepalived_vrrp[12439]: Registering gratuitous ARP shared channel
-    Aug 25 19:43:08 ncn-s001 Keepalived_vrrp[12439]: Sending gratuitous ARP on vlan002 for 10.252.1.3
-    Aug 25 19:43:08 ncn-s001 Keepalived_vrrp[12439]: (VI_0) Sending/queueing gratuitous ARPs on vlan002 for 10.252.1.3
+    Aug 25 19:43:08 ncn-s001 Keepalived_vrrp[12439]: Sending gratuitous ARP on bond0.nmn0 for 10.252.1.3
+    Aug 25 19:43:08 ncn-s001 Keepalived_vrrp[12439]: (VI_0) Sending/queueing gratuitous ARPs on bond0.nmn0 for 10.252.1.3
     ```
 
    `HAProxy:`

--- a/scripts/CASMINST-2015.sh
+++ b/scripts/CASMINST-2015.sh
@@ -9,10 +9,10 @@ ncns=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" \
   jq -r '.[] | ."ExtraProperties" | ."Aliases" | .[]' | sort)
 
 declare -A vlans_to_check
-# Do not be tempted to add vlan002 to this list without more checking as there are things like VIPs that should not be
+# Do not be tempted to add bond0.nmn0 to this list without more checking as there are things like VIPs that should not be
 # removed!
-vlans_to_check['vlan004']='hmn'
-vlans_to_check['vlan007']='can'
+vlans_to_check['bond0.hmn0']='hmn'
+vlans_to_check['bond0.cmn0']='can'
 
 for ncn in $ncns; do
   echo "Checking $ncn for incorrect IP addresses..."

--- a/upgrade/1.2/Stage_1.md
+++ b/upgrade/1.2/Stage_1.md
@@ -26,7 +26,7 @@
 
 ## Stage 1.3
 
-For `ncn-m001`, use `ncn-m002` as the stable NCN. Use `vlan007`/CAN IP address to `ssh` to `ncn-m002` for this `ncn-m001` install
+For `ncn-m001`, use `ncn-m002` as the stable NCN. Use `bond0.cmn0`/CAN IP address to `ssh` to `ncn-m002` for this `ncn-m001` install
 
 1. Authenticate with the Cray CLI on `ncn-m002`.
 

--- a/upgrade/1.2/scripts/upgrade/ncn-upgrade-cloud-init.sh
+++ b/upgrade/1.2/scripts/upgrade/ncn-upgrade-cloud-init.sh
@@ -178,12 +178,12 @@ function update_write_files_user_data() {
     # Format for ifroute-<interface> syntax
     nmn_routes=()
     for rt in $nmn_cabinet_subnets; do
-        nmn_routes+=("$rt $nmn_gateway - vlan002")
+        nmn_routes+=("$rt $nmn_gateway - bond0.nmn0")
     done
 
     hmn_routes=()
     for rt in $hmn_cabinet_subnets; do
-        hmn_routes+=("$rt $hmn_gateway - vlan004")
+        hmn_routes+=("$rt $hmn_gateway - bond0.hmn0")
     done
 
     printf -v nmn_routes_string '%s\\n' "${nmn_routes[@]}"
@@ -196,13 +196,13 @@ cat <<EOF>write-files-user-data.json
     "write_files": [{
         "content": "${nmn_routes_string%,}",
         "owner": "root:root",
-        "path": "/etc/sysconfig/network/ifroute-vlan002",
+        "path": "/etc/sysconfig/network/ifroute-bond0.nmn0",
         "permissions": "0644"
       },
       {
         "content": "${hmn_routes_string%,}",
         "owner": "root:root",
-        "path": "/etc/sysconfig/network/ifroute-vlan004",
+        "path": "/etc/sysconfig/network/ifroute-bond0.hmn0",
         "permissions": "0644"
       }
     ]


### PR DESCRIPTION
## Summary and Scope

Changes instances of `vlan00*` to the new names.


## Issues and Related PRs

* Resolves CASMINST-3416

## Testing

### Tested on:

N/A

## Risks and Mitigations

Low.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

