### PR TITLE
Improve pod priority script to wait for operator to report healthy members

### DIFF
--- a/upgrade/1.0.1/scripts/upgrade/add_pod_priority.sh
+++ b/upgrade/1.0.1/scripts/upgrade/add_pod_priority.sh
@@ -91,6 +91,15 @@ function wait_for_running_pods() {
     current_running_num=$(kubectl get po -n $ns | grep $etcd_cluster | grep Running | wc -l)
     if [[ "$desired_size" -eq "$current_running_num" ]]; then
       echo "Found $desired_size running pods in $etcd_cluster etcd cluster"
+      while true; do
+        operator_num_ready=$(kubectl get etcd $etcd_cluster -n $ns -o jsonpath='{.status.members.ready}' | jq .[] | wc -l)
+        if [[ "$desired_size" -eq "$operator_num_ready" ]]; then
+          echo "Found $desired_size ready members in $etcd_cluster etcd cluster"
+          break
+        fi
+        echo "Sleeping for ten seconds waiting for $desired_size ready members $etcd_cluster etcd cluster"
+        sleep 10
+      done
       break
     fi
     echo "Sleeping for ten seconds waiting for $desired_size pods in $etcd_cluster etcd cluster"

--- a/upgrade/1.0.11/scripts/upgrade/add_pod_priority.sh
+++ b/upgrade/1.0.11/scripts/upgrade/add_pod_priority.sh
@@ -91,6 +91,15 @@ function wait_for_running_pods() {
     current_running_num=$(kubectl get po -n $ns | grep $etcd_cluster | grep Running | wc -l)
     if [[ "$desired_size" -eq "$current_running_num" ]]; then
       echo "Found $desired_size running pods in $etcd_cluster etcd cluster"
+      while true; do
+        operator_num_ready=$(kubectl get etcd $etcd_cluster -n $ns -o jsonpath='{.status.members.ready}' | jq .[] | wc -l)
+        if [[ "$desired_size" -eq "$operator_num_ready" ]]; then
+          echo "Found $desired_size ready members in $etcd_cluster etcd cluster"
+          break
+        fi
+        echo "Sleeping for ten seconds waiting for $desired_size ready members $etcd_cluster etcd cluster"
+        sleep 10
+      done
       break
     fi
     echo "Sleeping for ten seconds waiting for $desired_size pods in $etcd_cluster etcd cluster"


### PR DESCRIPTION
## Summary and Scope

Instead of just relying on pod running state for etcd clusters, also verify the operator sees three healthy members before moving on with the rolling restart.

## Issues and Related PRs

* Resolves [CASMINST-4220](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4220)

## Testing

```
ncn-m001-ee11a084:/home/bklein # ./add_pod_priority.sh
validated etcd cluster: cray-bos-etcd has three running members...
validated etcd cluster: cray-bss-etcd has three running members...
validated etcd cluster: cray-hbtd-etcd has three running members...
validated etcd cluster: cray-hmnfd-etcd has three running members...
validated etcd cluster: cray-uas-mgr-etcd has three running members...
Patching cray-bss-etcd etcdcluster in services namespace
etcdcluster.etcd.database.coreos.com/cray-bss-etcd patched

pod "cray-bss-etcd-6w2pvnmgp4" deleted
Sleeping for ten seconds waiting for 3 pods in cray-bss-etcd etcd cluster
Sleeping for ten seconds waiting for 3 pods in cray-bss-etcd etcd cluster
Sleeping for ten seconds waiting for 3 pods in cray-bss-etcd etcd cluster
Sleeping for ten seconds waiting for 3 pods in cray-bss-etcd etcd cluster
Found 3 running pods in cray-bss-etcd etcd cluster
Sleeping for ten seconds waiting for 3 ready members cray-bss-etcd etcd cluster
Sleeping for ten seconds waiting for 3 ready members cray-bss-etcd etcd cluster
Found 3 ready members in cray-bss-etcd etcd cluster
pod "cray-bss-etcd-8w8wp89cbh" deleted
Sleeping for ten seconds waiting for 3 pods in cray-bss-etcd etcd cluster
Sleeping for ten seconds waiting for 3 pods in cray-bss-etcd etcd cluster
Sleeping for ten seconds waiting for 3 pods in cray-bss-etcd etcd cluster
Sleeping for ten seconds waiting for 3 pods in cray-bss-etcd etcd cluster
Found 3 running pods in cray-bss-etcd etcd cluster
Sleeping for ten seconds waiting for 3 ready members cray-bss-etcd etcd cluster
Found 3 ready members in cray-bss-etcd etcd cluster
pod "cray-bss-etcd-bvskzww4bq" deleted
Sleeping for ten seconds waiting for 3 pods in cray-bss-etcd etcd cluster
Sleeping for ten seconds waiting for 3 pods in cray-bss-etcd etcd cluster
Sleeping for ten seconds waiting for 3 pods in cray-bss-etcd etcd cluster
Sleeping for ten seconds waiting for 3 pods in cray-bss-etcd etcd cluster
Found 3 running pods in cray-bss-etcd etcd cluster
Sleeping for ten seconds waiting for 3 ready members cray-bss-etcd etcd cluster
Found 3 ready members in cray-bss-etcd etcd cluster
```

### Tested on:

  * `vshasta`

### Test description:

Observed the additional delay waiting for operator to see three healthy members.

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable