### PR TITLE
CASMINST-4206: Copy all NCN configuration changes/scripts from 1.2

### DIFF
--- a/operations/CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md
+++ b/operations/CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md
@@ -19,7 +19,8 @@ the SSH keys need to be changed per site requirements.
 The goal of passwordless SSH is to enable an easy way for interactive
 passwordless SSH from and between CSM product environments (management nodes) to
 downstream managed product environments (COS, UAN, etc), without requiring each
-downstream environment to create and apply individual changes to NCNs.
+downstream environment to create and apply individual changes to NCNs, and as a
+primary way to manage passwordless SSH configuration between management nodes.
 Passwordless SSH from downstream nodes into CSM management nodes is not intended
 or supported.
 
@@ -33,8 +34,6 @@ The management of keys on NCNs is achieved by the `trust-csm-ssh-keys` and
 `passwordless-ssh` Ansible roles in the CSM configuration management repository.
 The SSH keypair is applied to management nodes via NCN personalization.
 
-Choose one option from the following sections to enable or disable passwordless
-SSH on NCNs.
 
 ### Option 1: Use the CSM-provided SSH Keys
 
@@ -45,37 +44,70 @@ with CFS.
 ### Option 2: Provide Custom SSH Keys
 
 Administrators may elect to replace the CSM-provided keys with their own custom
-keys.
+keys. The `replace_ssh_keys.sh` script can be used to replace the keys from
+files.
+
+```bash
+ncn-m001# /usr/share/doc/csm/scripts/operations/configuration/replace_ssh_keys.sh \
+--public-key-file ./id_rsa-csm.pub --private-key-file ./id_rsa-csm
+```
+
+Alternatively, the keys stored in Kubernetes can be updated directly. 
 
 1. Replace the private key half:
    ```bash
-   ncn# kubectl get secret -n services csm-private-key -o json | jq --arg value "$(cat ~/.ssh/id_rsa | base64)" '.data["value"]=$value' | kubectl apply -f -
+   ncn# kubectl get secret -n services csm-private-key -o json | jq --arg value "$(cat ~/.ssh/id_rsa-csm | base64)" '.data["value"]=$value' | kubectl apply -f -
    ```
-   `~/.ssh/id_rsa` is a local file containing a valid SSH private key.
+   where `~/.ssh/id_rsa-csm` is a local file containing a valid SSH private key.
 
 1. Replace the public key half:
    ```bash
    ncn# kubectl delete configmap -n services csm-public-key && \
-      cat ~/.ssh/id_rsa.pub | \
+      cat ~/.ssh/id_rsa-csm.pub | \
       base64 > ./value && kubectl create configmap --from-file \
       value csm-public-key --namespace services && rm ./value
    ```
-   `~/.ssh/id_rsa.pub` is a local file containing a valid public key intended for
-    CSM and downstream products.
+   where `~/.ssh/id_rsa-csm.pub` is a local file containing a valid public key
+   intended for CSM and downstream products.
 
-Passwordless SSH with the provided keys will be setup once NCN personalization
+Passwordless SSH with the provided keys will be set up once NCN personalization
 runs on the NCNs.
 
-### Option 3: Disable CSM-provided Passwordless SSH
+**NOTE**: This key pair may or may not be the same key pair used for the NCN
+`root` user. See the _Configure the Root Password and Root SSH Keys in Vault_
+procedure below for setting the root user SSH keys on NCNs.
 
-Local site security requirements may preclude use of passwordless SSH access. If
-this is the case, remove or comment out the invocation of the
-`trust-csm-public-keys` role in Ansible plays in the configuration repositories
-of the environments where it is configured. By default, the HPE Cray Operating
-System (COS) and User Access Node (UAN) configurations enable passwordless SSH.
+###  Option 3: Disable CSM-provided Passwordless SSH
+
+Local site security requirements may preclude use of passwordless SSH access between
+management nodes. A variable has been added to the associated ansible roles that will
+allow you to disable passwordless SSH setup to any or all nodes. From the cloned
+csm-config-management repository directory:
+
+    ```
+    ncn# grep csm_passwordless_ssh_enabled roles/trust-csm-ssh-keys/defaults/main.yaml
+    ```
+    
+    Example output:
+
+    ```
+    csm_passwordless_ssh_enabled: 'false'
+    ```
+
+This variable can be overwritten using either a host-specific setting or 'global' to affect
+all nodes where the playbook is run. Please reference [Customize Configuration Values](../configuration_management/Customize_Configuration_Values.md)
+for more detailed information. Do not modify the value in the `roles/trust-csm-ssh-keys/defaults/main.yaml`
+file.
+
+Published roles within product configuration repositories can contain more comprehensive
+information regarding these role-specific flags. Please reference any role specific associated Readme.md
+documents for additional information, as role documentation is updated more frequently as
+changes are introduced.
+
 Consult the manual for each product to change the default configuration by 
 referring to the [1.5 HPE Cray EX System Software Getting Started Guide S-8000](https://www.hpe.com/support/ex-gsg)
-on the HPE Customer Support Center.
+on the HPE Customer Support Center. Similar configuration values for disabling the
+role will be required in these product specific configuration repositories.
 
 Modifying Ansible plays in a configuration repository will require a new commit
 and subsequent update of the [configuration layer](../configuration_management/Configuration_Layers.md)
@@ -90,11 +122,19 @@ associated with the product.
 > Use this procedure if switching from custom keys to the default CSM SSH keys
 > only, otherwise it can be skipped.
 
+To restore the default CSM keys, administrators can run the
+`restore_ssh_keys.sh` script.
+
+```bash
+ncn-m001# /usr/share/doc/csm/scripts/operations/configuration/restore_ssh_keys.sh
+```
+
+Alternatively, the keys can be deleted from Kubernetes directly.
 The `csm-ssh-keys` Kubernetes deployment provided by CSM periodically checks the
 ConfigMap and secret containing the key information. If these entries do not
-exist, it will recreate them from the default CSM keys. In this case, deleting
-the associated ConfigMap and secrets will republish them with the default
-CSM-provided keys.
+exist, it will recreate them from the default CSM keys. To manually restore
+keys, delete the associated ConfigMap and secret, and the default CSM-provided
+keys will be republished.
 
 1. Delete the `csm-private-key` Kubernetes secret.
    ```bash
@@ -106,27 +146,34 @@ CSM-provided keys.
    ```
 
 <a name="set_root_password"></a>
-## Set the Root Password
+## Configure the Root Password and Root SSH Keys in Vault
 
-This procedure should be run during CSM installation and afterwards whenever
-the password needs to be changed per site requirements.
+The root user password and SSH keys are managed on NCNs by using the
+`csm.password` and `csm.ssh_keys` Ansible roles, respectively, located in the
+CSM configuration management repository. Root user passwords and SSH keys are
+set and managed in Vault.
 
-The root password is managed on NCNs by using the `csm.password` Ansible role
-located in the CSM configuration management repository. Root passwords are set
-and managed in Vault.
+1. Set the root user password in Vault by following the _Configure Root Password in Vault_
+   procedure in [Update NCN User Passwords](../security_and_authentication/Update_NCN_Passwords.md#configure_root_password_in_vault).
+1. Set the root user SSH keys in Vault by following the _Configure Root SSH Keys in Vault_
+   procedure in [Update NCN User SSH Keys](../security_and_authentication/SSH_Keys.md#configure_root_keys_in_vault).
+1. Apply the Vault password to the NCNs in the
+   [Perform NCN personalization](#perform_ncn_personalization) procedure.
 
-1. Set the password in Vault by following steps 1-3 in the
-   [Update NCN Passwords](../security_and_authentication/Update_NCN_Passwords.md)
-   procedure.
-1. Run [NCN personalization](#run_ncn_personalization).
-
-<a name="run_ncn_personalization"></a>
-## Run NCN Personalization
+<a name="perform_ncn_personalization"></a>
+## Perform NCN Personalization
 
 After completing the previous procedures, apply the configuration to the NCNs
 by running NCN personalization with [CFS](../configuration_management/Configuration_Management.md).
+This can be accomplished by running the `apply_csm_configuration.sh` script, or
+running the steps manually. For more information on the script, see
+[Automatically Apply CSM Configuration to NCNs](#auto_apply_csm_config).
 
-Prior to running NCN personalization, gather the following information: 
+```bash
+ncn-m001# /usr/share/doc/csm/scripts/operations/configuration/apply_csm_configuration.sh
+```
+
+To manually run NCN personalization, first gather the following information: 
 
 * HTTP clone URL for the configuration repository in [VCS](../configuration_management/Version_Control_Service_VCS.md)
 * Path to the Ansible play to run in the repository
@@ -152,11 +199,11 @@ Prior to running NCN personalization, gather the following information:
 
    1.0.0:
       configuration:
-         clone_url: https://vcs.SYSTEM_DOMAIN_NAME/vcs/cray/csm-config-management.git
+         clone_url: https://vcs.cmn.SYSTEM_DOMAIN_NAME/vcs/cray/csm-config-management.git
          commit: 43ecfa8236bed625b54325ebb70916f55884b3a4
          import_branch: cray/csm/1.6.12
          import_date: 2021-07-28 03:26:01.869501
-         ssh_url: git@vcs.SYSTEM_DOMAIN_NAME:cray/csm-config-management.git
+         ssh_url: git@vcs.cmn.SYSTEM_DOMAIN_NAME:cray/csm-config-management.git
       ...
    ```
    The commit will be different for each system and version of CSM. For
@@ -173,12 +220,53 @@ Prior to running NCN personalization, gather the following information:
             "commit": "<retrieved git commit>"
          }
 
-2. (Install Only) Follow the procedure in [Run NCN Personalization](#run-ncn-personalization),
+1. (Install Only) Follow the procedure in [Perform NCN Personalization](Perform_NCN_Personalization.md),
    adding a CSM configuration layer to the NCN personalization using the JSON
    from step 3.
-3. (Upgrade Only) Follow the procedure in [Run NCN Personalization](#run-ncn-personalization),
+
+1. (Upgrade Only) Follow the procedure in [Perform NCN Personalization](Perform_NCN_Personalization.md),
    replacing the existing CSM configuration layer to the NCN personalization
    using the JSON from the step 3.
 
-> **NOTE**: The CSM configuration layer _MUST_ be the first layer in the
+> **NOTE:** The CSM configuration layer _MUST_ be the first layer in the
 > NCN personalization CFS configuration.
+
+<a name="auto_apply_csm_config"></a>
+## Automatically Apply CSM Configuration to NCNs
+
+CSM configuration can automatically be applied to NCNs by running the
+`apply_csm_configuration.sh` script.
+
+```bash
+ncn-m001# /usr/share/doc/csm/scripts/operations/configuration/apply_csm_configuration.sh
+```
+
+### Automatic CSM Configuration Steps
+ 
+By default the script will perform the following steps:
+1. Finds the latest installed release version of the CSM product stream.
+1. Finds the latest commit on the release branch of the `csm-config-management` repo.
+1. Creates or updates the `ncn-personalization.json` configuration file.
+1. Finds all nodes in HSM with the `Management` role.
+1. Disables configuration for all NCNs.
+1. Updates the `ncn-personalization` configuration in CFS from the `ncn-personalization.json` file.
+1. Enables configuration for all NCN nodes, and sets their desired configuration to `ncn-personalization`.
+1. Monitors CFS until all NCN nodes have successfully completed, or failed, configuration.
+
+### Automatic CSM Configuration Overrides
+
+The script also supports several flags to override these behaviors:
+- `csm-release:` Overrides the version of the CSM release that is used. Defaults
+  to the latest version.
+- `git-commit`: Overrides the git commit cloned for the configuration content.
+  Defaults to the latest commit on the csm-release branch.
+- `git-clone-url`: Overrides the source of the configuration content. Defaults
+  to `https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git`.
+- `ncn-config-file`: Sets a file other than `ncn-personalization.json` to be
+  used for the configuration.
+- `xnames`: A comma-separated list of component names (xnames) to deploy to. Defaults to all
+  `Management` nodes in HSM.
+- `clear-state`: Clears existing state from components to ensure CFS runs. This
+   can be used if configuration needs to be re-run on successful nodes with no
+   change to the git content since the previous run. For examples, if the ssh
+   keys have changed.

--- a/scripts/operations/configuration/apply_csm_configuration.sh
+++ b/scripts/operations/configuration/apply_csm_configuration.sh
@@ -1,0 +1,199 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+usage()
+{
+   # Display Help
+   echo "Runs CFS to setup passwordless ssh"
+   echo "All parameters are optional and the values will be determined automatically if not set."
+   echo
+   echo "Usage: deploy_ssh_keys.sh [ --csm-release version ] [ --git-commit hash ]"
+   echo "                            [ --git-clone-url url ] [ --ncn-config-file file ]"
+   echo "                            [ --xnames xname1,xname2... ] [ --clear-state ]"
+   echo
+   echo "Options:"
+   echo "csm-release          The version of the CSM release to use. (e.g. 1.6.11)"
+   echo "git-commit           The git commit hash for CFS to use."
+   echo "git-clone-url        The git clone url for CFS to use."
+   echo "ncn-config-file      A file containing the NCN CFS configuration."
+   echo "xnames               A comma seperated list of component names (xnames) to deploy to. All management nodes will be included if not set."
+   echo "clear-state          Clears existing state from components to ensure CFS runs."
+   echo
+}
+
+while [[ $# -gt 0 ]]; do
+  key="$1"
+
+  case $key in
+    --csm-release)
+      RELEASE="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --git-commit)
+      COMMIT="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --git-clone-url)
+      CLONE_URL="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --ncn-config-file)
+      NCN_CONFIG_FILE="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --xnames)
+      XNAMES="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --clear-state)
+      CLEAR_STATE="true"
+      shift # past argument
+      ;;
+    -h|--help) # help option
+      usage
+      exit 0
+      ;;
+    *) # unknown option
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+## CONFIGURATION SETUP ##
+if [[ -z "${RELEASE}" ]]; then
+    RELEASE=$(kubectl -n services get cm cray-product-catalog -o jsonpath='{.data.csm}' 2>/dev/null\
+        | yq r -j - 2>/dev/null | jq -r ' to_entries | .[0].value.configuration.import_branch' 2>/dev/null\
+        | awk -F'/' '{ print $NF }')
+    echo "Found release version ${RELEASE}"
+fi
+
+CSM_CONFIG_FILE="csm-config-$RELEASE.json"
+if [[ -z "${NCN_CONFIG_FILE}" ]]; then
+    NCN_CONFIG_FILE="ncn-personalization.json"
+fi
+if [[ -z "${CLONE_URL}" ]]; then
+    CLONE_URL="https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git"
+fi
+
+if [[ -z "${COMMIT}" ]]; then
+    VCS_USER=$(kubectl get secret -n services vcs-user-credentials --template={{.data.vcs_username}} | base64 --decode)
+    VCS_PASSWORD=$(kubectl get secret -n services vcs-user-credentials --template={{.data.vcs_password}} | base64 --decode)
+    TEMP_DIR=`mktemp -d`
+    TEMP_HOME=$HOME
+    HOME=$TEMP_DIR
+    cd $TEMP_DIR
+    echo "${CLONE_URL/\/\//\/\/${VCS_USER}:${VCS_PASSWORD}@}" > .git-credentials
+    git config --file .gitconfig credential.helper store
+    COMMIT=$(git ls-remote $CLONE_URL refs/heads/cray/csm/${RELEASE} | awk '{print $1}')
+    if [[ -n $COMMIT ]]; then
+        echo "Found git commit ${COMMIT}"
+    else
+        echo "No git commit found"
+        exit 1
+    fi
+    cd -
+    HOME=$TEMP_HOME
+    rm -r $TEMP_DIR
+fi
+
+CONFIG="{
+  \"layers\": [
+    {
+      \"name\": \"csm-${RELEASE}\",
+      \"cloneUrl\": \"$CLONE_URL\",
+      \"commit\": \"${COMMIT}\",
+      \"playbook\": \"site.yml\"
+    }
+  ]
+}"
+
+if [[ ! -f $CSM_CONFIG_FILE ]]; then
+    echo "Creating the configuration file ${CSM_CONFIG_FILE}"
+else
+    echo "Replacing the configuration file ${CSM_CONFIG_FILE}"
+fi
+echo $CONFIG | jq > $CSM_CONFIG_FILE
+
+if [ ! -f $NCN_CONFIG_FILE ]; then
+    echo "Creating the configuration file ${NCN_CONFIG_FILE}"
+    cp -p $CSM_CONFIG_FILE $NCN_CONFIG_FILE
+else
+    echo "Making a backup of old ${NCN_CONFIG_FILE}"
+    cp -p $NCN_CONFIG_FILE ${NCN_CONFIG_FILE}.backup
+    echo "Updating the configuration file ${NCN_CONFIG_FILE}"
+    jq -n --slurpfile new $CSM_CONFIG_FILE --slurpfile old $NCN_CONFIG_FILE \
+        '{"layers": ($new[0].layers + ($old[0].layers | del(.[] | select(.cloneUrl == $new[0].layers[0].cloneUrl and .playbook == $new[0].layers[0].playbook))))}'\
+        > ${NCN_CONFIG_FILE}.new
+    mv ${NCN_CONFIG_FILE}.new $NCN_CONFIG_FILE
+fi
+
+## RUNNING CFS ##
+if [[ -z $XNAMES ]]; then
+    echo "Retrieving a list of all management node component names (xnames)"
+    XNAMES=$(cray hsm state components list --role Management --type Node --format json | jq -r '.Components | map(.ID) | join(",")')
+fi
+XNAME_LIST=${XNAMES//,/ }
+
+echo "Disabling configuration for all listed components"
+for xname in $XNAME_LIST; do
+    cray cfs components update $xname --enabled false
+done
+
+echo "Updating ncn-personalization configuration"
+cray cfs configurations update ncn-personalization --file $NCN_CONFIG_FILE
+
+if [[ -n $CLEAR_STATE ]]; then
+    echo "Clearing state from all listed components"
+    for xname in $XNAME_LIST; do
+        cray cfs components update $xname --state []
+    done
+fi
+
+echo "Setting desired configuration and enabling all listed components"
+for xname in $XNAME_LIST; do
+    cray cfs components update $xname --enabled true --error-count 0 --desired-config ncn-personalization
+done
+
+while true; do
+  RESULT=$(cray cfs components list --status pending --ids ${XNAMES} --format json | jq length)
+  if [[ "$RESULT" -eq 0 ]]; then
+    break
+  fi
+  echo "Waiting for configuration to complete.  ${RESULT} components remaining."
+  sleep 60
+done
+
+CONFIGURED=$(cray cfs components list --status configured --ids ${XNAMES} --format json | jq length)
+FAILED=$(cray cfs components list --status failed --ids ${XNAMES} --format json | jq length)
+echo "Configuration complete. $CONFIGURED component(s) completed successfully.  $FAILED component(s) failed."
+if [ "$FAILED" -ne "0" ]; then
+   echo "The following components failed: $(cray cfs components list --status failed --ids ${XNAMES} --format json | jq -r '. | map(.id) | join(",")')"
+fi

--- a/scripts/operations/configuration/replace_ssh_keys.sh
+++ b/scripts/operations/configuration/replace_ssh_keys.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+usage()
+{
+   # Display Help
+   echo "Replaces the ssh keys in Kubernetes"
+   echo "At least one option must be specified"
+   echo "NOTE: This does not update deployed keys"
+   echo
+   echo "Usage: replace_ssh_keys.sh [ --public-key-file file ]"
+   echo "                           [ --private-key-file file ]"
+   echo
+   echo "Options:"
+   echo "public-key-file      File path for a public key."
+   echo "private-key-file     File path for a private key."
+   echo
+}
+
+if [[ $# -eq 0 ]]; then
+  usage
+fi
+
+while [[ $# -gt 0 ]]; do
+  key="$1"
+
+  case $key in
+    --public-key-file)
+      PUBLIC_KEY_FILE="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --private-key-file)
+      PRIVATE_KEY_FILE="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    -h|--help) # help option
+      usage
+      exit 0
+      ;;
+    *) # unknown option
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -n "${PUBLIC_KEY_FILE}" ]]; then
+  PUBLIC_KEY=$(cat $PUBLIC_KEY_FILE)
+  if [[ -z "${PUBLIC_KEY}" ]]; then
+    echo "Public key not found in specified file"
+    exit 1
+  fi
+fi
+
+if [[ -n "${PRIVATE_KEY_FILE}" ]]; then
+  PRIVATE_KEY=$(cat $PRIVATE_KEY_FILE)
+  if [[ -z "${PRIVATE_KEY}" ]]; then
+    echo "Private key not found in specified file"
+    exit 1
+  fi
+fi
+
+if [[ -n "${PUBLIC_KEY}" ]]; then
+  echo "Updating public key..."
+  kubectl delete configmap -n services csm-public-key
+  cat ${PUBLIC_KEY_FILE} | \
+    base64 > ./value && kubectl create configmap --from-file \
+    value csm-public-key --namespace services && rm ./value
+fi
+
+if [[ -n "${PRIVATE_KEY}" ]]; then
+  echo "Updatating private key..."
+  kubectl get secret -n services csm-private-key -o json | \
+    jq --arg value "$(cat ${PRIVATE_KEY_FILE} | base64)" \
+    '.data["value"]=$value' | kubectl apply -f -
+fi

--- a/scripts/operations/configuration/restore_ssh_keys.sh
+++ b/scripts/operations/configuration/restore_ssh_keys.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+usage()
+{
+   # Display Help
+   echo "Removes the ssh keys in Kubernetes to restore their value from vault"
+   echo "NOTE: This does not update deployed keys"
+   echo
+   echo "Usage: restore_ssh_keys.sh"
+   echo
+}
+
+while [[ $# -gt 0 ]]; do
+  key="$1"
+
+  case $key in
+    -h|--help) # help option
+      usage
+      exit 0
+      ;;
+    *) # unknown option
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+
+kubectl delete configmap -n services csm-public-key
+kubectl delete secret -n services csm-private-key
+echo "Keys removed.  Waiting for defaults to be populated."
+echo "csm-ssh-keys will be restarted to force the keys to be restored sooner."
+kubectl -n services rollout restart deployment csm-ssh-keys
+
+until kubectl get configmap -n services csm-public-key >/dev/null 2>&1 && \
+      kubectl get secret -n services csm-private-key >/dev/null 2>&1; do
+  echo "Waiting for defaults to be populated..."
+  sleep 10
+done
+
+echo "Defaults have been restored"


### PR DESCRIPTION
## Summary and Scope

Pulls in changes to the 1.2 docs for NCN configuration, including some helper scripts.  These were discovered missing while fixing an issue the the apply_csm_configuration script for CASMINST-4206 in the 1.2 branch.

This PR includes the new fix for CASMINST-4206:
Due to a recent change in the install process, BMCs are now given the Management role, and this was causing the apply_csm_configuration script to print non-impactful errors because BMCs are not valid targets for CFS.  This restricts the call listing Management components to only Nodes, which was previously the only component type that had the Management role.

## Issues and Related PRs

* Resolves CASMINST-4206

## Testing

### Tested on:

  * Surtur

### Test description:

Ran the new command and verified the output.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

