### PR TITLE
Add keycloak localize job re-run after deleting an ldap federation/group

### DIFF
--- a/troubleshooting/known_issues/craycli_403_forbidden_errors.md
+++ b/troubleshooting/known_issues/craycli_403_forbidden_errors.md
@@ -8,6 +8,16 @@ To recover from this situation, the following can be done.
 1. Log into the Keycloak admin console. See [Access the Keycloak User Management UI](Access_the_Keycloak_User_Management_UI.md)
 1. Delete the shasta-user-federation-ldap entry from the “User Federation” page.
 1. Wait three minutes for the configuration to resync.
+1. Re-run the keycloak localize job.
+   ```bash
+    ncn# kubectl get job -n services -l app.kubernetes.io/name=cray-keycloak-users-localize \
+    -ojson | jq '.items[0]' > keycloak-users-localize-job.json
+
+    ncn# cat keycloak-users-localize-job.json | jq 'del(.spec.selector)' | \
+    jq 'del(.spec.template.metadata.labels)' | kubectl replace --force -f -
+    job.batch "keycloak-users-localize-1" deleted
+    job.batch/keycloak-users-localize-1 replaced
+   ```
 1. Check to see if the keycloak-users-localize job has completed.
    ```
    kubectl -n services wait --for=condition=complete --timeout=10s job/`kubectl -n services get jobs | grep users-localize | awk '{print $1}'`
@@ -20,6 +30,16 @@ To recover from this situation, the following can be done.
 1. If you see an error showing that there is a duplicate group, complete the next step. 
 1. Go to the Groups page in the Keycloak admin console and delete the groups. 
 1. Wait three minutes for the configuration to resync. 
+1. Re-run the keycloak localize job.
+   ```bash
+    ncn# kubectl get job -n services -l app.kubernetes.io/name=cray-keycloak-users-localize \
+    -ojson | jq '.items[0]' > keycloak-users-localize-job.json
+
+    ncn# cat keycloak-users-localize-job.json | jq 'del(.spec.selector)' | \
+    jq 'del(.spec.template.metadata.labels)' | kubectl replace --force -f -
+    job.batch "keycloak-users-localize-1" deleted
+    job.batch/keycloak-users-localize-1 replaced
+   ```
 1. Check again to make sure the job has now completed.
    ```
    kubectl -n services wait --for=condition=complete --timeout=10s job/`kubectl -n services get jobs | grep users-localize | awk '{print $1}'`


### PR DESCRIPTION
## Summary and Scope

After deleting an LDAP federation or group, we must re-run the keycloak localize job to pick up the change.  This PR adds those steps.

## Issues and Related PRs

* Resolves [CASMINST-4158](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4158)

## Testing

Ran this process on tab when triaging CASMTRIAGE-3055.

### Tested on:

  * `tab`

### Test description:

Ran these steps on tab.

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

