### PR TITLE
Update kubeadm image repository prior to control plane upgrade

### DIFF
--- a/upgrade/1.2/scripts/k8s/upgrade_control_plane.sh
+++ b/upgrade/1.2/scripts/k8s/upgrade_control_plane.sh
@@ -22,6 +22,12 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+echo "Updating imageRepository in kubeadm-config configmap"
+echo ""
+kubectl get configmap kubeadm-config -n kube-system -o yaml > /tmp/kubeadm-config.yaml
+cp /tmp/kubeadm-config.yaml /tmp/kubeadm-config.yaml.back
+sed -i 's/imageRepository: k8s.gcr.io/imageRepository: artifactory.algol60.net\/csm-docker\/stable\/k8s.gcr.io/' /tmp/kubeadm-config.yaml
+kubectl -n kube-system apply -f /tmp/kubeadm-config.yaml
 
 export PDSH_SSH_ARGS_APPEND="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
 masters=$(grep -oP 'ncn-m\d+' /etc/hosts | sort -u)


### PR DESCRIPTION
## Summary and Scope

We need the new control plane images pulled with the artifactory prefix to match what's being precached and in nexus.  Need to update the config map used during upgrade to point to the same.

## Issues and Related PRs

* Resolves [CASMINST-4009](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4009)

## Testing

Tested manually on drax

### Tested on:

  * `drax`

### Test description:

Manually updated the configmap and the upgrade control plane script found the images.

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable