### PR TITLE
CASMPET-5207 - Document fixing space issue on k8s nodes

### DIFF
--- a/operations/node_management/Clear_Space_in_Root_File_System_on_Worker_Nodes.md
+++ b/operations/node_management/Clear_Space_in_Root_File_System_on_Worker_Nodes.md
@@ -1,14 +1,14 @@
-## Clear Space in Root File System on Worker Nodes
+# Clear Space in Root File System on Worker Nodes
 
 The disk space on an NCN worker node can fill up if any services are consuming a large portion of the root file system on the node. This procedure shows how to safely clear some space on worker nodes to return them to an appropriate storage threshold.
 
-### Prerequisites
+## Prerequisites
 
 An NCN worker node has a full disk.
 
 ### Procedure
 
-1.  Check to see if Docker is running.
+1. Check to see if Docker is running.
 
     ```bash
     ncn-w001# syctemctl status docker
@@ -29,7 +29,7 @@ An NCN worker node has a full disk.
 
     If Docker is active, proceed to the next step to check its usage.
 
-2.  View the file space usage for Docker.
+2. View the file space usage for Docker.
 
     ```bash
     ncn-w001# du -sh /var/lib/docker
@@ -38,7 +38,7 @@ An NCN worker node has a full disk.
 
     If the output indicates usage is over 100GB, proceed to the next step to prune Docker.
 
-3.  Prune the Docker images.
+3. Prune the Docker images.
 
     The `until=24` option in the command below preserves data less than one day old.
 
@@ -48,7 +48,7 @@ An NCN worker node has a full disk.
 
     Check the usage again with the `du -sh /var/lib/docker` command.
 
-4.  Prune the Docker volumes.
+4. Prune the Docker volumes.
 
     The `until=24` option in the command below preserves data less than one day old.
 
@@ -58,7 +58,7 @@ An NCN worker node has a full disk.
 
     Check the usage again with the `du -sh /var/lib/docker` command.
 
-5.  Check the usage of /var/log/cray.
+5. Check the usage of /var/log/cray.
 
     Another potentially large consumer of space is /var/log/cray when certain debug flags are enabled.
 
@@ -68,6 +68,3 @@ An NCN worker node has a full disk.
     ```
 
     If the usage is over 20GB, examine the logging and determine if any of the older log information needs to be kept. Candidates for clean up include old imfile-state files, as well as old forwarding-queue files. Reduce the quantity of any additional logging as soon as possible to prevent the disk from filling up again.
-
-
-

--- a/troubleshooting/known_issues/kubernetes_node_rootFS_out_of_space.md
+++ b/troubleshooting/known_issues/kubernetes_node_rootFS_out_of_space.md
@@ -1,0 +1,36 @@
+# Kubernetes Master or Worker node's root filesystem is out of space
+
+## Description
+
+ There is a known bug in Kubernetes 1.19.9 where movement of a pod with an attached volume may not complete in time and cause the kubelet service to stream error messages to the /var/log/messages log file.  If this goes unchecked, it will fill up the root file system.
+
+## Fix
+
+1. Log into the node that has space issues.
+1. Verify that you have a large messages file in `/var/log/`.
+
+   ```bash
+   ncn-m/w:/var/log # ls -lh messages-20211212
+   -rw-r----- 1 root root 67G Dec 13 12:24 messages-20211212
+   ```
+
+1. Remove the file.
+1. Restart kubelet to address the streaming log entries.
+
+   ```bash
+   ncn-m/w# systemctl restart kubelet.service
+   ```
+
+1. Restart the syslog service.
+
+   ```bash
+   ncn-m/w# systemctl restart rsyslog
+   ```
+
+1. Verify that the space issue is resolved
+
+   ```bash
+   ncn-m/w# df -h /
+   Filesystem      Size  Used Avail Use% Mounted on
+   LiveOS_rootfs   280G  933M  279G   1% /
+   ```


### PR DESCRIPTION
## Summary and Scope

This is to address a known bug and not users filling up the volume.

## Issues and Related PRs

* Resolves CASMPET-5207

## Testing

### Tested on:

  *N/A

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

N/A


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

