### PR TITLE
CASMINST-3475: Minor corrections, clarifications, revisions, and linting of fresh install docs

### DIFF
--- a/background/ncn_boot_workflow.md
+++ b/background/ncn_boot_workflow.md
@@ -107,37 +107,37 @@ The commands are the same for all hardware vendors, except where noted.
     * Gigabyte Technology
 
         ```bash
-        ncn# efibootmgr | grep -iP '(pxe ipv?4.*adapter)' | tee /tmp/bbs1
+        ncn/pit# efibootmgr | grep -iP '(pxe ipv?4.*adapter)' | tee /tmp/bbs1
         ```
         
     * Hewlett-Packard Enterprise
 
         ```bash
-        ncn# efibootmgr | grep -i 'port 1' | grep -i 'pxe ipv4' | tee /tmp/bbs1
+        ncn/pit# efibootmgr | grep -i 'port 1' | grep -i 'pxe ipv4' | tee /tmp/bbs1
         ```
 
     * Intel Corporation
 
         ```bash
-        ncn# efibootmgr | grep -i 'ipv4' | grep -iv 'baseboard' | tee /tmp/bbs1
+        ncn/pit# efibootmgr | grep -i 'ipv4' | grep -iv 'baseboard' | tee /tmp/bbs1
         ```
 
 1. Create a list of the cray disk boot devices.
 
     ```bash
-    ncn# efibootmgr | grep cray | tee /tmp/bbs2
+    ncn/pit# efibootmgr | grep cray | tee /tmp/bbs2
     ```
     
 1. Set the boot order to first PXE boot, with disk boot as the fallback options.
 
     ```bash
-    ncn# efibootmgr -o $(cat /tmp/bbs* | awk '!x[$0]++' | sed 's/^Boot//g' | tr -d '*' | awk '{print $1}' | tr -t '\n' ',' | sed 's/,$//') | grep -i bootorder
+    ncn/pit# efibootmgr -o $(cat /tmp/bbs* | awk '!x[$0]++' | sed 's/^Boot//g' | tr -d '*' | awk '{print $1}' | tr -t '\n' ',' | sed 's/,$//') | grep -i bootorder
     ```
 
 1. Set all of the desired boot options to be active.
 
     ```bash
-    ncn# cat /tmp/bbs* | awk '!x[$0]++' | sed 's/^Boot//g' | tr -d '*' | awk '{print $1}' | xargs -r -t -i efibootmgr -b {} -a
+    ncn/pit# cat /tmp/bbs* | awk '!x[$0]++' | sed 's/^Boot//g' | tr -d '*' | awk '{print $1}' | xargs -r -t -i efibootmgr -b {} -a
     ```
 
 After following the steps above on a given NCN, that NCN will now use the desired Shasta boot order.
@@ -159,29 +159,29 @@ In this case, the instructions are the same regardless of node type (management,
     * Gigabyte Technology
 
         ```bash
-        ncn# efibootmgr | grep -ivP '(pxe ipv?4.*)' | grep -iP '(adapter|connection|nvme|sata)' | tee /tmp/rbbs1
-        ncn# efibootmgr | grep -iP '(pxe ipv?4.*)' | grep -i connection | tee /tmp/rbbs2
+        ncn/pit# efibootmgr | grep -ivP '(pxe ipv?4.*)' | grep -iP '(adapter|connection|nvme|sata)' | tee /tmp/rbbs1
+        ncn/pit# efibootmgr | grep -iP '(pxe ipv?4.*)' | grep -i connection | tee /tmp/rbbs2
         ```
 
     * Hewlett-Packard Enterprise
         > **`NOTE`** This does not trim HSN Mellanox cards; these should disable their OpROMs using [the high speed network snippet(s)](../install/switch_pxe_boot_from_onboard_nic_to_pcie.md#high-speed-network).
 
         ```bash
-        ncn# efibootmgr | grep -vi 'pxe ipv4' | grep -i adapter |tee /tmp/rbbs1
-        ncn# efibootmgr | grep -iP '(sata|nvme)' | tee /tmp/rbbs2
+        ncn/pit# efibootmgr | grep -vi 'pxe ipv4' | grep -i adapter |tee /tmp/rbbs1
+        ncn/pit# efibootmgr | grep -iP '(sata|nvme)' | tee /tmp/rbbs2
         ```
 
     * Intel Corporation
 
         ```bash
-        ncn# efibootmgr | grep -vi 'ipv4' | grep -iP '(sata|nvme|uefi)' | tee /tmp/rbbs1
-        ncn# efibootmgr | grep -i baseboard | tee /tmp/rbbs2
+        ncn/pit# efibootmgr | grep -vi 'ipv4' | grep -iP '(sata|nvme|uefi)' | tee /tmp/rbbs1
+        ncn/pit# efibootmgr | grep -i baseboard | tee /tmp/rbbs2
         ```
 
 1. Remove them.
 
     ```bash
-    ncn# cat /tmp/rbbs* | awk '!x[$0]++' | sed 's/^Boot//g' | awk '{print $1}' | tr -d '*' | xargs -r -t -i efibootmgr -b {} -B
+    ncn/pit# cat /tmp/rbbs* | awk '!x[$0]++' | sed 's/^Boot//g' | awk '{print $1}' | tr -d '*' | xargs -r -t -i efibootmgr -b {} -B
     ```
 
 Your boot menu should be trimmed down to contain only relevant entries.
@@ -263,19 +263,19 @@ Reset the BIOS. Refer to vendor documentation for resetting the BIOS or attempt 
 1. Reset BIOS with `ipmitool`
 
     ```bash
-    ncn# ipmitool chassis bootdev none options=clear-cmos
+    ncn/pit# ipmitool chassis bootdev none options=clear-cmos
     ```
 
 1. Set next boot with `ipmitool`
 
     ```bash
-    ncn# ipmitool chassis bootdev pxe options=efiboot,persistent
+    ncn/pit# ipmitool chassis bootdev pxe options=efiboot,persistent
     ```
 
 1. Boot to BIOS for checkout of boot devices
 
     ```bash
-    ncn# ipmitool chassis bootdev bios options=efiboot
+    ncn/pit# ipmitool chassis bootdev bios options=efiboot
     ```
 
 This is the end of the Reverting Changes procedure.
@@ -292,7 +292,7 @@ Parsing the output of `efibootmgr` can be helpful in determining which device is
 1. Display the current UEFI boot selections.
 
     ```bash
-    ncn# efibootmgr
+    ncn/pit# efibootmgr
     BootCurrent: 0015
     Timeout: 1 seconds
     BootOrder: 000E,000D,0011,0012,0007,0005,0006,0008,0009,0000,0001,0002,000A,000B,000C,0003,0004,000F,0010,0013,0014
@@ -328,13 +328,13 @@ Parsing the output of `efibootmgr` can be helpful in determining which device is
     Notice the lack of "Boot" in the ID number given, we want `Boot0014` so we pass `0014` to `efibootmgr`:
 
     ```bash
-    ncn-m# efibootmgr -n 0014
+    ncn/pit# efibootmgr -n 0014
     ```
 
 1. Verify the `BootNext` device is what you selected:
 
     ```bash
-    ncn-m# efibootmgr | grep -i bootnext
+    ncn/pit# efibootmgr | grep -i bootnext
     BootNext: 0014
     ```
 

--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -98,19 +98,19 @@ proceed to step 2.
 
    Check the time on the PIT node to see whether it matches the current time:
 
-   ```
+   ```bash
    pit# date "+%Y-%m-%d %H:%M:%S.%6N%z"
    ```
 
    If the time is inaccurate, set the time manually.
 
-   ```
+   ```bash
    pit# timedatectl set-time "2019-11-15 00:00:00"
    ```
 
    Run the NTP script:
 
-   ```
+   ```bash
    pit# /root/bin/configure-ntp.sh
    ```
 
@@ -150,7 +150,7 @@ proceed to step 2.
       > To access the serial version of the BIOS setup. Perform the ipmitool steps above to boot the node. Then in conman press `ESC+9` key combination to when you
       > see the following messages in the console, this will open you to a menu that can be used to enter the BIOS via conman.
       >
-      > ```
+      > ```text
       > For access via BIOS Serial Console:
       > Press 'ESC+9' for System Utilities
       > Press 'ESC+0' for Intelligent Provisioning
@@ -195,10 +195,10 @@ firmware requirement before starting.
    on the HPE Customer Support Center at https://www.hpe.com/support/ex-gsg for information about the HPE Cray EX HPC Firmware Pack (HFP) product.
 
    In the HFP documentation there is information about the recommended firmware packages to be installed.
-   See "Product Details" in the _HPE Cray EX HPC Firwmare Pack Installation Guide_.
+   See "Product Details" in the _HPE Cray EX HPC Firmware Pack Installation Guide_.
 
    Some of the component types have manual procedures to check firmware versions and update firmware. 
-   See "Upgrading Firmware Without FAS" in the _HPE Cray EX HPC Firwmare Pack Installation Guide_.
+   See "Upgrading Firmware Without FAS" in the _HPE Cray EX HPC Firmware Pack Installation Guide_.
    It will be possible to extract the files from the product tarball, but the install.sh script from that product 
    will be unable to load the firmware versions into the Firmware Action Services (FAS) because the management nodes
    are not booted and running Kubernetes and FAS cannot be used until Kubernetes is running.
@@ -236,7 +236,7 @@ for all nodes, the Ceph storage will have been initialized and the Kubernetes cl
 
 <a name="deploy-workflow"></a>
 ### 3.1 Deploy Workflow
-The configuration workflow described here is intended to help understand the expected path for booting and configuring. See the actual steps below for the commands to deploy these management NCNs.
+The configuration workflow described here is intended to help understand the expected path for booting and configuring. The actual steps you will be performing are in the [Deploy](#deploy) section.
 
 1. Start watching the consoles for `ncn-s001` and at least one other storage node
 1. Boot all storage nodes at the same time
@@ -312,7 +312,7 @@ The configuration workflow described here is intended to help understand the exp
 
     Expected output looks similar to the following:
 
-    ```
+    ```text
     ncn-m001-mgmt
     ncn-m002-mgmt
     ncn-m003-mgmt
@@ -354,7 +354,7 @@ The configuration workflow described here is intended to help understand the exp
 
     Expected output looks similar to the following:
 
-    ```
+    ```text
     ncn-s001-mgmt
     ```
 
@@ -383,7 +383,7 @@ The configuration workflow described here is intended to help understand the exp
 1.  Stop watching the console from `ncn-s001`.
 
     Type the ampersand character and then the period character to exit from the conman session on `ncn-s001`.
-    ```
+    ```text
     &.
     pit#
     ```
@@ -398,7 +398,7 @@ The configuration workflow described here is intended to help understand the exp
 
     Expected output looks similar to the following:
 
-    ```
+    ```text
     ncn-m002-mgmt
     ```
 
@@ -421,7 +421,7 @@ The configuration workflow described here is intended to help understand the exp
 
     Expected output looks similar to the following:
 
-    ```
+    ```text
     NAME       STATUS   ROLES    AGE     VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                                                  KERNEL-VERSION         CONTAINER-RUNTIME
     ncn-m002   Ready    master   14m     v1.18.6   10.252.1.5    <none>        SUSE Linux Enterprise High Performance Computing 15 SP2   5.3.18-24.43-default   containerd://1.3.4
     ncn-m003   Ready    master   13m     v1.18.6   10.252.1.6    <none>        SUSE Linux Enterprise High Performance Computing 15 SP2   5.3.18-24.43-default   containerd://1.3.4
@@ -433,7 +433,7 @@ The configuration workflow described here is intended to help understand the exp
 1.  Stop watching the console from `ncn-m002`.
 
     Type the ampersand character and then the period character to exit from the conman session on `ncn-m002`.
-    ```
+    ```text
     &.
     pit#
     ```
@@ -452,7 +452,7 @@ pit# /usr/share/doc/csm/install/scripts/check_lvm.sh
 #### 3.3.2 Expected Check Output
 
 Expected output looks something like
-```
+```text
 When prompted, please enter the NCN password for ncn-m002
 Warning: Permanently added 'ncn-m002,10.252.1.11' (ECDSA) to the list of known hosts.
 Password:
@@ -476,6 +476,8 @@ Warning: Permanently added 'ncn-w003,10.252.1.7' (ECDSA) to the list of known ho
 ncn-w003: OK
 SUCCESS: LVM checks passed on all master and worker NCNs
 ```
+
+If the check succeeds, skip the manual check procedure and recovery steps.
 
 ***If the check fails for any nodes, the problem must be resolved before continuing.*** See [LVM Check Failure Recovery](#lvm-check-failure-recovery).
 
@@ -681,15 +683,42 @@ After the management nodes have been deployed, configuration can be applied to t
 
 The LiveCD needs to authenticate with the cluster to facilitate the rest of the CSM installation.
 
-1. Copy the Kubernetes config to the LiveCD to be able to use `kubectl` as cluster administrator.
+1. Determine which master node is the first master node.
 
-   > This will always be whatever node is the `first-master-hostname` in your `/var/www/ephemeral/configs/data.json | jq` file. If you are provisioning your HPE Cray EX system from `ncn-m001` then you can expect to fetch these from `ncn-m002`.
+   If you are provisioning your HPE Cray EX system from `ncn-m001` (i.e. it is your PIT node), then most likely this will be `ncn-m002`.
+
+   Run the following commands on the PIT node to extract the value of the `first-master-hostname` field from your `/var/www/ephemeral/configs/data.json` file:
+   
+   ```bash
+   pit# FM=$(cat /var/www/ephemeral/configs/data.json | jq -r '."Global"."meta-data"."first-master-hostname"')
+   pit# echo $FM
+   ```
+
+1. Copy the Kubernetes configuration file from that node to the LiveCD to be able to use `kubectl` as cluster administrator.
+
+   Run the following commands on the PIT node:
 
    ```bash
    pit# mkdir -v ~/.kube
-   pit# scp ncn-m002.nmn:/etc/kubernetes/admin.conf ~/.kube/config
+   pit# scp ${FM}.nmn:/etc/kubernetes/admin.conf ~/.kube/config
    ```
 
+1. Validate that you are now able to run `kubectl` commands from the PIT node.
+
+    ```bash
+    pit# kubectl get nodes -o wide
+    ```
+
+    Expected output looks similar to the following:
+
+    ```text
+    NAME       STATUS   ROLES    AGE     VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                                                  KERNEL-VERSION         CONTAINER-RUNTIME
+    ncn-m002   Ready    master   14m     v1.18.6   10.252.1.5    <none>        SUSE Linux Enterprise High Performance Computing 15 SP2   5.3.18-24.43-default   containerd://1.3.4
+    ncn-m003   Ready    master   13m     v1.18.6   10.252.1.6    <none>        SUSE Linux Enterprise High Performance Computing 15 SP2   5.3.18-24.43-default   containerd://1.3.4
+    ncn-w001   Ready    <none>   6m30s   v1.18.6   10.252.1.7    <none>        SUSE Linux Enterprise High Performance Computing 15 SP2   5.3.18-24.43-default   containerd://1.3.4
+    ncn-w002   Ready    <none>   6m16s   v1.18.6   10.252.1.8    <none>        SUSE Linux Enterprise High Performance Computing 15 SP2   5.3.18-24.43-default   containerd://1.3.4
+    ncn-w003   Ready    <none>   5m58s   v1.18.6   10.252.1.12   <none>        SUSE Linux Enterprise High Performance Computing 15 SP2   5.3.18-24.43-default   containerd://1.3.4
+    ```
 
 <a name="bgp-routing"></a>
 ### 4.2 BGP Routing
@@ -779,7 +808,7 @@ After the NCNs are booted, the BGP peers will need to be checked and updated if 
         * Mellanox: `show run protocol bgp` The passive neighbor configuration is required. `router bgp 65533 vrf default neighbor 10.252.1.7 transport connection-mode passive` 
 
             EXAMPLE ONLY
-            ```
+            ```text
             protocol bgp
             router bgp 65533 vrf default
             router bgp 65533 vrf default router-id 10.252.0.2 force
@@ -800,6 +829,8 @@ After the NCNs are booted, the BGP peers will need to be checked and updated if 
 
 <a name="install-tests"></a>
 ### 4.4 Install Tests and Test Server on NCNs
+
+Run the following commands on the PIT node.
 
 ```bash
 pit# export CSM_RELEASE=csm-x.y.z
@@ -829,7 +860,7 @@ Observe the output of the checks and note any failures, then remediate them.
    Once that command has finished, check the last line of output to see the results of the tests.
 
    Example last line of output:
-   ```
+   ```text
    Total Tests: 7, Total Passed: 7, Total Failed: 0, Total Execution Time: 1.4226 seconds
    ```
 
@@ -851,7 +882,7 @@ Observe the output of the checks and note any failures, then remediate them.
    ```
 
    Example output for a system with 5 master and worker nodes (other than the PIT node):
-   ```
+   ```text
    Total Tests: 16, Total Passed: 16, Total Failed: 0, Total Execution Time: 0.3072 seconds
    Total Tests: 16, Total Passed: 16, Total Failed: 0, Total Execution Time: 0.2727 seconds
    Total Tests: 12, Total Passed: 12, Total Failed: 0, Total Execution Time: 0.2841 seconds
@@ -861,50 +892,52 @@ Observe the output of the checks and note any failures, then remediate them.
 
    If these total lines report any failed tests, look through the full output of the test to see which node had the failed test and what the details are for that test.
 
-   > **`WARNING`** If there are failures for tests with names like "Worker Node CONLIB FS Label", then manual tests should be run on the node which reported the failure. See [Manual LVM Check Procedure](#manual-lvm-check-procedure). If the manul tests fail, then the problem must be resolved before continuing to the next step. See [LVM Check Failure Recovery](#lvm-check-failure-recovery).
+   > **`WARNING`** If there are failures for tests with names like "Worker Node CONLIB FS Label", then manual tests should be run on the node which reported the failure. See [Manual LVM Check Procedure](#manual-lvm-check-procedure). If the manual tests fail, then the problem must be resolved before continuing to the next step. See [LVM Check Failure Recovery](#lvm-check-failure-recovery).
 
 1. Ensure that weave has not split-brained
 
-   Run the following command on each member of the Kubernetes cluster (master nodes and worker nodes) to ensure that weave is operating as a single cluster:
+   To ensure that weave is operating as a single cluster, run the following command on each member of the Kubernetes cluster (master nodes and worker nodes but **not the PIT node**):
 
    ```bash
    ncn# weave --local status connections | grep failed
    ```
-   If you see messages like `IP allocation was seeded by different peers` then weave looks to have split-brained. At this point it is necessary to wipe the NCNs and start the PXE boot again:
+   
+   If the check is successful, there will be no output. If you see messages like `IP allocation was seeded by different peers`, then weave looks to have split-brained. At this point it is necessary to wipe the NCNs and start the PXE boot again:
 
    1. Wipe the NCNs using the 'Basic Wipe' section of [Wipe NCN Disks for Reinstallation](wipe_ncn_disks_for_reinstallation.md).
    1. Return to the 'Boot the **Storage Nodes**' step of [Deploy Management Nodes](#deploy_management_nodes) section above.
 
-
 <a name="optional-validation"></a>
 ### 5.2 Optional Validation
 
-   1. Verify all nodes have joined the cluster
+   1. Verify `etcd` is running outside Kubernetes on master nodes
 
-   Check that the status of kubernetes nodes is `Ready`.
-   ```bash
-   ncn# kubectl get nodes
-   ```
-   If one or more nodes are not in the `Ready` state, the following command can be run to get additional information:
-   ```bash
-   ncn# kubectl describe node <node-name>  #for example, ncn-m001
-   ```
+      On each Kubernetes master node (but not the PIT node), check the status of the `etcd` service and ensure it is active and running:
 
-   2. Verify etcd is running outside Kubernetes on master nodes
+      ```bash
+      ncn-m# systemctl status etcd.service
+      ```
+   
+      The second two lines of the expected output should look similar to the following:
+   
+      ```text
+         Loaded: loaded (/etc/systemd/system/etcd.service; enabled; vendor preset: disabled)
+         Active: active (running) since Mon 2021-12-13 20:12:00 UTC; 51min 6s ago
+      ```
 
-   On each kubernetes master node, check the status of the etcd service and ensure it is Active/Running:
-   ```bash
-   ncn-m# systemctl status etcd.service
-   ```
+   1. Verify that all the pods in the `kube-system` namespace are `Running` or `Completed`.
 
-   3. Verify that all the pods in the kube-system namespace are running
+      Run the following command on any Kubernetes master or worker node, or the PIT node:
 
-   Check that pods listed are in the `Running` or `Completed` state.
-   ```bash
-   ncn# kubectl get pods -o wide -n kube-system
-   ```
+      ```bash
+      ncn-mw/pit# kubectl get pods -o wide -n kube-system | grep -Ev '(Running|Completed)'
+      ```
+   
+      If any pods are listed by this command, it means they are not in the `Running` or `Completed` state. That needs to be investigated before proceeding.
 
-   4. Verify that the ceph-csi requirements are in place [Ceph CSI Troubleshooting](ceph_csi_troubleshooting.md)
+   1. Verify that the ceph-csi requirements are in place.
+   
+      See [Ceph CSI Troubleshooting](ceph_csi_troubleshooting.md) for details.
 
 # Important Checkpoint
 

--- a/install/index.md
+++ b/install/index.md
@@ -144,27 +144,23 @@ sections, but there is also a general troubleshooting topic.
 
    1. Validate CSM Health Before PIT Node Redeploy
 
-      After installing all of the CSM services now would be an good time to validate the health of the
-      management nodes and all CSM services. The advantage in doing it now is that if there are any problems
-      detected with the core infrastructure or the nodes, it is easy to rewind the installation to
-      [Deploy Management Nodes](#deploy_management_nodes) because the PIT node has not yet been redeployed.
+      After installing all of the CSM services, now validate the health of the management nodes and all CSM services. 
+      The reason to do it now is that if there are any problems detected with the core infrastructure or the nodes, it is
+      easy to rewind the installation to [Deploy Management Nodes](#deploy_management_nodes) because the PIT node has not
+      yet been redeployed. In addition, redeploying the PIT node successfully requires several CSM services to be working
+      properly, so validating this is important.
 
-      After installing all of the CSM services, wait at least 15 minutes to let the various Kubernetes
-      resources get initialized and started before trying to validate CSM health. Because there are a number
-      of dependencies between them, some services are not expected to work immediately after the install
-      script completes. Some of the time waiting can be spent preparing the `cray` CLI.
+      **Note**: At this point of the install, the `cray` CLI has not yet been configured. Some of the tests (Hardware State
+      Manager Discovery Validation, Booting the CSM Barebones Image on compute nodes, UAS/UAI) require it to be configured
+      in order to run. These tests may be skipped until after the PIT node has been redeployed, but **this is not recommended**.
 
-      **Note**: If doing the CSM validation at this point, some of the tests which use the 'cray' CLI may fail
-      until these two procedures have been done. These tests, such as Hardware State Manager Discovery Validation,
-      Booting the CSM Barebones Image on compute nodes, or the UAS/UAI Tests can be skipped until after the PIT
-      node has been redeployed.
+      To enable the 'cray' CLI in order to execute those tests, follow these two procedures before performing the CSM health
+      validation:
 
-      To enable the 'cray' CLI, these two procedures could be done now.
+         1. [Configure Keycloak Account](configure_administrative_access.md#configure_keycloak_account)
+         1. [Configure the Cray Command Line Interface (cray CLI)](configure_administrative_access.md#configure_cray_cli)
 
-      * Optional [Configure Keycloak Account](configure_administrative_access.md#configure_keycloak_account)
-      * Optional [Configure the Cray Command Line Interface (cray CLI)](configure_administrative_access.md#configure_cray_cli)
-
-      To run the CSM health checks now, see [Validate CSM Health](../operations/validate_csm_health.md)
+      To run the CSM health checks, see [Validate CSM Health](../operations/validate_csm_health.md)
    <a name="redeploy_pit_node"></a>
 
    1. Redeploy PIT Node

--- a/install/install_csm_services.md
+++ b/install/install_csm_services.md
@@ -13,10 +13,10 @@ This procedure will install CSM applications and services into the CSM Kubernete
    1. [Set NCNs to use Unbound](#set-ncns-to-use-unbound)
    1. [Apply Pod Priorities](#apply-pod-priorities)
    1. [Apply After Sysmgmt Manifest Workarounds](#apply-after-sysmgmt-manifest-workarounds)
+   1. [Wait For Everything To Settle](#wait-for-everything-to-settle)
    1. [Known Issues](#known-issues)
       * [`install.sh` Known Issues](#known-issues-install-sh)
    1. [Next Topic](#next-topic)
-
 
 ## Details
 
@@ -368,11 +368,17 @@ After running the `add_pod_priority.sh` script, the affected pods will be restar
 
 Follow the [workaround instructions](../update_product_stream/index.md#apply-workarounds) for the `after-sysmgmt-manifest` breakpoint.
 
+<a name="wait-for-everything-to-settle"></a>
+### 9. Wait For Everything To Settle
+
+Wait **at least 15 minutes** to let the various Kubernetes resources get initialized and started before proceeding with the rest of the install.
+Because there are a number of dependencies between them, some services are not expected to work immediately after the install script completes.
+
 <a name="known-issues"></a>
-### 9. Known Issues
+### 10. Known Issues
 
 <a name="known-issues-install-sh"></a>
-#### 9.1 `install.sh` Known Issues
+#### 10.1 `install.sh` Known Issues
 
 The `install.sh` script changes cluster state and should not simply be rerun
 in the event of a failure without careful consideration of the specific
@@ -414,7 +420,7 @@ The following error may occur when running `./install.sh`:
   4. Running `install.sh` again is expected to succeed.
 
 <a name="next-topic"></a>
-# 10. Next Topic
+# 11. Next Topic
 
    After completing this procedure the next step is to redeploy the PIT node.
 

--- a/install/redeploy_pit_node.md
+++ b/install/redeploy_pit_node.md
@@ -74,7 +74,7 @@ the Kubernetes cluster as the final of three master nodes forming a quorum.
         pit# popd
         ```
 
-    1. Start the new script:
+    1. Start the new script on the PIT node.
 
         > The prompts below are removed for easier copy-paste. This step is only useful as a whole.
 
@@ -216,7 +216,7 @@ the Kubernetes cluster as the final of three master nodes forming a quorum.
         pit# ssh ncn-m002 CSM_RELEASE=$(basename $(ls -d /var/www/ephemeral/csm*/ | head -n 1)) \
         "mkdir -pv /metal/bootstrap
         rsync -e 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' -rltD -P --delete pit.nmn:/var/www/ephemeral/prep /metal/bootstrap/
-        rsync -e 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' -rltD -P --delete  pit.nmn:/var/www/ephemeral/${CSM_RELEASE}/cray-pre-install-toolkit*.iso /metal/bootstrap/"
+        rsync -e 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' -rltD -P --delete pit.nmn:/var/www/ephemeral/${CSM_RELEASE}/cray-pre-install-toolkit*.iso /metal/bootstrap/"
         ```
 
         ```bash
@@ -232,11 +232,11 @@ the Kubernetes cluster as the final of three master nodes forming a quorum.
     pit# efibootmgr | grep -Ei "ip(v4|4)"
     ```
 
-1. Set the boot order and trim the boot order on the PIT node.
+1. Set and trim the boot order on the PIT node.
 
-    In [Deploy Management Nodes](deploy_management_nodes.md#configure-and-trim-uefi-entries), this procedure was done on the other NCNs. Now it is time to do it on the PIT node. See [Setting Boot Order](../background/ncn_boot_workflow.md#setting-order) and [Trimming Boot Order](../background/ncn_boot_workflow.md#trimming_boot_order).
+    This only needs to be done for the PIT node, not for any of the other NCNs. For the procedures to do this, see [Setting Boot Order](../background/ncn_boot_workflow.md#setting-order) and [Trimming Boot Order](../background/ncn_boot_workflow.md#trimming_boot_order).
 
-1. Tell the node to PXE boot on the next boot. 
+1. Tell the PIT node to PXE boot on the next boot. 
    
    Use `efibootmgr` to set the next boot device to the first PXE boot option. This step assumes the boot order was set up in the previous step.
 
@@ -344,13 +344,15 @@ the Kubernetes cluster as the final of three master nodes forming a quorum.
     pit# reboot
     ```
 
-1. After the node boots, acquire its hostname (i.e. `ncn-m001`), and run cloud-init.
+1. Wait for the node to boot, acquire its hostname (i.e. `ncn-m001`), and run cloud-init.
+
+    If all of that happens successfully, **skip the rest of this step and proceed to the next step**. Otherwise, use the following information to remediate the problems.
 
     > **NOTE:**: If the nodes has PXE boot issues, such as getting PXE errors or not pulling the ipxe.efi binary, see [PXE boot troubleshooting](pxe_boot_troubleshooting.md).
 
     > **NOTE:** If `ncn-m001` did not run all the cloud-init scripts, the following commands need to be run **(but only in that circumstance)**.
 
-    1. Run the following commands:
+    * Run the following commands on `ncn-m001` **ONLY IF** `ncn-m001` did not run all the cloud-init scripts:
 
         ```bash
         ncn-m001# cloud-init clean
@@ -373,7 +375,7 @@ the Kubernetes cluster as the final of three master nodes forming a quorum.
 
 1. Change the root password on `ncn-m001` if the pre-NCN deployment password change method was **not** used.
    
-   Run `passwd` on ncn-m001 and complete the prompts.
+   Run `passwd` on `ncn-m001` and complete the prompts.
 
     ```bash
     ncn-m001# passwd
@@ -446,21 +448,11 @@ the Kubernetes cluster as the final of three master nodes forming a quorum.
     ncn-m001# rm -v /etc/zypp/repos.d/* && zypper ms --remote --disable
     ```
 
-1. Install the latest documentation and workaround packages. This will require external access.
+1. Download and install/upgrade the workaround and documentation RPMs. 
 
-   If this machine does not have direct Internet access these RPMs will need to be externally downloaded and then copied to the system.
+    If this machine does not have direct internet access these RPMs will need to be externally downloaded and then copied to this machine.
 
-   **IMPORTANT:** In an earlier step, the CSM release plus any patches, workarounds, or hotfixes
-   were downloaded to a system using the instructions in [Check for Latest Workarounds and Documentation Updates](../update_product_stream/index.md#workarounds). Use that set of RPMs rather than downloading again.
-
-   ```bash
-   linux# wget https://storage.googleapis.com/csm-release-public/shasta-1.5/docs-csm/docs-csm-latest.noarch.rpm
-   linux# wget https://storage.googleapis.com/csm-release-public/shasta-1.5/csm-install-workarounds/csm-install-workarounds-latest.noarch.rpm
-   linux# scp -p docs-csm-*rpm csm-install-workarounds-*rpm ncn-m001:/root
-   linux# ssh ncn-m001
-   ncn-m001# rpm -Uvh docs-csm-latest.noarch.rpm
-   ncn-m001# rpm -Uvh csm-install-workarounds-latest.noarch.rpm
-   ```
+    **Important:** To ensure that the latest workarounds and documentation updates are available, see [Check for Latest Workarounds and Documentation Updates](../update_product_stream/index.md#workarounds)
 
 1. Follow the [workaround instructions](../update_product_stream/index.md#apply-workarounds) for the `livecd-post-reboot` breakpoint.
 
@@ -508,7 +500,7 @@ the Kubernetes cluster as the final of three master nodes forming a quorum.
     https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
     ```
 
-1.  **`IN-PLACE WORKAROUND`** Set the wipe safeguard to allow safe net-reboots. **This will set the safeguard on all NCNs**.
+1.  Set the wipe safeguard to allow safe net-reboots on all NCNs.
 
     ```bash
     ncn-m001# /tmp/csi handoff bss-update-param --set metal.no-wipe=1
@@ -517,7 +509,7 @@ the Kubernetes cluster as the final of three master nodes forming a quorum.
 > **`CSI NOTE`** `/tmp/csi` will delete itself on the next reboot. The `/tmp` directory is `tmpfs` and runs in memory, it normally will not persist on restarts.
 
 <a name="fix-ntp-config-on-ncn-m001"></a>
-### 6. Fix the NTP Config on `ncn-m001`
+### 6. Fix the NTP Configuration on `ncn-m001`
 
 Run the following commands on `ncn-m001` **only**:
 
@@ -532,43 +524,66 @@ ncn-m001# cloud-init single --name ntp --frequency always
 
  > **`NOTE`** If the system uses Gigabyte nodes or Intel nodes, skip this section.
 
-The following steps will configure DNS and NTP on the BMC for each management node **except ncn-m001**.
+Configure DNS and NTP on the BMC for each management node **except `ncn-m001`**. 
 
-1. Set environment variables. Make sure to set the appropriate value for the `IPMI_PASSWORD` variable.
+The commands in this section are all run on `ncn-m001`, but they are being run **for** 
+every management node **except `ncn-m001`**. That is, the `NCN` variable in the first step
+will end up being set to every NCN name **except** `ncn-m001`.
+
+Carry out the following steps for every NCN **except** `ncn-m001`:
+
+1. Set environment variables. 
+
+    Make sure to set the appropriate value for the `IPMI_PASSWORD` variable and `NCN` variable.
+
+    This example is for `ncn-m002`, but you will be repeating this procedure for every NCN **except** `ncn-m001`.
 
     ```bash
     ncn-m001# export IPMI_PASSWORD=changeme
     ncn-m001# export USERNAME=root
+    ncn-m001# NCN=ncn-m002
     ```
 
 1. Disable DHCP and configure NTP on the BMC using data from cloud-init.
 
     ```bash
-    ncn-m001# /opt/cray/csm/scripts/node_management/set-bmc-ntp-dns.sh ilo -H "$(hostname)-mgmt" -S -n
+    ncn-m001# /opt/cray/csm/scripts/node_management/set-bmc-ntp-dns.sh ilo -H "${NCN}-mgmt" -S -n
     ```
 
 1. Configure DNS on the BMC using data from cloud-init.
 
     ```bash
-    ncn-m001# /opt/cray/csm/scripts/node_management/set-bmc-ntp-dns.sh ilo -H "$(hostname)-mgmt" -d
+    ncn-m001# /opt/cray/csm/scripts/node_management/set-bmc-ntp-dns.sh ilo -H "${NCN}-mgmt" -d
     ```
 
 1. (Optional) View the settings of the BMC:
 
     ```bash
-    ncn-m001# /opt/cray/csm/scripts/node_management/set-bmc-ntp-dns.sh ilo -H "$(hostname)-mgmt" -s
+    ncn-m001# /opt/cray/csm/scripts/node_management/set-bmc-ntp-dns.sh ilo -H "${NCN}-mgmt" -s
     ```
+
+1. Repeat the previous steps for all remaining NCNs **except `ncn-m001`**.
 
 <a name="validate-bootraid-artifacts"></a>
 ### 8. Validate `BOOTRAID` artifacts
 
-Perform the following steps **on ncn-m001**.
+Perform the following steps **on `ncn-m001`**.
 
 1. Initialize the Cray CLI on `ncn-m001`. See [Configure the Cray Command Line Interface](../operations/configure_cray_cli.md) for details on how to do this.
 
-1. Run the script to ensure the local BOOTRAID has a valid kernel and initrd
+1. Ensure that `ssh` works from `ncn-m001` to itself.
 
+    The following command must work before proceeding to the next step.
+
+    ```bash
+    ncn-m001# ssh ncn-m001 date
     ```
+
+1. Run the script to ensure the local BOOTRAID has a valid kernel and initrd.
+
+    This script will perform the check on all NCNs, including `ncn-m001`.
+
+    ```bash
     ncn-m001# /opt/cray/tests/install/ncn/scripts/validate-bootraid-artifacts.sh
     ```
 

--- a/operations/conman/ConMan.md
+++ b/operations/conman/ConMan.md
@@ -2,11 +2,11 @@
 
 ConMan is a tool used for connecting to remote consoles and collecting console logs. These node logs can then be used for various administrative purposes, such as troubleshooting node boot issues.
 
-ConMan runs on the system as a containerized service. It runs in a set of Docker containers within Kubernetes pods named cray-console-operator and cray-console-node. ConMan can be configured to encrypt usernames and passwords. Node console logs are stored locally within the cray-console-operator pod in the /var/log/conman/ directory, as well as being collected by the System Monitoring Framework \(SMF\).
+ConMan runs on the system as a containerized service. It runs in a set of Docker containers within Kubernetes pods named `cray-console-operator` and `cray-console-node`. ConMan can be configured to encrypt usernames and passwords. Node console logs are stored locally within the `cray-console-operator pod` in the `/var/log/conman/` directory, as well as being collected by the System Monitoring Framework \(SMF\).
 
 ## New in Release 1.5
 
-In previous releases, the entire service was contained in the cray-conman pod, and both logs and interactive access was handled through that single pod. Starting with version 1.5, the logs can be accessed through the cray-console-operator pod but interactive console access is handled through one of the cray-console-node pods. There are multiple cray-console-node pods, scaled to the size of the system.
+In previous releases, the entire service was contained in the `cray-conman` pod, and both logs and interactive access were handled through that single pod. Starting with version 1.5, the logs can be accessed through the `cray-console-operator` pod, but interactive console access is handled through one of the `cray-console-node` pods. There are multiple `cray-console-node` pods, scaled to the size of the system.
 
 ## How To Use
 

--- a/operations/conman/Log_in_to_a_Node_Using_ConMan.md
+++ b/operations/conman/Log_in_to_a_Node_Using_ConMan.md
@@ -4,11 +4,11 @@ This procedure shows how to connect to the node's Serial Over Lan (SOL) via ConM
 
 ### Prerequisites
 
-The user performing this procedure needs to have access permission to the cray-console-operator and cray-console-node pods.
+The user performing this procedure needs to have access permission to the `cray-console-operator` and `cray-console-node` pods.
 
 ### Procedure
 
-1. Log in to a non-compute node (NCN) that acts as the Kubernetes master or worker. This procedure assumes that it is being carried out on an NCN acting as a Kubernetes master.
+1. Log in to a non-compute node (NCN) that acts as a Kubernetes master or worker.
 
 1. Retrieve the `cray-console-operator` pod ID.
 

--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -64,7 +64,6 @@ Health Check scripts can be run:
 * Any time there is unexpected behavior on the system to get a baseline of data for CSM services and components
 * In order to provide relevant information to support tickets that are being opened after CSM install.sh has been run
 
-
 Available Platform Health Checks:
 1. [ncnHealthChecks](#pet-ncnhealthchecks)
 1. [ncnPostgresHealthChecks](#pet-ncnpostgreshealthchecks)
@@ -78,10 +77,10 @@ Available Platform Health Checks:
 <a name="pet-ncnhealthchecks"></a>
 ### 1.1 ncnHealthChecks
 
-Health Check scripts can be found and run on any worker or master node (not on PIT node), from any directory.
+NCN Health Check scripts can be found and run on any worker or master node (**not on the PIT node**), from any directory.
 
    ```bash
-   ncn# /opt/cray/platform-utils/ncnHealthChecks.sh
+   ncn-mw# /opt/cray/platform-utils/ncnHealthChecks.sh
    ```
 
 The ncnHealthChecks script reports the following health information:
@@ -105,10 +104,10 @@ Execute the ncnHealthChecks script and analyze the output of each individual che
 **IMPORTANT:** Only when ncn-m001 has been booted, if the output of the ncnHealthChecks.sh script shows that there are nodes that do not have the metal.no-wipe=1 status, then do the following:
 
 ```bash
-ncn# csi handoff bss-update-param --set metal.no-wipe=1 --limit <SERVER_XNAME>
+ncn-mw# csi handoff bss-update-param --set metal.no-wipe=1 --limit <SERVER_XNAME>
 ```
 
-**IMPORTANT:** If the output of pod statuses indicates that there are pods in the `Evicted` state, it may be due to the /root file system being filled up on the Kubernetes node in question. Kubernetes will begin evicting pods once the root file system space is at 85% until it is back under 80%. This may commonly happen on ncn-m001 as it is a location that install and doc files may be downloaded to. It may be necessary to clean-up space in the /root directory if this is the root cause of pod evictions. The following commands can be used to determine if analysis of files under /root is needed to free-up space.
+**IMPORTANT:** If the output of pod statuses indicates that there are pods in the `Evicted` state, it may be due to the `/root` file system being filled up on the Kubernetes node in question. Kubernetes will begin evicting pods once the root file system space is at 85% until it is back under 80%. This may commonly happen on `ncn-m001` as it is a location that install and doc files may be downloaded to. It may be necessary to clean-up space in the `/root` directory if this is the cause of pod evictions. The following commands can be used to determine if analysis of files under `/root` is needed to free-up space.
 
 ```bash
 ncn# df -h /root
@@ -129,15 +128,14 @@ ncn# du -ah -B 1024M /root | sort -n -r | head -n 10
 are installed. In particular, this will be the case if executing this as part of the validation after completing the [Install CSM Services](../install/install_csm_services.md).
 If in doubt, validate the CRUS service using the [CMS Validation Tool](#sms-health-checks). If the CRUS check passes using that tool, do not worry about the `cray-crus-` pod state.
 
-Additionally, hmn-discovery and unbound manager cronjob pods may be in a 'NotReady' state. This is expected as these pods are periodically started and transition to the completed state.
+Additionally, `hms-discovery` and `cray-dns-unbound-manager` cronjob pods may be in a 'NotReady' state. This is expected as these pods are periodically started and should eventually transition to the `Completed` state.
 
-**IMPORTANT:** If `ncn-s001` is down when running the ncnHealthChecks script, status from the `ceph -s` command  will be unavailable. In this case, the `ceph -s` command can be executed on any available master or storage node to determine the status of the Ceph cluster.
+**IMPORTANT:** If `ncn-s001` is down when running the ncnHealthChecks script, status from the `ceph -s` command will be unavailable. In this case, the `ceph -s` command can be executed on any available master or storage node to determine the status of the Ceph cluster.
 
 <a name="pet-ncnpostgreshealthchecks"></a>
 ### 1.2 ncnPostgresHealthChecks
 
-
-Postgres Health Check scripts can be found and run on any worker or master node (not on PIT node), from any directory.
+Postgres Health Check scripts can be found and run on any worker or master node (**not on the PIT node**), from any directory.
 The ncnPostgresHealthChecks script reports the following postgres health information:
 * The status of each postgresql resource
 * The number of cluster members
@@ -357,7 +355,7 @@ Retrieve all the leases currently in KEA:
 ncn# curl -H "Authorization: Bearer ${TOKEN}" -X POST -H "Content-Type: application/json" -d '{ "command": "lease4-get-all", "service": [ "dhcp4" ] }' https://api-gw-service-nmn.local/apis/dhcp-kea | jq
 ```
 
-If there is an non-zero amount of DHCP leases for air-cooled hardware returned, that is a good indication that KEA is working.
+If there is a non-zero amount of DHCP leases for air-cooled hardware returned, then that is a good indication that KEA is working.
 
 <a name="net-extdns"></a>
 ### 1.5 Verify ability to resolve external DNS
@@ -480,6 +478,8 @@ Information to assist with troubleshooting some of the components mentioned in t
 
 Execute the HMS smoke and functional tests after the CSM install to confirm that the Hardware Management Services are running and operational.
 
+Note: Do not run HMS tests concurrently on multiple nodes. They may interfere with one another and cause false failures.
+
 <a name="hms-test-execution"></a>
 ### 2.1 HMS Test Execution
 
@@ -560,10 +560,10 @@ __For each__ of the BMCs that show up in either of mismatch lists use the follow
    x3000c0s1b0  # No mgmt port association
    ```
 
-* The node BMCs for HPE Apollo XL645D nodes may report as a mismatch depedning on the state of the system when the `hsm_discovery_verify.sh` script is ran. If the system is currently going through the process of installation, then this is an expected mistmatch as the [Preapre Compute Nodes](../install/prepare_compute_nodes.md) procedure required to configure the BMC of the HPE Apollo 6500 XL645D node may not have been completed yet. 
+* The node BMCs for HPE Apollo XL645D nodes may report as a mismatch depending on the state of the system when the `hsm_discovery_verify.sh` script is run. If the system is currently going through the process of installation, then this is an expected mismatch as the [Prepare Compute Nodes](../install/prepare_compute_nodes.md) procedure required to configure the BMC of the HPE Apollo 6500 XL645D node may not have been completed yet. 
    > For more information refer to [Configure HPE Apollo 6500 XL645d Gen10 Plus Compute Nodes](../install/prepare_compute_nodes.md#configure-hpe-apollo-6500-x645d-gen10-plus-compute-nodes) for additional required configuration for this type of BMC.
 
-   Example mistmatch for the BMC of a HPE Apollo XL654D:
+   Example mismatch for the BMC of a HPE Apollo XL654D:
    ```bash
    =============== BMCs in SLS not in HSM components ===============
    x3000c0s30b1
@@ -671,6 +671,8 @@ the Cray OS (COS) product, or similar, be used.
 ---
 **NOTES**
 
+* This test is **very important to run** during the CSM install prior to redeploying the PIT node
+because it validates all of the services required for that operation.
 * The CSM Barebones image included with the release will not successfully complete
 the beyond the dracut stage of the boot process. However, if the dracut stage is reached the
 boot can be considered successful and shows that the necessary CSM services needed to
@@ -711,7 +713,7 @@ Expected output is similar to the following:
     "path": "s3://boot-images/293b1e9c-2bc4-4225-b235-147d1d611eef/manifest.json",
     "type": "s3"
   },
-  "name": "cray-shasta-csm-sles15sp1-barebones.x86_64-shasta-1.4"
+  "name": "cray-shasta-csm-sles15sp1-barebones.x86_64-shasta-1.5"
 }
 ```
 
@@ -747,7 +749,7 @@ The session template below can be copied and used as the basis for the BOS Sessi
        "configuration": "cos-integ-config-1.4.0"
      },
      "enable_cfs": false,
-     "name": "shasta-1.4-csm-bare-bones-image"
+     "name": "shasta-1.5-csm-bare-bones-image"
    }
    ```
 
@@ -755,11 +757,11 @@ The session template below can be copied and used as the basis for the BOS Sessi
 
 2. Create the BOS session template using the following file as input:
    ```
-   ncn# cray bos sessiontemplate create --file sessiontemplate.json --name shasta-1.4-csm-bare-bones-image
+   ncn# cray bos sessiontemplate create --file sessiontemplate.json --name shasta-1.5-csm-bare-bones-image
    ```
    The expected output is:
    ```
-   /sessionTemplate/shasta-1.4-csm-bare-bones-image
+   /sessionTemplate/shasta-1.5-csm-bare-bones-image
    ```
 
 <a name="csm-node"></a>
@@ -808,14 +810,14 @@ ncn# export XNAME=x3000c0s17b2n0
 
 Create a BOS session to reboot the chosen node using the BOS session template that was created:
 ```bash
-ncn# cray bos session create --template-uuid shasta-1.4-csm-bare-bones-image --operation reboot --limit $XNAME
+ncn# cray bos session create --template-uuid shasta-1.5-csm-bare-bones-image --operation reboot --limit $XNAME
 ```
 
 Expected output looks similar to the following:
 ```
 limit = "x3000c0s17b2n0"
 operation = "reboot"
-templateUuid = "shasta-1.4-csm-bare-bones-image"
+templateUuid = "shasta-1.5-csm-bare-bones-image"
 [[links]]
 href = "/v1/session/8f2fc013-7817-4fe2-8e6f-c2136a5e3bd1"
 jobId = "boa-8f2fc013-7817-4fe2-8e6f-c2136a5e3bd1"
@@ -955,7 +957,7 @@ This procedure must run on a master or worker node (not the PIT node and not `nc
 
 1. Set `UAINAME` to the value of the `uai_name` field in the previous command output (`uai-vers-a00fb46b` in our example):
    ```bash
-   ncn# export UAINAME=uai-vers-a00fb46b
+   ncn# UAINAME=uai-vers-a00fb46b
    ```
 
 1. Check the current status of the UAI:


### PR DESCRIPTION
## Summary and Scope

This PR is correcting issues that I saw during an install of hela a while ago. Much of this PR consists of typical MitchLint(TM) of the install docs, as well as minor changes to clarify or add emphasis. Other than those types of changes, the main things in this PR are:
* Explain why the Barebones Boot Test is important and that skipping it is not recommended
* Warn that running HMS tests concurrently on different nodes can produce false failures.
* Add a jq command to directly extract the first-master-node field from data.json in the "deploy management nodes" procedure
* Remove redundant execution of "kubectl get nodes" command in "deploy management nodes" procedure
* Move "wait 15 minutes after csm install" to be an explicit step at the end of the CSM install procedure.
* Since the "set/trim boot order" step is no longer performed during the "deploy management nodes" procedure, I altered the language around that step in the "redeploy pit node" procedure.
* Add an ssh check before running the bootraid artifact validation in "redeploy pit node" procedure -- this is because usually that fails when ncn-m001 fails to ssh to itself (because the key needs to be accepted).

None of the changes are anything major, but many of them are correcting things that trip up or annoy installers.

## Issues and Related PRs

https://github.com/Cray-HPE/docs-csm/pull/690
https://github.com/Cray-HPE/docs-csm/pull/691

## Testing

Ran the docs through spell checks and manually proofread them.

## Risks and Mitigations

Low risk. Changes are mostly minor.

## Pull Request Checklist

- [N/A] Version number(s) incremented, if applicable
- [N/A] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [N/A] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [N/A [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

