### PR TITLE
added manual workaround for unbound clbo

### DIFF
--- a/troubleshooting/index.md
+++ b/troubleshooting/index.md
@@ -12,6 +12,7 @@ This document provides troubleshooting information for services and functionalit
     * [CFS Sessions are Stuck in a Pending State](known_issues/cfs_sessions_stuck_in_pending.md)
     * [Orphaned CFS Pods After Booting or Rebooting](known_issues/orphaned_cfs_pods.md)
     * [Wait_for_unbound or cray-dns-unbound-manager hangs](known_issues/wait_for_unbound_hang.md)
+    * [Unbound in CrashLoopBackOff after deployment restart](known_issues/unbound_clbo.md)
  * Kubernetes troubleshooting
     * [General Kubernetes Commands for Troubleshooting](./kubernetes/Kubernetes_Troubleshooting_Information.md)
     * [Kubernetes Log File Locations](./kubernetes/Kubernetes_Log_File_Locations.md)

--- a/troubleshooting/known_issues/unbound_clbo.md
+++ b/troubleshooting/known_issues/unbound_clbo.md
@@ -1,0 +1,11 @@
+#Unbound in CrashLoopBackOff After Deployment Restart
+
+* There is a known race condition that can cause cray-dns-unbound to go into CLBO after running:
+    ```bash
+    kubectl rollout restart deployment -n services cray-dns-unbound
+     ```
+* This can impact csm-1.0.10 or older.
+* Run the following command to get cray-dns-unbound out of CLBO
+  ```bash
+  kubectl patch deployment -n services cray-dns-unbound --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/command", "value": ["sh", "-c", "touch /etc/unbound/records.conf;/srv/unbound/entrypoint.sh"]}]'
+  ```

--- a/upgrade/1.0.10/README.md
+++ b/upgrade/1.0.10/README.md
@@ -141,6 +141,9 @@ Waiting for deployment "cray-dns-unbound" rollout to finish: 1 old replicas are 
 Waiting for deployment "cray-dns-unbound" rollout to finish: 1 old replicas are pending termination...
 deployment "cray-dns-unbound" successfully rolled out
 ```
+
+* If cray-dns-unbound goes into CLBO after deployment restart. 
+Please see [Unbound in CrashLoopBackOff after deployment restart](../../troubleshooting/known_issues/unbound_clbo.md)
 <a name="apply-pod-priorities"></a>
 
 ## Apply Pod Priorities


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
- added manual workaround for cray-dns-unbound going into clbo on a deployment restart with csm-1.0.10 and older
- 
_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

CASMTRIAGE-3031

## Testing

_List the environments in which these changes were tested._

### Tested on:

loki
hela
### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?n
- Were continuous integration tests run? If not, why?n
- Was upgrade tested? If not, why?n
- Was downgrade tested? If not, why?n
- Were new tests (or test issues/Jiras) created for this change?n

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_

none
## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

