### PR TITLE
CASMINST-3597-CASMINST-3593 update run_cmds

### DIFF
--- a/upgrade/1.2/scripts/upgrade/ncn-upgrade-cloud-init.sh
+++ b/upgrade/1.2/scripts/upgrade/ncn-upgrade-cloud-init.sh
@@ -203,20 +203,14 @@ function update_k8s_runcmd_user_data() {
 cat <<EOF>k8s-runcmd-user-data.json
 {
   "user-data": {
-      "runcmd": [
-          "/srv/cray/scripts/metal/install-bootloader.sh",
-          "/srv/cray/scripts/metal/set-host-records.sh",
-          "/srv/cray/scripts/metal/set-dhcp-to-static.sh",
-          "/srv/cray/scripts/metal/set-dns-config.sh",
-          "/srv/cray/scripts/metal/set-ntp-config.sh",
-          "/srv/cray/scripts/metal/enable-lldp.sh",
-          "/srv/cray/scripts/metal/set-bmc-bbs.sh",
-          "/srv/cray/scripts/metal/set-efi-bbs.sh",
-          "/srv/cray/scripts/metal/disable-cloud-init.sh",
-          "/srv/cray/scripts/common/update_ca_certs.py",
-          "/srv/cray/scripts/metal/install-rpms.sh",
-          "/srv/cray/scripts/common/kubernetes-cloudinit.sh"
-      ]
+    "runcmd": [
+      "/srv/cray/scripts/metal/net-init.sh",
+      "/srv/cray/scripts/common/update_ca_certs.py",
+      "/srv/cray/scripts/metal/install.sh",
+      "/srv/cray/scripts/common/kubernetes-cloudinit.sh",
+      "/srv/cray/scripts/join-spire-on-storage.sh",
+      "touch /etc/cloud/cloud-init.disabled"
+    ]
   }
 }
 EOF
@@ -228,21 +222,14 @@ function update_first_ceph_runcmd_user_data() {
 cat <<EOF>first-ceph-runcmd-user-data.json
 {
   "user-data": {
-      "runcmd": [
-          "/srv/cray/scripts/metal/install-bootloader.sh",
-          "/srv/cray/scripts/metal/set-host-records.sh",
-          "/srv/cray/scripts/metal/set-dhcp-to-static.sh",
-          "/srv/cray/scripts/metal/set-dns-config.sh",
-          "/srv/cray/scripts/metal/set-ntp-config.sh",
-          "/srv/cray/scripts/metal/enable-lldp.sh",
-          "/srv/cray/scripts/metal/set-bmc-bbs.sh",
-          "/srv/cray/scripts/metal/set-efi-bbs.sh",
-          "/srv/cray/scripts/metal/disable-cloud-init.sh",
-          "/srv/cray/scripts/common/update_ca_certs.py",
-          "/srv/cray/scripts/metal/install-rpms.sh",
-          "/srv/cray/scripts/common/pre-load-images.sh",
-          "/srv/cray/scripts/common/storage-ceph-cloudinit.sh"
-      ]
+    "runcmd": [
+      "/srv/cray/scripts/metal/net-init.sh",
+      "/srv/cray/scripts/common/update_ca_certs.py",
+      "/srv/cray/scripts/metal/install.sh",
+      "/srv/cray/scripts/common/pre-load-images.sh",
+      "touch /etc/cloud/cloud-init.disabled",
+      "/srv/cray/scripts/common/ceph-enable-services.sh"
+    ]
   }
 }
 EOF
@@ -254,20 +241,14 @@ function update_ceph_worker_runcmd_user_data() {
 cat <<EOF>ceph-worker-runcmd-user-data.json
 {
   "user-data": {
-      "runcmd": [
-          "/srv/cray/scripts/metal/install-bootloader.sh",
-          "/srv/cray/scripts/metal/set-host-records.sh",
-          "/srv/cray/scripts/metal/set-dhcp-to-static.sh",
-          "/srv/cray/scripts/metal/set-dns-config.sh",
-          "/srv/cray/scripts/metal/set-ntp-config.sh",
-          "/srv/cray/scripts/metal/enable-lldp.sh",
-          "/srv/cray/scripts/metal/set-bmc-bbs.sh",
-          "/srv/cray/scripts/metal/set-efi-bbs.sh",
-          "/srv/cray/scripts/metal/disable-cloud-init.sh",
-          "/srv/cray/scripts/common/update_ca_certs.py",
-          "/srv/cray/scripts/metal/install-rpms.sh",
-          "/srv/cray/scripts/common/pre-load-images.sh"
-      ]
+    "runcmd": [
+      "/srv/cray/scripts/metal/net-init.sh",
+      "/srv/cray/scripts/common/update_ca_certs.py",
+      "/srv/cray/scripts/metal/install.sh",
+      "/srv/cray/scripts/common/pre-load-images.sh",
+      "touch /etc/cloud/cloud-init.disabled",
+      "/srv/cray/scripts/common/ceph-enable-services.sh"
+    ]
   }
 }
 EOF


### PR DESCRIPTION
Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>

## Summary and Scope

1.2 has an updated set of `run_cmds`.  This aligns the upgrade path to use those
scripts and gets rid of non-existent ones.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMINST-3597
* Relates to CASMINST-3593

## Testing

### Tested on:

  * Local development environment

### Test description:

Validated the changes are valid JSON.  This plugs into an existing workflow known to work.

## Risks and Mitigations

Low.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
