### PR TITLE
Prevent target_ncn from being changed in parent upgrade script

### DIFF
--- a/upgrade/1.2/scripts/upgrade/upgrade-state.sh
+++ b/upgrade/1.2/scripts/upgrade/upgrade-state.sh
@@ -27,7 +27,7 @@ mkdir -p /etc/cray/upgrade/csm/$CSM_RELEASE
 
 function record_state () {
     state_name=$1
-    upgrade_ncn=$2
+    local upgrade_ncn=$2
 
     mkdir -p /etc/cray/upgrade/csm/$CSM_RELEASE/$upgrade_ncn
 
@@ -47,7 +47,7 @@ function record_state () {
 
 function is_state_recorded () {
     state_name=$1
-    upgrade_ncn=$2
+    local upgrade_ncn=$2
     mkdir -p /etc/cray/upgrade/csm/$CSM_RELEASE/$upgrade_ncn
     if [[ -z ${state_name} ]]; then
         echo "state name is not specified"


### PR DESCRIPTION
## Summary and Scope

Need to make target_ncn a local variable in function sourced by upgrade scripts, to prevent changing the value in the calling script.

## Issues and Related PRs

* Resolves [CASMINST-4209](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4209)

## Testing

Before:

```
ncn-m001:/etc/cray/upgrade/csm # /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/ncn-upgrade-master-nodes.sh ncn-m002
====> UPDATE_M001_KUBEAPI_SERVICE_ISSUER ...
BRAD1 target_ncn: ncn-m001
====> UPDATE_KUBEAPI_ISTIO_CA ...
BRAD2 target_ncn: ncn-m001
BRAD3 target_ncn: ncn-m001
```

After:
```
ncn-m001:/etc/cray/upgrade/csm # /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/ncn-upgrade-master-nodes.sh ncn-m002
====> UPDATE_M001_KUBEAPI_SERVICE_ISSUER ...
BRAD1 target_ncn: ncn-m002
====> UPDATE_KUBEAPI_ISTIO_CA ...
BRAD2 target_ncn: ncn-m002
BRAD3 target_ncn: ncn-m002
```

### Tested on:

  * `craystack`

### Test description:

Ran subset of the script before and after change.

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

