### PR TITLE
CASMINST-3962: Alter NTP time documentation to limit adjustments of hardware clock

### DIFF
--- a/install/deploy_final_ncn.md
+++ b/install/deploy_final_ncn.md
@@ -125,7 +125,7 @@ the Kubernetes cluster as the final of three master nodes forming a quorum.
 
     1. Set the variables.
 
-        **IMPORTANT:** The variables you set depend on whether or not you customized the default NCN images. The most
+        **IMPORTANT:** The variables you set depend on whether you customized the default NCN images. The most
         common procedures that involve customizing the images are
         [Configuring NCN Images to Use Local Timezone](../operations/node_management/Configure_NTP_on_NCNs.md#configure_ncn_images_to_use_local_timezone) and
         [Changing NCN Image Root Password and SSH Keys](../operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md).

--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -106,6 +106,13 @@ proceed to step 2.
 
    This ensures that the PIT is configured with an accurate date/time, which will be properly propagated to the NCNs during boot.
 
+   If you receive the error `Failed to set time: NTP unit is active` you will need to stop `chrony` first.
+
+   ```bash
+   pit# systemctl stop chronyd
+   ```
+   Then run the commands above to complete the process.
+
 1. Ensure the current time is set in BIOS for all management NCNs.
 
    > If each NCN is booted to the BIOS menu, you can check and set the current UTC time.

--- a/operations/resiliency/NTP_Resiliency.md
+++ b/operations/resiliency/NTP_Resiliency.md
@@ -8,7 +8,7 @@ This procedure requires administrative privileges.
 
 ### Procedure
 
-1.  Set the date manually if the time on NCNs is off by more than an a few hours, days, or more.
+1.  Set the date manually if the time on NCNs is off by more than a few hours.
 
     For example:
 


### PR DESCRIPTION
## Summary and Scope

The change in the documentation is related to a system administrator making changes to the timezone used by the system. The current documentation is missing any warnings in regards to the consequences of changing the system time, especially the hardware clock. A few warnings, notes, and exceptions have been added to the documentation. Also, a few lines have been removed that changed the hardware clock timezone as well. These commands might be copied without understanding the impact. And any system administrator that wants to change the hardware clock for a specific reason will probably already know what needs to be done.

## Issues and Related PRs

* Resolves [CASMINST-3962](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3962)

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

