### PR TITLE
CASMINST-3762 updated nexus_check_pod to exclude init pods in completed state

### DIFF
--- a/install/scripts/csm_services/steps/5.setup_nexus.yaml
+++ b/install/scripts/csm_services/steps/5.setup_nexus.yaml
@@ -33,7 +33,7 @@ spec:
           while [[ $nexus_resources_ready -eq 0 ]] && [[ "$counter" -le "$counter_max" ]]; do
               nexus_check_configmap=$(kubectl -n services get cm cray-dns-unbound -o json 2>&1 | jq '.binaryData."records.json.gz"' -r 2>&1 | base64 -d 2>&1| gunzip - 2>&1|jq 2>&1|grep $url|wc -l)
               nexus_check_dns=$(dig $url +short |wc -l)
-              nexus_check_pod=$(kubectl get pods -n nexus|grep nexus|awk {' print $3 '})
+              nexus_check_pod=$(kubectl get pods -n nexus| grep nexus | grep -v Completed |awk {' print $3 '})
 
               if [[ "$nexus_check_dns" -eq "1" ]] && [[ "$nexus_check_pod" == "Running" ]]; then
                   echo "$url is in dns."


### PR DESCRIPTION
Updated line 36 of nexus_check_pod to include a | grep -v Completed. This is necessary to ignore the nexus-init pods that stay in a Completed state. Similar PR for the setup-nexus.sh script in https://github.com/Cray-HPE/csm/pull/339.

## Summary and Scope

_Summarize what has changed. This is a critical bug fix. I added a grep -v Completed to the nexus_check_pod variable in the script. This is needed to ignore the init pods that stay in a Completed state.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix? Not Applicable

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMINST-3762 https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3762
* Change will also be needed in CASMINST-3762-grep-out-Completed-pods-from-setup-nexus.sh
* Future work required by N/A
* Documentation changes required in, N/A none required.
* Merge with/before/after N/A

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Surtur

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Yes
- Were continuous integration tests run? If not, why? No, simple change N/A
- Was upgrade tested? If not, why? N/A
- Was downgrade tested? If not, why? N/A
- Were new tests (or test issues/Jiras) created for this change? N/A

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
No

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

