### PR TITLE
Add WAR if podman overlay issue in load-container-images.sh script

### DIFF
--- a/install/prepare_site_init.md
+++ b/install/prepare_site_init.md
@@ -161,8 +161,13 @@ with system-specific customizations.
 
         1. Load the `openjdk` container image:
 
-           > **`NOTE`** Requires a properly configured Docker or Podman
-           > environment.
+           > **`NOTE`** Requires a properly configured Docker or Podman environment.
+           >
+           > If this step fails with an "overlay is not supported" error, run the following
+           > command and then re-run the `load-container-image.sh` script:
+           >
+           > `sed -i 's/skopeo_dest=.*/skopeo_dest="${transport}:${image}"/' /mnt/pitdata/${CSM_RELEASE}/hack/load-container-image.sh`
+           >
 
            ```bash
            linux# /mnt/pitdata/${CSM_RELEASE}/hack/load-container-image.sh dtr.dev.cray.com/library/openjdk:11-jre-slim
@@ -412,6 +417,12 @@ encrypted.
 1.  Load the `zeromq` container image required by Sealed Secret Generators:
 
     > **`NOTE`** Requires a properly configured Docker or Podman environment.
+    >
+    > If this step fails with an "overlay is not supported" error, run the following
+    > command and then re-run the `load-container-image.sh` script:
+    >
+    > `sed -i 's/skopeo_dest=.*/skopeo_dest="${transport}:${image}"/' /mnt/pitdata/${CSM_RELEASE}/hack/load-container-image.sh`
+    >
 
     ```bash
     linux# /mnt/pitdata/${CSM_RELEASE}/hack/load-container-image.sh dtr.dev.cray.com/zeromq/zeromq:v4.0.5


### PR DESCRIPTION
## Summary and Scope

Add work-around if podman overlay issue hit when running the load container images script.

## Issues and Related PRs

* Resolves [CASMINST-4280](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4280)

## Testing

Tested sed cmd in vshasta.

### Tested on:

  * `vshasta`

### Test description:

Tested sed cmd in vshasta.

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

