### PR TITLE
Point token cert refresh script at kube config file for run via cron

### DIFF
--- a/upgrade/1.2/scripts/k8s/promote-initial-master.sh
+++ b/upgrade/1.2/scripts/k8s/promote-initial-master.sh
@@ -47,6 +47,8 @@ mkdir -p /srv/cray/scripts/kubernetes
 cat > /srv/cray/scripts/kubernetes/token-certs-refresh.sh <<'EOF'
 #!/bin/bash
 
+export KUBECONFIG=/etc/kubernetes/admin.conf
+
 if [[ "$1" != "skip-upload-certs" ]]; then
   kubeadm init phase upload-certs --upload-certs --config /etc/cray/kubernetes/kubeadm.yaml
 fi


### PR DESCRIPTION
## Summary and Scope

The cert refresh join script runs fine during automation/manual runs, but not via cron since it doesn't know where the kubernetes config file is (non standard location).

## Issues and Related PRs

* Resolves [CASMTRIAGE-3068](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3068)

## Testing

```
W0307 17:23:01.641059 4090429 configset.go:348] WARNING: kubeadm cannot validate component configs for API groups [kubelet.config.k8s.io kubeproxy.config.k8s.io]
[upload-certs] Storing the certificates in Secret "kubeadm-certs" in the "kube-system" Namespace
[upload-certs] Using certificate key:
f49d64cca4647a383e9781a08872e58578de3de6b4d9c20e866a495c937c8d55
W0307 17:23:01.884750 4090489 configset.go:348] WARNING: kubeadm cannot validate component configs for API groups [kubelet.config.k8s.io kubeproxy.config.k8s.io]
```

### Tested on:

  * `odin`

### Test description:

Updated script on odin and cron execution worked

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

