### PR TITLE
CASMINST-3726:  Sync update-customizations.sh with recent changes to customizations.yaml

### DIFF
--- a/upgrade/1.2/scripts/upgrade/update-customizations.sh
+++ b/upgrade/1.2/scripts/upgrade/update-customizations.sh
@@ -117,7 +117,6 @@ yq w -i "$c" 'spec.kubernetes.services.cray-dns-powerdns.cray-service.sealedSecr
 
 # Add proxiedWebAppExternalHostnames
 yq w -i --style=single "$c" 'spec.proxiedWebAppExternalHostnames.customerManagement[+]' "{{ kubernetes.services['gatekeeper-policy-manager']['gatekeeper-policy-manager'].externalAuthority }}"
-yq w -i --style=single "$c" 'spec.proxiedWebAppExternalHostnames.customerManagement[+]' "{{ kubernetes.services['cray-nexus'].istio.ingress.hosts.ui.authority }}"
 yq w -i --style=single "$c" 'spec.proxiedWebAppExternalHostnames.customerManagement[+]' "{{ kubernetes.services['cray-istio'].istio.tracing.externalAuthority }}"
 yq w -i --style=single "$c" 'spec.proxiedWebAppExternalHostnames.customerManagement[+]' "{{ kubernetes.services['cray-kiali'].externalAuthority }}"
 yq w -i --style=single "$c" 'spec.proxiedWebAppExternalHostnames.customerManagement[+]' "{{ kubernetes.services['cray-sysmgmt-health']['prometheus-operator'].prometheus.prometheusSpec.externalAuthority }}"
@@ -184,7 +183,7 @@ yq w -i "$c" 'spec.kubernetes.services.cray-istio.services.istio-ingressgateway-
 yq w -i "$c" 'spec.kubernetes.services.cray-istio.services.istio-ingressgateway-can.serviceAnnotations.[external-dns.alpha.kubernetes.io/hostname]' 'api.can.{{ network.dns.external}},auth.can.{{ network.dns.external }}'
 
 yq w -i "$c" 'spec.kubernetes.services.cray-istio.services.istio-ingressgateway-cmn.serviceAnnotations.[metallb.universe.tf/address-pool]' 'customer-management'
-yq w -i "$c" 'spec.kubernetes.services.cray-istio.services.istio-ingressgateway-cmn.serviceAnnotations.[external-dns.alpha.kubernetes.io/hostname]' 'api.cmn.{{ network.dns.external}},auth.cmn.{{ network.dns.external }}'
+yq w -i "$c" 'spec.kubernetes.services.cray-istio.services.istio-ingressgateway-cmn.serviceAnnotations.[external-dns.alpha.kubernetes.io/hostname]' 'api.cmn.{{ network.dns.external}},auth.cmn.{{ network.dns.external }},nexus.cmn.{{ network.dns.external }}'
 
 yq w -i "$c" 'spec.kubernetes.services.cray-istio.services.istio-ingressgateway-chn.serviceAnnotations.[metallb.universe.tf/address-pool]' 'customer-high-speed'
 yq w -i "$c" 'spec.kubernetes.services.cray-istio.services.istio-ingressgateway-chn.serviceAnnotations.[external-dns.alpha.kubernetes.io/hostname]' 'api.chn.{{ network.dns.external}},auth.chn.{{ network.dns.external }}'
@@ -245,11 +244,16 @@ yq w -i "$c" 'spec.kubernetes.services.cray-kiali.kiali-operator.cr.spec.externa
 yq w -i "$c" 'spec.kubernetes.services.cray-kiali.kiali-operator.cr.spec.external_services.tracing.url' "https://{{ kubernetes.services['cray-istio'].istio.tracing.externalAuthority}}"
 
 # cray-uas-mgr changes
+yq w -i "$c" 'spec.kubernetes.services.cray-uas-mgr.uasConfig.require_bican' 'false'
+yq w -i --style=single "$c" 'spec.kubernetes.services.cray-uas-mgr.uasConfig.dns_domain' '{{ network.dns.external }}'
 yq w -i "$c" 'spec.kubernetes.services.cray-uas-mgr.images.images[+]' 'cray/cray-uai-sles15sp1:latest'
 yq w -i "$c" 'spec.kubernetes.services.cray-uas-mgr.images.defaultImage' 'cray/cray-uai-sles15sp1:latest'
 
 # cray-metallb
 yq w -i --style=single "$c" 'spec.kubernetes.services.cray-metallb.metallb.configInLine' '{{ network.metallb | toYaml }}'
+
+# wlm.macvlan
+yq d -i "$c" 'spec.wlm.macvlansetup.nmn_vlan'
 
 if [[ "$inplace" == "yes" ]]; then
     cp "$c" "$customizations"


### PR DESCRIPTION
## Summary and Scope

A few more changes were made to customizations.yaml in the release/1.2 branch of the csm repo without making matching changes to update-customizations.sh for upgrade.   This brings update-customizations.sh back up-to-date with the latest customizations.yaml.

## Issues and Related PRs

* Resolves CASMINST-3726

## Testing

### Tested on:

  * Local development environment

### Test description:

I ran update-customizations.sh against a 1.0 customizations.yaml and then compared the results against a 1.2 customizations.yaml without these changes to verify that the correct changes were made.

## Pull Request Checklist

- [n/a] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [n/a] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [n/a] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

