### PR TITLE
Several fixes to prerequisites.sh

### DIFF
--- a/upgrade/1.2/scripts/upgrade/prerequisites.sh
+++ b/upgrade/1.2/scripts/upgrade/prerequisites.sh
@@ -526,17 +526,31 @@ state_name="PRECACHE_NEXUS_IMAGES"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     echo "====> ${state_name} ..."
+
+    images=$(kubectl get configmap -n nexus cray-precache-images -o json | jq -r '.data.images_to_cache' | grep "sonatype\|proxy\|busybox")
     export PDSH_SSH_ARGS_APPEND="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
-    pdsh -b -S -w $(grep -oP 'ncn-w\w\d+' /etc/hosts | sort -u |  tr -t '\n' ',') 'for image in sonatype/nexus3:3.25.0 dtr.dev.cray.com/cray/proxyv2:1.6.13-cray1 dtr.dev.cray.com/baseos/busybox:1 docker.io/sonatype/nexus3:3.25.0 dtr.dev.cray.com/cray/cray-nexus-setup:0.3.2; do crictl pull $image; done'
+    output=$(pdsh -b -S -w $(grep -oP 'ncn-w\w\d+' /etc/hosts | sort -u | tr -t '\n' ',') 'for image in '$images'; do crictl pull $image; done' 2>&1)
+    echo "$output"
+
+    if [[ "$output" == *"failed"* ]]; then
+      echo ""
+      echo "Verify the images which failed in the output above are available in nexus."
+      exit 1
+    fi
 
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"
 fi
 
-# Take cps deployment snapshot
-cps_deployment_snapshot=$(cray cps deployment list --format json | jq -r '.[] | .node' || true)
-echo $cps_deployment_snapshot > /etc/cray/upgrade/csm/${CSM_RELEASE}/cp.deployment.snapshot
+# Take cps deployment snapshot (if cps installed)
+set +e
+kubectl get pod -n services | grep -q cray-cps
+if [ "$?" -eq 0 ]; then
+  cps_deployment_snapshot=$(cray cps deployment list --format json | jq -r '.[] | .node' || true)
+  echo $cps_deployment_snapshot > /etc/cray/upgrade/csm/${CSM_RELEASE}/cp.deployment.snapshot
+fi
+set -e
 
 # Alert the user of action to take for cleanup
 if [[ ${#UNMOUNTS[@]} -ne 0 ]]; then


### PR DESCRIPTION
## Summary and Scope

CASMINST-3749: BREAK/FIX: prerequisites.sh is installing wrong version of cray/proxy2 precache image
CASMINST-3750: BREAK/FIX: prerequisites.sh did not catch when the PRECACHE_NEXUS_IMAGES step failed
CASMINST-3752: BREAK/FIX: cray cps deployments list at the end of prerequisites.sh should only run if CPS is installed

## Issues and Related PRs

* Resolves [CASMINST-3749](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3749)
* Resolves [CASMINST-3750](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3750)
* Resolves [CASMINST-3752](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3752)

## Testing

Tested the new code on drax (and shandy to validate cps test works when cps installed)

### Tested on:

  * `drax/shandy`

### Test description:

Tested portions of the script w/out running complete script on existing systems.

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable