### PR TITLE
(CSM 1.2) CASMPET-3996: Add mention of new required SW_ADMIN_PASSWORD variable when running the LiveCD preflight checks and ncn-health-checks.

### DIFF
--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -305,6 +305,12 @@ The configuration workflow described here is intended to help understand the exp
 1. Validate that the LiveCD is ready for installing NCNs.
    > Observe the output of the checks and note any failures, then remediate them.
 
+    Specify the admin user password for the management switches in the system.
+    ```bash
+    pit# export SW_ADMIN_PASSWORD='changeme'
+    ```
+
+    Run the LiveCD preflight checks.
     ```bash
     pit# csi pit validate --livecd-preflight
     ```

--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -78,6 +78,11 @@ Run the NCN health checks with the following command (If m001 is the PIT node, r
 
 **IMPORTANT:** Do not run these as part of upgrade testing. This includes the Kubernetes check in the next block.
 
+Specify the admin user password for the management switches in the system which is required for the `ncn-healthcheck` test.
+```bash
+# export SW_ADMIN_PASSWORD='changeme'
+```
+
 ```bash
 # /opt/cray/tests/install/ncn/automated/ncn-healthcheck
 ```


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
Add mention of new required SW_ADMIN_PASSWORD variable when running the LiveCD preflight checks and ncn-health-checks.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
backwards compatible

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-3996](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-3996)
* Merge after https://github.com/Cray-HPE/csm-testing/pull/176

## Testing

For testing see: https://github.com/Cray-HPE/csm-testing/pull/176

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
Low risk


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

