### PR TITLE
CASMINST-3040: Add explicit reference to setting the boot order to st…

### DIFF
--- a/install/bootstrap_livecd_usb.md
+++ b/install/bootstrap_livecd_usb.md
@@ -571,9 +571,7 @@ reboot into the LiveCD.
 Some systems will boot the USB device automatically if no other OS exists (bare-metal). Otherwise the
 administrator may need to use the BIOS Boot Selection menu to choose the USB device.
 
-If an administrator is rebooting a node into the LiveCD, versus booting a bare-metal or wiped node, then `efibootmgr` will deterministically set the boot order.
-
-See the [set boot order](../background/ncn_boot_workflow.md#set-boot-order) page for more information on this topic..
+If an administrator has the node booted with an operating system which will next be rebooting into the LiveCD, then use `efibootmgr` to set the boot order to be the USB device.  See the [set boot order](../background/ncn_boot_workflow.md#set-boot-order) page for more information about how to set the boot order to have the USB device first.
 
 > UEFI booting must be enabled to find the USB device's EFI bootloader.
 


### PR DESCRIPTION
## Summary and Scope

CASMINST-3040: Add explicit reference to setting the boot order to start with USB for the USB LiveCD install

## Issues and Related PRs

## Testing

### Tested on:

### Test description:

## Risks and Mitigations

## Pull Request Checklist
