### PR TITLE
CASMINST-4238 remove references to 'csi pit validate --services' flag 

### DIFF
--- a/install/bootstrap_livecd_remote_iso.md
+++ b/install/bootstrap_livecd_remote_iso.md
@@ -563,14 +563,6 @@ Finally, cleanup the shim:
    pit# rpm -Uvh --force $(find ${CSM_PATH}/rpm/ -name "csm-testing*.rpm" | sort -V | tail -1)   
    ```
 
-1. Verify the system:
-
-   ```bash
-   pit# csi pit validate --services
-   ```
-
-1. Follow directions in the output from the 'csi pit validate' commands for failed validations before continuing.
-
 <a name="next-topic"></a>
 # Next Topic
 

--- a/install/bootstrap_livecd_usb.md
+++ b/install/bootstrap_livecd_usb.md
@@ -689,14 +689,6 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
    pit:/var/www/ephemeral# cd
    ```
 
-1. Verify the system:
-
-   ```bash
-   pit# csi pit validate --services
-   ```
-
-1. Follow directions in the output from the 'csi pit validate' commands for failed validations before continuing.
-
 <a name="next-topic"></a>
 # Next Topic
 


### PR DESCRIPTION
## Summary and Scope

Remove confusing and outdated references to `csi pit validate --services`, which have long since been replaced by GOSS tests.

## Issues and Related PRs

* Resolves CASMINST-4238
* Merge with https://github.com/Cray-HPE/cray-site-init/pull/132
* Merge with https://github.com/Cray-HPE/csm-testing/pull/245

## Testing

N/A

## Risks and Mitigations

Low.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

