### PR TITLE
CASMNET-866: Add gateway tests

### DIFF
--- a/operations/network/gateway_testing.md
+++ b/operations/network/gateway_testing.md
@@ -1,0 +1,147 @@
+# Gateway Testing 
+
+With the introduction of BiCAN, service APIs are now available on one or more networks depending on who is allowed access to the services and from where.
+The services are accessed via three different ingress gateways using a token that can be retrieved from keycloak.
+
+This page describes how to run a set of tests to determine if the gateways are functioning properly.  The gateway test will obtain an API token from keycloak and then use that token to attempt to access a set of service APIs on one or more networks as defined in the gateway test definition file (gateway-test-defn.yaml).  The test will check the return code to make sure it gets the expected response. 
+
+When the nmnlb network is specified, it will use `api-gw-service-nmn.local` as an override for `nmnlb.<system-domain>` in 1.2.   You can set `use-api-gw-override: false` in gateway-test-defn.yaml if you would like to disable that override and use `nmnlb.<system-domain>`.
+
+## Running gateway tests from an NCN
+
+The gateway test script can be found in `/usr/share/doc/csm/scripts/operations/gateway-test`.   When `gateway-test.py` is run from an NCN, it has access to the admin client secret using kubectl.   It will use the admin client secret to get the token for accessing the APIs.
+
+You can run the test by executing the following command.  You will need to specify the system domain (e.g. eniac.dev.cray.com) and the network you would like to use to obtain the token (e.g. nmnlb, can, cmn, chn)
+
+``` bash
+    ncn# /usr/share/doc/csm/scripts/operations/gateway-test/gateway-test.py eniac.dev.cray.com nmnlb
+```
+
+## Running gateway tests from UAN, Compute Node, or a device outside of the cluster
+
+You will need to install the docs-csm rpm on a device outside the cluster or copy both the `gateway-test.py` and `gateway-test-defn.yaml` files to a system that has python3 installed. Because we don't have access to kubectl outside the cluster, you will need to obtain the admin client secret from the system by the following command on an NCN.
+
+``` bash
+    ncn# kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d
+    26947343-d4ab-403b-14e937dbd700
+```
+You will then need to set the ADMIN_CLIENT_SECRET environment variable to the admin-client-auth secret you obtained.
+
+``` bash
+    linux# export ADMIN_CLIENT_SECRET=26947343-d4ab-403b-14e937dbd700
+```
+
+You can run the tests by executing the following the command.  You will need to specify the system domain (e.g. eniac.dev.cray.com) and the network you would like to use to obtain the token (e.g. nmnlb, can.cmn, chn).
+
+``` bash
+    linux# /usr/share/doc/csm/scripts/operations/gateway-test/gateway-test.py eniac.dev.cray.com cmn
+```
+
+## Example results
+
+The results of running the tests will show the following
+
+* Retrieval of a token on the CMN network in order to get SLS data to determine which networks are defined on the system
+* Retrieval of a token on the network specified on the command line to use for testing the APIs
+* Results from each of the networks defined in `gateway-test-defn.yaml`.  It will attempt to access each of the services on the network and check the expected results.
+  * It will show PASS or FAIL depending on the expected response for the service and the token being used. 
+  * It will show SKIP for services that are not expected to be installed on the system. 
+* The return code of the test will be non-zero if any of the tests fail or we are unable to retrieve a token on any of the networks that are expected to be accessible.
+
+NOTE: In this example we are running from a server outside the cluster.  It is expected that `api-gw-service-nmn.local` is unreachable from this location.
+
+``` bash
+# export ADMIN_CLIENT_SECRET=26947343-d4ab-403b-14e937dbd700
+# ./gateway-test.py eniac.dev.cray.com cmn
+auth.cmn.eniac.dev.cray.com is reachable
+Token successfully retrieved at https://auth.cmn.eniac.dev.cray.com/keycloak/realms/shasta/protocol/openid-connect/token
+
+auth.cmn.eniac.dev.cray.com is reachable
+Token successfully retrieved at https://auth.cmn.eniac.dev.cray.com/keycloak/realms/shasta/protocol/openid-connect/token
+
+
+------------- api-gw-service-nmn.local -------------------
+ping: api-gw-service-nmn.local: Name or service not known
+api-gw-service-nmn.local is NOT reachable
+
+------------- api.cmn.eniac.dev.cray.com -------------------
+api.cmn.eniac.dev.cray.com is reachable
+PASS - [cray-bos]: https://api.cmn.eniac.dev.cray.com/apis/bos/v1/session - 200
+PASS - [cray-bss]: https://api.cmn.eniac.dev.cray.com/apis/bss/boot/v1/bootparameters - 200
+FAIL - [cray-capmc]: https://api.cmn.eniac.dev.cray.com/apis/capmc/capmc/get_node_rules - 404
+PASS - [cray-cfs-api]: https://api.cmn.eniac.dev.cray.com/apis/cfs/v2/sessions - 200
+PASS - [cray-console-data]: https://api.cmn.eniac.dev.cray.com/apis/consoledata/liveness - 204
+PASS - [cray-console-node]: https://api.cmn.eniac.dev.cray.com/apis/console-node/console-node/liveness - 204
+PASS - [cray-console-operator]: https://api.cmn.eniac.dev.cray.com/apis/console-operator/console-operator/liveness - 204
+SKIP - [cray-cps]: https://api.cmn.eniac.dev.cray.com/apis/v2/cps/contents
+PASS - [cray-fas]: https://api.cmn.eniac.dev.cray.com/apis/fas/v1/snapshots - 200
+PASS - [cray-hbtd]: https://api.cmn.eniac.dev.cray.com/apis/hbtd/hmi/v1/health - 200
+PASS - [cray-hmnfd]: https://api.cmn.eniac.dev.cray.com/apis/hmnfd/hmi/v2/health - 200
+PASS - [cray-ims]: https://api.cmn.eniac.dev.cray.com/apis/ims/images - 200
+PASS - [cray-powerdns-manager]: https://api.cmn.eniac.dev.cray.com/apis/powerdns-manager/v1/liveness - 204
+PASS - [cray-reds]: https://api.cmn.eniac.dev.cray.com/apis/reds/v1/liveness - 204
+PASS - [cray-scsd]: https://api.cmn.eniac.dev.cray.com/apis/scsd/v1/health - 200
+PASS - [cray-sls]: https://api.cmn.eniac.dev.cray.com/apis/sls/v1/health - 200
+PASS - [cray-smd]: https://api.cmn.eniac.dev.cray.com/apis/smd/hsm/v1/service/ready - 200
+PASS - [cray-sts]: https://api.cmn.eniac.dev.cray.com/apis/sts/healthz - 200
+PASS - [cray-uas-mgr]: https://api.cmn.eniac.dev.cray.com/apis/uas-mgr/v1/images - 200
+PASS - [gitea-vcs-web]: https://api.cmn.eniac.dev.cray.com/vcs - 200
+SKIP - [nmdv2-service]: https://api.cmn.eniac.dev.cray.com/apis/v2/nmd/dumps
+SKIP - [slingshot-fabric-manager]: https://api.cmn.eniac.dev.cray.com/apis/fabric-manager/fabric/port-policies
+SKIP - [sma-telemetry]: https://api.cmn.eniac.dev.cray.com/apis/sma-telemetry-api/v1/ping
+
+------------- api.can.eniac.dev.cray.com -------------------
+api.can.eniac.dev.cray.com is reachable
+PASS - [cray-bos]: https://api.can.eniac.dev.cray.com/apis/bos/v1/session - 404
+PASS - [cray-bss]: https://api.can.eniac.dev.cray.com/apis/bss/boot/v1/bootparameters - 404
+PASS - [cray-capmc]: https://api.can.eniac.dev.cray.com/apis/capmc/capmc/get_node_rules - 404
+PASS - [cray-cfs-api]: https://api.can.eniac.dev.cray.com/apis/cfs/v2/sessions - 404
+PASS - [cray-console-data]: https://api.can.eniac.dev.cray.com/apis/consoledata/liveness - 404
+PASS - [cray-console-node]: https://api.can.eniac.dev.cray.com/apis/console-node/console-node/liveness - 404
+PASS - [cray-console-operator]: https://api.can.eniac.dev.cray.com/apis/console-operator/console-operator/liveness - 404
+SKIP - [cray-cps]: https://api.can.eniac.dev.cray.com/apis/v2/cps/contents
+PASS - [cray-fas]: https://api.can.eniac.dev.cray.com/apis/fas/v1/snapshots - 404
+PASS - [cray-hbtd]: https://api.can.eniac.dev.cray.com/apis/hbtd/hmi/v1/health - 404
+PASS - [cray-hmnfd]: https://api.can.eniac.dev.cray.com/apis/hmnfd/hmi/v2/health - 404
+PASS - [cray-ims]: https://api.can.eniac.dev.cray.com/apis/ims/images - 404
+PASS - [cray-powerdns-manager]: https://api.can.eniac.dev.cray.com/apis/powerdns-manager/v1/liveness - 404
+PASS - [cray-reds]: https://api.can.eniac.dev.cray.com/apis/reds/v1/liveness - 404
+PASS - [cray-scsd]: https://api.can.eniac.dev.cray.com/apis/scsd/v1/health - 404
+PASS - [cray-sls]: https://api.can.eniac.dev.cray.com/apis/sls/v1/health - 404
+PASS - [cray-smd]: https://api.can.eniac.dev.cray.com/apis/smd/hsm/v1/service/ready - 404
+PASS - [cray-sts]: https://api.can.eniac.dev.cray.com/apis/sts/healthz - 404
+PASS - [cray-uas-mgr]: https://api.can.eniac.dev.cray.com/apis/uas-mgr/v1/images - 404
+PASS - [gitea-vcs-web]: https://api.can.eniac.dev.cray.com/vcs - 404
+SKIP - [nmdv2-service]: https://api.can.eniac.dev.cray.com/apis/v2/nmd/dumps
+SKIP - [slingshot-fabric-manager]: https://api.can.eniac.dev.cray.com/apis/fabric-manager/fabric/port-policies
+SKIP - [sma-telemetry]: https://api.can.eniac.dev.cray.com/apis/sma-telemetry-api/v1/ping
+
+------------- api.chn.eniac.dev.cray.com -------------------
+api.chn.eniac.dev.cray.com is reachable
+PASS - [cray-bos]: https://api.chn.eniac.dev.cray.com/apis/bos/v1/session - 404
+PASS - [cray-bss]: https://api.chn.eniac.dev.cray.com/apis/bss/boot/v1/bootparameters - 404
+PASS - [cray-capmc]: https://api.chn.eniac.dev.cray.com/apis/capmc/capmc/get_node_rules - 404
+PASS - [cray-cfs-api]: https://api.chn.eniac.dev.cray.com/apis/cfs/v2/sessions - 404
+PASS - [cray-console-data]: https://api.chn.eniac.dev.cray.com/apis/consoledata/liveness - 404
+PASS - [cray-console-node]: https://api.chn.eniac.dev.cray.com/apis/console-node/console-node/liveness - 404
+PASS - [cray-console-operator]: https://api.chn.eniac.dev.cray.com/apis/console-operator/console-operator/liveness - 404
+SKIP - [cray-cps]: https://api.chn.eniac.dev.cray.com/apis/v2/cps/contents
+PASS - [cray-fas]: https://api.chn.eniac.dev.cray.com/apis/fas/v1/snapshots - 404
+PASS - [cray-hbtd]: https://api.chn.eniac.dev.cray.com/apis/hbtd/hmi/v1/health - 404
+PASS - [cray-hmnfd]: https://api.chn.eniac.dev.cray.com/apis/hmnfd/hmi/v2/health - 404
+PASS - [cray-ims]: https://api.chn.eniac.dev.cray.com/apis/ims/images - 404
+PASS - [cray-powerdns-manager]: https://api.chn.eniac.dev.cray.com/apis/powerdns-manager/v1/liveness - 404
+PASS - [cray-reds]: https://api.chn.eniac.dev.cray.com/apis/reds/v1/liveness - 404
+PASS - [cray-scsd]: https://api.chn.eniac.dev.cray.com/apis/scsd/v1/health - 404
+PASS - [cray-sls]: https://api.chn.eniac.dev.cray.com/apis/sls/v1/health - 404
+PASS - [cray-smd]: https://api.chn.eniac.dev.cray.com/apis/smd/hsm/v1/service/ready - 404
+PASS - [cray-sts]: https://api.chn.eniac.dev.cray.com/apis/sts/healthz - 404
+PASS - [cray-uas-mgr]: https://api.chn.eniac.dev.cray.com/apis/uas-mgr/v1/images - 404
+PASS - [gitea-vcs-web]: https://api.chn.eniac.dev.cray.com/vcs - 404
+SKIP - [nmdv2-service]: https://api.chn.eniac.dev.cray.com/apis/v2/nmd/dumps
+SKIP - [slingshot-fabric-manager]: https://api.chn.eniac.dev.cray.com/apis/fabric-manager/fabric/port-policies
+SKIP - [sma-telemetry]: https://api.chn.eniac.dev.cray.com/apis/sma-telemetry-api/v1/ping
+ # echo $?
+1
+```
+

--- a/scripts/operations/gateway-test/gateway-test-defn.yaml
+++ b/scripts/operations/gateway-test/gateway-test-defn.yaml
@@ -1,0 +1,198 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+
+use-api-gw-override: true
+networks:
+- name: nmnlb
+  gateway: services-gateway
+- name: cmn
+  gateway: services-gateway
+- name: can
+  gateway: customer-user-gateway
+- name: chn
+  gateway: customer-user-gateway
+
+ingress_api_services:
+- name: cray-bos
+  path: apis/bos/v1/session 
+  port: 443
+  expected-result: 200
+  namespace: services
+  gateways: ["services-gateway","customer-admin-gateway"]
+  project: CSM
+- name: cray-bss
+  path: apis/bss/boot/v1/bootparameters 
+  port: 443
+  expected-result: 200
+  namespace: services
+  gateways: ["services-gateway","customer-admin-gateway"]
+  project: CSM
+- name: cray-capmc
+  path: apis/capmc/capmc/get_node_rules
+  port: 443
+  expected-result: 200
+  namespace: services
+  gateways: ["services-gateway","customer-admin-gateway"]
+  project: CSM
+- name: cray-cfs-api
+  path: apis/cfs/v2/sessions
+  port: 443
+  expected-result: 200
+  namespace: services
+  gateways: ["services-gateway","customer-admin-gateway"]
+  project: CSM
+- name: cray-console-data
+  path: apis/consoledata/liveness
+  port: 443
+  expected-result: 204
+  namespace: services
+  gateways: ["services-gateway","customer-admin-gateway"]
+  project: CSM
+- name: cray-console-node
+  path: apis/console-node/console-node/liveness
+  expected-result: 204
+  port: 443
+  namespace: services
+  gateways: ["services-gateway","customer-admin-gateway"]
+  project: CSM
+- name: cray-console-operator
+  path: apis/console-operator/console-operator/liveness
+  port: 443
+  expected-result: 204
+  namespace: services
+  gateways: ["services-gateway","customer-admin-gateway"]
+  project: CSM
+- name: cray-cps
+  path: apis/v2/cps/contents
+  port: 443
+  expected-result: 200
+  namespace: services
+  gateways: ["services-gateway"]
+  project: Other
+- name: cray-fas
+  path: apis/fas/v1/snapshots
+  port: 443
+  expected-result: 200
+  namespace: services
+  gateways: ["services-gateway","customer-admin-gateway"]
+  project: CSM
+- name: cray-hbtd
+  path: apis/hbtd/hmi/v1/health
+  port: 443
+  expected-result: 200
+  namespace: services
+  gateways: ["services-gateway","customer-admin-gateway"]
+  project: CSM
+- name: cray-hmnfd
+  path: apis/hmnfd/hmi/v2/health
+  port: 443
+  expected-result: 200
+  namespace: services
+  gateways: ["services-gateway","customer-admin-gateway"]
+  project: CSM
+- name: cray-ims
+  path: apis/ims/images
+  port: 443
+  expected-result: 200
+  namespace: services
+  gateways: ["services-gateway","customer-admin-gateway"]
+  project: CSM
+- name: cray-powerdns-manager
+  path: apis/powerdns-manager/v1/liveness
+  port: 443
+  expected-result: 204
+  namespace: services
+  gateways: ["services-gateway","customer-admin-gateway"]
+  project: CSM
+- name: cray-reds
+  path: apis/reds/v1/liveness
+  port: 443
+  expected-result: 204
+  namespace: services
+  gateways: ["services-gateway","customer-admin-gateway"]
+  project: CSM
+- name: cray-scsd
+  path: apis/scsd/v1/health
+  port: 443
+  expected-result: 200
+  namespace: services
+  gateways: ["services-gateway","customer-admin-gateway"]
+  project: CSM
+- name: cray-sls
+  path: apis/sls/v1/health
+  port: 443
+  expected-result: 200
+  namespace: services
+  gateways: ["services-gateway","customer-admin-gateway"]
+  project: CSM
+- name: cray-smd
+  path: apis/smd/hsm/v1/service/ready
+  port: 443
+  expected-result: 200
+  namespace: services
+  gateways: ["services-gateway","customer-admin-gateway"]
+  project: CSM
+- name: cray-sts
+  path: apis/sts/healthz
+  port: 443
+  expected-result: 200
+  namespace: services
+  gateways: ["services-gateway","customer-admin-gateway"]
+  project: CSM
+- name: cray-uas-mgr
+  path: apis/uas-mgr/v1/images
+  port: 443
+  expected-result: 200
+  namespace: services
+  gateways: ["services-gateway","customer-admin-gateway"]
+  project: CSM
+- name: gitea-vcs-web 
+  path: vcs
+  port: 443
+  expected-result: 200
+  namespace: services
+  gateways: ["services-gateway"]
+  project: CSM
+- name: nmdv2-service
+  path: apis/v2/nmd/dumps
+  port: 443
+  expected-result: 200
+  namespace: services
+  gateways: ["services-gateway"]
+  project: Other
+- name: slingshot-fabric-manager
+  path: apis/fabric-manager/fabric/port-policies
+  port: 443
+  expected-result: 200
+  namespace: services
+  gateways: ["services-gateway"]
+  project: HSN
+- name: sma-telemetry
+  path: apis/sma-telemetry-api/v1/ping
+  port: 443
+  expected-result: 200
+  namespace: services
+  gateways: ["services-gateway"]
+  project: SMA

--- a/scripts/operations/gateway-test/gateway-test.py
+++ b/scripts/operations/gateway-test/gateway-test.py
@@ -1,0 +1,321 @@
+#! /usr/bin/env python3
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+#
+#
+#  ./gateway-test.py <system-domain> <token-network>
+#
+
+import json
+import sys
+import logging
+import requests
+import urllib3
+import yaml
+import base64
+import subprocess
+import os.path
+
+try:
+  from kubernetes import client, config
+except:
+  client = None
+  config = None
+
+
+# Some very light logging.
+LOG_LEVEL=logging.INFO
+
+# Start logging
+logging.basicConfig(filename='/tmp/' + sys.argv[0].split('/')[-1] + '.log',  level=LOG_LEVEL)
+logging.info("Starting up")
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+class GWException(Exception):
+    """
+    This is the base exception for all custom exceptions that can be raised from
+    this application.
+    """
+
+def reachable(service):
+    ret = os.system("ping -q -c 3 {} >/dev/null".format(service))
+    if ret != 0:
+        print("{} is NOT reachable".format(service))
+        return False
+    else:
+        print("{} is reachable".format(service))
+        return True
+
+def get_admin_secret(k8sClientApi):
+    """
+    Get the admin secret from k8s for the api gateway - command line equivalent is:
+    #`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d`
+    """
+
+    try:
+        sec = k8sClientApi.read_namespaced_secret("admin-client-auth", "default").data
+        adminSecret = base64.b64decode(sec['client-secret'])
+    except Exception as err:
+        logging.error(f"An unanticipated exception occurred while retrieving k8s secrets {err}")
+        raise GWException from None
+
+    return adminSecret
+
+def get_access_token(adminSecret, tokenNet, nmn_override):
+
+    # get an access token from keycloak
+    payload = {"grant_type":"client_credentials",
+               "client_id":"admin-client",
+               "client_secret":adminSecret}
+
+    if tokenNet == "nmnlb" and nmn_override:
+        tokendomain = "api-gw-service-nmn.local"
+    else:
+        tokendomain = "auth.{}.{}".format(tokenNet, SYSTEM_DOMAIN)
+
+    url = "https://{}/keycloak/realms/shasta/protocol/openid-connect/token".format(tokendomain)
+ 
+    if not reachable(tokendomain):
+        return None
+   
+    try: 
+      r = requests.post(url, data = payload, verify = False)
+    except Exception as err:
+        print("{}".format(err))
+        logging.error(f"An unanticipated exception occurred while retrieving gateway token {err}")
+        raise GWException from None
+
+    # if the token was not provided, log the problem
+    if r.status_code != 200:
+        print("Error retrieving gateway token:  keycloak return code: {} text: {}".format(r.status_code,r.text))
+        logging.error(f"Error retrieving gateway token: keycloak return code: {r.status_code}"
+            f" text: {r.text}")
+        raise GWException from None
+
+    # pull the access token from the return data
+    token = r.json()['access_token']
+
+    print("Token successfully retrieved at {}\n".format(url))
+
+    return token
+
+def get_sls_networks(adminSecret, systemDomain, nets):
+
+    sls_networks = []
+    slstok = get_access_token(adminSecret, "cmn", False)
+
+    if not slstok:
+      print("Could not get token to get SLS networks")
+      return sls_networks
+
+    headers = {
+        'Authorization': "Bearer " + slstok
+    }
+
+    for n in nets:
+
+        slsurl = "https://api.cmn.{}/apis/sls/v1/networks/{}".format(systemDomain,n['name'].upper())
+        try:
+            r = requests.request("GET", slsurl, headers=headers, verify = False)
+        except Exception as err:
+            print("{}".format(err))
+            logging.error(f"An unanticipated exception occurred while retrieving SLS {n.upper()} network data {err}")
+            raise GWException from None
+
+        if r.status_code == 200:
+            sls_networks.append(n['name'])
+        else:
+            print("Got {} for {}".format(r.status_code,slsurl))
+
+    return sls_networks
+
+
+def get_vs(service):
+
+    result = None	
+    try:
+        logging.debug("Getting gateways for service {}.".format(service['name']))
+        command_line = ['kubectl', 'get', 'vs', service['name'], '-n', service['namespace'], '-o', 'yaml']
+        result = subprocess.check_output(command_line, stderr=subprocess.STDOUT).decode("utf8")
+        logging.debug(result)
+
+    except subprocess.CalledProcessError as err:
+        logging.error(f"Could not get virtual service. Got exit code {err.returncode}. Msg: {err.output}")
+
+    return result
+
+def get_vs_gateways(vsyaml):
+
+    vs = yaml.safe_load(vsyaml)
+    gws = vs['spec']['gateways']
+    return gws
+
+if __name__ == '__main__':
+
+    numarg = len(sys.argv)
+    test_defn_file = "./gateway-test-defn.yaml"
+    TEST_FAILED = 0
+
+    # Process the arguments
+    if numarg < 3: 
+      print("Usage: {} <system-domain> <token-network>".format(sys.argv[0]))
+      logging.critical("Wrong number of arguments passed. Args = {}.".format(sys.argv))
+      sys.exit(1)
+
+    if not os.path.exists(test_defn_file):
+      print("{} does not exist".format(test_defn_file))
+      logging.critical("{} does not exist.".format(test_defn_file))
+      sys.exit(1)
+
+    SYSTEM_DOMAIN = (sys.argv[1]).lower() 
+    TOKEN_NET = (sys.argv[2]).lower()
+    ADMIN_SECRET = os.environ.get("ADMIN_CLIENT_SECRET", "")
+
+    # Load the service definitions
+    with open(test_defn_file, 'r') as f:
+        svcs = yaml.load(f, Loader=yaml.FullLoader)
+
+    # Validate the TOKEN_NET argument
+    if not any(d['name'] == TOKEN_NET for d in svcs['networks']):
+      print("{} is not a valid network".format(sys.argv[2]))
+      logging.critical("{} is not a valid network".format(sys.argv[2]))
+      sys.exit(1)
+
+    # initialize k8s if we are running from an NCN
+    if os.path.exists("/bin/craysys"):
+      config.load_kube_config()
+      k8sClientApi = client.CoreV1Api()
+      ADMIN_SECRET = get_admin_secret(k8sClientApi)
+    else:
+      ADMIN_SECRET = os.environ.get("ADMIN_CLIENT_SECRET", "")
+      if ADMIN_SECRET == "":
+        print("ADMIN_CLIENT_SECRET not defined")
+        sys.exit(1)
+
+    # Determine which user networks are defined
+    snets = get_sls_networks(ADMIN_SECRET, SYSTEM_DOMAIN, svcs['networks'])
+
+    mytok = get_access_token(ADMIN_SECRET, TOKEN_NET, svcs['use-api-gw-override'])
+ 
+    if not mytok:
+      # If we are not on an NCN and the token net is NMNLB, then it is expected
+      # that we cannot get the token
+      if TOKEN_NET == "nmnlb" and not os.path.exists("/bin/craysys"):
+          sys.exit(0)
+      else:
+          sys.exit(1)
+
+    for net in svcs['networks']:
+
+      netname = net['name'].lower()
+      if netname.lower() == "nmnlb" and svcs['use-api-gw-override']:
+         domain = "api-gw-service-nmn.local"
+      else:
+         domain = "api.{}.{}".format(netname, SYSTEM_DOMAIN)
+
+      print("\n------------- {} -------------------".format(domain))
+
+      if not reachable(domain):
+          if netname in snets:
+              if netname != "nmnlb" :
+                  print("{} is not reachable but defined in SLS".format(netname))
+                  TEST_FAILED = 1
+          else:
+              print("{} is not reachable and not defined in SLS".format(netname))
+          continue
+
+      if netname not in snets:
+          print("{} is reachable but not defined in SLS".format(netname))
+          TEST_FAILED = 1
+          continue
+
+      for i in range(len(svcs['ingress_api_services'])):
+        svcname = svcs['ingress_api_services'][i]['name']
+        svcpath = svcs['ingress_api_services'][i]['path']
+        svcport = svcs['ingress_api_services'][i]['port']
+        svcexp = svcs['ingress_api_services'][i]['expected-result']
+        svcproject = svcs['ingress_api_services'][i]['project']
+
+        if svcport == 443:
+            scheme = "https"
+        else:
+            scheme = "http"
+
+        url = scheme + "://" + domain + "/" + svcpath 
+
+        if os.path.exists("/bin/craysys"):
+        # Getting the gateways from the Virtual Service definitions
+        # This can only be done if we are running the tests from an NCN
+        # The best way I could find to determine if we are running on an NCN is to see if craysys is installed.
+        # There may be a better way
+            vsyaml = get_vs(svcs['ingress_api_services'][i])
+            if vsyaml is None:
+               print("SKIP - [" + svcname + "]: " + url + " - virtual service not found")
+               continue
+        
+            svcgws = get_vs_gateways(vsyaml)
+        elif svcproject != "CSM":
+            print("SKIP - [{}]: {}".format(svcname, url))
+            continue
+
+        # Otherwise, we get the gateways from the test defininition file (which may become stale)
+        else:
+            if "gateways" in svcs['ingress_api_services'][i]:
+                svcgws = svcs['ingress_api_services'][i]['gateways']
+            else:
+                print("SKIP - [" + svcname + "]: " + url + " - gateways not found")
+                continue
+
+        if net['gateway'] not in svcgws:
+          svcexp = 404
+        # if the token we have does not match the network we are testing, we expect a 403
+        # CMN tokens will work with NMN and vice versa, because they are using the same gateway in 1.2.
+        elif TOKEN_NET == "cmn" and netname != TOKEN_NET and netname != "nmnlb":
+          svcexp = 403
+        elif TOKEN_NET == "nmnlb" and netname != TOKEN_NET and netname != "cmn":
+          svcexp = 403
+        elif TOKEN_NET not in ["cmn","nmnlb"] and TOKEN_NET != netname:
+          svcexp = 403
+
+        headers = {
+            'Authorization': "Bearer " + mytok
+        }
+
+   
+        try:    
+            response = requests.request("GET", url, headers=headers, verify = False)
+        except Exception as err:
+            print("{}".format(err))
+            logging.error(f"An unanticipated exception occurred while retrieving {url} {err}")
+            break
+    
+        if response.status_code == svcexp:
+            print("PASS - [" + svcname + "]: " + url + " - " + str(response.status_code))
+        else:
+            print("FAIL - [" + svcname + "]: " + url + " - " + str(response.status_code))
+            TEST_FAILED = 1
+
+    sys.exit(TEST_FAILED)
+


### PR DESCRIPTION
## Summary and Scope

This adds the gateway tests to the docs repo to allow running as needed.   It includes a page of instructions to show how to run the tests from various location and what the expected output will be.

This includes tests for 24 services as defined on this page:  https://connect.us.cray.com/confluence/display/~johren/Multiple+Gateway+Testing

Further tests will be added.

## Issues and Related PRs

* CASMNET-866

## Testing


### Tested on:

  * `mug`
  * `surtur`
  * `hela`

### Test description:

The tests have been run from an NCN and from outside (laptop and csm-remote-pit).   The tests have also been run briefly from a compute node and a UAN on hela.  Further work is needed once those nodes are available again on hela.

## Risks and Mitigations

None


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

