### PR TITLE
Backup bss data using cray cli instead of s3fs mount point

### DIFF
--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -143,10 +143,11 @@ python3 /usr/share/doc/csm/scripts/patch-ceph-runcmd.py
 
 ## Stage 0.6 - Backup BSS Data
 
-In the event of a problem during the upgrade which may cause the loss of BSS data, perform the following to preserve this data.
+In the event of a problem during the upgrade which may cause the loss of BSS data, perform the following to preserve this data, and back it up to the config-data bucket in your Ceph cluster.
 
    ```bash
-   ncn-m001# cray bss bootparameters list --format=json >bss-backup-$(date +%Y-%m-%d).json
+   ncn-m001# cray bss bootparameters list --format=json > bss-backup-$(date +%Y-%m-%d).json
+   ncn-m001# cray artifacts create config-data bss-backup-$(date +%Y-%m-%d).json bss-backup-$(date +%Y-%m-%d).json
    ```
 
 The resulting file needs to be saved in the event that BSS data needs to be restored in the future.


### PR DESCRIPTION
## Summary and Scope

At this point in the upgrade, the config-data bucket will have been created, but the s3fs mount point won't be available until m001 is booted into his new image.  So let's use cray artifacts to push the backup to S3 instead of S3fs.

## Issues and Related PRs

* Resolves [CASMINST-3996](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3996)

## Testing

```
ncn-m001:~ # cray artifacts create config-data bss-backup-2022-02-11.json bss-backup-2022-02-11.json
artifact = "bss-backup-2022-02-11.json"
Key = "bss-backup-2022-02-11.json"

ncn-m001:~ # cray artifacts list config-data
[[artifacts]]
Key = "bss-backup-2022-02-11.json"
LastModified = "2022-02-14T17:45:29.624000+00:00"
ETag = "\"ae5757bfd9d6f4e0b4bba457e4d9b26a\""
Size = 76401
StorageClass = "STANDARD"

[artifacts.Owner]
DisplayName = ""
ID = "STS"
```

### Tested on:

  * `drax`

### Test description:

Ran the cli code on drax

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable