### PR TITLE
CASMINST-4206: Update apply_csm_config  script to restrict it to Nodes

### DIFF
--- a/scripts/operations/configuration/apply_csm_configuration.sh
+++ b/scripts/operations/configuration/apply_csm_configuration.sh
@@ -158,7 +158,7 @@ fi
 ## RUNNING CFS ##
 if [[ -z $XNAMES ]]; then
     echo "Retrieving a list of all management node component names (xnames)"
-    XNAMES=$(cray hsm state components list --role Management --format json | jq -r '.Components | map(.ID) | join(",")')
+    XNAMES=$(cray hsm state components list --role Management --type Node --format json | jq -r '.Components | map(.ID) | join(",")')
 fi
 XNAME_LIST=${XNAMES//,/ }
 


### PR DESCRIPTION
## Summary and Scope

Due to a recent change in the install process, BMCs are now given the Management role, and this was causing the apply_csm_configuration script to print non-impactful errors because BMCs are not valid targets for CFS.  This restricts the call listing Management components to only Nodes, which was previously the only component type that had the Management role.

## Issues and Related PRs

* Resolves CASMINST-4206

## Testing

### Tested on:

  * Surtur

### Test description:

Ran the new command and verified the output.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

