### PR TITLE
CASMNET-1020 - Document procedure to add a DNS alias or correct DNS entries in SLS

### DIFF
--- a/operations/index.md
+++ b/operations/index.md
@@ -421,6 +421,7 @@ The System Layout Service \(SLS\) holds information about the system design, suc
   * [Add Liquid-Cooled Cabinets to SLS](system_layout_service/Add_Liquid-Cooled_Cabinets_To_SLS.md)
   * [Add UAN CAN IP Addresses to SLS](system_layout_service/Add_UAN_CAN_IP_Addresses_to_SLS.md)
   * * [Update SLS with UAN Aliases](system_layout_service/Update_SLS_with_UAN_Aliases.md)
+  * [Add an alias to a service](system_layout_service/Add_an_alias_to_a_service.md)
   * [Create a Backup of the SLS Postgres Database](system_layout_service/Create_a_Backup_of_the_SLS_Postgres_Database.md)
   * [Restore SLS Postgres Database from Backup](system_layout_service/Restore_SLS_Postgres_Database_from_Backup.md)
   * [Restore SLS Postgres without an Existing Backup](system_layout_service/Restore_SLS_Postgres_without_an_Existing_Backup.md)

--- a/operations/system_layout_service/Add_an_alias_to_a_service.md
+++ b/operations/system_layout_service/Add_an_alias_to_a_service.md
@@ -1,0 +1,65 @@
+## Add an alias to a service
+
+Add an alias for an existing service to the IP address reservations in the System Layout Service \(SLS\). Adding these IP addresses will propagate the data needed for the Domain Name Service \(DNS\).
+
+### Prerequisites
+
+This procedure requires administrative privileges.
+
+### Procedure
+
+This example will add an alias to the `pbs_service` in the Node Management Network \(NMN\).
+
+1.  Retrieve the SLS data for the network the service resides in.
+
+    ```bash
+    ncn-m001# export TOKEN=$(curl -s -k -S -d grant_type=client_credentials \
+    -d client_id=admin-client -d client_secret=`kubectl get secrets admin-client-auth \
+    -o jsonpath='{.data.client-secret}' | base64 -d` \
+    https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token \
+    | jq -r '.access_token')
+
+    ncn-m001# curl -s -k -H "Authorization: Bearer ${TOKEN}" \
+    https://api-gw-service-nmn.local/apis/sls/v1/networks/NMN|jq > NMN.json
+
+    ncn-m001# cp NMN.json NMN.json.bak
+    ```
+
+2.  Edit the NMN.json file and add the desired alias in the ExtraProperties.Subnets section.
+
+    ```json
+	  {
+	    "Aliases": [
+	      "pbs-service",
+	      "pbs-service-nmn",
+	      "pbs_service.local",
+	      "test-alias"
+	    ],
+	    "Comment": "pbs-service,pbs-service-nmn",
+	    "IPAddress": "10.252.2.5",
+	    "Name": "pbs_service"
+	  }
+    ```
+
+3.  Upload the updated NMN.json file to SLS.
+
+    ```bash
+    ncn-m001# curl -s -k -H "Authorization: Bearer ${TOKEN}" --header \
+    "Content-Type: application/json" --request PUT --data @NMN.json \
+    https://api-gw-service-nmn.local/apis/sls/v1/networks/NMN
+    ```
+
+4.  Verify that DNS records were created.
+
+    It will take about five minutes before any records will show up.
+
+    For example:
+
+    ```bash
+    # nslookup test-alias
+    Server:     10.92.100.225
+    Address:    10.92.100.225#53
+
+    Name:    test-alias
+    Address: 10.252.2.5
+    ```


### PR DESCRIPTION
## Summary and Scope

Document procedure to add a DNS alias for an existing service definition such as pbs_service.

## Issues and Related PRs

* Resolves [CASMNET-1020](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1020)

## Testing

### Tested on:

  * `hela`

### Test description:

Followed procedure and verified the the DNS alias was successfully added.

## Risks and Mitigations

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

