### PR TITLE
CASMINST-3416 change vlan00* names to bond0.*mn0 names

### DIFF
--- a/operations/UAS_user_and_admin_topics/UAI_Network_Attachments.md
+++ b/operations/UAS_user_and_admin_topics/UAI_Network_Attachments.md
@@ -9,7 +9,7 @@ This section describes the data at each of those stages to show how the final ne
 
 The details of CSI localization are beyond the scope of this guide, but here are the important settings, and the values used in the following examples:
 
-- The interface name on which the Kubernetes worker nodes reach their NMN subnet: `vlan002`
+- The interface name on which the Kubernetes worker nodes reach their NMN subnet: `bond0.nmn0`
 - The network and CIDR configured on that interface: `10.252.0.0/17`
 - The IP address of the gateway to other NMN subnets found on that network: `10.252.0.1`
 - The subnets where compute nodes reside on this system:
@@ -34,7 +34,7 @@ spec:
       nmn_subnet: 10.252.2.0/23
       nmn_supernet: 10.252.0.0/17
       nmn_supernet_gateway: 10.252.0.1
-      nmn_vlan: vlan002
+      nmn_vlan: bond0.nmn0
       # NOTE: the term DHCP here is misleading, this is merely
       #       a range of reserved IPs for UAIs that should not
       #       be handed out to others because the network
@@ -116,7 +116,7 @@ items:
     config: '{
       "cniVersion": "0.3.0",
       "type": "macvlan",
-      "master": "vlan002",
+      "master": "bond0.nmn0",
       "mode": "bridge",
       "ipam": {
         "type": "host-local",

--- a/operations/boot_orchestration/Compute_Node_Boot_Issue_Symptom_Duplicate_Address_Warnings_and_Declined_DHCP_Offers_in_Logs.md
+++ b/operations/boot_orchestration/Compute_Node_Boot_Issue_Symptom_Duplicate_Address_Warnings_and_Declined_DHCP_Offers_in_Logs.md
@@ -47,7 +47,7 @@ There are multiple ways to check if this problem exists:
     ```bash
     ncn-m001# arp
     Address                  HWtype  HWaddress           Flags Mask            Iface
-    ncn-w002.local           ether   98:03:9b:b4:f1:fe   C                     vlan002
+    ncn-w002.local           ether   98:03:9b:b4:f1:fe   C                     bond0.nmn0
     10.46.11.201             ether   ca:d3:dc:33:29:e7   C                     weave
     10.46.12.7               ether   7e:7e:7f:f0:0d:2d   C                     weave
     10.46.11.197             ether   62:4c:91:91:ec:9f   C                     weave
@@ -60,10 +60,10 @@ There are multiple ways to check if this problem exists:
     10.48.15.0               ether   da:c2:40:ed:f4:ec   CM                    flannel.2
     10.46.11.183             ether   a2:f2:0d:34:cc:8b   C                     weave
     10.46.11.246             ether   7e:42:c4:0f:59:97   C                     weave
-    nid000003-nmn.local      ether   a4:bf:01:3e:f9:cd   C                     vlan002
+    nid000003-nmn.local      ether   a4:bf:01:3e:f9:cd   C                     bond0.nmn0
     10.46.11.242             ether   4e:06:ef:eb:5c:ba   C                     weave
     10.46.11.234             ether   f2:76:9d:1a:68:00   C                     weave
-    sw-spine01-nmn.local     ether   b8:59:9f:68:97:48   C                     vlan002
+    sw-spine01-nmn.local     ether   b8:59:9f:68:97:48   C                     bond0.nmn0
     10.46.11.230             ether   6a:a3:65:5c:37:ba   C                     weave
     10.46.12.28              ether   06:0e:54:02:a7:c4   C                     weave
     10.46.11.226             ether   5a:5b:55:77:97:b7   C                     weave
@@ -73,13 +73,13 @@ There are multiple ways to check if this problem exists:
     10.46.11.218             ether   66:81:68:6e:2e:38   C                     weave
     10.46.11.214             ether   ea:91:c2:b7:de:a2   C                     weave
     10.46.12.12              ether   5a:dd:d2:8b:20:66   C                     weave
-    ncn-m002.local           ether   b8:59:9f:1d:da:26   C                     vlan002
+    ncn-m002.local           ether   b8:59:9f:1d:da:26   C                     bond0.nmn0
     10.46.11.210             ether   2e:9f:17:a6:d7:d4   C                     weave
     10.48.52.0               ether   e2:9e:26:a4:d3:ba   CM                    flannel.2
-    ncn-s003.local           ether   98:03:9b:bb:a9:48   C                     vlan002
+    ncn-s003.local           ether   98:03:9b:bb:a9:48   C                     bond0.nmn0
     10.38.1.73               ether   46:67:08:21:f1:fc   C                     weave
     10.46.11.206             ether   36:b9:47:ad:69:8d   C                     weave
-    ncn-s002.local           ether   b8:59:9f:34:88:ca   C                     vlan002
+    ncn-s002.local           ether   b8:59:9f:34:88:ca   C                     bond0.nmn0
     10.46.12.0               ether   36:cb:f8:3c:b4:05   C                     weave
     10.46.11.194             ether   e2:7d:57:7e:9c:9e   C                     weave
     10.32.0.6                ether   46:e2:fe:29:1d:02   C                     weave
@@ -87,7 +87,7 @@ There are multiple ways to check if this problem exists:
     10.46.11.255             ether   3a:e6:e4:91:7a:ec   C                     weave
     10.48.16.0               ether   1a:fa:2e:8f:80:5c   CM                    flannel.2
     10.46.11.247             ether   c2:af:c4:53:ba:ff   C                     weave
-    nid000002-nmn.local      ether   a4:bf:01:3e:ef:d7   C                     vlan002
+    nid000002-nmn.local      ether   a4:bf:01:3e:ef:d7   C                     bond0.nmn0
     10.46.11.243             ether   de:5c:cc:47:db:55   C                     weave
     10.46.11.235             ether   c6:bb:07:55:8a:4d   C                     weave
     10.46.11.231             ether   6a:73:3c:fe:3f:95   C                     weave
@@ -97,7 +97,7 @@ There are multiple ways to check if this problem exists:
     10.46.11.219             ether   8a:47:b1:71:05:f9   C                     weave
     10.46.11.215             ether   ce:b1:cb:48:c7:e3   C                     weave
     10.46.12.13              ether   e2:34:38:f3:ce:3f   C                     weave
-    ncn-m001.local           ether   b8:59:9f:1d:d8:4a   C                     vlan002
+    ncn-m001.local           ether   b8:59:9f:1d:d8:4a   C                     bond0.nmn0
     10.46.11.211             ether   7e:ad:22:04:9b:32   C                     weave
     10.46.11.203             ether   16:23:a2:96:d4:d2   C                     weave
     10.46.12.1               ether   8e:51:2a:b6:f1:cc   C                     weave
@@ -109,25 +109,25 @@ There are multiple ways to check if this problem exists:
     10.46.11.248             ether   ea:ff:53:cd:27:36   C                     weave
     10.46.11.240             ether   6a:33:63:3a:50:0a   C                     weave
     cfgw-48-vrrp.us.cray.com  ether   00:00:5e:00:01:30   C                     em1
-    10.252.120.2             ether   b8:59:9f:1d:da:26   C                     vlan002
-    sw-leaf-001-can.local      ether   3c:2c:30:5e:6d:b5   C                     vlan007
-    nid000001-nmn.local      ether   a4:bf:01:3e:e0:93   C                     vlan002
+    10.252.120.2             ether   b8:59:9f:1d:da:26   C                     bond0.nmn0
+    sw-leaf-001-can.local      ether   3c:2c:30:5e:6d:b5   C                     bond0.cmn0
+    nid000001-nmn.local      ether   a4:bf:01:3e:e0:93   C                     bond0.nmn0
     10.46.11.232             ether   3a:69:e4:d9:7f:1f   C                     weave
     10.45.1.166              ether   9a:86:9c:c0:53:c5   C                     weave
     10.46.11.224             ether   d6:ec:f3:eb:6a:cb   C                     weave
     10.46.12.30              ether   a2:e1:8e:f5:65:64   C                     weave
     10.46.11.220             ether   1e:37:ab:42:15:24   C                     weave
     10.46.11.212             ether   16:82:52:f6:ca:de   C                     weave
-    sw-leaf-001-hmn.local      ether   3c:2c:30:5e:6d:b5   C                     vlan004
+    sw-leaf-001-hmn.local      ether   3c:2c:30:5e:6d:b5   C                     bond0.hmn0
     sw-leaf-001-mtl.local      ether   3c:2c:30:5e:6d:b5   C                     p1p1
     10.46.11.208             ether   0e:cf:3d:df:ea:21   C                     weave
     10.46.12.14              ether   92:73:ff:8d:8a:07   C                     weave
     10.46.12.10              ether   32:19:b3:75:3c:f7   C                     weave
-    ncn-w003.local           ether   98:03:9b:bb:a8:8c   C                     vlan002
+    ncn-w003.local           ether   98:03:9b:bb:a8:8c   C                     bond0.nmn0
     10.46.11.200             ether   1a:c3:46:0f:a0:b9   C                     weave
     10.48.3.0                ether   16:78:89:dd:ae:7c   CM                    flannel.2
     10.46.12.6               ether   c6:3d:da:ef:d8:a5   C                     weave
-    ncn-s001.local           ether   b8:59:9f:1d:d9:1e   C                     vlan002
+    ncn-s001.local           ether   b8:59:9f:1d:d9:1e   C                     bond0.nmn0
     10.46.11.196             ether   96:88:fc:f4:15:ac   C                     weave
     10.46.12.2               ether   d2:ac:dd:44:2c:0a   C                     weave
     10.46.11.192             ether   e6:aa:51:79:ee:83   C                     weave
@@ -136,7 +136,7 @@ There are multiple ways to check if this problem exists:
     10.46.11.249             ether   fa:37:7f:0a:ed:73   C                     weave
     10.46.11.186             ether   aa:d9:05:39:cd:77   C                     weave
     10.46.11.241             ether   36:a7:00:8a:8a:9e   C                     weave
-    nid000004-nmn.local      ether   a4:bf:01:3e:ca:61   C                     vlan002
+    nid000004-nmn.local      ether   a4:bf:01:3e:ca:61   C                     bond0.nmn0
     172.17.0.2               ether   02:42:ac:11:00:02   C                     docker0
     10.46.11.233             ether   3a:5f:0f:9f:ce:e1   C                     weave
     10.46.12.35              ether   9e:6d:fa:63:5e:2c   C                     weave
@@ -146,9 +146,9 @@ There are multiple ways to check if this problem exists:
     10.46.12.27              ether   1a:42:25:07:ee:0d   C                     weave
     10.46.11.213             ether   06:b8:de:1d:b2:99   C                     weave
     10.46.12.19              ether   82:61:83:18:fc:b7   C                     weave
-    sw-spine-001-hmn.local     ether   b8:59:9f:68:97:48   C                     vlan004
+    sw-spine-001-hmn.local     ether   b8:59:9f:68:97:48   C                     bond0.hmn0
     10.46.12.15              ether   ce:92:74:c6:4b:b3   C                     weave
-    ncn-m003.local           ether   b8:59:9f:1d:d9:f2   C                     vlan002
+    ncn-m003.local           ether   b8:59:9f:1d:d9:f2   C                     bond0.nmn0
     10.46.11.205             ether   16:e7:2e:6d:a3:e2   C                     weave
     10.46.12.11              ether   22:33:f7:4f:be:80   C                     weave
     ```

--- a/operations/network/customer_access_network/CAN_with_Dual-Spine_Configuration.md
+++ b/operations/network/customer_access_network/CAN_with_Dual-Spine_Configuration.md
@@ -128,7 +128,7 @@ Default route on the NCN \(configured by the can-network role\):
 
 ```screen
 ncn-m001# ip route
-default via 10.102.5.27 dev vlan007
+default via 10.102.5.27 dev bond0.cmn0
 ```
 
 

--- a/operations/network/customer_access_network/Troubleshoot_CAN_Issues.md
+++ b/operations/network/customer_access_network/Troubleshoot_CAN_Issues.md
@@ -6,15 +6,15 @@ The most frequent issue with the Customer Access Network \(CAN\) is trouble acce
 
 The best way to resolve this issue is to try to ping an outside IP address from one of the NCNs other than `ncn-m001`, which has a direct connection that it can use instead of the Customer Access Network \(CAN\). The following are some things to check to make sure CAN is configured correctly:
 
-### Does the NCN have an IP Address Configured on the vlan007 Interface?
+### Does the NCN have an IP Address Configured on the bond0.cmn0 Interface?
 
-Check the status of the vlan007 interface. Make sure it has an address specified.
+Check the status of the bond0.cmn0 interface. Make sure it has an address specified.
 
 ```screen
-ncn-w002# ip addr show vlan007
-534: vlan007@bond0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
+ncn-w002# ip addr show bond0.cmn0
+534: bond0.cmn0@bond0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
     link/ether 98:03:9b:b4:27:62 brd ff:ff:ff:ff:ff:ff
-    inet 10.102.5.5/26 brd 10.101.8.255 scope global vlan007
+    inet 10.102.5.5/26 brd 10.101.8.255 scope global bond0.cmn0
        valid_lft forever preferred_lft forever
     inet6 fe80::9a03:9bff:feb4:2762/64 scope link
        valid_lft forever preferred_lft forever
@@ -28,7 +28,7 @@ Check the default route on an NCN other than `ncn-m001`. There should be a defau
 
 ```screen
 ncn-w002# ip route | grep default
-default via 10.102.5.27 dev vlan007
+default via 10.102.5.27 dev bond0.cmn0
 ```
 
 If there is not an address specified, make sure the can- values have been defined in csi config init input.
@@ -73,7 +73,7 @@ If the outside IP address cannot be reached, check the spine switch configuratio
 
 ### Can the Spines Reach the NCN?
 
-Check that each of the spines can ping one or more of the NCNs at its vlan007 IP address. If there is only one spine being used on the system, only `spine-001` needs to be checked.
+Check that each of the spines can ping one or more of the NCNs at its bond0.cmn0 IP address. If there is only one spine being used on the system, only `spine-001` needs to be checked.
 
 ```screen
 sw-spine-001 [standalone: master] # ping 10.102.5.5

--- a/operations/network/network_management_install_guide/aruba/management_network_configuration_example.md
+++ b/operations/network/network_management_install_guide/aruba/management_network_configuration_example.md
@@ -1,0 +1,314 @@
+# Example of how to configure Scenario A or B
+
+Create the CAN VRF
+
+Aruba
+
+> switch#config
+> 
+> switch(config)#vrf CAN
+
+
+Move interfaces into CAN VRF
+
+* If you have existing CAN interface configuration it will be deleted once you move the interface into the new VRF.  You will have to re-apply it.
+* NOTE: These are example configs only, most implementations of Bi-CAN will be different.
+
+Aruba
+
+Aruba Primary Config
+
+```
+interface vlan 7
+    vsx-sync active-gateways
+    vrf attach CAN
+    description CAN
+    ip mtu 9198
+    ip address 128.55.176.2/23
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 128.55.176.1
+    ip ospf 2 area 0.0.0.210
+```
+
+Aruba Secondary Config
+
+```
+interface vlan 7
+    vsx-sync active-gateways
+    vrf attach CAN
+    description CAN
+    ip mtu 9198
+    ip address 128.55.176.3/23
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 128.55.176.1
+    ip ospf 2 area 0.0.0.210
+```
+
+Create BGP process in CAN VRF
+
+* A new BGP process will need to be running in the CAN VRF, this will peer with the CAN IPs on the NCN-Workers.
+* These are example configs only, the neighbors below are the IPs of the CAN interface on the Workers. 
+
+Aruba Config
+
+```
+router bgp 65533
+vrf CAN
+    maximum-paths 8
+        neighbor 128.55.176.3 remote-as 65533
+        neighbor 128.55.176.25 remote-as 65534
+        neighbor 128.55.176.25 passive
+        neighbor 128.55.176.26 remote-as 65534
+        neighbor 128.55.176.26 passive
+        neighbor 128.55.176.27 remote-as 65534
+        neighbor 128.55.176.27 passive
+```
+
+Setup Customer Edge Router
+
+* The customer Edge router has to be certified by the Slingshot team.  
+* The configuration for this is going to be unique for most customers.
+* Below is an example configuration of a single Arista switch with a static LAG to a single Slingshot switch.
+
+Arista LAG Config
+
+```
+interface Ethernet24/1
+   mtu 9214
+   flowcontrol send on
+   flowcontrol receive on
+   speed forced 100gfull
+   error-correction encoding reed-solomon
+   channel-group 1 mode on
+ 
+interface Ethernet25/1
+   mtu 9214
+   flowcontrol send on
+   flowcontrol receive on
+   speed forced 100gfull
+   error-correction encoding reed-solomon
+   channel-group 1 mode on
+ 
+interface Port-Channel1
+   mtu 9214
+   switchport access vlan 2
+   switchport trunk native vlan 2
+   switchport mode trunk
+```
+
+* We are using VLAN 2 for the HSN network.
+
+VLAN 2 config
+
+```
+interface Vlan2
+   ip address 10.101.10.1/24
+```
+   
+* The following is the Arista BGP config for peering over the HSN.
+	* The BGP neighbor IPs used are HSN IPs of Worker Nodes.
+	
+Example HSN IP
+
+```
+ncn-w001:~ # ip a show hsn0
+8: hsn0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc mq state UP group default qlen 1000
+    link/ether 02:00:00:00:00:0d brd ff:ff:ff:ff:ff:ff
+    inet 10.101.10.10/24 scope global hsn0
+       valid_lft forever preferred_lft forever
+    inet6 fe80::ff:fe00:d/64 scope link 
+       valid_lft forever preferred_lft forever
+```
+       
+* We are creating a prefix list and route-map to only accept routes from the HSN network.
+
+Arista BGP Config
+
+```
+ip prefix-list HSN seq 10 permit 10.101.10.0/24 ge 24 
+ 
+route-map HSN permit 5
+   match ip address prefix-list HSN
+ 
+ router bgp 65534
+   maximum-paths 32
+   neighbor 10.101.10.10 remote-as 65533
+   neighbor 10.101.10.10 transport connection-mode passive
+   neighbor 10.101.10.10 route-map HSN in
+   neighbor 10.101.10.11 remote-as 65533
+   neighbor 10.101.10.11 transport connection-mode passive
+   neighbor 10.101.10.11 route-map HSN in
+   neighbor 10.101.10.12 remote-as 65533
+   neighbor 10.101.10.12 transport connection-mode passive
+   neighbor 10.101.10.12 route-map HSN in
+```
+
+Configure MetalLB
+
+* We will need to configure MetalLB to peer with the new CAN VRF interfaces and the new HSN interface on the customer edge router.
+
+```
+apiVersion: v1
+data:
+  config: |
+    peers:
+    - peer-address: 10.252.0.2
+      peer-asn: 65533
+      my-asn: 65533
+    - peer-address: 10.252.0.3
+      peer-asn: 65533
+      my-asn: 65533
+    - peer-address: 10.101.8.2
+      peer-asn: 65533
+      my-asn: 65536
+    - peer-address: 10.101.8.3
+      peer-asn: 65533
+      my-asn: 65536
+    - peer-address: 10.101.10.1
+      peer-asn: 65534
+      my-asn: 65533
+    address-pools:
+    - name: customer-access
+      protocol: bgp
+      addresses:
+      - 10.101.8.128/25
+    - name: customer-access-static
+      protocol: bgp
+      addresses:
+      - 10.101.8.112/28
+    - name: customer-high-speed
+      protocol: bgp
+      addresses:
+      - 10.101.10.128/25
+    - name: customer-high-speed-static
+      protocol: bgp
+      addresses:
+      - 10.101.10.112/28
+    - name: hardware-management
+      protocol: bgp
+      addresses:
+      - 10.94.100.0/24
+    - name: node-management
+      protocol: bgp
+      addresses:
+      - 10.92.100.0/24
+```
+
+Verify BGP and Routes
+
+* Once MetalLB is configured the BGP peers on the Customer Edge router and the CAN VRF should be established.
+
+Arista Edge Router
+
+```
+sw-edge01(config-router-bgp)#show ip bgp summary
+BGP summary information for VRF default
+Router identifier 192.168.50.50, local AS number 65534
+Neighbor Status Codes: m - Under maintenance
+  Neighbor         V  AS           MsgRcvd   MsgSent  InQ OutQ  Up/Down State  PfxRcd PfxAcc
+  10.101.10.10     4  65533             23        12    0    0 00:03:49 Estab  14     14
+  10.101.10.11     4  65533             25        11    0    0 00:03:49 Estab  16     16
+  10.101.10.12     4  65533             23        11    0    0 00:03:49 Estab  14     14
+```
+
+* The Arista routing table should now include the external IPs exposed by metalLB.
+* The onsite network team will be responsible for distributing these routes to the rest of their network.
+
+```
+sw-edge01(config)#show ip route 
+B E    10.101.8.113/32 [200/0] via 10.101.10.10, Vlan2
+                                via 10.101.10.11, Vlan2
+                                via 10.101.10.12, Vlan2
+ B E    10.101.8.128/32 [200/0] via 10.101.10.10, Vlan2
+                                via 10.101.10.11, Vlan2
+                                via 10.101.10.12, Vlan2
+ B E    10.101.8.129/32 [200/0] via 10.101.10.10, Vlan2
+                                via 10.101.10.11, Vlan2
+                                via 10.101.10.12, Vlan2
+ B E    10.101.8.130/32 [200/0] via 10.101.10.10, Vlan2
+                                via 10.101.10.11, Vlan2
+                                via 10.101.10.12, Vlan2
+ O      10.101.8.0/24 [110/20] via 192.168.75.3, Ethernet1/1
+                               via 192.168.75.1, Ethernet2/1
+```
+
+Example of how BGP routes would look like in the switch located in Highspeed network.
+
+```
+sw-spine-001 [standalone: master] # show ip bgp vrf CAN summary 
+ 
+VRF name                  : CAN
+BGP router identifier     : 192.168.75.1
+local AS number           : 65533
+BGP table version         : 665
+Main routing table version: 665
+IPV4 Prefixes             : 44
+IPV6 Prefixes             : 0
+L2VPN EVPN Prefixes       : 0
+ 
+------------------------------------------------------------------------------------------------------------------
+Neighbor          V    AS           MsgRcvd   MsgSent   TblVer    InQ    OutQ   Up/Down       State/PfxRcd        
+------------------------------------------------------------------------------------------------------------------
+10.101.8.8        4    65536        24725     27717     665       0      0      0:11:52:43    ESTABLISHED/14
+10.101.8.9        4    65536        24836     27692     665       0      0      0:08:44:20    ESTABLISHED/16
+10.101.8.10       4    65536        24704     27741     665       0      0      0:08:44:18    ESTABLISHED/14
+```
+
+Configure default routes on Workers
+
+* The default route will need to change on the workers so they send their traffic out the HSN interface.
+
+> ncn-w001:/ # ip route replace default via 10.101.10.1 dev hsn0
+
+* To make it persistent we'll need to create a ifcfg file for hsn0 and remove the old vlan7 default route.
+
+> ncn-w001:/ # mv /etc/sysconfig/network/ifroute-bond0.cmn0 /etc/sysconfig/network/ifroute-bond0.cmn0.old
+> 
+> ncn-w001:/ # echo "default 10.101.10.1 - -" > /etc/sysconfig/network/ifroute-hsn0
+
+* Verify the routing table and external connectivity.
+
+```
+ncn-w001:/ # ip route
+default via 10.101.10.1 dev hsn0
+
+ncn-w001:/ # ping 8.8.8.8 -c 1
+PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
+64 bytes from 8.8.8.8: icmp_seq=1 ttl=110 time=13.6 ms
+```
+
+Verify External Connectivity
+
+* You should now have external connectivity from outside the Shasta system to the external services offered by MetalLB over the HSN.
+* Verify you're going over the HSN by a traceroute.
+
+```
+NCN-m001 ~ % traceroute 10.101.8.113
+traceroute to 10.101.8.113 (10.101.8.113), 64 hops max, 52 byte packets
+ 1  172.30.252.234 (172.30.252.234)  37.652 ms  37.930 ms  36.574 ms
+ 2  10.103.255.228 (10.103.255.228)  37.684 ms  37.180 ms  36.765 ms
+ 3  10.103.255.249 (10.103.255.249)  36.531 ms  38.350 ms  39.593 ms
+ 4  172.30.254.219 (172.30.254.219)  38.543 ms  38.699 ms  40.811 ms
+ 5  172.30.254.212 (172.30.254.212)  37.931 ms  37.347 ms  40.404 ms
+ 6  172.30.254.243 (172.30.254.243)  47.029 ms  39.014 ms  38.292 ms
+ 7  172.30.254.134 (172.30.254.134)  42.197 ms  37.267 ms  38.522 ms
+ 8  172.30.254.130 (172.30.254.130)  39.562 ms  38.094 ms  39.500 ms
+ 9  10.101.15.254 (10.101.15.254)  37.616 ms  37.741 ms  37.529 ms
+10  10.101.15.178 (10.101.15.178)  39.465 ms  37.052 ms  36.734 ms
+11  10.101.8.113 (10.101.8.113)  39.937 ms  38.565 ms  36.524 ms
+```
+
+* You can also listen on all the HSN interfaces for ping/traceroute while you ping the external facing iP, in this example 10.101.8.113.
+ 
+```
+ncn-m001:~ # nodes=$(kubectl get nodes| awk '{print $1}' | grep  ncn-w | awk -vORS=, '{print $1}'); pdsh -w ${nodes} "tcpdump -envli hsn0 icmp"
+
+ncn-w002: tcpdump: listening on hsn0, link-type EN10MB (Ethernet), capture size 262144 bytes
+ncn-w003: tcpdump: listening on hsn0, link-type EN10MB (Ethernet), capture size 262144 bytes
+ncn-w001: tcpdump: listening on hsn0, link-type EN10MB (Ethernet), capture size 262144 bytes
+ncn-w003: 04:59:35.826691 98:5d:82:71:ba:2d > 02:00:00:00:00:1e, ethertype IPv4 (0x0800), length 98: (tos 0x0, ttl 54, id 951, offset 0, flags [none], proto ICMP (1), length 84)
+ncn-w003:     172.25.64.129 > 10.101.8.113: ICMP echo request, id 37368, seq 0, length 64
+ncn-w003: 04:59:36.825591 98:5d:82:71:ba:2d > 02:00:00:00:00:1e, ethertype IPv4 (0x0800), length 98: (tos 0x0, ttl 54, id 33996, offset 0, flags [none], proto ICMP (1), length 84)
+```
+
+[Back to Index](./index.md)

--- a/operations/network/network_management_install_guide/aruba/ncn_tcpdump.md
+++ b/operations/network/network_management_install_guide/aruba/ncn_tcpdump.md
@@ -1,0 +1,29 @@
+# TCPDUMP
+
+If your host is not getting an IP address you can run a packet capture to see if DHCP traffic is being transmitted.
+
+On ncn-w001 or a worker/manager with kubectl, run:
+
+```
+tcpdump -w dhcp.pcap -envli bond0.nmn0 port 67 or port 68
+```
+
+This will make a .pcap file named dhcp in your current directory. It will collect all DHCP traffic on the port you specify, in this example we are looking for DHCP traffic on interface bond0.nmn0 (10.252.0.0/17)
+
+To view the DHCP traffic, run:
+
+```
+tcpdump -r dhcp.pcap -v -n
+```
+
+The output may be very long so you might have to use filters.
+
+If you want to do a tcpdump for a certain MAC address you can run:
+
+```
+tcpdump -i eth0 -vvv -s 1500 '((port 67 or port 68) and (udp[38:4] = 0x993b7030))'
+```
+
+Note: This example is using the MAC of b4:2e:99:3b:70:30 and will show the output on your terminal and not save to a file. 
+
+[Back to Index](./index.md)

--- a/operations/network/network_management_install_guide/aruba/reboot_pxe_fail.md
+++ b/operations/network/network_management_install_guide/aruba/reboot_pxe_fail.md
@@ -1,0 +1,35 @@
+# Rebooting NCN and PXE fails
+
+Common Error messages.
+
+```
+2021-04-19 23:27:09   PXE-E18: Server response timeout.
+2021-02-02 17:06:13   PXE-E99: Unexpected network error.
+```
+
+Verify the ip helper-address on VLAN 1 on the switches.  
+
+This is the same configuration as above "Aruba Configuration".
+
+Verify DHCP packets can be forwarded from the workers to the MTL network (VLAN1)
+
+* If the Worker nodes can't reach the metal network DHCP will fail.
+* ALL WORKERS need to be able to reach the MTL network!
+* This can normally be achieved by having a default route 
+
+Simple connectivity tests below:
+
+```
+ncn-w001:~ # ping 10.1.0.1
+PING 10.1.0.1 (10.1.0.1) 56(84) bytes of data.
+64 bytes from 10.1.0.1: icmp_seq=1 ttl=64 time=0.361 ms
+64 bytes from 10.1.0.1: icmp_seq=2 ttl=64 time=0.145 ms
+```
+
+If this fails you may have a misconfigured CAN or need to add a route to the MTL network.
+
+```
+ncn-w001:~ # ip route add 10.1.0.0/16 via 10.252.0.1 dev bond0.nmn0
+```
+
+[Back to Index](./index.md)

--- a/operations/network/network_management_install_guide/mellanox/management_network_configuration_example.md
+++ b/operations/network/network_management_install_guide/mellanox/management_network_configuration_example.md
@@ -1,0 +1,314 @@
+# Example of how to configure Scenario A or B
+
+Create the CAN VRF
+
+Aruba
+
+> switch#config
+> 
+> switch(config)#vrf CAN
+
+
+Move interfaces into CAN VRF
+
+* If you have existing CAN interface configuration it will be deleted once you move the interface into the new VRF.  You will have to re-apply it.
+* NOTE: These are example configs only, most implementations of Bi-CAN will be different.
+
+Aruba
+
+Aruba Primary Config
+
+```
+interface vlan 7
+    vsx-sync active-gateways
+    vrf attach CAN
+    description CAN
+    ip mtu 9198
+    ip address 128.55.176.2/23
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 128.55.176.1
+    ip ospf 2 area 0.0.0.210
+```
+
+Aruba Secondary Config
+
+```
+interface vlan 7
+    vsx-sync active-gateways
+    vrf attach CAN
+    description CAN
+    ip mtu 9198
+    ip address 128.55.176.3/23
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 128.55.176.1
+    ip ospf 2 area 0.0.0.210
+```
+
+Create BGP process in CAN VRF
+
+* A new BGP process will need to be running in the CAN VRF, this will peer with the CAN IPs on the NCN-Workers.
+* These are example configs only, the neighbors below are the IPs of the CAN interface on the Workers. 
+
+Aruba Config
+
+```
+router bgp 65533
+vrf CAN
+    maximum-paths 8
+        neighbor 128.55.176.3 remote-as 65533
+        neighbor 128.55.176.25 remote-as 65534
+        neighbor 128.55.176.25 passive
+        neighbor 128.55.176.26 remote-as 65534
+        neighbor 128.55.176.26 passive
+        neighbor 128.55.176.27 remote-as 65534
+        neighbor 128.55.176.27 passive
+```
+
+Setup Customer Edge Router
+
+* The customer Edge router has to be certified by the Slingshot team.  
+* The configuration for this is going to be unique for most customers.
+* Below is an example configuration of a single Arista switch with a static LAG to a single Slingshot switch.
+
+Arista LAG Config
+
+```
+interface Ethernet24/1
+   mtu 9214
+   flowcontrol send on
+   flowcontrol receive on
+   speed forced 100gfull
+   error-correction encoding reed-solomon
+   channel-group 1 mode on
+ 
+interface Ethernet25/1
+   mtu 9214
+   flowcontrol send on
+   flowcontrol receive on
+   speed forced 100gfull
+   error-correction encoding reed-solomon
+   channel-group 1 mode on
+ 
+interface Port-Channel1
+   mtu 9214
+   switchport access vlan 2
+   switchport trunk native vlan 2
+   switchport mode trunk
+```
+
+* We are using VLAN 2 for the HSN network.
+
+VLAN 2 config
+
+```
+interface Vlan2
+   ip address 10.101.10.1/24
+```
+   
+* The following is the Arista BGP config for peering over the HSN.
+	* The BGP neighbor IPs used are HSN IPs of Worker Nodes.
+	
+Example HSN IP
+
+```
+ncn-w001:~ # ip a show hsn0
+8: hsn0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc mq state UP group default qlen 1000
+    link/ether 02:00:00:00:00:0d brd ff:ff:ff:ff:ff:ff
+    inet 10.101.10.10/24 scope global hsn0
+       valid_lft forever preferred_lft forever
+    inet6 fe80::ff:fe00:d/64 scope link 
+       valid_lft forever preferred_lft forever
+```
+       
+* We are creating a prefix list and route-map to only accept routes from the HSN network.
+
+Arista BGP Config
+
+```
+ip prefix-list HSN seq 10 permit 10.101.10.0/24 ge 24 
+ 
+route-map HSN permit 5
+   match ip address prefix-list HSN
+ 
+ router bgp 65534
+   maximum-paths 32
+   neighbor 10.101.10.10 remote-as 65533
+   neighbor 10.101.10.10 transport connection-mode passive
+   neighbor 10.101.10.10 route-map HSN in
+   neighbor 10.101.10.11 remote-as 65533
+   neighbor 10.101.10.11 transport connection-mode passive
+   neighbor 10.101.10.11 route-map HSN in
+   neighbor 10.101.10.12 remote-as 65533
+   neighbor 10.101.10.12 transport connection-mode passive
+   neighbor 10.101.10.12 route-map HSN in
+```
+
+Configure MetalLB
+
+* We will need to configure MetalLB to peer with the new CAN VRF interfaces and the new HSN interface on the customer edge router.
+
+```
+apiVersion: v1
+data:
+  config: |
+    peers:
+    - peer-address: 10.252.0.2
+      peer-asn: 65533
+      my-asn: 65533
+    - peer-address: 10.252.0.3
+      peer-asn: 65533
+      my-asn: 65533
+    - peer-address: 10.101.8.2
+      peer-asn: 65533
+      my-asn: 65536
+    - peer-address: 10.101.8.3
+      peer-asn: 65533
+      my-asn: 65536
+    - peer-address: 10.101.10.1
+      peer-asn: 65534
+      my-asn: 65533
+    address-pools:
+    - name: customer-access
+      protocol: bgp
+      addresses:
+      - 10.101.8.128/25
+    - name: customer-access-static
+      protocol: bgp
+      addresses:
+      - 10.101.8.112/28
+    - name: customer-high-speed
+      protocol: bgp
+      addresses:
+      - 10.101.10.128/25
+    - name: customer-high-speed-static
+      protocol: bgp
+      addresses:
+      - 10.101.10.112/28
+    - name: hardware-management
+      protocol: bgp
+      addresses:
+      - 10.94.100.0/24
+    - name: node-management
+      protocol: bgp
+      addresses:
+      - 10.92.100.0/24
+```
+
+Verify BGP and Routes
+
+* Once MetalLB is configured the BGP peers on the Customer Edge router and the CAN VRF should be established.
+
+Arista Edge Router
+
+```
+sw-edge01(config-router-bgp)#show ip bgp summary
+BGP summary information for VRF default
+Router identifier 192.168.50.50, local AS number 65534
+Neighbor Status Codes: m - Under maintenance
+  Neighbor         V  AS           MsgRcvd   MsgSent  InQ OutQ  Up/Down State  PfxRcd PfxAcc
+  10.101.10.10     4  65533             23        12    0    0 00:03:49 Estab  14     14
+  10.101.10.11     4  65533             25        11    0    0 00:03:49 Estab  16     16
+  10.101.10.12     4  65533             23        11    0    0 00:03:49 Estab  14     14
+```
+
+* The Arista routing table should now include the external IPs exposed by metalLB.
+* The onsite network team will be responsible for distributing these routes to the rest of their network.
+
+```
+sw-edge01(config)#show ip route 
+B E    10.101.8.113/32 [200/0] via 10.101.10.10, Vlan2
+                                via 10.101.10.11, Vlan2
+                                via 10.101.10.12, Vlan2
+ B E    10.101.8.128/32 [200/0] via 10.101.10.10, Vlan2
+                                via 10.101.10.11, Vlan2
+                                via 10.101.10.12, Vlan2
+ B E    10.101.8.129/32 [200/0] via 10.101.10.10, Vlan2
+                                via 10.101.10.11, Vlan2
+                                via 10.101.10.12, Vlan2
+ B E    10.101.8.130/32 [200/0] via 10.101.10.10, Vlan2
+                                via 10.101.10.11, Vlan2
+                                via 10.101.10.12, Vlan2
+ O      10.101.8.0/24 [110/20] via 192.168.75.3, Ethernet1/1
+                               via 192.168.75.1, Ethernet2/1
+```
+
+Example of how BGP routes would look like in the switch located in Highspeed network.
+
+```
+sw-spine-001 [standalone: master] # show ip bgp vrf CAN summary 
+ 
+VRF name                  : CAN
+BGP router identifier     : 192.168.75.1
+local AS number           : 65533
+BGP table version         : 665
+Main routing table version: 665
+IPV4 Prefixes             : 44
+IPV6 Prefixes             : 0
+L2VPN EVPN Prefixes       : 0
+ 
+------------------------------------------------------------------------------------------------------------------
+Neighbor          V    AS           MsgRcvd   MsgSent   TblVer    InQ    OutQ   Up/Down       State/PfxRcd        
+------------------------------------------------------------------------------------------------------------------
+10.101.8.8        4    65536        24725     27717     665       0      0      0:11:52:43    ESTABLISHED/14
+10.101.8.9        4    65536        24836     27692     665       0      0      0:08:44:20    ESTABLISHED/16
+10.101.8.10       4    65536        24704     27741     665       0      0      0:08:44:18    ESTABLISHED/14
+```
+
+Configure default routes on Workers
+
+* The default route will need to change on the workers so they send their traffic out the HSN interface.
+
+> ncn-w001:/ # ip route replace default via 10.101.10.1 dev hsn0
+
+* To make it persistent we'll need to create a ifcfg file for hsn0 and remove the old vlan7 default route.
+
+> ncn-w001:/ # mv /etc/sysconfig/network/ifroute-bond0.cmn0 /etc/sysconfig/network/ifroute-bond0.cmn0.old
+> 
+> ncn-w001:/ # echo "default 10.101.10.1 - -" > /etc/sysconfig/network/ifroute-hsn0
+
+* Verify the routing table and external connectivity.
+
+```
+ncn-w001:/ # ip route
+default via 10.101.10.1 dev hsn0
+
+ncn-w001:/ # ping 8.8.8.8 -c 1
+PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
+64 bytes from 8.8.8.8: icmp_seq=1 ttl=110 time=13.6 ms
+```
+
+Verify External Connectivity
+
+* You should now have external connectivity from outside the Shasta system to the external services offered by MetalLB over the HSN.
+* Verify you're going over the HSN by a traceroute.
+
+```
+NCN-m001 ~ % traceroute 10.101.8.113
+traceroute to 10.101.8.113 (10.101.8.113), 64 hops max, 52 byte packets
+ 1  172.30.252.234 (172.30.252.234)  37.652 ms  37.930 ms  36.574 ms
+ 2  10.103.255.228 (10.103.255.228)  37.684 ms  37.180 ms  36.765 ms
+ 3  10.103.255.249 (10.103.255.249)  36.531 ms  38.350 ms  39.593 ms
+ 4  172.30.254.219 (172.30.254.219)  38.543 ms  38.699 ms  40.811 ms
+ 5  172.30.254.212 (172.30.254.212)  37.931 ms  37.347 ms  40.404 ms
+ 6  172.30.254.243 (172.30.254.243)  47.029 ms  39.014 ms  38.292 ms
+ 7  172.30.254.134 (172.30.254.134)  42.197 ms  37.267 ms  38.522 ms
+ 8  172.30.254.130 (172.30.254.130)  39.562 ms  38.094 ms  39.500 ms
+ 9  10.101.15.254 (10.101.15.254)  37.616 ms  37.741 ms  37.529 ms
+10  10.101.15.178 (10.101.15.178)  39.465 ms  37.052 ms  36.734 ms
+11  10.101.8.113 (10.101.8.113)  39.937 ms  38.565 ms  36.524 ms
+```
+
+* You can also listen on all the HSN interfaces for ping/traceroute while you ping the external facing iP, in this example 10.101.8.113.
+ 
+```
+ncn-m001:~ # nodes=$(kubectl get nodes| awk '{print $1}' | grep  ncn-w | awk -vORS=, '{print $1}'); pdsh -w ${nodes} "tcpdump -envli hsn0 icmp"
+
+ncn-w002: tcpdump: listening on hsn0, link-type EN10MB (Ethernet), capture size 262144 bytes
+ncn-w003: tcpdump: listening on hsn0, link-type EN10MB (Ethernet), capture size 262144 bytes
+ncn-w001: tcpdump: listening on hsn0, link-type EN10MB (Ethernet), capture size 262144 bytes
+ncn-w003: 04:59:35.826691 98:5d:82:71:ba:2d > 02:00:00:00:00:1e, ethertype IPv4 (0x0800), length 98: (tos 0x0, ttl 54, id 951, offset 0, flags [none], proto ICMP (1), length 84)
+ncn-w003:     172.25.64.129 > 10.101.8.113: ICMP echo request, id 37368, seq 0, length 64
+ncn-w003: 04:59:36.825591 98:5d:82:71:ba:2d > 02:00:00:00:00:1e, ethertype IPv4 (0x0800), length 98: (tos 0x0, ttl 54, id 33996, offset 0, flags [none], proto ICMP (1), length 84)
+```
+
+[Back to Index](./index.md)

--- a/operations/network/network_management_install_guide/mellanox/ncn_tcpdump.md
+++ b/operations/network/network_management_install_guide/mellanox/ncn_tcpdump.md
@@ -1,0 +1,29 @@
+# TCPDUMP
+
+If your host is not getting an IP address you can run a packet capture to see if DHCP traffic is being transmitted.
+
+On ncn-w001 or a worker/manager with kubectl, run:
+
+```
+tcpdump -w dhcp.pcap -envli bond0.nmn0 port 67 or port 68
+```
+
+This will make a .pcap file named dhcp in your current directory. It will collect all DHCP traffic on the port you specify, in this example we are looking for DHCP traffic on interface bond0.nmn0 (10.252.0.0/17)
+
+To view the DHCP traffic, run:
+
+```
+tcpdump -r dhcp.pcap -v -n
+```
+
+The output may be very long so you might have to use filters.
+
+If you want to do a tcpdump for a certain MAC address you can run:
+
+```
+tcpdump -i eth0 -vvv -s 1500 '((port 67 or port 68) and (udp[38:4] = 0x993b7030))'
+```
+
+Note: This example is using the MAC of b4:2e:99:3b:70:30 and will show the output on your terminal and not save to a file. 
+
+[Back to Index](./index.md)

--- a/operations/network/network_management_install_guide/mellanox/reboot_pxe_fail.md
+++ b/operations/network/network_management_install_guide/mellanox/reboot_pxe_fail.md
@@ -1,0 +1,35 @@
+# Rebooting NCN and PXE fails
+
+Common Error messages.
+
+```
+2021-04-19 23:27:09   PXE-E18: Server response timeout.
+2021-02-02 17:06:13   PXE-E99: Unexpected network error.
+```
+
+Verify the ip helper-address on VLAN 1 on the switches.  
+
+This is the same configuration as above "Aruba Configuration".
+
+Verify DHCP packets can be forwarded from the workers to the MTL network (VLAN1)
+
+* If the Worker nodes can't reach the metal network DHCP will fail.
+* ALL WORKERS need to be able to reach the MTL network!
+* This can normally be achieved by having a default route 
+
+Simple connectivity tests below:
+
+```
+ncn-w001:~ # ping 10.1.0.1
+PING 10.1.0.1 (10.1.0.1) 56(84) bytes of data.
+64 bytes from 10.1.0.1: icmp_seq=1 ttl=64 time=0.361 ms
+64 bytes from 10.1.0.1: icmp_seq=2 ttl=64 time=0.145 ms
+```
+
+If this fails you may have a misconfigured CAN or need to add a route to the MTL network.
+
+```
+ncn-w001:~ # ip route add 10.1.0.0/16 via 10.252.0.1 dev bond0.nmn0
+```
+
+[Back to Index](./index.md)

--- a/operations/node_management/Configuration_of_NCN_Bonding.md
+++ b/operations/node_management/Configuration_of_NCN_Bonding.md
@@ -49,20 +49,20 @@ To view a system wide interface network configuration:
 ncn-w001# wicked ifstatus all
 ```
 
-Use the following command to view information about a specific interface. In this example, vlan007 is used.
+Use the following command to view information about a specific interface. In this example, bond0.cmn0 is used.
 
 ```bash
-ncn-w001# wicked ifstatus --verbose vlan007
-vlan007         up
+ncn-w001# wicked ifstatus --verbose bond0.cmn0
+bond0.cmn0         up
       link:     #4603, state up, mtu 1500
       type:     vlan bond0[7], hwaddr b8:59:9f:c7:11:12
       control:  none
-      config:   compat:suse:/etc/sysconfig/network/ifcfg-vlan007,
+      config:   compat:suse:/etc/sysconfig/network/ifcfg-bond0.cmn0,
                 uuid: 5cce4d33-8d99-50a2-b6c0-b4b3d101c557
       leases:   ipv4 static granted
       addr:     ipv6 fe80::ba59:9fff:fec7:1112/64 scope link
-      addr:     ipv4 10.102.3.4/24 brd 10.102.3.4 scope universe label vlan007 [static]
-      route:    ipv4 0.0.0.0/0 via 10.102.3.20 dev vlan007 type unicast table 3 scope universe protocol boot
+      addr:     ipv4 10.102.3.4/24 brd 10.102.3.4 scope universe label bond0.cmn0 [static]
+      route:    ipv4 0.0.0.0/0 via 10.102.3.20 dev bond0.cmn0 type unicast table 3 scope universe protocol boot
       route:    ipv4 10.102.3.0/24 type unicast table main scope link protocol kernel pref-src 10.102.3.4
       route:    ipv6 fe80::/64 type unicast table main scope universe protocol kernel priority 256
 ```

--- a/operations/node_management/Rebuild_NCNs.md
+++ b/operations/node_management/Rebuild_NCNs.md
@@ -676,7 +676,7 @@ This section applies to master and worker nodes. Skip this section if rebuilding
     ncn-m# cloud-init clean; cloud-init init --local; cloud-init init
     ```
 
-1. Confirm vlan004 is up with the correct IP address on the rebuilt node.
+1. Confirm `bond0.hmn0` is up with the correct IP address on the rebuilt node.
 
     The following examples assume the NCN/hostname is `NODE`.
 
@@ -692,20 +692,20 @@ This section applies to master and worker nodes. Skip this section if rebuilding
         If the IP addresses match, proceed to the next step. If they do not match, continue with the following sub-steps.
 
         ```bash
-        NODE# ip addr show vlan004
-        14: vlan004@bond0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
+        ncn# ip addr show bond0.hmn0
+        14: bond0.hmn0@bond0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
             link/ether b8:59:9f:2b:2f:9e brd ff:ff:ff:ff:ff:ff
-            inet 10.254.1.16/17 brd 10.254.127.255 scope global vlan004
+            inet 10.254.1.16/17 brd 10.254.127.255 scope global bond0.hmn0
                valid_lft forever preferred_lft forever
             inet6 fe80::ba59:9fff:fe2b:2f9e/64 scope link
                valid_lft forever preferred_lft forever
         ```
 
-       1. Change the IP address for vlan004 if necessary.
+        1. Change the IP address for `bond0.hmn0` if necessary.
 
-           ```bash
-           NODE# vim /etc/sysconfig/network/ifcfg-vlan004
-           ```
+            ```bash
+            ncn# vim /etc/sysconfig/network/ifcfg-bond0.hmn0
+            ```
 
            Set the IPADDR line to the correct IP address with a `/17` mask.
 
@@ -713,19 +713,19 @@ This section applies to master and worker nodes. Skip this section if rebuilding
            IPADDR='10.254.1.16/17'
            ```
 
-    1. Restart the vlan004 network interface.
+        1. Restart the `bond0.hmn0` network interface.
 
-        ```bash
-        NODE# wicked ifreload vlan004
-        ```
+            ```bash
+            ncn# wicked ifreload bond0.hmn0
+            ```
 
     1. Confirm the output from the dig command matches the interface.
 
-        ```bash
-        NODE# ip addr show vlan004
-        ```
+            ```bash
+            ncn# ip addr show bond0.hmn0
+            ```
 
-1. Confirm that vlan007 is up with the correct IP address on the rebuilt node.
+1. Confirm that `bond0.cmn0` is up with the correct IP address on the rebuilt node.
 
     The following examples assume the NCN/hostname is `NODE`.
 
@@ -741,20 +741,20 @@ This section applies to master and worker nodes. Skip this section if rebuilding
         If the IP addresses match, proceed to the next step. If they do not match, continue with the following sub-steps.
 
         ```bash
-        NODE# ip addr show vlan007
-        15: vlan007@bond0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
+        ncn# ip addr show bond0.cmn0
+        15: bond0.cmn0@bond0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
             link/ether b8:59:9f:2b:2f:9e brd ff:ff:ff:ff:ff:ff
-            inet 10.103.8.11/24 brd 10.103.8.255 scope global vlan007
+            inet 10.103.8.11/24 brd 10.103.8.255 scope global bond0.cmn0
                valid_lft forever preferred_lft forever
             inet6 fe80::ba59:9fff:fe2b:2f9e/64 scope link
                valid_lft forever preferred_lft forever
         ```
 
-       1. Change the IP address for vlan007 if necessary.
+        1. Change the IP address for `bond0.cmn0` if necessary.
 
-           ```bash
-           NODE# vim /etc/sysconfig/network/ifcfg-vlan007
-           ```
+            ```bash
+            ncn# vim /etc/sysconfig/network/ifcfg-bond0.cmn0
+            ```
 
            Set the IPADDR line to the correct IP address with a `/24` mask.
 
@@ -762,13 +762,11 @@ This section applies to master and worker nodes. Skip this section if rebuilding
            IPADDR='10.103.8.11/24'
            ```
 
-    1. Restart the vlan007 network interface.
+        1. Restart the `bond0.cmn0` network interface.
 
-        ```bash
-        NODE# wicked ifreload vlan007
-        ```
-
-    1. Confirm the output from the dig command matches the interface.
+            ```bash
+            ncn# wicked ifreload bond0.cmn0
+            ```
 
         ```bash
         NODE# ip addr show vlan007
@@ -776,18 +774,9 @@ This section applies to master and worker nodes. Skip this section if rebuilding
 
 1. Verify the new node is in the cluster.
 
-    Run the following command several times to watch for the newly rebuilt node to join the cluster. This should occur within 10 to 20 minutes.
-
-    ```bash
-    ncn# kubectl get nodes
-    NAME       STATUS   ROLES    AGE    VERSION
-    ncn-m001   Ready    master   113m   v1.18.6
-    ncn-m002   Ready    master   113m   v1.18.6
-    ncn-m003   Ready    master   112m   v1.18.6
-    ncn-w001   Ready    <none>   112m   v1.18.6
-    ncn-w002   Ready    <none>   112m   v1.18.6
-    ncn-w003   Ready    <none>   112m   v1.18.6
-    ```
+            ```bash
+            ncn# ip addr show bond0.cmn0
+            ```
 
 1. Set the wipe flag back so it will not wipe the disk when the node is rebooted.
 

--- a/operations/package_repository_management/Troubleshoot_Nexus.md
+++ b/operations/package_repository_management/Troubleshoot_Nexus.md
@@ -68,7 +68,7 @@ If packages.local resolves to the correct addresses, verify basic
 connectivity using ping. If `ping packages.local` is unsuccessful, verify the
 IP routes from the PIT node to the NMN load balancer network. The
 typical `ip route` configuration is `10.92.100.0/24 via 10.252.0.1 dev
-vlan002`. If pings are successful, try checking the status of Nexus by
+bond0.nmn0`. If pings are successful, try checking the status of Nexus by
 running `curl -sS https://packages.local/service/rest/v1/status/writable`. If
 the connection times out, it indicates there is a more complex connection
 issue. Verify switches are configured properly and BGP peering is operating

--- a/operations/utility_storage/Troubleshoot_an_Unresponsive_S3_Endpoint.md
+++ b/operations/utility_storage/Troubleshoot_an_Unresponsive_S3_Endpoint.md
@@ -49,8 +49,8 @@ Expected Responses: 2xx, 3xx
     ```bash
     ncn-s# journalctl -u keepalived.service --no-pager |grep -i gratuitous
     Aug 25 19:33:12 ncn-s001 Keepalived_vrrp[12439]: Registering gratuitous ARP shared channel
-    Aug 25 19:43:08 ncn-s001 Keepalived_vrrp[12439]: Sending gratuitous ARP on vlan002 for 10.252.1.3
-    Aug 25 19:43:08 ncn-s001 Keepalived_vrrp[12439]: (VI_0) Sending/queueing gratuitous ARPs on vlan002 for 10.252.1.3
+    Aug 25 19:43:08 ncn-s001 Keepalived_vrrp[12439]: Sending gratuitous ARP on bond0.nmn0 for 10.252.1.3
+    Aug 25 19:43:08 ncn-s001 Keepalived_vrrp[12439]: (VI_0) Sending/queueing gratuitous ARPs on bond0.nmn0 for 10.252.1.3
     ```
 
    `HAProxy:`

--- a/scripts/CASMINST-2015.sh
+++ b/scripts/CASMINST-2015.sh
@@ -9,10 +9,10 @@ ncns=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" \
   jq -r '.[] | ."ExtraProperties" | ."Aliases" | .[]' | sort)
 
 declare -A vlans_to_check
-# Do not be tempted to add vlan002 to this list without more checking as there are things like VIPs that should not be
+# Do not be tempted to add bond0.nmn0 to this list without more checking as there are things like VIPs that should not be
 # removed!
-vlans_to_check['vlan004']='hmn'
-vlans_to_check['vlan007']='can'
+vlans_to_check['bond0.hmn0']='hmn'
+vlans_to_check['bond0.cmn0']='can'
 
 for ncn in $ncns; do
   echo "Checking $ncn for incorrect IPs..."

--- a/upgrade/1.2/Stage_1.md
+++ b/upgrade/1.2/Stage_1.md
@@ -6,9 +6,27 @@
 
 For each master node in the cluster (exclude ncn-m001), again follow the steps:
 
-```bash
-ncn-m001# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/ncn-upgrade-k8s-master.sh ncn-m002
-```
+    ```bash
+    ncn-m001# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/ncn-upgrade-k8s-master.sh ncn-m002
+    ```
+    
+1. Repeat the previous step for each other master node **excluding `ncn-m001`**, one at a time.
+
+## Stage 1.2
+
+1. Run `ncn-upgrade-k8s-worker.sh` for `ncn-w001`. Follow output of the script carefully. The script will pause for manual interaction.
+
+    ```bash
+    ncn-m001# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/ncn-upgrade-k8s-worker.sh ncn-w001
+    ```
+    
+    > NOTE: You may need to reset the root password for each node after it is rebooted
+
+1. Repeat the previous step for each other worker node, one at a time.
+
+## Stage 1.3
+
+For `ncn-m001`, use `ncn-m002` as the stable NCN. Use `bond0.cmn0`/CAN IP address to `ssh` to `ncn-m002` for this `ncn-m001` install
 
 > NOTE: Run the script once each for all master nodes, excluding ncn-m001. Follow output of above script carefully. The script will pause for manual interaction
 > NOTE: You may need to reset the root password for each node after it is rebooted

--- a/upgrade/1.2/scripts/upgrade/ncn-upgrade-cloud-init.sh
+++ b/upgrade/1.2/scripts/upgrade/ncn-upgrade-cloud-init.sh
@@ -164,12 +164,12 @@ function update_write_files_user_data() {
     # Format for ifroute-<interface> syntax
     nmn_routes=()
     for rt in $nmn_cabinet_subnets; do
-        nmn_routes+=("$rt $nmn_gateway - vlan002")
+        nmn_routes+=("$rt $nmn_gateway - bond0.nmn0")
     done
 
     hmn_routes=()
     for rt in $hmn_cabinet_subnets; do
-        hmn_routes+=("$rt $hmn_gateway - vlan004")
+        hmn_routes+=("$rt $hmn_gateway - bond0.hmn0")
     done
 
     printf -v nmn_routes_string '%s\\n' "${nmn_routes[@]}"
@@ -182,13 +182,13 @@ cat <<EOF>write-files-user-data.json
     "write_files": [{
         "content": "${nmn_routes_string%,}",
         "owner": "root:root",
-        "path": "/etc/sysconfig/network/ifroute-vlan002",
+        "path": "/etc/sysconfig/network/ifroute-bond0.nmn0",
         "permissions": "0644"
       },
       {
         "content": "${hmn_routes_string%,}",
         "owner": "root:root",
-        "path": "/etc/sysconfig/network/ifroute-vlan004",
+        "path": "/etc/sysconfig/network/ifroute-bond0.hmn0",
         "permissions": "0644"
       }
     ]


### PR DESCRIPTION
## Summary and Scope

Changes instances of `vlan00*` to the new names.


## Issues and Related PRs

* Resolves CASMINST-3416

## Testing

### Tested on:

N/A

## Risks and Mitigations

Low.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
