### PR TITLE
Update m001 kube api with istio-ca audience before workers get rebuilt

### DIFF
--- a/upgrade/1.2/scripts/upgrade/ncn-upgrade-k8s-master.sh
+++ b/upgrade/1.2/scripts/upgrade/ncn-upgrade-k8s-master.sh
@@ -201,6 +201,20 @@ if [[ ${upgrade_ncn} != "ncn-m001" ]]; then
    fi
 fi
 
+if [[ ${target_ncn} != "ncn-m001" ]]; then
+   state_name="UPDATE_M001_KUBEAPI_ISTIO_CA"
+   state_recorded=$(is_state_recorded "${state_name}" ncn-m001)
+   if [[ $state_recorded == "0" ]]; then
+      echo "====> ${state_name} ..."
+
+      /usr/share/doc/csm/upgrade/1.2/scripts/k8s/update_kubeapi_istio_ca.sh ncn-m001
+
+      record_state "${state_name}" ncn-m001
+   else
+      echo "====> ${state_name} has been completed"
+   fi
+fi
+
 # Update kubeapi istio-ca audience newly upgraded master
 state_name="UPDATE_KUBEAPI_ISTIO_CA"
 state_recorded=$(is_state_recorded "${state_name}" ${upgrade_ncn})


### PR DESCRIPTION
## Summary and Scope

Similar to updating m001's service issuer before workers get rebooted, we also need to add istio-ca to m001 before istio ingress gateways get restarted as part of the worker upgrades.

## Issues and Related PRs

* Resolves [CASMINST-4273](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4273)

## Testing

```
ncn-m002:/etc/cray/upgrade/csm/csm-1.2.0-beta.89 # /usr/share/doc/csm/upgrade/1.2/scripts/k8s/update_kubeapi_istio_ca.sh ncn-m001
Adding istio-ca api audience for kube-api on ncn-m001:
ncn-m001: Warning: Permanently added 'ncn-m001,10.252.1.4' (ECDSA) to the list of known hosts.
Sleeping for one minute to let kube-apiserver restart on ncn-m001
```

### Tested on:

  * `wasp`

### Test description:

Ran the script on wasp from m002 reconfiguring m001.

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

