### PR TITLE
CASMINST-3965: Correctly record cps nodes before csm upgrade

### DIFF
--- a/upgrade/1.2/scripts/upgrade/prerequisites.sh
+++ b/upgrade/1.2/scripts/upgrade/prerequisites.sh
@@ -437,7 +437,8 @@ set +e
 trap - ERR
 kubectl get pod -n services | grep -q cray-cps
 if [ "$?" -eq 0 ]; then
-  cps_deployment_snapshot=$(cray cps deployment list --format json | jq -r '.[] | .node' || true)
+  cps_deployment_snapshot=$(cray cps deployment list --format json | jq -r \
+    '.[] | select(."podname" != "NA" and ."podname" != "") | .node' || true)
   echo $cps_deployment_snapshot > /etc/cray/upgrade/csm/${CSM_RELEASE}/cp.deployment.snapshot
 fi
 trap 'err_report' ERR


### PR DESCRIPTION
This is the csm-1.2 version of this PR:
https://github.com/Cray-HPE/docs-csm/pull/852

The same issue exists in the prerequisites script for that version.