### PR TITLE
STP-3146-1.0: add missing step when customizations.yaml file is modified

### DIFF
--- a/operations/CSM_product_management/Post_Install_Customizations.md
+++ b/operations/CSM_product_management/Post_Install_Customizations.md
@@ -163,6 +163,11 @@ Update resources associated with Prometheus in the `sysmgmt-health` namespace. T
    ```
 
 1. **This step is critical.** Store the modified `customizations.yaml` in the `site-init` repository in the customer-managed location. If not done, these changes will not persist in future installs or upgrades.
+   
+   ```bash
+   ncn# kubectl delete secret -n loftsman site-init
+   ncn# kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
+   ```
 
 <a name="postgres_resources"></a>
 ### Postgres Pods are `OOMKilled` or CPU Throttled
@@ -257,6 +262,11 @@ A similar flow can be used to update the resources for `cray-sls-postgres`, `cra
    ```
 
 1. **This step is critical.** Store the modified `customizations.yaml` in the `site-init` repository in the customer-managed location. If not done, these changes will not persist in future installs or upgrades.
+   
+   ```bash
+   ncn# kubectl delete secret -n loftsman site-init
+   ncn# kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
+   ```
 
 **IMPORTANT:** If `cray-sls-postgres`, `cray-smd-postgres`, or `gitea-vcs-postgres` resources need to be adjusted, the same procedure as above can be used with the following changes:
 
@@ -351,6 +361,11 @@ Scale the replica count associated with the `cray-bss` service in the `services`
    ```
 
 1. **This step is critical.** Store the modified `customizations.yaml` in the `site-init` repository in the customer-managed location. If not done, these changes will not persist in future installs or upgrades.
+   
+   ```bash
+   ncn# kubectl delete secret -n loftsman site-init
+   ncn# kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
+   ```
 
 <a name="postgres_pvc_resize"></a>
 ### Postgres PVC Resize
@@ -424,6 +439,11 @@ A similar flow can be used to update the volume size for `cray-sls-postgres`, `g
 1. If the status on the above command is `SyncFailed` instead of `Running`, refer to *Case 1* in the *SyncFailed* section of [Troubleshoot Postgres Database](../kubernetes/Troubleshoot_Postgres_Database.md#syncfailed). At this point the Postgres cluster is healthy, but additional steps are required to complete the resize of the Postgres PVCs.
 
 1. **This step is critical.** Store the modified `customizations.yaml` in the `site-init` repository in the customer-managed location. If not done, these changes will not persist in future installs or upgrades.
+   
+   ```bash
+   ncn# kubectl delete secret -n loftsman site-init
+   ncn# kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
+   ```
 
 **IMPORTANT:** If `cray-sls-postgres`, `gitea-vcs-postgres`, or `spire-postgres` `volumeSize` need to be adjusted, the same procedure as above can be used with the following changes:
 

--- a/operations/package_repository_management/Nexus_Deployment.md
+++ b/operations/package_repository_management/Nexus_Deployment.md
@@ -12,6 +12,13 @@ For a complete set of available settings, consult the values.yaml file for the `
 |`istio.ingress.hosts.ui.authority`|`nexus.{{ network.dns.external }}`|Sets the CAN hostname \(default chart value is `nexus.local`\)|
 |`sonatype-nexus.persistence.storageSize`|`1000Gi`|Nexus storage size, may be increased after installation; critical if `spec.kubernetes.services.cray-nexus-setup.s3.enabled` is `false`|
 
+If modifying the customizations.yaml file, ensure to upload the new file to Kubernetes so the changes persist in future installs or upgrades.
+
+```bash
+ncn-m001# kubectl delete secret -n loftsman site-init
+ncn-m001# kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
+```
+
 ### Common Nexus Deployments
 
 A typical deployment will look similar to the following:

--- a/operations/security_and_authentication/Add_LDAP_User_Federation.md
+++ b/operations/security_and_authentication/Add_LDAP_User_Federation.md
@@ -436,7 +436,14 @@ LDAP user federation is not currently configured in Keycloak. For example, if it
         EOF
         ```
 
-4. Prepare to generate Sealed Secrets.
+4. Upload the modified customizations.yaml file to Kubernetes.
+   
+   ```bash
+   ncn-m001# kubectl delete secret -n loftsman site-init
+   ncn-m001# kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
+   ```
+   
+5. Prepare to generate Sealed Secrets.
    
    Secrets are stored in customizations.yaml as `SealedSecret` resources
    (encrypted secrets), which are deployed by specific charts and decrypted by the
@@ -447,7 +454,7 @@ LDAP user federation is not currently configured in Keycloak. For example, if it
    ncn-m001# ./utils/secrets-reencrypt.sh customizations.yaml ./certs/sealed_secrets.key ./certs/sealed_secrets.crt
    ```
       
-5. Encrypt the static values in the customizations.yaml file after making changes.
+6. Encrypt the static values in the customizations.yaml file after making changes.
 
    The following command must be run within the site-init directory.
 
@@ -492,14 +499,14 @@ LDAP user federation is not currently configured in Keycloak. For example, if it
       Generating type static...
       ```
 
-6. Decrypt the Sealed Secret to verify it was generated correctly.
+7. Decrypt the Sealed Secret to verify it was generated correctly.
    
    ```bash
    ncn-m001# ./utils/secrets-decrypt.sh keycloak_users_localize | jq -r '.data.ldap_connection_url' | base64 --decode
    ldaps://my_ldap.my_org.test
    ```
 
-7. Re-apply the cray-keycloak Helm chart with the updated customizations.yaml file.
+8. Re-apply the cray-keycloak Helm chart with the updated customizations.yaml file.
    
     1. Retrieve the current platform.yaml manifest.
        
@@ -552,7 +559,7 @@ LDAP user federation is not currently configured in Keycloak. For example, if it
        ncn-m001# kubectl get po -n services | grep cray-keycloak
        ```
 
-8. Re-apply the cray-keycloak-users-localize Helm chart with the updated customizations.yaml file.
+9. Re-apply the cray-keycloak-users-localize Helm chart with the updated customizations.yaml file.
 
     1.  Determine the cray-keycloak-users-localize chart version that is currently deployed.
 
@@ -614,7 +621,7 @@ LDAP user federation is not currently configured in Keycloak. For example, if it
         2020-07-20 18:26:15,774 - INFO    - keycloak_localize - keycloak-localize complete
         ```
 
-9.  Sync the users and groups from Keycloak to the compute nodes.
+10. Sync the users and groups from Keycloak to the compute nodes.
 
     1. Get the crayvcs password for pushing the changes.
 
@@ -673,7 +680,7 @@ LDAP user federation is not currently configured in Keycloak. For example, if it
         ncn-m001# cray bos session create --template-uuid BOS_TEMPLATE --operation reboot
         ```
 
-10. Validate that LDAP integration was added successfully.
+11. Validate that LDAP integration was added successfully.
    
     1. Retrieve the admin password for Keycloak.
 

--- a/operations/security_and_authentication/Change_the_Keycloak_Admin_Password.md
+++ b/operations/security_and_authentication/Change_the_Keycloak_Admin_Password.md
@@ -70,6 +70,13 @@ This procedure uses SYSTEM\_DOMAIN\_NAME as an example for the DNS name of the n
                   value: https://api-gw-service-nmn.local/keycloak/realms/master/protocol/openid-connect/token
     ```
 
+1. Upload the modified customizations.yaml file to Kubernetes.
+
+   ```bash
+   ncn-m001# kubectl delete secret -n loftsman site-init
+   ncn-m001# kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
+   ```
+
 1. Encrypt the values after changing the customizations.yaml file.
 
     ```bash

--- a/operations/security_and_authentication/Preserve_Username_Capitalization_for_Users_Exported_from_Keycloak.md
+++ b/operations/security_and_authentication/Preserve_Username_Capitalization_for_Users_Exported_from_Keycloak.md
@@ -19,9 +19,16 @@ The LDAP server that provides password resolution and user account federation su
     ncn-w001# vi customizations.yaml
     ```
 
-2.  Re-apply the cray-keycloak-users-localize Helm chart.
+1.  Re-apply the cray-keycloak-users-localize Helm chart.
 
     Re-apply the cray-keycloak-users-localize Helm chart with the updated customizations.yaml file.
+
+1. Upload the modified customizations.yaml file to Kubernetes.
+
+   ```bash
+   ncn-m001# kubectl delete secret -n loftsman site-init
+   ncn-m001# kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
+   ```
 
 
 


### PR DESCRIPTION
## Summary and Scope

Update instructions that edit customizations.yaml but never upload the new file to k8s so it is available later. This ensures updates are grabbed if we redeploy a newer version of Keycloak.

## Issues and Related PRs

* Resolves [STP-3146](https://jira-pro.its.hpecorp.net:8443/browse/STP-3146) and [CASMTRIAGE-3102](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3102)
* Merge with https://github.com/Cray-HPE/docs-csm/pull/1101 and https://github.com/Cray-HPE/docs-csm/pull/1109

## Testing

N/A

### Tested on:

N/A

### Test description:

N/A

## Risks and Mitigations

None

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

