### PR TITLE
CASMINST-4099 - Fix issue with ceph container image on node rebuild

### DIFF
--- a/upgrade/1.2/scripts/upgrade/ncn-upgrade-ceph-nodes.sh
+++ b/upgrade/1.2/scripts/upgrade/ncn-upgrade-ceph-nodes.sh
@@ -62,6 +62,11 @@ if [[ $state_recorded == "0" ]]; then
         ssh_keygen_keyscan "${upgrade_ncn}"
         ssh_keys_done=1
     fi
+
+    ## TEMP - Remove ceph v15.2.12 from images before backups - CASMINST-4099
+    ssh ${upgrade_ncn} 'podman rmi registry.local/ceph/ceph:v15.2.12'
+    ## END TEMP - CASMINST-4099
+
     ssh ${upgrade_ncn} 'systemctl stop ceph.target;sleep 30;tar -zcvf /tmp/$(hostname)-ceph.tgz /var/lib/ceph /var/lib/containers /etc/ceph;systemctl start ceph.target'
     scp ${upgrade_ncn}:/tmp/${upgrade_ncn}-ceph.tgz .
 


### PR DESCRIPTION
## Summary and Scope

The correct container image is present in the storage node image, however
the restore of the containers overwrites this and corrupts a layer of the image.

## Issues and Related PRs

* Resolves CASMINST-4099


## Testing

### Tested on:

  * Drax

### Test description:

Ran the command on drax-ncn-s002.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

