### PR TITLE
Change etcd check for number of pods to halt upgrade

### DIFF
--- a/upgrade/1.0.1/scripts/upgrade/ncn-upgrade-k8s-worker.sh
+++ b/upgrade/1.0.1/scripts/upgrade/ncn-upgrade-k8s-worker.sh
@@ -78,6 +78,7 @@ if [[ $state_recorded == "0" ]]; then
         numOfPods=$(kubectl get pods -A -l 'app=etcd'| grep $cluster | grep "Running" | wc -l)
         if [[ $numOfPods -ne 3 ]];then
             echo "ERROR - Etcd cluster: $cluster should have 3 pods running but only $numOfPods are running"
+            exit 1
         fi
     done
 


### PR DESCRIPTION
## Summary and Scope

Lumi saw this -- it caught the error but the script marched on.  This fix is specific to 1.0 (different path in progress for 1.2 upgrade).

## Issues and Related PRs

* Resolves [CASMINST-3844](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3844)

## Testing

N/A

### Tested on:

N/A

### Test description:

N/A

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable