### PR TITLE
Add instructions to back up BSS data before performing an upgrade.

### DIFF
--- a/upgrade/1.0.1/Stage_0_Prerequisites.md
+++ b/upgrade/1.0.1/Stage_0_Prerequisites.md
@@ -168,4 +168,14 @@ On ncn-m001:
 python3 /usr/share/doc/csm/scripts/patch-ceph-runcmd.py
 ```
 
+## Stage 0.6 - Backup BSS Data
+
+In the event of a problem during the upgrade which may cause the loss of BSS data, perform the following to preserve this data.
+
+   ```bash
+   ncn-m001# cray bss bootparameters list --format=json >bss-backup-$(date +%Y-%m-%d).json
+   ```
+
+The resulting file needs to be saved in the event that BSS data needs to be restored in the future.
+
 Once the above steps have been completed, proceed to [Stage 1](Stage_1.md).

--- a/upgrade/1.0.10/README.md
+++ b/upgrade/1.0.10/README.md
@@ -53,6 +53,16 @@ ncn-m001# grep -oP "(ncn-s\w+)" /etc/hosts | sort -u | xargs -t -i ssh {} 'trunc
 ncn-m001# grep -oP "(ncn-s\w+)" /etc/hosts | sort -u | xargs -t -i ssh {} 'grep -oP "(ncn-s\w+|ncn-m\w+|ncn-w\w+)" /etc/hosts | sort -u | xargs -t -i ssh-keyscan -H \{\} >> /root/.ssh/known_hosts'
 ```
 
+1. Backup BSS Data
+
+In the event of a problem during the upgrade which may cause the loss of BSS data, perform the following to preserve this data.
+
+   ```bash
+   ncn-m001# cray bss bootparameters list --format=json >bss-backup-$(date +%Y-%m-%d).json
+   ```
+
+The resulting file needs to be saved in the event that BSS data needs to be restored in the future.
+
 <a name="setup-nexus"></a>
 
 ## Setup Nexus


### PR DESCRIPTION
## Summary and Scope

Adds instructions to back up BSS data before performing a system upgrade.
This enables the restoration of this data should the BSS data get lost during the upgrade.

## Issues and Related PRs

* Resolves [CASMINST-3873](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3873)

## Testing

Verified given command produces the expected output.

### Tested on:

  * mug

### Test description:

Executed documented command and verified resulting file.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? N/A   If not, why? doc changes
- Was upgrade tested?  N/A   If not, why? doc changes
- Was downgrade tested?  N/A   If not, why? doc changes
- Were new tests (or test issues/Jiras) created for this change? No

## Risks and Mitigations

This is a low risk change to documentation.
