### PR TITLE
Backup BSS data in a bucket available in 1.0 during prereq step

### DIFF
--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -143,13 +143,13 @@ python3 /usr/share/doc/csm/scripts/patch-ceph-runcmd.py
 
 ## Stage 0.6 - Backup BSS Data
 
-In the event of a problem during the upgrade which may cause the loss of BSS data, perform the following to preserve this data, and back it up to the config-data bucket in your Ceph cluster.
+In the event of a problem during the upgrade which may cause the loss of BSS data, perform the following to preserve this data, and back it up to the vbis bucket in your Ceph cluster.
 
    ```bash
    ncn-m001# cray bss bootparameters list --format=json > bss-backup-$(date +%Y-%m-%d).json
-   ncn-m001# cray artifacts create config-data bss-backup-$(date +%Y-%m-%d).json bss-backup-$(date +%Y-%m-%d).json
+   ncn-m001# cray artifacts create vbis bss-backup-$(date +%Y-%m-%d).json bss-backup-$(date +%Y-%m-%d).json
    ```
 
-The resulting file needs to be saved in the event that BSS data needs to be restored in the future.
+The resulting file will be available in the vbis bucket in the event that BSS data needs to be restored in the future.
 
 Once the above steps have been completed, proceed to [Stage 1](Stage_1.md).


### PR DESCRIPTION
## Summary and Scope

Backing up BSS data to vbis bucket that exists in 1.0 (when prereq runs).

## Issues and Related PRs

* Resolves [CASMINST-4093](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4093)

## Testing

```
ncn-m001:~/UpgradeLogs # cray artifacts create vbis bss-backup-2022-02-22.json  bss-backup-2022-02-22.json
artifact = "bss-backup-2022-02-22.json"
Key = "bss-backup-2022-02-22.json"
```

### Tested on:

  * `drax`

### Test description:

Ran the command with vbis bucket

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable