### PR TITLE
CASMPET-5375 1.0 : DOCS : how to free up /dev/md/AUX, BOOT, ROOT and SQFS so the RAIDs can be stopped cleanly

### DIFF
--- a/install/wipe_ncn_disks_for_reinstallation.md
+++ b/install/wipe_ncn_disks_for_reinstallation.md
@@ -308,16 +308,6 @@ RAIDs, zeroing the disks, and then wiping the disks and RAIDs.
 
    > **WARNING:** Do not run these commands on ncn-m001
 
-   1. Stop the RAIDs.
-
-       This step shows status before and after stopping the RAIDs.
-
-       ```bash
-       ncn# cat /proc/mdstat
-       ncn# for md in /dev/md/*; do mdadm -S -v $md || echo nope ; done
-       ncn# cat /proc/mdstat
-       ```
-
    1. List the disks for verification.
 
        ```bash


### PR DESCRIPTION
## Summary and Scope

The issue was seen when testing NCN Remove/Add and was also noted many times in slack as triage questions.
There is no need to stop the raids as they will be wiped and rebuilt as part of the existing process.
During the testing, we continued after hitting these errors and thus determined that stopping the raids is not needed and just adds confusion.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_ Yes

## Issues and Related PRs

* Resolves [CASMPET-5375](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5375) (Was originally MTL-1627)
* Change will also be needed in main and 1.0
* Future work required by NA
* Documentation changes required in NA
* Merge with/before/after NA

## Testing

_List the environments in which these changes were tested._

### Tested on:

mug 

### Test description:

During testing of Remove/Add NCN we hit these errors stopping the raid and continued without any issues. 

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_ NA

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? NA
- Were continuous integration tests run? If not, why? NA
- Was upgrade tested? If not, why? NA
- Was downgrade tested? If not, why? NA
- Were new tests (or test issues/Jiras) created for this change? NA

## Risks and Mitigations
low

_Are there known issues with these changes? Any other special considerations?_ NA


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
