### PR TITLE
CASMINST-4212: Prevent the ADD_MTL_ROUTES section from exiting immediately on 1.2 -> 1.2 upgrades

### DIFF
--- a/upgrade/1.2/scripts/upgrade/prerequisites.sh
+++ b/upgrade/1.2/scripts/upgrade/prerequisites.sh
@@ -452,10 +452,12 @@ if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     SUBNET=$(cray sls networks describe MTL --format json | \
         jq -r '.ExtraProperties.Subnets[]|select(.FullName=="MTL Management Network Infrastructure")|.CIDR')
     DEVICE="vlan002"
+    set +e
     ip addr show | grep $DEVICE
     if [[ $? -ne 0 ]]; then
         DEVICE="bond0.nmn0"
     fi
+    set -e
     pdsh -w $HOSTS ip route add $SUBNET via $GATEWAY dev $DEVICE
     Rcount=$(pdsh -w $HOSTS ip route show | grep $SUBNET | wc -l)
     pdsh -w $HOSTS ip route show | grep $SUBNET


### PR DESCRIPTION

## Summary and Scope

The ADD_MTL_ROUTES section in prerequisites.sh fails on 1.2 -> 1.2 upgrades because it fails immediately when it doesn't find the vlan002 interface.  This happens because `set -e` is set at the beginning if prerequisites.sh.
The fix is to disable the -e in that small section of code that checks for the vlan002 since we expect a non-zero return code in that section.

## Issues and Related PRs

* Resolves CASMINST-4212

## Testing

### Tested on:

  * `surtur`

### Test description:

Tested by running that section of code on surtur including the `set -e` at the top.   I tested it first without the fix to verify that it was failing consistently.  I then tested with the fix to ensure that it was succeeding on a system with 1.2 installed.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

