### PR TITLE
CASMINST-3980 Add the nexus admin credential sealed secret

### DIFF
--- a/upgrade/1.2/scripts/upgrade/update-customizations.sh
+++ b/upgrade/1.2/scripts/upgrade/update-customizations.sh
@@ -367,6 +367,7 @@ if [[ -z "$(yq r "$c" 'spec.kubernetes.sealed_secrets.nexus-admin-credential')" 
         yq w -i "$c" 'spec.kubernetes.sealed_secrets.nexus-admin-credential.generate.data[1].args.url_safe' yes
     fi
 fi
+yq w -i --style=single "$c" 'spec.kubernetes.services.cray-nexus.sealedSecrets[+]' "{{ kubernetes.sealed_secrets['nexus-admin-credential'] | toYaml }}"
 
 # remove cray-keycloak-gatekeeper
 yq d -i "$c" 'spec.kubernetes.services.cray-keycloak-gatekeeper'


### PR DESCRIPTION
## Summary and Scope

Adds the nexus admin credential sealed secret to the cray-nexus chart at the time of an upgrade.

Resolves CASMINST-3980 

Tested by manually running the script against the current customizations and then feeding the output into manifestgen.
Verified the output had the expected sealed secret under the cray-nexus chart (details in the bug).

