### PR TITLE
Add script to apply anti-affinity to coredns pods on upgrade

### DIFF
--- a/upgrade/1.2/Stage_2.md
+++ b/upgrade/1.2/Stage_2.md
@@ -107,6 +107,14 @@ ncn-m002# /srv/cray/scripts/common/apply-networking-manifests.sh
 
 ## Stage 2.5
 
+Run the following script to apply anti-affinity to coredns pods:
+
+```bash
+ncn-m002# /usr/share/doc/csm/upgrade/1.2/scripts/k8s/apply-coredns-pod-affinity.sh
+```
+
+## Stage 2.6
+
 Run the following script to complete the Kubernetes upgrade _(this will restart several pods on each master to their new docker containers)_:
 
 ```bash

--- a/upgrade/1.2/scripts/k8s/apply-coredns-pod-affinity.sh
+++ b/upgrade/1.2/scripts/k8s/apply-coredns-pod-affinity.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+echo "Applying pod anti-affinity to coredns pods"
+
+cat > /tmp/coredns-affinity.yaml <<EOF
+spec:
+  template:
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: k8s-app
+                    operator: In
+                    values:
+                      - kube-dns
+              topologyKey: kubernetes.io/hostname
+EOF
+
+cfile=/tmp/coredns-deployment.yaml
+kubectl -n kube-system get deployment coredns -o yaml > $cfile
+yq m -i $cfile /tmp/coredns-affinity.yaml
+kubectl apply -f $cfile


### PR DESCRIPTION
## Summary and Scope

We added anti-affinity for coredns for fresh installs, but missed it on the 1.2 upgrade path.

## Issues and Related PRs

* Resolves [CASMINST-3938](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3938)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `vshasta`

### Test description:

```
ncn-m001-072d00d9:/home/bklein # ./apply-coredns-pod-affinity.sh
Applying pod anti-affinity to coredns pods
deployment.apps/coredns configured
```

```
ncn-m001-072d00d9:/home/bklein # kubectl get po -n kube-system coredns-7c5b77c849-9wkpq -o json | jq '.spec.affinity'
{
  "podAntiAffinity": {
    "requiredDuringSchedulingIgnoredDuringExecution": [
      {
        "labelSelector": {
          "matchExpressions": [
            {
              "key": "k8s-app",
              "operator": "In",
              "values": [
                "kube-dns"
              ]
            }
          ]
        },
        "topologyKey": "kubernetes.io/hostname"
      }
    ]
  }
}
```

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

