### PR TITLE
Add call to ntp upgrade script in 1.0.11

### DIFF
--- a/upgrade/1.0.11/scripts/upgrade/ncn-upgrade-ceph-nodes.sh
+++ b/upgrade/1.0.11/scripts/upgrade/ncn-upgrade-ceph-nodes.sh
@@ -145,6 +145,7 @@ if [[ $state_recorded == "0" ]]; then
         ssh_keys_done=1
     fi
     ssh ${upgrade_ncn} '/usr/share/doc/csm/upgrade/1.0.11/scripts/ceph/ceph-services-stage1.sh'
+    ssh ${upgrade_ncn} '/srv/cray/scripts/metal/ntp-upgrade-config.sh'
 
     record_state "${state_name}" ${upgrade_ncn}
 else


### PR DESCRIPTION
## Summary and Scope

/etc/chrony.d/cray.conf not being created on newly rebuild storage nodes -- we missed the call to the script in the upgrade steps for 1.0.11

## Issues and Related PRs

* Resolves [CASMINST-4166](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4166)

## Testing

Ran the script manually on odin

### Tested on:

  * `odin`

### Test description:

Ran on odin

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

