### PR TITLE
Add note to check BGP before first PXE boot

### DIFF
--- a/upgrade/1.0.1/Stage_2.md
+++ b/upgrade/1.0.1/Stage_2.md
@@ -8,6 +8,8 @@
 > ncn# unset CRAY_FORMAT
 >```
 
+1. In order for nodes to properly PXE boot, Border Gateway Protocol \(BGP\) must be healthy.  Before proceeding, check the status of BGP as described in the [Check BGP Status and Reset Sessions](../../operations/network/metallb_bgp/Check_BGP_Status_and_Reset_Sessions.md) procedure.
+
 1. Run `ncn-upgrade-ceph-nodes.sh` for `ncn-s001`. Follow output of the script carefully. The script will pause for manual interaction.
 
     ```bash


### PR DESCRIPTION
## Summary and Scope

Add note to verify BGP is healthy before starting NCN image upgrades in stage 2.

## Issues and Related PRs

* Resolves [CASMINST-3708](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3708)

## Testing

N/A

### Tested on:

N/A

### Test description:

N/A

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

