### PR TITLE
CASMINST-3655 - Remote ISO installs should use bind mount for /mnt/pitdata

### DIFF
--- a/install/bootstrap_livecd_remote_iso.md
+++ b/install/bootstrap_livecd_remote_iso.md
@@ -549,7 +549,7 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
 
     ```bash
     pit# mkdir -vp /mnt/pitdata
-    pit# mount -v -L PITDATA /mnt/pitdata
+    pit# mount -v --bind /var/www/ephemeral/ /mnt/pitdata/
     ```
 
 1. The following procedure will set up customized CA certificates for deployment using Shasta-CFG.


### PR DESCRIPTION
## Summary and Scope

The bootstrap_livecd_remote_iso.md procedure creates a duplicate mount of the PITDATA volume on /mnt/pitdata for compatibility with the prepare_site_init.md procedure.

SLES 15 SP3 flat out rejects a second mount of a device that is already mounted, a bind mount should be used instead.

## Issues and Related PRs

* Resolves [CASMINST-3655](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3655)

## Testing

### Tested on:

  * Tested during `hela` install.

### Test description:
Created bind mount
```
hela-ncn-m001-pit:~ # mount -v --bind /var/www/ephemeral/ /mnt/pitdata/
mount: /var/www/ephemeral bound on /mnt/pitdata.
```
The expected contents is visible on the new path
```
hela-ncn-m001-pit:~ # ls /mnt/pitdata
configs  cray-site-init-1.12.3-1~pr_96~20211202233331.1887911.x86_64.rpm  csm-1.2.0-alpha.31  csm-1.2.0-alpha.31.tar.gz  data  lost+found  prep  static
```

## Risks and Mitigations

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

