### PR TITLE
Fixes CASMINST-3728: handle multiple istiod pods in validate_versions script

### DIFF
--- a/upgrade/0.9/csm-0.9.6/scripts/validate_versions.sh
+++ b/upgrade/0.9/csm-0.9.6/scripts/validate_versions.sh
@@ -5,7 +5,7 @@
 
 validated=true
 # Confirm the version of istio pilot image is 1.6.13-cray2
-ver=$(kubectl describe pod istiod- -n istio-system | grep Image: | cut -d':' -f3)
+ver=$(kubectl describe pod istiod- -n istio-system | grep Image: | cut -d':' -f3 | uniq)
 if [ "$ver" != "1.6.13-cray2" ]; then
   echo "Error: istio pilot image version $ver is unexpected."
   validated=false


### PR DESCRIPTION
## Summary and Scope

validate_versions script for 0.9.6 upgrade does not handle multiple istiod pods appropriately. This PR
fixes the issue. 

## Issues and Related PRs

* Resolves [CASMINST-3728]

## Testing

### Tested on:

  * `wasp`

### Test description:

Tested the changed kubectl command in wasp, and verified that it produced the unique version string.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low. The script already does the similar thing for hms-redfish-translation-service, so it should work
as expected.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

