### PR TITLE
CASMTRIAGE-2929: Fix dmsetup description spelling error in 1.2

### DIFF
--- a/install/wipe_ncn_disks_for_reinstallation.md
+++ b/install/wipe_ncn_disks_for_reinstallation.md
@@ -253,7 +253,7 @@ If a node type is not specified, the step should be run regardless of node type.
 
 1. Remove etcd device **on master nodes ONLY**.
 
-    1. This `dmsetup` comand wil determine whether an etcd volume is present.
+    1. This `dmsetup` command will determine whether an etcd volume is present.
 
         ```bash
         ncn-m# dmsetup ls 


### PR DESCRIPTION
### Summary and Scope
1.2 - CASMTRIAGE-2929: Fix spelling errors for description of the dmsetup command in 1.2 

Fix spelling errors -  'wil' -> 'will'; 'comand' -> 'command' in dmsetup command description.

### Issues and Related PRs
CASMTRIAGE-2929

### Testing
N/A

Was a fresh Install tested? N - N/A
Was an Upgrade tested? N - N/A
Was a Downgrade tested? N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations
Low

### Requires:
N/A