### PR TITLE
CASMINST-3733 - updated line 514 of deploy management nodes to unique section number

### DIFF
--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -511,7 +511,7 @@ If needed, the LVM checks can be performed manually on the master and worker nod
 The manual checks are considered successful if all of the `blkid` commands report a disk device (such as `/dev/sdc` -- the particular device is unimportant). If any of the `lsblk` commands return no output, then the check is a failure. **Any failures must be resolved before continuing.** See the following section for details on how to do so.
 
 <a name="lvm-check-failure-recovery"></a>
-#### 3.3.3 LVM Check Failure Recovery
+#### 3.3.4 LVM Check Failure Recovery
 
 If there are LVM check failures, then the problem must be resolved before continuing with the install.
 


### PR DESCRIPTION


CASMINST-3733 - updated line 514 of deploy management nodes to unique section number 3.3.4 instead of duplicate 3.3.3

## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_ This is a simple section renumbering to remove a duplicate section number from the docs

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_ backwards compatible

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-3733](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3733)
* Change will also be needed in `N/A`
* Future work required by `N/A`
* Documentation changes required in `This is the docs change
* Merge with/before/after `N/A`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `Surtur`


### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Yes
- Were continuous integration tests run? If not, why? `No, not relevant, just a docs change`
- Was upgrade tested? If not, why? `No, not relevant, just a docs change`
- Was downgrade tested? If not, why? `No, not relevant, just a docs change`
- Were new tests (or test issues/Jiras) created for this change? `No, not relevant, just a docs change`

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_ `N\A`


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

