### PR TITLE
add HMN unbound DNS server to handoff command so it is used by BMCs

### DIFF
--- a/install/redeploy_pit_node.md
+++ b/install/redeploy_pit_node.md
@@ -192,10 +192,10 @@ data, so run them only when indicated. Instructions are in the `README` files.
     pit# python3 /usr/share/doc/csm/scripts/patch-ceph-runcmd.py
     ```
 
-1. Ensure the DNS server value is correctly set to point toward Unbound at `10.92.100.225`.
+1. Ensure the DNS server value is correctly set to point toward Unbound at `10.92.100.225` (NMN) and `10.94.100.225` (HMN).
 
     ```bash
-    pit# csi handoff bss-update-cloud-init --set meta-data.dns-server=10.92.100.225 --limit Global
+    pit# csi handoff bss-update-cloud-init --set meta-data.dns-server="10.92.100.225 10.94.100.225" --limit Global
     ```
 
 1. Upload the bootstrap information.


### PR DESCRIPTION
Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>

## Summary and Scope

Adds the HMN Unbound DNS server into the BSS metadata so it is picked up by the BMC DNS script.

## Issues and Related PRs

* Resolves CASMINST-3514
* Resolves CASMTRIAGE-2735 

## Testing

### Tested on:

  * `#wasp`


## Risks and Mitigations

Low.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
