### PR TITLE
Add istio-ca audience during upgrade to api server manifest prior to worker upgrades

### DIFF
--- a/upgrade/1.2/scripts/k8s/update_kubeapi_istio_ca.sh
+++ b/upgrade/1.2/scripts/k8s/update_kubeapi_istio_ca.sh
@@ -22,33 +22,19 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-echo "Updating imageRepository in kubeadm-config configmap"
-echo ""
-kubectl get configmap kubeadm-config -n kube-system -o yaml > /tmp/kubeadm-config.yaml
-cp /tmp/kubeadm-config.yaml /tmp/kubeadm-config.yaml.back
-sed -i 's/imageRepository: k8s.gcr.io/imageRepository: artifactory.algol60.net\/csm-docker\/stable\/k8s.gcr.io/' /tmp/kubeadm-config.yaml
-if ! grep -q istio-ca /tmp/kubeadm-config.yaml; then
-  sed -i '/      runtime-config/a\        api-audiences: "api,istio-ca"' /tmp/kubeadm-config.yaml
-fi
-kubectl -n kube-system apply -f /tmp/kubeadm-config.yaml
+master=$1
 
 export PDSH_SSH_ARGS_APPEND="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
-masters=$(grep -oP 'ncn-m\d+' /etc/hosts | sort -u)
-for master in $masters
-do
-  echo "Upgrading kube-system pods for $master:"
+echo "Adding istio-ca api audience for kube-api on $master:"
+pdsh -b -S -w $master "sed -i '/tls-private-key-file/a\    - --api-audiences=api,istio-ca' /etc/kubernetes/manifests/kube-apiserver.yaml"
+rc=$?
+if [ "$rc" -ne 0 ]; then
   echo ""
-  pdsh -b -S -w $master 'kubeadm upgrade apply v1.20.13 -y'
-  rc=$?
-  if [ "$rc" -ne 0 ]; then
-    echo ""
-    echo "ERROR: The 'kubeadm upgrade apply' failed. The output from this script should be inspected"
-    echo "       and addressed before moving on with the upgrade. If unable to determine the issue"
-    echo "       and run this script without errors, discontinue the upgrade and contact HPE Service"
-    echo "       for support."
-    exit 1
-  fi
-  echo ""
-  echo "Successfully upgraded kube-system pods for $master."
-  echo ""
-done
+  echo "ERROR: Updating kube-apiserver manifest failed. The output from this script should be inspected"
+  echo "       and addressed before moving on with the upgrade. If unable to determine the issue"
+  echo "       and run this script without errors, discontinue the upgrade and contact HPE Service"
+  echo "       for support."
+  exit 1
+fi
+echo "Sleeping for one minute to let kube-apiserver restart on $master"
+sleep 60

--- a/upgrade/1.2/scripts/upgrade/ncn-upgrade-k8s-master.sh
+++ b/upgrade/1.2/scripts/upgrade/ncn-upgrade-k8s-master.sh
@@ -201,6 +201,19 @@ if [[ ${upgrade_ncn} != "ncn-m001" ]]; then
    fi
 fi
 
+# Update kubeapi istio-ca audience newly upgraded master
+state_name="UPDATE_KUBEAPI_ISTIO_CA"
+state_recorded=$(is_state_recorded "${state_name}" ${upgrade_ncn})
+if [[ $state_recorded == "0" ]]; then
+   echo "====> ${state_name} ..."
+
+   /usr/share/doc/csm/upgrade/1.2/scripts/k8s/update_kubeapi_istio_ca.sh ${upgrade_ncn}
+
+   record_state "${state_name}" ${upgrade_ncn}
+else
+   echo "====> ${state_name} has been completed"
+fi
+
 cat <<EOF
 
 NOTE:


### PR DESCRIPTION
## Summary and Scope

kube-api needs to be reconfigured on upgrade of a master node to include the isito-ca audience prior to worker upgrades when istio ingress pods get restarted.

## Issues and Related PRs

* Resolves [CASMINST-4101](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4101)

## Testing

Ran the new script and calling code on drax.

### Tested on:

  * `drax`

### Test description:

Ran the new script and calling code on drax.

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable