### PR TITLE
CRAYSAT-1345: Remove unnecessary "| tee sat.capture-state"

### DIFF
--- a/operations/power_management/Prepare_the_System_for_Power_Off.md
+++ b/operations/power_management/Prepare_the_System_for_Power_Off.md
@@ -58,7 +58,7 @@ An authentication token is required to access the API gateway and to use the `sa
 1.  Use sat to capture state of the system before the shutdown.
 
     ```bash
-    ncn# sat bootsys shutdown --stage capture-state | tee sat.capture-state
+    ncn# sat bootsys shutdown --stage capture-state
     ```
 
 1.  Optional system health checks.


### PR DESCRIPTION
This change fixes a command line instruction which incorrectly told the
user to tee the contents of stdout to the file `sat.capture-state`. When
running `sat bootsys shutdown --stage capture-state`, no information is
expected to be written to stdout, and the state capture is instead
written to S3. Thus the `tee` pipeline should be removed as not to
confuse the admin.
