### PR TITLE
CASMINST-4004: Update CSM-1.0.11 patch instructions for log4j changes

### DIFF
--- a/upgrade/1.0.11/README.md
+++ b/upgrade/1.0.11/README.md
@@ -16,6 +16,28 @@ Remediation: upgrade Linux kernel to patched version `5.3.18-24.99`.
 More info: https://nvd.nist.gov/vuln/detail/CVE-2021-4034 \
 Remediation:  upgrade polkit and associated libpolkit0 packages to patched version `0.116-3.6.1`.
 
+### CVE-2022-23302: affects log4j 1.x when it is configured with JMSSink
+More info: https://nvd.nist.gov/vuln/detail/CVE-2022-23302 \
+Remediation: Removed the impacted JMSSink class from the jar file.
+
+### CVE-2022-23305: affects log4j 1.x when it is configured with JDBCAppender
+More info: https://nvd.nist.gov/vuln/detail/CVE-2022-23305 \
+Remediation: removed the impacted JDBCAppender class from the jar file.
+
+### CVE-2022-23307: deserialization issue in chainsaw used in log4j 1.2.x
+More info: https://nvd.nist.gov/vuln/detail/CVE-2022-23307 \
+Remediation: removed the chainsaw from the jar file.
+
+### CVE-2021-4104: affects log4j 1.x when it is configured with JMSAppender
+More info: https://nvd.nist.gov/vuln/detail/CVE-2021-4104 \
+Remediation: removed the impacted JMSAppender class from the jar file.
+
+
+>**`NOTE:`**
+>
+>After this patch/upgrade is installed, scanning may still flag CVE-2022-2330[257] and CVE-2021-4104 CVEs.  This is due to the version of the log4j library/jar file remains the same, though the offending features are removed.
+>
+
 ## Terminology
 
 Throughout the guide the terms "stable" and "upgrade" are used in the context of the management nodes (NCNs). The

--- a/upgrade/1.0.11/Stage_5.md
+++ b/upgrade/1.0.11/Stage_5.md
@@ -43,4 +43,27 @@
 
     Version of installed polkit package must be `0.116-3.6.1` on all NCN nodes. Note: previous version of polkit package was `0.116-3.3.1`.
 
+1.  Verify that fix for CVE-2022-23302, CVE-2022-23305, CVE-2022-23307 and CVE-2021-4104 is in place:
+
+    ```bash
+    ncn-m001:~ # kubectl describe pods cray-shared-kafka -n services |grep Image:
+    Image:         strimzi/operator:0.15.0-noJndiLookupClass
+    Image:         strimzi/operator:0.15.0-noJndiLookupClass
+    Image:         strimzi/kafka:0.15.0-kafka-2.3.1-noJSM-chainsaw
+    Image:         strimzi/kafka:0.15.0-kafka-2.2.1-noJSM-chainsaw
+    Image:         strimzi/kafka:0.15.0-kafka-2.3.1-noJSM-chainsaw
+    Image:         strimzi/kafka:0.15.0-kafka-2.2.1-noJSM-chainsaw
+    Image:         strimzi/kafka:0.15.0-kafka-2.3.1-noJSM-chainsaw
+    Image:         strimzi/kafka:0.15.0-kafka-2.2.1-noJSM-chainsaw
+    Image:         strimzi/kafka:0.15.0-kafka-2.3.1-noJSM-chainsaw
+    Image:         strimzi/kafka:0.15.0-kafka-2.3.1-noJSM-chainsaw
+    Image:         strimzi/kafka:0.15.0-kafka-2.3.1-noJSM-chainsaw
+    Image:         strimzi/kafka:0.15.0-kafka-2.3.1-noJSM-chainsaw
+    Image:         strimzi/kafka:0.15.0-kafka-2.3.1-noJSM-chainsaw
+    Image:         strimzi/kafka:0.15.0-kafka-2.3.1-noJSM-chainsaw
+    Image:         strimzi/kafka:0.15.0-kafka-2.3.1-noJSM-chainsaw
+    ```
+    
+    Version tag of installed strimzi/kafka image must be `0.15.0-kafka-2.2.1-noJSM-chainsaw` and `0.15.0-kafka-2.3.1-noJSM-chainsaw`. Note: previous version tag were `0.15.0-kafka-2.2.1` and `0.15.0-kafka-2.3.1`
+    
 [Return to main upgrade page](README.md)


### PR DESCRIPTION
## Summary and Scope

Provide CVE description and verification steps post 1.0.11 upgrade for:

- [CVE-2022-23307](https://nvd.nist.gov/vuln/detail/CVE-2022-23307) - critical vulnerability in chainsaw used in log4j 1.2.x.
- [CVE-2022-23305](https://nvd.nist.gov/vuln/detail/CVE-2022-23305) - affects log4j 1.x when it is configured with JDBCAppender.
- [CVE-2022-23302](https://nvd.nist.gov/vuln/detail/CVE-2022-23302) - affects log4j 1.x when it is configured with JMSSink.
- [CVE-2021-4104](https://nvd.nist.gov/vuln/detail/CVE-2021-4104) - affects log4j 1.x when it is configured with JMSAppender.

## Issues and Related PRs

* Resolves [CASMINST-4004](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4004)
