### PR TITLE
CASMINST-3932: Add instructions to workaround parted failure in bootstrap remote ISO procedure

### DIFF
--- a/install/bootstrap_livecd_remote_iso.md
+++ b/install/bootstrap_livecd_remote_iso.md
@@ -177,9 +177,32 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
 
     ```bash
     pit# disk="$(lsblk -l -o SIZE,NAME,TYPE,TRAN | grep -E '(sata|nvme|sas)' | sort -h | awk '{print $2}' | head -n 1 | tr -d '\n')"
+    pit# echo $disk
     pit# parted --wipesignatures -m --align=opt --ignore-busy -s /dev/$disk -- mklabel gpt mkpart primary ext4 2048s 100%
     pit# mkfs.ext4 -L PITDATA "/dev/${disk}1"
     ```
+
+    In some cases the `parted` command may give an error similar to the following:
+    ```text
+    Error: Partition(s) 4 on /dev/sda have been written, but we have been unable to inform the kernel of the change, probably 
+    because it/they are in use.  As a result, the old partition(s) will remain in use.  You should reboot now before making 
+    further changes.
+    ```
+
+    In that case, the following steps may resolve the problem without needing to reboot. These commands will remove 
+    volume groups and raid arrays that may be using the disk. **These commands only need to be run if the earlier 
+    `parted` command failed.**
+    
+    ```bash
+    pit# RAIDS=$(grep "${disk}[0-9]" /proc/mdstat | awk '{ print "/dev/"$1 }')
+    pit# echo $RAIDS
+    pit# VGS=$(echo $RAIDS | xargs -r pvs --noheadings -o vg_name 2>/dev/null)
+    pit# echo $VGS
+    pit# echo $VGS | xargs -r -t -n 1 vgremove -f -v
+    pit# echo $RAIDS | xargs -r -t -n 1 mdadm -S -f -v 
+    ```
+
+    After running the above procedure, retry the `parted` command which failed. If it succeeds, resume the install from that point.
 
 1. Mount local disk, check the output of each command as it goes.
    

--- a/update_product_stream/index.md
+++ b/update_product_stream/index.md
@@ -163,7 +163,7 @@ None.
    If this machine does not have direct Internet access these RPMs will need to be externally downloaded and then copied to the system. This example copies them to ncn-m001.
 
    ```bash
-   linux# wget https://storage.googleapis.com/csm-release-public/shasta-1.5/docs-csm/docs-csm-latest.noarch.rpm
+   linux# wget https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/docs-csm/1.2/noarch/docs-csm-latest.noarch.rpm
    linux# wget https://storage.googleapis.com/csm-release-public/shasta-1.5/csm-install-workarounds/csm-install-workarounds-latest.noarch.rpm
    linux# scp -p docs-csm-*rpm csm-install-workarounds-*rpm ncn-m001:/root
    linux# ssh ncn-m001


### PR DESCRIPTION
On some installs using remote ISO PIT nodes, the parted command used to prepare a temporary filesystem fails because the disk is in use by a volume group and/or raid array. This PR adds the steps needed to remediate this issue if it occurs. I tested them on my install of wasp, which hit this issue.