### PR TITLE
CASMINST-3866 - Copy the NCN Artifacts step is failing

### DIFF
--- a/install/bootstrap_livecd_usb.md
+++ b/install/bootstrap_livecd_usb.md
@@ -245,7 +245,7 @@ Some files are needed for generating the configuration payload. See these topics
 1. Change into the preparation directory plus necessary PIT directories (for later):
 
    ```bash
-   linux:usb# mkdir -pv /mnt/pitdata/admin /mnt/pitdata/prep /mnt/pitdata/configs /mnt/pitdata/data
+   linux:usb# mkdir -pv /mnt/pitdata/admin /mnt/pitdata/prep /mnt/pitdata/configs /mnt/pitdata/data/{k8s,ceph}
    linux:usb# cd /mnt/pitdata/prep
    ```
 


### PR DESCRIPTION
## Summary and Scope

`csi` throws a nonsensical error if the target specified in `csi pit populate pitdata` does not exist.

This documentation change ensures that the intended target directories are created along with the other required directories.

The error handling of `csi` will also be enhanced to correctly report when the target directory does not exist.

## Issues and Related PRs

* Resolves [CASMINST-3866](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3866)
* Change will also be needed in `release/1.2`

## Testing

### Tested on:

  * Local development environment

### Test description:

Tested directories are created as expected with new mkdir syntax
```
# mkdir -pv /mnt/pitdata/admin /mnt/pitdata/prep /mnt/pitdata/configs /mnt/pitdata/data/{k8s,ceph}
mkdir: created directory '/mnt/pitdata'
mkdir: created directory '/mnt/pitdata/admin'
mkdir: created directory '/mnt/pitdata/prep'
mkdir: created directory '/mnt/pitdata/configs'
mkdir: created directory '/mnt/pitdata/data'
mkdir: created directory '/mnt/pitdata/data/k8s'
mkdir: created directory '/mnt/pitdata/data/ceph'
```

## Risks and Mitigations

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

