### PR TITLE
CASMPET-5376 : DOCS: Update Power Cycle and Rebuild for vlan interface naming change

### DIFF
--- a/operations/node_management/Rebuild_NCNs/Power_Cycle_and_Rebuild_Nodes.md
+++ b/operations/node_management/Rebuild_NCNs/Power_Cycle_and_Rebuild_Nodes.md
@@ -79,7 +79,7 @@ This section applies to all node types. The commands in this section assume you 
 
 1. Then press enter on the console to ensure that the the login prompt is displayed including the correct hostname of this node. Then exit the ConMan console (**&** then **.**), and then use `ssh` to log in to the node to complete the remaining validation steps.
 
-    * **Troubleshooting:** If the `NBP file...` output never appears, or something else goes wrong, go back to the steps for modifying XNAME.json file (see the step to [inspect and modify the JSON file](Identify_Nodes_and_Update_Metadata.md#Inspect-and-modify-the-JSON-file) and make sure these instructions were completed correctly.
+    * **Troubleshooting:** If the `NBP file...` output never appears, or something else goes wrong, go back to the steps for modifying the `XNAME.json` file (see the step to [inspect and modify the JSON file](Identify_Nodes_and_Update_Metadata.md#Inspect-and-modify-the-JSON-file) and make sure these instructions were completed correctly.
 
     * **Master nodes only:** If `cloud-init` did not complete the newly-rebuilt node will need to have its etcd service definition manually updated. Reconfigure the etcd service, and restart the cloud init on the newly rebuilt master:
 
@@ -100,114 +100,7 @@ This section applies to all node types. The commands in this section assume you 
     ncn-m# cloud-init clean; cloud-init init --local; cloud-init init
     ```
 
-### Step 4 - Confirm `vlan004` is up with the correct IP address on the rebuilt node.
-
-Run these commands on the rebuilt node.
-
-1. Find the desired IP address.
-
-    * This command assumes you have set the variables from [the prerequisites section](../Rebuild_NCNs.md#Prerequisites).
-
-        ```bash
-        ncn# dig +short ${NODE}.hmn
-        10.254.1.16
-        ```
-
-2. Confirm the output from the dig command matches the interface.
-
-    1. If the IP addresses match, proceed to the next step. If they do not match, continue with the following sub-steps.
-
-        ```bash
-        ncn# ip addr show vlan004
-        14: vlan004@bond0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
-            link/ether b8:59:9f:2b:2f:9e brd ff:ff:ff:ff:ff:ff
-            inet 10.254.1.16/17 brd 10.254.127.255 scope global vlan004
-               valid_lft forever preferred_lft forever
-            inet6 fe80::ba59:9fff:fe2b:2f9e/64 scope link
-               valid_lft forever preferred_lft forever
-        ```
-
-    1. Change the IP address for `vlan004` if necessary.
-
-        ```bash
-        ncn# vim /etc/sysconfig/network/ifcfg-vlan004
-        ```
-
-        1. Set the `IPADDR` line to the correct IP address with a `/17` mask. For example, if the correct IP address is `10.254.1.16`, the line should be:
-
-             ```bash
-             IPADDR='10.254.1.16/17'
-             ```
-
-    1. Restart the `vlan004` network interface.
-
-        ```bash
-        ncn# wicked ifreload vlan004
-        ```
-
-    1. Confirm the output from the dig command matches the interface.
-
-        ```bash
-        ncn# ip addr show vlan004
-        ```
-
-### Step 5 - Confirm that `vlan007` is up with the correct IP address on the rebuilt node.
-
-Run these commands on the rebuilt node.
-
-1. Find the desired IP address.
-
-    * This command assumes you have set the variables from [the prerequisites section](../Rebuild_NCNs.md#Prerequisites).
-
-        ```bash
-        ncn# dig +short ${NODE}.can
-        10.103.8.11
-        ```
-
-2. Confirm the output from the dig command matches the interface.
-
-   * If the IP addresses match, proceed to the next step. If they do not match, continue with the following sub-steps.
-
-        ```bash
-        ip addr show vlan007
-        ```
-
-        Example Output:
-
-        ```screen
-        15: vlan007@bond0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
-            link/ether b8:59:9f:2b:2f:9e brd ff:ff:ff:ff:ff:ff
-            inet 10.103.8.11/24 brd 10.103.8.255 scope global vlan007
-               valid_lft forever preferred_lft forever
-            inet6 fe80::ba59:9fff:fe2b:2f9e/64 scope link
-               valid_lft forever preferred_lft forever
-        ```
-
-        1. Change the IP address for `vlan007` if necessary.
-
-            ```bash
-            vim /etc/sysconfig/network/ifcfg-vlan007
-            ```
-
-            Set the `IPADDR` line to the correct IP address with a `/24` mask. For example, if the correct IP address is `10.103.8.11`, the line should be:
-
-            ```bash
-            IPADDR='10.103.8.11/24'
-            ```
-
-        2. Restart the `vlan007` network interface.
-
-            ```bash
-            wicked ifreload vlan007
-            ```
-
-        3. Confirm the output from the dig command matches the interface.
-
-            ```bash
-            ip addr show vlan007
-            ```
-
-## Step 6 - Set the wipe flag back so it will not wipe the disk when the node is rebooted.
+## Step 4 - Set the wipe flag back so it will not wipe the disk when the node is rebooted.
 
 1. Run the following commands from a node that has cray cli initialized:
 
@@ -215,7 +108,7 @@ Run these commands on the rebuilt node.
     cray bss bootparameters list --name $XNAME --format=json | jq .[] > ${XNAME}.json
     ```
 
-2. Edit the XNAME.json file and set the `metal.no-wipe=1` value.
+2. Edit the `XNAME.json` file and set the `metal.no-wipe=1` value.
 
 3. Get a token to interact with BSS using the REST API.
 


### PR DESCRIPTION
## Summary and Scope
 
The vlan004 and vlan007 interfaces have changed in 1.2.  
This updates the vlan interface validation that is part of the post boot rebuild process.
*After further review - it was determined that these IP checks for vlan004 and vlan007 can be removed from the 1.2 docs*

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5376](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5376)
* Change will also be needed in `release/1.2`
* Future work required by NA
* Documentation changes required NA
* Merge with/before/after NA

## Testing

mug

### Tested on:

  * Local development environment

### Test description:

Verified the following which is now in sync with the docs
{code}
ncn-w006:~ # NODE=ncn-w006
ncn-w006:~ # dig +short ${NODE}.hmn
10.254.1.20
ncn-w006:~ # ip addr show bond0.hmn0
10: bond0.hmn0@bond0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc noqueue state UP group default qlen 1000
    link/ether a4:bf:01:65:6a:aa brd ff:ff:ff:ff:ff:ff
    inet 10.254.1.20/17 brd 10.254.127.255 scope global bond0.hmn0
       valid_lft forever preferred_lft forever
    inet6 fe80::a6bf:1ff:fe65:6aaa/64 scope link
       valid_lft forever preferred_lft forever

ncn-w006:~ # dig +short ${NODE}.cmn
10.101.5.27
ncn-w006:~ # ip addr show bond0.cmn0
9: bond0.cmn0@bond0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc noqueue state UP group default qlen 1000
    link/ether a4:bf:01:65:6a:aa brd ff:ff:ff:ff:ff:ff
    inet 10.101.5.27/25 brd 10.101.5.127 scope global bond0.cmn0
       valid_lft forever preferred_lft forever
    inet6 fe80::a6bf:1ff:fe65:6aaa/64 scope link
       valid_lft forever preferred_lft forever
{code}

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? NA
- Were continuous integration tests run? If not, why? NA
- Was upgrade tested? If not, why? NA
- Was downgrade tested? If not, why? NA
- Were new tests (or test issues/Jiras) created for this change? NA

## Risks and Mitigations
low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
