### PR TITLE
(CSM 1.0) CASMTRIAGE-2715: Use jq in place of python2 in get_token functions

### DIFF
--- a/operations/hardware_state_manager/Add_an_NCN_to_the_HSM_Database.md
+++ b/operations/hardware_state_manager/Add_an_NCN_to_the_HSM_Database.md
@@ -26,12 +26,12 @@ The examples in this procedure use `ncn-w0003-nmn` as the Customer Access Node \
    get\_token needs to be created or exist in the script with the following curl command. The get\_token function is defined below:
 
    ```bash
-   function get_token () {
-   ADMIN_SECRET=$(kubectl get secrets admin-client-auth -ojsonpath='{.data.client-secret}' | base64 -d)
-   curl -s -d grant_type=client_credentials -d client_id=admin-client -d client_secret=$ADMIN_SECRET \
-   https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | python -c 'import sys,
-   json; print json.load(sys.stdin)["access_token"]'
-   }
+    ncn-m001# function get_token () {
+        curl -s -S -d grant_type=client_credentials \
+            -d client_id=admin-client \
+            -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
+            https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token'
+    }
    ```
 
    The get\_token script adds the authorization required by the HTTPS security token. -H options tell the REST API to accept the data as JSON and that the information is for a JSON-enabled application.

--- a/operations/node_management/Move_a_Standard_Rack_Node.md
+++ b/operations/node_management/Move_a_Standard_Rack_Node.md
@@ -8,10 +8,10 @@ Update the location-based xname for a standard rack node within the system.
 
     ```screen
     ncn-m001# function get_token () {
-    ADMIN_SECRET=$(kubectl get secrets admin-client-auth -ojsonpath='{.data.client-secret}' | base64 -d)
-    curl -s -d grant_type=client_credentials -d client_id=admin-client -d client_secret=$ADMIN_SECRET \
-    https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token \
-    | python -c 'import sys, json; print json.load(sys.stdin)["access_token"]'
+        curl -s -S -d grant_type=client_credentials \
+            -d client_id=admin-client \
+            -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
+            https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token'
     }
     ```
 

--- a/operations/system_layout_service/Dump_SLS_Information.md
+++ b/operations/system_layout_service/Dump_SLS_Information.md
@@ -16,10 +16,11 @@ This procedure requires administrative privileges.
 1.  Use the get\_token function to retrieve a token to validate requests to the API gateway.
 
     ```bash
-    function get_token () {
-        ADMIN_SECRET=$(kubectl get secrets admin-client-auth -ojsonpath='{.data.client-secret}' | base64 -d)
-        curl -s -d grant_type=client_credentials -d client_id=admin-client -d client_secret=$ADMIN_SECRET \
-        https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | python -c 'import sys, json; print json.load(sys.stdin)["access_token"]'
+    ncn-m001# function get_token () {
+        curl -s -S -d grant_type=client_credentials \
+            -d client_id=admin-client \
+            -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
+            https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token'
     }
     ```
 

--- a/operations/system_layout_service/Load_SLS_Database_with_Dump_File.md
+++ b/operations/system_layout_service/Load_SLS_Database_with_Dump_File.md
@@ -14,10 +14,11 @@ The System Layout Service \(SLS\) database has been dumped. See [Dump SLS Inform
 1.  Use the get\_token function to retrieve a token to validate requests to the API gateway.
 
     ```bash
-    function get_token () {
-        ADMIN_SECRET=$(kubectl get secrets admin-client-auth -ojsonpath='{.data.client-secret}' | base64 -d)
-        curl -s -d grant_type=client_credentials -d client_id=admin-client -d client_secret=$ADMIN_SECRET \
-        https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | python -c 'import sys, json; print json.load(sys.stdin)["access_token"]'
+    ncn-m001# function get_token () {
+        curl -s -S -d grant_type=client_credentials \
+            -d client_id=admin-client \
+            -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
+            https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token'
     }
     ```
 


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
Updated the get_token functions that used python2 in the CSM documentation to now use jq instead, as python2 is no longer available on NCNs.

Also moved step 11 in the `Add a Standard Rack Node` procedure earlier in the procedure, and removed the command to discover a river chassis BMC as those don't exist.  

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-2715](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-2715)


## Testing

_List the environments in which these changes were tested._

### Tested on:
  * baldar

### Test description:
I verified on Baldar the get_token function worked as expected:


_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
Low risk, as the existing get_functions are currently broken.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

