### PR TITLE
CASMNET-1135 - Document mellanox_set_bgp_peers.py assumption that the CAN subnet is a /24

### DIFF
--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -761,7 +761,7 @@ After the NCNs are booted, the BGP peers will need to be checked and updated if 
        `*WARNING*` The mellanox_set_bgp_peers.py script assumes that the prefix length of the CAN is `/24`. If that value is incorrect for the system being installed then update the script with the correct prefix length by editing the following line.
 
        ```python
-       cmd_prefix_list_can = "ip prefix-list pl-can seq 30 permit {} /24 ge 24".format(
+       cmd_prefix_list_can = "ip prefix-list pl-can seq 30 permit {} /24 ge 24".format()
        ```
 
     * If you have Aruba switches, run CANU.

--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -758,6 +758,12 @@ After the NCNs are booted, the BGP peers will need to be checked and updated if 
         pit# /usr/local/bin/mellanox_set_bgp_peers.py 10.252.0.2 10.252.0.3 /var/www/ephemeral/prep/${SYSTEM_NAME}/networks/
         ```
 
+       `*WARNING*` The mellanox_set_bgp_peers.py script assumes that the prefix length of the CAN is `/24`. If that value is incorrect for the system being installed then update the script with the correct prefix length by editing the following line.
+
+       ```python
+       cmd_prefix_list_can = "ip prefix-list pl-can seq 30 permit {} /24 ge 24".format(
+       ```
+
     * If you have Aruba switches, run CANU.
      
         CANU requires three parameters: the IP address of switch 1, the IP address of switch 2, and the path to the to directory containing the file `sls_input_file.json`

--- a/operations/network/metallb_bgp/Update_BGP_Neighbors.md
+++ b/operations/network/metallb_bgp/Update_BGP_Neighbors.md
@@ -69,6 +69,12 @@ In order for these scripts to work the following commands will need to be applie
     pit# /usr/local/bin/mellanox_set_bgp_peers.py 10.252.0.2 10.252.0.3 "${CSI_PATH}"
     ```
 
+   `*WARNING*` The mellanox_set_bgp_peers.py script assumes that the prefix length of the CAN is `/24`. If that value is incorrect for the system being installed then update the script with the correct prefix length by editing the following line.
+
+    ```python
+    cmd_prefix_list_can = "ip prefix-list pl-can seq 30 permit {} /24 ge 24".format(
+    ```
+
 ### Verification
 
 After following the previous steps, you will need to verify the configuration and verify the BGP peers are `ESTABLISHED`. If it is early in the install process and the CSM services have not been deployed yet, there will not be speakers to peer with, so the peering sessions may not be `ESTABLISHED` yet. This is expected and not a problem.

--- a/operations/network/metallb_bgp/Update_BGP_Neighbors.md
+++ b/operations/network/metallb_bgp/Update_BGP_Neighbors.md
@@ -72,7 +72,7 @@ In order for these scripts to work the following commands will need to be applie
    `*WARNING*` The mellanox_set_bgp_peers.py script assumes that the prefix length of the CAN is `/24`. If that value is incorrect for the system being installed then update the script with the correct prefix length by editing the following line.
 
     ```python
-    cmd_prefix_list_can = "ip prefix-list pl-can seq 30 permit {} /24 ge 24".format(
+    cmd_prefix_list_can = "ip prefix-list pl-can seq 30 permit {} /24 ge 24".format()
     ```
 
 ### Verification


### PR DESCRIPTION
## Summary and Scope

The `mellanox_set_bgp_peers.py` script assumes the prefix length of the CAN network is `/24` which may not be correct for all users environments.

This script is deprecated in CSM 1.2 in favour of using CANU to configure BGP so this ticket updates the CSM 1.0 docs with a warning and workaround for this issue.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMNET-1135](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1135)

## Testing

### Tested on:

  * Discovered and workaround tested on the training system `brook`

### Test description:

Ran script after workaround was applied, verified BGP configuration was present and correct on both spine switches.

## Risks and Mitigations

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable