### PR TITLE
Add pod priority application to 1.0.10 upgrade path

### DIFF
--- a/upgrade/1.0.1/scripts/upgrade/add_pod_priority.sh
+++ b/upgrade/1.0.1/scripts/upgrade/add_pod_priority.sh
@@ -133,7 +133,7 @@ for etcdcluster in $ETCDCLUSTERS; do
   ns=$(kubectl get etcdcluster -A | grep " $etcdcluster " | awk '{print $1}')
   if [ ! -z "$ns" ]; then
     echo "Patching $etcdcluster etcdcluster in $ns namespace"
-    kubectl -n $ns patch etcdcluster $etcdcluster --type merge -p '{"spec": {"template": {"spec": {"priorityClassName": "csm-high-priority-service"}}}}'
+    kubectl -n $ns patch etcdcluster $etcdcluster --type merge -p '{"spec": {"pod": {"priorityClassName": "csm-high-priority-service"}}}'
     echo ""
     restart_etcd_pods $ns $etcdcluster
     echo ""

--- a/upgrade/1.0.10/README.md
+++ b/upgrade/1.0.10/README.md
@@ -6,6 +6,7 @@
 1. [Setup Nexus](#setup-nexus)
 1. [Upgrade Services](#upgrade-services)
 1. [Rollout Deployment Restart](#rollout-deployment-restart)
+1. [Apply Pod Priorities](#apply-pod-priorities)
 1. [Verification](#verification)
 1. [Run NCN Personalization](#run-ncn-personalization)
 1. [Exit Typescript](#exit-typescript)
@@ -130,6 +131,34 @@ Waiting for deployment "cray-dns-unbound" rollout to finish: 1 old replicas are 
 Waiting for deployment "cray-dns-unbound" rollout to finish: 1 old replicas are pending termination...
 deployment "cray-dns-unbound" successfully rolled out
 ```
+<a name="apply-pod-priorities"></a>
+
+## Apply Pod Priorities
+
+Run the `add_pod_priority.sh` script to create and apply a pod priority class to services critical to CSM. This will give these services a higher priority than others to ensure they get scheduled by Kubernetes in the event that resources limited on smaller deployments.
+
+```bash
+ncn-m001:~ # /usr/share/doc/csm/upgrade/1.0.1/scripts/upgrade/add_pod_priority.sh
+Creating csm-high-priority-service pod priority class
+priorityclass.scheduling.k8s.io/csm-high-priority-service configured
+
+Patching cray-postgres-operator deployment in services namespace
+deployment.apps/cray-postgres-operator patched
+
+Patching cray-postgres-operator-postgres-operator-ui deployment in services namespace
+deployment.apps/cray-postgres-operator-postgres-operator-ui patched
+
+Patching istio-operator deployment in istio-operator namespace
+deployment.apps/istio-operator patched
+
+Patching istio-ingressgateway deployment in istio-system namespace
+deployment.apps/istio-ingressgateway patched
+.
+.
+.
+```
+
+After running the `add_pod_priority.sh` script, the affected pods will be restarted as the pod priority class is applied to them.
 
 <a name="verification"></a>
 


### PR DESCRIPTION
## Summary and Scope

The script to apply pod priorities is not called on the 1.0.10 upgrade path, this change adds that.  Also, when applying to etcd clusters, the script needs a tweak to apply to the correct section in the etcdcluster crd.

## Issues and Related PRs

* Resolves [CASMINST-3856](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3856)

## Testing

tested on fanta

```
ncn-m001:/usr/share/doc # kubectl get po -n services cray-bss-etcd-8xplplwvpv -o yaml | grep prior
        f:priorityClassName: {}
  priority: 1000000
  priorityClassName: csm-high-priority-service
```

### Tested on:

  * `fanta`

### Test description:

Made the script change and ran it -- bss etcd pods came up with pod priorities

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

