### PR TITLE
Add back step to create new buckets, flip k8s/ceph image upgrade order

### DIFF
--- a/upgrade/1.2/README.md
+++ b/upgrade/1.2/README.md
@@ -23,8 +23,8 @@ upgrade that node.
 ## Upgrade Stages
 
 - [Stage 0 - Prerequisites](Stage_0_Prerequisites.md)
-- [Stage 1 - Kubernetes Upgrade](Stage_1.md)
-- [Stage 2 - Ceph Node Image Upgrade](Stage_2.md)
+- [Stage 1 - Ceph Node Image Upgrade](Stage_1.md)
+- [Stage 2 - Kubernetes Upgrade](Stage_2.md)
 - [Stage 3 - CSM Services Upgrade](Stage_3.md)
 - [Stage 4 - Apply Known Workarounds](Stage_4.md)
 - [Stage 5 - Return to Main Page and Proceed to *Validate CSM Health*](../index.md#validate_csm_health)

--- a/upgrade/1.2/Stage_1.md
+++ b/upgrade/1.2/Stage_1.md
@@ -1,118 +1,57 @@
-# Stage 1 - Kubernetes Upgrade from 1.19.9 to 1.20.13
+# Stage 1 - Ceph image upgrade
 
-> NOTE: During the CSM-0.9 install the LiveCD containing the initial install files for this system should have been unmounted from the master node when rebooting into the Kubernetes cluster. The scripts run in this section will also attempt to unmount/eject it if found to ensure the USB stick does not get erased.
-
-## Stage 1.1
-
-1. Run `ncn-upgrade-k8s-master.sh` for `ncn-m002`. Follow output of the script carefully. The script will pause for manual interaction.
+1. Run `ncn-upgrade-ceph-nodes.sh` for `ncn-s001`. Follow output of the script carefully. The script will pause for manual interaction.
 
     ```bash
-    ncn-m001# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/ncn-upgrade-k8s-master.sh ncn-m002
+    ncn-m001# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/ncn-upgrade-ceph-nodes.sh ncn-s001
     ```
-    
-1. Repeat the previous step for each other master node **excluding `ncn-m001`**, one at a time.
 
-## Stage 1.2
-
-1. Run `ncn-upgrade-k8s-worker.sh` for `ncn-w001`. Follow output of the script carefully. The script will pause for manual interaction.
-
-    ```bash
-    ncn-m001# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/ncn-upgrade-k8s-worker.sh ncn-w001
-    ```
-    
     > NOTE: You may need to reset the root password for each node after it is rebooted
 
-1. Repeat the previous step for each other worker node, one at a time.
+1. Repeat the previous step for each other storage node, one at a time.
 
-## Stage 1.3
-
-For `ncn-m001`, use `ncn-m002` as the stable NCN. Use `bond0.cmn0`/CAN IP address to `ssh` to `ncn-m002` for this `ncn-m001` install
-
-1. Authenticate with the Cray CLI on `ncn-m002`.
-
-    See [Configure the Cray Command Line Interface](../../operations/configure_cray_cli.md) for details on how to do this.
-
-1. Set the `CSM_RELEASE` variable to the correct value for the CSM release upgrade being applied.
-
+1. After `ncn-upgrade-ceph-nodes.sh` has successfully run for all storage nodes, rescan ssh keys on all storage nodes
     ```bash
-    ncn-m002# CSM_RELEASE=csm-1.2.0
+    ncn-m001# grep -oP "(ncn-s\w+)" /etc/hosts | sort -u | xargs -t -i ssh {} 'truncate --size=0 ~/.ssh/known_hosts'
+
+    ncn-m001# grep -oP "(ncn-s\w+)" /etc/hosts | sort -u | xargs -t -i ssh {} 'grep -oP "(ncn-s\w+|ncn-m\w+|ncn-w\w+)" /etc/hosts | sort -u | xargs -t -i ssh-keyscan -H \{\} >> /root/.ssh/known_hosts'
     ```
 
-1. Install document RPM and run check script on `ncn-m002`
+1. Deploy `node-exporter` and `alertmanager`.
 
-    * Option 1 - Internet Connected Environment
+    **NOTE:** This process will need to run on a node running `ceph-mon`, which in most cases will be `ncn-s001`, `ncn-s002`, and `ncn-s003`. It only needs to be run once, not on every one of these nodes.
 
-        1. Install document RPM package:
+    1. Deploy `node-exporter` and `alertmanager`:
 
-            ```bash
-            ncn-m002# wget https://storage.googleapis.com/csm-release-public/csm-1.2/docs-csm/docs-csm-latest.noarch.rpm
-            ncn-m002# rpm -Uvh docs-csm-latest.noarch.rpm
-            ```
+        ```bash
+        ncn-s# ceph orch apply node-exporter
+        Scheduled node-exporter update...
 
-        1. Set the `ENDPOINT` variable to the URL of the directory containing the CSM release tarball.
-        
-            In other words, the full URL to the CSM release tarball will be `${ENDPOINT}${CSM_RELEASE}.tar.gz`
-        
-            **NOTE** This step is optional for Cray/HPE internal installs.
-        
-            ```bash
-            ncn-m002# ENDPOINT=https://put.the/url/here/
-            ```
+        ncn-s# ceph orch apply alertmanager
+        Scheduled alertmanager update...
+        ```
 
-        1. Run the script
-        
-            **NOTE** The `--endpoint` argument is optional for Cray/HPE internal use.
+    1. Verify `node-exporter` and `alertmanager` are running:
 
-            ```bash
-            ncn-m002# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prerequisites.sh --csm-version $CSM_RELEASE --endpoint $ENDPOINT
-            ```
+        ```bash
+        ncn-s# ceph orch ps --daemon_type node-exporter
+        NAME                    HOST      STATUS         REFRESHED  AGE  VERSION  IMAGE NAME                                       IMAGE ID           CONTAINER ID
+        node-exporter.ncn-s001  ncn-s001  running (57m)  3m ago     67m  0.18.1   docker.io/prom/node-exporter:v0.18.1             e5a616e4b9cf       3465eade21da
+        node-exporter.ncn-s002  ncn-s002  running (57m)  3m ago     67m  0.18.1   registry.local/prometheus/node-exporter:v0.18.1  e5a616e4b9cf       7ed9b6cc9991
+        node-exporter.ncn-s003  ncn-s003  running (57m)  3m ago     67m  0.18.1   registry.local/prometheus/node-exporter:v0.18.1  e5a616e4b9cf       1078d9e555e4
 
-    * Option 2 - Air Gapped Environment
+        ncn-s# ceph orch ps --daemon_type alertmanager
+        NAME                   HOST      STATUS         REFRESHED  AGE  VERSION  IMAGE NAME                                      IMAGE ID           CONTAINER ID
+        alertmanager.ncn-s001  ncn-s001  running (66m)  3m ago     68m  0.20.0   registry.local/prometheus/alertmanager:v0.20.0  0881eb8f169f       775aa53f938f
+        ```
 
-        1. Copy the docs-csm RPM package and CSM release tarball to `ncn-m002`.
+        **IMPORTANT:** There should be a `node-exporter` container per Ceph node and a single `alertmanager` container for the cluster.
 
-        1. Install document RPM package:
-
-            ```bash
-            ncn-m002# rpm -Uvh [PATH_TO_docs-csm-*.noarch.rpm]
-            ```
-
-        1. Set the `TAR_DIR` variable to the directory on `ncn-m002` containing the CSM release tarball.
-        
-            In other words, the full path to the CSM release tarball will be `${TAR_DIR}/${CSM_RELEASE}.tar.gz`
-
-            ```bash
-            ncn-m002# TAR_DIR=/path/to/tarball/dir
-            ```
-
-        1. Run the script
-
-            ```bash
-            ncn-m002# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prerequisites.sh --csm-version $CSM_RELEASE --tarball-file ${TAR_DIR}/${CSM_RELEASE}.tar.gz
-            ```
-
-1. Upgrade `ncn-m001`
+1. Update BSS to ensure the Ceph images are loaded if a node is rebuilt.
 
     ```bash
-    ncn-m002# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/ncn-upgrade-k8s-master.sh ncn-m001
+    ncn-m001# . /usr/share/doc/csm/upgrade/1.2/scripts/ceph/lib/update_bss_metadata.sh
+    ncn-m001# update_bss_storage
     ```
 
-## Stage 1.4
-
-Run the following command to complete the upgrade of the weave and multus manifest versions:
-
-```bash
-ncn-m002# /srv/cray/scripts/common/apply-networking-manifests.sh
-```
-
-## Stage 1.5
-
-Run the following script to complete the Kubernetes upgrade _(this will restart several pods on each master to their new docker containers)_:
-
-```bash
-ncn-m002# /usr/share/doc/csm/upgrade/1.2/scripts/k8s/upgrade_control_plane.sh
-```
-
-> **`NOTE`**: `kubelet` has been upgraded already, so you can ignore the warning to upgrade it
-
-Once `Stage 1` is completed, all Kubernetes nodes have been rebooted into the new image. Now proceed to [Stage 2](Stage_2.md)
+ Once `Stage 1` is successfully completed, all the Ceph nodes have been rebooted into the new image. Now proceed to [Stage 2](Stage_2.md).

--- a/upgrade/1.2/scripts/upgrade/ncn-upgrade-ceph-nodes.sh
+++ b/upgrade/1.2/scripts/upgrade/ncn-upgrade-ceph-nodes.sh
@@ -162,6 +162,24 @@ fi
 . /usr/share/doc/csm/upgrade/1.2/scripts/ceph/lib/ceph-health.sh
 wait_for_health_ok
 
+if [[ ${upgrade_ncn} == "ncn-s001" ]]; then
+    state_name="POST_CEPH_IMAGE_UPGRADE_BUCKETS"
+    state_recorded=$(is_state_recorded "${state_name}" ${upgrade_ncn})
+    if [[ $state_recorded == "0" ]]; then
+        echo "====> ${state_name} ..."
+
+        if [[ $ssh_keys_done == "0" ]]; then
+            ssh_keygen_keyscan "${upgrade_ncn}"
+            ssh_keys_done=1
+        fi
+        scp /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/create_rgw_buckets.sh $upgrade_ncn:/tmp
+        ssh ${upgrade_ncn} '/tmp/create_rgw_buckets.sh'
+
+        record_state "${state_name}" ${upgrade_ncn}
+    else
+        echo "====> ${state_name} has been completed"
+    fi
+fi
 
 cat <<EOF
 


### PR DESCRIPTION
## Summary and Scope

Need to flip the order of image upgrades such that ceph goes first, so newer buckets/secrets are available to configure s3fs when the K8S cloud-init runs.

## Issues and Related PRs

* Resolves [CASMTRIAGE-2889](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-2889)

## Testing

N/A

### Tested on:

N/A

### Test description:

N/A

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

