### PR TITLE
CASMINST-3692 - Remove dtr.dev.cray.com references from prepare_site_init.md process

### DIFF
--- a/install/prepare_site_init.md
+++ b/install/prepare_site_init.md
@@ -154,7 +154,7 @@ with system-specific customizations.
         > environment.
 
         ```bash
-        linux# /mnt/pitdata/${CSM_RELEASE}/hack/load-container-image.sh dtr.dev.cray.com/library/openjdk:11-jre-slim
+        linux# /mnt/pitdata/${CSM_RELEASE}/hack/load-container-image.sh artifactory.algol60.net/csm-docker/stable/docker.io/library/openjdk:11-jre-slim
         ```
 
         Create (or update) `cert.jks` with the PEM-encoded CA certificate for an
@@ -163,7 +163,7 @@ with system-specific customizations.
         > **`IMPORTANT`** Replace `<ca-cert.pem>` and `<alias>` as appropriate.
 
         ```bash
-        linux# podman run --rm -v "$(pwd):/data" dtr.dev.cray.com/library/openjdk:11-jre-slim keytool \
+        linux# podman run --rm -v "$(pwd):/data" artifactory.algol60.net/csm-docker/stable/docker.io/library/openjdk:11-jre-slim keytool \
         -importcert -trustcacerts -file /data/<ca-cert.pem> -alias <alias> -keystore /data/certs.jks \
         -storepass password -noprompt
         ```
@@ -252,7 +252,7 @@ with system-specific customizations.
         *   Create `certs.jks`:
 
             ```bash
-            linux# podman run --rm -v "$(pwd):/data" dtr.dev.cray.com/library/openjdk:11-jre-slim keytool -importcert \
+            linux# podman run --rm -v "$(pwd):/data" artifactory.algol60.net/csm-docker/stable/docker.io/library/openjdk:11-jre-slim keytool -importcert \
             -trustcacerts -file /data/cacert.pem -alias cray-data-center-ca -keystore /data/certs.jks \
             -storepass password -noprompt
             ```
@@ -503,7 +503,7 @@ encrypted.
     > **`NOTE`** Requires a properly configured Docker or Podman environment.
 
     ```bash
-    linux# /mnt/pitdata/${CSM_RELEASE}/hack/load-container-image.sh dtr.dev.cray.com/zeromq/zeromq:v4.0.5
+    linux# /mnt/pitdata/${CSM_RELEASE}/hack/load-container-image.sh artifactory.algol60.net/csm-docker/stable/docker.io/zeromq/zeromq:v4.0.5
     ```
 
 1.  Re-encrypt existing secrets:


### PR DESCRIPTION
## Summary and Scope

Update commands in documentation to load images from the correct path now that dtr.dev.cray.com images are no longer being shipped.

## Issues and Related PRs

* Resolves [CASMINST-3692](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3692)
* Change will also be needed in `csm` to update the generator
* Merge with `https://github.com/Cray-HPE/csm/pull/262`

## Testing

### Tested on:

  * `surtur`

### Test description:

New documentation followed, updated generator used to generate PALs SealedSecret.

## Risks and Mitigations

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

