### PR TITLE
Add NodeBMCs to locking procedures for locking/unlocking NCNs

### DIFF
--- a/install/configure_administrative_access.md
+++ b/install/configure_administrative_access.md
@@ -45,16 +45,16 @@ BMC/controller passwords.
    <a name="lock_management_nodes"></a>
    1. Lock Management Nodes
 
-      The management nodes are unlocked at this point in the installation. Locking them will prevent actions from FAS to
-      update their firmware or CAPMC to power off or do a power reset. Doing any of these by accident will take down a
-      management node. If the management node is a Kubernetes master or worker node, this can have serious negative effects
-      on system operation.
+      The management nodes are unlocked at this point in the installation. Locking the management nodes and their BMCs will
+      prevent actions from FAS to update their firmware or CAPMC to power off or do a power reset. Doing any of these by
+      accident will take down a management node. If the management node is a Kubernetes master or worker node, this can have
+      serious negative effects on system operation.
 
       If a single node is taken down by mistake, it is possible that things will recover. However, if all management
       nodes are taken down, or all Kubernetes worker nodes are taken down by mistake, the system is dead and has to be
       completely restarted.
 
-      Lock the management nodes **now**!
+      Lock the management nodes and their BMCs **now**!
 
       See [Lock and Unlock Nodes](../operations/hardware_state_manager/Lock_and_Unlock_Management_Nodes.md)
    <a name="configure_with_scsd"></a>

--- a/operations/firmware/FAS_Admin_Procedures.md
+++ b/operations/firmware/FAS_Admin_Procedures.md
@@ -26,7 +26,7 @@ Procedures for leveraging the Firmware Action Service (FAS) CLI to manage firmwa
 
 ### Warning for Non-Compute Nodes (NCNs)</a>
 
-**WARNING:** NCNs should be locked with the HSM locking API to ensure they are not unintentionally updated by FAS. Research [Lock and Unlock Management Nodes](../hardware_state_manager/Lock_and_Unlock_Management_Nodes.md) for more information. Failure to lock the NCNs could result in unintentional update of the NCNs if FAS is not used correctly; this will lead to system instability problems.
+**WARNING:** NCNs and their BMCs should be locked with the HSM locking API to ensure they are not unintentionally updated by FAS. Research [Lock and Unlock Management Nodes](../hardware_state_manager/Lock_and_Unlock_Management_Nodes.md) for more information. Failure to lock the NCNs could result in unintentional update of the NCNs if FAS is not used correctly; this will lead to system instability problems.
 
 ---
 
@@ -36,7 +36,7 @@ Procedures for leveraging the Firmware Action Service (FAS) CLI to manage firmwa
 
 The default configuration of FAS no longer ignores `management` nodes, which prevents FAS from firmware updating the NCNs. To reconfigure the FAS deployment to exclude non-compute nodes (NCNs) and ensure they cannot have their firmware upgraded, the `NODE_BLACKLIST` value must be manually enabled
 
-Nodes can also be locked with the Hardware State Manager (HSM) API. Refer to [Lock and Unlock Management Nodes](../hardware_state_manager/Lock_and_Unlock_Management_Nodes.md) for more information.
+**Preferred Method:** Nodes can also be locked with the Hardware State Manager (HSM) API. Refer to [Lock and Unlock Management Nodes](../hardware_state_manager/Lock_and_Unlock_Management_Nodes.md) for more information.
 
 <a name="procedure"></a>
 

--- a/operations/firmware/Update_Firmware_with_FAS.md
+++ b/operations/firmware/Update_Firmware_with_FAS.md
@@ -33,7 +33,7 @@ FAS images contain the following information that is needed for a hardware devic
 
 ### Warning
 
-**WARNING:** Non-compute nodes (NCNs) should be locked with the HSM locking API to ensure they are not unintentionally updated by FAS. See [Lock and Unlock Management Nodes](../hardware_state_manager/Lock_and_Unlock_Management_Nodes.md) for more information. Failure to lock the NCNs could result in unintentional update of the NCNs if FAS is not used correctly; this will lead to system instability problems.
+**WARNING:** Non-compute nodes (NCNs) and their BMCs should be locked with the HSM locking API to ensure they are not unintentionally updated by FAS. See [Lock and Unlock Management Nodes](../hardware_state_manager/Lock_and_Unlock_Management_Nodes.md) for more information. Failure to lock the NCNs could result in unintentional update of the NCNs if FAS is not used correctly; this will lead to system instability problems.
 
 Follow the process outlined in [FAS CLI](FAS_CLI.md) to update the system. Use the recipes listed in [FAS Recipes](FAS_Recipes.md) to update each supported type.
 
@@ -99,7 +99,7 @@ For each item in the `Hardware Precedence Order`:
 After identifying which hardware is in the system, start with the top most item on this list to update. If any of the following hardware is not in the system, skip it.
 
 **IMPORTANT:**
-* This process does not communicate the SAFE way to update NCNs. If the NCNs have not been locked, or FAS is blindly used to update NCNs without following the correct process, then **THE STABILITY OF THE SYSTEM WILL BE JEOPARDIZED**.
+* This process does not communicate the SAFE way to update NCNs. If the NCNs and their BMCs have not been locked, or FAS is blindly used to update NCNs without following the correct process, then **THE STABILITY OF THE SYSTEM WILL BE JEOPARDIZED**.
 * Read the corresponding recipes before updating. There are sometimes ancillary actions that must be completed in order to ensure update integrity.
 
 **NOTE** to update Switch Controllers \(sC\) or RouterBMC refer to the Rosetta Documentation

--- a/operations/hardware_state_manager/Lock_and_Unlock_Management_Nodes.md
+++ b/operations/hardware_state_manager/Lock_and_Unlock_Management_Nodes.md
@@ -73,9 +73,14 @@ Use the `cray hsm locks lock` command to perform locking.
    The *processing-model rigid* parameter means that the operation must succeed on all
    target nodes or the entire operation will fail.
 
-1. Lock the management nodes
+1. Lock the management nodes.
    ```bash
    ncn# cray hsm locks lock create --role Management --processing-model rigid
+   ```
+
+   Example output:
+
+   ```bash
    Failure = []
 
    [Counts]
@@ -87,9 +92,14 @@ Use the `cray hsm locks lock` command to perform locking.
    ComponentIDs = [ "x3000c0s5b0n0", "x3000c0s4b0n0", "x3000c0s7b0n0", "x3000c0s6b0n0", "x3000c0s3b0n0", "x3000c0s2b0n0", "x3000c0s9b0n0", "x3000c0s8b0n0",]
    ```
    
-1. Lock the NodeBMCs of those management nodes
+1. Lock the NodeBMCs of those management nodes.
    ```bash
    ncn# cray hsm locks lock create --component-ids $(cray hsm state components list --role management --type node --format json | jq '.Components[].ID' | sed 's/n[0-9]*//;s/"//g' | tr '\n' ',' | sed 's/.$//')
+   ```
+
+   Example output:
+
+   ```bash
    Failure = []
 
    [Counts]
@@ -103,9 +113,14 @@ Use the `cray hsm locks lock` command to perform locking.
 
 #### To lock single nodes or lists of specific nodes (and their BMCs).
 
-1. Lock the management nodes
+1. Lock the management nodes.
    ```bash
    ncn# cray hsm locks lock create --role Management --component-ids x3000c0s6b0n0 --processing-model rigid
+   ```
+
+   Example output:
+
+   ```bash
    Failure = []
 
    [Counts]
@@ -117,10 +132,15 @@ Use the `cray hsm locks lock` command to perform locking.
    ComponentIDs = [ "x3000c0s6b0n0",]
    ```
 
-1. Lock the BMC of those nodes
+1. Lock the BMC of those nodes.
    ```bash
    // Remove 'n0' from all of the xnames to get a list of the NodeBMCs that need to be locked.
    ncn# cray hsm locks lock create --component-ids x3000c0s6b0 --processing-model rigid
+   ```
+
+   Example output:
+
+   ```bash
    Failure = []
 
    [Counts]
@@ -142,9 +162,14 @@ Use the `cray hsm locks unlock` command to perform unlocking.
 
 #### To unlock all nodes (and their BMCs) with the _Management_ role.
 
-1. Unlock the management nodes
+1. Unlock the management nodes.
    ```bash
    ncn# cray hsm locks unlock create --role Management --processing-model rigid
+   ```
+
+   Example output:
+
+   ```bash
    Failure = []
 
    [Counts]
@@ -156,9 +181,14 @@ Use the `cray hsm locks unlock` command to perform unlocking.
    ComponentIDs = [ "x3000c0s7b0n0", "x3000c0s6b0n0", "x3000c0s3b0n0", "x3000c0s2b0n0", "x3000c0s9b0n0", "x3000c0s8b0n0", "x3000c0s5b0n0", "x3000c0s4b0n0",]
    ```
 
-1. Unlock the BMCs of those management nodes
+1. Unlock the BMCs of those management nodes.
    ```bash
    ncn# cray hsm locks unlock create --component-ids $(cray hsm state components list --role management --type node --format json | jq '.Components[].ID' | sed 's/n[0-9]*//;s/"//g' | tr '\n' ',' | sed 's/.$//')
+   ```
+
+   Example output:
+
+   ```bash
    Failure = []
 
    [Counts]
@@ -172,9 +202,14 @@ Use the `cray hsm locks unlock` command to perform unlocking.
 
 #### To unlock single or lists of specific nodes (and their BMCs).
 
-1. Unlock the management nodes
+1. Unlock the management nodes.
    ```bash
    ncn# cray hsm locks unlock create --role Management --component-ids x3000c0s6b0n0 --processing-model rigid
+   ```
+
+   Example output:
+
+   ```bash
    Failure = []
 
    [Counts]
@@ -186,10 +221,15 @@ Use the `cray hsm locks unlock` command to perform unlocking.
    ComponentIDs = [ "x3000c0s6b0n0",]
    ```
    
-1. Unlock the BMCs of those management nodes
+1. Unlock the BMCs of those management nodes.
    ```bash
    // Remove 'n0' from all of the xnames to get a list of the NodeBMCs that need to be locked.
    ncn# cray hsm locks unlock create --component-ids x3000c0s6b0 --processing-model rigid
+   ```
+
+   Example output:
+
+   ```bash
    Failure = []
 
    [Counts]

--- a/operations/hardware_state_manager/Lock_and_Unlock_Management_Nodes.md
+++ b/operations/hardware_state_manager/Lock_and_Unlock_Management_Nodes.md
@@ -66,11 +66,14 @@ should once again be locked.
 
 Use the `cray hsm locks lock` command to perform locking.
 
-* To lock all nodes with the _Management_ role.
+***NOTE: When locking NCNs, you must lock their NodeBMCs as well.***
+
+#### To lock all nodes (and their BMCs) with the _Management_ role.
 
    The *processing-model rigid* parameter means that the operation must succeed on all
    target nodes or the entire operation will fail.
 
+1. Lock the management nodes
    ```bash
    ncn# cray hsm locks lock create --role Management --processing-model rigid
    Failure = []
@@ -83,9 +86,24 @@ Use the `cray hsm locks lock` command to perform locking.
    [Success]
    ComponentIDs = [ "x3000c0s5b0n0", "x3000c0s4b0n0", "x3000c0s7b0n0", "x3000c0s6b0n0", "x3000c0s3b0n0", "x3000c0s2b0n0", "x3000c0s9b0n0", "x3000c0s8b0n0",]
    ```
+   
+1. Lock the NodeBMCs of those management nodes
+   ```bash
+   ncn# cray hsm locks lock create --component-ids $(cray hsm state components list --role management --type node --format json | jq '.Components[].ID' | sed 's/n[0-9]*//;s/"//g' | tr '\n' ',' | sed 's/.$//')
+   Failure = []
 
-* To lock single nodes or lists of specific nodes.
+   [Counts]
+   Total = 8
+   Success = 8
+   Failure = 0
 
+   [Success]
+   ComponentIDs = [ "x3000c0s5b0", "x3000c0s4b0", "x3000c0s7b0", "x3000c0s6b0", "x3000c0s3b0", "x3000c0s2b0", "x3000c0s9b0", "x3000c0s8b0",]
+   ```
+
+#### To lock single nodes or lists of specific nodes (and their BMCs).
+
+1. Lock the management nodes
    ```bash
    ncn# cray hsm locks lock create --role Management --component-ids x3000c0s6b0n0 --processing-model rigid
    Failure = []
@@ -99,14 +117,32 @@ Use the `cray hsm locks lock` command to perform locking.
    ComponentIDs = [ "x3000c0s6b0n0",]
    ```
 
+1. Lock the BMC of those nodes
+   ```bash
+   // Remove 'n0' from all of the xnames to get a list of the NodeBMCs that need to be locked.
+   ncn# cray hsm locks lock create --component-ids x3000c0s6b0 --processing-model rigid
+   Failure = []
+
+   [Counts]
+   Total = 1
+   Success = 1
+   Failure = 0
+
+   [Success]
+   ComponentIDs = [ "x3000c0s6b0",]
+   ```
+
 <a name="how-to-unlock-management-nodes"></a>
 
 ### How To Unlock Management Nodes
 
 Use the `cray hsm locks unlock` command to perform unlocking.
 
-* To lock all nodes with the _Management_ role.
+***NOTE: When unlocking NCNs, you must unlock their NodeBMCs as well.***
 
+#### To unlock all nodes (and their BMCs) with the _Management_ role.
+
+1. Unlock the management nodes
    ```bash
    ncn# cray hsm locks unlock create --role Management --processing-model rigid
    Failure = []
@@ -120,8 +156,23 @@ Use the `cray hsm locks unlock` command to perform unlocking.
    ComponentIDs = [ "x3000c0s7b0n0", "x3000c0s6b0n0", "x3000c0s3b0n0", "x3000c0s2b0n0", "x3000c0s9b0n0", "x3000c0s8b0n0", "x3000c0s5b0n0", "x3000c0s4b0n0",]
    ```
 
-* To unlock single nodes or lists of specific nodes.
+1. Unlock the BMCs of those management nodes
+   ```bash
+   ncn# cray hsm locks unlock create --component-ids $(cray hsm state components list --role management --type node --format json | jq '.Components[].ID' | sed 's/n[0-9]*//;s/"//g' | tr '\n' ',' | sed 's/.$//')
+   Failure = []
 
+   [Counts]
+   Total = 8
+   Success = 8
+   Failure = 0
+
+   [Success]
+   ComponentIDs = [ "x3000c0s5b0", "x3000c0s4b0", "x3000c0s7b0", "x3000c0s6b0", "x3000c0s3b0", "x3000c0s2b0", "x3000c0s9b0", "x3000c0s8b0",]
+   ```
+
+#### To unlock single or lists of specific nodes (and their BMCs).
+
+1. Unlock the management nodes
    ```bash
    ncn# cray hsm locks unlock create --role Management --component-ids x3000c0s6b0n0 --processing-model rigid
    Failure = []
@@ -133,5 +184,20 @@ Use the `cray hsm locks unlock` command to perform unlocking.
 
    [Success]
    ComponentIDs = [ "x3000c0s6b0n0",]
+   ```
+   
+1. Unlock the BMCs of those management nodes
+   ```bash
+   // Remove 'n0' from all of the xnames to get a list of the NodeBMCs that need to be locked.
+   ncn# cray hsm locks unlock create --component-ids x3000c0s6b0 --processing-model rigid
+   Failure = []
+
+   [Counts]
+   Total = 1
+   Success = 1
+   Failure = 0
+
+   [Success]
+   ComponentIDs = [ "x3000c0s6b0",]
    ```
 


### PR DESCRIPTION
## Summary and Scope

This adds instructions for locking/unlocking NodeBMCs of NCNs when locking/unlocking NCNs. Locking NCNs as well as their BMCs will prevent unintended FAS actions from affecting NCNs

## Issues and Related PRs

* Resolves [CASMHMS-5346](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5346)

## Testing

### Tested on:

  * loki

### Test description:

The new procedure was tested by running it on Loki.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? If not, why? N/A
- Was upgrade tested? If not, why? N/A
- Was downgrade tested? If not, why? N/A
- Were new tests (or test issues/Jiras) created for this change? N/A

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

