### PR TITLE
CASMINST-4230 remove references to 'csi pit validate --network' flag

### DIFF
--- a/install/bootstrap_livecd_remote_iso.md
+++ b/install/bootstrap_livecd_remote_iso.md
@@ -566,7 +566,6 @@ Finally, cleanup the shim:
 1. Verify the system:
 
    ```bash
-   pit# csi pit validate --network
    pit# csi pit validate --services
    ```
 

--- a/install/bootstrap_livecd_usb.md
+++ b/install/bootstrap_livecd_usb.md
@@ -692,7 +692,6 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
 1. Verify the system:
 
    ```bash
-   pit# csi pit validate --network
    pit# csi pit validate --services
    ```
 

--- a/install/collect_mac_addresses_for_ncns.md
+++ b/install/collect_mac_addresses_for_ncns.md
@@ -130,6 +130,8 @@ making a backup of them, in case they need to be examined at a later time.
 
 1. Check that IP addresses are set for each interface and investigate any failures.
 
+  > Note that bond0.can0 is optional in CSM 1.2+
+
     1. Check IP addresses. Do not run tests if these are missing and instead start triaging the issue.
 
        ```bash
@@ -164,11 +166,6 @@ making a backup of them, in case they need to be examined at a later time.
        addr:     ipv4 10.254.1.4/17 [static]
        ```
 
-    1. Run tests; inspect failures.
-
-       ```bash
-       pit# csi pit validate --network
-       ```
 1. Copy the service config files generated earlier by `csi config init` for DNSMasq, Metal
    Basecamp (cloud-init), and Conman.
 
@@ -319,6 +316,8 @@ making a backup of them, in case they need to be examined at a later time.
 
 1. Check that IP addresses are set for each interface and investigate any failures.
 
+  > Note that bond0.can0 is optional in CSM 1.2+
+  
     1. Check IP addresses. Do not run tests if these are missing and instead start triaging the issue.
 
        ```bash
@@ -353,11 +352,6 @@ making a backup of them, in case they need to be examined at a later time.
        addr:     ipv4 10.254.1.4/17 [static]
        ```
 
-    1. Run tests; inspect failures.
-
-       ```bash
-       pit# csi pit validate --network
-       ```
 1. Copy the service config files generated earlier by `csi config init` for DNSMasq, Metal
    Basecamp (cloud-init), and Conman.
 


### PR DESCRIPTION
Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>

## Summary and Scope

This removes references to `csi pit validate --network`, which was only in place until GOSS tests could be added.  The output from that flag is useless without context as it only prints the output of `ip a s`.  This has been fully replaced with GOSS tests so it is no longer needed.

This is not backwards compatible, as the flag will be removed in the related PR below for 1.2.

## Issues and Related PRs


* Resolves CASMINST-4230
* Merge with https://github.com/Cray-HPE/cray-site-init/pull/131

## Testing

N/A this is removing deprecated and confusing functionality.

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

