### PR TITLE
CASMNET-1164 and CASMTRIAGE-3007 SLS upgrade BGP and IP overlap fixes

### DIFF
--- a/upgrade/1.2/scripts/sls/sls_updater_csm_1.2.py
+++ b/upgrade/1.2/scripts/sls/sls_updater_csm_1.2.py
@@ -117,9 +117,9 @@ help = """Upgrade a system SLS file from CSM 1.0 to CSM 1.2.
 @click.option(
     "--bgp-nmn-asn",
     required=False,
-    help="The autonomous system number for NMN BGP clients",
+    help="The autonomous system number for NMN BGP clients (preserve <= CSM 1.0 defaults)",
     type=click.IntRange(64512, 65534),
-    default=65531,
+    default=65533,
     show_default=True,
 )
 @click.option(
@@ -252,10 +252,6 @@ def main(
     remove_api_gw_from_hmnlb_reservations(networks)
 
     #
-    # Remove kube-api reservations from all networks except NMN.
-    remove_kube_api_reservations(networks)
-
-    #
     # Create BICAN network
     #   (not order dependent)
     create_bican_network(networks, default_route_network_name=bican_user_network_name)
@@ -278,6 +274,10 @@ def main(
     remove_can_static_pool(networks)
 
     #
+    # Remove kube-api reservations from all networks except NMN.
+    remove_kube_api_reservations(networks)
+
+    #
     # Create (new) CHN network
     #   (not order dependent)
     create_chn_network(networks, customer_highspeed_network)
@@ -290,7 +290,13 @@ def main(
     #
     # Add BGP peering data to CMN and NMN
     #   (ORDER DEPENDENT!!! - Must be run after CMN creation)
-    create_metallb_pools_and_asns(networks, bgp_asn, bgp_chn_asn, bgp_cmn_asn, bgp_nmn_asn)
+    create_metallb_pools_and_asns(
+        networks,
+        bgp_asn,
+        bgp_chn_asn,
+        bgp_cmn_asn,
+        bgp_nmn_asn,
+    )
 
     #
     # Update uai_macvlan dhcp ranges in the NMN network.


### PR DESCRIPTION
   ## Summary and Scope

Bugfixes:
* Previous BGP ASN defaults included an RFC-specified "documentation" ASN.  This was fixed in the SLS upgrade as well as CSI, but during upgrade from CSM 1.0 to CSM 1.0 this new default caused issues if it was not matched with MetalLB configs.  This fix retains the <= CSM 1.0 defaults for upgraded systems.
* During upgrade the kube-api and CAN switch reservations were removed very early on in the process to prevent gaps in sequential IPs from occuring.  This, unfortunately caused NCN IP's to shift around by one to three IP addresses during upgrade which caused overlapping IPs just during the upgrade process.  This overlap caused a race condition.  This fix removes kube-api and CAN switch IPs much later in the process to help retain NCN IPs and prevent the race condition.

Doc changes:
* Fixed a noted mismatch in DOCDIR vs DOC_DIR environment variables in docs.
* Removed docs for preserving vestigial CAN data if CHN is used to prevent misinterpretation.
* Added warnings and more guidance on the important need for installers to compare and verify the upgraded SLS data.
* Added small guidance for network experts to enable pinning of subnets during upgrade to prevent any noted overlapping IPs and to provide "hints" to the upgrader on where subnets should fall in a network.


## Issues and Related PRs

* Resolves [CASMNET-1164](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1164)
* Resolves [CASMTRIAGE-3007](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3007)

## Testing

### Tested on:

  * Locally on Fanta and Surtur data.
  * Directly on Surtur (for runtime checks).
  * One very large customer system.

### Test description:

* Ensure the existing NMN BGP ASN from 1.0 is used as seen in the upgraded SLS file.
* Ensure that for the most frequent use case where external-dns IP needs to be preserved, that the resulting upgrade either does not change NCN IPs or "expert" mode guidance can be used to retain NCN IPs.

## Risks and Mitigations
Shifting around subnets while pinning desired IPs as a constraint is difficult in corner cases.  The upgrader is designed for 90% of the use cases (as outlined in the docs). Expert mode can bring this to about 98% coverage.
