### PR TITLE
CASMINST-4100 Fix strimzi script paths

### DIFF
--- a/upgrade/1.2/scripts/strimzi/kafka-prereq.sh
+++ b/upgrade/1.2/scripts/strimzi/kafka-prereq.sh
@@ -39,7 +39,7 @@ echo "Backing up helm release cray-kafka-operator secret to /tmp/sh.helm.release
 kubectl get secret -n operators sh.helm.release.v1.cray-kafka-operator.v1 -o yaml >/tmp/sh.helm.release.v1.cray-kafka-operator.v1.yaml
 
 echo "Removing helm secret"
-kubectl delete secret -n operators sh.helm.release.v1.cray-kafka-operator.v1
+kubectl delete secret -n operators sh.helm.release.v1.cray-kafka-operator.v1 || true
 
 echo "Creating a snapshot file in zookeeper if one does not already exist"
 for i in $(kubectl get pods -A | grep zookeeper | awk '{print $1":"$2}'); do

--- a/upgrade/1.2/scripts/upgrade/csm-service-upgrade.sh
+++ b/upgrade/1.2/scripts/upgrade/csm-service-upgrade.sh
@@ -67,7 +67,11 @@ state_name="PRE_STRIMZI_UPGRADE"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" ]]; then
     echo "====> ${state_name} ..."
-    /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/strimzi/kafka-prereq.sh
+
+    pushd /usr/share/doc/csm/upgrade/1.2/scripts/strimzi
+    ./kafka-prereq.sh
+    popd +0
+
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"
@@ -101,7 +105,7 @@ state_name="POST_STRIMZI_UPGRADE"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" ]]; then
     echo "====> ${state_name} ..."
-    /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/strimzi/kafka-restart.sh
+    /usr/share/doc/csm/upgrade/1.2/scripts/strimzi/kafka-restart.sh
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"


### PR DESCRIPTION
The paths were set incorrect in the previous PR. This fixes that issue. pushd/popd is also being added to the kafka-prereq run since that script references paths based on that directory instead of using the full paths to files.