### PR TITLE
Change velero backup test remediation to really delete PartiallyFailed backups

### DIFF
--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -461,7 +461,7 @@ pit# /opt/cray/tests/install/ncn/automated/ncn-kubernetes-checks
         ```
      1. Delete the backup, where <backup> is replaced with a backup returned in the previous step.
         ```bash
-        ncn# kubectl delete backups <backup> -n velero
+        ncn# velero backup delete <backup> --confirm
         ```
 
 <a name="check-of-system-management-monitoring-tools"></a>


### PR DESCRIPTION
## Summary and Scope

Remediation steps for velero backup test don't permanently delete a backup, need to use velero command instead (not kubectl).

## Issues and Related PRs

* Resolves [CASMINST-4059](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4059)

## Testing

Ran the velero delete on surtur, the backup did not come back.

### Tested on:

  * `surtur`

### Test description:

Manually ran the new remediation step and it worked.

## Risks and Mitigations

None/Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable