### PR TITLE
CASMINST-4070: Doc fixes based on csm-1.2.0-alpha.70 surtur install

### DIFF
--- a/operations/network/management_network/collect_data.md
+++ b/operations/network/management_network/collect_data.md
@@ -31,7 +31,7 @@ cat /etc/hosts | grep sw-
 If /etc/hosts is not available because the system is being installed you will be on the pit and will need to run:  
 
 ```
-cat /var/www/ephemeral/prep/redbull/sls_input_file.json | jq ‘.Networks | .HMN | .ExtraProperties.Subnets | .[] | select(.Name==“network_hardware”)' 
+cat /var/www/ephemeral/prep/redbull/sls_input_file.json | jq '.Networks | .HMN | .ExtraProperties.Subnets | .[] | select(.Name=="network_hardware")' 
 ```
 
 Run the script below to automatically collect all switch configs.  If the command fails then log in to each individual switch and run show run. 

--- a/operations/network/management_network/validate_shcd.md
+++ b/operations/network/management_network/validate_shcd.md
@@ -17,7 +17,7 @@ Use CANU (CSM Automated Network Utility) to validate the SHCD. SHCD validation i
 
 * NMN contains network management nodes 
 
-* HMN contains device BMC’s and other 1G management ports. 
+* HMN contains device BMC's and other 1G management ports. 
 
 * MTN_TDS, Mountain-TDS-Management (or some variation thereof for Mountain cabinets). 
 
@@ -43,7 +43,7 @@ canu validate shcd -a full --shcd ./HPE\ System\ Hela\ CCD.revA27.xlsx --tabs 10
 * ***Full*** 	– Aruba-based Leaf-Spine systems, usually customer production systems. 
 * ***V1*** 	– Dell and Mellanox based systems of either a TDS or Full layout. 
 
-CANU will ensure that each cell has valid data and that the connections between devices are allowed. Errors will stop processing and must be fixed in the spreadsheet before moving on. A “clean run” through a worksheet will include the model, a port-map of each node and may include warnings. See a list of typical errors at the end of this document to help in fixing the worksheet data. 
+CANU will ensure that each cell has valid data and that the connections between devices are allowed. Errors will stop processing and must be fixed in the spreadsheet before moving on. A "clean run" through a worksheet will include the model, a port-map of each node and may include warnings. See a list of typical errors at the end of this document to help in fixing the worksheet data. 
 
 Once the worksheet is validated you can check for any errors: 
 
@@ -53,9 +53,9 @@ canu validate shcd -a full --shcd ./HPE\ System\ Hela\ CCD.revA27.xlsx --tabs 10
 
 #### Checks and Validations 
 
-A worksheet that runs "cleanly” will have checked that: 
+A worksheet that runs "cleanly" will have checked that: 
 
-Nodes are “architecturally allowed” to connect to each other. 
+Nodes are "architecturally allowed" to connect to each other. 
 
 * No overlapping ports specified. 
 
@@ -73,7 +73,7 @@ A clean run will have the following sections:
 
 	* A list of cell-by-cell warnings of misspellings and other nit-picking items that CANU has autocorrected on the system. 
 
-***Critically***, the Warnings output will contain a section headed “Node type could not be determined for the following”.  This needs to be carefully reviewed because it may contain site uplinks that are not tracked by CANU but may also contain mis-spelled or mis-categorized nodes. As an example: 
+***Critically***, the Warnings output will contain a section headed "Node type could not be determined for the following".  This needs to be carefully reviewed because it may contain site uplinks that are not tracked by CANU but may also contain mis-spelled or mis-categorized nodes. As an example: 
 
 ```
 Node type could not be determined for the following. 
@@ -102,12 +102,12 @@ Cell: P16      Name: SITE
 
 ***From the above example two important observations can be made:***
 
-1. CAN and SITE uplinks are not in the “clean run” model. This means that these ports will not be configured. 
+1. CAN and SITE uplinks are not in the "clean run" model. This means that these ports will not be configured. 
 
-2. Critically, Cell I38 has a name of “sw-spinx-002". This should be noted as a misspelling of “sw-spine-002" and corrected. 
+2. Critically, Cell I38 has a name of "sw-spinx-002". This should be noted as a misspelling of "sw-spine-002" and corrected. 
 
 
-Today CANU validates many things, but a future feature is full cable specification checking of nodes (e.g. what NCN ports go to which switches to properly form bonds).  There are several CANU roadmap items, but today a manual review of the “SHCD Port Usage” connections list is vital.  Specifically, check: 
+Today CANU validates many things, but a future feature is full cable specification checking of nodes (e.g. what NCN ports go to which switches to properly form bonds).  There are several CANU roadmap items, but today a manual review of the "SHCD Port Usage" connections list is vital.  Specifically, check: 
 
 * K8S NCN cabling (manager, worker, storage) follows PoR cabling https://github.com/Cray-HPE/docs-csm/blob/main/install/cable_management_network_servers.md 
 
@@ -117,11 +117,11 @@ Today CANU validates many things, but a future feature is full cable specificati
 
 * Switch-to-switch cabling is appropriate for LAG formation. 
 
-* 	“Other” nodes on the network seem sane. 
+* 	"Other" nodes on the network seem sane. 
 
 #### Logging and Updates 
 
-Once the SHCD has run cleanly through CANU and CANU output has been manually validated, changes to the SHCD should be “committed” so that work is not lost, and other users can take advantage of the CANU changes.  
+Once the SHCD has run cleanly through CANU and CANU output has been manually validated, changes to the SHCD should be "committed" so that work is not lost, and other users can take advantage of the CANU changes.  
 
 Add an entry to the changelog Config. Summary first worksheet.  The changelog should include: 
 

--- a/operations/network/management_network/validate_switch_configs.md
+++ b/operations/network/management_network/validate_switch_configs.md
@@ -9,7 +9,7 @@
 
  Next you would want to compare the current running configuration with the generated configuration.  
 
-For the comparison, since we’ve pulled the configuration to our working directory we can compare the files locally. You can also have Canu pull the configuration from the switch by defining ip list and username &  password field.  
+For the comparison, since we've pulled the configuration to our working directory we can compare the files locally. You can also have Canu pull the configuration from the switch by defining ip list and username &  password field.  
 
 Example of Canu pulling configuration.  
 
@@ -36,13 +36,13 @@ canu validate network config --csm 1.2 --running ./running/ --generated ./genera
 
 CANU generated switch configurations will not include any ports or devices not defined in the model. These were previously discussed in the Validate the SHCD section but include edge uplinks (CAN/CMN) and custom configurations applied by the customer..  When looking at the generated configurations being applied against existing running configurations CANU will recommend removal of some critical configurations. It is vital that these devices and configurations be identified and protected. This can be accomplished in three ways: 
 
-* Provide CANU validation of generated configurations against running configurations with an override or “blackout” configuration – a yaml file which tells CANU to ignore customer-specific configurations. The process of creating this file was previously described in the This file will be custom to every site and must be distributed with the analysis and configuration file bundle to be used in the future. 
+* Provide CANU validation of generated configurations against running configurations with an override or "blackout" configuration – a yaml file which tells CANU to ignore customer-specific configurations. The process of creating this file was previously described in the This file will be custom to every site and must be distributed with the analysis and configuration file bundle to be used in the future. 
 
 * Based on experienced networking knowledge, manually reorder the proposed upgrade configurations. This may require manual exclusion of required configurations which the CANU analysis says to remove. 
 
 * Some devices may be used by multiple sites and may not currently be in the CANU architecture and configuration. If a device type is more universally used on several sites, then it should be added to the architectural and configuration definitions via the CANU code and Pull Request (PR) process. 
 
-Note:  A roadmap item for CANU is the ability to “inject” customer configurations into CANU and provide solid, repeatable configuration customization. 
+Note:  A roadmap item for CANU is the ability to "inject" customer configurations into CANU and provide solid, repeatable configuration customization. 
 
  
 #### Analyze CSM 1.2 configuration upgrade 

--- a/operations/network/upgrade_planning.md
+++ b/operations/network/upgrade_planning.md
@@ -9,7 +9,7 @@ For example: in rel/1.2 we will upgrade Aruba/Mellanox switches to newer code.
 
 In this case and cases where configuration changes are extensive you may want to consider taking the generated configurations after review and uploading them to the switches startup config prior to booting to new code to upgrade both configuration and software simultaneously.  
 
-This will prevent human error, especially from the extensive changes like say modifying 10’s or 100’s of ports away and have you install the generated configuration via the system without having to do the individual changes by hand.  
+This will prevent human error, especially from the extensive changes like say modifying 10's or 100's of ports away and have you install the generated configuration via the system without having to do the individual changes by hand.  
 
 In addition to firmware upgrade paths, the application of CANU-generated switch configurations should be carefully considered and detailed.  The following are important considerations: 
 
@@ -19,4 +19,4 @@ In addition to firmware upgrade paths, the application of CANU-generated switch 
 
 * Where system outages or interruptions are expected to occur, provide details on the change order of operations, expected timing of interruptions and guidance should the interruption be beyond expected timing. 
 
-The resulting “plan” should provide a procedure which can be followed by the customer to upgrade the system from current state to a newer version.   
+The resulting "plan" should provide a procedure which can be followed by the customer to upgrade the system from current state to a newer version.   

--- a/operations/system_configuration_service/Configure_BMC_and_Controller_Parameters_with_scsd.md
+++ b/operations/system_configuration_service/Configure_BMC_and_Controller_Parameters_with_scsd.md
@@ -3,7 +3,7 @@
 The System Configuration Service (SCSD) allows administrators to set various BMC and controller parameters for
 components in liquid-cooled cabinets. These parameters are typically set during discovery, but this
 tool enables parameters to be set before or after discovery. The operations to change these parameters
-are available in the `cray` CLI under the scsd command.
+are available in the `cray` CLI under the `scsd` command.
 
 The parameters which can be set are:
 
@@ -13,10 +13,9 @@ The parameters which can be set are:
 * BMC/Controller passwords
 * SSH console key
 
-   IMPORTANT: If the scsd tool is used to update the SSHConsoleKey value outside of ConMan, it will
+   IMPORTANT: If the `scsd` tool is used to update the SSHConsoleKey value outside of ConMan, it will
    disrupt the ConMan connection to the console and collection of console logs. See [ConMan](../conman/ConMan.md)
    for more information about remote consoles and collecting console logs.
-
 
 However, this procedure only describes how to change the SSH key to enable passwordless SSH for
 troubleshooting of power down and power up logs on the node BMCs.
@@ -35,7 +34,7 @@ The NTP server and syslog server for BMCs in the liquid-cooled cabinet are typic
 
 ## Details
 
-Setting the SSH keys for mountain controllers is done by running the *set_ssh_keys.py* script:
+Setting the SSH keys for mountain controllers is done by running the `/opt/cray/csm/scripts/admin_access/set_ssh_keys.py` script:
 
 ```
 Usage: set_ssh_keys.py [options]
@@ -57,10 +56,10 @@ Usage: set_ssh_keys.py [options]
    --sshkey=key     SSH key to set on BMCs. If none is specified, will use
 ```
 
-If no command line arguments are needed, SSH keys are set on all discovered mountain controllers, using the root account's public RSA key. Using an alternate key requires the --sshkey=key argument:
+If no command line arguments are needed, SSH keys are set on all discovered mountain controllers using the root account's public RSA key. Using an alternate key requires the `--sshkey=key` argument:
 
 ```bash
-  # set_ssh_keys.py --sshkey="AAAbbCcDddd...."
+  # /opt/cray/csm/scripts/admin_access/set_ssh_keys.py --sshkey="AAAbbCcDddd...."
 ```
 
 After the script runs, verify that it worked:
@@ -78,7 +77,7 @@ After the script runs, verify that it worked:
 
    Notice that the command prompt (`x1000c1s0b0:>`) includes the hostname for this node controller.
 
-2. The logs from power actions for node 0 and node 1 on this node controller are in /var/log.
+1. The logs from power actions for node 0 and node 1 on this node controller are in /var/log.
 
    ```bash
    x1000c1s0b0:> cd /var/log
@@ -87,7 +86,7 @@ After the script runs, verify that it worked:
 
    Expected output looks similar to the following:
 
-   ```
+   ```text
    -rw-r--r--    1 root     root           306 May 10 15:32 powerfault_dn.Node0
    -rw-r--r--    1 root     root           306 May 10 15:32 powerfault_dn.Node1
    -rw-r--r--    1 root     root          5781 May 10 15:36 powerfault_up.Node0
@@ -100,5 +99,5 @@ If this script does not achieve the goal of setting SSH keys, check the followin
 
 * Make sure the SSH key is correct.
 * If `--exclude=` or `--include=` was used with the script, ensure the correct XNames were specified.
-* Re-run the script with --debug=3 for verbose debugging output. Look for things like missing BMCs, bad authentication token, bad communications with BMCs, etc.
+* Re-run the script with `--debug=3` for verbose debugging output. Look for things like missing BMCs, bad authentication token, or bad communications with BMCs.
 

--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -121,6 +121,13 @@ There are multiple Goss test suites available that cover a variety of subsystems
         ncn/pit# renewncnjoin ncn-xxxx
         ```
   - The `spire-agent` service may also fail if an NCN was powered off for too long and its tokens expired. If this happens, delete `/root/spire/agent_svid.der`, `/root/spire/bundle.der`, and `/root/spire/data/svid.key` off the NCN before deleting the `request-ncn-join-token` daemonset pod.
+* `cfs-state-reporter` errors on storage nodes
+  - If the `cfs-state-reporter` check is failing on one or more storage nodes, it could be an issue with their spire tokens. The following procedure may resolve the problem:
+     1. Run the following script on `ncn-m002`:
+        ```bash
+        ncn-m002# /opt/cray/platform-utils/spire/fix-spire-on-storage.sh
+        ```
+     1. Then re-run the check to see if the problem has been resolved.
 
 <a name="pet-optional-ncnhealthchecks-resources"></a>
 ### 1.2 NCN Resource Checks (optional)

--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -3,7 +3,7 @@
 Anytime after the installation of the CSM services, the health of the management nodes and all CSM services can be validated.
 
 The following are examples of when to run health checks:
-* After CSM install.sh completes
+* After completing the [Install CSM Services](../install/index.md#install_csm_services) step of the CSM install (**not** before)
 * Before and after NCN reboots
 * After the system is brought back up
 * Any time there is unexpected behavior observed
@@ -53,14 +53,6 @@ The Cray CLI must be configured on all NCNs and the PIT node. The following proc
 
 All platform health checks are expected to pass. Each check has been implemented as a [Goss](https://github.com/aelsabbahy/goss) test which reports a PASS or FAIL.
 
-Health Check scripts can be run:
-* After CSM install.sh has been run (not before)
-* Before and after one of the NCNs reboots
-* After the system or a single node goes down unexpectedly
-* After the system is gracefully shut down and brought up
-* Any time there is unexpected behavior on the system to get a baseline of data for CSM services and components
-* In order to provide relevant information to support tickets that are being opened after CSM install.sh has been run
-
 Available Platform Health Checks:
 1. [ncnHealthChecks](#pet-ncnhealthchecks)
 1. [OPTIONAL Check of ncnHealthChecks Resources](#pet-optional-ncnhealthchecks-resources)
@@ -69,28 +61,33 @@ Available Platform Health Checks:
 <a name="pet-ncnhealthchecks"></a>
 ### 1.1 NCN Health Checks
 
-This check requires that the [Cray CLI is configured](#cray-command-line-interface) on all worker NCNs.
+These checks require that the [Cray CLI is configured](#cray-command-line-interface) on all worker NCNs.
+
+If `ncn-m001` is the PIT node, run these checks on `ncn-m001`, otherwise run them from any NCN.
 
 There are multiple Goss test suites available that cover a variety of subsystems. The platform health checks are defined in the test suites `ncn-healthcheck` and `ncn-kubernetes-checks`.
 
-Run the NCN health checks with the following command (If m001 is the PIT node, run on the PIT, otherwise run from any NCN):
+1. Specify the admin user password for the management switches in the system, which is required for the `ncn-healthcheck` test.
 
-Specify the admin user password for the management switches in the system which is required for the `ncn-healthcheck` test.
-```bash
-# export SW_ADMIN_PASSWORD='changeme'
-```
+    ```bash
+    ncn/pit# export SW_ADMIN_PASSWORD='changeme'
+    ```
 
-```bash
-# /opt/cray/tests/install/ncn/automated/ncn-healthcheck
-```
+1. Run the NCN health checks.
 
-And the Kubernetes test suite via:
+    ```bash
+    ncn/pit# /opt/cray/tests/install/ncn/automated/ncn-healthcheck
+    ```
 
-```bash
-# /opt/cray/tests/install/ncn/automated/ncn-kubernetes-checks
-```
+1. Run the Kubernetes checks.
 
-Review the output for `Result: FAIL` and follow the instructions provided to resolve any such test failures. With the exception of the [Known Test Issues](#autogoss-issues), all health checks are expected to pass.
+    ```bash
+    ncn/pit# /opt/cray/tests/install/ncn/automated/ncn-kubernetes-checks
+    ```
+
+1. Review results.
+
+    Review the output for `Result: FAIL` and follow the instructions provided to resolve any such test failures. With the exception of the [Known Test Issues](#autogoss-issues), all health checks are expected to pass.
 
 <a name="autogoss-issues"></a>
 #### 1.1.1 Known Test Issues
@@ -101,31 +98,29 @@ Review the output for `Result: FAIL` and follow the instructions provided to res
   - Because of a [known issue](https://github.com/vmware-tanzu/velero/issues/1980) with Velero, a backup may be attempted immediately upon the deployment of a backup schedule (for example, vault). It may be necessary to delete backups from a Kubernetes node to clear this situation. See the output of the test for more details on how to cleanup backups that have failed due to a known interruption. For example:
      1. Run the following to find the failed backup.
         ```bash
-        ncn# kubectl get backups -A -o json | jq -e ‘.items[] | select(.status.phase == “PartiallyFailed”) | .metadata.name’
+        ncn/pit# kubectl get backups -A -o json | jq -e ‘.items[] | select(.status.phase == “PartiallyFailed”) | .metadata.name’
         ```
      1. Delete the backup, where <backup> is replaced with a backup returned in the previous step.
         ```bash
-        ncn# kubectl delete backups <backup> -n velero
+        ncn/pit# kubectl delete backups <backup> -n velero
         ```
-
 * Verify spire-agent is enabled and running
-
-  - The `spire-agent` service may fail to start on Kubernetes NCNs (all worker nodes and master nodes), logging errors (via journalctl) similar to "join token does not exist or has already been used" or the last logs containing multiple lines of "systemd[1]: spire-agent.service: Start request repeated too quickly.". Deleting the `request-ncn-join-token` daemonset pod running on the node may clear the issue. Even though the `spire-agent` systemctl service on the Kubernetes node should eventually restart cleanly, the user may have to log in to the impacted nodes and restart the service. The following recovery procedure can be run from any Kubernetes node in the cluster.
-     1. Set `NODE` to the NCN which is experiencing the issue. In this example, `ncn-w002`.
-        ```bash
-          ncn# export NODE=ncn-w002
-          ```
+  - The `spire-agent` service may fail to start on Kubernetes NCNs (all worker nodes and master nodes), logging errors (via `journalctl`) similar to "join token does not exist or has already been used" or the last logs containing multiple lines of "systemd[1]: spire-agent.service: Start request repeated too quickly.". Deleting the `request-ncn-join-token` daemonset pod running on the node may clear the issue. Even though the `spire-agent` systemctl service on the Kubernetes node should eventually restart cleanly, the user may have to log in to the impacted nodes and restart the service. The following recovery procedure can be run from any Kubernetes node in the cluster.
      1. Define the following function
         ```bash
-        ncn# function renewncnjoin() { for pod in $(kubectl get pods -n spire |grep request-ncn-join-token | awk '{print $1}'); do if kubectl describe -n spire pods $pod | grep -q "Node:.*$1"; then echo "Restarting $pod running on $1"; kubectl delete -n spire pod "$pod"; fi done }
+        ncn/pit# function renewncnjoin() { 
+            for pod in $(kubectl get pods -n spire |grep request-ncn-join-token | awk '{print $1}'); do 
+                if kubectl describe -n spire pods $pod | grep -q "Node:.*$1"; then
+                    echo "Restarting $pod running on $1"
+                    kubectl delete -n spire pod "$pod"
+                fi
+            done }
         ```
-     1. Run the function as follows:
+     1. Run the function as follows (substituting the name of the impacted NCN):
         ```bash
-        ncn# renewncnjoin $NODE
+        ncn/pit# renewncnjoin ncn-xxxx
         ```
-
   - The `spire-agent` service may also fail if an NCN was powered off for too long and its tokens expired. If this happens, delete `/root/spire/agent_svid.der`, `/root/spire/bundle.der`, and `/root/spire/data/svid.key` off the NCN before deleting the `request-ncn-join-token` daemonset pod.
-
 
 <a name="pet-optional-ncnhealthchecks-resources"></a>
 ### 1.2 NCN Resource Checks (optional)
@@ -133,15 +128,16 @@ Review the output for `Result: FAIL` and follow the instructions provided to res
 To dump the NCN uptimes, the node resource consumptions, and/or the list of pods not in a running state, run the following:
 
 ```bash
-ncn# /opt/cray/platform-utils/ncnHealthChecks.sh -s ncn_uptimes
-ncn# /opt/cray/platform-utils/ncnHealthChecks.sh -s node_resource_consumption
-ncn# /opt/cray/platform-utils/ncnHealthChecks.sh -s pods_not_running
+ncn/pit# /opt/cray/platform-utils/ncnHealthChecks.sh -s ncn_uptimes
+ncn/pit# /opt/cray/platform-utils/ncnHealthChecks.sh -s node_resource_consumption
+ncn/pit# /opt/cray/platform-utils/ncnHealthChecks.sh -s pods_not_running
 ```
+
 <a name="known-issues"></a>
 #### 1.2.1 Known Issues
 
 * pods_not_running
-  - If the output of `pods_not_running` indicates that there are pods in the `Evicted` state, it may be due to the root file system being filled up on the Kubernetes node in question. Kubernetes will begin evicting pods once the root file system space is at 85% until it is back under 80%. This may commonly happen on ncn-m001 as it is a location that install and doc files may be downloaded to. It may be necessary to clean up space in the / directory if this is the root cause of pod evictions. The following commands can be used to determine if analysis of files under / is needed to free-up space. Listing the top 10 files that are 1024M or larger is one way to start the analysis.
+  - If the output of `pods_not_running` indicates that there are pods in the `Evicted` state, it may be due to the root file system being filled up on the Kubernetes node in question. Kubernetes will begin evicting pods once the root file system space is at 85% full until it is back under 80%. This commonly happens on `ncn-m001`, because it is a location where install and documentation files may have been downloaded. It may be necessary to clean up space in the `/` directory if this is the root cause of pod evictions. Listing the top 10 files that are 1024M or larger is one way to start the analysis.
 
     ```bash
     ncn# df -h /
@@ -185,18 +181,18 @@ Information to assist with troubleshooting some of the components mentioned in t
 
 The checks in this section require that the [Cray CLI is configured](#cray-command-line-interface) on nodes where the checks are executed.
 
-Execute the HMS smoke and functional tests after the CSM install to confirm that the Hardware Management Services are running and operational.
+Execute the HMS tests to confirm that the Hardware Management Services are running and operational.
 
 Note: Do not run HMS tests concurrently on multiple nodes. They may interfere with one another and cause false failures.
 
 <a name="hms-test-execution"></a>
 ### 2.1 HMS CT Test Execution
 
-These tests should be executed as root on at least one worker NCN and one master NCN (but **not** ncn-m001 if it is still the PIT node).
+These tests may be executed on any one worker or master NCN (but **not** `ncn-m001` if it is still the PIT node).
 
-Run the HMS CT smoke tests. This is done by running the `run_hms_ct_tests.sh` script:
+Run the HMS CT tests. This is done by running the `run_hms_ct_tests.sh` script:
 
-```
+```bash
 ncn# /opt/cray/csm/scripts/hms_verification/run_hms_ct_tests.sh
 ```
 
@@ -217,16 +213,14 @@ BMC components and Redfish endpoints) are present in HSM.
 
 To perform this comparison execute the `verify_hsm_discovery.py` script on a Kubernetes master or worker NCN. The result is pass/fail (returns 0 or non-zero):
 
-```
+```bash
 ncn# /opt/cray/csm/scripts/hms_verification/verify_hsm_discovery.py
 ```
 
 The output will ideally appear as follows, if there are mismatches these will be displayed in the appropriate section of
 the output. Refer to [2.3.1 Interpreting results](#hms-smd-discovery-validation-interpreting-results) and
 [2.2.2 Known Issues](#hms-smd-discovery-validation-known-issues) below to troubleshoot any mismatched BMCs.
-```bash
-ncn# /opt/cray/csm/scripts/hms_verification/verify_hsm_discovery.py
-
+```text
 HSM Cabinet Summary
 ===================
 x1000 (Mountain)
@@ -284,12 +278,12 @@ that are not discovered in HSM. All other items (nodes, node BMCs and router
 BMCs) which are not discovered are considered warnings.
 
 Any failures need to be investigated by the admin for rectification. Any
-warnings should also be examined by the admin to insure they are accurate and
+warnings should also be examined by the administrator to ensure they are accurate and
 expected.
 
 For each of the BMCs that show up as not being present in HSM components or
-Redfish Endpoints use the following notes to determine if the issue with the
-BMC can be safely ignored, or if there is a legitimate issue with the BMC.
+Redfish Endpoints use the following notes to determine whether the issue with the
+BMC can be safely ignored or needs to be addressed before proceeding.
 
 * The node BMC of 'ncn-m001' will not typically be present in HSM component data, as it is typically connected to the site network instead of the HMN network.
 
@@ -317,7 +311,7 @@ BMC can be safely ignored, or if there is a legitimate issue with the BMC.
 ...
 ```
 
-* HPE PDUs are supported and should show up as being found in HSM. If they are not, they should be investigated since that may indicate that configuration steps have not yet been executed which are required for the PDUs to be discovered. Refer to [HPE PDU Admin Procedures](./hpe_pdu/hpe_pdu_admin_procedures.md) for additional configuration for this type of PDU. The steps to run will depend on if the PDU has been set up yet, and whether or not an upgrade or fresh install of CSM is being performed.
+* HPE PDUs are supported and should show up as being found in HSM. If they are not, they should be investigated since that may indicate that configuration steps have not yet been executed which are required for the PDUs to be discovered. Refer to [HPE PDU Admin Procedures](hpe_pdu/hpe_pdu_admin_procedures.md) for additional configuration for this type of PDU. The steps to run will depend on if the PDU has been set up yet, and whether or not an upgrade or fresh install of CSM is being performed.
    > Cabinet PDU Controllers have xnames in the form of `xXmM`, where `X` is the cabinet and `M` is the ordinal of the Cabinet PDU Controller.
 
    Example mismatch for HPE PDU:
@@ -439,8 +433,7 @@ ncn# /opt/cray/tests/integration/csm/barebonesImageTest
 ```
 
 A successful run would generate output like the following:
-```bash
-ncn# /opt/cray/tests/integration/csm/barebonesImageTest
+```text
 cray.barebones-boot-test: INFO     Barebones image boot test starting
 cray.barebones-boot-test: INFO       For complete logs look in the file /tmp/cray.barebones-boot-test.log
 cray.barebones-boot-test: INFO     Creating bos session with template:csm-barebones-image-test, on node:x3000c0s10b1n0
@@ -464,7 +457,7 @@ The commands in this section require that the [Cray CLI is configured](#cray-com
 
 The procedures below use the CLI as an authorized user and run on two separate node types. The first part runs on the LiveCD node, while the second part runs on a non-LiveCD Kubernetes master or worker node. When using the CLI on either node, the CLI configuration needs to be initialized and the user running the procedure needs to be authorized.
 
-The following procedures run on separate nodes of the system. They are, therefore, separated into separate sub-sections.
+The following procedures run on separate nodes of the system.
 
 1. [Validate Basic UAS Installation](#uas-uai-validate-install)
 1. [Validate UAI Creation](#uas-uai-validate-create)
@@ -486,7 +479,7 @@ This section can be run on any NCN or the PIT node.
       ```
 
       Expected output looks similar to the following:
-      ```
+      ```text
       service_name = "cray-uas-mgr"
       version = "1.11.5"
       ```
@@ -498,7 +491,7 @@ This section can be run on any NCN or the PIT node.
       ```
 
       Expected output looks similar to the following:
-      ```
+      ```text
       results = []
       ```
 
@@ -509,7 +502,7 @@ This section can be run on any NCN or the PIT node.
    ```
 
    Expected output looks similar to the following:
-   ```
+   ```text
    default_image = "registry.local/cray/cray-uai-sles15sp3:1.0.11"
    image_list = [ "registry.local/cray/cray-uai-sles15sp3:1.0.11",]
    ```
@@ -527,7 +520,7 @@ This section can be run on any NCN or the PIT node.
    > take the form of UAIs stuck in 'waiting' state trying to set up volume mounts. See the
    > [UAI Troubleshooting](#uas-uai-validate-debug) section for more information.
 
-This procedure must run on a master or worker node (not the PIT node and not `ncn-w001`) on the system. (It is also possible to do from an external host, but the procedure for that is not covered here).
+This procedure must run on a master or worker node (**not the PIT node and not `ncn-w001`**) on the system.
 
 1. Verify that a UAI can be created:
    ```bash
@@ -535,7 +528,7 @@ This procedure must run on a master or worker node (not the PIT node and not `nc
    ```
 
    Expected output looks similar to the following:
-   ```
+   ```text
    uai_connect_string = "ssh vers@10.16.234.10"
    uai_host = "ncn-w001"
    uai_img = "registry.local/cray/cray-uai-sles15sp3:1.0.11"
@@ -561,7 +554,7 @@ This procedure must run on a master or worker node (not the PIT node and not `nc
    ```
 
    Expected output looks similar to the following:
-   ```
+   ```text
    [[results]]
    uai_age = "0m"
    uai_connect_string = "ssh vers@10.16.234.10"
@@ -587,7 +580,7 @@ This procedure must run on a master or worker node (not the PIT node and not `nc
    ```
 
    Expected output looks similar to the following:
-   ```
+   ```text
    UID          PID    PPID  C STIME TTY          TIME CMD
    root           1       0  0 18:51 ?        00:00:00 /bin/bash /usr/bin/uai-ssh.sh
    munge         36       1  0 18:51 ?        00:00:00 /usr/sbin/munged
@@ -611,7 +604,7 @@ This procedure must run on a master or worker node (not the PIT node and not `nc
    ```
 
    Expected output looks similar to the following:
-   ```
+   ```text
    results = [ "Successfully deleted uai-vers-a00fb46b",]
    ```
 
@@ -633,7 +626,7 @@ ncn# cray uas list
 ```
 
 The symptom of this problem is output similar to the following:
-```
+```text
 Usage: cray uas list [OPTIONS]
 Try 'cray uas list --help' for help.
 
@@ -653,7 +646,7 @@ ncn# cray uas list
 ```
 
 The symptom of this problem is output similar to the following:
-```
+```text
 Usage: cray uas list [OPTIONS]
 Try 'cray uas list --help' for help.
 
@@ -664,26 +657,26 @@ If the wrong hostname was used to reach the API gateway, re-run the CLI initiali
 
 The following shows an example of looking at UAS logs effectively (this example shows only one UAS manager, normally there would be two):
 
-1. Determine the pod name of the uas-mgr pod
+1. Determine the pod name of the `uas-mgr` pod
    ```bash
    ncn# kubectl get po -n services | grep "^cray-uas-mgr" | grep -v etcd
    ```
 
    Expected output looks similar to:
-   ```
+   ```text
    cray-uas-mgr-6bbd584ccb-zg8vx                                    2/2     Running            0          12d
    ```
-2. Set PODNAME to the name of the manager pod whose logs are being viewed.
+2. Set `PODNAME` to the name of the manager pod whose logs are going to be viewed.
    ```bash
    ncn# export PODNAME=cray-uas-mgr-6bbd584ccb-zg8vx
    ```
-3. View its last 25 log entries of the cray-uas-mgr container in that pod, excluding `GET` events:
+3. View the last 25 log entries of the `cray-uas-mgr` container in that pod, excluding `GET` events:
    ```bash
    ncn# kubectl logs -n services $PODNAME cray-uas-mgr | grep -v 'GET ' | tail -25
    ```
 
    Example output:
-   ```
+   ```text
    2021-02-08 15:32:41,211 - uas_mgr - INFO - getting deployment uai-vers-87a0ff6e in namespace user
    2021-02-08 15:32:41,225 - uas_mgr - INFO - creating deployment uai-vers-87a0ff6e in namespace user
    2021-02-08 15:32:41,241 - uas_mgr - INFO - creating the UAI service uai-vers-87a0ff6e-ssh
@@ -720,7 +713,7 @@ ncn# cray uas list
 ```
 
 There may be something similar to the following output:
-```
+```text
 [[results]]
 uai_age = "0m"
 uai_connect_string = "ssh vers@10.103.13.172"

--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -75,8 +75,6 @@ There are multiple Goss test suites available that cover a variety of subsystems
 
 Run the NCN health checks with the following command (If m001 is the PIT node, run on the PIT, otherwise run from any NCN):
 
-**IMPORTANT:** Do not run these as part of upgrade testing. This includes the Kubernetes check in the next block.
-
 Specify the admin user password for the management switches in the system which is required for the `ncn-healthcheck` test.
 ```bash
 # export SW_ADMIN_PASSWORD='changeme'

--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -98,7 +98,7 @@ There are multiple Goss test suites available that cover a variety of subsystems
   - Because of a [known issue](https://github.com/vmware-tanzu/velero/issues/1980) with Velero, a backup may be attempted immediately upon the deployment of a backup schedule (for example, vault). It may be necessary to delete backups from a Kubernetes node to clear this situation. See the output of the test for more details on how to cleanup backups that have failed due to a known interruption. For example:
      1. Run the following to find the failed backup.
         ```bash
-        ncn/pit# kubectl get backups -A -o json | jq -e ‘.items[] | select(.status.phase == “PartiallyFailed”) | .metadata.name’
+        ncn/pit# kubectl get backups -A -o json | jq -e '.items[] | select(.status.phase == "PartiallyFailed") | .metadata.name'
         ```
      1. Delete the backup, where <backup> is replaced with a backup returned in the previous step.
         ```bash


### PR DESCRIPTION
* Add CSM health validation remediation step for cfs-state-reporter test failures on storage nodes
* Correct command syntax errors caused by using "fancy" quote characters
* Removed outdated warning about running some health checks during CSM upgrades
* Include path to set_ssh_keys.py script on Configure_BMC_and_Controller_Parameters_with_scsd.md
* Improve Deploy Final NCN procedure by using previously-defined environment variables and other small tweaks
* Linting (of course)