### PR TITLE
CRAYSAT-1346: Remove link to "System Security and Authentication" page

### DIFF
--- a/operations/power_management/Power_On_Compute_and_IO_Cabinets.md
+++ b/operations/power_management/Power_On_Compute_and_IO_Cabinets.md
@@ -11,7 +11,7 @@ After the CDU is switched on and healthy, the liquid-cooled PDU circuit breakers
 ### Prerequisites
 
 * The cabinet PDUs and coolant distribution units are connected to facility power and are healthy.
-* An authentication token is required to access the API gateway and to use the `sat` command. See the [System Security and Authentication](../security_and_authentication/System_Security_and_Authentication.md) and "SAT Authentication" in the System Admin Tookit (SAT) product stream documentation.
+* An authentication token is required to access the API gateway and to use the `sat` command. See the "SAT Authentication" section of the HPE Cray EX System Admin Toolkit (SAT) product stream documentation (S-8031) for instructions on how to acquire a SAT authentication token.
 
 ### Procedure
 

--- a/operations/power_management/Shut_Down_and_Power_Off_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Shut_Down_and_Power_Off_the_Management_Kubernetes_Cluster.md
@@ -20,7 +20,7 @@ The `sat bootsys` command automates the shutdown of Ceph and the Kubernetes mana
 
 ### Prerequisites
 
-An authentication token is required to access the API gateway and to use the `sat` command. See the [System Security and Authentication](../security_and_authentication/System_Security_and_Authentication.md) and "SAT Authentication" in the System Admin Toolkit (SAT) product stream documentation.
+An authentication token is required to access the API gateway and to use the `sat` command. See the "SAT Authentication" section of the HPE Cray EX System Admin Toolkit (SAT) product stream documentation (S-8031) for instructions on how to acquire a SAT authentication token.
 
 - A work-around may be required to set an SSH key when running the `sat bootsys shutdown --stage platform-services` command below if performing a re-install of a 1.4.x system.
 


### PR DESCRIPTION
This change removes a link to the "System Security and Authentication"
page in the Prerequisites sections of the k8s power off and compute/IO
cabinet power off instructions in relation to authenticating SAT. This
link does not contain information on SAT and so is not relevant to that
instruction.