### PR TITLE
CASMINST-3458: Fix broken "update management networks" procedure

### DIFF
--- a/upgrade/scripts/get_mountain_cmm_firmware_versions.py
+++ b/upgrade/scripts/get_mountain_cmm_firmware_versions.py
@@ -1,0 +1,239 @@
+#!/usr/bin/python3
+# Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# (MIT License)
+
+# Script for getting firmware versions from Mountain BMCs
+# Requires the following environment variables to be set:
+# TOKEN - API token
+# BMC_USER - Mountain BMC username
+# BMC_PASS - Mountain BMC password
+
+# usage: get_mountain_cmm_firmware_versions.py
+
+import os
+import requests
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
+from simplejson.errors import JSONDecodeError
+import sys
+
+api_gw_url="https://api-gw-service-nmn.local/apis"
+
+def print_stderr(msg):
+    print(msg, file=sys.stderr)
+
+def err_exit(msg):
+    print_stderr(f"ERROR: {msg}")
+    sys.exit(1)
+
+# Returns the values of the TOKEN, BMC_USER, and BMC_PASS environment variables
+# Exits script in error if any are not set
+def get_env_parameters():
+    try:
+        token = os.environ["TOKEN"]
+    except KeyError:
+        err_exit("Must export TOKEN variable with API authorization token")
+    try:
+        user = os.environ["BMC_USER"]
+    except KeyError:
+        err_exit("Must export BMC_USER variable with the Mountain BMC username")
+    try:
+        password = os.environ["BMC_PASS"]
+    except KeyError:
+        err_exit(f"Must export BMC_PASS variable with the Mountain BMC password for user {user}")
+    return token, user, password
+
+def api_get(url, exit_on_fail=True, **kwargs):
+    print(f"Making GET request to {url}")
+    response = requests.get(url, verify=False, **kwargs)
+    if response.status_code != 200:
+        if response.reason:
+            print_stderr(f"Response reason: {response.reason}")
+        if response.text:
+            print_stderr(f"Response text: {response.text}")
+        msg = f"GET request to {url} returned with status code {response.status_code} (expected 200)"
+        if exit_on_fail:
+            err_exit(msg)
+        else:
+            print_stderr(f"ERROR: {msg}")
+            return None
+    try:
+        return response.json()
+    except JSONDecodeError:
+        print_stderr("Response status code was 200 but error decoding response text into JSON")
+        if response.text:
+            print_stderr("Response test:")
+            print_stderr(f"Response text: {response.text}")
+        else:
+            print_stderr("No text in response")
+        msg = "Unable to decode response text into JSON"
+        if exit_on_fail:
+            err_exit(msg)
+        else:
+            print_stderr(f"ERROR: {msg}")
+            return None
+
+def api_gw_get(uri, token):
+    url = f"{api_gw_url}/{uri}"
+    return api_get(url, headers={"Authorization": f"Bearer {token}"})
+
+# Assumes we have already verified that this is a list
+# This function verifies that every entry in the list is a non-empty string
+def list_of_nonempty_strings(obj_list):
+    # This could be done more efficiently, but in the interest of clarity
+    # I am breaking this into multiple checks
+    if not all( isinstance(obj, str) for obj in obj_list ):
+        return False
+    elif not all( obj for obj in obj_list ):
+        return False
+    return True
+
+def response_object_error(obj, msg, exit_on_fail=True):
+    # Surround API response with whitespace
+    print_stderr(f"\nAPI response object:\n{obj}\n")
+    if exit_on_fail:
+        err_exit(msg)
+    else:
+        print_stderr(f"ERROR: {msg}")
+
+def get_mountain_cmm_xnames(token):
+    print("Retrieving list of Mountain CMM xnames")
+    json_object = api_gw_get(
+        "sls/v1/search/hardware?type=comptype_chassis_bmc&class=Mountain",
+        token)
+    if json_object == None:
+        # This is what HSM returns when no matching objects are found
+        json_object = []
+    elif not isinstance(json_object, list):
+        response_object_error(json_object,
+            f"Expected API response to be a list, but we received a {type(json_object).__name__}")
+    try:
+        xnames = [ cmm["Xname"] for cmm in json_object ]
+    except KeyError:
+        response_object_error(json_object,
+            "Every entry in the API response should have an 'Xname' field but at least one does not.")
+    if not list_of_nonempty_strings(xnames):
+        response_object_error(json_object,
+            "Every 'Xname' field should be a nonempty string, but at least one is not.")
+    return xnames
+
+def get_redfish_endpoint_fqdns(xnames, token):
+    print("Retrieving list of Redfish endpoint FQDNs of the Mountain CMM(s)")
+    parameters = "&id=".join(xnames)
+    json_object = api_gw_get(
+        f"smd/hsm/v2/Inventory/ComponentEndpoints?id={parameters}",
+        token)
+    if not isinstance(json_object, dict):
+        response_object_error(json_object,
+            f"Expected API response to be a dict, but we received a {type(json_object).__name__}")
+    try:
+        endpoints = json_object["ComponentEndpoints"]
+    except KeyError:
+        response_object_error(json_object,
+            "'ComponentEndpoints' field not found in API response")
+    if not isinstance(endpoints, list):
+        response_object_error(json_object,
+            f"Expected 'ComponentEndpoints' field to map to a list, but it maps to a {type(endpoints).__name__}")
+    try:
+        fqdns = [ endpoint["RedfishEndpointFQDN"] for endpoint in endpoints ]
+    except KeyError:
+        response_object_error(json_object,
+            "Every entry in the ComponentEndpoints list should have a 'RedfishEndpointFQDN' field but at least one does not.")
+    if not list_of_nonempty_strings(fqdns):
+        response_object_error(json_object,
+            "Every 'RedfishEndpointFQDN' field should be a nonempty string, but at least one is not.")
+    print(f"\nFound {len(fqdns)} Mountain CMM Redfish FQDN(s) in the system: {', '.join(fqdns)}")
+    if len(xnames) != len(fqdns):
+        response_object_error(json_object,
+            "Number of FQDNs ({len(fqdns)}) does not match number of xnames ({len(xnames)})")
+    return fqdns
+
+def get_firmware_version(fqdn, user, password):
+    print(f"\nChecking firmware version of {fqdn}")
+    json_object = api_get(
+        f"https://{fqdn}/redfish/v1/UpdateService/FirmwareInventory/BMC",
+        exit_on_fail=False, 
+        auth=(user, password))
+    if json_object == None:
+        return None
+    if not isinstance(json_object, dict):
+        response_object_error(json_object,
+            f"Expected API response to be a dict, but we received a {type(json_object).__name__}",
+            exit_on_fail=False)
+        return None
+    try:
+        version = json_object["Version"]
+    except KeyError:
+        response_object_error(json_object,
+            "'Version' field not found in API response\n",
+            exit_on_fail=False)
+        return None
+    if not isinstance(version, str):
+        response_object_error(json_object,
+            f"Expected 'Version' field to map to a string, but it maps to a {type(version).__name__}",
+            exit_on_fail=False)
+        return None
+    elif not version:
+        print_stderr(f"ERROR: Version string is blank for {fqdn}")
+        return None
+    return version
+
+def main():
+    # Get necessary parameters
+    token, user, password = get_env_parameters()
+
+    # Suppress insecure request warnings. This script is replacing a curl command, and
+    # that curl command used -k, so the script will behave in the same way.
+    requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+    
+    xnames = get_mountain_cmm_xnames(token)
+    if not xnames:
+        print("\nNo Mountain CMMs found in the system.\n")
+        sys.exit(0)
+    print(f"\nFound {len(xnames)} Mountain CMM(s) in the system: {', '.join(xnames)}\n")
+
+    fqdns = get_redfish_endpoint_fqdns(xnames, token)
+    
+    rc=0
+    fqdn_to_fw_version = dict()
+    for fqdn in fqdns:
+        ver = get_firmware_version(fqdn, user, password)
+        if ver == None:
+            print_stderr(f"ERROR: Unable to obtain firmware version for {fqdn}")
+            ver = "UNKNOWN"
+            rc=1
+        fqdn_to_fw_version[fqdn] = ver
+    table_header = [ "Mountain CMM", "Firmware Version" ]
+    max_cmm_len = max(
+                    len(table_header[0]), 
+                    max([len(f) for f in fqdns]))
+    table_format="{:<%d} | {}" % max_cmm_len
+    print("\n"+table_format.format(*table_header))
+    for fqdn in sorted(fqdns):
+        print(table_format.format(fqdn, fqdn_to_fw_version[fqdn]))
+
+    if rc != 0:
+        err_exit("\nAt least one error occurred. Investigate and resolve the problems, then re-run this script.")
+    print("\nFirmware versions successfully reported")
+    sys.exit(0)
+
+if __name__ == "__main__":
+    main()

--- a/upgrade/update_management_network.md
+++ b/upgrade/update_management_network.md
@@ -1,77 +1,198 @@
-# Update management network from 1.4 to 1.5
+# Update Management Network From 1.4 To 1.5
 
 **IMPORTANT**: These procedures only need to be followed if upgrading from CSM 0.9 (Shasta 1.4). If upgrading from CSM 1.0.1 (Shasta 1.5), these procedures should already have been done.
 
-## New Features and Functions for v1.5
+1. [New Features and Functions for v1.5](#new-features-and-functions)
+1. [Accessing Network Switches](#accessing-network-switches)
+    1. [Finding Switch Hostnames and IP Addresses](#finding-switch-hostnames)
+    1. [Reminders](#switch-reminders)
+1. [CMM Static Lag Configuration](#cmm-static-lag-configuration)
+1. [BGP](#bgp-updates)
+    1. [Aruba](#bgp-aruba)
+    1. [Mellanox](#bgp-mellanox)
+1. [Apollo Server Configuration](#apollo-server-configuration)
+
+<a name="new-features-and-functions"></a>
+## 1. New Features and Functions for v1.5
 
 - Static Lags from the CDU switches to the CMMs (Aruba and Dell).
 - HPE Apollo server port config, requires a trunk port to the iLO.
 - BGP TFTP static route removal (Aruba).
 - BGP passive neighbors (Aruba and Mellanox)
 
-Some of these changes are applied as hotfixes and patches for 1.4, they may have already been applied.
+Some of these changes are applied as hotfixes and patches for 1.4; they may have already been applied.
 
-## CMM Static Lag configuration
+<a name="accessing-network-switches"></a>
+## 2. Accessing Network Switches
 
-For systems with mountain cabinets ONLY. Changes must
+For some of the procedures on this page you will need to SSH into your switches as the `admin` user to verify settings and possibly make changes.
 
-- Verify the version of the CMM firmware, the firmware must be on version 1.4.20 or greater in order to support static LAGs on the CDU switches.
-- The command below should get you all the cmm firmware for a system.
-- Update the password in the command before usage. Change `root:password` to the correct BMC password.
+<a name="finding-switch-hostnames"></a>
+### 2.1 Finding Switch Hostnames and IP Addresses
 
-```bash
-ncn# export TOKEN=$(curl -s -k -S -d grant_type=client_credentials -d client_id=admin-client -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token'); cmms=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?type=comptype_chassis_bmc" | jq -r '.[] | .Xname'); for cmm in ${cmms}; do echo ${cmm}; curl -sk -u root:password https://${cmm}/redfish/v1/UpdateService/FirmwareInventory/BMC | jq .Version; done
+If you do not already know the hostnames or IP addresses of the switches in the system, here are some methods to determine them.
+
+#### Default Values
+
+The default switch hostnames are in the following formats:
+```text
+sw-spine-001
+sw-spine-002
+sw-agg-001
+sw-agg-002
+...
+sw-leaf-001
+sw-leaf-002
+...
+sw-cdu-001
+sw-cdu-002
+...
 ```
 
-Expected output
+#### Get Spine Switch IPs from Kubernetes
 
+One way to get the IP addresses for the two spine switches is from the `metallb-system` configmap in Kubernetes:
 ```bash
-"cc.1.4.2x-shasta-release.arm64.2021-03-24T17:47:03+00:00.0b7eb31"
+ncn# kubectl get cm config -n metallb-system -o json | 
+        jq -r '.data | .config' | 
+        yq r -  -j | 
+        jq -r '.peers | .[]."peer-address"'
 ```
 
-- If the firmware is not on 1.4.20 or greater, notify the admin and get it updated before proceeding.
-- If you cannot get the firmware version, have the admin check for you.
-- (Aruba and Dell) If the CMMs are on the correct version, verify the LAG configuration is setup correctly.
-- These configurations can be found on the CDU switch pages under the "Configure LAG for CMMs" section.
-  - Dell [Dell CDU](../install/configure_dell_cdu_switch.md)
-  - Aruba [Aruba CDU](../install/configure_aruba_cdu_switch.md)
+Expected output is similar to the following:
+```text
+10.252.0.2
+10.252.0.3
+```
 
-## BGP updates
+#### Check `/etc/hosts`
 
-- This configuration is applied to the switches running BGP, this is set during CSI configuration. This is likely the spine switches if there are no aggregation switches on the system.
-- To check if the switches are running BGP run the commands below, the output might not be exact but it shows that the switch is running BGP.
-
-### Check BGP Status
-
-**Aruba:**
-
+A quick method to look for the hostnames and IP addresses is by looking in `/etc/hosts` on an NCN:
 ```bash
+ncn# grep sw /etc/hosts
+```
+
+Expected output looks similar to the following:
+```text
+10.252.0.2      sw-spine-001
+10.252.0.3      sw-spine-002
+10.252.0.4      sw-agg-001
+10.252.0.5      sw-agg-002
+10.252.0.6      sw-agg-003
+10.252.0.7      sw-agg-004
+10.252.0.8      sw-leaf-001
+10.252.0.9      sw-leaf-002
+10.252.0.10     sw-leaf-003
+10.252.0.11     sw-leaf-004
+10.252.0.12     sw-cdu-001
+10.252.0.13     sw-cdu-002
+```
+
+<a name="switch-reminders"></a>
+### 2.2 Reminders
+
+> On Mellanox switches, the `enable` command must be issued before some other commands will work properly.
+
+> If changes are made to a switch configuration, to not forget to save them with the `write memory` command.
+
+<a name="cmm-static-lag-configuration"></a>
+## 3. CMM Static Lag Configuration
+
+For systems with Mountain cabinets ONLY, one must verify the version of the Mountain CMM firmware. The firmware must be on version 1.4.20 or greater in order to support static LAGs on the CDU switches. Follow this procedure to do so:
+
+1. Set environment variables with the credentials for the Mountain CMMs:
+
+    ```bash
+    ncn# read -s BMC_USER
+    ncn# read -s BMC_PASS
+    ncn# export BMC_USER BMC_PASS
+    ```
+
+1. Obtain an API token:
+
+    ```bash
+    ncn# export TOKEN=$(curl -s -k -S -d grant_type=client_credentials -d client_id=admin-client \
+                            -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
+                            https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | 
+                        jq -r '.access_token')
+    ```
+
+1. Run the following script to get a report on the Mountain CMM firmware levels:
+
+    ```bash
+    ncn# /usr/share/doc/csm/upgrade/scripts/get_mountain_cmm_firmware_versions.py
+    ```
+
+    Expected output looks similar to the following:
+    ```text
+    Retrieving list of Mountain CMM xnames
+    Making GET request to https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?type=comptype_chassis_bmc&class=Mountain
+    
+    Found 3 Mountain CMM(s) in the system: x1001c5, x1001c4, x1000c5
+    
+    Retrieving list of Redfish endpoint FQDNs of the Mountain CMM(s)
+    Making GET request to https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints?id=x1001c5&id=x1001c4&id=x1000c5
+    
+    Found 3 Mountain CMM Redfish FQDN(s) in the system: x1001c5b0, x1000c5b0, x1001c4b0
+    
+    Checking firmware version of x1001c5b0
+    Making GET request to https://x1001c5b0/redfish/v1/UpdateService/FirmwareInventory/BMC
+    
+    Checking firmware version of x1000c5b0
+    Making GET request to https://x1000c5b0/redfish/v1/UpdateService/FirmwareInventory/BMC
+    
+    Checking firmware version of x1001c4b0
+    Making GET request to https://x1001c4b0/redfish/v1/UpdateService/FirmwareInventory/BMC
+    
+    Mountain CMM | Firmware Version
+    x1000c5b0    | cc.1.5-31-shasta-release.arm64.2021-11-03T03:50:18+00:00.b9ced71
+    x1001c4b0    | cc.1.5-31-shasta-release.arm64.2021-11-03T03:50:18+00:00.b9ced71
+    x1001c5b0    | cc.1.5-31-shasta-release.arm64.2021-11-03T03:50:18+00:00.b9ced71
+    
+    Firmware versions successfully reported
+    ```
+
+1. Proceed to the appropriate next step:
+    - If the firmware is not on 1.4.20 or greater, notify the admin and get it updated before proceeding.
+    - If you cannot get the firmware version, have the admin check for you.
+    - (Aruba and Dell) If the CMMs are on the correct version, verify the LAG configuration is setup correctly. These configurations can be found on the CDU switch pages under the "Configure LAG for CMMs" section:
+        - [Dell CDU](../install/configure_dell_cdu_switch.md)
+        - [Aruba CDU](../install/configure_aruba_cdu_switch.md)
+
+<a name="bgp-updates"></a>
+## 4. BGP
+
+- This configuration is applied to the switches running BGP. This is set during CSI configuration. This is likely the spine switches, if there are no aggregation switches on the system.
+- To check if the switches are running BGP, run the commands below. The output might not be exact, but it shows that the switch is running BGP.
+- These checks and procedures must be followed on ALL switches running BGP.
+- More BGP documentation can be found here [Update BGP Neighbors](../operations/network/metallb_bgp/Update_BGP_Neighbors.md).
+
+The procedures to follow are broken up by switch type:
+* [Aruba](#bgp-aruba)
+* [Mellanox](#bgp-mellanox)
+
+<a name="bgp-aruba"></a>
+### 4.1 BGP: Aruba
+
+#### BGP: Aruba: Check Status
+
+```
 sw-spine-001# show run | include bgp
 router bgp 65533
     bgp router-id 10.252.0.2
 ```
 
-**Mellanox:**
+#### BGP: Aruba: Make Updates
 
-```bash
-sw-spine-001 [standalone: master] # show run | include bgp
-   protocol bgp
-   router bgp 65533 vrf default
-   router bgp 65533 vrf default router-id 10.252.0.2 force
-   router bgp 65533 vrf default maximum-paths ibgp 32
+- Remove the TFTP static route entry on the switches that are participating in BGP.
+- This was set during initial install to workaround an issue with TFTP booting.
+- Log into the switches running BGP. In this example it is the spine switches.
+- Run the following command once logged in:
+
 ```
-
-### Aruba BGP updates
-
-- Remove the TFTP static route entry on the switches that are BGP participating in BGP.
-- This was set during initial install to workaround an issue with tftp booting.
-- Log into the switches running BGP, in this example it is the spine switches.
-- Run the following command once logged in.
-
-```bash
 sw-spine01# show ip route 10.92.100.60
 
-Displaying ipv4 routes selected for forwarding
+Displaying IPv4 routes selected for forwarding
 
 '[x/y]' denotes [distance/metric]
 
@@ -79,9 +200,9 @@ Displaying ipv4 routes selected for forwarding
     via  10.252.1.x,  [1/0],  static
 ```
 
-- If you see `via  10.252.1.x,  [1/0],  static` then you will need to remove this route.
+- If you see `via  10.252.1.x,  [1/0],  static`, then you will need to remove this route.
 
-```bash
+```
 sw-spine01# config t
 sw-spine01(config)# no ip route 10.92.100.60/32 10.252.1.x
 ```
@@ -90,18 +211,18 @@ sw-spine01(config)# no ip route 10.92.100.60/32 10.252.1.x
 - It is located at `/opt/cray/csm/scripts/networking/BGP/Aruba_BGP_Peers.py`
 - This is documented on this page [Update BGP Neighbors](../operations/network/metallb_bgp/Update_BGP_Neighbors.md)
 
-### Check Aruba BGP configuration
+#### BGP: Aruba: Check Configuration
 
-- Log into the switches that you ran the BGP script against and execute `sw-spine-001# show run | begin "ip prefix-list"`
+Log into the switches that you ran the BGP script against and execute `sw-spine-001# show run | begin "ip prefix-list"`
 
 Do not copy this configuration onto your switches.
-Note: the following configuration needs to be present.
+The following configuration needs to be present.
 `ip prefix-list tftp seq 10 permit 10.92.100.60/32 ge 32 le 32`
 `neighbor 10.252.1.x passive`
-The neighbors should be the NMN IP of the worker nodes.
+The neighbors should be the NMN IP addresses of the worker nodes.
 Here is an example output from an Aruba switch with 3 worker nodes.
 
-```bash
+```
 ip prefix-list pl-can seq 10 permit 10.103.11.0/24 ge 24
 ip prefix-list pl-hmn seq 20 permit 10.94.100.0/24 ge 24
 ip prefix-list pl-nmn seq 30 permit 10.92.100.0/24 ge 24
@@ -202,14 +323,29 @@ router bgp 65533
 !
 ```
 
-### Mellanox BGP updates
+If the configuration does not look like the example above, check the [Update BGP Neighbors](../operations/network/metallb_bgp/Update_BGP_Neighbors.md) docs.
 
-- The Mellanox BGP neighbors need to configured as passive.
+When the configuration is correct, if any configuration changes were made, run `write memory` on all of the switches to save it.
+
+<a name="bgp-mellanox"></a>
+### 4.2 BGP: Mellanox
+
+#### BGP: Mellanox: Check Status
+
+```
+sw-spine-001 [standalone: master] > enable
+sw-spine-001 [standalone: master] > show protocols | include bgp
+ bgp:                    enabled
+```
+
+#### BGP: Mellanox: Make Updates
+
+The Mellanox BGP neighbors need to configured as passive.
 
 To do this, log into the switches and run the commands below.
-the neighbor will be the NMN IP of ALL the worker nodes. You may have more than 3.
+The neighbors will be the NMN IP addresses of ALL the worker nodes. You may have more than 3.
 
-```bash
+```
 sw-spine-001 [standalone: master] > ena
 sw-spine-001 [standalone: master] # conf t
 sw-spine-001 [standalone: master] (config) # router bgp 65533 vrf default neighbor 10.252.1.10 transport connection-mode passive
@@ -219,20 +355,16 @@ sw-spine-001 [standalone: master] (config) # router bgp 65533 vrf default neighb
 
 Run the command below to verify the configuration got applied correctly.
 
-```bash
-sw-spine-001 [standalone: master] (config) # show run protocol bgp
+```
+sw-spine-001 [standalone: master] (config) # show protocols | include bgp
 ```
 
-### Check Mellanox BGP Configuration
+#### BGP: Mellanox: Check Configuration
 
 The configuration should look similar to the following. This is an example only.
-More BGP documentation can be found here [Update BGP Neighbors](../operations/network/metallb_bgp/Update_BGP_Neighbors.md).
+The neighbors should be the ALL of the NCN Workers and their NMN addresses; they will not peer over any other network.
 
-The neighbors should be the ALL of the NCN-Workers and their NMN address, they will not peer over any other network.
-
-```bash
-## BGP configuration
-##
+```
    protocol bgp
    router bgp 65533 vrf default
    router bgp 65533 vrf default router-id 10.252.0.2 force
@@ -246,11 +378,17 @@ The neighbors should be the ALL of the NCN-Workers and their NMN address, they w
    router bgp 65533 vrf default neighbor 10.252.1.10 transport connection-mode passive
    router bgp 65533 vrf default neighbor 10.252.1.11 transport connection-mode passive
    router bgp 65533 vrf default neighbor 10.252.1.12 transport connection-mode passive
-
 ```
-If the configuration does not look like the example above check the [Update BGP Neighbors](../operations/network/metallb_bgp/Update_BGP_Neighbors.md) docs.
-#### Apollo Server configuration
 
-If the system has Apollo servers, the configuration can be found [here](../operations/configure_mgmt_net_ports.md) under the section "Apollo Server port config".
+If the configuration does not look like the example above, check the [Update BGP Neighbors](../operations/network/metallb_bgp/Update_BGP_Neighbors.md) docs.
 
-[Return to main upgrade page](../index.md)
+When the configuration is correct, if any configuration changes were made, run `write memory` on all of the switches to save it.
+
+<a name="apollo-server-configuration"></a>
+## 5. Apollo Server Configuration
+
+If the system has Apollo servers, the required configuration can be found in the 
+[Management Network Access Port Configurations page](../operations/network/management_network/Management_Network_Access_Port_Configurations.md), 
+under the section "Apollo Server Port Configuration".
+
+[Return to main upgrade page](index.md)


### PR DESCRIPTION
## Summary and Scope

The changes made in this PR correct problems first observed by me last year during the SSI install of hela, and then more recently on the Pawsey customer upgrade.

This PR corrects a number of errors on the "update management networks" procedure for the upgrade to csm-1.0. Most notably it fixes some commands which are incorrect and do not work as given, as well as supplying some commands which are absent from the page.

The procedure to get the Mountain CMM firmware has been replaced with a Python script, rather than having the user run a large number of commands manually.

In addition to those major changes this PR also reorganizes the procedure to make it clearer, fixes some broken links, and does other linting.

All changes are to that single page.

## Issues and Related PRs

None.

## Testing

I tested the changes (most notably the new script) on the Pawsey system, fanta, groot, and hela. 

## Risks and Mitigations

Very low risk. Currently much of the page does not work, so even if the changes are bad, it won't be any worse than before. Given my testing, I see little risk.

## Pull Request Checklist

- [N/A] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [N/A] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [N/A] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

