### PR TITLE
Change validation step to use /etc/hosts instead of script in tarball

### DIFF
--- a/upgrade/1.0.11/Stage_5.md
+++ b/upgrade/1.0.11/Stage_5.md
@@ -12,7 +12,7 @@
 1. Verify that fix for CVE-2022-0185 (Linux kernel buffer overflow/container escape) is in place:
 
     ```bash
-    ncn-m001:~ # pdsh -w $(/etc/cray/upgrade/csm/csm-1.0.*/tarball/csm-1.0.*/lib/list-ncns.sh 2>/dev/null | paste -sd,) "uname -a"
+    ncn-m001:~ # pdsh -w $(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u | tr -t '\n' ',') "uname -a"
     ncn-m001: Linux ncn-m002 5.3.18-24.99-default #1 SMP Sun Jan 23 19:03:51 UTC 2022 (712a8e6) x86_64 x86_64 x86_64 GNU/Linux
     ncn-m002: Linux ncn-m002 5.3.18-24.99-default #1 SMP Sun Jan 23 19:03:51 UTC 2022 (712a8e6) x86_64 x86_64 x86_64 GNU/Linux
     ncn-m003: Linux ncn-m003 5.3.18-24.99-default #1 SMP Sun Jan 23 19:03:51 UTC 2022 (712a8e6) x86_64 x86_64 x86_64 GNU/Linux
@@ -29,7 +29,7 @@
 1. Verify that fix for CVE-2021-4034 (pwnkit: Local Privilege Escalation in polkit's pkexec) is in place:
 
     ```bash
-    ncn-m001:~ # pdsh -w $(/etc/cray/upgrade/csm/csm-1.0.*/tarball/csm-1.0.*/lib/list-ncns.sh 2>/dev/null | paste -sd,) "rpm -q polkit"
+    ncn-m002:~ # pdsh -w $(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u | tr -t '\n' ',') "rpm -q polkit"
     ncn-m001: polkit-0.116-3.6.1.x86_64
     ncn-m002: polkit-0.116-3.6.1.x86_64
     ncn-m003: polkit-0.116-3.6.1.x86_64


### PR DESCRIPTION
## Summary and Scope

This will allow the validation to occur from any master, not just the original master where the tarball existed

## Issues and Related PRs

* Resolves [CASMINST-4150](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4150)

## Testing

```
ncn-m001:/usr/share/doc # pdsh -w $(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u | tr -t '\n' ',') "uname -a"
ncn-s002: Linux ncn-s002 5.3.18-24.99-default #1 SMP Sun Jan 23 19:03:51 UTC 2022 (712a8e6) x86_64 x86_64 x86_64 GNU/Linux
ncn-s001: Linux ncn-s001 5.3.18-24.99-default #1 SMP Sun Jan 23 19:03:51 UTC 2022 (712a8e6) x86_64 x86_64 x86_64 GNU/Linux
ncn-s003: Linux ncn-s003 5.3.18-24.99-default #1 SMP Sun Jan 23 19:03:51 UTC 2022 (712a8e6) x86_64 x86_64 x86_64 GNU/Linux
ncn-m001: Linux ncn-m001 5.3.18-24.99-default #1 SMP Sun Jan 23 19:03:51 UTC 2022 (712a8e6) x86_64 x86_64 x86_64 GNU/Linux
ncn-m002: Linux ncn-m002 5.3.18-24.99-default #1 SMP Sun Jan 23 19:03:51 UTC 2022 (712a8e6) x86_64 x86_64 x86_64 GNU/Linux
ncn-m003: Linux ncn-m003 5.3.18-24.99-default #1 SMP Sun Jan 23 19:03:51 UTC 2022 (712a8e6) x86_64 x86_64 x86_64 GNU/Linux
ncn-w003: Linux ncn-w003 5.3.18-24.99-default #1 SMP Sun Jan 23 19:03:51 UTC 2022 (712a8e6) x86_64 x86_64 x86_64 GNU/Linux
ncn-w002: Linux ncn-w002 5.3.18-24.99-default #1 SMP Sun Jan 23 19:03:51 UTC 2022 (712a8e6) x86_64 x86_64 x86_64 GNU/Linux
ncn-w001: Linux ncn-w001 5.3.18-24.99-default #1 SMP Sun Jan 23 19:03:51 UTC 2022 (712a8e6) x86_64 x86_64 x86_64 GNU/Linux
```

```
ncn-m001:/usr/share/doc # pdsh -w $(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u | tr -t '\n' ',') "rpm -q polkit"
ncn-s003: polkit-0.116-3.6.1.x86_64
ncn-s002: polkit-0.116-3.6.1.x86_64
ncn-s001: polkit-0.116-3.6.1.x86_64
ncn-m001: polkit-0.116-3.6.1.x86_64
ncn-m002: polkit-0.116-3.6.1.x86_64
ncn-m003: polkit-0.116-3.6.1.x86_64
ncn-w001: polkit-0.116-3.6.1.x86_64
ncn-w003: polkit-0.116-3.6.1.x86_64
ncn-w002: polkit-0.116-3.6.1.x86_64
```

### Tested on:

  * `baldar`

### Test description:

Ran the new pdsh cmd from m001 on baldar

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

