### PR TITLE
CASMINST-3628 BREAK/FIX: install CSM service script is failed

### DIFF
--- a/install/scripts/csm_services/steps/1.initialize_bootstrap_registry.yaml
+++ b/install/scripts/csm_services/steps/1.initialize_bootstrap_registry.yaml
@@ -45,7 +45,7 @@ spec:
           # XXX dtr.dev.cray.com and quay.io are also uploaded to the root of
           # XXX registry.local. This is only necessary while charts and procedures still
           # XXX reference dtr.dev.cray.com or quay.io/skopeo/stable:latest.
-          if [ -d "/var/www/ephemeral/{{ getEnv "CSM_RELEASE" }}/docker/dtr.dev.cray.com" ]]; then
+          if [ -d "/var/www/ephemeral/{{ getEnv "CSM_RELEASE" }}/docker/dtr.dev.cray.com" ]; then
               podman run --rm --network host -v /var/www/ephemeral/{{ getEnv "CSM_RELEASE" }}/docker/dtr.dev.cray.com:/images:ro \
                   quay.io/skopeo/stable sync --scoped --src dir --dest docker --dest-tls-verify=false --dest-creds admin:admin123 \
                   /images localhost:5000


### PR DESCRIPTION
## Summary and Scope

Fixing a typo introduced into YAPL pipeline script with https://github.com/Cray-HPE/docs-csm/pull/607/

## Issues and Related PRs

* Resolves CASMIST-3628

## Testing

### Tested on:

  * `surtur`

### Test description:

Uploaded modified script and re-run yapl pipeline with `--no-cache` option

## Risks and Mitigations

Low risk - alpha release

