### PR TITLE
Bump version of K8S version to 1.20.13 for upgrade in 1.2

### DIFF
--- a/upgrade/1.2/Stage_1.md
+++ b/upgrade/1.2/Stage_1.md
@@ -1,4 +1,4 @@
-# Stage 1 - Kubernetes Upgrade from 1.19.9 to 1.20.12
+# Stage 1 - Kubernetes Upgrade from 1.19.9 to 1.20.13
 
 > NOTE: During the CSM-0.9 install the LiveCD containing the initial install files for this system should have been unmounted from the master node when rebooting into the Kubernetes cluster. The scripts run in this section will also attempt to unmount/eject it if found to ensure the USB stick does not get erased.
 
@@ -97,7 +97,7 @@ Run the following command to complete the Kubernetes upgrade _(this will restart
 
 ```bash
 ncn-m002# export PDSH_SSH_ARGS_APPEND="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
-ncn-m002# pdsh -b -S -w $(grep -oP 'ncn-m\d+' /etc/hosts | sort -u |  tr -t '\n' ',') 'kubeadm upgrade apply v1.20.12 -y'
+ncn-m002# pdsh -b -S -w $(grep -oP 'ncn-m\d+' /etc/hosts | sort -u |  tr -t '\n' ',') 'kubeadm upgrade apply v1.20.13 -y'
 ```
 
 > **`NOTE`**: kubelet has been upgraded already so you can ignore the warning to upgrade kubelet

--- a/upgrade/1.2/scripts/upgrade/verify-k8s-nodes-upgraded.sh
+++ b/upgrade/1.2/scripts/upgrade/verify-k8s-nodes-upgraded.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Copyright 2021 Hewlett Packard Enterprise Development LP
 
-EXPECTED_VERSION="v1.20.12"
+EXPECTED_VERSION="v1.20.13"
 display_output=$(kubectl get nodes)
 versions=$(kubectl get nodes -o json | jq -r '.items[].status.nodeInfo.kubeletVersion')
 stringarray=($versions)


### PR DESCRIPTION
## Summary and Scope

Update k8s upgrade version to 1.20.13

## Issues and Related PRs

* Resolves [CASMINST-3653](https://connect.us.cray.com/jira/browse/CASMINST-3653)

## Testing

craystack

### Tested on:

craystack

### Test description:

```
ncn-m002:~ # kubectl get nodes
NAME       STATUS   ROLES                  AGE     VERSION
ncn-m001   Ready    control-plane,master   5m34s   v1.20.13
ncn-m002   Ready    control-plane,master   8m12s   v1.20.13
ncn-m003   Ready    control-plane,master   5m33s   v1.20.13
ncn-w001   Ready    <none>                 5m35s   v1.20.13
ncn-w002   Ready    <none>                 5m34s   v1.20.13
ncn-w003   Ready    <none>                 5m35s   v1.20.13
```

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
