### PR TITLE
Add script to lower cpu requests for tds systems

### DIFF
--- a/operations/kubernetes/TDS_Lower_CPU_Requests.md
+++ b/operations/kubernetes/TDS_Lower_CPU_Requests.md
@@ -1,0 +1,47 @@
+## TDS Lower CPU Requests
+
+TDS systems with three worker nodes may encounter pod scheduling issues when worker nodes are taken out of the Kubernetes cluster and being upgraded.  _*For systems with only three worker nodes*_, the following script can be executed to reduce the CPU request for some services with high CPU requests in order to allow critical upgrade related services to be successfully scheduled on two worker nodes:
+
+>
+>```bash
+> ncn-m001# /usr/share/doc/csm/upgrade/1.2/scripts/k8s/tds_lower_cpu_requests.sh
+>```
+>
+
+Note that some services with these lower CPU request may encounter CPU throttling (see [Determine if Pods are Hitting Resource Limits](./Determine_if_Pods_are_Hitting_Resource_Limits.md)).  If needed, the top portion of the script (see below) can be edited and re-run to further adjust these CPU requests.  Note that commenting out any of the lines below will indicate the script should not adjust the CPU resource for that service.  Also see the `Kubernetes/Compute Resources/Namespace (Pods)` grafana page ([Access System Management Health Services](../system_management_health/Access_System_Management_Health_Services.md)) for a historical view of a given pod's CPU utilization for this specific system.
+
+>
+>```
+> spire_postgres_new_limit=1000m
+> elasticsearch_master_new_cpu_request=1500m
+> cluster_kafka_new_cpu_request=1
+> sma_grafana_new_cpu_request=100m
+> sma_kibana_new_cpu_request=100m
+> cluster_zookeeper_new_cpu_request=100m
+> cray_smd_new_cpu_request=1
+> cray_smd_postgres_new_cpu_request=500m
+> sma_postgres_cluster_new_cpu_request=500m
+> cray_capmc_new_cpu_request=500m
+> nexus_new_cpu_request=2
+> cray_metallb_speaker_new_cpu_request=1
+>```
+>
+
+The script will output the current value of the request along with the new value. It is recommended to capture and save the output (and store it external to the cluster) from this script in order to retain which values were changed (and from what value) in the event rolling back to the original value is desired:
+
+>
+>```
+> Patching cray-capmc deployment with new cpu request of 500m (from 2100m)
+> deployment.apps/cray-capmc patched
+> Waiting for deployment spec update to be observed...
+> Waiting for deployment "cray-capmc" rollout to finish: 0 out of 3 new replicas have been updated...
+> Waiting for deployment "cray-capmc" rollout to finish: 1 out of 3 new replicas have been updated...
+> Waiting for deployment "cray-capmc" rollout to finish: 1 out of 3 new replicas have been updated...
+> Waiting for deployment "cray-capmc" rollout to finish: 1 out of 3 new replicas have been updated...
+> Waiting for deployment "cray-capmc" rollout to finish: 2 out of 3 new replicas have been updated...
+> Waiting for deployment "cray-capmc" rollout to finish: 2 out of 3 new replicas have been updated...
+> Waiting for deployment "cray-capmc" rollout to finish: 2 out of 3 new replicas have been updated...
+> Waiting for deployment "cray-capmc" rollout to finish: 1 old replicas are pending termination...
+> Waiting for deployment "cray-capmc" rollout to finish: 1 old replicas are pending termination...
+> deployment "cray-capmc" successfully rolled out
+>```

--- a/upgrade/1.2/README.md
+++ b/upgrade/1.2/README.md
@@ -15,6 +15,11 @@ When doing a rolling upgrade of the entire cluster, at some point you will need 
 responsibility of the "stable" NCN to another master node. However, you do not need to do this before you are ready to
 upgrade that node.
 
+>**`IMPORTANT:`**
+>
+> For TDS systems with only three worker nodes, see [TDS Lower CPU Requests](../../operations/kubernetes/TDS_Lower_CPU_Requests.md) for information on how to lower CPU requests on several services which can improve pod scheduling on smaller systems during this upgrade.
+>
+
 ## Upgrade Stages
 
 - [Stage 0 - Prerequisites](Stage_0_Prerequisites.md)

--- a/upgrade/1.2/scripts/k8s/tds_lower_cpu_requests.sh
+++ b/upgrade/1.2/scripts/k8s/tds_lower_cpu_requests.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+
+#
+# Edit the following values as needed to suit specific system
+# requirements, ensuring pods run well and aren't being throttled
+# at an unacceptable level.  Comment out any of the following lines
+# if changing the CPU request for that particular service is not
+# desired.
+#
+
+spire_postgres_new_limit=2100m
+cray_capmc_new_cpu_request=500m
+elasticsearch_master_new_cpu_request=1500m
+cluster_kafka_new_cpu_request=1
+sma_grafana_new_cpu_request=100m
+sma_kibana_new_cpu_request=100m
+cluster_zookeeper_new_cpu_request=100m
+cray_smd_new_cpu_request=1
+cray_smd_postgres_new_cpu_request=1
+sma_postgres_cluster_new_cpu_request=500m
+nexus_new_cpu_request=2
+cray_metallb_speaker_new_cpu_request=1
+
+
+if [ ! -z $spire_postgres_new_limit ]; then
+  current_req=$(kubectl get postgresql -n spire spire-postgres -o json | jq -r '.spec.resources.requests.cpu')
+  echo "Patching spire-postgres cluster with new cpu request of $spire_postgres_new_limit (from $current_req)"
+  kubectl patch postgresql spire-postgres -n spire --type=json -p="[{'op' : 'replace', 'path':'/spec/resources/requests/cpu', 'value' : \"$spire_postgres_new_limit\" }]"
+  until [[ $(kubectl get postgresql -n spire spire-postgres -o json | jq -r '.status.PostgresClusterStatus') == "Running" ]]
+  do
+    echo "Waiting for spire-postgres cluster to reach running state..."
+    sleep 30
+  done
+  echo ""
+fi
+
+
+if [ ! -z $cray_smd_postgres_new_cpu_request ]; then
+  current_req=$(kubectl get postgresql cray-smd-postgres -n services -o json | jq -r '.spec.resources.requests.cpu')
+  echo "Patching cray-smd-postgres cluster with new cpu request of $cray_smd_postgres_new_cpu_request (from $current_req)"
+  kubectl patch postgresql cray-smd-postgres -n services --type=json -p="[{'op' : 'replace', 'path':'/spec/resources/requests/cpu', 'value' : \"$cray_smd_postgres_new_cpu_request\" }]"
+  until [[ $(kubectl get postgresqls.acid.zalan.do -n services cray-smd-postgres -o json | jq -r '.status.PostgresClusterStatus') == "Running" ]]
+  do
+    echo "Waiting for cray-smd-postgres cluster to reach running state..."
+    sleep 30
+  done
+  echo ""
+fi
+
+
+if [ ! -z $cray_smd_new_cpu_request ]; then
+  current_req=$(kubectl get deployment -n services cray-smd -o json | jq -r '.spec.template.spec.containers[] | select(.name== "cray-smd") | .resources.requests.cpu')
+  echo "Patching cray-smd deployment with new cpu request of $cray_smd_new_cpu_request (from $current_req)"
+  kubectl patch deployment cray-smd -n services --type=json -p="[{'op' : 'replace', 'path':'/spec/template/spec/containers/0/resources/requests/cpu', 'value' : \"$cray_smd_new_cpu_request\" }]"
+  kubectl rollout status deployment -n services cray-smd
+  echo ""
+fi
+
+
+if [ ! -z $cray_capmc_new_cpu_request ]; then
+  current_req=$(kubectl get deployment -n services cray-capmc -o json | jq -r '.spec.template.spec.containers[] | select(.name== "cray-capmc") | .resources.requests.cpu')
+  echo "Patching cray-capmc deployment with new cpu request of $cray_capmc_new_cpu_request (from $current_req)"
+  kubectl patch deployment cray-capmc -n services --type=json -p="[{'op' : 'replace', 'path':'/spec/template/spec/containers/0/resources/requests/cpu', 'value' : \"$cray_capmc_new_cpu_request\" }]"
+  kubectl rollout status deployment -n services cray-capmc
+  echo ""
+fi
+
+
+if [ ! -z $elasticsearch_master_new_cpu_request ]; then
+  current_req=$(kubectl get statefulset elasticsearch-master -n sma -o json | jq -r '.spec.template.spec.containers[] | select(.name== "sma-elasticsearch") | .resources.requests.cpu')
+  echo "Patching elasticsearch-master statefulset with new cpu request of $elasticsearch_master_new_cpu_request (from $current_req)"
+  kubectl patch statefulset elasticsearch-master -n sma --type=json -p="[{'op' : 'replace', 'path':'/spec/template/spec/containers/0/resources/requests/cpu', 'value' : \"$elasticsearch_master_new_cpu_request\" }]"
+  kubectl rollout status statefulset -n sma elasticsearch-master
+  echo ""
+fi
+
+
+if [ ! -z $cluster_kafka_new_cpu_request ]; then
+  current_req=$(kubectl get kafkas -n sma cluster -o json | jq -r '.spec.kafka.resources.requests.cpu')
+  echo "Patching cluster-kafka with new cpu request of $cluster_kafka_new_cpu_request (from $current_req)"
+  kubectl patch kafkas cluster -n sma --type=json -p="[{'op' : 'replace', 'path':'/spec/kafka/resources/requests/cpu', 'value' : \"$cluster_kafka_new_cpu_request\" }]"
+  sleep 10
+  until [[ $(kubectl -n sma get statefulset cluster-kafka -o json | jq -r '.status.updatedReplicas') -eq 3 ]]
+  do
+    echo "Waiting for cluster-kafka cluster to have three updated replicas..."
+    sleep 30
+  done
+  echo ""
+fi
+
+
+if [ ! -z $sma_grafana_new_cpu_request ]; then
+  current_req=$(kubectl get deployment sma-grafana -n services -o json | jq -r '.spec.template.spec.containers[] | select(.name== "sma-grafana") | .resources.requests.cpu')
+  echo "Patching sma-grafana deployment with new cpu request of $sma_grafana_new_cpu_request (from $current_req)"
+  kubectl patch deployment sma-grafana -n services --type=json -p="[{'op' : 'replace', 'path':'/spec/template/spec/containers/0/resources/requests/cpu', 'value' : \"$sma_grafana_new_cpu_request\" }]"
+  kubectl rollout status deployment -n services sma-grafana
+  echo ""
+fi
+
+
+if [ ! -z $sma_kibana_new_cpu_request ]; then
+  current_req=$(kubectl get deployment sma-kibana -n services -o json | jq -r '.spec.template.spec.containers[] | select(.name== "sma-kibana") | .resources.requests.cpu')
+  echo "Patching sma-kibana deployment with new cpu request of $sma_kibana_new_cpu_request (from $current_req)"
+  kubectl patch deployment sma-kibana -n services --type=json -p="[{'op' : 'replace', 'path':'/spec/template/spec/containers/0/resources/requests/cpu', 'value' : \"$sma_kibana_new_cpu_request\" }]"
+  kubectl rollout status deployment -n services sma-kibana
+  echo ""
+fi
+
+
+if [ ! -z $cluster_zookeeper_new_cpu_request ]; then
+  current_req=$(kubectl get kafkas -n sma cluster -o json | jq -r '.spec.zookeeper.resources.requests.cpu')
+  echo "Patching cluster-zookeeper statefulset with new cpu request of $cluster_zookeeper_new_cpu_request (from $current_req)"
+  kubectl patch kafkas cluster -n sma --type=json -p="[{'op' : 'replace', 'path':'/spec/zookeeper/resources/requests/cpu', 'value' : \"$cluster_zookeeper_new_cpu_request\" }]"
+  sleep 10
+  until [[ $(kubectl -n sma get statefulset cluster-zookeeper -o json | jq -r '.status.updatedReplicas') -eq 3 ]]
+  do
+    echo "Waiting for cluster-zookeeper cluster to have three updated replicas..."
+    sleep 30
+  done
+  echo ""
+fi
+
+
+if [ ! -z $sma_postgres_cluster_new_cpu_request ]; then
+  current_req=$(kubectl get postgresql -n sma sma-postgres-cluster -o json | jq -r '.spec.resources.requests.cpu')
+  echo "Patching sma-postgres-cluster statefulset with new cpu request of $sma_postgres_cluster_new_cpu_request (from $current_req)"
+  kubectl patch postgresql -n sma sma-postgres-cluster --type=json -p="[{'op' : 'replace', 'path':'/spec/resources/requests/cpu', 'value' : \"$sma_postgres_cluster_new_cpu_request\" }]"
+  until [[ $(kubectl get postgresql -n sma sma-postgres-cluster -o json | jq -r '.status.PostgresClusterStatus') == "Running" ]]
+  do
+    echo "Waiting for sma-postgres-cluster cluster to reach running state..."
+    sleep 30
+  done
+  echo ""
+fi
+
+
+if [ ! -z $nexus_new_cpu_request ]; then
+  current_req=$(kubectl get deployment -n nexus nexus -o json | jq -r '.spec.template.spec.containers[] | select(.name== "nexus") | .resources.requests.cpu')
+  echo "Patching nexus deployment with new cpu request of $nexus_new_cpu_request (from $current_req)"
+  kubectl patch deployment nexus -n nexus --type=json -p="[{'op' : 'replace', 'path':'/spec/template/spec/containers/0/resources/requests/cpu', 'value' : \"$nexus_new_cpu_request\" }]"
+  kubectl rollout status deployment -n nexus nexus
+  echo ""
+fi
+
+
+if [ ! -z $cray_metallb_speaker_new_cpu_request ]; then
+  current_req=$(kubectl get daemonset cray-metallb-speaker -n metallb-system -o json | jq -r '.spec.template.spec.containers[] | select(.name== "speaker") | .resources.requests.cpu')
+  echo "Patching nexus deployment with new cpu request of $cray_metallb_speaker_new_cpu_request (from $current_req)"
+  kubectl patch daemonset cray-metallb-speaker -n metallb-system --type=json -p="[{'op' : 'replace', 'path':'/spec/template/spec/containers/0/resources/requests/cpu', 'value' : \"$cray_metallb_speaker_new_cpu_request\" }]"
+  kubectl rollout status daemonset -n metallb-system cray-metallb-speaker
+  echo ""
+fi


### PR DESCRIPTION
## Summary and Scope

New script to lower CPU requests for several services which have unnecessarily high CPU request for three worker node systems.

## Issues and Related PRs

* Resolves [CAST-28531](https://jira-pro.its.hpecorp.net:8443/browse/CAST-28531)

## Testing

twister

### Tested on:

  * `twister`

### Test description:

Ran on twister.  


Before:

```
  Resource           Requests           Limits
  --------           --------           ------
  cpu                54605m (85%)       432 (675%)
  memory             73980585728 (27%)  732824456448 (271%)
  Resource           Requests            Limits
  --------           --------            ------
  cpu                61342m (95%)        503250m (786%)
  memory             102818069760 (38%)  653225176320 (242%)
  Resource           Requests           Limits
  --------           --------           ------
  cpu                48650m (76%)       445650m (696%)
  memory             94009753344 (34%)  640030944512 (237%)
```
After:

```
  Resource           Requests           Limits
  --------           --------           ------
  cpu                29005m (45%)       402 (628%)
  memory             69014529792 (25%)  708128394496 (262%)
  Resource           Requests            Limits
  --------           --------            ------
  cpu                37642m (58%)        471250m (736%)
  memory             104294464768 (38%)  658593885440 (244%)
  Resource           Requests           Limits
  --------           --------           ------
  cpu                37640m (58%)       503650m (786%)
  memory             97298087680 (36%)  656137071872 (243%)
```

```
Patching cray-smd-postgres cluster with new cpu request of 1 (from 4)
postgresql.acid.zalan.do/cray-smd-postgres patched
Waiting for cray-smd-postgres cluster to reach running state...
Waiting for cray-smd-postgres cluster to reach running state...
Waiting for cray-smd-postgres cluster to reach running state...
Waiting for cray-smd-postgres cluster to reach running state...
Waiting for cray-smd-postgres cluster to reach running state...
Waiting for cray-smd-postgres cluster to reach running state...
Waiting for cray-smd-postgres cluster to reach running state...
Waiting for cray-smd-postgres cluster to reach running state...
Waiting for cray-smd-postgres cluster to reach running state...
Waiting for cray-smd-postgres cluster to reach running state...

Patching cray-smd deployment with new cpu request of 1 (from 4)
deployment.apps/cray-smd patched
Waiting for deployment "cray-smd" rollout to finish: 1 out of 3 new replicas have been updated...
Waiting for deployment "cray-smd" rollout to finish: 1 out of 3 new replicas have been updated...
Waiting for deployment "cray-smd" rollout to finish: 1 out of 3 new replicas have been updated...
Waiting for deployment "cray-smd" rollout to finish: 2 out of 3 new replicas have been updated...
Waiting for deployment "cray-smd" rollout to finish: 2 out of 3 new replicas have been updated...
Waiting for deployment "cray-smd" rollout to finish: 2 out of 3 new replicas have been updated...
Waiting for deployment "cray-smd" rollout to finish: 1 old replicas are pending termination...
Waiting for deployment "cray-smd" rollout to finish: 1 old replicas are pending termination...
deployment "cray-smd" successfully rolled out

Patching spire-postgres cluster with new cpu request of 2100m (from 4)
postgresql.acid.zalan.do/spire-postgres patched
Waiting for spire-postgres cluster to reach running state...
Waiting for spire-postgres cluster to reach running state...
Waiting for spire-postgres cluster to reach running state...
Waiting for spire-postgres cluster to reach running state...
Waiting for spire-postgres cluster to reach running state...
Waiting for spire-postgres cluster to reach running state...
Waiting for spire-postgres cluster to reach running state...
Waiting for spire-postgres cluster to reach running state...
Waiting for spire-postgres cluster to reach running state...
Waiting for spire-postgres cluster to reach running state...
Waiting for spire-postgres cluster to reach running state...
Waiting for spire-postgres cluster to reach running state...
Waiting for spire-postgres cluster to reach running state...
Waiting for spire-postgres cluster to reach running state...

Patching cray-capmc deployment with new cpu request of 500m (from 2)
deployment.apps/cray-capmc patched
Waiting for deployment "cray-capmc" rollout to finish: 1 out of 3 new replicas have been updated...
Waiting for deployment "cray-capmc" rollout to finish: 1 out of 3 new replicas have been updated...
Waiting for deployment "cray-capmc" rollout to finish: 1 out of 3 new replicas have been updated...
Waiting for deployment "cray-capmc" rollout to finish: 2 out of 3 new replicas have been updated...
Waiting for deployment "cray-capmc" rollout to finish: 2 out of 3 new replicas have been updated...
Waiting for deployment "cray-capmc" rollout to finish: 2 out of 3 new replicas have been updated...
Waiting for deployment "cray-capmc" rollout to finish: 1 old replicas are pending termination...
Waiting for deployment "cray-capmc" rollout to finish: 1 old replicas are pending termination...
deployment "cray-capmc" successfully rolled out

Patching nexus deployment with new cpu request of 2 (from 4)
deployment.apps/nexus patched
Waiting for deployment "nexus" rollout to finish: 0 out of 1 new replicas have been updated...
Waiting for deployment "nexus" rollout to finish: 0 out of 1 new replicas have been updated...
Waiting for deployment "nexus" rollout to finish: 0 out of 1 new replicas have been updated...
Waiting for deployment "nexus" rollout to finish: 0 of 1 updated replicas are available...
deployment "nexus" successfully rolled out

Patching nexus deployment with new cpu request of 1 (from 2)
daemonset.apps/cray-metallb-speaker patched
Waiting for daemon set "cray-metallb-speaker" rollout to finish: 1 out of 3 new pods have been updated...
Waiting for daemon set "cray-metallb-speaker" rollout to finish: 1 out of 3 new pods have been updated...
Waiting for daemon set "cray-metallb-speaker" rollout to finish: 2 out of 3 new pods have been updated...
Waiting for daemon set "cray-metallb-speaker" rollout to finish: 2 out of 3 new pods have been updated...
Waiting for daemon set "cray-metallb-speaker" rollout to finish: 2 of 3 updated pods are available...
daemon set "cray-metallb-speaker" successfully rolled out

Patching elasticsearch-master statefulset with new cpu request of 1500m (from 4)
statefulset.apps/elasticsearch-master patched
waiting for statefulset rolling update to complete 0 pods at revision elasticsearch-master-5d6bb97d8c...
Waiting for 1 pods to be ready...
Waiting for 1 pods to be ready...
waiting for statefulset rolling update to complete 1 pods at revision elasticsearch-master-5d6bb97d8c...
Waiting for 1 pods to be ready...
Waiting for 1 pods to be ready...
waiting for statefulset rolling update to complete 2 pods at revision elasticsearch-master-5d6bb97d8c...
Waiting for 1 pods to be ready...
Waiting for 1 pods to be ready...
statefulset rolling update complete 3 pods at revision elasticsearch-master-5d6bb97d8c...

Patching cluster-kafka with new cpu request of 1 (from 5)
kafka.kafka.strimzi.io/cluster patched
Waiting for cluster-kafka cluster to have three updated replicas...
Waiting for cluster-kafka cluster to have three updated replicas...
Waiting for cluster-kafka cluster to have three updated replicas...
Waiting for cluster-kafka cluster to have three updated replicas...

Patching sma-grafana deployment with new cpu request of 100m (from 1)
deployment.apps/sma-grafana patched
Waiting for deployment "sma-grafana" rollout to finish: 1 old replicas are pending termination...
Waiting for deployment "sma-grafana" rollout to finish: 1 old replicas are pending termination...
deployment "sma-grafana" successfully rolled out

Patching sma-kibana deployment with new cpu request of 100m (from 1)
deployment.apps/sma-kibana patched
Waiting for deployment "sma-kibana" rollout to finish: 1 old replicas are pending termination...
Waiting for deployment "sma-kibana" rollout to finish: 1 old replicas are pending termination...
deployment "sma-kibana" successfully rolled out

Patching cluster-zookeeper statefulset with new cpu request of 100m (from 1)
kafka.kafka.strimzi.io/cluster patched
Waiting for cluster-zookeeper cluster to have three updated replicas...
Waiting for cluster-zookeeper cluster to have three updated replicas...
Waiting for cluster-zookeeper cluster to have three updated replicas...

Patching sma-postgres-cluster statefulset with new cpu request of 500m (from 2)
postgresql.acid.zalan.do/sma-postgres-cluster patched
Waiting for sma-postgres-cluster cluster to reach running state...
Waiting for sma-postgres-cluster cluster to reach running state...
Waiting for sma-postgres-cluster cluster to reach running state...
Waiting for sma-postgres-cluster cluster to reach running state...
Waiting for sma-postgres-cluster cluster to reach running state...
Waiting for sma-postgres-cluster cluster to reach running state...
Waiting for sma-postgres-cluster cluster to reach running state...
Waiting for sma-postgres-cluster cluster to reach running state...
Waiting for sma-postgres-cluster cluster to reach running state...
Waiting for sma-postgres-cluster cluster to reach running state...
Waiting for sma-postgres-cluster cluster to reach running state...
Waiting for sma-postgres-cluster cluster to reach running state...
Waiting for sma-postgres-cluster cluster to reach running state...
Waiting for sma-postgres-cluster cluster to reach running state...
Waiting for sma-postgres-cluster cluster to reach running state...
Waiting for sma-postgres-cluster cluster to reach running state...
Waiting for sma-postgres-cluster cluster to reach running state...
Waiting for sma-postgres-cluster cluster to reach running state...
Waiting for sma-postgres-cluster cluster to reach running state...
Waiting for sma-postgres-cluster cluster to reach running state...
Waiting for sma-postgres-cluster cluster to reach running state...
Waiting for sma-postgres-cluster cluster to reach running state...
```

## Risks and Mitigations

Medium

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable


