### PR TITLE
Add create_rgw_buckets.sh script to 1.2 upgrade path

### DIFF
--- a/upgrade/1.2/scripts/upgrade/create_rgw_buckets.sh
+++ b/upgrade/1.2/scripts/upgrade/create_rgw_buckets.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+num_storage_nodes=$(printf "%03d" $(craysys metadata get num_storage_nodes))
+sed -i "s/LASTNODE/$num_storage_nodes/g" /etc/ansible/hosts
+
+source /etc/ansible/boto3_ansible/bin/activate
+
+playbook=/etc/ansible/ceph-rgw-users/ceph-rgw-users.yaml
+cat > $playbook <<EOF
+#!/usr/bin/env ansible-playbook
+---
+
+- hosts: mons
+  any_errors_fatal: false
+  remote_user: root
+  roles:
+    - ceph-rgw-users
+EOF
+
+chmod 755 $playbook
+/etc/ansible/ceph-rgw-users/ceph-rgw-users.yaml
+deactivate


### PR DESCRIPTION
## Summary and Scope

We missed porting this script from 1.0 -- needed in 1.2 as well.

## Issues and Related PRs

* Resolves [CASMINST-3948](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3948)

## Testing

Script is well tested in 1.0

### Tested on:

  * `fanta`

### Test description:

Manually copied to continue with fanta upgrade.

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable