### PR TITLE
CASMINST-4218: clarify ncn configuration enable/disable during 1.2 upgrade

### DIFF
--- a/operations/CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md
+++ b/operations/CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md
@@ -197,11 +197,11 @@ To manually run NCN personalization, first gather the following information:
    ```bash
    ncn# kubectl -n services get cm cray-product-catalog -o jsonpath='{.data.csm}'
 
-   1.0.0:
+   1.2.0:
       configuration:
          clone_url: https://vcs.cmn.SYSTEM_DOMAIN_NAME/vcs/cray/csm-config-management.git
          commit: 43ecfa8236bed625b54325ebb70916f55884b3a4
-         import_branch: cray/csm/1.6.12
+         import_branch: cray/csm/1.9.24
          import_date: 2021-07-28 03:26:01.869501
          ssh_url: git@vcs.cmn.SYSTEM_DOMAIN_NAME:cray/csm-config-management.git
       ...

--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -8,6 +8,7 @@
 * [Stage 0.4 - Upgrade Management Network](#update-management-network)
 * [Stage 0.5 - Prerequisites Check](#prerequisites-check)
 * [Stage 0.6 - Backup VCS Data](#backup-vcs-data)
+* [Stage 0.7 - Suspend NCN Configuration](#suspend-ncn-config)
 
 <a name="install-latest-docs"></a>
 ## Stage 0.1 - Install latest docs RPM
@@ -220,5 +221,20 @@ Run check script:
 To prevent any possibility of losing configuration data, backup the VCS data and store it in a safe location. See [Version_Control_Service_VCS.md](../../operations/configuration_management/Version_Control_Service_VCS.md#backup-and-restore-data) for these procedures.
 
 **`IMPORTANT:`** As part of this stage, **only perform the backup, not the restore**. The backup procedure is being done here as a precautionary step.
+
+<a name="suspend-ncn-config"></a>
+## Stage 0.7 - Suspend NCN Configuration
+
+Suspend automatic reconfiguration on NCNs to ensure that previous CSM version
+configuration is not applied during the upgrade. Automatic reconfiguration
+will be re-enabled in [Stage 5](Stage_5.md).
+
+   ```bash
+   ncn# export CRAY_FORMAT=json
+   ncn# for xname in $(cray hsm state components list --role Management --type node | jq -r .Components[].ID)
+   do
+       cray cfs components update --enabled false $xname
+   done
+```
 
 Once the above steps have been completed, proceed to [Stage 1](Stage_1.md).

--- a/upgrade/1.2/Stage_4.md
+++ b/upgrade/1.2/Stage_4.md
@@ -134,5 +134,5 @@ Only processes running the v15.2.8 image will be upgraded.  This will include `M
 
    Please ***NOTE*** that this may take up to 30 seconds to apply and the health to return to **HEALTH_OK**.
 
+Once the above steps have been completed, proceed to [Stage 5](Stage_5.md).
 
-Once `Stage 4` upgrade is complete, proceed to [Return to Main Page and Proceed to *Validate CSM Health*](../index.md#validate_csm_health)

--- a/upgrade/1.2/Stage_5.md
+++ b/upgrade/1.2/Stage_5.md
@@ -1,0 +1,54 @@
+# Stage 5 - Perform NCN Personalization
+
+## Procedure
+
+1. If custom configuration content was merged with content from a previous CSM
+   installation, merge the new CSM configuration in with it in the `csm-config-management`
+   git repository. This is not necessary if the NCN personalization configuration
+   was using a commit on a `cray/csm/VERSION` branch (i.e using default
+   configuration).
+
+   The new CSM configuration content is found in the `cray-product-catalog`
+   config map. If using the default CSM configuration, simply note the value in
+   the `commit` field.
+
+   ```bash
+   ncn# kubectl -n services get cm cray-product-catalog -o jsonpath='{.data.csm}'
+
+   1.2.0:
+     configuration:
+       clone_url: https://vcs.cmn.SYSTEM_DOMAIN_NAME/vcs/cray/csm-config-management.git
+       commit: 43ecfa8236bed625b54325ebb70916f55884b3a4
+       import_branch: cray/csm/1.9.24
+       import_date: 2022-07-28 03:26:01.869501
+       ssh_url: git@vcs.cmn.SYSTEM_DOMAIN_NAME:cray/csm-config-management.git
+   ...
+   ```
+
+   The specific dates, commits, and other values may not be the same as the output above.
+
+1. Write out the current `ncn-personalization` configuration to a JSON file.
+
+   ```bash
+   ncn-m001# cray cfs configurations describe ncn-personalization --format json > ncn-personalization.json
+   ```
+
+1. Run the `apply_csm_configuration.sh` script. This script will update the CSM
+   layer in the `ncn-personalization` configuration, enable configuration of
+   the NCNs, and monitor the progress of the NCN personalization process.
+
+   **IMPORTANT:**
+
+   > * If you are using a different branch than the default to include custom
+       changes, use the `--git-commit` option to override the commit to the
+       commit on your branch.
+   > * If you are using the default CSM configuration found in the product
+       catalog above, you may omit this option.
+
+   ```bash
+   ncn-m001# /usr/share/doc/csm/scripts/operations/configuration/apply_csm_configuration.sh [--git-commit COMMIT]
+   ```
+
+   For more information on this script, see [Automatically Apply CSM Configuration to NCNs](../../operations/CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md#automatically-apply-csm-configuration-to-ncns)
+
+Once `Stage 5` upgrade is complete, proceed to [*Validate CSM Health*](../index.md#validate_csm_health) on the main upgrade page.


### PR DESCRIPTION
## Summary and Scope

Ensure that NCN personalization doesn't run on NCNs when they reboot since this will configure them with old Ansible plays from a previous version. Add a stage 5 to re-enable configuration using the current configuration from the new configuration branch in git.

## Issues and Related PRs

* Resolves CASMINST-4218

## Testing

### Tested on:

  * `Hela`

## Risks and Mitigations

None