### PR TITLE
CASMUSER-2940 - Add Troubleshooting for Broker UAI SSSD Configuration Issues

### DIFF
--- a/operations/UAS_user_and_admin_topics/Configure_a_Broker_UAI_Class.md
+++ b/operations/UAS_user_and_admin_topics/Configure_a_Broker_UAI_Class.md
@@ -96,6 +96,11 @@ This example, uses Kubernetes secrets and assumes that the Broker UAIs run in th
                    --volume-description \
                    '{"secret": {"secret_name": "broker-sssd-conf", "default_mode": 384}}' \
                     --volumename broker-sssd-config
+     ```
+
+     Example output:
+
+     ```
      mount_path = "/etc/sssd"
      volume_id = "1ec36af0-d5b6-4ad9-b3e8-755729765d76"
      volumename = "broker-sssd-config"
@@ -110,10 +115,15 @@ This example, uses Kubernetes secrets and assumes that the Broker UAIs run in th
      * The secret is mounted on the directory `/etc/sssd` not the file `/etc/sssd/sssd.conf` because Kubernetes does not permit the replacement of an existing regular file with a volume but does allow overriding a directory
      * The value `384` is used here for the default mode of the file instead of `0600`, which would be easier to read, because JSON does not accept octal numbers in the leading zero form
 
-4. Make a volume to hold an empty and writeable `/etc/sssd/conf.d` in the Broker UAI
+4. Make a volume to hold an empty and writeable `/etc/sssd/conf.d` in the Broker UAI:
 
    ```
-   ncn-m001:~ # cray uas admin config volumes create --mount-path /etc/sssd/conf.d --volume-description '{"empty_dir": {"medium": "Memory"}}' --volumename sssd-conf-d --format yaml
+   ncn-m001# cray uas admin config volumes create --mount-path /etc/sssd/conf.d --volume-description '{"empty_dir": {"medium": "Memory"}}' --volumename sssd-conf-d --format yaml
+   ```
+   
+   Example output:
+
+   ```
    mount_path: /etc/sssd/conf.d
    volume_description:
      empty_dir:
@@ -128,6 +138,11 @@ This example, uses Kubernetes secrets and assumes that the Broker UAIs run in th
 
    ```
    ncn-m001-pit# cray uas admin config images list
+   ```
+   
+   Example output:
+   
+   ```
    [[results]]
    default = true
    image_id = "1996c7f7-ca45-4588-bc41-0422fe2a1c3d"
@@ -189,6 +204,11 @@ This example, uses Kubernetes secrets and assumes that the Broker UAIs run in th
                 --public-ip yes \
                 --comment "UAI broker class" \
                 --uai-creation-class bdb4988b-c061-48fa-a005-34f8571b88b4
+    ```
+
+    Example output:
+
+    ```
     class_id = "d764c880-41b8-41e8-bacc-f94f7c5b053d"
     comment = "UAI broker class"
     default = false
@@ -240,6 +260,6 @@ This example, uses Kubernetes secrets and assumes that the Broker UAIs run in th
     imagename = "registry.local/cray/cray-uai-broker:1.2.4"
     ```
 
-    NOTE: in some versions of UAS, SSSD will not start correctly when customized as described above because `/etc/sssd/sssd.conf` is mounted with the wrong mode in spite of being configured with the right mode.  If SSSD is not working in a Broker UAI, refer to this [troubleshooting section](Troubleshoot_Broker_SSSD_Cant_Use_sssd_conf.md).
+    __NOTE__: in some versions of UAS, SSSD will not start correctly when customized as described above because `/etc/sssd/sssd.conf` is mounted with the wrong mode in spite of being configured with the right mode. If SSSD is not working in a Broker UAI, refer to this [troubleshooting section](Troubleshoot_Broker_SSSD_Cant_Use_sssd_conf.md).
 
 [Next Topic: Start a Broker UAI](Start_a_Broker_UAI.md)

--- a/operations/UAS_user_and_admin_topics/Configure_a_Broker_UAI_Class.md
+++ b/operations/UAS_user_and_admin_topics/Configure_a_Broker_UAI_Class.md
@@ -212,4 +212,7 @@ This example, uses Kubernetes secrets and assumes that the Broker UAIs run in th
     image_id = "8f180ddc-37e5-4ead-b261-2b401914a79f"
     imagename = "registry.local/cray/cray-uai-broker:1.2.4"
     ```
+
+    NOTE: in some versions of UAS, SSSD will not start correctly when customized as described above because `/etc/sssd/sssd.conf` is mounted with the wrong mode in spite of being configured with the right mode.  If SSSD is not working in a Broker UAI, refer to this [troubleshooting section](Troubleshoot_Broker_SSSD_Cant_Use_sssd_conf.md).
+
 [Next Topic: Start a Broker UAI](Start_a_Broker_UAI.md)

--- a/operations/UAS_user_and_admin_topics/Configure_a_Broker_UAI_Class.md
+++ b/operations/UAS_user_and_admin_topics/Configure_a_Broker_UAI_Class.md
@@ -110,7 +110,19 @@ This example, uses Kubernetes secrets and assumes that the Broker UAIs run in th
      * The secret is mounted on the directory `/etc/sssd` not the file `/etc/sssd/sssd.conf` because Kubernetes does not permit the replacement of an existing regular file with a volume but does allow overriding a directory
      * The value `384` is used here for the default mode of the file instead of `0600`, which would be easier to read, because JSON does not accept octal numbers in the leading zero form
 
-4. Obtain the information needed to create a UAI class for the Broker UAI containing the updated configuration in the volume list.
+4. Make a volume to hold an empty and writeable `/etc/sssd/conf.d` in the Broker UAI
+
+   ```
+   ncn-m001:~ # cray uas admin config volumes create --mount-path /etc/sssd/conf.d --volume-description '{"empty_dir": {"medium": "Memory"}}' --volumename sssd-conf-d --format yaml
+   mount_path: /etc/sssd/conf.d
+   volume_description:
+     empty_dir:
+       medium: Memory
+   volume_id: 541980f9-fadc-41cd-8222-e2ffdb6421c4
+   volumename: sssd-conf-d
+   ```
+
+5. Obtain the information needed to create a UAI class for the Broker UAI containing the updated configuration in the volume list.
 
    The image-id of the Broker UAI image, the volume-ids of the volumes to be added to the broker class, and the class-id of the End-User UAI class managed by the broker are required:
 
@@ -156,14 +168,21 @@ This example, uses Kubernetes secrets and assumes that the Broker UAIs run in th
    [results.volume_description.host_path]
    path = "/lus"
    type = "DirectoryOrCreate"
+   [[results]]
+   mount_path = "/etc/sssd/conf.d"
+   volume_id = "541980f9-fadc-41cd-8222-e2ffdb6421c4"
+   volumename = "sssd-conf-d"
+
+   [results.volume_description.empty_dir]
+   medium = "Memory"
    ```
 
-5. Create the Broker UAI class with the content retrieved in the previous step.
+6. Create the Broker UAI class with the content retrieved in the previous step.
 
     ```
     ncn-m001-pit#cray uas admin config classes create \
                 --image-id 8f180ddc-37e5-4ead-b261-2b401914a79f \
-                --volume-list 11a4a22a-9644-4529-9434-d296eef2dc48,1ec36af0-d5b6-4ad9-b3e8-755729765d76,a3b149fd-c477-41f0-8f8d-bfcee87fdd0a \
+                --volume-list 11a4a22a-9644-4529-9434-d296eef2dc48,1ec36af0-d5b6-4ad9-b3e8-755729765d76,a3b149fd-c477-41f0-8f8d-bfcee87fdd0a,541980f9-fadc-41cd-8222-e2ffdb6421c4 \
                 --replicas 3 \
                 --namespace uas \
                 --uai-compute-network no \
@@ -181,7 +200,7 @@ This example, uses Kubernetes secrets and assumes that the Broker UAIs run in th
     replicas = 3
     uai_compute_network = false
     uai_creation_class = "bdb4988b-c061-48fa-a005-34f8571b88b4"
-    volume_list = [ "11a4a22a-9644-4529-9434-d296eef2dc48", "1ec36af0-d5b6-4ad9-b3e8-755729765d76", "a3b149fd-c477-41f0-8f8d-bfcee87fdd0a",]
+    volume_list = [ "11a4a22a-9644-4529-9434-d296eef2dc48", "1ec36af0-d5b6-4ad9-b3e8-755729765d76", "a3b149fd-c477-41f0-8f8d-bfcee87fdd0a","541980f9-fadc-41cd-8222-e2ffdb6421c4"]
     [[volume_mounts]]
     mount_path = "/etc/localtime"
     volume_id = "11a4a22a-9644-4529-9434-d296eef2dc48"
@@ -206,6 +225,14 @@ This example, uses Kubernetes secrets and assumes that the Broker UAIs run in th
     [volume_mounts.volume_description.host_path]
     path = "/lus"
     type = "DirectoryOrCreate"
+    
+    [[results.volume_mounts]]
+    mount_path = "/etc/sssd/conf.d"
+    volume_id = "541980f9-fadc-41cd-8222-e2ffdb6421c4"
+    volumename = "sssd-conf-d"
+
+    [results.volume_mounts.volume_description.empty_dir]
+    medium = "Memory"
     
     [uai_image]
     default = false

--- a/operations/UAS_user_and_admin_topics/Troubleshoot_Broker_SSSD_Cant_Use_sssd_conf.md
+++ b/operations/UAS_user_and_admin_topics/Troubleshoot_Broker_SSSD_Cant_Use_sssd_conf.md
@@ -1,0 +1,151 @@
+[Top: User Access Service (UAS)](User_Access_Service_UAS.md)
+
+[Next Topic: Clear UAS Configuration](Reset_the_UAS_Configuration_to_Original_Installed_Settings.md)
+
+## Troubleshoot Broker UAI SSSD Can't Use `/etc/sssd/sssd.conf`
+
+### Symptom
+
+A Broker UAI has been created using an SSSD configuration in a secret and volume as described in [Configure a Broker UAI Class](Configure_a_Broker_UAI_Class.md) but logging into the broker does not work.  Upon investigation using
+
+```
+ncn-m001:~ # cray uas admin uais list --format yaml
+```
+
+to get the UAI name of the Broker UAI,
+
+```
+ncn-m001:~ # kubectl get po -n uas
+```
+
+to find the broker pod name, and
+
+```
+ncn-m001:~ # kubectl logs -n uas <pod-name> -c <uai-name>
+```
+
+The following errors appear in the log output:
+
+```
+(2022-01-28 17:46:44:642510): [sssd] [confdb_ldif_from_ini_file] (0x0020): Permission check on config file failed.
+(2022-01-28 17:46:44:642549): [sssd] [confdb_init_db] (0x0020): Cannot convert INI to LDIF [1]: [Operation not permitted]
+(2022-01-28 17:46:44:642568): [sssd] [confdb_setup] (0x0010): ConfDB initialization has failed [1]: Operation not permitted
+(2022-01-28 17:46:44:642644): [sssd] [load_configuration] (0x0010): Unable to setup ConfDB [1]: Operation not permitted
+(2022-01-28 17:46:44:642764): [sssd] [main] (0x0020): Cannot read config file /etc/sssd/sssd.conf. Please check that the file is accessible only by the owner and owned by root.root.
+```
+
+### Problem Explanation
+
+In the current release of UAS, the `default` Service Account on the `uas` namespace in Kubernetes is bound to a Cluster Role that uses a Pod Security Policy that defines a specific `fsGroup` range and a `MustRunAs` rule instead of simly using the `RunAsAny` rule.  Because of the way Kubernetes handles volumes, when a volume containing a Secret or a ConfigMap is mounted on a Kubernetes pod with an `fsGroup` rule that is not `RunAsAny` in the Pod Security Policy, the requested mode of the volume is adjusted to something Kubernetes deems more appropriate.  In this case, the requested mode (decimal 384 or octal 600) becomes octal 640 instead in the mounted volume.  Unfortunately, SSSD requires that this mode be octal 600 or it will refuse to use the configuration file.
+
+### Workaround
+
+While this problem will be resolved in an upcoming release of UAS, if this behavior occurs, it is necessary to create a new Pod Security Policy and a Cluster Role using that Pod Security Policy, then change the existing Cluster Role Binding to bind the new Cluster Role instead of the one it currently uses.  The following procedure does that.
+
+First, verify that the system is set up the same way as the system on which this workaround was prepared.  To do that, list the Cluster Role Binding named `uas-default-psp` and determine what Cluster Role it is bound to:
+
+```
+ncn-m001:~ # kubectl get clusterrolebindings uas-default-psp -o yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+
+...
+
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: restricted-transition-net-raw-psp
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: uas
+```
+
+Notice the `roleRef` setting binds the `restricted-transition-net-raw-psp` Cluster Role. That Cluster Role uses the `restricted-transition-net-raw-psp` Pod Security Policy, which is used by several CSM services, but does not work for Broker UAIs.
+
+Assuming this configuration is present, it is necessary to create a new Pod Security Policy called `uas-default-psp`, then create a Cluster Role called `uas-default-psp` that uses the new Pod Security Policy and finally a change the Cluster Role Binding called `uas-defaul-psp` to bind the new Cluster Role to the `default` Service Account in the `uas` namespace.  Since Kubernetes does not allow simply updating the existing `uas-default-psp` Cluster Role Binding the existing one must be removed and replaced.  To remove the existing Cluster Role Binding:
+
+```
+ncn-m001:~ # kubectl delete clusterrolebindings uas-default-psp
+```
+
+Now prepare a YAML file containing the new Kubernetes objects:
+
+```
+ncn-m001:~ # cat << EOF > /tmp/uas-default-psp.yaml
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: uas-default-psp
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - NET_ADMIN
+  - NET_RAW
+  allowedHostPaths:
+  - pathPrefix: /lustre
+  - pathPrefix: /root/registry
+  - pathPrefix: /lib/modules
+  - pathPrefix: /
+  - pathPrefix: /var/lib/nfsroot/nmd
+  - pathPrefix: /lus
+  - pathPrefix: /var/tmp/cps-local
+  fsGroup:
+    rule: RunAsAny
+  hostNetwork: true
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - configMap
+  - emptyDir
+  - projected
+  - secret
+  - downwardAPI
+  - persistentVolumeClaim
+  - hostPath
+  - flexVolume
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: uas-default-psp
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - uas-default-psp
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: uas-default-psp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: uas-default-psp
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: uas
+EOF
+```
+
+Finally, apply this new configuration to Kubernetes:
+
+```
+ncn-m001:~ # kubectl apply -f /tmp/uas-default-psp.yaml 
+```
+
+After this delete and re-create the offending Broker UAI(s) and they should come up and SSSD should run properly.
+
+[Next Topic: Clear UAS Configuration](Reset_the_UAS_Configuration_to_Original_Installed_Settings.md)

--- a/operations/UAS_user_and_admin_topics/Troubleshoot_Broker_SSSD_Cant_Use_sssd_conf.md
+++ b/operations/UAS_user_and_admin_topics/Troubleshoot_Broker_SSSD_Cant_Use_sssd_conf.md
@@ -6,146 +6,172 @@
 
 ### Symptom
 
-A Broker UAI has been created using an SSSD configuration in a secret and volume as described in [Configure a Broker UAI Class](Configure_a_Broker_UAI_Class.md) but logging into the broker does not work.  Upon investigation using
+A Broker UAI has been created using an SSSD configuration in a secret and volume as described in [Configure a Broker UAI Class](Configure_a_Broker_UAI_Class.md), but logging into the Broker UAI does not work.
 
-```
-ncn-m001:~ # cray uas admin uais list --format yaml
-```
+Diagnose the problem as follows:
 
-to get the UAI name of the Broker UAI,
+1. Find the UAI name of the Broker UAI in a list of existing UAIs:
 
-```
-ncn-m001:~ # kubectl get po -n uas
-```
+   ```
+   ncn-m001# cray uas admin uais list --format yaml
+   ```
 
-to find the broker pod name, and
+2. Find the Broker UAI pod name by looking for a pod with the UAI name as the first part of its name in the list of Broker UAI pods:
 
-```
-ncn-m001:~ # kubectl logs -n uas <pod-name> -c <uai-name>
-```
+   ```
+   ncn-m001# kubectl get po -n uas
+   ```
 
-The following errors appear in the log output:
+3. Obtain logs from the Broker UAI:
 
-```
-(2022-01-28 17:46:44:642510): [sssd] [confdb_ldif_from_ini_file] (0x0020): Permission check on config file failed.
-(2022-01-28 17:46:44:642549): [sssd] [confdb_init_db] (0x0020): Cannot convert INI to LDIF [1]: [Operation not permitted]
-(2022-01-28 17:46:44:642568): [sssd] [confdb_setup] (0x0010): ConfDB initialization has failed [1]: Operation not permitted
-(2022-01-28 17:46:44:642644): [sssd] [load_configuration] (0x0010): Unable to setup ConfDB [1]: Operation not permitted
-(2022-01-28 17:46:44:642764): [sssd] [main] (0x0020): Cannot read config file /etc/sssd/sssd.conf. Please check that the file is accessible only by the owner and owned by root.root.
-```
+   ```
+   ncn-m001# kubectl logs -n uas <pod-name> -c <uai-name>
+   ```
+
+4. See if the the following errors appear in the log output:
+
+   ```
+   (2022-01-28 17:46:44:642510): [sssd] [confdb_ldif_from_ini_file] (0x0020): Permission check on config file failed.
+   (2022-01-28 17:46:44:642549): [sssd] [confdb_init_db] (0x0020): Cannot convert INI to LDIF [1]: [Operation not permitted]
+   (2022-01-28 17:46:44:642568): [sssd] [confdb_setup] (0x0010): ConfDB initialization has failed [1]: Operation not permitted
+   (2022-01-28 17:46:44:642644): [sssd] [load_configuration] (0x0010): Unable to setup ConfDB [1]: Operation not permitted
+   (2022-01-28 17:46:44:642764): [sssd] [main] (0x0020): Cannot read config file /etc/sssd/sssd.conf. Please check that the file is accessible only by the owner and owned by root.root.
+   ```
 
 ### Problem Explanation
 
-In the current release of UAS, the `default` Service Account on the `uas` namespace in Kubernetes is bound to a Cluster Role that uses a Pod Security Policy that defines a specific `fsGroup` range and a `MustRunAs` rule instead of simly using the `RunAsAny` rule.  Because of the way Kubernetes handles volumes, when a volume containing a Secret or a ConfigMap is mounted on a Kubernetes pod with an `fsGroup` rule that is not `RunAsAny` in the Pod Security Policy, the requested mode of the volume is adjusted to something Kubernetes deems more appropriate.  In this case, the requested mode (decimal 384 or octal 600) becomes octal 640 instead in the mounted volume.  Unfortunately, SSSD requires that this mode be octal 600 or it will refuse to use the configuration file.
+In the current release of UAS, the `default` Service Account on the `uas` namespace in Kubernetes is bound to a Cluster Role that uses a Pod Security Policy that defines a specific `fsGroup` range and a `MustRunAs` rule instead of simply using the `RunAsAny` rule. Because of the way Kubernetes handles volumes, when a volume containing a Secret or a ConfigMap is mounted on a Kubernetes pod with an `fsGroup` rule that is not `RunAsAny` in the Pod Security Policy, the requested mode of the volume is adjusted to something Kubernetes deems more appropriate. In this case, the requested mode (decimal 384 or octal 600) becomes octal 640 instead in the mounted volume. Unfortunately, SSSD requires that this mode be octal 600 or it will refuse to use the configuration file.
 
 ### Workaround
 
-While this problem will be resolved in an upcoming release of UAS, if this behavior occurs, it is necessary to create a new Pod Security Policy and a Cluster Role using that Pod Security Policy, then change the existing Cluster Role Binding to bind the new Cluster Role instead of the one it currently uses.  The following procedure does that.
+While this problem will be resolved in an upcoming release of UAS, if this behavior occurs, it is necessary to create a new Pod Security Policy and a Cluster Role using that Pod Security Policy, then change the existing Cluster Role Binding to bind the new Cluster Role instead of the one it currently uses. The following procedure does that.
 
-First, verify that the system is set up the same way as the system on which this workaround was prepared.  To do that, list the Cluster Role Binding named `uas-default-psp` and determine what Cluster Role it is bound to:
+1. Verify that the system is set up the same way as the system on which this workaround was prepared. To do that, list the Cluster Role Binding named `uas-default-psp` and determine what Cluster Role it is bound to:
 
-```
-ncn-m001:~ # kubectl get clusterrolebindings uas-default-psp -o yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
+   ```
+   ncn-m001# kubectl get clusterrolebindings uas-default-psp -o yaml
+   ```
 
-...
+   Example output:
 
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: restricted-transition-net-raw-psp
-subjects:
-- kind: ServiceAccount
-  name: default
-  namespace: uas
-```
+   ```
+   apiVersion: rbac.authorization.k8s.io/v1
+   kind: ClusterRoleBinding
+   metadata:
 
-Notice the `roleRef` setting binds the `restricted-transition-net-raw-psp` Cluster Role. That Cluster Role uses the `restricted-transition-net-raw-psp` Pod Security Policy, which is used by several CSM services, but does not work for Broker UAIs.
+   ...
 
-Assuming this configuration is present, it is necessary to create a new Pod Security Policy called `uas-default-psp`, then create a Cluster Role called `uas-default-psp` that uses the new Pod Security Policy and finally a change the Cluster Role Binding called `uas-defaul-psp` to bind the new Cluster Role to the `default` Service Account in the `uas` namespace.  Since Kubernetes does not allow simply updating the existing `uas-default-psp` Cluster Role Binding the existing one must be removed and replaced.  To remove the existing Cluster Role Binding:
+   roleRef:
+     apiGroup: rbac.authorization.k8s.io
+     kind: ClusterRole
+     name: restricted-transition-net-raw-psp
+   subjects:
+   - kind: ServiceAccount
+     name: default
+     namespace: uas
+   ```
 
-```
-ncn-m001:~ # kubectl delete clusterrolebindings uas-default-psp
-```
+   Notice the `roleRef` setting binds the `restricted-transition-net-raw-psp` Cluster Role. That Cluster Role uses the `restricted-transition-net-raw-psp` Pod Security Policy, which is used by several CSM services, but does not work for Broker UAIs.
 
-Now prepare a YAML file containing the new Kubernetes objects:
+   Assuming the system is configured as shown above, the following steps will
 
-```
-ncn-m001:~ # cat << EOF > /tmp/uas-default-psp.yaml
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  name: uas-default-psp
-spec:
-  allowPrivilegeEscalation: true
-  allowedCapabilities:
-  - NET_ADMIN
-  - NET_RAW
-  allowedHostPaths:
-  - pathPrefix: /lustre
-  - pathPrefix: /root/registry
-  - pathPrefix: /lib/modules
-  - pathPrefix: /
-  - pathPrefix: /var/lib/nfsroot/nmd
-  - pathPrefix: /lus
-  - pathPrefix: /var/tmp/cps-local
-  fsGroup:
-    rule: RunAsAny
-  hostNetwork: true
-  privileged: true
-  runAsUser:
-    rule: RunAsAny
-  seLinux:
-    rule: RunAsAny
-  supplementalGroups:
-    rule: RunAsAny
-  volumes:
-  - configMap
-  - emptyDir
-  - projected
-  - secret
-  - downwardAPI
-  - persistentVolumeClaim
-  - hostPath
-  - flexVolume
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: uas-default-psp
-rules:
-- apiGroups:
-  - policy
-  resourceNames:
-  - uas-default-psp
-  resources:
-  - podsecuritypolicies
-  verbs:
-  - use
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: uas-default-psp
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: uas-default-psp
-subjects:
-- kind: ServiceAccount
-  name: default
-  namespace: uas
-EOF
-```
+   - Remove the existing incorrect ClusterRoleBinding so that it can be relaced later.
+   - Create a new Pod Security Policy called `uas-default-psp`.
+   - Create a Cluster Role called `uas-default-psp` that uses the new Pod Security Policy
+   - Replace the Cluster Role Binding called `uas-defaul-psp` with a new one that binds the new Cluster Role to the `default` Service Account in the `uas` namespace.
 
-Finally, apply this new configuration to Kubernetes:
+   If the system is configured differently, it may be necessary to investigate further, which is largely beyond the scope of this section.  The important thing here is that the `default` Service Account in the `uas` namespace must not be bound to a Pod Security Policy with an `fsGroup` or `supplementalGroups` configured with anything but the `RunAsAny` rule.
 
-```
-ncn-m001:~ # kubectl apply -f /tmp/uas-default-psp.yaml 
-```
+2. Remove the existing Cluster Role Binding:
 
-After this delete and re-create the offending Broker UAI(s) and they should come up and SSSD should run properly.
+   ```
+   ncn-m001# kubectl delete clusterrolebindings uas-default-psp
+   ```
+
+3. Prepare a YAML file containing the new Kubernetes objects:
+
+   ```
+   ncn-m001# cat << EOF > /tmp/uas-default-psp.yaml
+   apiVersion: policy/v1beta1
+   kind: PodSecurityPolicy
+   metadata:
+     name: uas-default-psp
+   spec:
+     allowPrivilegeEscalation: true
+     allowedCapabilities:
+     - NET_ADMIN
+     - NET_RAW
+     allowedHostPaths:
+     - pathPrefix: /lustre
+     - pathPrefix: /root/registry
+     - pathPrefix: /lib/modules
+     - pathPrefix: /
+     - pathPrefix: /var/lib/nfsroot/nmd
+     - pathPrefix: /lus
+     - pathPrefix: /var/tmp/cps-local
+     fsGroup:
+       rule: RunAsAny
+     hostNetwork: true
+     privileged: true
+     runAsUser:
+       rule: RunAsAny
+     seLinux:
+       rule: RunAsAny
+     supplementalGroups:
+       rule: RunAsAny
+     volumes:
+     - configMap
+     - emptyDir
+     - projected
+     - secret
+     - downwardAPI
+     - persistentVolumeClaim
+     - hostPath
+     - flexVolume
+   ---
+   apiVersion: rbac.authorization.k8s.io/v1
+   kind: ClusterRole
+   metadata:
+     name: uas-default-psp
+   rules:
+   - apiGroups:
+     - policy
+     resourceNames:
+     - uas-default-psp
+     resources:
+     - podsecuritypolicies
+     verbs:
+     - use
+   ---
+   apiVersion: rbac.authorization.k8s.io/v1
+   kind: ClusterRoleBinding
+   metadata:
+     name: uas-default-psp
+   roleRef:
+     apiGroup: rbac.authorization.k8s.io
+     kind: ClusterRole
+     name: uas-default-psp
+   subjects:
+   - kind: ServiceAccount
+     name: default
+     namespace: uas
+   EOF
+   ```
+
+4. Apply this new configuration to Kubernetes:
+
+   ```
+   ncn-m001# kubectl apply -f /tmp/uas-default-psp.yaml 
+   ```
+
+5. Delete and re-create the offending Broker UAI(s) and they should come up and SSSD should run properly.
+
+   ```
+   ncn-m001# cray uas admin uais delete OPTIONS
+   ```
+
+   ```
+   ncn-m001# cray uas admin uais create OPTIONS
+   ```
 
 [Next Topic: Clear UAS Configuration](Reset_the_UAS_Configuration_to_Original_Installed_Settings.md)

--- a/operations/UAS_user_and_admin_topics/Troubleshoot_UAI_Authentication_Issues.md
+++ b/operations/UAS_user_and_admin_topics/Troubleshoot_UAI_Authentication_Issues.md
@@ -1,6 +1,6 @@
 [Top: User Access Service (UAS)](User_Access_Service_UAS.md)
 
-[Next Topic: Clear UAS Configuration](Reset_the_UAS_Configuration_to_Original_Installed_Settings.md)
+[Next Topic: Troubleshoot Broker UAI SSSD Can't Use /etc/sssd/sssd.conf](Troubleshoot_Broker_SSSD_Cant_Use_sssd_conf.md)
 
 ## Troubleshoot UAS / CLI Authentication Issues
 
@@ -109,4 +109,4 @@ uai_age = "11m"
 uai_name = ""
 ```
 
-[Next Topic: Clear UAS Configuration](Reset_the_UAS_Configuration_to_Original_Installed_Settings.md)
+[Next Topic: Troubleshoot Broker UAI SSSD Can't Use /etc/sssd/sssd.conf](Troubleshoot_Broker_SSSD_Cant_Use_sssd_conf.md)

--- a/operations/UAS_user_and_admin_topics/User_Access_Service_UAS.md
+++ b/operations/UAS_user_and_admin_topics/User_Access_Service_UAS.md
@@ -112,6 +112,7 @@ Another important topic, once administrators are familiar with setting up UAS to
     * [Troubleshoot UAIs with Administrative Access](Troubleshoot_UAIs_with_Administrative_Access.md)
     * [Troubleshoot Common Mistakes when Creating a Custom End-User UAI Image](Troubleshoot_Common_Mistakes_when_Creating_a_Custom_End-User_UAI_Image.md)
     * [Troubleshoot UAS / CLI Authentication Issues](Troubleshoot_UAI_Authentication_Issues.md)
+    * [Troubleshoot Broker UAI SSSD Can't Use /etc/sssd/sssd.conf](Troubleshoot_Broker_SSSD_Cant_Use_sssd_conf.md)
 * [Clear UAS Configuration](Reset_the_UAS_Configuration_to_Original_Installed_Settings.md)
 
 [Next Topic: UAS Limitations](UAS_Limitations.md)


### PR DESCRIPTION
## Summary and Scope

Add a Troubleshooting sub-section to the UAS/UAI Guide to describe how to reconfigure the Pod Security Policy for the `uas` namespace so that Broker UAIs can be configured correctly for SSSD.  Also add a step to the _Configure a Broker UAI_ section of that document to put back `/etc/sssd/conf.d` after `/etc/sssd/sssd.conf` has been mounted as a volume.

This change is backwards compatible.

## Issues and Related PRs

* Resolves [CASMUSER-2940](https://jira-pro.its.hpecorp.net:8443/browse/CASMUSER-2940)

## Testing

Reproduced the original problem described in the CAST and then play tested this documentation using virtual shasta.

### Tested on:

  * Virtual Shasta

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? If not, why? N/A
- Was upgrade tested? If not, why? N/A
- Was downgrade tested? If not, why? N/A
- Were new tests (or test issues/Jiras) created for this change? N/A

## Risks and Mitigations

There are no known risks associated with this change.

## Pull Request Checklist

- [ N/A ] Version number(s) incremented, if applicable
- [ N/A ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ N/A ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

