### PR TITLE
CASMINST-3927 - update-customizations.sh is not idempotent

### DIFF
--- a/upgrade/1.2/scripts/upgrade/util/update-customizations.sh
+++ b/upgrade/1.2/scripts/upgrade/util/update-customizations.sh
@@ -276,11 +276,10 @@ if [[ -z "$(yq r "$c" 'spec.kubernetes.sealed_secrets.dnssec')" ]]; then
 fi
 
 # Remove unused cray-externaldns configuration and add domain filters required for bifurcated CAN.
-if [[ ! -z "$(yq r "$c" 'spec.kubernetes.services.cray-externaldns.coredns')" ]]; then
-    yq d -i "$c" 'spec.kubernetes.services.cray-externaldns.coredns'
-    yq d -i "$c" 'spec.kubernetes.services.cray-externaldns.sharedIPServices'
-fi
 if [[ -z "$(yq r "$c" 'spec.kubernetes.services.cray-externaldns.external-dns.domainFilters')" ]]; then
+    yq w -i --style=single "$c" 'spec.kubernetes.services.cray-externaldns.external-dns'
+    yq w -i --style=single "$c" 'spec.kubernetes.services.cray-externaldns.external-dns.domainFilters[]'
+    yq w -i --style=single "$c" 'spec.kubernetes.services.cray-externaldns.external-dns.domainFilters[+]' 'cmn.{{ network.dns.external }}'
     yq w -i --style=single "$c" 'spec.kubernetes.services.cray-externaldns.external-dns.domainFilters[+]' 'cmn.{{ network.dns.external }}'
     yq w -i --style=single "$c" 'spec.kubernetes.services.cray-externaldns.external-dns.domainFilters[+]' 'can.{{ network.dns.external }}'
     yq w -i --style=single "$c" 'spec.kubernetes.services.cray-externaldns.external-dns.domainFilters[+]' 'chn.{{ network.dns.external }}'
@@ -288,6 +287,10 @@ if [[ -z "$(yq r "$c" 'spec.kubernetes.services.cray-externaldns.external-dns.do
     yq w -i --style=single "$c" 'spec.kubernetes.services.cray-externaldns.external-dns.domainFilters[+]' 'hmn.{{ network.dns.external }}'
     yq w -i --style=single "$c" 'spec.kubernetes.services.cray-externaldns.external-dns.domainFilters[+]' 'nmnlb.{{ network.dns.external }}'
     yq w -i --style=single "$c" 'spec.kubernetes.services.cray-externaldns.external-dns.domainFilters[+]' 'hmnlb.{{ network.dns.external }}'
+fi
+if [[ ! -z "$(yq r "$c" 'spec.kubernetes.services.cray-externaldns.coredns')" ]]; then
+    yq d -i "$c" 'spec.kubernetes.services.cray-externaldns.coredns'
+    yq d -i "$c" 'spec.kubernetes.services.cray-externaldns.sharedIPServices'
 fi
 
 # Add required PowerDNS and Unbound configuration

--- a/upgrade/1.2/scripts/upgrade/util/update-customizations.sh
+++ b/upgrade/1.2/scripts/upgrade/util/update-customizations.sh
@@ -276,7 +276,7 @@ if [[ -z "$(yq r "$c" 'spec.kubernetes.sealed_secrets.dnssec')" ]]; then
 fi
 
 # Remove unused cray-externaldns configuration and add domain filters required for bifurcated CAN.
-if [[ -z "$(yq r "$c" 'spec.kubernetes.services.cray-externaldns.coredns')" ]]; then
+if [[ ! -z "$(yq r "$c" 'spec.kubernetes.services.cray-externaldns.coredns')" ]]; then
     yq d -i "$c" 'spec.kubernetes.services.cray-externaldns.coredns'
     yq d -i "$c" 'spec.kubernetes.services.cray-externaldns.sharedIPServices'
 fi

--- a/upgrade/1.2/scripts/upgrade/util/update-customizations.sh
+++ b/upgrade/1.2/scripts/upgrade/util/update-customizations.sh
@@ -276,14 +276,19 @@ if [[ -z "$(yq r "$c" 'spec.kubernetes.sealed_secrets.dnssec')" ]]; then
 fi
 
 # Remove unused cray-externaldns configuration and add domain filters required for bifurcated CAN.
-yq d -i "$c" 'spec.kubernetes.services.cray-externaldns'
-yq w -i --style=single "$c" 'spec.kubernetes.services.cray-externaldns.external-dns.domainFilters[+]' 'cmn.{{ network.dns.external }}'
-yq w -i --style=single "$c" 'spec.kubernetes.services.cray-externaldns.external-dns.domainFilters[+]' 'can.{{ network.dns.external }}'
-yq w -i --style=single "$c" 'spec.kubernetes.services.cray-externaldns.external-dns.domainFilters[+]' 'chn.{{ network.dns.external }}'
-yq w -i --style=single "$c" 'spec.kubernetes.services.cray-externaldns.external-dns.domainFilters[+]' 'nmn.{{ network.dns.external }}'
-yq w -i --style=single "$c" 'spec.kubernetes.services.cray-externaldns.external-dns.domainFilters[+]' 'hmn.{{ network.dns.external }}'
-yq w -i --style=single "$c" 'spec.kubernetes.services.cray-externaldns.external-dns.domainFilters[+]' 'nmnlb.{{ network.dns.external }}'
-yq w -i --style=single "$c" 'spec.kubernetes.services.cray-externaldns.external-dns.domainFilters[+]' 'hmnlb.{{ network.dns.external }}'
+if [[ -z "$(yq r "$c" 'spec.kubernetes.services.cray-externaldns.coredns')" ]]; then
+    yq d -i "$c" 'spec.kubernetes.services.cray-externaldns.coredns'
+    yq d -i "$c" 'spec.kubernetes.services.cray-externaldns.sharedIPServices'
+fi
+if [[ -z "$(yq r "$c" 'spec.kubernetes.services.cray-externaldns.external-dns.domainFilters')" ]]; then
+    yq w -i --style=single "$c" 'spec.kubernetes.services.cray-externaldns.external-dns.domainFilters[+]' 'cmn.{{ network.dns.external }}'
+    yq w -i --style=single "$c" 'spec.kubernetes.services.cray-externaldns.external-dns.domainFilters[+]' 'can.{{ network.dns.external }}'
+    yq w -i --style=single "$c" 'spec.kubernetes.services.cray-externaldns.external-dns.domainFilters[+]' 'chn.{{ network.dns.external }}'
+    yq w -i --style=single "$c" 'spec.kubernetes.services.cray-externaldns.external-dns.domainFilters[+]' 'nmn.{{ network.dns.external }}'
+    yq w -i --style=single "$c" 'spec.kubernetes.services.cray-externaldns.external-dns.domainFilters[+]' 'hmn.{{ network.dns.external }}'
+    yq w -i --style=single "$c" 'spec.kubernetes.services.cray-externaldns.external-dns.domainFilters[+]' 'nmnlb.{{ network.dns.external }}'
+    yq w -i --style=single "$c" 'spec.kubernetes.services.cray-externaldns.external-dns.domainFilters[+]' 'hmnlb.{{ network.dns.external }}'
+fi
 
 # Add required PowerDNS and Unbound configuration
 yq w -i "$c" 'spec.kubernetes.services.cray-dns-unbound.domain_name' '{{ network.dns.external }}'
@@ -296,19 +301,24 @@ yq w -i "$c" 'spec.kubernetes.services.cray-dns-powerdns.service.cmn.loadBalance
 yq w -i "$c" 'spec.kubernetes.services.cray-dns-powerdns.cray-service.sealedSecrets[0]' '{{ kubernetes.sealed_secrets.powerdns | toYaml }}'
 
 # Add proxiedWebAppExternalHostnames
-yq w -i --style=single "$c" 'spec.proxiedWebAppExternalHostnames.customerManagement[+]' "{{ kubernetes.services['gatekeeper-policy-manager']['gatekeeper-policy-manager'].externalAuthority }}"
-yq w -i --style=single "$c" 'spec.proxiedWebAppExternalHostnames.customerManagement[+]' "{{ kubernetes.services['cray-istio'].istio.tracing.externalAuthority }}"
-yq w -i --style=single "$c" 'spec.proxiedWebAppExternalHostnames.customerManagement[+]' "{{ kubernetes.services['cray-kiali'].externalAuthority }}"
-yq w -i --style=single "$c" 'spec.proxiedWebAppExternalHostnames.customerManagement[+]' "{{ kubernetes.services['cray-sysmgmt-health']['prometheus-operator'].prometheus.prometheusSpec.externalAuthority }}"
-yq w -i --style=single "$c" 'spec.proxiedWebAppExternalHostnames.customerManagement[+]' "{{ kubernetes.services['cray-sysmgmt-health']['prometheus-operator'].alertmanager.alertmanagerSpec.externalAuthority }}"
-yq w -i --style=single "$c" 'spec.proxiedWebAppExternalHostnames.customerManagement[+]' "{{ kubernetes.services['cray-sysmgmt-health']['prometheus-operator'].grafana.externalAuthority }}"
-yq w -i --style=single "$c" 'spec.proxiedWebAppExternalHostnames.customerManagement[+]' '{{ kubernetes.services.gitea.externalHostname }}'
-yq w -i --style=single "$c" 'spec.proxiedWebAppExternalHostnames.customerManagement[+]' 'sma-grafana.cmn.{{ network.dns.external }}'
-yq w -i --style=single "$c" 'spec.proxiedWebAppExternalHostnames.customerManagement[+]' 'sma-kibana.cmn.{{network.dns.external}}'
-yq w -i --style=single "$c" 'spec.proxiedWebAppExternalHostnames.customerManagement[+]' 'csms.cmn.{{ network.dns.external }}'
-yq w -i --style=single "$c" 'spec.proxiedWebAppExternalHostnames.customerAccess[+]' 'capsules.can.{{ network.dns.external }}'
-yq w -i --style=single "$c" 'spec.proxiedWebAppExternalHostnames.customerHighSpeed[+]' 'capsules.chn.{{ network.dns.external }}'
-
+if [[ -z "$(yq r "$c" 'spec.proxiedWebAppExternalHostnames.customerManagement')" ]]; then
+    yq w -i --style=single "$c" 'spec.proxiedWebAppExternalHostnames.customerManagement[+]' "{{ kubernetes.services['gatekeeper-policy-manager']['gatekeeper-policy-manager'].externalAuthority }}"
+    yq w -i --style=single "$c" 'spec.proxiedWebAppExternalHostnames.customerManagement[+]' "{{ kubernetes.services['cray-istio'].istio.tracing.externalAuthority }}"
+    yq w -i --style=single "$c" 'spec.proxiedWebAppExternalHostnames.customerManagement[+]' "{{ kubernetes.services['cray-kiali'].externalAuthority }}"
+    yq w -i --style=single "$c" 'spec.proxiedWebAppExternalHostnames.customerManagement[+]' "{{ kubernetes.services['cray-sysmgmt-health']['prometheus-operator'].prometheus.prometheusSpec.externalAuthority }}"
+    yq w -i --style=single "$c" 'spec.proxiedWebAppExternalHostnames.customerManagement[+]' "{{ kubernetes.services['cray-sysmgmt-health']['prometheus-operator'].alertmanager.alertmanagerSpec.externalAuthority }}"
+    yq w -i --style=single "$c" 'spec.proxiedWebAppExternalHostnames.customerManagement[+]' "{{ kubernetes.services['cray-sysmgmt-health']['prometheus-operator'].grafana.externalAuthority }}"
+    yq w -i --style=single "$c" 'spec.proxiedWebAppExternalHostnames.customerManagement[+]' '{{ kubernetes.services.gitea.externalHostname }}'
+    yq w -i --style=single "$c" 'spec.proxiedWebAppExternalHostnames.customerManagement[+]' 'sma-grafana.cmn.{{ network.dns.external }}'
+    yq w -i --style=single "$c" 'spec.proxiedWebAppExternalHostnames.customerManagement[+]' 'sma-kibana.cmn.{{network.dns.external}}'
+    yq w -i --style=single "$c" 'spec.proxiedWebAppExternalHostnames.customerManagement[+]' 'csms.cmn.{{ network.dns.external }}'
+fi
+if [[ -z "$(yq r "$c" 'spec.proxiedWebAppExternalHostnames.customerAccess')" ]]; then
+    yq w -i --style=single "$c" 'spec.proxiedWebAppExternalHostnames.customerAccess[+]' 'capsules.can.{{ network.dns.external }}'
+fi
+if [[ -z "$(yq r "$c" 'spec.proxiedWebAppExternalHostnames.customerHighSpeed')" ]]; then
+    yq w -i --style=single "$c" 'spec.proxiedWebAppExternalHostnames.customerHighSpeed[+]' 'capsules.chn.{{ network.dns.external }}'
+fi
 
 # Add network to externalAuthority names
 yq w -i "$c" 'spec.kubernetes.services.cray-nexus.istio.ingress.hosts.ui.authority' 'nexus.cmn.{{ network.dns.external }}'
@@ -345,13 +355,15 @@ yq d -i "$c" 'spec.kubernetes.services.cray-istio.istio.prometheus'
 yq d -i "$c" 'spec.kubernetes.services.cray-istio.istio.kiali'
 yq d -i "$c" 'spec.kubernetes.services.cray-istio.istio.grafana'
 yq d -i "$c" 'spec.kubernetes.services.cray-istio.istio.gateways'
-yq w -i --style=single "$c" 'spec.kubernetes.services.cray-istio.certificate.dnsNames[+]' '*.cmn.{{ network.dns.external }}'
-yq w -i --style=single "$c" 'spec.kubernetes.services.cray-istio.certificate.dnsNames[+]' '*.can.{{ network.dns.external }}'
-yq w -i --style=single "$c" 'spec.kubernetes.services.cray-istio.certificate.dnsNames[+]' '*.chn.{{ network.dns.external }}'
-yq w -i --style=single "$c" 'spec.kubernetes.services.cray-istio.certificate.dnsNames[+]' '*.nmn.{{ network.dns.external }}'
-yq w -i --style=single "$c" 'spec.kubernetes.services.cray-istio.certificate.dnsNames[+]' '*.hmn.{{ network.dns.external }}'
-yq w -i --style=single "$c" 'spec.kubernetes.services.cray-istio.certificate.dnsNames[+]' '*.nmnlb.{{ network.dns.external }}'
-yq w -i --style=single "$c" 'spec.kubernetes.services.cray-istio.certificate.dnsNames[+]' '*.hmnlb.{{ network.dns.external }}'
+if [[ -z "$(yq r "$c" 'spec.kubernetes.services.cray-istio.certificate.dnsNames(.==*.cmn.{{ network.dns.external }})')" ]]; then
+    yq w -i --style=single "$c" 'spec.kubernetes.services.cray-istio.certificate.dnsNames[+]' '*.cmn.{{ network.dns.external }}'
+    yq w -i --style=single "$c" 'spec.kubernetes.services.cray-istio.certificate.dnsNames[+]' '*.can.{{ network.dns.external }}'
+    yq w -i --style=single "$c" 'spec.kubernetes.services.cray-istio.certificate.dnsNames[+]' '*.chn.{{ network.dns.external }}'
+    yq w -i --style=single "$c" 'spec.kubernetes.services.cray-istio.certificate.dnsNames[+]' '*.nmn.{{ network.dns.external }}'
+    yq w -i --style=single "$c" 'spec.kubernetes.services.cray-istio.certificate.dnsNames[+]' '*.hmn.{{ network.dns.external }}'
+    yq w -i --style=single "$c" 'spec.kubernetes.services.cray-istio.certificate.dnsNames[+]' '*.nmnlb.{{ network.dns.external }}'
+    yq w -i --style=single "$c" 'spec.kubernetes.services.cray-istio.certificate.dnsNames[+]' '*.hmnlb.{{ network.dns.external }}'
+fi
 yq d -i "$c" 'spec.kubernetes.services.cray-istio.extraIngressServices'
 yq d -i "$c" 'spec.kubernetes.services.cray-istio.ingressgatewayhmn'
 
@@ -400,8 +412,9 @@ if [[ -z "$(yq r "$c" 'spec.kubernetes.sealed_secrets.nexus-admin-credential')" 
         yq w -i "$c" 'spec.kubernetes.sealed_secrets.nexus-admin-credential.generate.data[1].args.url_safe' yes
     fi
 fi
-yq w -i --style=single "$c" 'spec.kubernetes.services.cray-nexus.sealedSecrets[+]' "{{ kubernetes.sealed_secrets['nexus-admin-credential'] | toYaml }}"
-
+if [[ -z "$(yq r "$c" 'spec.kubernetes.services.cray-nexus.sealedSecrets')" ]]; then
+    yq w -i --style=single "$c" 'spec.kubernetes.services.cray-nexus.sealedSecrets[+]' "{{ kubernetes.sealed_secrets['nexus-admin-credential'] | toYaml }}"
+fi
 # remove cray-keycloak-gatekeeper
 yq d -i "$c" 'spec.kubernetes.services.cray-keycloak-gatekeeper'
 
@@ -450,14 +463,15 @@ yq w -i "$c" 'spec.kubernetes.services.cray-kiali.kiali-operator.cr.spec.externa
 # cray-uas-mgr changes
 yq w -i "$c" 'spec.kubernetes.services.cray-uas-mgr.uasConfig.require_bican' 'false'
 yq w -i --style=single "$c" 'spec.kubernetes.services.cray-uas-mgr.uasConfig.dns_domain' '{{ network.dns.external }}'
-yq w -i "$c" 'spec.kubernetes.services.cray-uas-mgr.images.images[+]' 'cray/cray-uai-sles15sp1:latest'
-yq w -i "$c" 'spec.kubernetes.services.cray-uas-mgr.images.defaultImage' 'cray/cray-uai-sles15sp1:latest'
 
 # cray-metallb
 yq w -i --style=single "$c" 'spec.kubernetes.services.cray-metallb.metallb.configInline' '{{ network.metallb | toYaml }}'
 
 # wlm.macvlan
-yq d -i "$c" 'spec.wlm.macvlansetup.nmn_vlan'
+yq w -i "$c" 'spec.wlm.macvlansetup.nmn_vlan' 'bond0.nmn0'
+yq w -i "$c" 'spec.kubernetes.services.cray-slurmctld.macvlan.master' '{{ wlm.macvlansetup.nmn_vlan }}'
+yq w -i "$c" 'spec.kubernetes.services.cray-slurmdbd.macvlan.master' '{{ wlm.macvlansetup.nmn_vlan }}'
+yq w -i "$c" 'spec.kubernetes.services.cray-pbs.macvlan.master' '{{ wlm.macvlansetup.nmn_vlan }}'
 
 # lower cpu request for tds systems (3 workers)
 num_workers=$(kubectl get nodes | grep ncn-w | wc -l)


### PR DESCRIPTION
## Summary and Scope

The `update-customizations.sh` script is not idempotent and when run multiple times introduces duplicate data into `customizations.yaml` as new array content is appended to what is already there.

```
    customerAccess:
    - 'capsules.can.{{ network.dns.external }}'
    - 'capsules.can.{{ network.dns.external }}'
    customerHighSpeed:
    - 'capsules.chn.{{ network.dns.external }}'
    - 'capsules.chn.{{ network.dns.external }}'
 ```

This PR adds some checks so that new content is only added if it does not already exist.

## Issues and Related PRs

* Resolves [CASMINST-3927](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3927)

## Testing

### Tested on:

  * `hela`
  * Local development environment

### Test description:

Ran script to update a CSM 1.0 `customizations.yaml` file to CSM 1.2. Then ran it again using the updated input file.

New implementation
```
# update-customizations.sh -i ./customizations.yaml
# cp customizations.yaml customizations.yaml.updated
# ./docs-csm/upgrade/1.2/scripts/upgrade/util/update-customizations.sh -i ./customizations.yaml
ncn-m001:~/cspiller/test # diff customizations.yaml customizations.yaml.updated
ncn-m001:~/cspiller/test #
```

Original implementation
```
# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/util/update-customizations.sh -i ./customizations.yaml
# cp customizations.yaml customizations.yaml.updated
# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/util/update-customizations.sh -i ./customizations.yaml
# diff customizations.yaml customizations.yaml.updated
440,446d439
<             - '*.cmn.{{ network.dns.external }}'
<             - '*.can.{{ network.dns.external }}'
<             - '*.chn.{{ network.dns.external }}'
<             - '*.nmn.{{ network.dns.external }}'
<             - '*.hmn.{{ network.dns.external }}'
<             - '*.nmnlb.{{ network.dns.external }}'
<             - '*.hmnlb.{{ network.dns.external }}'
519d511
<           - '{{ kubernetes.sealed_secrets[''nexus-admin-credential''] | toYaml }}'
611d602
<             - cray/cray-uai-sles15sp1:latest
797a789,798
>       cray-externaldns:
>         external-dns:
>           domainFilters:
>             - 'cmn.{{ network.dns.external }}'
>             - 'can.{{ network.dns.external }}'
>             - 'chn.{{ network.dns.external }}'
>             - 'nmn.{{ network.dns.external }}'
>             - 'hmn.{{ network.dns.external }}'
>             - 'nmnlb.{{ network.dns.external }}'
>             - 'hmnlb.{{ network.dns.external }}'
852,861d852
<       cray-externaldns:
<         external-dns:
<           domainFilters:
<             - 'cmn.{{ network.dns.external }}'
<             - 'can.{{ network.dns.external }}'
<             - 'chn.{{ network.dns.external }}'
<             - 'nmn.{{ network.dns.external }}'
<             - 'hmn.{{ network.dns.external }}'
<             - 'nmnlb.{{ network.dns.external }}'
<             - 'hmnlb.{{ network.dns.external }}'
874,883d864
<       - '{{ kubernetes.services[''gatekeeper-policy-manager''][''gatekeeper-policy-manager''].externalAuthority }}'
<       - '{{ kubernetes.services[''cray-istio''].istio.tracing.externalAuthority }}'
<       - '{{ kubernetes.services[''cray-kiali''].externalAuthority }}'
<       - '{{ kubernetes.services[''cray-sysmgmt-health''][''prometheus-operator''].prometheus.prometheusSpec.externalAuthority }}'
<       - '{{ kubernetes.services[''cray-sysmgmt-health''][''prometheus-operator''].alertmanager.alertmanagerSpec.externalAuthority }}'
<       - '{{ kubernetes.services[''cray-sysmgmt-health''][''prometheus-operator''].grafana.externalAuthority }}'
<       - '{{ kubernetes.services.gitea.externalHostname }}'
<       - 'sma-grafana.cmn.{{ network.dns.external }}'
<       - 'sma-kibana.cmn.{{network.dns.external}}'
<       - 'csms.cmn.{{ network.dns.external }}'
886d866
<       - 'capsules.can.{{ network.dns.external }}'
888d867
<       - 'capsules.chn.{{ network.dns.external }}'
```

## Risks and Mitigations

This modification to `update-customizations.sh` resolves the issues that have come up repeatedly during upgrade testing  .

It tests for the existence of entries in related blocks (e.g. all external-dns entries) rather than testing before every single array insertion. This may cause issues for CSM 1.2 -> 1.2 upgrade testing if new content is added to one of the blocks.

To fix this more comprehensively a rewrite is required.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

