### PR TITLE
CASMINST-3509 PR 1.2 Correct wipe_ncn_disks_for_reinstallation

### DIFF
--- a/install/create_ncn_metadata_csv.md
+++ b/install/create_ncn_metadata_csv.md
@@ -4,7 +4,7 @@ The information in the `ncn_metadata.csv` file identifies each of the management
 as a master, worker, or storage node, and provides the MAC address information needed to identify the BMC and
 the NIC which will be used to boot the node.
 
-Some of the data in the `ncn_metadata.csv` can be found in the SHCD. However, the hardest data
+Some of the data in the `ncn_metadata.csv` can be found in the SHCD in the HMN tab. However, the hardest data
 to collect is the MAC addresses for the node's BMC, the node's bootable network interface, and the
 pair of network interfaces which will become the bonded interface `bond0`.
 
@@ -30,7 +30,7 @@ Xname,Role,Subrole,BMC MAC,Bootstrap MAC,Bond0 MAC0,Bond0 MAC1
 x3000c0s9b0n0,Management,Storage,94:40:c9:37:77:26,14:02:ec:d9:76:88,14:02:ec:d9:76:88,94:40:c9:5f:b6:92
 ```
 
-For each management node, the xname, role, and subrole can be extracted from the SHCD. However, the rest of the
+For each management node, the xname, role, and subrole can be extracted from the SHCD in the HMN tab. However, the rest of the
 MAC address information needs to be collected another way.
 
 Check the description for component names while mapping names between the SHCD and the `ncn_metadata.csv` file.

--- a/install/wipe_ncn_disks_for_reinstallation.md
+++ b/install/wipe_ncn_disks_for_reinstallation.md
@@ -239,7 +239,7 @@ RAIDs, zeroing the disks, and then wiping the disks and RAIDs.
         umount: /var/lib/containers unmounted
         ```
 
-1. Remove auxiliary LVMs.
+1. Stop `cray-sdu-rda`.
 
     1. Stop `cray-sdu-rda` container if necessary.
 

--- a/install/wipe_ncn_disks_for_reinstallation.md
+++ b/install/wipe_ncn_disks_for_reinstallation.md
@@ -95,9 +95,9 @@ wiping the disks and RAIDs.
 This section is the preferred method for all nodes. A full wipe includes deleting the Ceph volumes (where applicable), stopping the
 RAIDs, zeroing the disks, and then wiping the disks and RAIDs.
 
-**IMPORTANT:** Step 2 is to wipe the Ceph OSD drives. ***Steps 1, 3, 4, and 5 are for all node types.***
+**IMPORTANT:** Pay attention to whether the command is to be run on a worker node, master node, or storage node.
 
-1. Reset Kubernetes on each master and worker node.
+1. Reset Kubernetes on each worker node.
 
    This will stop kubelet, underlying containers, and remove the contents of `/var/lib/kubelet`.
 
@@ -105,70 +105,98 @@ RAIDs, zeroing the disks, and then wiping the disks and RAIDs.
 
     1. For each worker node, run the following:
 
+       1. Reset Kubernetes.
         ```bash
-        ncn-mw# kubeadm reset --force
+        ncn-w# kubeadm reset --force
         ```
 
-    1. List any containers running in `containerd`.
+       1. List any containers running in `containerd`.
 
+           ```bash
+           ncn-w# crictl ps
+           CONTAINER           IMAGE               CREATED              STATE               NAME                                                ATTEMPT             POD ID
+           66a78adf6b4c2       18b6035f5a9ce       About a minute ago   Running             spire-bundle                                        1212                6d89f7dee8ab6
+           7680e4050386d       c8344c866fa55       24 hours ago         Running             speaker                                             0                   5460d2bffb4d7
+           b6467c907f063       8e6730a2b718c       3 days ago           Running             request-ncn-join-token                              0                   a3a9ca9e1ca78
+           e8ce2d1a8379f       64d4c06dc3fb4       3 days ago           Running             istio-proxy                                         0                   6d89f7dee8ab6
+           c3d4811fc3cd0       0215a709bdd9b       3 days ago           Running             weave-npc                                    0                   f5e25c12e617e
+           ```
+
+       1. If there are any running containers from the output of the `crictl ps` command, stop them.
+
+           ```bash
+           ncn-w# crictl stop <container id from the CONTAINER column>
+           ```
+
+1. Reset Kubernetes on each master node.
+
+   This will stop kubelet, underlying containers, and remove the contents of `/var/lib/kubelet`.
+
+    1. For each master node, run the following:
+
+       1.  Reset Kubernetes.
         ```bash
-        ncn-mw# crictl ps
-        CONTAINER           IMAGE               CREATED              STATE               NAME                                                ATTEMPT             POD ID
-        66a78adf6b4c2       18b6035f5a9ce       About a minute ago   Running             spire-bundle                                        1212                6d89f7dee8ab6
-        7680e4050386d       c8344c866fa55       24 hours ago         Running             speaker                                             0                   5460d2bffb4d7
-        b6467c907f063       8e6730a2b718c       3 days ago           Running             request-ncn-join-token                              0                   a3a9ca9e1ca78
-        e8ce2d1a8379f       64d4c06dc3fb4       3 days ago           Running             istio-proxy                                         0                   6d89f7dee8ab6
-        c3d4811fc3cd0       0215a709bdd9b       3 days ago           Running             weave-npc                                    0                   f5e25c12e617e
+        ncn-m# kubeadm reset --force
         ```
 
-    1. If there are any running containers from the output of the `crictl ps` command, stop them.
+       1. List any containers running in `containerd`.
 
-        ```bash
-        ncn-mw# crictl stop <container id from the CONTAINER column>
-        ```
+           ```bash
+           ncn-m# crictl ps
+           CONTAINER           IMAGE               CREATED              STATE               NAME                                                ATTEMPT             POD ID
+           66a78adf6b4c2       18b6035f5a9ce       About a minute ago   Running             spire-bundle                                        1212                6d89f7dee8ab6
+           7680e4050386d       c8344c866fa55       24 hours ago         Running             speaker                                             0                   5460d2bffb4d7
+           b6467c907f063       8e6730a2b718c       3 days ago           Running             request-ncn-join-token                              0                   a3a9ca9e1ca78
+           e8ce2d1a8379f       64d4c06dc3fb4       3 days ago           Running             istio-proxy                                         0                   6d89f7dee8ab6
+           c3d4811fc3cd0       0215a709bdd9b       3 days ago           Running             weave-npc                                    0                   f5e25c12e617e
+           ```
 
-    1. After performing the previous steps for the worker nodes to be wiped, then perform them for the master nodes to be wiped.
+       1. If there are any running containers from the output of the `crictl ps` command, stop them.
+
+           ```bash
+           ncn-m# crictl stop <container id from the CONTAINER column>
+           ```
 
 1. Delete Ceph Volumes **on storage nodes ONLY**.
 
-    For each storage node:
+    1. For each storage node:
 
-    1. Stop Ceph.
+       1. Stop Ceph.
 
-        * ***1.4 or earlier***
+           * ***1.4 or earlier***
 
-            ```bash
-            ncn-s# systemctl stop ceph-osd.target
-            ```
+               ```bash
+               ncn-s# systemctl stop ceph-osd.target
+               ```
 
-        * ***1.5 or later***
+           * ***1.5 or later***
 
-            ```bash
-            ncn-s# cephadm rm-cluster --fsid $(cephadm ls|jq -r '.[0].fsid') --force
-            ```
+               ```bash
+               ncn-s# cephadm rm-cluster --fsid $(cephadm ls|jq -r '.[0].fsid') --force
+               ```
 
-    1. Make sure the OSDs (if any) are not running.
+       1. Make sure the OSDs (if any) are not running.
 
-        * ***1.4 or earlier***
+           * ***1.4 or earlier***
 
-            ```bash
-            ncn-s# ps -ef|grep ceph-osd
-            ```
+               ```bash
+               ncn-s# ps -ef|grep ceph-osd
+               ```
 
-        * ***1.5 or later***
+           * ***1.5 or later***
 
-            ```bash
-            ncn-s# podman ps
-            ```
+               ```bash
+               ncn-s# podman ps
+               ```
 
-        Examine the output. There should be no running `ceph-osd` processes or containers.
+           Examine the output. There should be no running `ceph-osd` processes or containers.
 
-    1. Remove the VGs.
+       1. Remove the VGs.
 
-        ```bash
-        ncn-s# ls -1 /dev/sd* /dev/disk/by-label/*
-        ncn-s# vgremove -f -v --select 'vg_name=~ceph*'
-        ```
+           ```bash
+           ncn-s# ls -1 /dev/sd* /dev/disk/by-label/*
+           ncn-s# vgremove -f -v --select 'vg_name=~ceph*'
+           ```
 
 1. Unmount volumes.
 
@@ -178,14 +206,17 @@ RAIDs, zeroing the disks, and then wiping the disks and RAIDs.
 
     1. Master nodes.
 
+        Stop the etcd service on the master node before unmounting /var/lib/etcd
+
         ```bash
-        ncn-m# umount -v /var/lib/etcd /var/lib/sdu
+        ncn-m# systemctl stop etcd.service
+        ncn-m# umount -v /run/lib-etcd /var/lib/etcd /var/lib/sdu
         ```
 
     1. Worker nodes.
 
         ```bash
-        ncn-w# umount -v /var/lib/containerd /var/lib/kubelet /var/lib/sdu
+        ncn-w# umount -v /var/lib/kubelet /var/lib/sdu /run/containerd /var/lib/containerd /run/lib-containerd 
         ```
 
     1. Storage nodes.
@@ -228,34 +259,89 @@ RAIDs, zeroing the disks, and then wiping the disks and RAIDs.
         7741d50966259410298bb4c3210e6665cdbd57a82e34e467d239f519ae3f17d4
         ```
 
-    1. Remove metal LVM.
+1. Remove etcd device **on master nodes ONLY**.
 
-        ```bash
-        ncn# vgremove -f -v --select 'vg_name=~metal*'
-        ```
+   1. This `dmsetup` comand wil determine whether an etcd volume is present.
 
-       > **NOTE:** Optionally, run the `pvs` command and if any drives are still listed, remove them with `pvremove`, but this is rarely needed. Also, if the above command fails or returns a warning about the filesystem being in use, you should ignore the error and proceed to the next step, as this will not inhibit the wipe process.
+      ```bash
+      ncn-m# dmsetup -ls 
+      ```
 
-1. Stop the RAIDs.
+      Expected output when the etcd volume is present will show `ETCDLVM`, but the numbers might be different.
 
-    ```bash
-    ncn# for md in /dev/md/*; do mdadm -S -v $md || echo nope ; done
-    ```
+      ```bash
+      ETCDLVM (254:1)
+      ```
 
-1. List the disks for verification.
+   1. This `dmsetup` command will remove the etcd device mapper.
 
-    ```bash
-    ncn# ls -1 /dev/sd* /dev/disk/by-label/*
-    ```
+      ```bash
+      ncn-m# dmsetup remove $(dmsetup ls | grep -i etcd | awk '{print $1}')
+      ```
 
-1. Wipe the disks and RAIDs.
+      > **Note:** The following output  means the etcd volume  mapper is not present.
+      ```bash
+      No device specified.
+      Command failed.
+      ```
+1. Remove etcd Volumes **on master nodes ONLY**.
 
-    ```bash
-    ncn# sgdisk --zap-all /dev/sd*
-    ncn# wipefs --all --force /dev/sd* /dev/disk/by-label/*
-    ```
+   ```bash
+   ncn-m# vgremove etcdvg0
+   ```
 
-   > **NOTE:** On worker nodes, it is a known issue that the `sgdisk` command sometimes encounters a hard hang. If you see no output from the command for 90 seconds, close the terminal session to the worker node, open a new terminal session to it, and complete the disk wipe procedure by running the above `wipefs` command.
+1. Remove metal LVM.
+
+     ```bash
+     ncn# vgremove -f -v --select 'vg_name=~metal*'
+     ```
+
+   > **NOTE:** Optionally, run the `pvs` command. If any drives are still listed, remove them with `pvremove`, but this is rarely needed. Also, if the above command fails or returns a warning about the filesystem being in use, ignore the error and proceed to the next step, as this will not inhibit the wipe process.
+1. Group these commands together for each node.
+
+   This group of commands should be done in succession on one node before moving to do the same set of commands on the next node. The nodes would be addressed in descending order for each type of node.  Start with the utility storage nodes, then the worker nodes, then ncn-m003, then ncn-m002. 
+
+   > **WARNING:** Do not run these commands on ncn-m001
+   1. Stop the RAIDs.
+
+       This step shows status before and after stopping the RAIDs.
+
+       ```bash
+       ncn# cat /proc/mdstat
+       ncn# for md in /dev/md/*; do mdadm -S -v $md || echo nope ; done
+       ncn# cat /proc/mdstat
+       ```
+
+   1. List the disks for verification.
+
+       ```bash
+       ncn# ls -1 /dev/sd* /dev/disk/by-label/*
+       ```
+
+   1. Wipe the disks and RAIDs.
+
+       ```bash
+       ncn# wipefs --all --force /dev/sd* /dev/disk/by-label/*
+       ```
+
+       If any disks had labels present, output from `wipefs` looks similar to the following:
+
+   **NOTE:** On worker nodes, it is a known issue that the `sgdisk` command sometimes encounters a hard hang. If there is no output from the command for 90 seconds, close the terminal session to the worker node, open a new terminal session to it, and complete the disk wipe procedure by running the above `wipefs` command.
+       ```
+       /dev/sda: 8 bytes were erased at offset 0x00000200 (gpt): 45 46 49 20 50 41 52 54
+       /dev/sda: 8 bytes were erased at offset 0x6fc86d5e00 (gpt): 45 46 49 20 50 41 52 54
+       /dev/sda: 2 bytes were erased at offset 0x000001fe (PMBR): 55 aa
+       /dev/sdb: 6 bytes were erased at offset 0x00000000 (crypto_LUKS): 4c 55 4b 53 ba be
+       /dev/sdb: 6 bytes were erased at offset 0x00004000 (crypto_LUKS): 53 4b 55 4c ba be
+       /dev/sdc: 8 bytes were erased at offset 0x00000200 (gpt): 45 46 49 20 50 41 52 54
+       /dev/sdc: 8 bytes were erased at offset 0x6fc86d5e00 (gpt): 45 46 49 20 50 41 52 54
+       /dev/sdc: 2 bytes were erased at offset 0x000001fe (PMBR): 55 aa
+       ```
+
+   See [Basic Wipe](#basic-wipe) section for expected output from the `wipefs` command.
+       Verify there are no error messages in the output.
+
+       The `wipefs` command may fail if no labeled disks are found, which is an indication of a larger problem.
 
    See [Basic Wipe](#basic-wipe) section for expected output from the `wipefs` command.
 


### PR DESCRIPTION
## Summary and Scope

CASMINST-3509: Correct wipe_ncn_disks_for_reinstallation
Several commands were added that had been used on the test on hela and the overall flow of the steps was adjusted to be more explicit upon which type of node the command should be run.

Also, indicate that install/create_ncn_metadata_csv.md will be pulling data from the SHCD HMN tab.

## Issues and Related PRs

## Testing

### Tested on:

### Test description:

## Risks and Mitigations

## Pull Request Checklist
