### PR TITLE
CASMINST-3702 1.0.0-v2 : Add note where ncn-upgrade-k8s-worker.sh is run to re-try in 30m if postgres check fails

### DIFF
--- a/upgrade/1.0.1/Stage_3.md
+++ b/upgrade/1.0.1/Stage_3.md
@@ -28,6 +28,8 @@
 
     > NOTE: It is expected that some pods may be in bad states during a worker node upgrade. This is due to a temporary lack of computing resources. Once the worker node has been upgraded and has rejoined the cluster, those pods will be up and running again. All critical services have more than one replica so that if one pod is down, the service is still available.
 
+    > NOTE: It is possible that some postgres clusters may report errors when `ncn-upgrade-k8s-worker.sh` runs and checks the postgres clusters. If errors are reported indicating that a cluster does not have a leader or is lagging, it is recommended to re-run the `ncn-upgrade-k8s-worker.sh` again after waiting about 30 minutes to give the clusters time to resume to a healthy state. If postgres clusters still report leader or lag issues, then refer to [Troubleshoot Postgres Database](../../operations/kubernetes/Troubleshoot_Postgres_Database.md).
+
     ```bash
     ncn-m001# /usr/share/doc/csm/upgrade/1.0.1/scripts/upgrade/ncn-upgrade-k8s-worker.sh ncn-w001
     ```


### PR DESCRIPTION
## Summary and Scope

Adds note to wait and retry if  ncn-upgrade-k8s-worker.sh postgres cluster check fails
Also add link to Postgres troubleshooting if above does not resolve the issue

## Issues and Related PRs

* Resolves [CASMINST-3702](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3702)
* Change will also be needed in NA
* Future work required by NA
* Documentation changes required in NA
* Merge with/before/after NA

## Testing

_List the environments in which these changes were tested._

### Tested on:

Based on what was seen on fanta during 0.9.6 -> 1.0.1 upgrade.

### Test description:

NA

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

NA

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

