### PR TITLE
Update Configure_Keycloak_Account.md

### DIFF
--- a/operations/CSM_product_management/Configure_Keycloak_Account.md
+++ b/operations/CSM_product_management/Configure_Keycloak_Account.md
@@ -9,7 +9,7 @@ of external accounts in keycloak.
 However, if the external accounts are not available, then an "internal user account" could be
 created in keycloak. Having a usable account in keycloak with administrative authorization
 enables the use of the `cray` CLI for many administrative commands, such as those used to
-[Validate CSM Health](../../validate_csm_health.md) and general operation of the management services
+[Validate CSM Health](../validate_csm_health.md) and general operation of the management services
 via the API gateway.
 
 See [System Security and Authentication](../security_and_authentication/System_Security_and_Authentication.md)


### PR DESCRIPTION
## Summary and Scope

Trying to navigate to the link target fails.

The file being targetted in the link

 `operations/validate_csm_health.md`

is only one directory up from

 `operations/CSM_product_management/Configure_Keycloak_Account.md`

but the link sends it up two

## Testing

Tried navigating to the link target

### Tested on:

Git Hub

### Test description:

Looked at the changed file at GitHub and was able to navigate to the link target

## Risks and Mitigations

None

## Pull Request Checklist

Most of the checklist items seem to be stuff that Cray folk would do,
after accepting a Pull, so have left as an execise for the reader(s)!
