### PR TITLE
CASMINST-3495: For CSM 1.2 Update info about troubleshooting Prometheus alerts

### DIFF
--- a/operations/system_management_health/Access_System_Management_Health_Services.md
+++ b/operations/system_management_health/Access_System_Management_Health_Services.md
@@ -32,11 +32,15 @@ This procedure enables administrators to set up the service and access its compo
 
         For more information regarding the use of the Prometheus interface, see [https://prometheus.io/docs/prometheus/latest/getting\_started/](https://prometheus.io/docs/prometheus/latest/getting_started/).
 
+        Some alerts may be falsely triggered. This occurs if they are alerts which will be improved in the future, or if they are alerts impacted by whether all software products have been installed yet. See [Troubleshoot Prometheus Alerts](operations/system_management_health/Troubleshoot_Prometheus_Alerts.md).
+
     -   **https://alertmanager.\{\{shasta\_domain\}\}/**
 
-        Central Alertmanager instance that manages prometheus alerts.
+        Central Alertmanager instance that manages Prometheus alerts.
 
         The alertmanager manages the alerts it receives and generates notifications to users or applications. For more information about `alert-manager`, refer to the following documentation: [https://prometheus.io/docs/prometheus/latest/getting\_started/](https://prometheus.io/docs/prometheus/latest/getting_started/).
+
+        Some alerts may be falsely triggered. This occurs if they are alerts which will be improved in the future, or if they are alerts impacted by whether all software products have been installed yet. See [Troubleshoot Prometheus Alerts](operations/system_management_health/Troubleshoot_Prometheus_Alerts.md).
 
     -   **https://grafana.\{\{shasta\_domain\}\}/**
 
@@ -59,3 +63,13 @@ This procedure enables administrators to set up the service and access its compo
         Jaeger provides distributed tracing of requests across micro-services based on headers automatically injected by Envoy.
 
         For more information regarding the `jaeger-istio` front end/UI configuration, refer to the online documentation \([https://www.jaegertracing.io/](https://www.jaegertracing.io/)\). Click on the 'Docs' section to get more information around the Jaeger Frontend/UI.
+
+    Additional components are also exposed, though only for convenience. Do not rely on these components to always be available:
+
+    -   **https://prometheus-istio.\{\{shasta\_domain\}\}/**
+
+        Prometheus instance that collects Istio metrics \(included as part of `istio` Helm chart\).
+
+        For more information regarding the use of the Prometheus interface, see [https://prometheus.io/docs/alerting/overview/](https://prometheus.io/docs/alerting/overview/).
+
+

--- a/operations/system_management_health/Troubleshoot_Prometheus_Alerts.md
+++ b/operations/system_management_health/Troubleshoot_Prometheus_Alerts.md
@@ -1,11 +1,69 @@
 # Troubleshoot Prometheus Alerts
 
 General Prometheus Alert Troubleshooting Topics
+- [CephMgrIsAbsent and CephMgrIsMissingReplicas](#cephmgrmissing)
+- [CephNetworkPacketsDropped](#networkpatcketsdropped))
+- [CPUThrottlingHigh](#cputhrottlinghigh)
+- [KubePodNotReady](#kubepodnotready)
 - [PostgresqlFollowerReplicationLagSMA](#followerlagsma)
 - [PostgresqlHighRollbackRate](#highrollbackrate)
 - [PostgresqlInactiveReplicationSlot](#inactiveslot)
 - [PostgresqlNotEnoughConnections](#notenoughconnections)
-- [CPUThrottlingHigh](#cputhrottlinghigh)
+
+<a name="cephmgrmissing"></a>
+## CephMgrIsAbsent and CephMgrIsMissingReplicas
+
+If the CephMgrIsAbsent and/or CephMgrIsMissingReplicas alerts fire, use the following steps to ensure the `prometheus` module has been enabled for `Ceph`. The following steps should be executed on ncn-s001:
+
+```bash
+ncn-s001# ceph mgr module ls | jq '.enabled_modules'
+[
+  "cephadm",
+  "iostat",
+  "restful"
+]
+```
+
+If `prometheus` is missing from the output, enable with the following command:
+
+```bash
+ncn-s001# ceph mgr module enable prometheus
+```
+
+Confirm the module is now enabled:
+
+```bash
+ncn-s001# ceph mgr module ls | jq '.enabled_modules'
+[
+  "cephadm",
+  "iostat",
+  "prometheus",
+  "restful"
+]
+```
+
+The CephMgrIsAbsent and CephMgrIsMissingReplicas alerts should now clear in Prometheus.
+
+
+<a name="networkpacketsdropped"></a>
+## CephNetworkPacketsDropped
+
+The CephNetworkPacketsDropped alert does not necessarily indicate there are packets being dropped on an interface on a storage node. In a future release this alert will be renamed to be more generic. If this alert fires, inspect the IP address in the details of the alert to determine the node in question (can be storage, master or worker node). If the interface in question is determined to be healthy, this alert can be ignored.
+
+
+<a name="cputhrottlinghigh"></a>
+## CPUThrottlingHigh
+
+Alerts for CPUThrottlingHigh on gatekeeper-audit can be ignored. This pod is not utilized in this release.
+
+Alerts for CPUThrottlingHigh on CFS services such as cfs-batcher and cfs-trust can be ignored. Because CFS is idle most of the time these services have low CPU requests, and it is normal for CFS service resource usage to spike when it is in use.
+
+
+<a name="kubepodnotready"></a>
+## KubePodNotReady
+
+Alerts for KubePodNotReady on cray-crus could be ignored if the Slurm software has not been installed. The cray-crus pod interacts with Slurm to manage compute node rolling upgrades.
+
 
 <a name="followerlagsma"></a>
 ## PostgresqlFollowerReplicationLagSMA
@@ -31,13 +89,8 @@ Alerts for PostgresqlInactiveReplicationSlot on sma-postgres-cluster pods with s
 Alerts for PostgresqlNotEnoughConnections for datname="foo" and datname="bar" can be ignored. These databases are not used and will be removed in a future release.
 
 
-<a name="cputhrottlinghigh"></a>
-## CPUThrottlingHigh
+<a name="networkpacketsdropped"></a>
+## CephNetworkPacketsDropped
 
-Alerts for CPUThrottlingHigh on gatekeeper-audit can be ignored. This pod is not utilized in this release.
-
-Alerts for CPUThrottlingHigh on CFS services such as cfs-batcher and cfs-trust can be ignored. Because CFS is idle most of the time these services have low CPU requests, and it is normal for CFS service resource usage to spike when it is in use.
-
-
-
+The CephNetworkPacketsDropped alert does not necessarily indicate there are packets being dropped on an interface on a storage node. In a future release this alert will be renamed to be more generic. If this alert fires, inspect the IP address in the details of the alert to determine the node in question (can be storage, master or worker node). If the interface in question is determined to be healthy, this alert can be ignored.
 

--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -20,7 +20,7 @@ The areas should be tested in the order they are listed on this page. Errors in 
       - [1.1.1 Known Test Issues](#autogoss-issues)
     - [1.2 OPTIONAL Check of ncnHealthChecks Resources](#pet-ncnhealthchecks-resources)
       - [1.2.1 Known Issues](#known-issues)
-    - [1.3 OPTIONAL Check of System Management Monitoring Tools](#optional-check-of-system-management-monitoring-tools)
+    - [1.3 Check of System Management Monitoring Tools](#check-of-system-management-monitoring-tools)
   - [2. Hardware Management Services Health Checks](#hms-health-checks)
     - [2.1 HMS CT Test Execution](#hms-test-execution)
     - [2.2 Aruba Switch SNMP Fixup](#hms-aruba-fixup)
@@ -57,7 +57,7 @@ Health Check scripts can be run:
 Available Platform Health Checks:
 1. [ncnHealthChecks](#pet-ncnhealthchecks)
 1. [OPTIONAL Check of ncnHealthChecks Resources](#pet-optional-ncnhealthchecks-resources)
-1. [OPTIONAL Check of System Management Monitoring Tools](#optional-check-of-system-management-monitoring-tools)
+1. [Check of System Management Monitoring Tools](#check-of-system-management-monitoring-tools)
 
 <a name="pet-ncnhealthchecks"></a>
 ### 1.1 ncnHealthChecks
@@ -142,8 +142,8 @@ If in doubt, validate the CRUS service using the [CMS Validation Tool](#sms-heal
   - The `hmn-discovery` and `cray-dns-unbound-manager` cronjob pods may be in a 'NotReady' state. This is expected as these pods are periodically started and transition to the completed state.
 
 
-<a name="optional-check-of-system-management-monitoring-tools"></a>
-### 1.3 OPTIONAL Check of System Management Monitoring Tools
+<a name="check-of-system-management-monitoring-tools"></a>
+### 1.3 Check of System Management Monitoring Tools
 
 If all designated prerequisites are met, the availability of system management health services may optionally be validated by accessing the URLs listed in [Access System Management Health Services](system_management_health/Access_System_Management_Health_Services.md).
 It is very important to check the `Prerequisites` section of this document.
@@ -156,6 +156,7 @@ Information to assist with troubleshooting some of the components mentioned in t
 * [Check BGP Status and Reset Sessions](network/metallb_bgp/Check_BGP_Status_and_Reset_Sessions.md)
 * [Troubleshoot BGP not Accepting Routes from MetalLB](network/metallb_bgp/Troubleshoot_BGP_not_Accepting_Routes_from_MetalLB.md)
 * [Troubleshoot Services without an Allocated IP Address](network/metallb_bgp/Troubleshoot_Services_without_an_Allocated_IP_Address.md)
+* [Troubleshoot Prometheus Alerts](system_management_health/Troubleshoot_Prometheus_Alerts.md)
 
 
 <a name="hms-health-checks"></a>


### PR DESCRIPTION
## Summary and Scope

CASMINST-3495: For CSM 1.2 Update info about troubleshooting Prometheus alerts

## Issues and Related PRs

Related to CSM 1.0 version
https://github.com/Cray-HPE/docs-csm/pull/625

## Testing

Documentation only change.


### Tested on:



### Test description:



## Risks and Mitigations



## Pull Request Checklist

