### PR TITLE
CASMINST-3965: Correctly record cps nodes before csm upgrade

### DIFF
--- a/upgrade/1.0.1/scripts/upgrade/prerequisites.sh
+++ b/upgrade/1.0.1/scripts/upgrade/prerequisites.sh
@@ -570,9 +570,17 @@ else
     echo "====> ${state_name} has been completed"
 fi
 
-# Take cps deployment snapshot
-cps_deployment_snapshot=$(cray cps deployment list --format json | jq -r '.[] | .node' || true)
-echo $cps_deployment_snapshot > /etc/cray/upgrade/csm/${CSM_RELEASE}/cp.deployment.snapshot
+# Take cps deployment snapshot (if cps installed)
+set +e
+trap - ERR
+kubectl get pod -n services | grep -q cray-cps
+if [ "$?" -eq 0 ]; then
+  cps_deployment_snapshot=$(cray cps deployment list --format json | jq -r \
+    '.[] | select(."podname" != "NA" and ."podname" != "") | .node' || true)
+  echo $cps_deployment_snapshot > /etc/cray/upgrade/csm/${CSM_RELEASE}/cp.deployment.snapshot
+fi
+trap 'err_report' ERR
+set -e
 
 # Alert the user of action to take for cleanup
 if [[ ${#UNMOUNTS[@]} -ne 0 ]]; then


### PR DESCRIPTION
## Summary and Scope

During the pawsey upgrade to csm-1.0, we observed that the upgrade script incorrectly recorded the CPS nodes, which resulted in CPS being deployed on all of the worker nodes. The fix is just a small change to the jq query being used when generating the list of CPS nodes.

## Issues and Related PRs

[csm-1.2 PR](https://github.com/Cray-HPE/docs-csm/pull/853)

## Testing

I tested the updated command on pawsey and verified that it worked as expected.

## Risks and Mitigations

Low risk. The fix is very straightforward.

## Pull Request Checklist

- [N/A] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [N/A] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [N/A] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

