### PR TITLE
Add istio-ca api audience on upgrade path for kube-api

### DIFF
--- a/upgrade/1.2/scripts/k8s/upgrade_control_plane.sh
+++ b/upgrade/1.2/scripts/k8s/upgrade_control_plane.sh
@@ -27,6 +27,19 @@ export PDSH_SSH_ARGS_APPEND="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/
 masters=$(grep -oP 'ncn-m\d+' /etc/hosts | sort -u)
 for master in $masters
 do
+  echo "Adding istio-ca api audience for kube-api on $master:"
+  pdsh -b -S -w $master "sed -i '/tls-private-key-file/a\    - --api-audiences=api,istio-ca' /etc/kubernetes/manifests/kube-apiserver.yaml"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo ""
+    echo "ERROR: Updating kube-apiserver manifest failed. The output from this script should be inspected"
+    echo "       and addressed before moving on with the upgrade. If unable to determine the issue"
+    echo "       and run this script without errors, discontinue the upgrade and contact HPE Service"
+    echo "       for support."
+    exit 1
+  fi
+  echo "Sleeping for one minute to let kube-apiserver restart on $master"
+  sleep 60
   echo "Upgrading kube-system pods for $master:"
   echo ""
   pdsh -b -S -w $master 'kubeadm upgrade apply v1.20.13 -y'


### PR DESCRIPTION
## Summary and Scope

Add istio-ca as api audience for kube-api on upgrade (already handled in fresh install)

## Issues and Related PRs

* Resolves [CASMINST-3978)](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3978)

## Testing

Fanta

### Tested on:

  * `fanta`

### Test description:

Ran subset of script on fanta, saw kube-api pods restart with correct audience.

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable