### PR TITLE
CASMINST-4184 - Copy of typescript log uses incorrect directory path

### DIFF
--- a/install/bootstrap_livecd_remote_iso.md
+++ b/install/bootstrap_livecd_remote_iso.md
@@ -588,4 +588,3 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
 
    * See [Configure Management Network Switches](index.md#configure_management_network)
 
-!vi

--- a/install/bootstrap_livecd_remote_iso.md
+++ b/install/bootstrap_livecd_remote_iso.md
@@ -191,10 +191,9 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
 1. Quit the typescript session with the `exit` command, copy the file (csm-install-remoteis.<date>.txt) from its initial location to the newly created directory, and restart the typescript.
 
     ```bash
-    pit# mkdir -pv /mnt/pitdata/prep/admin
     pit# exit # The typescript
-    pit# cp ~/csm-install-remoteiso.*.txt /mnt/pitdata/prep/admin
-    pit# cd /mnt/pitdata/prep/admin
+    pit# cp -v ~/csm-install-remoteiso.*.txt /var/www/ephemeral/prep/admin
+    pit# cd /var/www/ephemeral/prep/admin
     pit# script -af $(ls -tr csm-install-remoteiso* | head -n 1)
     pit# export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
     pit# pushd /var/www/ephemeral


### PR DESCRIPTION
## Summary and Scope

The `bootstrap_livecd_remote_iso.md` document has the admin copy the session typescript log to `/mnt/pitdata/prep/admin` however `/mnt/pitdata` is not mounted at this time when performing a remote ISO install.

The correct directory path is `/var/www/ephemeral/admin/prep`

## Issues and Related PRs

* Resolves [CASMINST-4184](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4184)

## Testing

### Tested on:

  * `hela`

### Test description:

Tested new procedure, session log present in the expected location. This procedure is already present in the CSM 1.2 documentation.

## Risks and Mitigations

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

