### PR TITLE
CASMINST-3509-main Correct wipe_ncn_disks_for_reinstallation

### DIFF
--- a/install/create_ncn_metadata_csv.md
+++ b/install/create_ncn_metadata_csv.md
@@ -4,7 +4,7 @@ The information in the `ncn_metadata.csv` file identifies each of the management
 as a master, worker, or storage node, and provides the MAC address information needed to identify the BMC and
 the NIC which will be used to boot the node.
 
-Some of the data in the `ncn_metadata.csv` can be found in the SHCD. However, the hardest data
+Some of the data in the `ncn_metadata.csv` can be found in the SHCD in the HMN tab. However, the hardest data
 to collect is the MAC addresses for the node's BMC, the node's bootable network interface, and the
 pair of network interfaces which will become the bonded interface `bond0`.
 
@@ -29,7 +29,7 @@ Xname,Role,Subrole,BMC MAC,Bootstrap MAC,Bond0 MAC0,Bond0 MAC1
 x3000c0s9b0n0,Management,Storage,94:40:c9:37:77:26,14:02:ec:d9:76:88,14:02:ec:d9:76:88,94:40:c9:5f:b6:92
 ```
 
-For each management node, the xname, role, and subrole can be extracted from the SHCD. However, the rest of the
+For each management node, the xname, role, and subrole can be extracted from the SHCD in the HMN tab. However, the rest of the
 MAC address information needs to be collected another way.
 
 Check the description for component names while mapping names between the SHCD and your `ncn_metadata.csv` file.

--- a/install/wipe_ncn_disks_for_reinstallation.md
+++ b/install/wipe_ncn_disks_for_reinstallation.md
@@ -237,7 +237,7 @@ RAIDs, zeroing the disks, and then wiping the disks and RAIDs.
       umount: /var/lib/containers unmounted
       ```
 
-1. Remove auxiliary LVMs.
+1. Stop `cray-sdu-rda`.
 
    1. Stop `cray-sdu-rda` container if necessary.
 

--- a/install/wipe_ncn_disks_for_reinstallation.md
+++ b/install/wipe_ncn_disks_for_reinstallation.md
@@ -111,7 +111,7 @@ RAIDs, zeroing the disks, and then wiping the disks and RAIDs.
       1. List any containers running in `containerd`.
 
          ```bash
-         ncn-m/w # crictl ps
+         ncn-w # crictl ps
          CONTAINER           IMAGE               CREATED              STATE               NAME                                                ATTEMPT             POD ID
          66a78adf6b4c2       18b6035f5a9ce       About a minute ago   Running             spire-bundle                                        1212                6d89f7dee8ab6
          7680e4050386d       c8344c866fa55       24 hours ago         Running             speaker                                             0                   5460d2bffb4d7


### PR DESCRIPTION
## Summary and Scope

CASMINST-3509: Correct wipe_ncn_disks_for_reinstallation
Several commands were added that had been used on the test on hela and the overall flow of the steps was adjusted to be more explicit upon which type of node the command should be run.

Also, indicate that install/create_ncn_metadata_csv.md will be pulling data from the SHCD HMN tab.

## Issues and Related PRs

## Testing

### Tested on:

### Test description:

## Risks and Mitigations

## Pull Request Checklist