### PR TITLE
CASMINST-4003: Update 1.0.11 patch instructions for kernel and polkit CVE fixes

### DIFF
--- a/upgrade/1.0.11/README.md
+++ b/upgrade/1.0.11/README.md
@@ -6,7 +6,15 @@ This document is intended to guide an administrator through the process going fr
 
 ## Contents
 
-TODO: Add CVE descriptions here
+CSM v1.0.11 is a security patch release, which addresses the following CVE's:
+
+### CVE-2022-0185: Linux kernel buffer overflow/container escape 
+More info: https://nvd.nist.gov/vuln/detail/CVE-2022-0185 \
+Remediation: upgrade Linux kernel to patched version `5.3.18-24.99`.
+
+### CVE-2021-4034: pwnkit: Local Privilege Escalation in polkit's pkexec
+More info: https://nvd.nist.gov/vuln/detail/CVE-2021-4034 \
+Remediation:  upgrade polkit and associated libpolkit0 packages to patched version `0.116-3.6.1`.
 
 ## Terminology
 

--- a/upgrade/1.0.11/Stage_5.md
+++ b/upgrade/1.0.11/Stage_5.md
@@ -9,6 +9,38 @@
    1.0.11
    ```
 
-1. TODO: Kernel/polkit/kafka verfication
+1. Verify that fix for CVE-2022-0185 (Linux kernel buffer overflow/container escape) is in place:
+
+    ```bash
+    ncn-m001:~ # pdsh -w $(/etc/cray/upgrade/csm/csm-1.0.*/tarball/csm-1.0.*/lib/list-ncns.sh 2>/dev/null | paste -sd,) "uname -a"
+    ncn-m001: Linux ncn-m002 5.3.18-24.99-default #1 SMP Sun Jan 23 19:03:51 UTC 2022 (712a8e6) x86_64 x86_64 x86_64 GNU/Linux
+    ncn-m002: Linux ncn-m002 5.3.18-24.99-default #1 SMP Sun Jan 23 19:03:51 UTC 2022 (712a8e6) x86_64 x86_64 x86_64 GNU/Linux
+    ncn-m003: Linux ncn-m003 5.3.18-24.99-default #1 SMP Sun Jan 23 19:03:51 UTC 2022 (712a8e6) x86_64 x86_64 x86_64 GNU/Linux
+    ncn-s001: Linux ncn-s001 5.3.18-24.99-default #1 SMP Sun Jan 23 19:03:51 UTC 2022 (712a8e6) x86_64 x86_64 x86_64 GNU/Linux
+    ncn-s002: Linux ncn-s002 5.3.18-24.99-default #1 SMP Sun Jan 23 19:03:51 UTC 2022 (712a8e6) x86_64 x86_64 x86_64 GNU/Linux
+    ncn-s003: Linux ncn-s003 5.3.18-24.99-default #1 SMP Sun Jan 23 19:03:51 UTC 2022 (712a8e6) x86_64 x86_64 x86_64 GNU/Linux
+    ncn-w001: Linux ncn-s001 5.3.18-24.99-default #1 SMP Sun Jan 23 19:03:51 UTC 2022 (712a8e6) x86_64 x86_64 x86_64 GNU/Linux
+    ncn-w002: Linux ncn-s002 5.3.18-24.99-default #1 SMP Sun Jan 23 19:03:51 UTC 2022 (712a8e6) x86_64 x86_64 x86_64 GNU/Linux
+    ncn-w003: Linux ncn-s003 5.3.18-24.99-default #1 SMP Sun Jan 23 19:03:51 UTC 2022 (712a8e6) x86_64 x86_64 x86_64 GNU/Linux
+    ```
+
+    Version of running kernel must be `5.3.18-24.99` on all NCN nodes. Note: previous version of kernel was `5.3.18-24.75`.
+
+1. Verify that fix for CVE-2021-4034 (pwnkit: Local Privilege Escalation in polkit's pkexec) is in place:
+
+    ```bash
+    ncn-m001:~ # pdsh -w $(/etc/cray/upgrade/csm/csm-1.0.*/tarball/csm-1.0.*/lib/list-ncns.sh 2>/dev/null | paste -sd,) "rpm -q polkit"
+    ncn-m001: polkit-0.116-3.6.1.x86_64
+    ncn-m002: polkit-0.116-3.6.1.x86_64
+    ncn-m003: polkit-0.116-3.6.1.x86_64
+    ncn-s001: polkit-0.116-3.6.1.x86_64
+    ncn-s002: polkit-0.116-3.6.1.x86_64
+    ncn-s003: polkit-0.116-3.6.1.x86_64
+    ncn-w001: polkit-0.116-3.6.1.x86_64
+    ncn-w002: polkit-0.116-3.6.1.x86_64
+    ncn-w003: polkit-0.116-3.6.1.x86_64
+    ```
+
+    Version of installed polkit package must be `0.116-3.6.1` on all NCN nodes. Note: previous version of polkit package was `0.116-3.3.1`.
 
 [Return to main upgrade page](README.md)


### PR DESCRIPTION
## Summary and Scope

Provide CVE description and verification steps post 1.0.11 upgrade for:

* CVE-2022-0185: Linux kernel buffer overflow/container escape 
* CVE-2021-4034: pwnkit: Local Privilege Escalation in polkit's pkexec

## Issues and Related PRs

* Resolves [CASMINST-4003](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4003)
