### PR TITLE
CASMTRIAGE-3123 - Update externaldns domain filters to only permit subdomain updates

### DIFF
--- a/upgrade/1.2/scripts/upgrade/util/update-customizations.sh
+++ b/upgrade/1.2/scripts/upgrade/util/update-customizations.sh
@@ -278,15 +278,7 @@ fi
 # Remove unused cray-externaldns configuration and add domain filters required for bifurcated CAN.
 if [[ -z "$(yq r "$c" 'spec.kubernetes.services.cray-externaldns.external-dns.domainFilters')" ]]; then
     yq w -i --style=single "$c" 'spec.kubernetes.services.cray-externaldns.external-dns'
-    yq w -i --style=single "$c" 'spec.kubernetes.services.cray-externaldns.external-dns.domainFilters[]'
-    yq w -i --style=single "$c" 'spec.kubernetes.services.cray-externaldns.external-dns.domainFilters[+]' 'cmn.{{ network.dns.external }}'
-    yq w -i --style=single "$c" 'spec.kubernetes.services.cray-externaldns.external-dns.domainFilters[+]' 'cmn.{{ network.dns.external }}'
-    yq w -i --style=single "$c" 'spec.kubernetes.services.cray-externaldns.external-dns.domainFilters[+]' 'can.{{ network.dns.external }}'
-    yq w -i --style=single "$c" 'spec.kubernetes.services.cray-externaldns.external-dns.domainFilters[+]' 'chn.{{ network.dns.external }}'
-    yq w -i --style=single "$c" 'spec.kubernetes.services.cray-externaldns.external-dns.domainFilters[+]' 'nmn.{{ network.dns.external }}'
-    yq w -i --style=single "$c" 'spec.kubernetes.services.cray-externaldns.external-dns.domainFilters[+]' 'hmn.{{ network.dns.external }}'
-    yq w -i --style=single "$c" 'spec.kubernetes.services.cray-externaldns.external-dns.domainFilters[+]' 'nmnlb.{{ network.dns.external }}'
-    yq w -i --style=single "$c" 'spec.kubernetes.services.cray-externaldns.external-dns.domainFilters[+]' 'hmnlb.{{ network.dns.external }}'
+    yq w -i --style=single "$c" 'spec.kubernetes.services.cray-externaldns.external-dns.domainFilters[+]' '.{{ network.dns.external }}'
 fi
 if [[ ! -z "$(yq r "$c" 'spec.kubernetes.services.cray-externaldns.coredns')" ]]; then
     yq d -i "$c" 'spec.kubernetes.services.cray-externaldns.coredns'


### PR DESCRIPTION
## Summary and Scope

It was found that the way externaldns domain filters were configured could result in records being created in the wrong zone (e.g. `cmn.hela.dev.cray.com` records could be created in the `hela.dev.cray.com` zone) if externaldns performed an update before powerdns-manager had completed its first pass and created all the zones.

Reconfigured externaldns to prohibit updates to the TLD.

## Issues and Related PRs

* Resolves [CASMTRIAGE-3123](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3123)
* Merge with https://github.com/Cray-HPE/csm/pull/605

## Testing

### Tested on:

  * `hela`

### Test description:

Ran new version of `update-customizations.sh` on a CSM 1.0 `customizations.yaml` on hela and validated the output file had the desired change.
```
ncn-m001:~ # yq r customizations.yaml spec.kubernetes.services.cray-externaldns
external-dns:
  domainFilters:
    - '.{{ network.dns.external }}'
```
## Risks and Mitigations

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

