### PR TITLE
CASMINST-4198 

### DIFF
--- a/background/ncn_boot_workflow.md
+++ b/background/ncn_boot_workflow.md
@@ -154,7 +154,7 @@ The commands are the same for all hardware vendors, except where noted.
 1. Create a list of the cray disk boot devices.
 
     ```bash
-    ncn/pit# efibootmgr | grep cray | tee /tmp/bbs2
+    ncn/pit# efibootmgr | grep -i cray | tee /tmp/bbs2
     ```
     
 1. Set the boot order to first PXE boot, with disk boot as the fallback options.


### PR DESCRIPTION
Fix disk boot order command in 1.2 install docs deploy final ncn step 1 sub-step 2 here https://github.com/Cray-HPE/docs-csm/blob/release/1.2/background/ncn_boot_workflow.md#setting-order. 

First command as currently written gives no output. Correct one is below it with its output.
pit 2022-03-09 05:03:28 /var/www/ephemeral/prep/admin # efibootmgr | grep cray | tee /tmp/bbs2
pit 2022-03-09 05:03:32 /var/www/ephemeral/prep/admin # efibootmgr | grep -i cray | tee /tmp/bbs2
Boot0012* CRAY UEFI OS 1

## Summary and Scope

Docs change for bad command

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-4198](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4198)
* Change will also be needed in NA
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * surtur
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

