### PR TITLE
Ensure ceph commands can run on all storage nodes

### DIFF
--- a/upgrade/1.0/scripts/ceph/ceph-upgrade.sh
+++ b/upgrade/1.0/scripts/ceph/ceph-upgrade.sh
@@ -272,3 +272,11 @@ for host in $(ceph node ls| jq -r '.osd|keys[]'); do
     fi
   done
 done
+
+echo "Ensuring ceph commands can be executed on all storage nodes"
+for host in $(ceph node ls| jq -r '.osd|keys[]'); do
+  if [[ ! "$host" =~ ^ncn-s00[1-3]*$ ]]; then
+    echo "Copying client.admin key to: $host"
+    scp /etc/ceph/ceph.client.admin.keyring $host:/etc/ceph
+  fi
+done


### PR DESCRIPTION
## Summary and Scope

This change ensures ceph commands can run on non-mon nodes such that haproxy can be properly configured and goss tests can run on nodes greater than 3.

## Issues and Related PRs

* Resolves [CASMINST-3681](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3681)

## Testing

Ran the code:

```
ncn-s001:~/bklein # ./foo.sh
Ensuring ceph commands can be executed on all storage nodes
Copying client.admin key to: ncn-s004
ceph.client.admin.keyring
```

...now tests succeed:

```
ncn-s004:~ # GOSS_BASE=/opt/cray/tests/install/ncn goss -g /opt/cray/tests/install/ncn/suites/ncn-upgrade-tests-storage.yaml --vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml validate
..........

Total Duration: 37.579s
Count: 10, Failed: 0, Skipped: 0
```

...and re-running the script to setup haproxy now succeeds:

```
ncn-s004:~ # tail /etc/haproxy/haproxy.cfg
    default_backend rgw-backend

backend rgw-backend
    option forwardfor
    balance static-rr
    option httpchk GET /
        server server-ncn-s001-rgw0 10.252.1.7:8080 check weight 100
        server server-ncn-s002-rgw0 10.252.1.6:8080 check weight 100
        server server-ncn-s003-rgw0 10.252.1.5:8080 check weight 100
        server server-ncn-s004-rgw0 10.252.1.4:8080 check weight 100
```
### Tested on:

  * `fanta`

### Test description:

Ran the new code on fanta

## Risks and Mitigations

N/A

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable