### PR TITLE
CASMTRIAGE-2944: Incorrect Security and Authentication link in 1.0

### DIFF
--- a/operations/CSM_product_management/Configure_Keycloak_Account.md
+++ b/operations/CSM_product_management/Configure_Keycloak_Account.md
@@ -9,11 +9,11 @@ of external accounts in keycloak.
 However, if the external accounts are not available, then an "internal user account" could be
 created in keycloak. Having a usable account in keycloak with administrative authorization
 enables the use of the `cray` CLI for many administrative commands, such as those used to
-[Validate CSM Health](../../validate_csm_health.md) and general operation of the management services
+[Validate CSM Health](../validate_csm_health.md) and general operation of the management services
 via the API gateway.
 
-See [System Security and Authentication](../security_and_authentication/System_Security_and_Authentication.md)
-in the "Default Keycloak Realms, Accounts, and Clients" section for more information about these topics.
+In [Security and Authentication](../index.md#security-and-authentication)
+see the "Default Keycloak Realms, Accounts, and Clients" section for more information about these topics:
 
    * Certificate Types
    * Change the Keycloak Admin Password


### PR DESCRIPTION
### Summary and Scope
1.0 - CASMTRIAGE-2944: Incorrect Security and Authentication link in 1.0

Fix "Validate CSM Health" link.

Update link to "Security and Authentication"

### Issues and Related PRs
CASMTRIAGE-2944

### Testing
N/A

Was a fresh Install tested? N - N/A
Was an Upgrade tested? N - N/A
Was a Downgrade tested? N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations
Low

### Requires:
N/A