### PR TITLE
CASMINST-3645 - Fixes to the 1.0 storage upgrade to address clusters larger than 3

### DIFF
--- a/upgrade/1.0/scripts/ceph/lib/ceph-upgrade-rgws.sh
+++ b/upgrade/1.0/scripts/ceph/lib/ceph-upgrade-rgws.sh
@@ -11,7 +11,7 @@ function upgrade_rgws () {
 
   echo "sleeping 20 seconds to allow for old rgw instances to stop"
   sleep 20
-  ceph orch apply rgw site1 zone1 --placement="3 $(ceph node ls|jq -r '.mon|keys| join(" ")')" --port=8080
+  ceph orch apply rgw site1 zone1 --placement="$(ceph node ls|jq -r '.osd|keys[]'|wc -l) $(ceph node ls|jq -r '.osd|keys| join(" ")')" --port=8080
 
   while [[ $(ceph health) != "HEALTH_OK" ]]; do
     echo "sleeping 5 seconds before next check"

--- a/upgrade/1.0/scripts/upgrade/ncn-upgrade-ceph-nodes.sh
+++ b/upgrade/1.0/scripts/upgrade/ncn-upgrade-ceph-nodes.sh
@@ -108,9 +108,7 @@ if [[ $state_recorded == "0" ]]; then
     ssh-copy-id -f -i ~/ceph.pub root@${upgrade_ncn}
     ceph orch host add ${upgrade_ncn}
     sleep 20
-    ceph orch daemon redeploy mon.${upgrade_ncn}
-    sleep 20
-    for s in $(ceph orch ps | grep ${upgrade_ncn} | awk '{print $1}'); do  ceph orch daemon start $s; done
+    for s in $(ceph orch ps | grep ${upgrade_ncn} | awk '{print $1}'); do  ceph orch daemon redeploy $s; done
 
     record_state "${state_name}" ${upgrade_ncn}
 else


### PR DESCRIPTION
## Summary and Scope

- Fixes issue with the rgw only deploying on 3 nodes.  It will now deploy across all storage nodes.
- Fixes issue with a mon process redeploy which only works on nodes 1,2,3.  This has been removed and the second command in the will loop and include this now.

## Issues and Related PRs

* Resolves CASMINST-3645

## Testing

### Tested on:

  * mug - command syntax only (waiting on fanta for full testing)

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? 
- Were continuous integration tests run? If not, why? N/A
- Was upgrade tested? If not, why? 
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

- N/A


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

