### PR TITLE
CASMPET-5318 1.0 : Automate reinit of cluster members found to be lagging in csm 1.0 ncn-upgrade-k8s-worker.sh

### DIFF
--- a/upgrade/1.0.1/scripts/k8s/reinit-postgres.sh
+++ b/upgrade/1.0.1/scripts/k8s/reinit-postgres.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# Given a postgres cluster name and namespace, reinitialize any members with lag.
+#   Fail if no leader is found.
+#   Succeed if no lag is present.
+#   Reinitialize any cluster members found to have lag >0 or unknown.
+#   Do not wait for the reinitialization to complete.
+#   Save any output to /tmp/reinit-postgres.txt
+#
+# Patronctl json output:
+#   Leader : .Role == "Leader"
+#     Lag : .Lag in MB is always ""
+#   Member : .Role == ""
+#     Lag : .Lag in MB can be >=0 or "unknown"
+
+# Check usage
+if [ $# -ne 2 ]
+then
+    echo "Usage:   $0 <cluster> <namespace>"
+    echo "example: $0 cray-smd-postgres services"
+    exit 1
+fi
+
+# Set postgres cluster name and namespace
+c_name=$1
+c_ns=$2
+
+date >> /tmp/reinit-postgres.txt 2>&1
+
+# Get the postgres leader
+c_leader=$(kubectl exec "${c_name}-0" -c postgres -n ${c_ns} -- patronictl list -f json 2>/dev/null | jq -r '.[] | select((.Role == "Leader") and (.State =="running")) | .Member')
+
+if [[ -z $c_leader ]]; then
+    echo "No Leader exists for $c_name cluster - unable to reinit." >> /tmp/reinit-postgres.txt 2>&1
+    exit 1
+fi
+
+# Get the cluster details from the leader
+c_cluster_details=$(kubectl exec ${c_leader} -c postgres -it -n ${c_ns} -- patronictl list -f json)
+
+# Determine the max lag across all members, unknown lag count across all members, list of lagging member by pod name
+c_max_lag=$(echo $c_cluster_details | jq '[.[] | select((.Role == "") and (."Lag in MB" != "unknown"))."Lag in MB"] | max')
+c_unknown_lag=$(echo $c_cluster_details | jq '.[] | select(.Role == "")."Lag in MB"' | grep "unknown" | wc -l)
+c_members_lagging=$(echo $c_cluster_details | jq -r '.[] | select((.Role == "") and ((."Lag in MB" > 0) or (."Lag in MB" == "unknown"))).Member')
+
+# Exit with success if no lag is found
+if [[ $c_unknown_lag -eq 0 ]] && [[ $c_max_lag -eq 0 ]]; then
+    echo "No lag was found for $c_name cluster - reinit not needed." >> /tmp/reinit-postgres.txt 2>&1
+    exit 0
+fi
+
+# Reinit any members found to be lagging ( >0 or "unknown" )
+for member in $c_members_lagging
+do
+    kubectl exec $c_leader -n $c_ns -c postgres -- patronictl reinit $c_name $member --force >> /tmp/reinit-postgres.txt 2>&1
+done
+

--- a/upgrade/1.0.1/scripts/upgrade/ncn-upgrade-k8s-worker.sh
+++ b/upgrade/1.0.1/scripts/upgrade/ncn-upgrade-k8s-worker.sh
@@ -98,16 +98,16 @@ UPGRADE_POSTGRES_MAX_LAG=${UPGRADE_POSTGRES_MAX_LAG:-'0'}
 # UPGRADE_POSTGRES_MAX_ATTEMPTS specifies the maximum number of times the
 # postgres check will be performed on a given cluster before failing. Note that
 # failures other than due to maximum lag are always fatal and are not retried.
-# If unset or set to a non-positive integer, default to 10
+# If unset or set to a non-positive integer, default to 2
 if [[ ! $UPGRADE_POSTGRES_MAX_ATTEMPTS =~ ^[1-9][0-9]*$ ]]; then
-    UPGRADE_POSTGRES_MAX_ATTEMPTS=10
+    UPGRADE_POSTGRES_MAX_ATTEMPTS=2
 fi
 
 # UPGRADE_POSTGRES_WAIT_SECONDS_BETWEEN_ATTEMPTS specifies the time (in seconds)
 # between postgres checks on a given cluster.
-# If unset or set to a non-positive integer, default to 10
+# If unset or set to a non-positive integer, default to 20
 if [[ ! $UPGRADE_POSTGRES_WAIT_SECONDS_BETWEEN_ATTEMPTS =~ ^[1-9][0-9]*$ ]]; then
-    UPGRADE_POSTGRES_WAIT_SECONDS_BETWEEN_ATTEMPTS=10
+    UPGRADE_POSTGRES_WAIT_SECONDS_BETWEEN_ATTEMPTS=20
 fi
 
 state_name="ENSURE_POSTGRES_HEALTHY"
@@ -160,9 +160,17 @@ if [[ $state_recorded == "0" ]]; then
             c_unknown_lag=$(echo $c_cluster_details | jq '.[] | select(.Role == "")."Lag in MB"' | grep "unknown" | wc -l)
 
             if [[ -n $c_lag_history ]]; then
-                c_lag_history+=", $c_max_lag"
+                if [[ $c_unknown_lag -gt 0 ]]; then
+                    c_lag_history+=", unknown"
+                else
+                    c_lag_history+=", $c_max_lag"
+                fi
             else
-                c_lag_history="$c_max_lag"
+                if [[ $c_unknown_lag -gt 0 ]]; then
+                    c_lag_history="unknown"
+                else
+                    c_lag_history="$c_max_lag"
+                fi
             fi
 
             # check number of members
@@ -178,21 +186,24 @@ if [[ $state_recorded == "0" ]]; then
                 fi
             fi
 
-            #check lag:unknown
-            if [[ $c_unknown_lag -gt 0 ]]; then
-                echo -e "\n--- ERROR --- $c cluster has lag: unknown"
-                exit 1
-            fi
-
             if [[ $UPGRADE_POSTGRES_MAX_LAG =~ ^[0-9][0-9]*$ ]]; then
                 #check max_lag is <= $UPGRADE_POSTGRES_MAX_LAG
-                if [[ $c_max_lag -gt $UPGRADE_POSTGRES_MAX_LAG ]]; then
-                    # If we have not exhausted our number of attempts, retry
-                    [[ $c_attempt -ge $UPGRADE_POSTGRES_MAX_ATTEMPTS ]] || continue
-                    
-                    echo -e "\n--- ERROR --- $c cluster has lag: $c_lag_history"
-                    exit 1
-                fi
+                if [[ $c_max_lag -gt $UPGRADE_POSTGRES_MAX_LAG ]] || [[ $c_unknown_lag -gt 0 ]] ; then
+                     # If we have not exhausted our number of attempts, reinit lagging clusters and retry
+                     if [[ $c_attempt -ge $UPGRADE_POSTGRES_MAX_ATTEMPTS ]]; then
+                         echo -e "\n--- ERROR --- $c cluster has max lag: $c_lag_history"
+                         exit 1
+                     else
+                         #skip reinit on sma
+                         if [[ $c_name != "sma-postgres-cluster" ]]; then
+
+                             echo -n " REINIT "
+                             ${BASEDIR}/../k8s/reinit-postgres.sh $c_name $c_ns
+
+                         fi
+                         continue
+                     fi
+                 fi
             fi
             echo " OK"
             break

--- a/upgrade/1.0.11/scripts/k8s/reinit-postgres.sh
+++ b/upgrade/1.0.11/scripts/k8s/reinit-postgres.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# Given a postgres cluster name and namespace, reinitialize any members with lag.
+#   Fail if no leader is found.
+#   Succeed if no lag is present.
+#   Reinitialize any cluster members found to have lag >0 or unknown.
+#   Do not wait for the reinitialization to complete.
+#   Save any output to /tmp/reinit-postgres.txt
+#
+# Patronctl json output:
+#   Leader : .Role == "Leader"
+#     Lag : .Lag in MB is always ""
+#   Member : .Role == ""
+#     Lag : .Lag in MB can be >=0 or "unknown"
+
+# Check usage
+if [ $# -ne 2 ]
+then
+    echo "Usage:   $0 <cluster> <namespace>"
+    echo "example: $0 cray-smd-postgres services"
+    exit 1
+fi
+
+# Set postgres cluster name and namespace
+c_name=$1
+c_ns=$2
+
+date >> /tmp/reinit-postgres.txt 2>&1
+
+# Get the postgres leader
+c_leader=$(kubectl exec "${c_name}-0" -c postgres -n ${c_ns} -- patronictl list -f json 2>/dev/null | jq -r '.[] | select((.Role == "Leader") and (.State =="running")) | .Member')
+
+if [[ -z $c_leader ]]; then
+    echo "No Leader exists for $c_name cluster - unable to reinit." >> /tmp/reinit-postgres.txt 2>&1
+    exit 1
+fi
+
+# Get the cluster details from the leader
+c_cluster_details=$(kubectl exec ${c_leader} -c postgres -it -n ${c_ns} -- patronictl list -f json)
+
+# Determine the max lag across all members, unknown lag count across all members, list of lagging member by pod name
+c_max_lag=$(echo $c_cluster_details | jq '[.[] | select((.Role == "") and (."Lag in MB" != "unknown"))."Lag in MB"] | max')
+c_unknown_lag=$(echo $c_cluster_details | jq '.[] | select(.Role == "")."Lag in MB"' | grep "unknown" | wc -l)
+c_members_lagging=$(echo $c_cluster_details | jq -r '.[] | select((.Role == "") and ((."Lag in MB" > 0) or (."Lag in MB" == "unknown"))).Member')
+
+# Exit with success if no lag is found
+if [[ $c_unknown_lag -eq 0 ]] && [[ $c_max_lag -eq 0 ]]; then
+    echo "No lag was found for $c_name cluster - reinit not needed." >> /tmp/reinit-postgres.txt 2>&1
+    exit 0
+fi
+
+# Reinit any members found to be lagging ( >0 or "unknown" )
+for member in $c_members_lagging
+do
+    kubectl exec $c_leader -n $c_ns -c postgres -- patronictl reinit $c_name $member --force >> /tmp/reinit-postgres.txt 2>&1
+done
+

--- a/upgrade/1.0.11/scripts/upgrade/ncn-upgrade-k8s-worker.sh
+++ b/upgrade/1.0.11/scripts/upgrade/ncn-upgrade-k8s-worker.sh
@@ -98,16 +98,16 @@ UPGRADE_POSTGRES_MAX_LAG=${UPGRADE_POSTGRES_MAX_LAG:-'0'}
 # UPGRADE_POSTGRES_MAX_ATTEMPTS specifies the maximum number of times the
 # postgres check will be performed on a given cluster before failing. Note that
 # failures other than due to maximum lag are always fatal and are not retried.
-# If unset or set to a non-positive integer, default to 10
+# If unset or set to a non-positive integer, default to 2
 if [[ ! $UPGRADE_POSTGRES_MAX_ATTEMPTS =~ ^[1-9][0-9]*$ ]]; then
-    UPGRADE_POSTGRES_MAX_ATTEMPTS=10
+    UPGRADE_POSTGRES_MAX_ATTEMPTS=2
 fi
 
 # UPGRADE_POSTGRES_WAIT_SECONDS_BETWEEN_ATTEMPTS specifies the time (in seconds)
 # between postgres checks on a given cluster.
-# If unset or set to a non-positive integer, default to 10
+# If unset or set to a non-positive integer, default to 20
 if [[ ! $UPGRADE_POSTGRES_WAIT_SECONDS_BETWEEN_ATTEMPTS =~ ^[1-9][0-9]*$ ]]; then
-    UPGRADE_POSTGRES_WAIT_SECONDS_BETWEEN_ATTEMPTS=10
+    UPGRADE_POSTGRES_WAIT_SECONDS_BETWEEN_ATTEMPTS=20
 fi
 
 state_name="ENSURE_POSTGRES_HEALTHY"
@@ -160,9 +160,17 @@ if [[ $state_recorded == "0" ]]; then
             c_unknown_lag=$(echo $c_cluster_details | jq '.[] | select(.Role == "")."Lag in MB"' | grep "unknown" | wc -l)
 
             if [[ -n $c_lag_history ]]; then
-                c_lag_history+=", $c_max_lag"
+                if [[ $c_unknown_lag -gt 0 ]]; then
+                    c_lag_history+=", unknown"
+                else
+                    c_lag_history+=", $c_max_lag"
+                fi
             else
-                c_lag_history="$c_max_lag"
+                if [[ $c_unknown_lag -gt 0 ]]; then
+                    c_lag_history="unknown"
+                else
+                    c_lag_history="$c_max_lag"
+                fi
             fi
 
             # check number of members
@@ -178,21 +186,24 @@ if [[ $state_recorded == "0" ]]; then
                 fi
             fi
 
-            #check lag:unknown
-            if [[ $c_unknown_lag -gt 0 ]]; then
-                echo -e "\n--- ERROR --- $c cluster has lag: unknown"
-                exit 1
-            fi
-
             if [[ $UPGRADE_POSTGRES_MAX_LAG =~ ^[0-9][0-9]*$ ]]; then
                 #check max_lag is <= $UPGRADE_POSTGRES_MAX_LAG
-                if [[ $c_max_lag -gt $UPGRADE_POSTGRES_MAX_LAG ]]; then
-                    # If we have not exhausted our number of attempts, retry
-                    [[ $c_attempt -ge $UPGRADE_POSTGRES_MAX_ATTEMPTS ]] || continue
-                    
-                    echo -e "\n--- ERROR --- $c cluster has lag: $c_lag_history"
-                    exit 1
-                fi
+                if [[ $c_max_lag -gt $UPGRADE_POSTGRES_MAX_LAG ]] || [[ $c_unknown_lag -gt 0 ]] ; then
+                     # If we have not exhausted our number of attempts, reinit lagging clusters and retry
+                     if [[ $c_attempt -ge $UPGRADE_POSTGRES_MAX_ATTEMPTS ]]; then
+                         echo -e "\n--- ERROR --- $c cluster has max lag: $c_lag_history"
+                         exit 1
+                     else
+                         #skip reinit on sma
+                         if [[ $c_name != "sma-postgres-cluster" ]]; then
+
+                             echo -n " REINIT "
+                             ${BASEDIR}/../k8s/reinit-postgres.sh $c_name $c_ns
+
+                         fi
+                         continue
+                     fi
+                 fi
             fi
             echo " OK"
             break


### PR DESCRIPTION
## Summary and Scope

Adds reinit-postgres.sh which is an independent script that can be run to re-init any postgres cluster.
Adds automated re-init process to the existing ncn-upgrade-k8s-workers.sh script.
* If a postgres clusters is found to have lagging member(s), an attempt will be made to reinit the member(s).
* If needed, a reinit is done for any cluster except sma; sma re-init can take hours so this is better handled outside of the upgrade if found to not be healthy.
* In addition, the retry login has been modified to check the health twice and reinit if the first attempt finds lag.

The upgrade script will still exit if after two attempts any of the clusters are not healthy (no leader, lag, etc)

This change is only needed for csm 1.0.x (1.0.1 & 1.0.11)

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_yes

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5318](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5318)
* Change will also be needed in NA
* Future work required by NA
* Documentation changes required in NA
* Merge with/before/after NA

## Testing

vshasta

### Tested on:

### Test description:

Mocked up various cases of the output from `patronictl list -o json`

Four test cases:
(1) spire has lag that reinit does not resolve - expect REINIT & ERROR
```
====> ENSURE_POSTGRES_HEALTHY ...
Postgres cluster checks may take several minutes, depending on latency
Checking postgres cluster cray-console-data-postgres in namespace services .... OK
Checking postgres cluster cray-sls-postgres in namespace services .... OK
Checking postgres cluster cray-smd-postgres in namespace services .... OK
Checking postgres cluster gitea-vcs-postgres in namespace services .... OK
Checking postgres cluster keycloak-postgres in namespace services .... OK
Checking postgres cluster spire-postgres in namespace spire .... REINIT .
--- ERROR --- spire,spire-postgres cluster has max lag: 1, 1
```

(2) spire has lag that reinit does resolve - expect REINIT & OK
```
====> ENSURE_POSTGRES_HEALTHY ...
Postgres cluster checks may take several minutes, depending on latency
Checking postgres cluster cray-console-data-postgres in namespace services .... OK
Checking postgres cluster cray-sls-postgres in namespace services .... OK
Checking postgres cluster cray-smd-postgres in namespace services .... OK
Checking postgres cluster gitea-vcs-postgres in namespace services .... OK
Checking postgres cluster keycloak-postgres in namespace services .... OK
Checking postgres cluster spire-postgres in namespace spire .... REINIT . OK
```

(3) Both spire members have unknown lag that reinit does not resolve -  - expect REINIT & ERROR
```
====> ENSURE_POSTGRES_HEALTHY ...
Postgres cluster checks may take several minutes, depending on latency
Checking postgres cluster cray-console-data-postgres in namespace services .... OK
Checking postgres cluster cray-sls-postgres in namespace services .... OK
Checking postgres cluster cray-smd-postgres in namespace services .... OK
Checking postgres cluster gitea-vcs-postgres in namespace services .... OK
Checking postgres cluster keycloak-postgres in namespace services .... OK
Checking postgres cluster spire-postgres in namespace spire .... REINIT .
--- ERROR --- spire,spire-postgres cluster has max lag: unknown, unknown
```

(4) Keycloak member has lag that reinit resolves and remaining cluster are OK -  - expect REINIT & OK
```
====> ENSURE_POSTGRES_HEALTHY ...
Postgres cluster checks may take several minutes, depending on latency
Checking postgres cluster cray-console-data-postgres in namespace services .... OK
Checking postgres cluster cray-sls-postgres in namespace services .... OK
Checking postgres cluster cray-smd-postgres in namespace services .... OK
Checking postgres cluster gitea-vcs-postgres in namespace services .... OK
Checking postgres cluster keycloak-postgres in namespace services .... REINIT . OK
Checking postgres cluster spire-postgres in namespace spire .... OK
```


- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? NA
- Were continuous integration tests run? If not, why? NA
- Was upgrade tested? If not, why? NA
- Was downgrade tested? If not, why? NA
- Were new tests (or test issues/Jiras) created for this change? NA

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

