### PR TITLE
Cleanup ssh keygen noise that is confusing

### DIFF
--- a/upgrade/1.2/scripts/upgrade/ncn-upgrade-common.sh
+++ b/upgrade/1.2/scripts/upgrade/ncn-upgrade-common.sh
@@ -94,10 +94,10 @@ function ssh_keygen_keyscan() {
     [ -n "${ncn_ip}" ]
     # Because we may be called without set -e, we should check return codes after running commands
     [ $? -ne 0 ] && return 1
-    echo "${upgrade_ncn} IP address is ${ncn_ip}"
-    ssh-keygen -R "${upgrade_ncn}" -f "${known_hosts}"
+    echo "Updating SSH keys for node ${upgrade_ncn} with IP address of ${ncn_ip}"
+    ssh-keygen -R "${upgrade_ncn}" -f "${known_hosts}" > /dev/null 2>&1
     [ $? -ne 0 ] && return 1
-    ssh-keygen -R "${ncn_ip}" -f "${known_hosts}"
+    ssh-keygen -R "${ncn_ip}" -f "${known_hosts}" > /dev/null 2>&1
     [ $? -ne 0 ] && return 1
     ssh-keyscan -H "${upgrade_ncn},${ncn_ip}" >> "${known_hosts}"
     return $?

--- a/upgrade/1.2/scripts/upgrade/prerequisites.sh
+++ b/upgrade/1.2/scripts/upgrade/prerequisites.sh
@@ -205,7 +205,7 @@ state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" ]]; then
     echo "====> ${state_name} ..."
     if [[ ! -f /root/docs-csm-latest.noarch.rpm ]]; then
-        echo "Please make sure 'docs-csm-latest.noarch.rpm' exists under: /root"
+        echo "ERROR: docs-csm-latest.noarch.rpm is missing under: /root -- halting..."
         exit 1
     fi
     cp /root/docs-csm-latest.noarch.rpm ${CSM_ARTI_DIR}/rpm/cray/csm/sle-15sp2/


### PR DESCRIPTION
## Summary and Scope

Cleanup normal ssh keygen messages that look like errors, make missing doc rpm obviously an error

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-4124](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4124)

## Testing

```
ncn-m001:~ # ./foo.sh
Updating SSH keys for node ncn-m001 with IP address of 10.248.5.11
# ncn-m001:22 SSH-2.0-OpenSSH_8.4
# ncn-m001:22 SSH-2.0-OpenSSH_8.4
# ncn-m001:22 SSH-2.0-OpenSSH_8.4
# ncn-m001:22 SSH-2.0-OpenSSH_8.4
# ncn-m001:22 SSH-2.0-OpenSSH_8.4
Updating SSH keys for node ncn-m002 with IP address of 10.248.2.52
# ncn-m002:22 SSH-2.0-OpenSSH_8.4
# ncn-m002:22 SSH-2.0-OpenSSH_8.4
# ncn-m002:22 SSH-2.0-OpenSSH_8.4
# ncn-m002:22 SSH-2.0-OpenSSH_8.4
# ncn-m002:22 SSH-2.0-OpenSSH_8.4
Updating SSH keys for node ncn-m003 with IP address of 10.248.3.25
# ncn-m003:22 SSH-2.0-OpenSSH_8.4
# ncn-m003:22 SSH-2.0-OpenSSH_8.4
# ncn-m003:22 SSH-2.0-OpenSSH_8.4
# ncn-m003:22 SSH-2.0-OpenSSH_8.4
# ncn-m003:22 SSH-2.0-OpenSSH_8.4
Updating SSH keys for node ncn-s001 with IP address of 10.248.2.208
# ncn-s001:22 SSH-2.0-OpenSSH_8.4
# ncn-s001:22 SSH-2.0-OpenSSH_8.4
# ncn-s001:22 SSH-2.0-OpenSSH_8.4
# ncn-s001:22 SSH-2.0-OpenSSH_8.4
# ncn-s001:22 SSH-2.0-OpenSSH_8.4
Updating SSH keys for node ncn-s002 with IP address of 10.248.6.35
# ncn-s002:22 SSH-2.0-OpenSSH_8.4
# ncn-s002:22 SSH-2.0-OpenSSH_8.4
# ncn-s002:22 SSH-2.0-OpenSSH_8.4
# ncn-s002:22 SSH-2.0-OpenSSH_8.4
# ncn-s002:22 SSH-2.0-OpenSSH_8.4
Updating SSH keys for node ncn-s003 with IP address of 10.248.3.120
# ncn-s003:22 SSH-2.0-OpenSSH_8.4
# ncn-s003:22 SSH-2.0-OpenSSH_8.4
# ncn-s003:22 SSH-2.0-OpenSSH_8.4
# ncn-s003:22 SSH-2.0-OpenSSH_8.4
# ncn-s003:22 SSH-2.0-OpenSSH_8.4
Updating SSH keys for node ncn-w001 with IP address of 10.248.1.172
# ncn-w001:22 SSH-2.0-OpenSSH_8.4
# ncn-w001:22 SSH-2.0-OpenSSH_8.4
# ncn-w001:22 SSH-2.0-OpenSSH_8.4
# ncn-w001:22 SSH-2.0-OpenSSH_8.4
# ncn-w001:22 SSH-2.0-OpenSSH_8.4
Updating SSH keys for node ncn-w002 with IP address of 10.248.0.59
# ncn-w002:22 SSH-2.0-OpenSSH_8.4
# ncn-w002:22 SSH-2.0-OpenSSH_8.4
# ncn-w002:22 SSH-2.0-OpenSSH_8.4
# ncn-w002:22 SSH-2.0-OpenSSH_8.4
# ncn-w002:22 SSH-2.0-OpenSSH_8.4
Updating SSH keys for node ncn-w003 with IP address of 10.248.5.251
# ncn-w003:22 SSH-2.0-OpenSSH_8.4
# ncn-w003:22 SSH-2.0-OpenSSH_8.4
# ncn-w003:22 SSH-2.0-OpenSSH_8.4
# ncn-w003:22 SSH-2.0-OpenSSH_8.4
# ncn-w003:22 SSH-2.0-OpenSSH_8.4
```

### Tested on:

  * `craystack`

### Test description:

Ran subsets of code with changes

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

