### PR TITLE
CASMINST-3954 - Fix 1.2 ceph node upgrade

### DIFF
--- a/upgrade/1.2/scripts/upgrade/ncn-upgrade-ceph-nodes.sh
+++ b/upgrade/1.2/scripts/upgrade/ncn-upgrade-ceph-nodes.sh
@@ -292,9 +292,7 @@ if [[ $state_recorded == "0" ]]; then
     ssh-copy-id -f -i ~/ceph.pub root@${upgrade_ncn}
     ceph orch host add ${upgrade_ncn}
     sleep 20
-    ceph orch daemon redeploy mon.${upgrade_ncn}
-    sleep 20
-    for s in $(ceph orch ps | grep ${upgrade_ncn} | awk '{print $1}'); do  ceph orch daemon start $s; done
+    for s in $(ceph orch ps | grep ${upgrade_ncn} | awk '{print $1}'); do  ceph orch daemon redeploy $s; done    
 
     record_state "${state_name}" ${upgrade_ncn}
 else


### PR DESCRIPTION
## Summary and Scope

This adds in a change that got missed in a carry forward from 1.0.

Fixes 1.2 ceph node image upgrades for cluster larger than 3.

## Issues and Related PRs

* Resolves CASMINST-3954

## Testing

### Tested on:

  * in 1.0 code

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

