### PR TITLE
(main) CASMTRIAGE-2715: Use jq in place of python2 in get_token functions

### DIFF
--- a/operations/hardware_state_manager/Add_an_NCN_to_the_HSM_Database.md
+++ b/operations/hardware_state_manager/Add_an_NCN_to_the_HSM_Database.md
@@ -26,12 +26,12 @@ The examples in this procedure use `ncn-w0003-nmn` as the Customer Access Node \
    get\_token needs to be created or exist in the script with the following curl command. The get\_token function is defined below:
 
    ```bash
-   function get_token () {
-   ADMIN_SECRET=$(kubectl get secrets admin-client-auth -ojsonpath='{.data.client-secret}' | base64 -d)
-   curl -s -d grant_type=client_credentials -d client_id=admin-client -d client_secret=$ADMIN_SECRET \
-   https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | python -c 'import sys,
-   json; print json.load(sys.stdin)["access_token"]'
-   }
+    ncn-m001# function get_token () {
+        curl -s -S -d grant_type=client_credentials \
+            -d client_id=admin-client \
+            -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
+            https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token'
+    }
    ```
 
    The get\_token script adds the authorization required by the HTTPS security token. -H options tell the REST API to accept the data as JSON and that the information is for a JSON-enabled application.

--- a/operations/node_management/Add_a_Standard_Rack_Node.md
+++ b/operations/node_management/Add_a_Standard_Rack_Node.md
@@ -7,10 +7,10 @@ These procedures are intended for trained technicians and support personnel only
 
     ```screen
     ncn-m001# function get_token () {
-    ADMIN_SECRET=$(kubectl get secrets admin-client-auth -ojsonpath='{.data.client-secret}' | base64 -d)
-    curl -s -d grant_type=client_credentials -d client_id=admin-client -d client_secret=$ADMIN_SECRET
-    https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token
-    | python -c 'import sys, json; print json.load(sys.stdin)["access_token"]'
+        curl -s -S -d grant_type=client_credentials \
+            -d client_id=admin-client \
+            -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
+            https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token'
     }
     ```
 
@@ -128,7 +128,33 @@ For this procedure, a new object must be created in the SLS and modifications wi
     ncn-m001# ping x3000c0s27b0
     ```
 
-8.  Verify that the nodes are enabled in the HSM.
+8. Verify that discovery has completed. The 
+
+    ```screen
+    ncn-m001# cray hsm inventory redfishEndpoints describe x3000c0s27b0
+    ID = "x3000c0s2b0"
+    Type = "NodeBMC"
+    Hostname = ""
+    Domain = ""
+    FQDN = "x3000c0s27b0"
+    Enabled = true
+    UUID = "990150e5-03bc-58b5-b986-cfd418d5778b"
+    User = "root"
+    Password = ""
+    RediscoverOnUpdate = true
+
+    [DiscoveryInfo]
+    LastDiscoveryAttempt = "2021-10-20T21:19:32.332521Z"
+    RedfishVersion = "1.6.0"
+    LastDiscoveryStatus = **"DiscoverOK"**
+    ```
+
+    - When `LastDiscoveryStatus` displays as `DiscoverOK`, the node BMC has been successfully discovered.
+    -  If the last discovery state is `DiscoveryStarted` then the BMC is currently being inventoried by HSM.
+    - If the last discovery state is `HTTPsGetFailed` or `ChildVerificationFailed`, then an error has
+      occurred during the discovery process.
+
+9.  Verify that the nodes are enabled in the HSM.
 
     ```screen
     ncn-m001# cray hsm state components describe x3000c0s27b0n0
@@ -166,46 +192,15 @@ For this procedure, a new object must be created in the SLS and modifications wi
     -   If the last discovery state is `DiscoveryStarted` then the BMC is currently being inventoried by HSM.
     -   If the last discovery state is `HTTPsGetFailed` or `ChildVerificationFailed` then an error occurred during the discovery process.
 
-9.  Enable each node individually in the HSM database \(in this example, the nodes are `x3000c0s27b1n0-n3`\).
+10. Enable the nodes in the HSM database \(in this example, the nodes are `x3000c0s27b1n0-n3`\).
 
     ```screen
-    ncn-m001# cray hsm state components enabled update --enabled true x3000c0s27b1n0
-    ncn-m001# cray hsm state components enabled update --enabled true x3000c0s27b0n1
-    ncn-m001# cray hsm state components enabled update --enabled true x3000c0s27b0n2
-    ncn-m001# cray hsm state components enabled update --enabled true x3000c0s27b0n3
+    ncn-m001# cray hsm state components bulkEnabled update --enabled true --component-ids x3000c0s27b1n0,x3000c0s27b1n1,x3000c0s27b1n2,x3000c0s27b1n3
     ```
 
-10. To force rediscovery of the components in rack 3000 \(standard racks are chassis 0\).
+11. Verify that the correct firmware versions for node BIOS, BMC, HSN NICs, GPUs, and so on.
 
-    ```screen
-    ncn-m001# cray hsm inventory discover create --xnames x3000c0
-    ```
-
-11. Verify that discovery has completed.
-
-    ```screen
-    ncn-m001# cray hsm inventory redfishEndpoints describe x3000c0
-    Type = "ChassisBMC"
-    Domain = ""
-    MACAddr = "02:13:88:03:00:00"
-    Enabled = true
-    Hostname = "x3000c0"
-    RediscoverOnUpdate = true
-    FQDN = "x3000c0"
-    User = "root"
-    Password = ""
-    IPAddress = "10.104.0.76"
-    ID = "x3000c0b0"
-
-    [DiscoveryInfo]
-    LastDiscoveryAttempt = "2020-09-03T19:03:47.989621Z"
-    RedfishVersion = "1.2.0"
-    LastDiscoveryStatus = **"DiscoverOK"**
-    ```
-
-12. Verify that the correct firmware versions for node BIOS, BMC, HSN NICs, GPUs, and so on.
-
-13. If necessary, update the firmware.
+12. If necessary, update the firmware.
 
     ```screen
     ncn-m001# cray fas actions create CUSTOM_DEVICE_PARAMETERS.json
@@ -213,7 +208,7 @@ For this procedure, a new object must be created in the SLS and modifications wi
 
     See [Update Firmware with FAS](../firmware/Update_Firmware_with_FAS.md).
 
-14. Use the Boot Orchestration Service \(BOS\) to power on and boot the nodes.
+13. Use the Boot Orchestration Service \(BOS\) to power on and boot the nodes.
 
     Use the appropriate BOS template for the node type.
 
@@ -222,7 +217,6 @@ For this procedure, a new object must be created in the SLS and modifications wi
     --operation reboot --limit x3000c0s27b0n0,x3000c0s27b0n1,x3000c0s27b0n2,x3000c0s27b00n3
     ```
 
-15. Verify the chassis status LEDs indicate normal operation.
-
+14. Verify the chassis status LEDs indicate normal operation.
 
 

--- a/operations/node_management/Move_a_Standard_Rack_Node.md
+++ b/operations/node_management/Move_a_Standard_Rack_Node.md
@@ -8,10 +8,10 @@ Update the location-based xname for a standard rack node within the system.
 
     ```screen
     ncn-m001# function get_token () {
-    ADMIN_SECRET=$(kubectl get secrets admin-client-auth -ojsonpath='{.data.client-secret}' | base64 -d)
-    curl -s -d grant_type=client_credentials -d client_id=admin-client -d client_secret=$ADMIN_SECRET \
-    https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token \
-    | python -c 'import sys, json; print json.load(sys.stdin)["access_token"]'
+        curl -s -S -d grant_type=client_credentials \
+            -d client_id=admin-client \
+            -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
+            https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token'
     }
     ```
 

--- a/operations/system_layout_service/Dump_SLS_Information.md
+++ b/operations/system_layout_service/Dump_SLS_Information.md
@@ -16,10 +16,11 @@ This procedure requires administrative privileges.
 1.  Use the get\_token function to retrieve a token to validate requests to the API gateway.
 
     ```bash
-    function get_token () {
-        ADMIN_SECRET=$(kubectl get secrets admin-client-auth -ojsonpath='{.data.client-secret}' | base64 -d)
-        curl -s -d grant_type=client_credentials -d client_id=admin-client -d client_secret=$ADMIN_SECRET \
-        https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | python -c 'import sys, json; print json.load(sys.stdin)["access_token"]'
+    ncn-m001# function get_token () {
+        curl -s -S -d grant_type=client_credentials \
+            -d client_id=admin-client \
+            -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
+            https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token'
     }
     ```
 

--- a/operations/system_layout_service/Load_SLS_Database_with_Dump_File.md
+++ b/operations/system_layout_service/Load_SLS_Database_with_Dump_File.md
@@ -14,10 +14,11 @@ The System Layout Service \(SLS\) database has been dumped. See [Dump SLS Inform
 1.  Use the get\_token function to retrieve a token to validate requests to the API gateway.
 
     ```bash
-    function get_token () {
-        ADMIN_SECRET=$(kubectl get secrets admin-client-auth -ojsonpath='{.data.client-secret}' | base64 -d)
-        curl -s -d grant_type=client_credentials -d client_id=admin-client -d client_secret=$ADMIN_SECRET \
-        https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | python -c 'import sys, json; print json.load(sys.stdin)["access_token"]'
+    ncn-m001# function get_token () {
+        curl -s -S -d grant_type=client_credentials \
+            -d client_id=admin-client \
+            -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
+            https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token'
     }
     ```
 


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
Updated the get_token functions that used python2 in the CSM documentation to now use jq instead, as python2 is no longer available on NCNs.

Also moved step 11 in the `Add a Standard Rack Node` procedure earlier in the procedure, and removed the command to discover a river chassis BMC as those don't exist.

Changes from this PR are missing from the main branch: https://github.com/Cray-HPE/docs-csm/pull/372

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-2715](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-2715)


## Testing

_List the environments in which these changes were tested._

### Tested on:
  * baldar

### Test description:
I verified on Baldar the get_token function worked as expected:


_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
Low risk, as the existing get_functions are currently broken.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

