### PR TITLE
CASMINST-3647 - fix enable ceph services

### DIFF
--- a/upgrade/1.0/scripts/ceph/ceph-upgrade.sh
+++ b/upgrade/1.0/scripts/ceph/ceph-upgrade.sh
@@ -233,7 +233,7 @@ if [ -f "$upgrade_rgws_file" ]; then
 else
   echo "Upgrading radosgw to 15.2.8"
   upgrade_rgws
-  wait_for_running_daemons rgw 3
+  wait_for_running_daemons rgw $(ceph node ls|jq -r '.osd|keys[]'|wc -l)
   echo "Enabling STS"
   enable_sts
   mark_initialized $upgrade_rgws_file

--- a/upgrade/1.0/scripts/ceph/ceph-upgrade.sh
+++ b/upgrade/1.0/scripts/ceph/ceph-upgrade.sh
@@ -255,9 +255,9 @@ scale_up_cephfs_clients
 echo "Enabling all Ceph services to start on boot"
 for host in $(ceph node ls| jq -r '.osd|keys[]'); do
   echo "Enabling services on host: $host"
-  ssh "$host" 'for service in $(cephadm ls |jq -r .[].systemd_unit|grep $(ceph status -f json-pretty |jq -r .fsid));do echo "Enabling service $service on $(hostname)"; systemctl enable $service; done'
+  ssh "$host" 'for service in $(cephadm ls |jq -r .[].systemd_unit);do echo "Enabling service $service on $(hostname)"; systemctl enable $service; done'
   echo "Verifying services on host: $host"
-  output=$(ssh "$host" 'for service in $(cephadm ls |jq -r .[].systemd_unit|grep $(ceph status -f json-pretty |jq -r .fsid));do echo $service; systemctl is-enabled $service; done')
+  output=$(ssh "$host" 'for service in $(cephadm ls |jq -r .[].systemd_unit);do echo $service; systemctl is-enabled $service; done')
   cnt=0
   client_array=( $output )
   array_length=${#client_array[@]}


### PR DESCRIPTION
## Summary and Scope

This was making an unused call to the ceph cluster which will not work
on nodes that do not have admin creds

## Issues and Related PR

* Resolves CASMINST-3647

## Testing

### Tested on:


### Test description:


- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

