### PR TITLE
CASMTRIAGE-3065: Remove merge conflict left from backport

### DIFF
--- a/operations/power_management/Prepare_the_System_for_Power_Off.md
+++ b/operations/power_management/Prepare_the_System_for_Power_Off.md
@@ -205,37 +205,7 @@ An authentication token is required to access the API gateway and to use the `sa
 
          Determine which BOS session(s) to cancel. To cancel a BOS session, kill
 	 its associated Boot Orchestration Agent (BOA) Kubernetes job.
-         
-<<<<<<< HEAD
-         **Method #1: Use BOS Session Status**
 
-         Use the following script to find the BOS session that have ended (true) or are still running (false)
-         ```bash
-         #! /bin/bash
-         # List all of the BOS sessions. Look for ones whose status says they are
-         # not complete, i.e. still running.
-         # Output the BOA Job ID for each BOS Session that is still running.
-         for ID in $(cray bos session list --format json | jq .[] | tr -d \"); do
-             result=$(cray bos session status list --format json $ID | jq .metadata.complete)
-             if [[ $result == "false" ]]; then
-                 cray bos v1 session describe --format json $ID | jq .boa_job_name | tr -d \";
-             fi
-         done
-         ````
-	 
-         These IDs are the BOA Kubernetes job IDs. Delete these to cancel the BOS
-	 session.
-         
-         However, the BOS status output can be buggy, and it may misidentify BOS
-	 sessions as still running when they have actually finished.
-	 If you only want to delete currently running jobs, then use Method #2. 
-         Method #2 is a more reliable method for identifying running BOA jobs
-	 because it interacts directly with the BOA Kubernetes job.
-         
-         **Method #2: Look at BOA Kubernetes jobs**
-         
-=======
->>>>>>> 64568ee3fd8... CASMTRIAGE-3065: Removed unreliable method of finding running BOS sessions
          To find a list of BOA jobs that are still running:
          ```bash
          kubectl -n services get jobs|egrep -i "boa|Name"


### PR DESCRIPTION
## Summary and Scope

Fixes backport cruft left in https://github.com/Cray-HPE/docs-csm/pull/1058/files

## Issues and Related PRs

* Resolves CASMTRIAGE-3065

## Testing

### Tested on:

  * NA

### Test description:

NA

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

