### PR TITLE
CASMINST-3835: Update kubectl get nodes output for csm-1.2

### DIFF
--- a/background/ncn_operating_system_releases.md
+++ b/background/ncn_operating_system_releases.md
@@ -21,17 +21,18 @@ lrwxrwxrwx 1 root root   12 Jan  1 06:43 baseproduct -> SLE_HPC.prod
 -rw-r--r-- 1 root root 2956 Jun 10  2020 SLE_HPC.prod
 ncn-s# grep '<summary' /etc/products.d/*.prod
 /etc/products.d/ses.prod:  <summary>SUSE Enterprise Storage 7</summary>
-/etc/products.d/SLE_HPC.prod:  <summary>SUSE Linux Enterprise High Performance Computing 15 SP2</summary>
+/etc/products.d/SLE_HPC.prod:  <summary>SUSE Linux Enterprise High Performance Computing 15 SP3</summary>
 ```
 
 Kubernetes nodes will report SLE HPC only, which is reflected in the `kubectl` output.
 
 ```bash
 ncn# kubectl get nodes -o wide
-NAME       STATUS   ROLES    AGE    VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                                                  KERNEL-VERSION         CONTAINER-RUNTIME
-ncn-m002   Ready    master   128m   v1.18.6   10.252.1.14   <none>        SUSE Linux Enterprise High Performance Computing 15 SP2   5.3.18-24.37-default   containerd://1.3.4
-ncn-m003   Ready    master   127m   v1.18.6   10.252.1.13   <none>        SUSE Linux Enterprise High Performance Computing 15 SP2   5.3.18-24.37-default   containerd://1.3.4
-ncn-w001   Ready    <none>   90m    v1.18.6   10.252.1.12   <none>        SUSE Linux Enterprise High Performance Computing 15 SP2   5.3.18-24.37-default   containerd://1.3.4
-ncn-w002   Ready    <none>   88m    v1.18.6   10.252.1.11   <none>        SUSE Linux Enterprise High Performance Computing 15 SP2   5.3.18-24.37-default   containerd://1.3.4
-ncn-w003   Ready    <none>   82m    v1.18.6   10.252.1.10   <none>        SUSE Linux Enterprise High Performance Computing 15 SP2   5.3.18-24.37-default   containerd://1.3.4
+NAME       STATUS   ROLES                  AGE   VERSION    INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                                                  KERNEL-VERSION         CONTAINER-RUNTIME
+ncn-m001   Ready    control-plane,master   27h   v1.20.13   10.252.1.4    <none>        SUSE Linux Enterprise High Performance Computing 15 SP3   5.3.18-59.19-default   containerd://1.5.7
+ncn-m002   Ready    control-plane,master   8d    v1.20.13   10.252.1.5    <none>        SUSE Linux Enterprise High Performance Computing 15 SP3   5.3.18-59.19-default   containerd://1.5.7
+ncn-m003   Ready    control-plane,master   8d    v1.20.13   10.252.1.6    <none>        SUSE Linux Enterprise High Performance Computing 15 SP3   5.3.18-59.19-default   containerd://1.5.7
+ncn-w001   Ready    <none>                 8d    v1.20.13   10.252.1.7    <none>        SUSE Linux Enterprise High Performance Computing 15 SP3   5.3.18-59.19-default   containerd://1.5.7
+ncn-w002   Ready    <none>                 8d    v1.20.13   10.252.1.8    <none>        SUSE Linux Enterprise High Performance Computing 15 SP3   5.3.18-59.19-default   containerd://1.5.7
+ncn-w003   Ready    <none>                 8d    v1.20.13   10.252.1.9    <none>        SUSE Linux Enterprise High Performance Computing 15 SP3   5.3.18-59.19-default   containerd://1.5.7
 ```

--- a/install/deploy_final_ncn.md
+++ b/install/deploy_final_ncn.md
@@ -391,14 +391,14 @@ the Kubernetes cluster as the final of three master nodes forming a quorum.
 
     Expected output looks similar to the following:
 
-    ```
-    NAME       STATUS   ROLES    AGE     VERSION
-    ncn-m001   Ready    master   7s      v1.18.6
-    ncn-m002   Ready    master   4h40m   v1.18.6
-    ncn-m003   Ready    master   4h38m   v1.18.6
-    ncn-w001   Ready    <none>   4h39m   v1.18.6
-    ncn-w002   Ready    <none>   4h39m   v1.18.6
-    ncn-w003   Ready    <none>   4h39m   v1.18.6
+    ```text
+    NAME       STATUS   ROLES                  AGE   VERSION
+    ncn-m001   Ready    control-plane,master   27s   v1.20.13
+    ncn-m002   Ready    control-plane,master   4h    v1.20.13
+    ncn-m003   Ready    control-plane,master   4h    v1.20.13
+    ncn-w001   Ready    <none>                 4h    v1.20.13
+    ncn-w002   Ready    <none>                 4h    v1.20.13
+    ncn-w003   Ready    <none>                 4h    v1.20.13
     ```
 
 1. Restore and verify the site link. It will be necessary to restore the `ifcfg-lan0` file from either manual backup taken during the prior "Hand-Off" step or re-mount the USB and copy it from the prep directory to `/etc/sysconfig/network/`.

--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -428,12 +428,12 @@ The configuration workflow described here is intended to help understand the exp
     Expected output looks similar to the following:
 
     ```text
-    NAME       STATUS   ROLES    AGE     VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                                                  KERNEL-VERSION         CONTAINER-RUNTIME
-    ncn-m002   Ready    master   14m     v1.18.6   10.252.1.5    <none>        SUSE Linux Enterprise High Performance Computing 15 SP2   5.3.18-24.43-default   containerd://1.3.4
-    ncn-m003   Ready    master   13m     v1.18.6   10.252.1.6    <none>        SUSE Linux Enterprise High Performance Computing 15 SP2   5.3.18-24.43-default   containerd://1.3.4
-    ncn-w001   Ready    <none>   6m30s   v1.18.6   10.252.1.7    <none>        SUSE Linux Enterprise High Performance Computing 15 SP2   5.3.18-24.43-default   containerd://1.3.4
-    ncn-w002   Ready    <none>   6m16s   v1.18.6   10.252.1.8    <none>        SUSE Linux Enterprise High Performance Computing 15 SP2   5.3.18-24.43-default   containerd://1.3.4
-    ncn-w003   Ready    <none>   5m58s   v1.18.6   10.252.1.12   <none>        SUSE Linux Enterprise High Performance Computing 15 SP2   5.3.18-24.43-default   containerd://1.3.4
+    NAME       STATUS   ROLES                  AGE   VERSION    INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                                                  KERNEL-VERSION         CONTAINER-RUNTIME
+    ncn-m002   Ready    control-plane,master   2h    v1.20.13   10.252.1.5    <none>        SUSE Linux Enterprise High Performance Computing 15 SP3   5.3.18-59.19-default   containerd://1.5.7
+    ncn-m003   Ready    control-plane,master   2h    v1.20.13   10.252.1.6    <none>        SUSE Linux Enterprise High Performance Computing 15 SP3   5.3.18-59.19-default   containerd://1.5.7
+    ncn-w001   Ready    <none>                 2h    v1.20.13   10.252.1.7    <none>        SUSE Linux Enterprise High Performance Computing 15 SP3   5.3.18-59.19-default   containerd://1.5.7
+    ncn-w002   Ready    <none>                 2h    v1.20.13   10.252.1.8    <none>        SUSE Linux Enterprise High Performance Computing 15 SP3   5.3.18-59.19-default   containerd://1.5.7
+    ncn-w003   Ready    <none>                 2h    v1.20.13   10.252.1.9    <none>        SUSE Linux Enterprise High Performance Computing 15 SP3   5.3.18-59.19-default   containerd://1.5.7
     ```
 
 1.  Stop watching the console from `ncn-m002`.
@@ -717,12 +717,12 @@ The LiveCD needs to authenticate with the cluster to facilitate the rest of the 
     Expected output looks similar to the following:
 
     ```text
-    NAME       STATUS   ROLES    AGE     VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                                                  KERNEL-VERSION         CONTAINER-RUNTIME
-    ncn-m002   Ready    master   14m     v1.18.6   10.252.1.5    <none>        SUSE Linux Enterprise High Performance Computing 15 SP2   5.3.18-24.43-default   containerd://1.3.4
-    ncn-m003   Ready    master   13m     v1.18.6   10.252.1.6    <none>        SUSE Linux Enterprise High Performance Computing 15 SP2   5.3.18-24.43-default   containerd://1.3.4
-    ncn-w001   Ready    <none>   6m30s   v1.18.6   10.252.1.7    <none>        SUSE Linux Enterprise High Performance Computing 15 SP2   5.3.18-24.43-default   containerd://1.3.4
-    ncn-w002   Ready    <none>   6m16s   v1.18.6   10.252.1.8    <none>        SUSE Linux Enterprise High Performance Computing 15 SP2   5.3.18-24.43-default   containerd://1.3.4
-    ncn-w003   Ready    <none>   5m58s   v1.18.6   10.252.1.12   <none>        SUSE Linux Enterprise High Performance Computing 15 SP2   5.3.18-24.43-default   containerd://1.3.4
+    NAME       STATUS   ROLES                  AGE   VERSION    INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                                                  KERNEL-VERSION         CONTAINER-RUNTIME
+    ncn-m002   Ready    control-plane,master   2h    v1.20.13   10.252.1.5    <none>        SUSE Linux Enterprise High Performance Computing 15 SP3   5.3.18-59.19-default   containerd://1.5.7
+    ncn-m003   Ready    control-plane,master   2h    v1.20.13   10.252.1.6    <none>        SUSE Linux Enterprise High Performance Computing 15 SP3   5.3.18-59.19-default   containerd://1.5.7
+    ncn-w001   Ready    <none>                 2h    v1.20.13   10.252.1.7    <none>        SUSE Linux Enterprise High Performance Computing 15 SP3   5.3.18-59.19-default   containerd://1.5.7
+    ncn-w002   Ready    <none>                 2h    v1.20.13   10.252.1.8    <none>        SUSE Linux Enterprise High Performance Computing 15 SP3   5.3.18-59.19-default   containerd://1.5.7
+    ncn-w003   Ready    <none>                 2h    v1.20.13   10.252.1.9    <none>        SUSE Linux Enterprise High Performance Computing 15 SP3   5.3.18-59.19-default   containerd://1.5.7
     ```
 
 <a name="install-tests"></a>

--- a/install/install_csm_services.md
+++ b/install/install_csm_services.md
@@ -29,24 +29,32 @@ pit# rpm -Uvh /var/www/ephemeral/${CSM_RELEASE}/rpm/cray/csm/sle-15sp2/x86_64/ya
 
 > **NOTE**: During this step, on (only) TDS systems with three worker nodes the `customizations.yaml` file will be edited (automatically) to lower pod CPU requests for some services in order to better facilitate scheduling on smaller systems. See the file: `/var/www/ephemeral/${CSM_RELEASE}/tds_cpu_requests.yaml` for these settings. If desired, this file can be modified with different values (prior to executing the `yapl` command below) if other settings are desired in the `customizations.yaml` file for this system. For more information about modifying `customizations.yaml` and tuning based on specific systems, see [Post Install Customizations](https://github.com/Cray-HPE/docs-csm/blob/release/1.2/operations/CSM_product_management/Post_Install_Customizations.md).
 
-Setup password-less SSH for the pit node:
+1. Setup passwordless SSH for the pit node:
 
-```bash
-pit# rsync -av ncn-m002:.ssh/ /root/.ssh/
-```
+    ```bash
+    pit# rsync -av ncn-m002:.ssh/ /root/.ssh/
+    ```
 
-Install csm services using `yapl`:
+1. Install csm services using `yapl`:
 
-```bash
-pit# cd /usr/share/doc/csm/install/scripts/csm_services
-pit# yapl -f install.yaml execute
-```
+    ```bash
+    pit# pushd /usr/share/doc/csm/install/scripts/csm_services
+    pit# yapl -f install.yaml execute
+    pit# popd
+    ```
 
-> **`IMPORTANT:`** If any errors are encountered, then potential fixes should be displayed where the error occurred. You can rerun above command any time.
+    > **`IMPORTANT:`** If any errors are encountered, then potential fixes should be displayed where the error occurred. You can rerun above command any time.
 
-> **NOTE**: stdout is redirected to `/usr/share/doc/csm/install/scripts/csm_services/yapl.log` . If you would like to show stdout in the terminal, you can use `yapl -f install.yaml --console-output execute`
+    > **NOTE**: stdout is redirected to `/usr/share/doc/csm/install/scripts/csm_services/yapl.log` . If you would like to show stdout in the terminal, you can use `yapl -f install.yaml --console-output execute`
 
-> **NOTE**: If you want to force a rerun, you can use `--no-cache`: `yapl -f install.yaml execute --no-cache`
+    > **NOTE**: If you want to force a rerun, you can use `--no-cache`: `yapl -f install.yaml execute --no-cache`
+
+1. Copy `yapl` log files so they can be retained with other install logs:
+
+    ```bash
+    pit# mkdir -pv /var/www/ephemeral/prep/logs &&
+         cp -v /usr/share/doc/csm/install/scripts/csm_services/yapl.log /var/www/ephemeral/prep/logs
+    ```
 
 <a name="apply-after-sysmgmt-manifest-workarounds"></a>
 ### 3. Apply After Sysmgmt Manifest Workarounds
@@ -89,7 +97,7 @@ The following error may occur when running `./install.sh`:
    sls-s3-credentials   Opaque   7      28d
    ```
 
-2. Check for running sonar-sync jobs. If there are no sonar-sync jobs, then wait for one to complete. The sonar-sync cronjob is responsible for copying the `sls-s3-credentials` secret from the `default` to `services` namespaces.
+1. Check for running sonar-sync jobs. If there are no sonar-sync jobs, then wait for one to complete. The sonar-sync cronjob is responsible for copying the `sls-s3-credentials` secret from the `default` to `services` namespaces.
 
    ```bash
    pit# kubectl -n services get pods -l cronjob-name=sonar-sync
@@ -98,7 +106,7 @@ The following error may occur when running `./install.sh`:
    sonar-sync-1634322900-pnvl6   1/1     Running     0          13s
    ```
 
-3. Verify the `sls-s3-credentials` secret now exists in the `services` namespaces.
+1. Verify the `sls-s3-credentials` secret now exists in the `services` namespaces.
 
    ```bash
    pit# kubectl -n services get secret sls-s3-credentials
@@ -106,7 +114,7 @@ The following error may occur when running `./install.sh`:
    sls-s3-credentials   Opaque   7      20s
    ```
 
-4. Running `install.sh` again is expected to succeed.
+1. Running `install.sh` again is expected to succeed.
 
 <a name="known-issues-setup-nexus"></a>
 #### 5.2 Setup Nexus known issues

--- a/operations/UAS_user_and_admin_topics/Troubleshoot_UAS_Issues.md
+++ b/operations/UAS_user_and_admin_topics/Troubleshoot_UAS_Issues.md
@@ -96,7 +96,7 @@ If UAS pods are stuck in the `Pending` state, the admin needs to ensure the Kube
 ```bash
 ncn-w001# kubectl get nodes -l uas
 NAME        STATUS   ROLES    AGE   VERSION
-ncn-w001   Ready    master   11d   v1.13.3
+ncn-w001   Ready    <none>   11d   v1.20.13
 ```
 
 If none of the nodes are found or if the nodes listed are marked as `NotReady`, the UAI pods will not be scheduled and will not start.
@@ -117,8 +117,8 @@ Specify the location of the Kubernetes certificate with `KUBECONFIG`.
 ```bash
 [user@uai-user-be3a6770-6876c88676-2p2lk ~]# KUBECONFIG=/tmp/CONFIG kubectl get nodes
 NAME STATUS ROLES AGE VERSION
-ncn-m001 Ready master 16d v1.13.3
-ncn-m002 Ready master 16d v1.13.3
+ncn-m001 Ready control-plane,master 16d v1.20.13
+ncn-m002 Ready control-plane,master 16d v1.20.13
 ```
 
 Users must specify `KUBECONFIG` with every kubectl command or specify the kubeconfig file location for the life of the UAI. To do this, either set the `KUBECONFIG` environment variable or set the `--kubeconfig` flag .

--- a/operations/UAS_user_and_admin_topics/UAI_Host_Node_Selection.md
+++ b/operations/UAS_user_and_admin_topics/UAI_Host_Node_Selection.md
@@ -15,9 +15,9 @@ UAI host node identification is an exclusive activity, not an inclusive one, so 
   ```
   ncn-m001-pit# kubectl get nodes | grep -v master
   NAME       STATUS   ROLES    AGE   VERSION
-  ncn-w001   Ready    <none>   10d   v1.18.6
-  ncn-w002   Ready    <none>   25d   v1.18.6
-  ncn-w003   Ready    <none>   23d   v1.18.6
+  ncn-w001   Ready    <none>   10d   v1.20.13
+  ncn-w002   Ready    <none>   25d   v1.20.13
+  ncn-w003   Ready    <none>   23d   v1.20.13
   ```
 
   In this example, there are three nodes known by Kubernetes that are not running as Kubernetes master nodes. These are all potential UAI host nodes.
@@ -27,7 +27,7 @@ UAI host node identification is an exclusive activity, not an inclusive one, so 
   ```
   ncn-m001-pit# kubectl get no -l uas=False
   NAME       STATUS   ROLES    AGE   VERSION
-  ncn-w001   Ready    <none>   10d   v1.18.6
+  ncn-w001   Ready    <none>   10d   v1.20.13
   ```
 
   **NOTE:** Given the fact that labels are textual not boolean, it is a good idea to try various common spellings of false. The ones that will prevent UAIs from running are 'False', 'false' and 'FALSE'. Repeat the above with all three options to be sure.

--- a/operations/kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md
+++ b/operations/kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md
@@ -266,13 +266,13 @@ Run the following steps on each master node.
    error: You must be logged in to the server (Unauthorized)
    ncn-m# cp /etc/kubernetes/admin.conf /root/.kube/config
    ncn-m#  # kubectl get nodes
-   NAME       STATUS   ROLES    AGE    VERSION
-   ncn-m001   Ready    master   370d   v1.18.6
-   ncn-m002   Ready    master   370d   v1.18.6
-   ncn-m003   Ready    master   370d   v1.18.6
-   ncn-w001   Ready    <none>   370d   v1.18.6
-   ncn-w002   Ready    <none>   370d   v1.18.6
-   ncn-w003   Ready    <none>   370d   v1.18.6
+   NAME       STATUS   ROLES                  AGE   VERSION
+   ncn-m001   Ready    control-plane,master   27h   v1.20.13
+   ncn-m002   Ready    control-plane,master   8d    v1.20.13
+   ncn-m003   Ready    control-plane,master   8d    v1.20.13
+   ncn-w001   Ready    <none>                 8d    v1.20.13
+   ncn-w002   Ready    <none>                 8d    v1.20.13
+   ncn-w003   Ready    <none>                 8d    v1.20.13
    ```
 
 1. Distribute the client certificate to the rest of the cluster.

--- a/operations/kubernetes/Configure_kubectl_Credentials_to_Access_the_Kubernetes_APIs.md
+++ b/operations/kubernetes/Configure_kubectl_Credentials_to_Access_the_Kubernetes_APIs.md
@@ -27,13 +27,13 @@ This procedure requires administrative privileges and assumes that the device be
     If the command was successful, the system will return output similar to the following:
 
     ```bash
-    NAME       STATUS   ROLES    AGE   VERSION
-    ncn-m001   Ready    master   23h   v1.14.3
-    ncn-m002   Ready    master   23h   v1.14.3
-    ncn-m003   Ready    master   23h   v1.14.3
-    ncn-w001   Ready    <none>   23h   v1.14.3
-    ncn-w002   Ready    <none>   23h   v1.14.3
-    ncn-w003   Ready    <none>   23h   v1.14.3
+    NAME       STATUS   ROLES                  AGE   VERSION
+    ncn-m001   Ready    control-plane,master   27h   v1.20.13
+    ncn-m002   Ready    control-plane,master   8d    v1.20.13
+    ncn-m003   Ready    control-plane,master   8d    v1.20.13
+    ncn-w001   Ready    <none>                 8d    v1.20.13
+    ncn-w002   Ready    <none>                 8d    v1.20.13
+    ncn-w003   Ready    <none>                 8d    v1.20.13
     ```
 
     The information above is only an example and may appear differently than it is shown above.

--- a/operations/kubernetes/Retrieve_Cluster_Health_Information_Using_Kubernetes.md
+++ b/operations/kubernetes/Retrieve_Cluster_Health_Information_Using_Kubernetes.md
@@ -7,13 +7,13 @@ The `kubectl` CLI commands can be used to retrieve information about the Kuberne
 
 ```bash
 ncn# kubectl get nodes
-NAME       STATUS     ROLES    AGE   VERSION
-ncn-m001   Ready      master   19d   v1.14.3
-ncn-m002   Ready      master   19d   v1.14.3
-ncn-m003   Ready      master   19d   v1.14.3
-ncn-w001   Ready      <none>   19d   v1.14.3
-ncn-w002   Ready      <none>   19d   v1.14.3
-ncn-w003   Ready      <none>   19d   v1.14.3
+NAME       STATUS   ROLES                  AGE   VERSION
+ncn-m001   Ready    control-plane,master   27h   v1.20.13
+ncn-m002   Ready    control-plane,master   8d    v1.20.13
+ncn-m003   Ready    control-plane,master   8d    v1.20.13
+ncn-w001   Ready    <none>                 8d    v1.20.13
+ncn-w002   Ready    <none>                 8d    v1.20.13
+ncn-w003   Ready    <none>                 8d    v1.20.13
 ```
 
 ### Retrieve Pod Status

--- a/operations/node_management/Rebuild_NCNs.md
+++ b/operations/node_management/Rebuild_NCNs.md
@@ -915,13 +915,13 @@ Skip this section if a master or storage node was rebuilt.
 
       ```bash
       ncn-mw# kubectl get nodes
-      NAME       STATUS   ROLES    AGE    VERSION
-      ncn-m001   Ready    master   113m   v1.18.6
-      ncn-m002   Ready    master   113m   v1.18.6
-      ncn-m003   Ready    master   112m   v1.18.6
-      ncn-w001   Ready    <none>   112m   v1.18.6
-      ncn-w002   Ready    <none>   112m   v1.18.6
-      ncn-w003   Ready    <none>   112m   v1.18.6
+      NAME       STATUS   ROLES                  AGE   VERSION
+      ncn-m001   Ready    control-plane,master   27h   v1.20.13
+      ncn-m002   Ready    control-plane,master   8d    v1.20.13
+      ncn-m003   Ready    control-plane,master   8d    v1.20.13
+      ncn-w001   Ready    <none>                 8d    v1.20.13
+      ncn-w002   Ready    <none>                 8d    v1.20.13
+      ncn-w003   Ready    <none>                 8d    v1.20.13
       ```
 
 1. Ensure there is proper routing set up for liquid-cooled hardware.
@@ -999,13 +999,13 @@ Skip this section if a worker or storage node was rebuilt.
 
     ```bash
     ncn-mw# kubectl get nodes
-    NAME       STATUS   ROLES    AGE    VERSION
-    ncn-m001   Ready    master   113m   v1.18.6
-    ncn-m002   Ready    master   113m   v1.18.6
-    ncn-m003   Ready    master   112m   v1.18.6
-    ncn-w001   Ready    <none>   112m   v1.18.6
-    ncn-w002   Ready    <none>   112m   v1.18.6
-    ncn-w003   Ready    <none>   112m   v1.18.6
+    NAME       STATUS   ROLES                  AGE   VERSION
+    ncn-m001   Ready    control-plane,master   27h   v1.20.13
+    ncn-m002   Ready    control-plane,master   8d    v1.20.13
+    ncn-m003   Ready    control-plane,master   8d    v1.20.13
+    ncn-w001   Ready    <none>                 8d    v1.20.13
+    ncn-w002   Ready    <none>                 8d    v1.20.13
+    ncn-w003   Ready    <none>                 8d    v1.20.13
     ```
 
 1. Ensure there is proper routing set up for liquid-cooled hardware.

--- a/operations/resiliency/Restore_System_Functionality_if_a_Kubernetes_Worker_Node_is_Down.md
+++ b/operations/resiliency/Restore_System_Functionality_if_a_Kubernetes_Worker_Node_is_Down.md
@@ -101,13 +101,13 @@ This procedure requires administrative privileges.
 
     ```bash
     ncn# kubectl get nodes -o wide
-    NAME       STATUS   ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                              KERNEL-VERSION           CONTAINER-RUNTIME
-    ncn-m001   Ready    master   27d   v1.18.2   10.252.0.10   <none>        SUSE Linux Enterprise Server 15 SP1   4.12.14-197.45-default   containerd://1.3.3
-    ncn-m002   Ready    master   27d   v1.18.2   10.252.0.11   <none>        SUSE Linux Enterprise Server 15 SP1   4.12.14-197.45-default   containerd://1.3.3
-    ncn-m003   Ready    master   27d   v1.18.2   10.252.0.12   <none>        SUSE Linux Enterprise Server 15 SP1   4.12.14-197.45-default   containerd://1.3.3
-    ncn-w001   Ready    <none>   27d   v1.18.2   10.252.0.4    <none>        SUSE Linux Enterprise Server 15 SP1   4.12.14-197.45-default   containerd://1.3.3
-    ncn-w002   Ready    <none>   27d   v1.18.2   10.252.0.5    <none>        SUSE Linux Enterprise Server 15 SP1   4.12.14-197.45-default   containerd://1.3.3
-    ncn-w003   Ready    <none>   27d   v1.18.2   10.252.0.6    <none>        SUSE Linux Enterprise Server 15 SP1   4.12.14-197.45-default   containerd://1.3.3
+    NAME       STATUS   ROLES                  AGE   VERSION    INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                                                  KERNEL-VERSION         CONTAINER-RUNTIME
+    ncn-m001   Ready    control-plane,master   27h   v1.20.13   10.252.1.4    <none>        SUSE Linux Enterprise High Performance Computing 15 SP3   5.3.18-59.19-default   containerd://1.5.7
+    ncn-m002   Ready    control-plane,master   8d    v1.20.13   10.252.1.5    <none>        SUSE Linux Enterprise High Performance Computing 15 SP3   5.3.18-59.19-default   containerd://1.5.7
+    ncn-m003   Ready    control-plane,master   8d    v1.20.13   10.252.1.6    <none>        SUSE Linux Enterprise High Performance Computing 15 SP3   5.3.18-59.19-default   containerd://1.5.7
+    ncn-w001   Ready    <none>                 8d    v1.20.13   10.252.1.7    <none>        SUSE Linux Enterprise High Performance Computing 15 SP3   5.3.18-59.19-default   containerd://1.5.7
+    ncn-w002   Ready    <none>                 8d    v1.20.13   10.252.1.8    <none>        SUSE Linux Enterprise High Performance Computing 15 SP3   5.3.18-59.19-default   containerd://1.5.7
+    ncn-w003   Ready    <none>                 8d    v1.20.13   10.252.1.9    <none>        SUSE Linux Enterprise High Performance Computing 15 SP3   5.3.18-59.19-default   containerd://1.5.7
     ```
 
 ### Collect Information After Powering Down the Node

--- a/troubleshooting/kubernetes/Troubleshoot_Kubernetes_Node_NotReady.md
+++ b/troubleshooting/kubernetes/Troubleshoot_Kubernetes_Node_NotReady.md
@@ -12,13 +12,13 @@ The `kubectl get nodes` command returns a NotReady state for a master or worker 
 
     ```bash
     ncn-w001# kubectl get nodes
-    NAME       STATUS   ROLES    AGE   VERSION
-    ncn-m001   Ready    master   27h   v1.19.9
-    ncn-m002   Ready    master   19h   v1.19.9
-    ncn-m003   Ready    master   18h   v1.19.9
-    ncn-w001   NotReady <none>   36h   v1.19.9
-    ncn-w002   Ready    <none>   36h   v1.19.9
-    ncn-w003   Ready    <none>   36h   v1.19.9
+    NAME       STATUS   ROLES                  AGE   VERSION
+    ncn-m001   Ready    control-plane,master   27h   v1.20.13
+    ncn-m002   Ready    control-plane,master   8d    v1.20.13
+    ncn-m003   Ready    control-plane,master   8d    v1.20.13
+    ncn-w001   NotReady <none>                 8d    v1.20.13
+    ncn-w002   Ready    <none>                 8d    v1.20.13
+    ncn-w003   Ready    <none>                 8d    v1.20.13
     ```
 
 ### Recovery Steps


### PR DESCRIPTION
The output of the "kubectl get nodes" command changed in csm-1.2. This updates the example output in the docs to reflect that. No content changes.

I just added another commit which does some linting of the "Install CSM services" page, and adds commands to retain the log file from the yapl tool.