### PR TITLE
Update image path for SHCD parser image

### DIFF
--- a/install/create_hmn_connections_json.md
+++ b/install/create_hmn_connections_json.md
@@ -31,14 +31,14 @@ The [SHCD/HMN Connections Rules document](shcd_hmn_connections_rules.md) explain
     Determine the version of the `hms-shcd-parser` container image:
     
     ```bash
-    linux# SHCD_PARSER_VERSION=$(realpath ./${CSM_RELEASE}/docker/dtr.dev.cray.com/cray/hms-shcd-parser* | egrep  -o '[0-9]+\.[0-9]+\.[0-9]+$')
+    linux# SHCD_PARSER_VERSION=$(realpath ./${CSM_RELEASE}/docker/artifactory.algol60.net/csm-docker/stable/hms-shcd-parser* | egrep  -o '[0-9]+\.[0-9]+\.[0-9]+$')
     linux# echo $SHCD_PARSER_VERSION
     ```
 
     Load the `hms-shcd-parser` container image into Podman:
     
     ```bash
-    linux# ./${CSM_RELEASE}/hack/load-container-image.sh dtr.dev.cray.com/cray/hms-shcd-parser:$SHCD_PARSER_VERSION
+    linux# ./${CSM_RELEASE}/hack/load-container-image.sh artifactory.algol60.net/csm-docker/stable/hms-shcd-parser:$SHCD_PARSER_VERSION
     ```
 
 3. Copy the system's SHCD over the machine being used to prepare the `hmn_connections.json` file.
@@ -54,7 +54,7 @@ The [SHCD/HMN Connections Rules document](shcd_hmn_connections_rules.md) explain
 5. Generate the hmn_connections.json file from the SHCD. This will either create or overwrite the `hmn_connections.json` file in the current directory:
 
     ```bash
-    linux# podman run --rm -it --name hms-shcd-parser -v "$(realpath "$SHCD_FILE")":/input/shcd_file.xlsx -v "$(pwd)":/output dtr.dev.cray.com/cray/hms-shcd-parser:$SHCD_PARSER_VERSION
+    linux# podman run --rm -it --name hms-shcd-parser -v "$(realpath "$SHCD_FILE")":/input/shcd_file.xlsx -v "$(pwd)":/output artifactory.algol60.net/csm-docker/stable/hms-shcd-parser:$SHCD_PARSER_VERSION
     ```
 
 


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
Update image path for the hms-shcd-parser-image to reflect changes from CASM-2670.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMINST-3939
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:
  * Mug

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_
Used the csm-1.2.0-alpha.52 release downloaded on mug, and followed the steps in the `Create HMN Connections JSON` procedure with the updated image path.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? If not, why? N/A
- Was upgrade tested? If not, why? N/A
- Was downgrade tested? If not, why? N/A
- Were new tests (or test issues/Jiras) created for this change? N/A

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
Low risk.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

