### PR TITLE
CASMINST-3926: Handle case where secrets don't exist

### DIFF
--- a/upgrade/1.2/scripts/upgrade/prerequisites.sh
+++ b/upgrade/1.2/scripts/upgrade/prerequisites.sh
@@ -219,9 +219,11 @@ if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     ${CSM_ARTI_DIR}/hack/load-container-image.sh artifactory.algol60.net/csm-docker/stable/docker.io/zeromq/zeromq:v4.0.5
     cp -r ${CSM_ARTI_DIR}/shasta-cfg/* ${SITE_INIT_DIR}
     mkdir -p certs
+    set -o pipefail
     kubectl -n loftsman get secret site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d - > customizations.yaml
     kubectl -n kube-system get secret sealed-secrets-key -o jsonpath='{.data.tls\.crt}' | base64 -d - > certs/sealed_secrets.crt
     kubectl -n kube-system get secret sealed-secrets-key -o jsonpath='{.data.tls\.key}' | base64 -d - > certs/sealed_secrets.key
+    set +o pipefail
     . ${BASEDIR}/update-customizations.sh -i ${SITE_INIT_DIR}/customizations.yaml
     yq delete -i ./customizations.yaml spec.kubernetes.tracked_sealed_secrets.cray_reds_credentials
     yq delete -i ./customizations.yaml spec.kubernetes.tracked_sealed_secrets.cray_meds_credentials


### PR DESCRIPTION
## Summary and Scope

Hardening for update-customizations.sh section of prerequisites.sh.

CASMINST-3926 was opened when update-customizations.yaml was run on an empty customizations.yaml file.   This allows us to catch the error when the site-init file doesn't exist rather than moving on with the empty customizations.yaml.

## Issues and Related PRs

* Resolves CASMINST-3926

## Testing

### Tested on:

  * `fanta`

### Test description:

Tested by running the fixed section of prerequisites.sh on fanta with changes that trigger failures in the three piped commands.   Also ran the success case with valid secrets.

## Risks and Mitigations

Low risk.  Just adds hardening against failure cases.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

