### PR TITLE
CASMINST-1673: Remove note about having to reset the terminal after livecd-preflight test

### DIFF
--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -306,7 +306,6 @@ The configuration workflow described here is intended to help understand the exp
     pit# csi pit validate --livecd-preflight
     ```
 
-    > Note: This check sometimes leaves the terminal in a state where input is not echoed to the screen. If this happens, running the `reset` command will correct it.
     > Note: You can ignore any errors about not being able resolve arti.dev.cray.com.
 
 1. Print the consoles available to you:


### PR DESCRIPTION

## Summary and Scope

CASMINST-1673 has been fixed so we no longer need the note about having to reset the terminal after running the livecd-preflight-check.

## Issues and Related PRs

* Related to CASMINST-1673



## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

