### PR TITLE
CASMINST-3094 - Added note to meta/init.sh step of prepare_site_init.md

### DIFF
--- a/install/prepare_site_init.md
+++ b/install/prepare_site_init.md
@@ -53,6 +53,9 @@ installation-centric artifacts such as:
     ```bash
     linux# /mnt/pitdata/${CSM_RELEASE}/shasta-cfg/meta/init.sh /mnt/pitdata/prep/site-init
     ```
+    **`IMPORTANT`** The output of this command states that customizations.yaml should be reviewed and updated before
+    running the secrets-reencrypt.sh and secrets-seed-customizations.sh scripts. These two scripts will be run
+    later in this document, do not run them at this time.
 
 1.  The `yq` tool used in the following procedures is available under
 `/mnt/pitdata/prep/site-init/utils/bin` once the SHASTA-CFG repo has been


### PR DESCRIPTION
## Summary and Scope

Added note to indicate that `secrets-reencrypt.sh` and `secrets-seed-customizations.sh` should not be run until directed to by the `prepare_site_init.md` document.

## Issues and Related PRs

* Resolves [CASMINST-3094](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3094)

## Testing

### Tested on:

### Test description:

## Risks and Mitigations

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable