### PR TITLE
Update first master in bss after new master is promoted

### DIFF
--- a/upgrade/1.0/scripts/upgrade/ncn-upgrade-k8s-master.sh
+++ b/upgrade/1.0/scripts/upgrade/ncn-upgrade-k8s-master.sh
@@ -103,14 +103,10 @@ if [[ ${first_master_hostname} == ${upgrade_ncn} ]]; then
         exit 1
       fi
 
-      VERBOSE=1 csi handoff bss-update-cloud-init --set meta-data.first-master-hostname=$promotingMaster --limit Global
       ssh $promotingMaster -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "rpm --force -Uvh ${DOC_RPM_NEXUS_URL}"
       ssh $promotingMaster -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "/usr/share/doc/csm/upgrade/1.0/scripts/k8s/promote-initial-master.sh"
-<<<<<<< HEAD
- 
-=======
+      VERBOSE=1 csi handoff bss-update-cloud-init --set meta-data.first-master-hostname=$promotingMaster --limit Global
 
->>>>>>> e2bccf80e3789ab2f1a495252bff38c8a51a3c44
       record_state "${state_name}" ${upgrade_ncn}
    else
       echo "====> ${state_name} has been completed"

--- a/upgrade/1.2/scripts/upgrade/ncn-upgrade-k8s-master.sh
+++ b/upgrade/1.2/scripts/upgrade/ncn-upgrade-k8s-master.sh
@@ -105,9 +105,9 @@ if [[ ${first_master_hostname} == ${upgrade_ncn} ]]; then
         exit 1
       fi
 
-      VERBOSE=1 csi handoff bss-update-cloud-init --set meta-data.first-master-hostname=$promotingMaster --limit Global
       ssh $promotingMaster -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "rpm --force -Uvh ${DOC_RPM_NEXUS_URL}"
       ssh $promotingMaster -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "/usr/share/doc/csm/upgrade/1.2/scripts/k8s/promote-initial-master.sh"
+      VERBOSE=1 csi handoff bss-update-cloud-init --set meta-data.first-master-hostname=$promotingMaster --limit Global
 
       record_state "${state_name}" ${upgrade_ncn}
    else


### PR DESCRIPTION
## Summary and Scope

Change order to update bss last when promoting a new master, so if any steps fail, re-running the script will get back into the RECONFIGURE step.

## Issues and Related PRs

* Resolves [CASMTRIAGE-3053](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3053)

## Testing

Simple order change to what we know is necessary

### Tested on:

No new code, just order flip

### Test description:

N/A

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

