### PR TITLE
MTL-1640: issue a warning if a node is down

### DIFF
--- a/upgrade/lib/validation/CASMREL-776-CSM12-NCN-boot-order-backport/install-hotfix.sh
+++ b/upgrade/lib/validation/CASMREL-776-CSM12-NCN-boot-order-backport/install-hotfix.sh
@@ -55,7 +55,10 @@ function copy {
     echo "Copying ${WORKING_DIR}/mini-install.sh and ${WORKING_DIR}/metal-lib.sh ${WORKING_DIR}/lib.sh to ..."
     for ncn in $(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u); do
         echo "$ncn:/srv/cray/scripts/metal/mini-install.sh"
-        scp ${WORKING_DIR}/scripts/mini-install.sh ${ncn}:/srv/cray/scripts/metal/ >/dev/null
+        if ! scp ${WORKING_DIR}/scripts/mini-install.sh ${ncn}:/srv/cray/scripts/metal/ >/dev/null; then
+            echo "WARNING: unable to copy files to $ncn, skipping"
+            continue
+        fi
         echo "$ncn:/srv/cray/scripts/metal/metal-lib.sh"
         scp ${WORKING_DIR}/scripts/metal-lib.sh ${ncn}:/srv/cray/scripts/metal/ >/dev/null
         echo "$ncn:/srv/cray/scripts/common/lib.sh"


### PR DESCRIPTION
## Summary and Scope

Instead of assuming all target NCNs are up, check for a successful
scp and emit a warning if it fails.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [MTL-1640](https://jira-pro.its.hpecorp.net:8443/browse/MTL-1640)
* Relates to: [CAST-29492](https://jira-pro.its.hpecorp.net:8443/browse/CAST-29492)

## Testing

### Tested on:

  * code snippet change was tested on redbull

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

