### PR TITLE
CASMINST-4125: never wipe USB devices

### DIFF
--- a/upgrade/1.0.11/scripts/upgrade/ncn-upgrade-wipe-rebuild.sh
+++ b/upgrade/1.0.11/scripts/upgrade/ncn-upgrade-wipe-rebuild.sh
@@ -78,11 +78,10 @@ if [[ $state_recorded == "0" ]]; then
 EOF
     elif [[ $upgrade_ncn == ncn-m* ]]; then
     cat <<'EOF' > wipe_disk.sh
-    usb_device=$(lsblk -b -l -o TRAN,PATH | grep usb)
+    usb_device_path=$(lsblk -b -l -o TRAN,PATH | awk /usb/'{print $2}')
     usb_rc=$?
     set -e
     if [[ "$usb_rc" -eq 0 ]]; then
-      usb_device_path=$(echo $usb_device | awk '{print $2}')
       if blkid -p $usb_device_path; then
         have_mnt=0
         for mnt_point in /mnt/rootfs /mnt/sqfs /mnt/livecd /mnt/pitdata; do
@@ -100,8 +99,12 @@ EOF
     for md in /dev/md/*; do mdadm -S $md || echo nope ; done
     vgremove -f --select 'vg_name=~metal*' || true
     pvremove /dev/md124 || true
-    wipefs --all --force /dev/sd* /dev/disk/by-label/* || true
-    sgdisk --zap-all /dev/sd*
+    # Select the devices we care about; RAID, SATA, and NVME devices/handles (but *NOT* USB)
+    disk_list=$(lsblk -l -o SIZE,NAME,TYPE,TRAN | grep -E '(raid|sata|nvme|sas)' | sort -u | awk '{print "/dev/"$2}' | tr '\n' ' ')
+    for disk in $disk_list; do
+        wipefs --all --force wipefs --all --force "$disk" || true
+        sgdisk --zap-all "$disk"
+    done
 EOF
     else
     cat <<'EOF' > wipe_disk.sh


### PR DESCRIPTION
## Summary and Scope

The wipe commands don't care if a device is mounted or not.  They
will wipe it regardless.

Modify the code so the list of devices to wipe doesn't include the
USB.  This borrows code that is in dracut for the same reason.

While here, reduce the number of lines needed to figure out which
device is the USB device.  (IMO, this code doesn't need to care about
whether the USB device is mounted or not, but it's a smaller code
change to leave that logic in place.  And it's harmless.)

## Issues and Related PRs

* Resolves [CASMINST-4125](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4125)

## Testing

### Tested on:

  * `redbull`


### Test description:

Tested the snippets on redbull, but echoing the commands instead of executing them.

## Risks and Mitigations

No additional risk.


