### PR TITLE
Casminst-4239 Fixes to ceph node image upgrade

### DIFF
--- a/upgrade/1.2/scripts/upgrade/ncn-upgrade-ceph-nodes.sh
+++ b/upgrade/1.2/scripts/upgrade/ncn-upgrade-ceph-nodes.sh
@@ -66,11 +66,11 @@ if [[ $state_recorded == "0" ]]; then
     ## TEMP - Remove ceph v15.2.12 from images before backups - CASMINST-4099
     if [[ $(ssh ${target_ncn} "podman images --format json|jq '.[].Names|.[]'|grep -q 15.2.12") ]]
     then
-      ssh ${target_ncn} 'podman rmi registry.local/ceph/ceph:v15.2.12'
+      ssh ${target_ncn} 'podman rmi -af'
     fi
     ## END TEMP - CASMINST-4099
 
-    ssh ${target_ncn} 'systemctl stop ceph.target;sleep 30;tar -zcvf /tmp/$(hostname)-ceph.tgz /var/lib/ceph /var/lib/containers /etc/ceph;systemctl start ceph.target'
+    ssh ${target_ncn} 'systemctl stop ceph.target;sleep 30;podman prune -af;tar -zcvf /tmp/$(hostname)-ceph.tgz /var/lib/ceph /var/lib/containers /etc/ceph;systemctl start ceph.target'
     scp ${target_ncn}:/tmp/${target_ncn}-ceph.tgz .
 
     record_state "${state_name}" ${target_ncn}
@@ -122,7 +122,7 @@ if [[ $state_recorded == "0" ]]; then
 
     # sleep 30s before redeploy ceph
     sleep 30
-    
+    ## Added
     ceph cephadm get-pub-key > ~/ceph.pub
     ssh-copy-id -f -i ~/ceph.pub root@${target_ncn}
     ceph orch host add ${target_ncn}
@@ -187,7 +187,7 @@ if [[ $ssh_keys_done == "0" ]]; then
     ssh_keygen_keyscan "${target_ncn}"
     ssh_keys_done=1
 fi
-ssh $target_ncn -t 'GOSS_BASE=/opt/cray/tests/install/ncn goss -g /opt/cray/tests/install/ncn/suites/ncn-upgrade-tests-storage.yaml --vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml validate'
+ssh $target_ncn -t 'GOSS_BASE=/opt/cray/tests/install/ncn goss -g /opt/cray/tests/install/ncn/suites/ncn-upgrade-tests-storage.yaml --vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml validate' || true 
 
 move_state_file ${target_ncn}
 


### PR DESCRIPTION
## Summary and Scope

This is to fix container image corruption of cached images

## Issues and Related PRs

* Resolves CASMINST-4239

## Testing

### Tested on:

  * surtur

### Test description:

Performed a boot loop with this change overnight.  we hit first try success 88% of the time and the additional 12% were boot based issues that resolved on the second boot.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

