### PR TITLE
CASMINST-3807: Manually install/upgrade RPMs on ncn-m001 after PIT redeploy

### DIFF
--- a/install/deploy_final_ncn.md
+++ b/install/deploy_final_ncn.md
@@ -455,6 +455,15 @@ the Kubernetes cluster as the final of three master nodes forming a quorum.
 
     **Important:** To ensure that the latest workarounds and documentation updates are available, see [Check for Latest Workarounds and Documentation Updates](../update_product_stream/index.md#workarounds)
 
+1. Install/upgrade testing and utility RPMs on `ncn-m001` from Nexus.
+
+    ```bash
+    ncn-m001# zypper ar --gpgcheck-allow-unsigned https://packages.local/repository/csm-sle-15sp2 csm-sle-15sp2
+    ncn-m001# zypper install -y csm-testing goss-servers platform-utils
+    ncn-m001# zypper rr csm-sle-15sp2
+    ncn-m001# systemctl restart goss-servers
+    ```
+
 1. Follow the [workaround instructions](../update_product_stream/index.md#apply-workarounds) for the `livecd-post-reboot` breakpoint.
 
 1. Exit the typescript and move the backup to `ncn-m001`, thus removing the need to track `ncn-m002` as yet-another bootstrapping agent. This is required to facilitate reinstallations, because it pulls the preparation data back over to the documented area (`ncn-m001`).


### PR DESCRIPTION
This adds the commands needed to install the testing RPMs on m001 after being redeployed from the PIT node. This will happen automatically during NCN customization, but often that is not done until after the CSM health validation procedure, and these RPMs are necessary for that.

NOTE that these commands will need to be updated after [CASMINST-3810](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3810) is resolved (I've made a comment to this effect in that ticket as well). 