### PR TITLE
CASMINST-3664: add 1.0.10 patch info to run NCN personalization

### DIFF
--- a/upgrade/1.0.10/README.md
+++ b/upgrade/1.0.10/README.md
@@ -7,6 +7,7 @@
 1. [Upgrade Services](#upgrade-services)
 1. [Rollout Deployment Restart](#rollout-deployment-restart)
 1. [Verification](#verification)
+1. [Run NCN Personalization](#run-ncn-personalization)
 1. [Exit Typescript](#exit-typescript)
 
 <a name="preparation"></a>
@@ -154,6 +155,40 @@ deployment "cray-dns-unbound" successfully rolled out
    ```bash
    ncn-m001# kubectl get cm cray-product-catalog -n services -o jsonpath='{.data.csm}' | yq r  - '"1.0.10".configuration.import_date'
    ```
+
+<a name="run-ncn-personalization"></a>
+
+## Run NCN Personalization
+
+1. Run NCN Personalization to update the NCNs to the latest configruation.
+   Complete the [Run NCN Personalization](../../operations/CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md#run-ncn-personalization)
+   procedure.
+
+1. Confirm the version of the Loftsman RPM installed on each NCN. Output below
+   will vary based on the number of NCNs in the system.
+
+   ```bash
+   ncn-m001# for xname in $(cray hsm state components list --role Management | jq -r .Components[].ID);
+   do
+       out=$(ssh -oStrictHostKeyChecking=no -q $xname "rpm -qa | grep loftsman")
+       echo $name $out
+   done
+   x3000c0s11b0n0 loftsman-1.2.0-1.x86_64
+   x3000c0s13b0n0 loftsman-1.2.0-1.x86_64
+   x3000c0s15b0n0 loftsman-1.2.0-1.x86_64
+   x3000c0s17b0n0 loftsman-1.2.0-1.x86_64
+   x3000c0s1b0n0 loftsman-1.2.0-1.x86_64
+   x3000c0s36b0n0 loftsman-1.2.0-1.x86_64
+   x3000c0s38b0n0 loftsman-1.2.0-1.x86_64
+   x3000c0s3b0n0 loftsman-1.2.0-1.x86_64
+   x3000c0s5b0n0 loftsman-1.2.0-1.x86_64
+   x3000c0s7b0n0 loftsman-1.2.0-1.x86_64
+   x3000c0s9b0n0 loftsman-1.2.0-1.x86_64
+   ```
+
+   If the version of the Loftsman RPM does not match the output above, review
+   the Ansible play output in the CFS session logs created during NCN
+   Personalization for any errors.
 
 <a name="exit-typescript"></a>
 


### PR DESCRIPTION
## Summary and Scope

Add NCN personalization step to 1.0.10 patch does per CASMINST-3664. This is being done to ensure that a new Loftsman RPM is installed during the patch and is configured in the NCN personalization CFS configuration for install of the new RPM when NCNs reboot and are subsequently reconfigured.

## Issues and Related PRs

* Resolves CASMINST-3664

## Testing

### Tested on:

  * `fanta`

### Test description:

See https://github.com/Cray-HPE/csm-config/pull/36

## Risks and Mitigations

See https://github.com/Cray-HPE/csm-config/pull/36
