### PR TITLE
Ensure we have 3 etcd members before applying pod priorities

### DIFF
--- a/upgrade/1.0.1/scripts/upgrade/add_pod_priority.sh
+++ b/upgrade/1.0.1/scripts/upgrade/add_pod_priority.sh
@@ -23,6 +23,19 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
+# Ensure etcd clusters have three running members before proceeding
+for cluster in $(kubectl get etcd -n services | grep -v NAME | awk '{print $1}')
+do
+  size=$(kubectl get etcd -n services $cluster -o json | jq '.status.size')
+  if [ $size -ne 3 ]; then
+    echo >&2 "ERROR: etcd cluster: $cluster does not have three running members."
+    echo >&2 "       This must be addressed prior to continuing with the install."
+    exit 1
+  else
+    echo "validated etcd cluster: $cluster has three running members..."
+  fi
+done
+
 DEPLOYMENTS="\
 cray-bss \
 cray-keycloak-gatekeeper-ingress \

--- a/upgrade/1.0.11/scripts/upgrade/add_pod_priority.sh
+++ b/upgrade/1.0.11/scripts/upgrade/add_pod_priority.sh
@@ -23,6 +23,19 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
+# Ensure etcd clusters have three running members before proceeding
+for cluster in $(kubectl get etcd -n services | grep -v NAME | awk '{print $1}')
+do
+  size=$(kubectl get etcd -n services $cluster -o json | jq '.status.size')
+  if [ $size -ne 3 ]; then
+    echo >&2 "ERROR: etcd cluster: $cluster does not have three running members."
+    echo >&2 "       This must be addressed prior to continuing with the install."
+    exit 1
+  else
+    echo "validated etcd cluster: $cluster has three running members..."
+  fi
+done
+
 DEPLOYMENTS="\
 cray-bss \
 cray-keycloak-gatekeeper-ingress \


### PR DESCRIPTION
## Summary and Scope

Ensure we have 3 etcd members before applying pod priorities

## Issues and Related PRs

* Resolves [CASMINST-4136](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4136)

## Testing

```
ncn-m001-ee11a084:~/bklein # ./add_pod_priority.sh
validated etcd cluster: cray-bos-etcd has three running members...
validated etcd cluster: cray-bss-etcd has three running members...
validated etcd cluster: cray-hbtd-etcd has three running members...
validated etcd cluster: cray-hmnfd-etcd has three running members...
validated etcd cluster: cray-uas-mgr-etcd has three running members...
Creating csm-high-priority-service pod priority class
priorityclass.scheduling.k8s.io/csm-high-priority-service configured

Patching cray-bss deployment in services namespace
deployment.apps/cray-bss patched
.
.
```

### Tested on:

  * `vshasta`

### Test description:

Ran on vshasta

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

