### PR TITLE
CASMINST-3711 - Correct documentation for editing bss.ipxe script

### DIFF
--- a/operations/boot_orchestration/Edit_the_iPXE_Embedded_Boot_Script.md
+++ b/operations/boot_orchestration/Edit_the_iPXE_Embedded_Boot_Script.md
@@ -66,8 +66,7 @@ This procedure requires administrative privileges.
 
             ```bash
             ncn-m001# kubectl delete configmap -n services cray-ipxe-bss-ipxe
-            ncn-m001# kubectl create configmap -n services cray-ipxe-bss-ipxe \
-            --from-file=/root/k8s/cray-ipxe-bss-ipxe.yaml
+            ncn-m001# kubectl create -f /root/k8s/cray-ipxe-bss-ipxe.yaml
             ```
 
 2.  Delete the iPXE pod to ensure the updated ConfigMap will be used.


### PR DESCRIPTION
## Summary and Scope

The `Edit_the_iPXE_Embedded_Boot_Script.md` document uses an incorrect command to load in the edited cray-ipxe-bss-ipxe ConfigMap which causes cray-ipxe to fail to build the binary on restart.

## Issues and Related PRs

* Resolves [CASMINST-3711](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3711)

## Testing

### Tested on:

  * `hela`

### Test description:

* Set the maxattempts parameter to 10 in the ConfigMap
* Validated that cray-ipxe successfully built a new ipxe.efi binary 
* Validated that the new binary contained the amended maxattempts parameter.

## Risks and Mitigations

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
