### PR TITLE
CASMINST-3936, CASMINST-3911, CASMINST-3937

### DIFF
--- a/index.md
+++ b/index.md
@@ -39,9 +39,8 @@ scripts, revision control with git, configuration management with Ansible, YAML,
 
 1. [Update CSM Product Stream](update_product_stream/index.md)
 
-   This chapter explains how to get the CSM product release, any patches, update to the latest set of
-   documentation and any installation workarounds, and check for any Field Notices or Hotfixes.
-
+   This chapter explains how to get the CSM product release, get any patches, update to the latest 
+   documentation, and check for any Field Notices or Hotfixes.
 
 1. [Install CSM](install/index.md)
 

--- a/install/bootstrap_livecd_remote_iso.md
+++ b/install/bootstrap_livecd_remote_iso.md
@@ -15,11 +15,9 @@ lack of removable storage.
    1. [Attaching and Booting the LiveCD with the BMC](#attaching-and-booting-the-livecd-with-the-bmc)
    1. [First Login](#first-login)
    1. [Configure the Running LiveCD](#configure-the-running-livecd)
-      1. [Before Configuration Payload Workarounds](#before-configuration-payload-workarounds)
       1. [Generate Installation Files](#generate-installation-files)
          1. [Subsequent Fresh-Installs (Re-Installs)](#subsequent-fresh-installs-re-installs)
          1. [First-Time/Initial Installs (bare-metal)](#first-timeinitial-installs-bare-metal)
-      1. [CSI Workarounds](#csi-workarounds)
       1. [Prepare Site Init](#prepare-site-init)
    1. [Bring-up the PIT Services and Validate PIT Health](#bring---up-the-pit-services-and-validate-pit-health)
    1. [Next Topic](#next-topic)
@@ -44,8 +42,8 @@ the instructions for attaching to the BMC will differ.
 
 1. The CSM software release should be downloaded and expanded for use.
 
-   **Important:** To ensure that the CSM release plus any patches, workarounds, or hotfixes are included
-   follow the instructions in [Update CSM Product Stream](../update_product_stream/index.md)
+   **Important:** Ensure that you have the CSM release plus any patches or hotfixes by
+   following the instructions in [Update CSM Product Stream](../update_product_stream/index.md)
 
    The cray-pre-install-toolkit ISO and other files are now available in the directory from the extracted CSM tar.
    The ISO will have a name similar to
@@ -226,8 +224,8 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
 
 1. Download the CSM software release to the PIT node.
 
-   **Important:** In an earlier step, the CSM release plus any patches, workarounds, or hotfixes
-   were downloaded to a system using the instructions in [Update CSM Product Stream](../update_product_stream/index.md)
+   **Important:** In an earlier step, the CSM release plus any patches or hotfixes
+   was downloaded to a system using the instructions in [Update CSM Product Stream](../update_product_stream/index.md)
    Either copy from that system to the PIT node or set the ENDPOINT variable to URL and use `wget`.
 
    1. Set helper variables
@@ -280,11 +278,10 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
    pit# rpm -Uvh $(find ${CSM_PATH}/rpm/ -name "cray-site-init-*.x86_64.rpm" | sort -V | tail -1)
    ```
 
-1. Download and install/upgrade the workaround and documentation RPMs. If this machine does not have direct internet
-   access these RPMs will need to be externally downloaded and then copied to this machine.
+1. Download and install/upgrade the documentation RPM. If this machine does not have direct internet
+   access this RPM will need to be externally downloaded and then copied to this machine.
 
-   **Important:** To ensure that the latest workarounds and documentation updates are available,
-   see [Check for Latest Workarounds and Documentation Updates](../update_product_stream/index.md#workarounds)
+   See [Check for Latest Documentation](../update_product_stream/index.md#documentation)
 
 1. Show the version of CSI installed.
 
@@ -312,13 +309,8 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
    = PIT Identification = COPY/CUT END =========================================
    ```
 
-<a name="before-configuration-payload-workarounds"></a>
-#### 4.1 Before Configuration Payload Workarounds
-
-Follow the [workaround instructions](../update_product_stream/index.md#apply-workarounds) for the `before-configuration-payload` breakpoint.
-
 <a name="generate-installation-files"></a>
-#### 4.2 Generate Installation Files
+#### 4.1 Generate Installation Files
 
 Some files are needed for generating the configuration payload. See these topics in [Prepare Configuration Payload](prepare_configuration_payload.md) if one has not already prepared the information for this system.
 
@@ -351,7 +343,7 @@ Some files are needed for generating the configuration payload. See these topics
    After gathering the files into this working directory, move on to [Subsequent Fresh-Installs (Re-Installs)](#subsequent-fresh-installs-re-installs).
 
 <a name="subsequent-fresh-installs-re-installs"></a>
-##### 4.2.a Subsequent Fresh-Installs (Re-Installs)
+##### 4.1.a Subsequent Fresh-Installs (Re-Installs)
 
 1. **For subsequent fresh-installs (re-installs) where the `system_config.yaml` parameter file is available**, generate the updated system configuration (see [avoiding parameters](../background/cray_site_init_files.md#save-file--avoiding-parameters)).
 
@@ -416,10 +408,10 @@ Some files are needed for generating the configuration payload. See these topics
       >   {"Source":"x3000door-Motiv","SourceRack":"x3000","SourceLocation":" ","DestinationRack":"x3000","DestinationLocation":"u36","DestinationPort":"j27"}}
       >   ```
 
-   1. Skip the next step and continue with the [CSI Workarounds](#csi-workarounds).
+   1. Skip the next step and continue to [prepare site init](#prepare-site-init).
 
 <a name="first-timeinitial-installs-bare-metal"></a>
-##### 4.2.b First-Time/Initial Installs (bare-metal)
+##### 4.1.b First-Time/Initial Installs (bare-metal)
 
 1. **For first-time/initial installs (without a `system_config.yaml`file)**, generate the system configuration. See below for an explanation of the command line parameters and some common settings.
 
@@ -524,15 +516,10 @@ Some files are needed for generating the configuration payload. See these topics
       >    {"Source":"x3000door-Motiv","SourceRack":"x3000","SourceLocation":" ","DestinationRack":"x3000","DestinationLocation":"u36","DestinationPort":"j27"}}
       >    ```
 
-   1. Continue with the next step to apply the [csi-config workarounds](#33-csi-workarounds).
-
-<a name="csi-workarounds"></a>
-#### 4.3 CSI Workarounds
-
-Follow the [workaround instructions](../update_product_stream/index.md#apply-workarounds) for the `csi-config` breakpoint.
+   1. Continue with the next step to [prepare site init](#prepare-site-init).
 
 <a name="prepare-site-init"></a>
-#### 4.4 Prepare Site Init
+#### 4.2 Prepare Site Init
 
 First, prepare a shim to facilitate going through the site-init guide:
 

--- a/install/bootstrap_livecd_remote_iso.md
+++ b/install/bootstrap_livecd_remote_iso.md
@@ -212,7 +212,7 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
     pit# mkdir -v admin prep prep/admin configs data
     ```
 
-1. Quit the typescript session with the `exit` command, copy the file (csm-install-remoteis.<date>.txt) from its initial location to the newly created directory, and restart the typescript.
+1. Quit the typescript session with the `exit` command, copy the file (csm-install-remoteiso.<date>.txt) from its initial location to the newly created directory, and restart the typescript.
 
     ```bash
     pit# exit # The typescript
@@ -440,7 +440,7 @@ Some files are needed for generating the configuration payload. See these topics
       ```
 
    1. Generate the system config:
-      > **`NOTE`** the provided command below is an **example only**, run `csi config init --help` to print a full list of parameters that must be set. These will vary sifnificatnly depending on ones system and site configuration.
+      > **`NOTE`** the provided command below is an **example only**, run `csi config init --help` to print a full list of parameters that must be set. These will vary significatnly depending on ones system and site configuration.
 
       ```bash
       pit:/var/www/ephemeral/prep/# csi config init \
@@ -542,7 +542,7 @@ Finally, cleanup the shim:
 ### 5. Bring-up the PIT Services and Validate PIT Health
 
 1. Set the same variables from the `csi config init` step from earlier, and then invoke "PIT init" to setup the PIT server for deploying NCNs.
-   > **`NOTE`** `pit-init` will re-run `csi config init`, copy all generated files into place, apply the CA patch, and finally restart daemons. This will also re-print the `metalid.sh` content incase it was skipped in the previous step. **Re-installs** can skip running `csi config init` entirely and simply run `pit-init.sh` after gathering CSI input files into `/var/www/ephemeral/prep`.
+   > **`NOTE`** `pit-init` will re-run `csi config init`, copy all generated files into place, apply the CA patch, and finally restart daemons. This will also re-print the `metalid.sh` content in case it was skipped in the previous step. **Re-installs** can skip running `csi config init` entirely and simply run `pit-init.sh` after gathering CSI input files into `/var/www/ephemeral/prep`.
 
     ```bash
     pit# export USERNAME=root

--- a/install/bootstrap_livecd_usb.md
+++ b/install/bootstrap_livecd_usb.md
@@ -34,8 +34,8 @@ Fetch the base installation CSM tarball and extract it, installing the contained
 1. Set up the Typescript directory as well as the initial typescript. This directory will be returned to for every typescript in the entire CSM installation.
 
    ```bash
-   linux:usb# script -af csm-install-usb.$(date +%Y-%m-%d).txt
-   linux:usb# export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
+   linux# script -af csm-install-usb.$(date +%Y-%m-%d).txt
+   linux# export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
    ```
 
 1. The CSM software release should be downloaded and expanded for use.
@@ -47,15 +47,14 @@ Fetch the base installation CSM tarball and extract it, installing the contained
 
    > Note: Expansion of the tarball may take more than 45 minutes.
 
-   The rest of this procedure will use the CSM_RELEASE variable and expect to have the
-   contents of the CSM software release tarball plus any patches or hotfixes.
+   The rest of this procedure will use the `CSM_RELEASE` and `CSM_PATH` variables.
 
    ```bash
-   linux:usb# CSM_RELEASE=csm-x.y.z
-   linux:usb# echo $CSM_RELEASE
-   linux:usb# tar -zxvf ${CSM_RELEASE}.tar.gz
-   linux:usb# ls -l ${CSM_RELEASE}
-   linux:usb# CSM_PATH=$(pwd)/${CSM_RELEASE}
+   linux# CSM_RELEASE=csm-x.y.z
+   linux# echo $CSM_RELEASE
+   linux# tar -zxvf ${CSM_RELEASE}.tar.gz
+   linux# ls -l ${CSM_RELEASE}
+   linux# CSM_PATH=$(pwd)/${CSM_RELEASE}
    ```
 
    The ISO and other files are now available in the directory from the extracted CSM tar.
@@ -63,7 +62,7 @@ Fetch the base installation CSM tarball and extract it, installing the contained
 1. Install/upgrade CSI; check if a newer version was included in the tar-ball.
 
    ```bash
-   linux:usb# rpm -Uvh $(find ./${CSM_RELEASE}/rpm/cray/csm/ -name "cray-site-init-*.x86_64.rpm" | sort -V | tail -1)
+   linux# rpm -Uvh $(find ./${CSM_RELEASE}/rpm/cray/csm/ -name "cray-site-init-*.x86_64.rpm" | sort -V | tail -1)
    ```
 
 1. Download and install/upgrade the documentation RPM. If this machine does not have direct internet
@@ -74,7 +73,7 @@ Fetch the base installation CSM tarball and extract it, installing the contained
 1. Show the version of CSI installed.
 
    ```bash
-   linux:usb# csi version
+   linux# csi version
    ```
 
    Expected output looks similar to the following:
@@ -92,7 +91,7 @@ Fetch the base installation CSM tarball and extract it, installing the contained
 1. Configure zypper with the `embedded` repository from the CSM release.
 
    ```bash
-   linux:usb# zypper ar -fG "${CSM_PATH}/rpm/embedded" "${CSM_RELEASE}-embedded"
+   linux# zypper ar -fG "${CSM_PATH}/rpm/embedded" "${CSM_RELEASE}-embedded"
    ```
 
 1. Install podman or docker to support container tools required to generated
@@ -104,14 +103,14 @@ Fetch the base installation CSM tarball and extract it, installing the contained
    * Install `podman` and `podman-cni-config` packages:
 
      ```bash
-     linux:usb# zypper in --repo ${CSM_RELEASE}-embedded -y podman podman-cni-config
+     linux# zypper in --repo ${CSM_RELEASE}-embedded -y podman podman-cni-config
      ```
 
    Or one may use `rpm -Uvh` to install RPMs (and their dependencies) manually
    from the `${CSM_PATH}/rpm/embedded` directory.
    ```bash
-   linux:usb# rpm -Uvh ${CSM_PATH}/rpm/embedded/suse/SLE-Module-Containers/15-SP2/x86_64/update/x86_64/podman-*.x86_64.rpm
-   linux:usb# rpm -Uvh ${CSM_PATH}/rpm/embedded/suse/SLE-Module-Containers/15-SP2/x86_64/update/noarch/podman-cni-config-*.noarch.rpm
+   linux# rpm -Uvh ${CSM_PATH}/rpm/embedded/suse/SLE-Module-Containers/15-SP2/x86_64/update/x86_64/podman-*.x86_64.rpm
+   linux# rpm -Uvh ${CSM_PATH}/rpm/embedded/suse/SLE-Module-Containers/15-SP2/x86_64/update/noarch/podman-cni-config-*.noarch.rpm
    ```
 
 1. Install lsscsi to view attached storage devices.
@@ -122,22 +121,16 @@ Fetch the base installation CSM tarball and extract it, installing the contained
    * Install `lsscsi` package:
 
      ```bash
-     linux:usb# zypper in --repo ${CSM_RELEASE}-embedded -y lsscsi
+     linux# zypper in --repo ${CSM_RELEASE}-embedded -y lsscsi
      ```
 
    Or one may use `rpm -Uvh` to install RPMs (and their dependencies) manually
    from the `${CSM_PATH}/rpm/embedded` directory.
    ```bash
-   linux:usb# rpm -Uvh ${CSM_PATH}/rpm/embedded/suse/SLE-Module-Basesystem/15-SP2/x86_64/product/x86_64/lsscsi-*.x86_64.rpm
+   linux# rpm -Uvh ${CSM_PATH}/rpm/embedded/suse/SLE-Module-Basesystem/15-SP2/x86_64/product/x86_64/lsscsi-*.x86_64.rpm
    ```
 
-
-1. Although not strictly required, the procedures for setting up the
-   `site-init` directory recommend persisting `site-init` files in a Git
-   repository.
-
-   Follow the procedure in [Prepare Site Init](prepare_site_init.md) to set up the site-init directory for your system.
-
+1. Follow the procedure in [Prepare Site Init](prepare_site_init.md) to set up the `site-init` directory for your system.
 
 <a name="create-the-bootable-media"></a>
 ### 2. Create the Bootable Media
@@ -150,7 +143,7 @@ which device that is.
     This example shows the USB device is /dev/sdd on the host.
 
     ```bash
-    linux:usb# lsscsi
+    linux# lsscsi
     ```
 
     Expected output looks similar to the following:
@@ -167,7 +160,7 @@ which device that is.
     Set a variable with your disk to avoid mistakes:
 
     ```bash
-    linux:usb# export USB=/dev/sd<disk_letter>
+    linux# export USB=/dev/sd<disk_letter>
     ```
 
 1. Format the USB device
@@ -175,7 +168,7 @@ which device that is.
     On Linux using the CSI application:
 
     ```bash
-    linux:usb# csi pit format $USB ${CSM_PATH}/cray-pre-install-toolkit-*.iso 50000
+    linux# csi pit format $USB ${CSM_PATH}/cray-pre-install-toolkit-*.iso 50000
     ```
 
     > Note: If the previous command fails with this error message, this indicates that this Linux computer does not have the checkmedia RPM installed. In that case, the RPM can be installed and `csi pit format` can be run again
@@ -186,14 +179,14 @@ which device that is.
     >   1.  Install the missing rpms
     >
     >   ```bash
-    >   linux:usb# zypper in --repo ${CSM_RELEASE}-embedded -y libmediacheck5 checkmedia
-    >   linux:usb# csi pit format $USB ${CSM_PATH}/cray-pre-install-toolkit-*.iso 50000
+    >   linux# zypper in --repo ${CSM_RELEASE}-embedded -y libmediacheck5 checkmedia
+    >   linux# csi pit format $USB ${CSM_PATH}/cray-pre-install-toolkit-*.iso 50000
     >   ```
 
     On MacOS using the bash script:
 
     ```bash
-    macos:usb# ./cray-site-init/write-livecd.sh $USB ${CSM_PATH}/cray-pre-install-toolkit-*.iso 50000
+    macos# ./cray-site-init/write-livecd.sh $USB ${CSM_PATH}/cray-pre-install-toolkit-*.iso 50000
     ```
 
     > NOTE: At this point the USB device is usable in any server with an x86_64 architecture based CPU. The remaining steps help add the installation data and enable SSH on boot.
@@ -201,14 +194,14 @@ which device that is.
 1. Mount the configuration and persistent data partition:
 
     ```bash
-    linux:usb# mkdir -pv /mnt/{cow,pitdata}
-    linux:usb# mount -vL cow /mnt/cow && mount -vL PITDATA /mnt/pitdata
+    linux# mkdir -pv /mnt/{cow,pitdata}
+    linux# mount -vL cow /mnt/cow && mount -vL PITDATA /mnt/pitdata
     ```
 
 1.  Copy and extract the tarball (compressed) into the USB:
     ```bash
-    linux:usb# cp -v ${CSM_PATH}.tar.gz /mnt/pitdata/
-    linux:usb# tar -zxvf ${CSM_PATH}.tar.gz -C /mnt/pitdata/
+    linux# cp -v ${CSM_PATH}.tar.gz /mnt/pitdata/
+    linux# tar -zxvf ${CSM_PATH}.tar.gz -C /mnt/pitdata/
     ```
 
 The USB device is now bootable and contains our artifacts. This may be useful for internal or quick usage. Administrators seeking a Shasta installation must continue onto the [configuration payload](#configuration-payload).
@@ -235,8 +228,8 @@ Some files are needed for generating the configuration payload. See these topics
 1. Change into the preparation directory plus necessary PIT directories (for later):
 
    ```bash
-   linux:usb# mkdir -pv /mnt/pitdata/admin /mnt/pitdata/prep /mnt/pitdata/configs /mnt/pitdata/data/{k8s,ceph}
-   linux:usb# cd /mnt/pitdata/prep
+   linux# mkdir -pv /mnt/pitdata/admin /mnt/pitdata/prep /mnt/pitdata/configs /mnt/pitdata/data/{k8s,ceph}
+   linux# cd /mnt/pitdata/prep
    ```
 
 1. Pull these files into the current working directory, or create them if this is a first-time/initial install:
@@ -322,7 +315,7 @@ Some files are needed for generating the configuration payload. See these topics
       >   {"Source":"x3000door-Motiv","SourceRack":"x3000","SourceLocation":" ","DestinationRack":"x3000","DestinationLocation":"u36","DestinationPort":"j27"}}
       >   ```
 
-   1. Skip the next step and continue to [prepare site init](#prepare_site_init).
+   1. Skip the next step and continue to [prepare site init](#prepare-site-init).
 
 <a name="first-timeinitial-installs-bare-metal"></a>
 ##### 3.1.b First-Time/Initial Installs (bare-metal)
@@ -354,7 +347,7 @@ Some files are needed for generating the configuration payload. See these topics
       ```
 
    1. Generate the system config:
-      > **`NOTE`** the provided command below is an **example only**, run `csi config init --help` to print a full list of parameters that must be set. These will vary sifnificatnly depending on ones system and site configuration.
+      > **`NOTE`** the provided command below is an **example only**, run `csi config init --help` to print a full list of parameters that must be set. These will vary significatnly depending on ones system and site configuration.
       
       ```bash
       linux:/mnt/pitdata/prep# csi config init \
@@ -430,9 +423,9 @@ Some files are needed for generating the configuration payload. See these topics
       >    {"Source":"x3000door-Motiv","SourceRack":"x3000","SourceLocation":" ","DestinationRack":"x3000","DestinationLocation":"u36","DestinationPort":"j27"}}
       >    ```
 
-   1. Continue to the next step to [prepare site init](#prepare_site_init).
+   1. Continue to the next step to [prepare site init](#prepare-site-init).
       
-<a name="prepare_site_init"></a>
+<a name="prepare-site-init"></a>
 #### 3.2 Prepare Site Init
 
 > **`NOTE`**: It is assumed at this point that `/mnt/pitdata` is still mounted on the linux system, this is important as the following procedure depends on that mount existing.  
@@ -657,7 +650,7 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
 
 1. Set the same variables from the `csi config init` step from earlier, and then invoke "PIT init" to setup the PIT server for deploying NCNs.
     > The data partition is set to `fsopt=noauto` to facilitate LiveCDs over virtual-ISO mount. USB installations need to mount this manually.
-   > **`NOTE`** `pit-init` will re-run `csi config init`, copy all generated files into place, apply the CA patch, and finally restart daemons. This will also re-print the `metalid.sh` content incase it was skipped in the previous step. **Re-installs** can skip running `csi config init` entirely and simply run `pit-init.sh` after gathering CSI input files into `/var/www/ephemeral/prep`.
+   > **`NOTE`** `pit-init` will re-run `csi config init`, copy all generated files into place, apply the CA patch, and finally restart daemons. This will also re-print the `metalid.sh` content in case it was skipped in the previous step. **Re-installs** can skip running `csi config init` entirely and simply run `pit-init.sh` after gathering CSI input files into `/var/www/ephemeral/prep`.
    
     ```bash
     pit# export SYSTEM_NAME=eniac
@@ -674,7 +667,7 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
 
 1. Set shell environment variables.
 
-   The CSM_RELEASE and CSM_PATH variables will be used later.
+   The `CSM_RELEASE` and `CSM_PATH` variables will be used later.
 
    ```bash
    pit# cd /var/www/ephemeral
@@ -686,7 +679,7 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
 
 1. Install Goss Tests and Server
 
-   The following assumes the CSM_PATH environment variable is set to the absolute path of the unpacked CSM release.
+   The following assumes the `CSM_PATH` environment variable is set to the absolute path of the unpacked CSM release.
 
    ```bash
    pit:/var/www/ephemeral# rpm -Uvh --force $(find ${CSM_PATH}/rpm/cray/csm/ -name "goss-servers*.rpm" | sort -V | tail -1)

--- a/install/bootstrap_livecd_usb.md
+++ b/install/bootstrap_livecd_usb.md
@@ -130,26 +130,6 @@ Fetch the base installation CSM tarball and extract it, installing the contained
    linux# rpm -Uvh ${CSM_PATH}/rpm/embedded/suse/SLE-Module-Basesystem/15-SP2/x86_64/product/x86_64/lsscsi-*.x86_64.rpm
    ```
 
-1. Although not strictly required, the procedures for setting up the
-   `site-init` directory recommend persisting `site-init` files in a Git
-   repository.
-
-   Git RPMs are included in the `embedded` repository in the CSM release and
-   may be installed in your pre-LiveCD environment using `zypper` as follows:
-
-   * Install `git` package:
-
-     ```bash
-     linux:usb# zypper in --repo ${CSM_RELEASE}-embedded -y git
-     ```
-
-   Or one may use `rpm -Uvh` to install RPMs (and their dependencies) manually
-   from the `${CSM_PATH}/rpm/embedded` directory.
-   ```bash
-   linux:usb# rpm -Uvh ${CSM_PATH}/rpm/embedded/suse/SLE-Module-Basesystem/15-SP2/x86_64/update/x86_64/git-core-*.x86_64.rpm
-   linux:usb# rpm -Uvh ${CSM_PATH}/rpm/embedded/suse/SLE-Module-Development-Tools/15-SP2/x86_64/update/x86_64/git-*.x86_64.rpm
-   ```
-
 <a name="create-the-bootable-media"></a>
 ### 2. Create the Bootable Media
 
@@ -448,7 +428,13 @@ Some files are needed for generating the configuration payload. See these topics
 
 > **`NOTE`**: It is assumed at this point that `/mnt/pitdata` is still mounted on the linux system, this is important as the following procedure depends on that mount existing.  
 
-Follow the procedures to [Prepare Site Init](prepare_site_init.md) directory for your system.
+1. Install Git if not already installed (recommended).
+
+    Although not strictly required, the procedures for setting up the
+   `site-init` directory recommend persisting `site-init` files in a Git
+   repository.
+
+1. Follow all of the [Prepare Site Init](prepare_site_init.md) procedures.
 
 <a name="prepopulate-livecd-daemons-configuration-and-ncn-artifacts"></a>
 ### 4. Prepopulate LiveCD Daemons Configuration and NCN Artifacts

--- a/install/bootstrap_livecd_usb.md
+++ b/install/bootstrap_livecd_usb.md
@@ -10,11 +10,9 @@ There are 5 overall steps that provide a bootable USB with SSH enabled, capable 
    1. [Download and Expand the CSM Release](#download-and-expand-the-csm-release)
    1. [Create the Bootable Media](#create-the-bootable-media)
    1. [Configuration Payload](#configuration-payload)
-      1. [Before Configuration Payload Workarounds](#before-configuration-payload-workarounds)
       1. [Generate Installation Files](#generate-installation-files)
          1. [Subsequent Fresh-Installs (Re-Installs)](#subsequent-fresh-installs-re-installs)
          1. [First-Time/Initial Installs (bare-metal)](#first-timeinitial-installs-bare-metal)
-      1. [CSI Workarounds](#csi-workarounds)
       1. [Prepare Site Init](#prepare-site-init)
    1. [Prepopulate LiveCD Daemons Configuration and NCN Artifacts](#prepopulate-livecd-daemons-configuration-and-ncn-artifacts)
    1. [Boot the LiveCD](#boot-the-livecd)
@@ -42,15 +40,15 @@ Fetch the base installation CSM tarball and extract it, installing the contained
 
 1. The CSM software release should be downloaded and expanded for use.
 
-   **Important:** To ensure that the CSM release plus any patches, workarounds, or hotfixes are included
-   follow the instructions in [Update CSM Product Stream](../update_product_stream/index.md)
+   **Important:** In order to ensure that the CSM release plus any patches, documentation updates, 
+   or hotfixes are included, follow the instructions in [Update CSM Product Stream](../update_product_stream/index.md)
 
    **Important:** Download to a location that has sufficient space for both the tarball and the expanded tarball.
 
    > Note: Expansion of the tarball may take more than 45 minutes.
 
    The rest of this procedure will use the CSM_RELEASE variable and expect to have the
-   contents of the CSM software release tarball plus any patches, workarounds, or hotfixes.
+   contents of the CSM software release tarball plus any patches or hotfixes.
 
    ```bash
    linux:usb# CSM_RELEASE=csm-x.y.z
@@ -68,11 +66,10 @@ Fetch the base installation CSM tarball and extract it, installing the contained
    linux:usb# rpm -Uvh $(find ./${CSM_RELEASE}/rpm/cray/csm/ -name "cray-site-init-*.x86_64.rpm" | sort -V | tail -1)
    ```
 
-1. Download and install/upgrade the workaround and documentation RPMs. If this machine does not have direct internet
-   access these RPMs will need to be externally downloaded and then copied to this machine.
+1. Download and install/upgrade the documentation RPM. If this machine does not have direct internet
+   access this RPM will need to be externally downloaded and then copied to this machine.
 
-   **Important:** To ensure that the latest workarounds and documentation updates are available,
-   see [Check for Latest Workarounds and Documentation Updates](../update_product_stream/index.md#workarounds)
+   See [Check for Latest Documentation](../update_product_stream/index.md#documentation)
 
 1. Show the version of CSI installed.
 
@@ -220,18 +217,11 @@ The USB device is now bootable and contains our artifacts. This may be useful fo
 
 The SHASTA-CFG structure and other configuration files will be prepared, then `csi` will generate system-unique configuration payload used for the rest of the CSM installation on the USB device.
 
-* [Before Configuration Payload Workarounds](#before-configuration-payload-workarounds)
 * [Generate Installation Files](#generate-installation-files)
-* [CSI Workarounds](#csi-workarounds)
 * [Prepare Site Init](#prepare-site-init)
 
-<a name="before-configuration-payload-workarounds"></a>
-#### 3.1 Before Configuration Payload Workarounds
-
-Follow the [workaround instructions](../update_product_stream/index.md#apply-workarounds) for the `before-configuration-payload` breakpoint.
-
 <a name="generate-installation-files"></a>
-#### 3.2 Generate Installation Files
+#### 3.1 Generate Installation Files
 
 Some files are needed for generating the configuration payload. See these topics in [Prepare Configuration Payload](prepare_configuration_payload.md) if one has not already prepared the information for this system.
 
@@ -267,7 +257,7 @@ Some files are needed for generating the configuration payload. See these topics
    After gathering the files into this working directory, move on to [Subsequent Fresh-Installs (Re-Installs)](#subsequent-fresh-installs-re-installs).
 
 <a name="subsequent-fresh-installs-re-installs"></a>
-##### 3.2.a Subsequent Fresh-Installs (Re-Installs)
+##### 3.1.a Subsequent Fresh-Installs (Re-Installs)
 
 1. **For subsequent fresh-installs (re-installs) where the `system_config.yaml` parameter file is available**, generate the updated system configuration (see [avoiding parameters](../background/cray_site_init_files.md#save-file--avoiding-parameters)).
 
@@ -332,10 +322,10 @@ Some files are needed for generating the configuration payload. See these topics
       >   {"Source":"x3000door-Motiv","SourceRack":"x3000","SourceLocation":" ","DestinationRack":"x3000","DestinationLocation":"u36","DestinationPort":"j27"}}
       >   ```
 
-   1. Skip the next step and continue with the [CSI Workarounds](#csi-workarounds).
+   1. Skip the next step and continue to [prepare site init](#prepare_site_init).
 
 <a name="first-timeinitial-installs-bare-metal"></a>
-##### 3.2.b First-Time/Initial Installs (bare-metal)
+##### 3.1.b First-Time/Initial Installs (bare-metal)
 
 1. **For first-time/initial installs (without a `system_config.yaml`file)**, generate the system configuration. See below for an explanation of the command line parameters and some common settings.
 
@@ -440,15 +430,10 @@ Some files are needed for generating the configuration payload. See these topics
       >    {"Source":"x3000door-Motiv","SourceRack":"x3000","SourceLocation":" ","DestinationRack":"x3000","DestinationLocation":"u36","DestinationPort":"j27"}}
       >    ```
 
-   1. Continue with the next step to apply the [csi-config workarounds](#33-csi-workarounds).
+   1. Continue to the next step to [prepare site init](#prepare_site_init).
       
-<a name="csi-workarounds"></a>
-#### 3.3 CSI Workarounds
-
-Follow the [workaround instructions](../update_product_stream/index.md#apply-workarounds) for the `csi-config` breakpoint.
-
 <a name="prepare_site_init"></a>
-#### 3.4 Prepare Site Init
+#### 3.2 Prepare Site Init
 
 > **`NOTE`**: It is assumed at this point that `/mnt/pitdata` is still mounted on the linux system, this is important as the following procedure depends on that mount existing.  
 

--- a/install/bootstrap_livecd_usb.md
+++ b/install/bootstrap_livecd_usb.md
@@ -130,7 +130,25 @@ Fetch the base installation CSM tarball and extract it, installing the contained
    linux# rpm -Uvh ${CSM_PATH}/rpm/embedded/suse/SLE-Module-Basesystem/15-SP2/x86_64/product/x86_64/lsscsi-*.x86_64.rpm
    ```
 
-1. Follow the procedure in [Prepare Site Init](prepare_site_init.md) to set up the `site-init` directory for your system.
+1. Although not strictly required, the procedures for setting up the
+   `site-init` directory recommend persisting `site-init` files in a Git
+   repository.
+
+   Git RPMs are included in the `embedded` repository in the CSM release and
+   may be installed in your pre-LiveCD environment using `zypper` as follows:
+
+   * Install `git` package:
+
+     ```bash
+     linux:usb# zypper in --repo ${CSM_RELEASE}-embedded -y git
+     ```
+
+   Or one may use `rpm -Uvh` to install RPMs (and their dependencies) manually
+   from the `${CSM_PATH}/rpm/embedded` directory.
+   ```bash
+   linux:usb# rpm -Uvh ${CSM_PATH}/rpm/embedded/suse/SLE-Module-Basesystem/15-SP2/x86_64/update/x86_64/git-core-*.x86_64.rpm
+   linux:usb# rpm -Uvh ${CSM_PATH}/rpm/embedded/suse/SLE-Module-Development-Tools/15-SP2/x86_64/update/x86_64/git-*.x86_64.rpm
+   ```
 
 <a name="create-the-bootable-media"></a>
 ### 2. Create the Bootable Media

--- a/install/collect_mac_addresses_for_ncns.md
+++ b/install/collect_mac_addresses_for_ncns.md
@@ -120,8 +120,6 @@ making a backup of them, in case they need to be examined at a later time.
          {"Source":"x3000door-Motiv","SourceRack":"x3000","SourceLocation":" ","DestinationRack":"x3000","DestinationLocation":"u36","DestinationPort":"j27"}}
 
 
-1. Follow the [workaround instructions](../update_product_stream/index.md#apply-workarounds) for the `csi-config` breakpoint.
-
 1. Copy the interface config files generated earlier by `csi config init` into `/etc/sysconfig/network/`.
 
    ```bash
@@ -187,8 +185,6 @@ making a backup of them, in case they need to be examined at a later time.
         ```bash
         pit# systemctl restart basecamp nexus dnsmasq conman
         ```
-
-1. Follow the [workaround instructions](../update_product_stream/index.md#apply-workarounds) for the `before-ncn-boot` breakpoint.
 
 1. Verify that all BMCs can be pinged.
 
@@ -313,8 +309,6 @@ making a backup of them, in case they need to be examined at a later time.
          {"Source":"x3000door-Motiv","SourceRack":"x3000","SourceLocation":" ","DestinationRack":"x3000","DestinationLocation":"u36","DestinationPort":"j27"}}
 
 
-1. Follow the [workaround instructions](../update_product_stream/index.md#apply-workarounds) for the `csi-config` breakpoint.
-
 1. Copy the interface config files generated earlier by `csi config init` into `/etc/sysconfig/network/`.
 
    ```bash
@@ -397,8 +391,6 @@ making a backup of them, in case they need to be examined at a later time.
    pit# alias yq="/var/www/ephemeral/prep/site-init/utils/bin/$(uname | awk '{print tolower($0)}')/yq"
    pit# yq merge -xP -i /var/www/ephemeral/prep/site-init/customizations.yaml <(yq prefix -P "/var/www/ephemeral/prep/${SYSTEM_NAME}/customizations.yaml" spec)
    ```
-
-1. Follow the [workaround instructions](../update_product_stream/index.md#apply-workarounds) for the `before-ncn-boot` breakpoint.
 
 <a name="next-topic"></a>
 # Next Topic

--- a/install/collecting_ncn_mac_addresses.md
+++ b/install/collecting_ncn_mac_addresses.md
@@ -270,11 +270,7 @@ If the  `ncn_metadata.csv` file is incorrect, the NCNs will be unable to deploy.
     pit# yq merge -xP -i /var/www/ephemeral/prep/site-init/customizations.yaml <(yq prefix -P "/var/www/ephemeral/prep/${SYSTEM_NAME}/customizations.yaml" spec)
     ```
 
-8. Follow the [workaround instructions](../update_product_stream/index.md#apply-workarounds) for the `before-ncn-boot` breakpoint.
-   
-   Return to this procedure after applying the workaround instructions.
-
-9. Wipe the disks before relaunching the NCNs.
+8. Wipe the disks before relaunching the NCNs.
 
    See [full wipe from Wipe NCN Disks for Reinstallation](wipe_ncn_disks_for_reinstallation.md#full-wipe).
 

--- a/install/deploy_final_ncn.md
+++ b/install/deploy_final_ncn.md
@@ -84,8 +84,6 @@ the Kubernetes cluster as the final of three master nodes forming a quorum.
         export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
         ```
 
-1. Follow the [workaround instructions](../update_product_stream/index.md#apply-workarounds) for the `livecd-pre-reboot` breakpoint.
-
 1. Upload SLS file.
     
     > **NOTE:** The system name environment variable `SYSTEM_NAME` must be set.
@@ -165,7 +163,7 @@ the Kubernetes cluster as the final of three master nodes forming a quorum.
 
 1. <a name="csi-handoff-bss-metadata"></a>Upload the same `data.json` file we used to BSS, our Kubernetes cloud-init DataSource. 
 
-    __If you have made any changes__ to this file as a result of any customizations or workarounds, use the path to that file instead. This step will prompt for the root password of the NCNs.
+    __If you have made any changes__ to this file (for example, as a result of any customizations or workarounds), use the path to that file instead. This step will prompt for the root password of the NCNs.
 
     ```bash
     pit# csi handoff bss-metadata --data-file /var/www/ephemeral/configs/data.json || echo "ERROR: csi handoff bss-metadata failed"
@@ -449,13 +447,10 @@ the Kubernetes cluster as the final of three master nodes forming a quorum.
     ncn-m001# rm -v /etc/zypp/repos.d/* && zypper ms --remote --disable
     ```
 
-1. Download and install/upgrade the workaround and documentation RPMs. 
+1. Download and install/upgrade the documentation RPM. If this machine does not have direct internet
+   access this RPM will need to be externally downloaded and then copied to this machine.
 
-    If this machine does not have direct internet access these RPMs will need to be externally downloaded and then copied to this machine.
-
-    **Important:** To ensure that the latest workarounds and documentation updates are available, see [Check for Latest Workarounds and Documentation Updates](../update_product_stream/index.md#workarounds)
-
-1. Follow the [workaround instructions](../update_product_stream/index.md#apply-workarounds) for the `livecd-post-reboot` breakpoint.
+    See [Check for Latest Documentation](../update_product_stream/index.md#documentation)
 
 1. Exit the typescript and move the backup to `ncn-m001`, thus removing the need to track `ncn-m002` as yet-another bootstrapping agent. This is required to facilitate reinstallations, because it pulls the preparation data back over to the documented area (`ncn-m001`).
 

--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -22,7 +22,6 @@ the number of storage and worker nodes.
 
    1. [Prepare for Management Node Deployment](#prepare_for_management_node_deployment)
       1. [Tokens and IPMI Password](#tokens-and-ipmi-password)
-      1. [Apply NCN Pre-Boot Workarounds](#apply-ncn-pre-boot-workarounds)
       1. [Ensure Time Is Accurate Before Deploying NCNs](#ensure-time-is-accurate-before-deploying-ncns)
    1. [Update Management Node Firmware](#update_management_node_firmware)
    1. [Deploy Management Nodes](#deploy_management_nodes)
@@ -30,7 +29,6 @@ the number of storage and worker nodes.
       1. [Deploy](#deploy)
       1. [Check LVM on Masters and Workers](#check-lvm-on-masters-and-workers)
       1. [Check for Unused Drives on Utility Storage Nodes](#check-for-unused-drives-on-utility-storage-nodes)
-      1. [Apply NCN Post-Boot Workarounds](#apply-ncn-post-boot-workarounds)
    1. [Configure after Management Node Deployment](#configure_after_management_node_deployment)
       1. [LiveCD Cluster Authentication](#livecd-cluster-authentication)
       1. [Install Tests and Test Server on NCNs](#install-tests)
@@ -75,15 +73,8 @@ Preparation of the environment must be done before attempting to deploy the mana
    pit# grep -oP "($mtoken|$stoken|$wtoken)" /etc/dnsmasq.d/statics.conf | sort -u | xargs -t -i ipmitool -I lanplus -U $USERNAME -E -H {} power off
    ```
 
-<a name="apply-ncn-pre-boot-workarounds"></a>
-### 1.2 Apply NCN Pre-Boot Workarounds
-
-_There will be post-boot workarounds as well._
-
-Follow the [workaround instructions](../update_product_stream/index.md#apply-workarounds) for the `before-ncn-boot` breakpoint.
-
 <a name="ensure-time-is-accurate-before-deploying-ncns"></a>
-### 1.3 Ensure Time Is Accurate Before Deploying NCNs
+### 1.2 Ensure Time Is Accurate Before Deploying NCNs
 
 **NOTE**: If you wish to use a timezone other than UTC, instead of step 1 below, follow
 [this procedure for setting a local timezone](../operations/node_management/Configure_NTP_on_NCNs.md#set-a-local-timezone), then
@@ -337,8 +328,6 @@ The configuration workflow described here is intended to help understand the exp
     ncn-w002-mgmt
     ncn-w003-mgmt
     ```
-
-    > **`IMPORTANT`** This is the administrator's _last chance_ to run [NCN pre-boot workarounds](#apply-ncn-pre-boot-workarounds) (the `before-ncn-boot` breakpoint).
 
     > **`NOTE`**: All consoles are located at `/var/log/conman/console*`
 <a name="boot-the-storage-nodes"></a>
@@ -678,16 +667,10 @@ If there are LVM check failures, then the problem must be resolved before contin
 
 More information can be found at [the `cephadm` reference page](../operations/utility_storage/Cephadm_Reference_Material.md).
 
-<a name="apply-ncn-post-boot-workarounds"></a>
-### 3.5 Apply NCN Post-Boot Workarounds
-
-Follow the [workaround instructions](../update_product_stream/index.md#apply-workarounds) for the `after-ncn-boot` breakpoint.
-
 <a name="configure_after_management_node_deployment"></a>
 ## 4. Configure after Management Node Deployment
 
 After the management nodes have been deployed, configuration can be applied to the booted nodes.
-
 
 <a name="livecd-cluster-authentication"></a>
 ### 4.1 LiveCD Cluster Authentication

--- a/install/install_csm_services.md
+++ b/install/install_csm_services.md
@@ -8,7 +8,6 @@ This procedure will install CSM applications and services into the CSM Kubernete
 
 1.  [Install Yapl](#install-yapl)
 1.  [Install CSM Services](#install-csm-services)
-1.  [Apply After Sysmgmt Manifest Workarounds](#apply-after-sysmgmt-manifest-workarounds)
 1.  [Wait For Everything To Settle](#wait-for-everything-to-settle)
 1.  [Known Issues](#known-issues)
     - [install.sh known issues](#known-issues-install-sh)
@@ -56,22 +55,17 @@ pit# rpm -Uvh /var/www/ephemeral/${CSM_RELEASE}/rpm/cray/csm/sle-15sp2/x86_64/ya
          cp -v /usr/share/doc/csm/install/scripts/csm_services/yapl.log /var/www/ephemeral/prep/logs
     ```
 
-<a name="apply-after-sysmgmt-manifest-workarounds"></a>
-### 3. Apply After Sysmgmt Manifest Workarounds
-
-Follow the [workaround instructions](../update_product_stream/index.md#apply-workarounds) for the `after-sysmgmt-manifest` breakpoint.
-
 <a name="wait-for-everything-to-settle"></a>
-### 4. Wait For Everything To Settle
+### 3. Wait For Everything To Settle
 
 Wait **at least 15 minutes** to let the various Kubernetes resources get initialized and started before proceeding with the rest of the install.
 Because there are a number of dependencies between them, some services are not expected to work immediately after the install script completes.
 
 <a name="known-issues"></a>
-### 5. Known Issues
+### 4. Known Issues
 
 <a name="known-issues-install-sh"></a>
-#### 5.1 install.sh known issues
+#### 4.1 install.sh known issues
 
 The `install.sh` script changes cluster state and should not simply be rerun
 in the event of a failure without careful consideration of the specific
@@ -117,12 +111,12 @@ The following error may occur when running `./install.sh`:
 1. Running `install.sh` again is expected to succeed.
 
 <a name="known-issues-setup-nexus"></a>
-#### 5.2 Setup Nexus known issues
+#### 4.2 Setup Nexus known issues
 
 Known potential issues with suggested fixes are listed in [Troubleshoot Nexus](../operations/package_repository_management/Troubleshoot_Nexus.md).
 
 <a name="next-topic"></a>
-### 6. Next Topic
+### 5. Next Topic
 
 After completing this procedure the next step is to validate CSM health before redeploying the final NCN.
 

--- a/introduction/index.md
+++ b/introduction/index.md
@@ -48,7 +48,7 @@ See [Scenarios for Shasta v1.5](scenarios.md)
 <a name="product-stream-updates"></a>
 ## CSM Product Stream Updates
 
-   The software included in the CSM product stream is released in more than one way. The initial product release may be augmented with late-breaking workarounds and documentation updates or hotfixes after the release.
+   The software included in the CSM product stream is released in more than one way. The initial product release may be augmented with late-breaking documentation updates or hotfixes after the release.
 
    See [CSM Product Stream Updates](../update_product_stream/index.md)
 

--- a/troubleshooting/index.md
+++ b/troubleshooting/index.md
@@ -60,19 +60,20 @@ Press any key to continue...
 
 Follow these steps on any NCN to fix the issue:
 
-   1. Run the `CASMINST-2689.sh` script from the `CASMINST-2689` workaround at the `livecd-post-reboot` breakpoint.
+   1. Install the Shasta 1.4 (a.k.a. CSM 0.9) install workaround RPM. See the CSM 0.9 documentation for details on how to do this.
 
-      Follow the usual [workaround instructions](../update_product_stream/index.md#apply-workarounds) **with the following exceptions**:
-         * Use the latest Shasta 1.4 install workaround RPM, **not** the Shasta 1.5 install workaround RPM
-         * For the  `livecd-post-reboot` breakpoint, ignore any workarounds other than `CASMINST-2689`
-         * Do not follow the workaround `README.md` instructions -- only run the `CASMINST-2689.sh` script in the `CASMINST-2689` subdirectory
+   1. Run the `CASMINST-2689.sh` script from the `CASMINST-2689` workaround at the `livecd-post-reboot` breakpoint:
+   
+      ```bash
+      ncn# /opt/cray/csm/workarounds/livecd-post-reboot/CASMINST-2689/CASMINST-2689.sh
+      ```
 
    1. Run these commands:
 
       ```bash
       ncn# for i in $(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u |  tr -t '\n' ' '); do
-         scp -r csm-install-workarounds/workarounds/livecd-post-reboot/CASMINST-2689/ $i:/opt/cray/csm/workarounds/livecd-post-reboot/
-      done
+               scp -r /opt/cray/csm/workarounds/livecd-post-reboot/CASMINST-2689 $i:/opt/cray/csm/workarounds/livecd-post-reboot/
+            done
       ncn# pdsh -b -S -w $(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u |  tr -t '\n' ',') '/opt/cray/csm/workarounds/livecd-post-reboot/CASMINST-2689/CASMINST-2689.sh'
       ```
 

--- a/update_product_stream/index.md
+++ b/update_product_stream/index.md
@@ -1,21 +1,15 @@
 # Update CSM Product Stream
 
-The software included in the CSM product stream is released in more than one way. The initial product release may be augmented with patches, late-breaking workarounds and documentation updates, or hotfixes after the release.
+The software included in the CSM product stream is released in more than one way. The initial product release may be augmented with patches, documentation updates, or hotfixes after the release.
 
-The CSM documentation is included within the CSM product release tarball inside the docs-csm RPM.
-After it has been installed, the documentation will be available at `/usr/share/doc/csm` as installed by
-the docs-csm RPM.
+The CSM documentation is included within the CSM product release tarball inside the `docs-csm` RPM.
+After the RPM has been installed, the documentation will be available at `/usr/share/doc/csm`.
 
-### Topics:
+## Topics:
    * [Download and Extract CSM Product Release](#download-and-extract)
    * [Apply Patch to CSM Release](#patch)
-   * [Check for Latest Workarounds and Documentation Updates](#workarounds)
-   * [Check for and Apply Workarounds](#apply-workarounds)
+   * [Check for Latest Documentation](#documentation)
    * [Check for Field Notices about Hotfixes](#hotfixes)
-
-The topics in this chapter need to be done as part of an ordered procedure so are shown here with numbered topics.
-
-## Details
 
 <a name="download-and-extract"></a>
 ## Download and Extract CSM Product Release
@@ -124,8 +118,8 @@ None.
 
 This tarball can now be used in place of the original CSM software release tarball.
 
-<a name="workarounds"></a>
-## Check for Latest Workarounds and Documentation Updates
+<a name="documentation"></a>
+## Check for Latest Documentation
 
 ### About this task
 
@@ -133,14 +127,7 @@ This tarball can now be used in place of the original CSM software release tarba
 System installer
 
 #### Objective
-Acquire the late-breaking CSM workarounds and documentation update RPMs. These fixes were not available until after the software release. The software installation and upgrade processes have several breakpoints where you check and apply workarounds before or after a critical procedure.
-
-This command will report the version of your installed documentation.
-
-```bash
-ncn# rpm -q docs-csm
-```
-
+Acquire the latest documentation RPM. This may include updates, corrections, and enhancements that were not available until after the software release.
 
 #### Limitations
 None.
@@ -150,91 +137,25 @@ None.
 1. Check the version of the currently installed CSM documentation.
 
    ```bash
-   ncn# rpm -q docs-csm
+   linux# rpm -q docs-csm
    ```
 
-1. Download and upgrade the latest workaround and documentation RPMs.
+1. Download and upgrade the latest documentation RPM.
 
    ```bash
    linux# rpm -Uvh --force https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/docs-csm/1.2/noarch/docs-csm-latest.noarch.rpm
-   linux# rpm -Uvh --force https://storage.googleapis.com/csm-release-public/shasta-1.5/csm-install-workarounds/csm-install-workarounds-latest.noarch.rpm
    ```
 
-   If this machine does not have direct Internet access these RPMs will need to be externally downloaded and then copied to the system. This example copies them to ncn-m001.
+   If this machine does not have direct Internet access, this RPM will need to be externally downloaded and then copied to the system. This example copies it to `ncn-m001`.
 
    ```bash
    linux# wget https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/docs-csm/1.2/noarch/docs-csm-latest.noarch.rpm
-   linux# wget https://storage.googleapis.com/csm-release-public/shasta-1.5/csm-install-workarounds/csm-install-workarounds-latest.noarch.rpm
-   linux# scp -p docs-csm-*rpm csm-install-workarounds-*rpm ncn-m001:/root
+   linux# scp -p docs-csm-*rpm ncn-m001:/root
    linux# ssh ncn-m001
    ncn-m001# rpm -Uvh --force docs-csm-latest.noarch.rpm
-   ncn-m001# rpm -Uvh --force csm-install-workarounds-latest.noarch.rpm
    ```
 
-1. Check the version of the newly installed documentation.
-
-   ```bash
-   ncn# rpm -q docs-csm
-   ```
-
-<a name="apply-workarounds"></a>
-## Check for and Apply Workarounds
-
-### About this task
-
-#### Role
-System installer
-
-#### Objective
-The software installation and upgrade processes have several breakpoints where you check and apply workarounds before or after a critical procedure. Check to see if workarounds need to be applied at a particular point of the install process. If there are, apply those workarounds.
-
-#### Limitations
-None.
-
-#### Prerequisites
-
-   * The [latest workaround RPM](#workarounds) is installed.
-   * The name of the workaround breakpoint (e.g. `before-configuration-payload` or `after-sysmgmt-manifest`) is known.
-
-### Procedure
-
-   1. Change to the directory containing the workarounds to be applied at this breakpoint.
-
-      ```bash
-      linux# pushd /opt/cray/csm/workarounds/<put-actual-breakpoint-name-here>
-      ```
-
-   1. List all subdirectories of this directory.
-
-      ```bash
-      linux# find -maxdepth 1 -type d ! -name . | cut -c3-
-      ```
-
-      If there is nothing listed, there are no workarounds to be applied at this breakpoint, and you can skip the next step.
-
-   1. For each subdirectory which is listed, apply the workaround described within it.
-
-      Perform the following steps for each subdirectory which was listed in the previous step.
-
-      1. Change directory into the subdirectory.
-
-         ```bash
-         linux# pushd <put-subdirectory-name-here>
-         ```
-
-      1. View the `README.md` file in this directory, and carefully follow its instructions.
-
-      1. Return to the main directory for workarounds for this breakpoint.
-
-         ```bash
-         linux# popd
-         ```
-
-   1. The procedure is complete. Return to your original directory.
-
-      ```bash
-      linux# popd
-      ```
+1. Repeat the first step in this procedure to display the version of the CSM documentation after the update.
 
 <a name="hotfixes"></a>
 ## Check for Field Notices about Hotfixes

--- a/upgrade/1.2/README.md
+++ b/upgrade/1.2/README.md
@@ -1,9 +1,9 @@
-# CSM 1.1.0 or later to 1.2.0 Upgrade Process (WIP)
+# CSM 1.0.0 or later to 1.2.0 Upgrade Process (WIP)
 #NOTE: this is a WIP doc
 
 ## Introduction
 
-This document is intended to guide an administrator through the upgrade process going from Cray Systems Management v1.1 to v1.2. When upgrading a system, this top-level README.md file should be followed top to bottom, and the content on this top level page is meant to be terse. See the additional files in the various directories under the resource_material directory for additional reference material in support of the process/scripts mentioned explicitly on this page.
+This document is intended to guide an administrator through the upgrade process going from Cray Systems Management v1.0 to v1.2. When upgrading a system, this top-level README.md file should be followed top to bottom, and the content on this top level page is meant to be terse. See the additional files in the various directories under the resource_material directory for additional reference material in support of the processes/scripts mentioned explicitly on this page.
 
 ## Terminology
 


### PR DESCRIPTION
* [CASMINST-3936](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3936): In csm-1.2, if there are any workarounds needed for the release, they will be embedded into the docs. As such, there will not be a need for the csm-install-workarounds RPM. This PR removes references to it (and the workaround breakpoints) from the docs. And because I cannot resist, there was also some linting.
* [CASMINST-3911](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3911): I also pulled in a commit which takes care of [CASMINST-3911](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3911), reducing the chance of errors when completing the BMC NTP/DNS section by replacing manual commands with a bash loop.
* [CASMINST-3937](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3937): Revert the commit for [CASMINST-3543](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3543) and move the git install procedure next to the prepare site-init procedure in the bootstrap USB doc.