### PR TITLE
CASMTRIAGE-3070: Add troubleshooting section for upgraded CFS content

### DIFF
--- a/upgrade/1.2/README.md
+++ b/upgrade/1.2/README.md
@@ -62,6 +62,15 @@ Please see [Troubleshoot Postgres Database](../../operations/kubernetes/Troubles
 
 Please see [Troubleshoot Spire Failing to Start on NCNs](../../operations/spire/Troubleshoot_Spire_Failing_to_Start_on_NCNs.md).
 
+### Troubleshooting CFS Sessions That Can't Find Playbooks
+
+Due to an issue with the Ansible content import logic, the git commit ids for some
+release branches may have changed, making old CFS configurations invalid.  If CFS
+fails to find the specified playbook, or fails to checkout the appropriate commit
+in the `git-clone` containers, check that the commit still exists by manually
+cloning the git repo and attempting to checkout the commit.  If it no longer exists,
+find the most recent commit id for the desired branch and update the configuration
+as usual for CFS.  This will be fixed in a future version.
 
 ### Rerun a step/script
 


### PR DESCRIPTION
## Summary and Scope

This adds workaround information for a bug that can invalidate CFS configurations on upgrades.

## Issues and Related PRs

* Resolves CASMTRIAGE-3070

## Testing

### Tested on:

  * NA

### Test description:

NA, docs only

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

