### PR TITLE
CASMNET-1152

### DIFF
--- a/operations/network/management_network/load_saved_switch_config.md
+++ b/operations/network/management_network/load_saved_switch_config.md
@@ -59,5 +59,8 @@ Unsaved changes     : yes
 ```
 switch to desired configuration.
 ```
-sw-spine-001 [standalone: master] (config) # configuration switch-to csm1.0 no-reboot
+sw-spine-001 [standalone: master] (config) # configuration switch-to csm1.0
+This requires a reboot.
+Type 'yes' to confirm: yes
 ```
+The switch will then reboot to choosen configuration.


### PR DESCRIPTION
## Summary and Scope

require the switch to reboot after config is applied.
this is required when adding/removing a port from a VRF.

## Issues and Related PRs

CASMNET-1152

## Testing

_List the environments in which these changes were tested._

### Tested on:

drax
