### PR TITLE
Authoring of triple-backtick codblocks prevents rendering in Jekyll/Liquid (Follow up)

### DIFF
--- a/install/bootstrap_livecd_remote_iso.md
+++ b/install/bootstrap_livecd_remote_iso.md
@@ -350,6 +350,7 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
                ```json
                {"level":"warn","ts":1612552159.2962296,"msg":"Cooling door found, but xname does not yet exist for cooling doors!","row":
                {"Source":"x3000door-Motiv","SourceRack":"x3000","SourceLocation":" ","DestinationRack":"x3000","DestinationLocation":"u36","DestinationPort":"j27"}}
+               ```
 
       1. Skip the next step and continue with the [CSI Workarounds](#csi-workarounds).
 

--- a/install/bootstrap_livecd_usb.md
+++ b/install/bootstrap_livecd_usb.md
@@ -327,6 +327,7 @@ Some files are needed for generating the configuration payload. See these topics
          ```json
          {"level":"warn","ts":1612552159.2962296,"msg":"Cooling door found, but xname does not yet exist for cooling doors!","row":
          {"Source":"x3000door-Motiv","SourceRack":"x3000","SourceLocation":" ","DestinationRack":"x3000","DestinationLocation":"u36","DestinationPort":"j27"}}
+         ```
 
    1. Skip the next step and continue with the [CSI Workarounds](#csi-workarounds).
 

--- a/install/collect_mac_addresses_for_ncns.md
+++ b/install/collect_mac_addresses_for_ncns.md
@@ -118,6 +118,7 @@ making a backup of them, in case they need to be examined at a later time.
          ```json
          {"level":"warn","ts":1612552159.2962296,"msg":"Cooling door found, but xname does not yet exist for cooling doors!","row":
          {"Source":"x3000door-Motiv","SourceRack":"x3000","SourceLocation":" ","DestinationRack":"x3000","DestinationLocation":"u36","DestinationPort":"j27"}}
+         ```
 
 
 1. Follow the [workaround instructions](../update_product_stream/index.md#apply-workarounds) for the `csi-config` breakpoint.
@@ -311,6 +312,7 @@ making a backup of them, in case they need to be examined at a later time.
          ```json
          {"level":"warn","ts":1612552159.2962296,"msg":"Cooling door found, but xname does not yet exist for cooling doors!","row":
          {"Source":"x3000door-Motiv","SourceRack":"x3000","SourceLocation":" ","DestinationRack":"x3000","DestinationLocation":"u36","DestinationPort":"j27"}}
+         ```
 
 
 1. Follow the [workaround instructions](../update_product_stream/index.md#apply-workarounds) for the `csi-config` breakpoint.

--- a/install/configure_dell_aggregation_switch.md
+++ b/install/configure_dell_aggregation_switch.md
@@ -340,6 +340,7 @@ These are ports that are connected to management nodes.
        spanning-tree bpdu-guard
        spanning-tree port-type admin-edge
        exit
+   ```
 
 1. Set the Dell UAN CAN configuration.
 

--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -709,7 +709,7 @@ After the NCNs are booted, the BGP peers will need to be checked and updated if 
 
    1. Run CANU if you have Aruba switches.
      
-      CANU requires three parameters: the IP address of switch 1, the IP addresss of switch 2, and the path to the to directory containing the file ```sls_input_file.json```
+      CANU requires three parameters: the IP address of switch 1, the IP addresss of switch 2, and the path to the to directory containing the file `sls_input_file.json`
 
       The IP addresses in this example should be replaced by the IP addresses of the switches.
 

--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -381,7 +381,6 @@ The configuration workflow described here is intended to help understand the exp
 
       > ```bash
       > pit# ls /opt/cray/csm/workarounds/after-ncn-boot
-      > ```
       > CASMINST-1093
       > ```
 
@@ -705,7 +704,8 @@ After the NCNs are booted, the BGP peers will need to be checked and updated if 
       The IP addresses in this example should be replaced by the IP addresses of the switches.
 
       ```bash
-      pit# /usr/local/bin/mellanox_set_bgp_peers.py 10.252.0.2 10.252.0.3 /var/www/ephemeral/prep/${SYSTEM_NAME}/networks/```
+      pit# /usr/local/bin/mellanox_set_bgp_peers.py 10.252.0.2 10.252.0.3 /var/www/ephemeral/prep/${SYSTEM_NAME}/networks/
+      ```
 
    1. Run CANU if you have Aruba switches.
      
@@ -714,7 +714,8 @@ After the NCNs are booted, the BGP peers will need to be checked and updated if 
       The IP addresses in this example should be replaced by the IP addresses of the switches.
 
       ```bash
-      pit# canu -s 1.5 config bgp --ips 10.252.0.2,10.252.0.3 --csi-folder /var/www/ephemeral/prep/${SYSTEM_NAME}/```
+      pit# canu -s 1.5 config bgp --ips 10.252.0.2,10.252.0.3 --csi-folder /var/www/ephemeral/prep/${SYSTEM_NAME}/
+      ```
 
    1. Check the status of the BGP peering sessions **on each switch**.
       - Aruba: `show bgp ipv4 unicast summary`
@@ -726,7 +727,7 @@ After the NCNs are booted, the BGP peers will need to be checked and updated if 
 
       You should see that the `MsgRcvd` and `MsgSent` columns for the worker IP addresses are 0.
    1. Check the BGP config ***on each switch*** to verify that the NCN neighbors are configured as passive.
-      - Aruba: ```show run bgp``` The passive neighbor configuration is required. ```neighbor 10.252.1.7 passive``` 
+      - Aruba: `show run bgp` The passive neighbor configuration is required. `neighbor 10.252.1.7 passive` 
       EXAMPLE ONLY
 
         ```
@@ -743,7 +744,7 @@ After the NCNs are booted, the BGP peers will need to be checked and updated if 
         neighbor 10.252.1.9 remote-as 65533
         neighbor 10.252.1.9 passive
         ```
-      - Mellanox: ```show run protocol bgp``` The passive neighbor configuration is required. ```router bgp 65533 vrf default neighbor 10.252.1.7 transport connection-mode passive``` 
+      - Mellanox: `show run protocol bgp` The passive neighbor configuration is required. `router bgp 65533 vrf default neighbor 10.252.1.7 transport connection-mode passive` 
       EXAMPLE ONLY
 
         ```

--- a/install/restart_network_services_and_interfaces_on_ncns.md
+++ b/install/restart_network_services_and_interfaces_on_ncns.md
@@ -135,7 +135,7 @@ sorted by safest to touch relative to keeping an SSH connection up.
          route:    ipv6 fe80::/64 type unicast table main scope universe protocol kernel priority 256
 
    eth0            no-device
-
+   ```
 
 * Print real devices ( ignore no-device )
 

--- a/install/wipe_ncn_disks_for_reinstallation.md
+++ b/install/wipe_ncn_disks_for_reinstallation.md
@@ -208,6 +208,7 @@ RAIDs, zeroing the disks, and then wiping the disks and RAIDs.
 
       ncn-s001:~ # umount -v /var/lib/containers
       umount: /var/lib/containers unmounted
+      ```
 
 1. Remove auxiliary LVMs
 

--- a/operations/UAS_user_and_admin_topics/Configure_a_Broker_UAI_Class.md
+++ b/operations/UAS_user_and_admin_topics/Configure_a_Broker_UAI_Class.md
@@ -82,6 +82,7 @@ This example, uses Kubernetes secrets and assumes that the broker UAIs run in th
 
         ```
         ncn-m001-pit# kubectl create secret generic -n uas broker-sssd-conf --from-file=sssd.conf
+        ```
 
   3. Make a volume for the secret in the UAS configuration.
 
@@ -139,6 +140,7 @@ This example, uses Kubernetes secrets and assumes that the broker UAIs run in th
    comment = "UAI User Class"
    class_id = "bb28a35a-6cbc-4c30-84b0-6050314af76b"
    comment = "Non-Brokered UAI User Class"
+   ```
 
 5. Create the broker UAI class with the content retrieved in the previous step.
 
@@ -182,7 +184,5 @@ This example, uses Kubernetes secrets and assumes that the broker UAIs run in th
    default = false
    image_id = "c5dcb261-5271-49b3-9347-afe7f3e31941"
    imagename = "dtr.dev.cray.com/cray/cray-uai-broker:latest"
-
-
-
+   ```
 

--- a/operations/firmware/FAS_Admin_Procedures.md
+++ b/operations/firmware/FAS_Admin_Procedures.md
@@ -145,6 +145,7 @@ If an update fails because of `"No Image available"`, it may be caused by FAS un
            "overwriteSameImage":false
          }
        }
+   ```
 
 3. Verify the correct image ID was found.
 

--- a/operations/system_layout_service/Restore_SLS_Postgres_Database_from_Backup.md
+++ b/operations/system_layout_service/Restore_SLS_Postgres_Database_from_Backup.md
@@ -22,6 +22,7 @@ This procedure can be used to restore the SLS Postgres database from a previousl
     > ncn# cray artifacts list postgres-backup --format json | jq -r '.artifacts[].Key | select(contains("sls"))'
     > cray-sls-postgres-2021-07-11T23:10:08.manifest
     > cray-sls-postgres-2021-07-11T23:10:08.psql
+    > ```
 
 ## Procedure
 1. Retrieve a previously taken SLS Postgres backup. This can be either a previously taken manual SLS backup or an automatic Postgres backup in the `postgres-backup` S3 bucket.

--- a/troubleshooting/cms_barebones_image_boot.md
+++ b/troubleshooting/cms_barebones_image_boot.md
@@ -147,6 +147,7 @@ The session template below can be copied and used as the basis for the BOS sessi
      "enable_cfs": false,
      "name": "shasta-1.4-csm-bare-bones-image"
    }
+   ```
 
    **NOTE**: Be sure to replace the values of the `etag` and `path` fields with the ones noted earlier in the `cray ims images list` command.
 


### PR DESCRIPTION
## Summary and Scope

In my original reporting of the underlying issue

https://github.com/Cray-HPE/docs-csm/issues/952

I'd stated that

> Reason for not forking is that there is just too much of it to clean up!

although, in absence of any feedback around that issue, I decided to
take a closer look at the problem and, after some head scratching, as
regards trying to see where triple-backtick code blocks have not been
properly closed off, have narrowed down a smaller set of instances, and, 
one instance, which turned out to be the one that made it appear that 
there were many more issues than now seems to be the case, where
triple-backticks had been used "in-line", when there is no need to use
them.

Hope this patch helps you: it has certainly helped me!
