### PR TITLE
CASMPET-5292 1.0 : DOCS: Add case for postgres cluster member stopped after reinit

### DIFF
--- a/operations/kubernetes/Troubleshoot_Postgres_Database.md
+++ b/operations/kubernetes/Troubleshoot_Postgres_Database.md
@@ -31,11 +31,17 @@ The following is an example for `keycloak-postgres` where no endpoints are liste
 
 ```bash
 ncn-w001# kubectl get endpoints keycloak-postgres -n services
+```
+
+Example output:
+
+```
 NAME                ENDPOINTS         AGE
 keycloak-postgres   <none>            3d22h
 ```
 
 If the database is unavailable, check if the [Disk Full](#diskfull) is the cause of the issue. Otherwise, check the `postgres-operator` logs for errors.
+
 ```bash
 ncn-w001# kubectl logs -l app.kubernetes.io/name=postgres-operator -n services
 ```
@@ -103,10 +109,15 @@ The following is an example where replication is working:
 
 ```bash
 ncn-w001# kubectl exec keycloak-postgres-0 -c postgres -n services -it -- patronictl list
+```
+
+Example output:
+
+```
 +-------------------+---------------------+------------+--------+---------+----+-----------+
 |      Cluster      |        Member       |    Host    |  Role  |  State  | TL | Lag in MB |
 +-------------------+---------------------+------------+--------+---------+----+-----------+
-| keycloak-postgres | keycloak-postgres-0 | 10.40.0.23 | Leader | running |  1 |         0 |
+| keycloak-postgres | keycloak-postgres-0 | 10.40.0.23 | Leader | running |  1 |           |
 | keycloak-postgres | keycloak-postgres-1 | 10.42.0.25 |        | running |  1 |         0 |
 | keycloak-postgres | keycloak-postgres-2 | 10.42.0.29 |        | running |  1 |         0 |
 +-------------------+---------------------+------------+--------+---------+----+-----------+
@@ -119,7 +130,7 @@ The following is an example where replication is broken:
 |      Cluster      |        Member       |     Host     |  Role  |  State   | TL | Lag in MB |
 +-------------------+---------------------+--------------+--------+----------+----+-----------+
 | keycloak-postgres | keycloak-postgres-0 | 10.42.10.22  |        | starting |    |   unknown |
-| keycloak-postgres | keycloak-postgres-1 | 10.40.11.191 | Leader | running  | 47 |         0 |
+| keycloak-postgres | keycloak-postgres-1 | 10.40.11.191 | Leader | running  | 47 |           |
 | keycloak-postgres | keycloak-postgres-2 | 10.40.11.190 |        | running  | 14 |       608 |
 +-------------------+---------------------+--------------+--------+----------+----+-----------+
 ```
@@ -133,12 +144,24 @@ A reinitialize will get the lagging replica member re-synced and replicating aga
 ```bash
 ncn-w001# kubectl exec keycloak-postgres-1 -n services -it -- bash
 root@keycloak-postgres-1:/home/postgres# patronictl reinit keycloak-postgres keycloak-postgres-0
+```
+
+Example output:
+
+```
 Are you sure you want to reinitialize members keycloak-postgres-0? [y/N]: y
 Failed: reinitialize for member keycloak-postgres-0, status code=503, (restarting after failure already in progress)
 Do you want to cancel it and reinitialize anyway? [y/N]: y
 Success: reinitialize for member keycloak-postgres-0
+```
 
+```bash
 root@keycloak-postgres-1:/home/postgres# patronictl reinit keycloak-postgres keycloak-postgres-2
+```
+
+Example output:
+
+```
 Are you sure you want to reinitialize members keycloak-postgres-2? [y/N]: y
 Failed: reinitialize for member keycloak-postgres-2, status code=503, (restarting after failure already in progress)
 Do you want to cancel it and reinitialize anyway? [y/N]: y
@@ -148,14 +171,118 @@ Success: reinitialize for member keycloak-postgres-2
 Verify that replication has recovered:
 
 ```bash
-ncn-w001# kubectl exec keycloak-postgres-0 -c postgres -n services -it -- bash
-postgres@keycloak-postgres-2:~$ patronictl list
+ncn-w001# kubectl exec keycloak-postgres-0 -c postgres -n services -it -- patronictl list
+```
+
+Example output:
+
+```
 +-------------------+---------------------+--------------+--------+---------+----+-----------+
 |      Cluster      |        Member       |     Host     |  Role  |  State  | TL | Lag in MB |
 +-------------------+---------------------+--------------+--------+---------+----+-----------+
 | keycloak-postgres | keycloak-postgres-0 | 10.42.10.22  |        | running | 47 |         0 |
-| keycloak-postgres | keycloak-postgres-1 | 10.40.11.191 | Leader | running | 47 |         0 |
-| keycloak-postgres | keycloak-postgres-2 | 10.40.11.190 |        | running | 47 |           |
+| keycloak-postgres | keycloak-postgres-1 | 10.40.11.191 | Leader | running | 47 |           |
+| keycloak-postgres | keycloak-postgres-2 | 10.40.11.190 |        | running | 47 |         0 |
++-------------------+---------------------+--------------+--------+---------+----+-----------+
+```
+
+If a cluster member is `stopped` after a successful reinitialization, check for pg_internal.init.* files that may need to be cleaned up. This can occur if the pgdata disk was full prior to the reinitialization, leaving truncated pg_internal.init.* files in the pgdata directory.
+
+```bash
+ncn-w001# kubectl exec keycloak-postgres-0 -c postgres -n services -it -- patronictl list
+```
+
+Example output:
+
+```
++-------------------+---------------------+--------------+--------+---------+----+-----------+
+|      Cluster      |        Member       |     Host     |  Role  |  State  | TL | Lag in MB |
++-------------------+---------------------+--------------+--------+---------+----+-----------+
+| keycloak-postgres | keycloak-postgres-0 | 10.42.10.22  |        | running | 47 |         0 |
+| keycloak-postgres | keycloak-postgres-1 | 10.40.11.191 | Leader | running | 47 |           |
+| keycloak-postgres | keycloak-postgres-2 | 10.40.11.190 |        | stopped |    |   unknown |
++-------------------+---------------------+--------------+--------+---------+----+-----------+
+```
+ 
+Exec into that pod that is `stopped` and check the most recent postgres log for any `invalid segment number 0` errors relating to pg_internal.init.* files.
+
+```bash
+ncn-w001# kubectl exec keycloak-postgres-2 -n services -it -- bash
+postgres@keycloak-postgres-2:~$ export LOG=`ls -t /home/postgres/pgdata/pgroot/pg_log/*.csv | head -1`
+postgres@keycloak-postgres-2:~$ grep pg_internal.init $LOG | grep "invalid segment number 0" | tail -1
+```
+
+Example output:
+
+```
+2022-02-01 16:59:35.529 UTC,"standby","",227600,"127.0.0.1:42264",61f966f7.37910,3,"sending backup ""pg_basebackup base backup""",2022-02-01 16:59:35 UTC,7/0,0,ERROR,XX000,"invalid segment number 0 in file ""pg_internal.init.2239188""",,,,,,,,,"pg_basebackup"
+```
+
+If the check above finds such files, first find any zero length pg_internal.init.* files.
+```bash
+postgres@keycloak-postgres-2:~$ find /home/postgres/pgdata -name pg_internal.init.* -size 0 
+```
+
+Example output:
+
+```
+./pgroot/data/base/16622/pg_internal.init.2239004
+...
+./pgroot/data/base/16622/pg_internal.init.2239010
+```
+
+Then delete the zero length pg_internal.init.* files. Double check the syntax of the command in this step before executing it `-size 0 -exec rm {} \;`.
+
+
+```bash
+postgres@keycloak-postgres-2:~$ find /home/postgres/pgdata -name pg_internal.init.* -size 0 -exec rm {} \;
+```
+
+Next find any non-zero length pg_internal.init.* files that were truncated when the file system filled up.
+
+```bash
+postgres@keycloak-postgres-2:~$ grep pg_internal.init $LOG | grep "invalid segment number 0" | tail -1
+```
+
+Example output:
+
+```
+2022-02-01 16:59:35.529 UTC,"standby","",227600,"127.0.0.1:42264",61f966f7.37910,3,"sending backup ""pg_basebackup base backup""",2022-02-01 16:59:35 UTC,7/0,0,ERROR,XX000,"invalid segment number 0 in file ""pg_internal.init.2239188""",,,,,,,,,"pg_basebackup"
+```
+
+Locate the non-zero length pg_internal.init.* file.
+
+```bash
+postgres@keycloak-postgres-2:~$ find ~/pgdata -name pg_internal.init.2239188
+```
+
+Example output:
+
+```
+/home/postgres/pgdata/pgroot/data/base/16622/pg_internal.init.2239188
+```
+
+Then delete (or move to a different location) the non-zero length pg_internal.init.* file.
+
+```bash
+postgres@keycloak-postgres-2:~$ rm /home/postgres/pgdata/pgroot/data/base/16622/pg_internal.init.2239188
+```
+
+Iterate over the above steps to find, locate and delete non-zero length pg_internal.init.* files until there are no more new `invalid segment number 0` messages. At this point, verify that the cluster member has started.
+
+```bash
+ncn-w001# kubectl exec keycloak-postgres-0 -c postgres -n services -it -- patronictl list
+```
+
+Example output:
+
+```
++-------------------+---------------------+--------------+--------+---------+----+-----------+
+|      Cluster      |        Member       |     Host     |  Role  |  State  | TL | Lag in MB |
++-------------------+---------------------+--------------+--------+---------+----+-----------+
+| keycloak-postgres | keycloak-postgres-0 | 10.42.10.22  |        | running | 47 |         0 |
+| keycloak-postgres | keycloak-postgres-1 | 10.40.11.191 | Leader | running | 47 |           |
+| keycloak-postgres | keycloak-postgres-2 | 10.40.11.190 |        | running | 47 |         0 |
 +-------------------+---------------------+--------------+--------+---------+----+-----------+
 ```
 
@@ -179,24 +306,43 @@ Check for any postgresql resource that has a `STATUS` of `SyncFailed`. `SyncFail
 
 Other `STATUS` values such as `Updating` are a non issue. It is expected that this will eventually change to `Running` or possibly `SyncFailed` if the `postgres-operator` encounters issues syncing updates to the postgresql cluster.
 
-```bash
-ncn-w001# kubectl get postgresql -A
-NAMESPACE   NAME                         TEAM                VERSION   PODS   VOLUME   CPU-REQUEST   MEMORY-REQUEST   AGE     STATUS
-services    cray-console-data-postgres   cray-console-data   11        3      2Gi                                     4h10m   Running
-services    cray-sls-postgres            cray-sls            11        3      1Gi                                     4h12m   SyncFailed
-services    cray-smd-postgres            cray-smd            11        3      30Gi     500m          8Gi              4h12m   Updating
-services    gitea-vcs-postgres           gitea-vcs           11        3      50Gi                                    4h11m   Running
-services    keycloak-postgres            keycloak            11        3      1Gi                                     4h13m   Running
-spire       spire-postgres               spire               11        3      20Gi     1             4Gi              4h10m   Running
-```
+1. Check for any postgresql resource that has a `STATUS` of `SyncFailed`.
+   
+    ```bash
+    ncn-w001# kubectl get postgresql -A
+    ```
 
-```bash
-ncn-w001# kubectl get pods -l app.kubernetes.io/name=postgres-operator -n services
-NAME                                      READY   STATUS    RESTARTS   AGE
-cray-postgres-operator-6fffc48b4c-mqz7z   2/2     Running   0          5h26m
+    Example output:
 
-ncn-w001# kubectl logs cray-postgres-operator-6fffc48b4c-mqz7z -n services -c postgres-operator | grep -i sync | grep -i msg
-```
+    ```
+    NAMESPACE   NAME                         TEAM                VERSION   PODS   VOLUME   CPU-REQUEST   MEMORY-REQUEST   AGE     STATUS
+    services    cray-console-data-postgres   cray-console-data   11        3      2Gi                                     4h10m   Running
+    services    cray-sls-postgres            cray-sls            11        3      1Gi                                     4h12m   SyncFailed
+    services    cray-smd-postgres            cray-smd            11        3      30Gi     500m          8Gi              4h12m   Updating
+    services    gitea-vcs-postgres           gitea-vcs           11        3      50Gi                                    4h11m   Running
+    services    keycloak-postgres            keycloak            11        3      1Gi                                     4h13m   Running
+    spire       spire-postgres               spire               11        3      20Gi     1             4Gi              4h10m   Running
+    ```
+
+1. Find the the `postgres-operator` pod name.
+
+    ```bash
+    ncn-w001# kubectl get pods -l app.kubernetes.io/name=postgres-operator -n services
+    ```
+
+    Example output:
+
+    ```
+    NAME                                      READY   STATUS    RESTARTS   AGE
+    cray-postgres-operator-6fffc48b4c-mqz7z   2/2     Running   0          5h26m
+    ```
+
+1. Check the logs for the `postgres-operator`.
+
+    ```
+    ncn-w001# kubectl logs cray-postgres-operator-6fffc48b4c-mqz7z -n services \
+    -c postgres-operator | grep -i sync | grep -i msg
+    ```
 
 #### Case 1 : msg="could not sync cluster: could not sync persistent volumes: could not sync volumes: could not resize EBS volumes: some persistent volumes are not compatible with existing resizing providers"
 
@@ -354,6 +500,7 @@ Most services expect to maintain a Postgres cluster consisting of three pods for
 ### Determine if a cluster member is missing
 
 For a given Postgres cluster, check how many pods are running.
+
 ```bash
 ncn-w001# POSTGRESQL=keycloak-postgres
 ncn-w001# NAMESPACE=services
@@ -364,29 +511,56 @@ ncn-w001# kubectl get pods -A -l "application=spilo,cluster-name=${POSTGRESQL}"
 
 If the number of Postgres pods for the given cluster is more or less than expected, increase or decrease as needed. This example will patch the keycloak-postgres cluster resource so that three pods should be running.
 
-```bash
-ncn-w001# POSTGRESQL=keycloak-postgres
-ncn-w001# NAMESPACE=services
-ncn-w001# kubectl patch postgresql "${POSTGRESQL}" -n "${NAMESPACE}" --type='json' -p='[{"op" : "replace", "path":"/spec/numberOfInstances", "value" : 3}]'
-```
-Confirm the number of cluster members, otherwise known as pods, by checking the postgresql resource.
-```bash
-ncn-w001# kubectl get postgresql ${POSTGRESQL} -n ${NAMESPACE}
-NAME                TEAM       VERSION   PODS   VOLUME   CPU-REQUEST   MEMORY-REQUEST   AGE   STATUS
-keycloak-postgres   keycloak   11        3      10Gi                                    29m   Running
-```
+1. Set the POSTGRESQL and NAMESPACE variables.
+    
+    ```bash
+    ncn-w001# POSTGRESQL=keycloak-postgres
+    ncn-w001# NAMESPACE=services
+    ```
 
-If a pod is starting but remains in Pending, CrashLoopBackOff, ImagePullBackOff or other non Running states, describe the pod and/or get logs from the pod for further analysis. For example:
-```bash
-ncn-w001# kubectl get pods -A -l "application=spilo,cluster-name=${POSTGRESQL}"
-NAMESPACE   NAME                  READY   STATUS    RESTARTS   AGE
-services    keycloak-postgres-0   0/3     Pending   0          36m
-services    keycloak-postgres-1   3/3     Running   0          35m
-services    keycloak-postgres-2   3/3     Running   0          34m
+1. Patch the keycloak-postgres cluster resource to ensure three pods are running.
 
-ncn-w001# kubectl describe pod "${POSTGRESQL}-0" -n ${NAMESPACE}
-ncn-w001# kubectl logs "${POSTGRESQL}-0" -c postgres -n ${NAMESPACE}
-```
+    ```bash
+    ncn-w001# kubectl patch postgresql "${POSTGRESQL}" -n "${NAMESPACE}" --type='json' \
+    -p='[{"op" : "replace", "path":"/spec/numberOfInstances", "value" : 3}]'
+    ```
+
+1. Confirm the number of cluster members, otherwise known as pods, by checking the postgresql resource.
+
+    ```bash
+    ncn-w001# kubectl get postgresql ${POSTGRESQL} -n ${NAMESPACE}
+    NAME                TEAM       VERSION   PODS   VOLUME   CPU-REQUEST   MEMORY-REQUEST   AGE   STATUS
+    keycloak-postgres   keycloak   11        3      10Gi                                    29m   Running
+    ```
+
+1. If a pod is starting but remains in Pending, CrashLoopBackOff, ImagePullBackOff or other non Running states, describe the pod and/or get logs from the pod for further analysis.
+
+    1. Find the pod name.
+    
+        ```bash
+        ncn-w001# kubectl get pods -A -l "application=spilo,cluster-name=${POSTGRESQL}"
+        ```
+
+        Example output:
+
+        ```
+        NAMESPACE   NAME                  READY   STATUS    RESTARTS   AGE
+        services    keycloak-postgres-0   0/3     Pending   0          36m
+        services    keycloak-postgres-1   3/3     Running   0          35m
+        services    keycloak-postgres-2   3/3     Running   0          34m
+        ```
+
+    1. Describe the pod.
+    
+        ```
+        ncn-w001# kubectl describe pod "${POSTGRESQL}-0" -n ${NAMESPACE}
+        ```
+
+    1. View the pod logs.
+    
+        ```
+        ncn-w001# kubectl logs "${POSTGRESQL}-0" -c postgres -n ${NAMESPACE}
+        ```
 
 <a name="leader"></a>
 ## Is the Postgres Leader missing?
@@ -394,18 +568,32 @@ ncn-w001# kubectl logs "${POSTGRESQL}-0" -c postgres -n ${NAMESPACE}
 If a Postgres cluster no longer has a leader, the database will need to be recovered.
 
 ### Determine if the Postgres Leader is missing
-```bash
-ncn-w001# POSTGRESQL=cray-smd-postgres
-ncn-w001# NAMESPACE=services
-ncn-w001# kubectl exec ${POSTGRESQL}-0 -n ${NAMESPACE} -c postgres -- patronictl list
-+-------------------+---------------------+------------+------+--------------+----+-----------+
-|      Cluster      |        Member       |    Host    | Role |    State     | TL | Lag in MB |
-+-------------------+---------------------+------------+------+--------------+----+-----------+
-| cray-smd-postgres | cray-smd-postgres-0 | 10.42.0.25 |      |  running     |    |   unknown |
-| cray-smd-postgres | cray-smd-postgres-1 | 10.44.0.34 |      | start failed |    |   unknown |
-| cray-smd-postgres | cray-smd-postgres-2 | 10.36.0.44 |      | start failed |    |   unknown |
-+-------------------+---------------------+------------+------+--------------+----+-----------+
-```
+
+1. Set the POSTGRESQL and NAMESPACE variables.
+   
+    ```bash
+    ncn-w001# POSTGRESQL=cray-smd-postgres
+    ncn-w001# NAMESPACE=services
+    ```
+
+1. Check if the leader is missing.
+    
+    ```
+    ncn-w001# kubectl exec ${POSTGRESQL}-0 -n ${NAMESPACE} -c postgres -- patronictl list
+    ```
+
+    Example output:
+
+    ```
+    +-------------------+---------------------+------------+------+--------------+----+-----------+
+    |      Cluster      |        Member       |    Host    | Role |    State     | TL | Lag in MB |
+    +-------------------+---------------------+------------+------+--------------+----+-----------+
+    | cray-smd-postgres | cray-smd-postgres-0 | 10.42.0.25 |      |  running     |    |   unknown |
+    | cray-smd-postgres | cray-smd-postgres-1 | 10.44.0.34 |      | start failed |    |   unknown |
+    | cray-smd-postgres | cray-smd-postgres-2 | 10.36.0.44 |      | start failed |    |   unknown |
+    +-------------------+---------------------+------------+------+--------------+----+-----------+
+    ```
+
 ### Recover from a missing Postgres Leader
 
 See the [Recover from Postgres WAL Event](Recover_from_Postgres_WAL_Event.md) procedure.


### PR DESCRIPTION
## Summary and Scope

Adding to the Troubleshoot Postgres a case where after the reinit (to fix lag), the member remains stopped. 
In Pawsey prod environment this was seen and was a result of one member running out of disk space prior to the reinit.
The reinit did cleanup the WAL files but there were remaining pg_internal.init.* files that were truncated when the file system filled up; these needed to be cleaned up so that the stopped member would restart.

This change also includes a minor change to remove lag number from Leader line in patronictl list output.
This change also pulls in some formatting changes that were done on the release/1.2 branch to improve readability.

Is this change is backwards compatible

## Issues and Related PRs

* Resolves [CASMPET-5292](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5292) for CAST-28984
* Change will also be needed in release/1.2
* Future work required by NA
* Documentation changes required NA
* Merge with/before/after NA

## Testing

Verified with Field Technical Support

### Tested on:

  * Virtual Shasta

### Test description:

Based on what was done to correct the issue in Pawsey environment plus data in CASMTRIAGE-1398 for similar issue.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? NA
- Were continuous integration tests run? If not, why? NA
- Was upgrade tested? If not, why? NA
- Was downgrade tested? If not, why? NA
- Were new tests (or test issues/Jiras) created for this change? NA

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

