### PR TITLE
CASMINST-3714: Linting of redeploy pit node / deploy final NCN page

### DIFF
--- a/install/redeploy_pit_node.md
+++ b/install/redeploy_pit_node.md
@@ -29,12 +29,12 @@ Topics:
 These services must be healthy before the reboot of the LiveCD can take place. If the health checks performed earlier in the install completed successfully \([Validate CSM Health](../operations/validate_csm_health.md)\), the following platform services will be healthy and ready for reboot of the LiveCD:
 
    * Utility Storage (Ceph)
-   * cray-bss
-   * cray-dhcp-kea
-   * cray-dns-unbound
-   * cray-ipxe
-   * cray-sls
-   * cray-tftp
+   * `cray-bss`
+   * `cray-dhcp-kea`
+   * `cray-dns-unbound`
+   * `cray-ipxe`
+   * `cray-sls`
+   * `cray-tftp`
 
 <a name="notice-of-danger"></a>
 ### 2. Notice of Danger
@@ -66,25 +66,24 @@ the Kubernetes cluster as the final of three master nodes forming a quorum.
 #### 3.1 Start Hand-Off
 
 1. Start a new typescript (quit).
-   
-   Run this on the PIT node as root.
-   The prompts are removed for easier copy-paste; this step is only useful as a whole.
+    
+    1. Exit the current typescript if one has arrived here from the prior pages:
 
-   - Exit the current typescript if one has arrived here from the prior pages:
+        ```bash
+        pit# exit
+        pit# popd
+        ```
 
-      ```bash
-      pit# exit
-      pit# popd
-      ```
+    1. Start the new script:
 
-   - Start the new script:
+        > The prompts below are removed for easier copy-paste. This step is only useful as a whole.
 
-      ```bash
-      mkdir -pv /var/www/ephemeral/prep/admin
-      pushd /var/www/ephemeral/prep/admin
-      script -af csm-livecd-reboot.$(date +%Y-%m-%d).txt
-      export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
-      ```
+        ```bash
+        mkdir -pv /var/www/ephemeral/prep/admin
+        pushd /var/www/ephemeral/prep/admin
+        script -af csm-livecd-reboot.$(date +%Y-%m-%d).txt
+        export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
+        ```
 
 1. Follow the [workaround instructions](../update_product_stream/index.md#apply-workarounds) for the `livecd-pre-reboot` breakpoint.
 
@@ -98,7 +97,7 @@ the Kubernetes cluster as the final of three master nodes forming a quorum.
 
     Expected output looks similar to the following:
 
-    ```
+    ```text
     2021/02/02 14:05:15 Retrieving S3 credentials ( sls-s3-credentials ) for SLS
     2021/02/02 14:05:15 Uploading SLS file: /var/www/ephemeral/prep/eniac/sls_input_file.json
     2021/02/02 14:05:15 Successfully uploaded SLS Input File.
@@ -142,7 +141,7 @@ the Kubernetes cluster as the final of three master nodes forming a quorum.
             pit# export cephdir=$artdir/ceph
             ```
 
-    2. After setting the variables in the previous step, run the following command.
+    1. After setting the variables in the previous step, run the following command.
 
         ```bash
         pit# csi handoff ncn-images \
@@ -184,7 +183,21 @@ the Kubernetes cluster as the final of three master nodes forming a quorum.
     pit# csi handoff bss-update-cloud-init --set meta-data.dns-server=10.92.100.225 --limit Global
     ```
 
-1. Upload the bootstrap information; note this denotes information that should always be kept together in order to fresh-install the system again.
+1.  Preserve the ConMan console logs for the other NCNs if desired. (optional)
+
+    You may wish to preserve them for later examination, but it is not required. However, **this is the last chance to do so**. They will be lost after rebooting the PIT node.
+    
+    The following commands will copy them into a directory that will be backed up before the PIT node reboot.
+    
+    ```bash
+    
+    pit# mkdir -pv /var/www/ephemeral/prep/logs
+    pit# cp -prv /var/log/conman /var/www/ephemeral/prep/logs/conman.$(date +%Y-%m-%d_%H-%M-%S)
+    ```
+
+1. Upload the bootstrap information.
+   
+    > **NOTE:** This denotes information that should always be kept together in order to fresh-install the system again.
 
     1. Log in; setup passwordless SSH _to_ the PIT node by copying ONLY the public keys from `ncn-m002` and `ncn-m003` to the PIT (**do not setup passwordless SSH _from_ the PIT** or the key will have to be securely tracked or expunged if using a USB installation).
 
@@ -197,13 +210,13 @@ the Kubernetes cluster as the final of three master nodes forming a quorum.
         pit# chmod 600 /root/.ssh/authorized_keys
         ```
 
-    2. Run this to create the backup; in one swoop, log in to `ncn-m002` and `ncn-m003` and pull the files off the PIT. _This runs `rsync` with specific parameters; `partial`, `non-verbose`, and `progress`._
+    1. Run this backup files from the PIT to `ncn-m002` and `ncn-m003`. _This runs `rsync` with specific parameters; `partial`, `non-verbose`, and `progress`._
 
         ```bash
         pit# ssh ncn-m002 CSM_RELEASE=$(basename $(ls -d /var/www/ephemeral/csm*/ | head -n 1)) \
         "mkdir -pv /metal/bootstrap
         rsync -e 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' -rltD -P --delete pit.nmn:/var/www/ephemeral/prep /metal/bootstrap/
-        rsync -e 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' -rltD -P --delete pit.nmn:/var/www/ephemeral/${CSM_RELEASE}/cray-pre-install-toolkit*.iso /metal/bootstrap/"
+        rsync -e 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' -rltD -P --delete  pit.nmn:/var/www/ephemeral/${CSM_RELEASE}/cray-pre-install-toolkit*.iso /metal/bootstrap/"
         ```
 
         ```bash
@@ -240,14 +253,14 @@ the Kubernetes cluster as the final of three master nodes forming a quorum.
         pit# ssh ncn-m002 'ip a show vlan007 | grep inet'
         ```
 
-        _Expected output (values may differ)_:
+        _Expected output will look similar to the following (exact values may differ)_:
 
-        ```
+        ```text
         inet 10.102.11.13/24 brd 10.102.11.255 scope global vlan007
         inet6 fe80::1602:ecff:fed9:7820/64 scope link
         ```
 
-    2. Log in from another external machine to verify SSH is up and running for this session.
+    1. Log in from another external machine to verify SSH is up and running for this session.
 
         ```bash
         external# ssh root@10.102.11.13
@@ -257,13 +270,13 @@ the Kubernetes cluster as the final of three master nodes forming a quorum.
     > Keep this terminal active as it will enable `kubectl` commands during the bring-up of the new NCN.
     If the reboot successfully deploys the LiveCD, this terminal can be exited.
 
-    > **POINT OF NO RETURN** The next step will wipe the underlying nodes disks clean, it will ignore USB devices. RemoteISOs are at risk here, even though a backup has been
-    > performed of the PIT node we cannot simply boot back to the same state.
+    > **POINT OF NO RETURN:** The next step will wipe the underlying nodes disks clean, it will ignore USB devices. RemoteISOs are at risk here; even though a backup has been
+    > performed of the PIT node, we cannot simply boot back to the same state.
     > This is the last step before rebooting the node.
 
 1. Wipe the disks on the PIT node.
 
-    > **`WARNING : USER ERROR`** Do not assume to wipe the first three disks (e.g. `sda, sdb, and sdc`), they float and are not pinned to any physical disk layout. **Choosing the wrong ones may result in wiping the USB device**, the USB device can only be wiped by operators at this point in the install. The USB device are never wiped by the CSM installer.
+    > **`WARNING : USER ERROR`** Do not assume to wipe the first three disks (e.g. `sda, sdb, and sdc`), they float and are not pinned to any physical disk layout. **Choosing the wrong ones may result in wiping the USB device**. USB devices can only be wiped by operators at this point in the install. USB devices are never wiped by the CSM installer.
 
     1. Select disks to wipe (SATA/NVME/SAS).
 
@@ -279,7 +292,7 @@ the Kubernetes cluster as the final of three master nodes forming a quorum.
 
         Expected output looks similar to the following:
 
-        ```
+        ```text
         /dev/sda /dev/sdb /dev/sdc
         ```
 
@@ -291,7 +304,7 @@ the Kubernetes cluster as the final of three master nodes forming a quorum.
 
         If any disks had labels present, output looks similar to the following:
 
-        ```
+        ```text
         /dev/sda: 8 bytes were erased at offset 0x00000200 (gpt): 45 46 49 20 50 41 52 54
         /dev/sda: 8 bytes were erased at offset 0x6fc86d5e00 (gpt): 45 46 49 20 50 41 52 54
         /dev/sda: 2 bytes were erased at offset 0x000001fe (PMBR): 55 aa
@@ -302,11 +315,7 @@ the Kubernetes cluster as the final of three master nodes forming a quorum.
         /dev/sdc: 2 bytes were erased at offset 0x000001fe (PMBR): 55 aa
         ```
 
-        If there was any wiping done, output should appear similar to the snippet above. If this is re-ran, there may be no output or an ignorable error.
-
-1. Preserve the ConMan console logs for the other NCNs if desired.
-    
-    > **WARNING:** This is the last chance to do so. The logs will be lost after rebooting. They are located in `/var/log/conman` on the PIT node.
+        If there was any wiping done, output should appear similar to the snippet above. If this is re-run, there may be no output or an ignorable error.
 
 1. Quit the typescript session with the `exit` command and copy the file (`csm-livecd-reboot.<date>.txt`) to a location on another server for reference later.
 
@@ -508,14 +517,14 @@ the Kubernetes cluster as the final of three master nodes forming a quorum.
 > **`CSI NOTE`** `/tmp/csi` will delete itself on the next reboot. The `/tmp` directory is `tmpfs` and runs in memory, it normally will not persist on restarts.
 
 <a name="fix-ntp-config-on-ncn-m001"></a>
-### 6. Fix the NTP Config on ncn-m001
+### 6. Fix the NTP Config on `ncn-m001`
 
-Run the following commands on ncn-m001 **only**:
+Run the following commands on `ncn-m001` **only**:
 
 ```bash
-cp /usr/share/doc/csm/scripts/cc_ntp.py /usr/lib/python3.6/site-packages/cloudinit/config/cc_ntp.py
-cp /usr/share/doc/csm/scripts/chrony.conf.cray.tmpl /etc/cloud/templates/chrony.conf.cray.tmpl
-cloud-init single --name ntp --frequency always
+ncn-m001# cp /usr/share/doc/csm/scripts/cc_ntp.py /usr/lib/python3.6/site-packages/cloudinit/config/cc_ntp.py
+ncn-m001# cp /usr/share/doc/csm/scripts/chrony.conf.cray.tmpl /etc/cloud/templates/chrony.conf.cray.tmpl
+ncn-m001# cloud-init single --name ntp --frequency always
 ```
 
 <a name="configure-dns-and-ntp-on-each-bmc"></a>


### PR DESCRIPTION
## Summary and Scope

Mostly minor linting of the redeploy PIT node page. 

The only non-trivial change is that I moved the reminder about backing up conman console logs to an earlier step and provided commands to do it. This way those logs will be backed up along with the other stuff in the prep directory, using the existing backup steps. I've been meaning to make this change for a while, because especially for our internal installs it is useful to preserve those logs.

## Issues and Related PRs

https://github.com/Cray-HPE/docs-csm/pull/675
https://github.com/Cray-HPE/docs-csm/pull/676

## Testing

None other than visual inspection of the changes through GitHub.

## Risks and Mitigations

Very low risk.

## Pull Request Checklist

- [N/A] Version number(s) incremented, if applicable
- [N/A] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [N/A] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [N/A] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

