### PR TITLE
CASMPET-5264 1.0.x : Doc: failed to pull and unpack image "docker.io/nfvpe/multus:v3.1"

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -145,3 +145,4 @@ and many more...
 * Rarely, Nexus is not available when scaling down NCN workers to two nodes.
 * The boot order for Gigabyte NCNs does not persist after a reboot or reinstall.
 * Intermittently, storage nodes have clock skew during fresh install.
+* Kube-multus pods may fail to restart due to ImagePullBackOff. For more information see [Kube-multus pod is in ImagePullBackOff](troubleshooting/known_issues/kube_multus_pod_in_ImagePullBackOff.md).

--- a/troubleshooting/known_issues/kube_multus_pod_in_ImagePullBackOff.md
+++ b/troubleshooting/known_issues/kube_multus_pod_in_ImagePullBackOff.md
@@ -1,0 +1,34 @@
+# Kube-multus pod is in ImagePullBackOff
+
+## Description
+
+There is a known problem where kube-multus pods may fail to re-start due to an ImagePullBackOff error. The multus:v3.1 image will need to be re-tagged in Nexus and the kube-multus pod will need to be restarted.
+
+* Run the following command to determine if any kube-multus pods are failing due to this issue. If any pods are in ImagePullBackOff, proceed with the fix.
+
+    ```bash
+    ncn# kubectl get pods -n kube-system -l app=multus | grep ImagePullBackOff
+
+    kube-multus-ds-amd64-4wkb5   0/1    ImagePullBackOff    0          18h
+    ```
+
+## Fix
+
+1. Re-tag the multus image in Nexus.
+
+   ```bash
+   ncn# podman run --rm --network host quay.io/skopeo/stable copy --src-tls-verify=false --dest-tls-verify=false docker://registry.local/docker.io/nfvpe/multus:v3.1 docker://registry.local/nfvpe/multus:v3.1
+   ```
+
+1. Restart the kube-multus pod that was found above to be in ImagePullBackOff.
+
+   ```bash
+   ncn# kubectl delete pod <KUBE-MULTUS-POD> -n kube-system
+   ```
+
+1. Verify all kube-multus pods are now Running.
+
+   ```bash
+   ncn# kubectl get pods -n kube-system -l app=multus
+   ```
+


### PR DESCRIPTION
## Summary and Scope

Doc a known issue for csm-1.0.x regarding kube-multus IPBO issue

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5264](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5264)
* Change will also be needed in NA (not an issue for csm-1.2)
* Future work required by NA
* Documentation changes required NA
* Merge with/before/after NA

## Testing
Issue was encountered and fixed on odin and loki.

### Tested on:

  * odin, loki

### Test description:

Verified the IPBO issue and followed doc'ed steps to resolve.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? NA
- Were continuous integration tests run? If not, why? NA
- Was upgrade tested? If not, why? NA
- Was downgrade tested? If not, why? NA
- Were new tests (or test issues/Jiras) created for this change? NA

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

