### PR TITLE
CASMINST-3025: Correct UAI image references for SP2 and registry.local

### DIFF
--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -674,7 +674,7 @@ the Cray OS (COS) product, or similar, be used.
 * This test is **very important to run** during the CSM install prior to redeploying the PIT node
 because it validates all of the services required for that operation.
 * The CSM Barebones image included with the release will not successfully complete
-the beyond the dracut stage of the boot process. However, if the dracut stage is reached the
+beyond the dracut stage of the boot process. However, if the dracut stage is reached the
 boot can be considered successful and shows that the necessary CSM services needed to
 boot a node are up and available.
    * This inability to boot the barebones image fully will be resolved in future releases of the
@@ -713,7 +713,7 @@ Expected output is similar to the following:
     "path": "s3://boot-images/293b1e9c-2bc4-4225-b235-147d1d611eef/manifest.json",
     "type": "s3"
   },
-  "name": "cray-shasta-csm-sles15sp1-barebones.x86_64-shasta-1.5"
+  "name": "cray-shasta-csm-sles15sp2-barebones.x86_64-shasta-1.5"
 }
 ```
 
@@ -913,11 +913,11 @@ This section can be run on any NCN or the PIT node.
 
    Expected output looks similar to the following:
    ```
-   default_image = "dtr.dev.cray.com/cray/cray-uai-sles15sp1:latest"
-   image_list = [ "dtr.dev.cray.com/cray/cray-uai-sles15sp1:latest",]
+   default_image = "registry.local/cray/cray-uai-sles15sp2:1.0.11"
+   image_list = [ "registry.local/cray/cray-uai-sles15sp2:1.0.11",]
    ```
 
-   This example output shows that the pre-made end-user UAI image (`cray/cray-uai-sles15sp1:latest`) is registered with UAS. This does not necessarily mean this image is installed in the container image registry, but it is configured for use. If other UAI images have been created and registered, they may also show up here, which is acceptable.
+   This example output shows that the pre-made end-user UAI image (`cray/cray-uai-sles15sp2:1.0.11`) is registered with UAS. This does not necessarily mean this image is installed in the container image registry, but it is configured for use. If other UAI images have been created and registered, they may also show up here, which is acceptable.
 
 <a name="uas-uai-validate-create"></a>
 ### 5.2 Validate UAI Creation
@@ -943,7 +943,7 @@ This procedure must run on a master or worker node (not the PIT node and not `nc
    ```
    uai_connect_string = "ssh vers@10.16.234.10"
    uai_host = "ncn-w001"
-   uai_img = "registry.local/cray/cray-uai-sles15sp1:latest"
+   uai_img = "registry.local/cray/cray-uai-sles15sp2:1.0.11"
    uai_ip = "10.16.234.10"
    uai_msg = ""
    uai_name = "uai-vers-a00fb46b"
@@ -971,7 +971,7 @@ This procedure must run on a master or worker node (not the PIT node and not `nc
    uai_age = "0m"
    uai_connect_string = "ssh vers@10.16.234.10"
    uai_host = "ncn-w001"
-   uai_img = "registry.local/cray/cray-uai-sles15sp1:latest"
+   uai_img = "registry.local/cray/cray-uai-sles15sp2:1.0.11"
    uai_ip = "10.16.234.10"
    uai_msg = ""
    uai_name = "uai-vers-a00fb46b"
@@ -1097,7 +1097,7 @@ The following shows an example of looking at UAS logs effectively (this example 
    2021-02-08 15:32:41,267 - uas_mgr - INFO - getting pod info uai-vers-87a0ff6e
    2021-02-08 15:32:41,360 - uas_mgr - INFO - No start time provided from pod
    2021-02-08 15:32:41,361 - uas_mgr - INFO - getting service info for uai-vers-87a0ff6e-ssh in namespace user
-   127.0.0.1 - - [08/Feb/2021 15:32:41] "POST /v1/uas?imagename=registry.local%2Fcray%2Fno-image-registered%3Alatest HTTP/1.1" 200 -
+   127.0.0.1 - - [08/Feb/2021 15:32:41] "POST /v1/uas?imagename=registry.local%2Fcray%2Fno-image-registered%3A1.0.11 HTTP/1.1" 200 -
    2021-02-08 15:32:54,455 - uas_auth - INFO - UasAuth lookup complete for user vers
    2021-02-08 15:32:54,455 - uas_mgr - INFO - UAS request for: vers
    2021-02-08 15:32:54,455 - uas_mgr - INFO - listing deployments matching: host None, labels uas=managed,user=vers
@@ -1130,7 +1130,7 @@ There may be something similar to the following output:
 uai_age = "0m"
 uai_connect_string = "ssh vers@10.103.13.172"
 uai_host = "ncn-w001"
-uai_img = "registry.local/cray/cray-uai-sles15sp1:latest"
+uai_img = "registry.local/cray/cray-uai-sles15sp2:1.0.11"
 uai_ip = "10.103.13.172"
 uai_msg = "ErrImagePull"
 uai_name = "uai-vers-87a0ff6e"


### PR DESCRIPTION
## Summary and Scope

CASMINST-3025: Correct UAI image references for SP2 and registry.local instead of dtr.dev.cray.com

## Issues and Related PRs

## Testing

### Tested on:

### Test description:

## Risks and Mitigations

## Pull Request Checklist
