### PR TITLE
CASMINST-4187: Clarify minimum CSM versions for different upgrade paths

### DIFF
--- a/upgrade/1.0.1/README.md
+++ b/upgrade/1.0.1/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-This document is intended to guide an administrator through the upgrade process going from Cray Systems Management v0.9.4 or later to v1.0.1. When upgrading a system, this top-level README.md file should be followed top to bottom, and the content on this top level page is meant to be terse. See the additional files in the various directories under the resource_material directory for additional reference material in support of the process/scripts mentioned explicitly on this page.
+This document is intended to guide an administrator through the upgrade process going to Cray Systems Management v1.0.1 from v0.9 (v0.9.4 or later) or v1.0.0. When upgrading a system, this top-level README.md file should be followed top to bottom, and the content on this top level page is meant to be terse. See the additional files in the various directories under the resource_material directory for additional reference material in support of the process/scripts mentioned explicitly on this page.
 
 ## Terminology
 

--- a/upgrade/1.0.10/README.md
+++ b/upgrade/1.0.10/README.md
@@ -1,5 +1,9 @@
 # CSM 1.0.10 Patch Installation Instructions
 
+## Introduction
+
+This document is intended to guide an administrator through the process going to Cray Systems Management v1.0.10 from v1.0.1. If you are at an earlier version, you must first upgrade to at least v1.0.1. For information on how to do that, see [Upgrade CSM](../index.md).
+
 ## Steps
 
 1. [Preparation](#preparation)

--- a/upgrade/1.0.11/README.md
+++ b/upgrade/1.0.11/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-This document is intended to guide an administrator through the process going from Cray Systems Management v1.0.1 or v1.0.10 to v1.0.11. If you are at an earlier version, you must first upgrade to at least v1.0.1. For information on how to do that, see [Upgrade CSM](../index.md).
+This document is intended to guide an administrator through the process going to Cray Systems Management v1.0.11 from v1.0.0, v1.0.1, or v1.0.10. If you are at an earlier version, you must first upgrade. For information on how to do that, see [Upgrade CSM](../index.md).
 
 This top-level `README.md` file should be followed top to bottom.
 

--- a/upgrade/index.md
+++ b/upgrade/index.md
@@ -29,20 +29,26 @@ The procedure you follow depends on the new CSM version to which you are upgradi
    
 * Upgrading **to CSM 1.0.1**
 
-    The upgrade of CSM software will do a controlled, rolling reboot of all management nodes before updating the CSM services.
+    **IMPORTANT**: You must be at CSM 0.9 (0.9.4 or later) or CSM 1.0.0 in order to upgrade to CSM 1.0.1.
 
-    The upgrade is a guided process starting with [Upgrade Management Nodes and CSM Services](1.0.1/README.md).
+    The upgrade is a guided process starting with [CSM 1.0.1 Upgrade Instructions](1.0.1/README.md).
 
 * Upgrading **to CSM 1.0.10**
    
-    **IMPORTANT**: You must already be at CSM 1.0.1 in order to upgrade to CSM 1.0.10.
+    **IMPORTANT**: You must be at CSM 1.0.1 in order to upgrade to CSM 1.0.10.
   
-    The upgrade is a guided process starting with [CSM 1.0.10 Patch Installation Instructions](1.0.10/README.md).
+    The upgrade is a guided process starting with [CSM 1.0.10 Upgrade Instructions](1.0.10/README.md).
+
+* Upgrading **to CSM 1.0.11**
+   
+    **IMPORTANT**: You must be at CSM 1.0.0, CSM 1.0.1, or CSM 1.0.10 in order to upgrade to CSM 1.0.11.
+  
+    The upgrade is a guided process starting with [CSM 1.0.11 Upgrade Instructions](1.0.11/README.md).
 
 <a name="update_management_network"></a>
 ## Update Management Network
 
-**IMPORTANT**: Only do this step if upgrading from CSM 0.9 (Shasta 1.4). If upgrading from CSM 1.0.1 (Shasta 1.5), skip this step.
+**IMPORTANT**: Only do this step if upgrading from CSM 0.9 (Shasta 1.4). If upgrading from CSM 1.0 (Shasta 1.5), skip this step.
 
 There are new features and functions with Shasta v1.5. Some of these changes were available as patches and hotfixes
 for Shasta v1.4, so may already be applied.


### PR DESCRIPTION
Modified the upgrade docs to clearly state the required CSM levels for the different upgrade paths.