### PR TITLE
Add cfs v1 api removal in differences.md

### DIFF
--- a/introduction/differences.md
+++ b/introduction/differences.md
@@ -64,6 +64,7 @@ The following features have been completely removed:
 
    * cray-conman pod. This has been replaced by cray-console-node.
    * The cray-externaldns-coredns, cray-externaldns-etcd, and cray-externaldns-wait-for-etcd pods have been removed. PowerDNS is now the provider of the external DNS service.
+   * CFS v1 API and CLI. The v2 API/CLI has been the default since CSM 0.9 (Shasta 1.4).
 
 <a name="other_changes"></a>
 ### Other Changes


### PR DESCRIPTION
## Summary and Scope

Added a note about the removal of the unused CFS v1 API.

## Issues and Related PRs

* Resolves CASMCMS-7287
* Merge after Cray-HPE/csm#450

## Testing

See Cray-HPE/csm#450

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct