### PR TITLE
CASMCMS-7890: Revert CASMTRIAGE-3070 (CSM 1.2 version)

### DIFF
--- a/upgrade/1.2/README.md
+++ b/upgrade/1.2/README.md
@@ -62,15 +62,6 @@ Please see [Troubleshoot Postgres Database](../../operations/kubernetes/Troubles
 
 Please see [Troubleshoot Spire Failing to Start on NCNs](../../operations/spire/Troubleshoot_Spire_Failing_to_Start_on_NCNs.md).
 
-### Troubleshooting CFS Sessions That Can't Find Playbooks
-
-Due to an issue with the Ansible content import logic, the git commit ids for some
-release branches may have changed, making old CFS configurations invalid.  If CFS
-fails to find the specified playbook, or fails to checkout the appropriate commit
-in the `git-clone` containers, check that the commit still exists by manually
-cloning the git repo and attempting to checkout the commit.  If it no longer exists,
-find the most recent commit id for the desired branch and update the configuration
-as usual for CFS.  This will be fixed in a future version.
 
 ### Rerun a step/script
 


### PR DESCRIPTION
## Summary and Scope

CASMCMS-7890: Revert "CASMTRIAGE-3070: Add troubleshooting section for upgraded CFS content"

This reverts commit 105c766e71051b4e401d4292c5e12803e80ad0ad.

A new version of csm-config provided in CASMCMS-7890 (v1.9.24) makes this doc change unnecessary.

## Issues and Related PRs

* Resolves CASMCMS-7890
* Reverts CASMINST-3070
* Merge with https://github.com/Cray-HPE/csm/pull/592

## Testing

See https://github.com/Cray-HPE/csm/pull/592 for testing information.

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Target branch correct