### PR TITLE
CASMTRIAGE-2929: Fix dmsetup syntax error in main

### DIFF
--- a/install/wipe_ncn_disks_for_reinstallation.md
+++ b/install/wipe_ncn_disks_for_reinstallation.md
@@ -256,7 +256,7 @@ RAIDs, zeroing the disks, and then wiping the disks and RAIDs.
 
 1. Remove etcd device **on master nodes ONLY**.
 
-   1. This `dmsetup` comand wil determine whether an etcd volume is present.
+   1. This `dmsetup` command will determine whether an etcd volume is present.
 
       ```bash
       ncn-m# dmsetup ls

--- a/install/wipe_ncn_disks_for_reinstallation.md
+++ b/install/wipe_ncn_disks_for_reinstallation.md
@@ -259,7 +259,7 @@ RAIDs, zeroing the disks, and then wiping the disks and RAIDs.
    1. This `dmsetup` comand wil determine whether an etcd volume is present.
 
       ```bash
-      ncn-m# dmsetup -ls
+      ncn-m# dmsetup ls
       ```
 
       Expected output when the etcd volume is present will show `ETCDLVM`, but the numbers might be different.


### PR DESCRIPTION
### Summary and Scope
Master - CASMTRIAGE-2929: Fix dmsetup syntax error in main

Fix syntax error - remove "-" in `dmsetup -ls' command line.

### Issues and Related PRs
CASMTRIAGE-2929

### Testing
N/A

Was a fresh Install tested? N - N/A
Was an Upgrade tested? N - N/A
Was a Downgrade tested? N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations
Low

### Requires:
N/A