### PR TITLE
CASMTRIAGE-2988: Instructions on adding xnames to BOS session templates

### DIFF
--- a/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System.md
+++ b/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System.md
@@ -345,13 +345,45 @@ This procedure will add a liquid-cooled blades from a HPE Cray EX system.
 
 #### Power on and boot the nodes
 
-16. Use boot orchestration to power on and boot the nodes. Specify the appropriate BOS template for the node type.
+Use boot orchestration to power on and boot the nodes. Specify the appropriate BOS template for the node type.
 
-    ```bash
-    ncn-m001# BOS_TEMPLATE=cos-2.0.30-slurm-healthy-compute
-    ncn-m001# cray bos session create --template-uuid $BOS_TEMPLATE \
-      --operation reboot --limit x1005c3s0b0n0,x1005c3s0b0n1,x1005c3s0b1n0,x1005c3s0b1n1
-    ```
+16. Determine how the BOS Session template references compute hosts.
+    Typically, they are referenced by their "Compute" role. However, if they are referenced by xname, then these new nodes should added to the BOS Session template.
+      ```bash
+      ncn-m001# BOS_TEMPLATE=cos-2.0.30-slurm-healthy-compute
+      ncn-m001# cray bos sessiontemplate describe $BOS_TEMPLATE --format json|jq '.boot_sets[] | select(.node_list)'
+      ```
+    If this query returns empty, then skip to sub-step 3.
+    If this query returns with data, then one or more boot sets within the BOS Session template reference nodes explicity by xname. Consider adding your new nodes to this list (sub-step 1) or adding them on the command line (sub-step 2).
+
+    1. Adding new nodes to your list.
+          1. Dump the current Session template.
+             ```bash
+             ncn-m001# cray bos sessiontemplate describe $BOS_TEMPLATE --format json > tmp.txt
+             ```	  
+          2. Edit the tmp.txt file adding the new nodes to the node_list.
+             ```bash
+             ncn-m001# vi tmp.txt
+             ```
+    2. Create the Session template.
+         1. The name of the Session template is determined by the name provided to the '--name' option on the command line. Use the current value of $BOS_TEMPLATE if you want to overwrite the existing Session template. If you want to use the current value, skip this sub-step and go on to sub-step 2. Otherwise, provide a different name for BOS_TEMPLATE which will be used the '--name' option. The name specified in tmp.txt is overridden by the value provided by the '--name' option.
+  	    ```bash
+	    ncn-m001# $BOS_TEMPLATE=<New Session Template name>
+	    ```
+	 2. Create the Session template.
+            ```bash	  
+            ncn-m001# cray bos sessiontemplate create --file tmp.txt --name $BOS_TEMPLATE
+            ```	  	  
+         3. Verify that the Session template contains the additional nodes and the proper name.
+            ```bash	  
+            ncn-m001# cray bos sessiontemplate describe $BOS_TEMPLATE --format json
+            ```	  	  
+	  
+    3. Boot the nodes.
+       ```bash
+       ncn-m001# cray bos session create --template-uuid $BOS_TEMPLATE \
+         --operation reboot --limit x1005c3s0b0n0,x1005c3s0b0n1,x1005c3s0b1n0,x1005c3s0b1n1
+       ```
 
 #### Check firmware
 17. Verify that the correct firmware versions for node BIOS, node controller (nC), NIC mezzanine card (NMC), GPUs, and so on.


### PR DESCRIPTION
## Summary and Scope

When a new blade is added to the system, the sysadmin will want to boot
these new nodes. This docuentation update checks if a BOS Session
template uses the node_list to specify names explicitly. If so, the
new nodes need to be added into the Session template, so they can be
booted using that template.

(cherry picked from commit 1a7a16a4467dadb0fb3baf351c182aeb9a0e5582)



## Issues and Related PRs

* Resolves CASMTRIAGE-2988

## Testing


### Tested on:

  * Hela

### Test description:

Tested to see the commands worked.

## Risks and Mitigations

Low.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

