### PR TITLE
CASMINST-3841:  Move update-customizations.sh into prerequisites.sh and add sealed secret generation

### DIFF
--- a/operations/security_and_authentication/Manage_Sealed_Secrets.md
+++ b/operations/security_and_authentication/Manage_Sealed_Secrets.md
@@ -65,21 +65,22 @@ If LDAP user federation is required, refer to [Add LDAP User Federation](../secu
    1. Extract the certificate and key used to create the sealed secrets.
 
       ```bash
+      ncn-m001# mkdir -p certs
       ncn-m001# kubectl -n kube-system get secret sealed-secrets-key -o jsonpath='{.data.tls\.crt}' | base64 -d - > certs/sealed_secrets.crt
       ncn-m001# kubectl -n kube-system get secret sealed-secrets-key -o jsonpath='{.data.tls\.key}' | base64 -d - > certs/sealed_secrets.key
       ```
 
 1. (Optional) Prevent tracked sealed secrets from being regenerated.
     
-    1. Remove the sealed secrets not being regenerated from the `spec.kubernetes.tracked_sealed_secrets` list in `/root/site-init/${CSM_DISTDIR}/shasta-cfg/customizations.yaml` prior to executing the remaining steps in this section.
+   Remove the sealed secrets not being regenerated from the `spec.kubernetes.tracked_sealed_secrets` list in `/root/site-init/${CSM_DISTDIR}/shasta-cfg/customizations.yaml` prior to executing the remaining steps in this section.
 
-    2. Retain the REDS/MEDS/RTS credentials.
+   Retain the REDS/MEDS/RTS credentials.
 
-       ```bash
-       linux# yq delete -i ./${CSM_DISTDIR}/shasta-cfg/customizations.yaml spec.kubernetes.tracked_sealed_secrets.cray_reds_credentials
-       linux# yq delete -i ./${CSM_DISTDIR}/shasta-cfg/customizations.yaml spec.kubernetes.tracked_sealed_secrets.cray_meds_credentials
-       linux# yq delete -i ./${CSM_DISTDIR}/shasta-cfg/customizations.yaml spec.kubernetes.tracked_sealed_secrets.cray_hms_rts_credentials
-       ```
+   ```bash
+   ncn-m001# yq delete -i customizations.yaml spec.kubernetes.tracked_sealed_secrets.cray_reds_credentials
+   ncn-m001# yq delete -i customizations.yaml spec.kubernetes.tracked_sealed_secrets.cray_meds_credentials
+   ncn-m001# yq delete -i customizations.yaml spec.kubernetes.tracked_sealed_secrets.cray_hms_rts_credentials
+   ```
 
 2. Prepare to generate sealed secrets.
    

--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -22,73 +22,28 @@
         ncn-m001# rpm -Uvh [PATH_TO_docs-csm-*.noarch.rpm]
         ```
 
-## Stage 0.2 - Update `customizations.yaml`
+## Stage 0.2 - Update SLS
 
-Perform these steps to update `customizations.yaml`:
-
-1. Extract `customizations.yaml` from the `site-init` secret:
-
-    ```bash
-    ncn-m001# cd /tmp
-    ncn-m001# kubectl -n loftsman get secret site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d - > customizations.yaml
-    ```
-
-1. Update `customizations.yaml`:
-
-    > **`IMPORTANT:`** If the password for the local Nexus `admin` account has
-    > been changed from the default `admin123` (not typical), then set the
-    > `NEXUS_PASSWORD` environment variable to the correct `admin` password
-    > before running update-customizations.sh! For example:
-    >
-    > ```bash
-    > ncn-m001# export NEXUS_PASSWORD=cu$t0m@DM1Np4s5w0rd
-    > ```
-    >
-    > Otherwise, a random 32-character base64-encoded string will be generated
-    > and updated as the default `admin` password when Nexus is upgraded.
-
-    ```bash
-    ncn-m001# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/update-customizations.sh -i customizations.yaml
-    ```
-
-    > **`IMPORTANT:`** If the `NEXUS_PASSWORD` environment variable was set as
-    > previously mentioned, then remove it before continuing:
-    >
-    > ```bash
-    > ncn-m001# export -n NEXUS_PASSWORD
-    > ncn-m001# unset NEXUS_PASSWORD
-    > ```
-
-1. Update the `site-init` secret:
-
-    ```bash
-    ncn-m001# kubectl delete secret -n loftsman site-init
-    ncn-m001# kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
-    ```
-
-1. If [using an external Git repository for managing customizations](../../install/prepare_site_init.md#version-control-site-init-files) as recommended,
-   clone a local working tree and commit appropriate changes to `customizations.yaml`.
-
-    For example:
-
-    ```bash
-    ncn-m001# git clone <URL> site-init
-    ncn-m001# cp /tmp/customizations.yaml site-init
-    ncn-m001# cd site-init
-    ncn-m001# git add customizations.yaml
-    ncn-m001# git commit -m 'Remove Gitea PVC configuration from customizations.yaml'
-    ncn-m001# git push
-    ```
-
-5. Return to original working directory:
-
-    ```bash
-    ncn-m001# cd -
-    ```
+SLS needs to be updated. Right now this is manual. There will be a tool coming soon.
+This is a placeholder until the tool is ready to be added to the automation.
 
 ## Stage 0.3 - Execute Prerequisites Check
 
 Run check script:
+
+   > **`IMPORTANT:`** If the password for the local Nexus `admin` account has
+   > been changed from the default `admin123` (not typical), then set the
+   > `NEXUS_PASSWORD` environment variable to the correct `admin` password
+   > before running prerequisites.sh! 
+   >
+   > For example:
+   >
+   > ```bash
+   > ncn-m001# export NEXUS_PASSWORD=cu$t0m@DM1Np4s5w0rd
+   > ```
+   >
+   > Otherwise, a random 32-character base64-encoded string will be generated
+   > and updated as the default `admin` password when Nexus is upgraded.
 
 * Internet Connected
 
@@ -100,11 +55,32 @@ Run check script:
 
 * Air Gapped
 
-    ```bash
-    ncn-m001# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prerequisites.sh --csm-version [CSM_RELEASE] --tarball-file [PATH_TO_CSM_TARBALL_FILE]
-    ```
+   ```bash
+   ncn-m001# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prerequisites.sh --csm-version [CSM_RELEASE] --tarball-file [PATH_TO_CSM_TARBALL_FILE]
+   ```
 
 **`IMPORTANT:`** If any errors are encountered, then potential fixes should be displayed where the error occurred. **IF** the upgrade `prerequisites.sh` script fails and does not provide guidance, then try rerunning it. If the failure persists, then open a support ticket for guidance before proceeding.
+
+**`IMPORTANT:`** If the `NEXUS_PASSWORD` environment variable was set as previously mentioned, then remove it before continuing:
+   
+   ```bash
+   ncn-m001# export -n NEXUS_PASSWORD
+   ncn-m001# unset NEXUS_PASSWORD
+   ```
+
+**`OPTIONAL:`** Customizations.yaml has been updated in this step. If [using an external Git repository for managing customizations](../../install/prepare_site_init.md#version-control-site-init-files) as recommended,
+   clone a local working tree and commit appropriate changes to `customizations.yaml`.
+
+   For example:
+
+   ```bash
+   ncn-m001# git clone <URL> site-init
+   ncn-m001# cd site-init
+   ncn-m001# kubectl -n loftsman get secret site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d - > customizations.yaml
+   ncn-m001# git add customizations.yaml
+   ncn-m001# git commit -m 'CSM 1.2 upgrade - customizations.yaml'
+   ncn-m001# git push
+   ```
 
 ## Stage 0.4 - Backup VCS Data
 


### PR DESCRIPTION

## Summary and Scope

The stage0 instructions are missing the step to generate the 5 sealed secrets that get added to customizations.yaml in 1.2.    The steps to do that regeneration need to have the extracted tarball which happens in prerequisites.sh.  Therefore, all of the customizations update steps were added into prerequisites.sh.

The manual steps documented in stage0 were replaced by a placeholder for updating SLS for now installers don't miss doing that.   There is a tool being implemented in CASMNET-693 that will be added to the instructions or to the automation in place of this placeholder.

Also, while referencing https://github.com/Cray-HPE/docs-csm/blob/release/1.2/operations/security_and_authentication/Manage_Sealed_Secrets.md, I found a couple of minor things to be fixed.

## Issues and Related PRs

* Resolves CASMINST-3841

## Testing

### Tested on:

  * `drax`


### Test description:

I ran the new "UPDATE_CUSTOMIZATIONS" step on drax and made sure the resulting customizations.yaml was updated and had the sealed secrets generated.

## Risks and Mitigations

I wasn't able to run the full prerequisites.sh script because I didn't want to mess up the upgrade in process so that full path hasn't been tested, but any unexpected issues should be easy to resolve.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

