### PR TITLE
CASMNET-1157: Add peer for CHN edge router if it exists

### DIFF
--- a/upgrade/1.2/scripts/upgrade/update-customizations.sh
+++ b/upgrade/1.2/scripts/upgrade/update-customizations.sh
@@ -100,8 +100,20 @@ errors=0
 peerindex=0
 
 # Gather the metallb peer information and add it to customizations
-for n in "NMN" "CMN"; do
+for n in "NMN" "CMN" "CHN"; do
 numpeers=0
+
+    netName=$(echo "${NETWORKSJSON}" | jq --arg n "$n" '.[] | select(.Name == $n) | .Name')
+
+    if [ -z "${netName}" ]; then
+        if [ "$n" == "CHN" ]; then
+            echo >&2 "info:  No CHN defined in SLS"
+        else
+            echo >&2 "error:  No ${n} defined in SLS"
+            errors=$((errors+1))
+        fi
+        continue
+    fi
 
     peerASN=$(echo "${NETWORKSJSON}" | jq --arg n "$n" '.[] | select(.Name == $n) | .ExtraProperties.PeerASN')
     myASN=$(echo "${NETWORKSJSON}" | jq --arg n "$n" '.[] | select(.Name == $n) | .ExtraProperties.MyASN')
@@ -118,7 +130,28 @@ numpeers=0
 
     subnets=$(echo "${NETWORKSJSON}" | jq -r --arg n "$n" '.[] | select(.Name == $n) | .ExtraProperties.Subnets[].Name')
     for i in ${subnets}; do
-        if [ "${i}" == "network_hardware" ]; then
+        if [[ "${n}" == "CHN" && "${i}" == "bootstrap_dhcp" ]]; then
+            reservations=$(echo "${NETWORKSJSON}" | jq -r --arg n "$n" --arg i "$i" '.[] | select(.Name == $n) | .ExtraProperties.Subnets[] | select(.Name == $i) | .IPReservations[].Name')
+            for j in ${reservations}; do
+                if [[ "${j}" =~ "chn-switch".* ]]; then
+                    numpeers=$((numpeers+1))
+                    peerIP=$(echo "${NETWORKSJSON}" | jq -r --arg n "$n" --arg i "$i" --arg j "$j" '.[] | select(.Name == $n) | .ExtraProperties.Subnets[] | select(.Name == $i) | .IPReservations[] | select(.Name == $j) | .IPAddress')
+
+                    if [ -z "${peerIP}" -o "${peerIP}" == "null" -o "${peerIP}" == "" ]; then
+                        echo >&2 "error:  IPAddress missing in SLS for ${j} in network ${n}"
+                        errors=$((errors+1))
+                    fi
+
+                    if [ $errors -eq 0 ]; then
+                        yq w -i "$c" 'spec.network.metallb.peers['${peerindex}'].peer-address' "${peerIP}"
+                        yq w -i "$c" 'spec.network.metallb.peers['${peerindex}'].peer-asn' "${peerASN}"
+                        yq w -i "$c" 'spec.network.metallb.peers['${peerindex}'].my-asn' "${myASN}"
+                        peerindex=$((peerindex+1))
+                    fi
+                fi
+            done
+
+        elif [[ ("${n}" == "NMN" || "${n}" == "CMN")  && "${i}" == "network_hardware" ]]; then
             reservations=$(echo "${NETWORKSJSON}" | jq -r --arg n "$n" --arg i "$i" '.[] | select(.Name == $n) | .ExtraProperties.Subnets[] | select(.Name == $i) | .IPReservations[].Name')
             for j in ${reservations}; do
                 if [[ "${j}" =~ .*"spine".* ]]; then
@@ -177,7 +210,7 @@ for n in ${networks}; do
             if [ $errors -eq 0 ]; then
                 yq w -i "$c" 'spec.network.metallb.address-pools['${poolindex}'].name' ${poolName}
                 yq w -i "$c" 'spec.network.metallb.address-pools['${poolindex}'].protocol' 'bgp'
-                yq w -i "$c" 'spec.network.metallb.address-pools['${poolindex}'].addresses[+]' ${poolCIDR}
+                yq w -i "$c" 'spec.network.metallb.address-pools['${poolindex}'].addresses[0]' ${poolCIDR}
                 poolindex=$((poolindex+1))
             fi
         fi


### PR DESCRIPTION
## Summary and Scope

If a Customer selects the CHN for Bifurcated CAN (User traffic comes in over the HSN), then MetalLB needs to peer with the edge routers (generally Arista) to distribute CSM service endpoints to to the customer site.

This adds logic to update-customizations.sh to add the edge router peer to the metallb config map if it exists in SLS.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves item #3 in CASMNET-1157

## Testing

Tested by running on hela (with CHN) and fanta (without CHN).

### Test description:

I ran the update-customizations.yaml in the following scenarios:
* on hela (CHN) with customizations.yaml that did not have `spec.network.metallb`
* on hela (CHN) with customizations.yaml from the previous run. (effectively 1.2 -> 1.2 upgrade)
* on fanta (no CHN) with customizations.yaml that did not have `spec.network.metallb`
* on fanta (no CHN) with customizations.yaml from the previous run. (effectively 1.2 -> 1.2 upgrade)

## Risks and Mitigations

Low risk


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

