### PR TITLE
Fix path to goss-servers rpm (and others) during livecd bootstrap

### DIFF
--- a/install/bootstrap_livecd_usb.md
+++ b/install/bootstrap_livecd_usb.md
@@ -684,8 +684,8 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
    The following assumes the `CSM_PATH` environment variable is set to the absolute path of the unpacked CSM release.
 
    ```bash
-   pit:/var/www/ephemeral# rpm -Uvh --force $(find ${CSM_PATH}/rpm/cray/csm/ -name "goss-servers*.rpm" | sort -V | tail -1)
-   pit:/var/www/ephemeral# rpm -Uvh --force $(find ${CSM_PATH}/rpm/cray/csm/ -name "csm-testing*.rpm" | sort -V | tail -1)   
+   pit:/var/www/ephemeral# rpm -Uvh --force $(find ${CSM_PATH}/rpm/ -name "goss-servers*.rpm" | sort -V | tail -1)
+   pit:/var/www/ephemeral# rpm -Uvh --force $(find ${CSM_PATH}/rpm/ -name "csm-testing*.rpm" | sort -V | tail -1)
    pit:/var/www/ephemeral# cd
    ```
 


### PR DESCRIPTION
## Summary and Scope

Simplify the search path for rpms in the tarball.

## Issues and Related PRs

* Resolves [CASMINST-4037](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4037)

## Testing

```
rax-ncn-m001-pit:/var/www/ephemeral/csm-1.0.11-alpha.6 # find ${CSM_RELEASE}/rpm/ -name "goss-servers*.rpm" | sort -V | tail -1
/var/www/ephemeral/csm-1.0.11-alpha.6/rpm/embedded/cray/csm/sle-15sp2/noarch/noarch/goss-servers-1.6.28-20210722162456_b3376c5.noarch.rpm
```

### Tested on:

  * `drax`

### Test description:

Changing the path worked for the find command

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

