### PR TITLE
CASMINST-4289-1.0 Revised password, ssh key, and timezone change for k8s-image and ceph-image

### DIFF
--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -268,10 +268,13 @@ The configuration workflow described here is intended to help understand the exp
 ### 3.2 Deploy
 
 1. Change the default root password and SSH keys
-   > If you want to avoid using the default install root password and SSH keys for the NCNs, follow the
-   > NCN image customization steps in [Change NCN Image Root Password and SSH Keys](../operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md)
 
-   This step is **strongly encouraged** for all systems.
+   The management nodes deploy with a default password in the image, so it is a recommended best
+   practice for system security to change the root password in the image so that it is
+   not the documented default password.
+
+   It is **strongly encouraged** to change the default root password and SSH keys in the images used to boot the management nodes.
+   Follow the NCN image customization steps in [Change NCN Image Root Password and SSH Keys on PIT Node](../operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md)
 
 1. Create boot directories for any NCN in DNS:
     > This will create folders for each host in `/var/www`, allowing each host to have their own unique set of artifacts; kernel, initrd, SquashFS, and `script.ipxe` bootscript.

--- a/install/redeploy_pit_node.md
+++ b/install/redeploy_pit_node.md
@@ -121,17 +121,8 @@ the Kubernetes cluster as the final of three master nodes forming a quorum.
         **IMPORTANT**: The variables set depend on whether or not the default NCN images are customized. The most
         common procedures that involve customizing the images are
         [Configuring NCN Images to Use Local Timezone](../operations/node_management/Configure_NTP_on_NCNs.md#configure_ncn_images_to_use_local_timezone) and
-        [Changing NCN Image Root Password and SSH Keys](../operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md).
+        [Changing NCN Image Root Password and SSH Keys on PIT Node](../operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md).
         The two paths forward are listed below:
-
-        * If the NCN images were **not** customized, set the following variables (this is the default path):
-
-            ```bash
-            pit# export CSM_RELEASE=csm-x.y.z
-            pit# export artdir=/var/www/ephemeral/${CSM_RELEASE}/images
-            pit# export k8sdir=$artdir/kubernetes
-            pit# export cephdir=$artdir/storage-ceph
-            ```
 
         * If the NCN images were customized, set the following variables:
 
@@ -139,6 +130,15 @@ the Kubernetes cluster as the final of three master nodes forming a quorum.
             pit# export artdir=/var/www/ephemeral/data
             pit# export k8sdir=$artdir/k8s
             pit# export cephdir=$artdir/ceph
+            ```
+
+        * If the NCN images were **not** customized, set the following variables:
+
+            ```bash
+            pit# export CSM_RELEASE=csm-x.y.z
+            pit# export artdir=/var/www/ephemeral/${CSM_RELEASE}/images
+            pit# export k8sdir=$artdir/kubernetes
+            pit# export cephdir=$artdir/storage-ceph
             ```
 
     1. After setting the variables in the previous step, run the following command.

--- a/operations/index.md
+++ b/operations/index.md
@@ -286,6 +286,7 @@ Mechanisms used by the system to ensure the security and authentication of inter
    * [Manage System Passwords](security_and_authentication/Manage_System_Passwords.md)
      * [Update NCN Passwords](security_and_authentication/Update_NCN_Passwords.md)
      * [Change Root Passwords for Compute Nodes](security_and_authentication/Change_Root_Passwords_for_Compute_Nodes.md)
+     * [Change NCN Image Root Password and SSH Keys on Pit Node](security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md)
      * [Change NCN Image Root Password and SSH Keys](security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md)
      * [Change EX Liquid-Cooled Cabinet Global Default Password](security_and_authentication/Change_EX_Liquid-Cooled_Cabinet_Global_Default_Password.md)
      * [Provisioning a Liquid-Cooled EX Cabinet CEC with Default Credentials](security_and_authentication/Provisioning_a_Liquid-Cooled_EX_Cabinet_CEC_with_Default_Credentials.md)

--- a/operations/node_management/Configure_NTP_on_NCNs.md
+++ b/operations/node_management/Configure_NTP_on_NCNs.md
@@ -309,11 +309,11 @@ there. You can find a list of timezones to use in the commands below by running 
 Adjust the node images so that they also boot in the local timezone. This is accomplished by `chroot`ing into the unsquashed images, making some modifications, and then squashing it back up and moving the new images into place.  This is included as an optional image modification step in the two procedures below.
 
 1. If the PIT node is booted, see
-[Change NCN Image Root Password and SSH Keys on PIT Node](Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_node.md)
+[Change NCN Image Root Password and SSH Keys on PIT Node](../security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_node.md)
 for more information.
 
    **Note:** Make a note that when performing the [csi handoff of NCN boot artifacts in Redeploy PIT Node](../../install/redeploy_pit_node.md#ncn-boot-artifacts-hand-off), these new images are specified. Otherwise ncn-m001 will use the default timezone when it boots, and subsequent reboots of the other NCNs will also lose the customized timezone changes.
 
 1. If the PIT node is not booted, see
-[Change NCN Image Root Password and SSH Keys](Change_NCN_Image_Root_Password_and_SSH_Keys.md)
+[Change NCN Image Root Password and SSH Keys](../security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md)
 for more information.

--- a/operations/node_management/Configure_NTP_on_NCNs.md
+++ b/operations/node_management/Configure_NTP_on_NCNs.md
@@ -312,8 +312,8 @@ Adjust the node images so that they also boot in the local timezone. This is acc
 [Change NCN Image Root Password and SSH Keys on PIT Node](Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_node.md)
 for more information.
 
+   **Note:** Make a note that when performing the [csi handoff of NCN boot artifacts in Redeploy PIT Node](../../install/redeploy_pit_node.md#ncn-boot-artifacts-hand-off), these new images are specified. Otherwise ncn-m001 will use the default timezone when it boots, and subsequent reboots of the other NCNs will also lose the customized timezone changes.
+
 1. If the PIT node is not booted, see
 [Change NCN Image Root Password and SSH Keys](Change_NCN_Image_Root_Password_and_SSH_Keys.md)
 for more information.
-
-1. Make a note that when performing the [csi handoff of NCN boot artifacts in Redeploy PIT Node](../../install/redeploy_pit_node.md#ncn-boot-artifacts-hand-off), these new images are specified. Otherwise ncn-m001 will use the default timezone when it boots, and subsequent reboots of the other NCNs will also lose the customized timezone changes.

--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
@@ -120,7 +120,7 @@ The Kubernetes image ```k8s-image``` is used by the master and worker nodes.
          chroot-ncn-m# grep -i utc /srv/cray/scripts/metal/ntp-upgrade-config.sh
          ```
 
-         Change only if the grep command shows these lines set to UTC.
+         Change only if the `grep` command shows these lines set to UTC.
 
          ```bash
          chroot-ncn-m# sed -i "s#^timedatectl set-timezone UTC#timedatectl set-timezone $NEWTZ#" /srv/cray/scripts/metal/ntp-upgrade-config.sh
@@ -290,7 +290,7 @@ The Ceph image `ceph-image` is used by the utility storage nodes.
          chroot-ncn-m# grep -i utc /srv/cray/scripts/metal/ntp-upgrade-config.sh
          ```
 
-         Change only if the grep command shows these lines set to UTC.
+         Change only if the `grep` command shows these lines set to UTC.
 
          ```bash
          chroot-ncn-m# sed -i "s#^timedatectl set-timezone UTC#timedatectl set-timezone $NEWTZ#" /srv/cray/scripts/metal/ntp-upgrade-config.sh

--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
@@ -429,4 +429,4 @@ The Ceph image `ceph-image` is used by the utility storage nodes.
 
    **WARNING:** If doing a CSM software upgrade, skip this step since the upgrade process does a rolling rebuild with some additional steps.
 
-   > If not doing a CSM software upgrade, follow the procedure to do a [Rolling Rebuild](../operations/node_management/Rebuild_NCNs.md) of all management nodes.
+   > If not doing a CSM software upgrade, follow the procedure to do a [Rolling Rebuild](..//node_management/Rebuild_NCNs.md) of all management nodes.

--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
@@ -12,9 +12,9 @@ There is some common preparation before making the Kubernetes image for master n
 
 ### Common Preparation
 
-1. Prepare new ssh keys for the root account in advance.  The same key information will be added to both k8s-image and ceph-image.
+1. Prepare new ssh keys for the root account in advance. The same key information will be added to both k8s-image and ceph-image.
 
-   Either replace the root public and private ssh keys with your own previously generated keys or generate a new pair with `ssh-keygen(1)`.  By default `ssh-keygen` will create an RSA key, but other types could be chosen and different filenames would need to be substituted in later steps.
+   Either replace the root public and private ssh keys with your own previously generated keys or generate a new pair with `ssh-keygen(1)`. By default `ssh-keygen` will create an RSA key, but other types could be chosen and different filenames would need to be substituted in later steps.
 
    ```bash
    ncn-m# mkdir /root/.ssh
@@ -85,7 +85,7 @@ The Kubernetes image ```k8s-image``` is used by the master and worker nodes.
    ncn-m# chmod 640 k8s/${K8SVERSION}/filesystem.squashfs/root/.ssh/authorized_keys
    ```
 
-1. Change root into the image root.
+1. Change into the image root.
 
    ```bash
    ncn-m# chroot k8s/${K8SVERSION}/filesystem.squashfs
@@ -97,20 +97,18 @@ The Kubernetes image ```k8s-image``` is used by the master and worker nodes.
    chroot-ncn-m# passwd
    ```
 
-1. If there are any other things to be changed in the image, they could also be done at this point.
-
-   For example, some sites may want to change the timezone.
+1. (Optional) If there are any other things to be changed in the image, they could also be done at this point.
 
    1. (Optional) Set default timezone on management nodes.
 
-      1. Check whether TZ variable is already set in `/etc/environment`.  The setting for NEWTZ must be a valid timesone from the set under /usr/share/zoneinfo.
+      1. Check whether TZ variable is already set in `/etc/environment`. The setting for NEWTZ must be a valid timezone from the set under `/usr/share/zoneinfo`.
 
          ```bash
          chroot-ncn-m# NEWTZ=US/Pacific
          chroot-ncn-m# grep TZ /etc/environment
          ```
 
-         Add only if TZ is not present
+         Add only if TZ is not present.
 
          ```bash
          chroot-ncn-m# echo TZ=${NEWTZ} >> /etc/environment
@@ -118,7 +116,9 @@ The Kubernetes image ```k8s-image``` is used by the master and worker nodes.
 
       1. Check for `utc` setting.
 
+         ```bash
          chroot-ncn-m# grep -i utc /srv/cray/scripts/metal/ntp-upgrade-config.sh
+         ```
 
          Change only if the grep command shows these lines set to UTC.
 
@@ -267,20 +267,18 @@ The Ceph image `ceph-image` is used by the utility storage nodes.
    chroot-ncn-m# passwd
    ```
 
-1. If there are any other things to be changed in the image, they could also be done at this point.
-
-   For example, some sites may want to change the timezone.
+1. (Optional) If there are any other things to be changed in the image, they could also be done at this point.
 
    1. (Optional) Set default timezone on management nodes.
 
-      1. Check whether TZ variable is already set in `/etc/environment`.  The setting for NEWTZ must be a valid timesone from the set under /usr/share/zoneinfo.
+      1. Check whether TZ variable is already set in `/etc/environment`. The setting for NEWTZ must be a valid timezone from the set under `/usr/share/zoneinfo`.
 
          ```bash
          chroot-ncn-m# NEWTZ=US/Pacific
          chroot-ncn-m# grep TZ /etc/environment
          ```
 
-         Add only if TZ is not present
+         Add only if TZ is not present.
 
          ```bash
          chroot-ncn-m# echo TZ=${NEWTZ} >> /etc/environment
@@ -288,7 +286,9 @@ The Ceph image `ceph-image` is used by the utility storage nodes.
 
       1. Check for `utc` setting.
 
+         ```bash
          chroot-ncn-m# grep -i utc /srv/cray/scripts/metal/ntp-upgrade-config.sh
+         ```
 
          Change only if the grep command shows these lines set to UTC.
 

--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
@@ -1,10 +1,26 @@
 ## Change NCN Image Root Password and SSH Keys
 
-Customize the NCN image by changing the root password or adding different ssh keys for the root account.
+Customize the NCN images by changing the root password or adding different ssh keys for the root account.
 This procedure shows this process being done on the PIT node during a first time installation of the CSM
 software.
 
-This process should be done for the "Kubernetes" image used by master and worker nodes and then repeated for the "ceph" image used by the utility storage nodes.
+There is some common preparation before making the Kuberentes image for master nodes and worker nodes and making the Ceph image for utility storage nodes and some common cleanup afterwards.
+
+
+***Note:*** This procedure can only be done before the PIT node is rebuilt to become a normal master node.
+
+### Common Preparation
+
+1. Prepare new ssh keys on the PIT node for the root account in advance.  The same key information will be added to both k8s-image and ceph-image.
+
+   Either replace the root public and private ssh keys with your own previously generated keys or generate a new pair with `ssh-keygen(1)`.  By default `ssh-keygen` will create an RSA key, but other types could be chosen and different filenames would need to be substituted in later steps.
+
+   ```bash
+   pit# mkdir /root/.ssh
+   pit# ssh-keygen -f /root/.ssh/id_rsa -t rsa
+   pit# ls -l /root/.ssh/id_rsa*
+   pit# chmod 600 /root/.ssh/id_rsa
+   ```
 
 ### Kubernetes Image
 
@@ -31,6 +47,23 @@ The Kubernetes image is used by the master and worker nodes.
    pit# mv -v *squashfs *kernel initrd* old
    ```
 
+1. Copy the generated public and private ssh keys for the root account into the image.
+
+   This example assumes that an RSA key was generated.
+
+   ```bash
+   pit# cp -p /root/.ssh/id_rsa /root/.ssh/id_rsa.pub squashfs-root/root/.ssh
+   ```
+
+1. Add the public ssh key for the root account to `authorized_keys`.
+
+   This example assumes that an RSA key was generated so it adds the id_rsa.pub file to authorized_keys.
+
+   ```bash
+   pit# cat /root/.ssh/id_rsa.pub >> squashfs-root/root/.ssh/authorized_keys
+   pit# chmod 640 squashfs-root/root/.ssh/authorized_keys
+   ```
+
 1. Chroot into the image root
 
    ```bash
@@ -43,19 +76,35 @@ The Kubernetes image is used by the master and worker nodes.
    chroot-pit# passwd
    ```
 
-1. Replace the ssh keys
+1. If there are any other things to be changed in the image, they could also be done at this point.
 
-   ```bash
-   chroot-pit# cd root
-   ```
+   For example, some sites may want to change the timezone.
 
-1. Replace the default root public and private ssh keys with your own or generate a new pair with `ssh-keygen(1)`
+   1. (Optional) Set defalt timezone on management nodes.
 
-   ```bash
-   chroot-pit# mknod /dev/urandom c 1 9
-   chroot-pit# ssh-keygen <options>
-   chroot-pit# rm /dev/urandom
-   ```
+      1. Check whether TZ variable is already set in `/etc/environment`.  The setting for NEWTZ must be a valid timesone from the set under /usr/share/zoneinfo.
+
+         ```bash
+         chroot-pit# NEWTZ=US/Pacific
+         chroot-pit# grep TZ /etc/environment
+         ```
+
+         Add only if TZ is not present
+
+         ```bash
+         chroot-pit# echo TZ=${NEWTZ} >> /etc/environment
+         ```
+
+      1. Check for `utc` setting.
+
+         chroot-pit# grep -i utc /srv/cray/scripts/metal/ntp-upgrade-config.sh
+
+         Change only if the grep command shows these lines set to UTC.
+
+         ```bash
+         chroot-pit# sed -i "s#^timedatectl set-timezone UTC#timedatectl set-timezone $NEWTZ#" /srv/cray/scripts/metal/ntp-upgrade-config.sh
+         chroot-pit# sed -i 's/--utc/--localtime/' /srv/cray/scripts/metal/ntp-upgrade-config.sh
+         ```
 
 1. Create the new SquashFS artifact
 
@@ -98,10 +147,10 @@ The Kubernetes image is used by the master and worker nodes.
    -rw-r--r--  1 root root 5135859712 Aug 19 19:10 kubernetes-0.1.69.squashfs
    ```
 
-   Set the VERSION variable based on the version string displayed by the above command.
+   Set the VERSION variable based on the version string displayed by the above command with an incremented suffix added to show a build iteration.
 
    ```bash
-   pit# VERSION=0.1.69-1
+   pit# export VERSION=0.1.69-1
    pit# mv filesystem.squashfs kubernetes-${VERSION}.squashfs
    pit# mv initrd.img.xz initrd.img-${VERSION}.xz
    ```
@@ -132,10 +181,10 @@ The Kubernetes image will have the new password for the next boot.
 
 The Ceph image is used by the utility storage nodes.
 
-1. Change to the working directory for the Kubernetes image.
+1. Change to the working directory for the Ceph image.
 
    ```bash
-   pit# cd /var/www/ephemeral/data/k8s
+   pit# cd /var/www/ephemeral/data/ceph
    ```
 
 1. Open the image.
@@ -153,6 +202,23 @@ The Ceph image is used by the utility storage nodes.
    pit# mv -v *squashfs *kernel initrd* old
    ```
 
+1. Copy the generated public and private ssh keys for the root account into the image.
+
+   This example assumes that an RSA key was generated.
+
+   ```bash
+   pit# cp -p /root/.ssh/id_rsa /root/.ssh/id_rsa.pub squashfs-root/root/.ssh
+   ```
+
+1. Add the public ssh key for the root account to `authorized_keys`.
+
+   This example assumes that an RSA key was generated so it adds the id_rsa.pub file to authorized_keys.
+
+   ```bash
+   pit# cat /root/.ssh/id_rsa.pub >> squashfs-root/root/.ssh/authorized_keys
+   pit# chmod 640 squashfs-root/root/.ssh/authorized_keys
+   ```
+
 1. Change into the image root
 
    ```bash
@@ -164,14 +230,6 @@ The Ceph image is used by the utility storage nodes.
    ```bash
    chroot-pit# passwd
    ```
-
-1. Replace the ssh keys
-
-   ```bash
-   chroot-pit# cd root
-   ```
-
-1. Replace the default root public and private ssh keys with your own or generate a new pair with `ssh-keygen(1)`
 
 1. Create the new SquashFS artifact
 
@@ -221,7 +279,7 @@ The Ceph image is used by the utility storage nodes.
    -rw-r--r--  1 root root 5135859712 Aug 19 19:10 storage-ceph-0.1.69.squashfs
    ```
 
-   Set the VERSION variable based on the version string displayed by above command.
+   Set the VERSION variable based on the version string displayed by the above command with an incremented suffix added to show a build iteration.
 
    ```bash
    pit# VERSION=0.1.69-1
@@ -250,3 +308,14 @@ The Ceph image is used by the utility storage nodes.
    ```
 
 The Ceph image will have the new password for the next boot.
+
+### Common Cleanup
+
+1. Clean up temporary storage used to prepare images.
+
+   These could be removed now or after verification that the nodes are able to boot successfully with the new images.
+
+   ```bash
+   pit# cd /var/www/ephemeral/data
+   pit# rm -rf ceph/old k8s/old
+   ```

--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md
@@ -10,9 +10,9 @@ There is some common preparation before making the Kubernetes image for master n
 
 ### Common Preparation
 
-1. Prepare new ssh keys on the PIT node for the root account in advance.  The same key information will be added to both k8s-image and ceph-image.
+1. Prepare new ssh keys on the PIT node for the root account in advance. The same key information will be added to both k8s-image and ceph-image.
 
-   Either replace the root public and private ssh keys with your own previously generated keys or generate a new pair with `ssh-keygen(1)`.  By default `ssh-keygen` will create an RSA key, but other types could be chosen and different filenames would need to be substituted in later steps.
+   Either replace the root public and private ssh keys with your own previously generated keys or generate a new pair with `ssh-keygen(1)`. By default `ssh-keygen` will create an RSA key, but other types could be chosen and different filenames would need to be substituted in later steps.
 
    ```bash
    pit# mkdir /root/.ssh
@@ -63,7 +63,7 @@ The Kubernetes image is used by the master and worker nodes.
    pit# chmod 640 squashfs-root/root/.ssh/authorized_keys
    ```
 
-1. Change root into the image root.
+1. Change into the image root.
 
    ```bash
    pit# chroot ./squashfs-root
@@ -75,20 +75,18 @@ The Kubernetes image is used by the master and worker nodes.
    chroot-pit# passwd
    ```
 
-1. If there are any other things to be changed in the image, they could also be done at this point.
-
-   For example, some sites may want to change the timezone.
+1. (Optional) If there are any other things to be changed in the image, they could also be done at this point.
 
    1. (Optional) Set default timezone on management nodes.
 
-      1. Check whether TZ variable is already set in `/etc/environment`.  The setting for NEWTZ must be a valid timesone from the set under /usr/share/zoneinfo.
+      1. Check whether TZ variable is already set in `/etc/environment`. The setting for NEWTZ must be a valid timezone from the set under `/usr/share/zoneinfo`.
 
          ```bash
          chroot-pit# NEWTZ=US/Pacific
          chroot-pit# grep TZ /etc/environment
          ```
 
-         Add only if TZ is not present
+         Add only if TZ is not present.
 
          ```bash
          chroot-pit# echo TZ=${NEWTZ} >> /etc/environment
@@ -96,7 +94,9 @@ The Kubernetes image is used by the master and worker nodes.
 
       1. Check for `utc` setting.
 
+         ```bash
          chroot-pit# grep -i utc /srv/cray/scripts/metal/ntp-upgrade-config.sh
+         ```
 
          Change only if the grep command shows these lines set to UTC.
 
@@ -230,20 +230,18 @@ The Ceph image is used by the utility storage nodes.
    chroot-pit# passwd
    ```
 
-1. If there are any other things to be changed in the image, they could also be done at this point.
-
-   For example, some sites may want to change the timezone.
+1. (Optional) If there are any other things to be changed in the image, they could also be done at this point.
 
    1. (Optional) Set default timezone on management nodes.
 
-      1. Check whether TZ variable is already set in `/etc/environment`.  The setting for NEWTZ must be a valid timesone from the set under /usr/share/zoneinfo.
+      1. Check whether TZ variable is already set in `/etc/environment`. The setting for NEWTZ must be a valid timezone from the set under `/usr/share/zoneinfo`.
 
          ```bash
          chroot-pit# NEWTZ=US/Pacific
          chroot-pit# grep TZ /etc/environment
          ```
 
-         Add only if TZ is not present
+         Add only if TZ is not present.
 
          ```bash
          chroot-pit# echo TZ=${NEWTZ} >> /etc/environment
@@ -251,7 +249,9 @@ The Ceph image is used by the utility storage nodes.
 
       1. Check for `utc` setting.
 
+         ```bash
          chroot-pit# grep -i utc /srv/cray/scripts/metal/ntp-upgrade-config.sh
+         ```
 
          Change only if the grep command shows these lines set to UTC.
 

--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md
@@ -1,0 +1,350 @@
+## Change NCN Image Root Password and SSH Keys on PIT Node
+
+Customize the NCN images by changing the root password or adding different ssh keys for the root account.
+This procedure shows this process being done on the PIT node during a first time installation of the CSM
+software.
+
+There is some common preparation before making the Kubernetes image for master nodes and worker nodes, making the Ceph image for utility storage nodes, and then some common cleanup afterwards.
+
+***Note:*** This procedure can only be done before the PIT node is rebuilt to become a normal master node.
+
+### Common Preparation
+
+1. Prepare new ssh keys on the PIT node for the root account in advance.  The same key information will be added to both k8s-image and ceph-image.
+
+   Either replace the root public and private ssh keys with your own previously generated keys or generate a new pair with `ssh-keygen(1)`.  By default `ssh-keygen` will create an RSA key, but other types could be chosen and different filenames would need to be substituted in later steps.
+
+   ```bash
+   pit# mkdir /root/.ssh
+   pit# ssh-keygen -f /root/.ssh/id_rsa -t rsa
+   pit# ls -l /root/.ssh/id_rsa*
+   pit# chmod 600 /root/.ssh/id_rsa
+   ```
+
+### Kubernetes Image
+
+The Kubernetes image is used by the master and worker nodes.
+
+1. Change to the working directory for the Kubernetes image.
+
+   ```bash
+   pit# cd /var/www/ephemeral/data/k8s
+   ```
+
+1. Open the image.
+
+   The Kubernetes image will be of the form "kubernetes-0.1.69.squashfs" in /var/www/ephemeral/data/k8s, but the version number may be different.
+
+   ```bash
+   pit# unsquashfs kubernetes-0.1.69.squashfs
+   ```
+
+1. Save the old SquashFS image, kernel, and initrd.
+
+   ```bash
+   pit# mkdir -v old
+   pit# mv -v *squashfs *kernel initrd* old
+   ```
+
+1. Copy the generated public and private ssh keys for the root account into the image.
+
+   This example assumes that an RSA key was generated.
+
+   ```bash
+   pit# cp -p /root/.ssh/id_rsa /root/.ssh/id_rsa.pub squashfs-root/root/.ssh
+   ```
+
+1. Add the public ssh key for the root account to `authorized_keys`.
+
+   This example assumes that an RSA key was generated so it adds the id_rsa.pub file to authorized_keys.
+
+   ```bash
+   pit# cat /root/.ssh/id_rsa.pub >> squashfs-root/root/.ssh/authorized_keys
+   pit# chmod 640 squashfs-root/root/.ssh/authorized_keys
+   ```
+
+1. Change root into the image root.
+
+   ```bash
+   pit# chroot ./squashfs-root
+   ```
+
+1. Change the password.
+
+   ```bash
+   chroot-pit# passwd
+   ```
+
+1. If there are any other things to be changed in the image, they could also be done at this point.
+
+   For example, some sites may want to change the timezone.
+
+   1. (Optional) Set default timezone on management nodes.
+
+      1. Check whether TZ variable is already set in `/etc/environment`.  The setting for NEWTZ must be a valid timesone from the set under /usr/share/zoneinfo.
+
+         ```bash
+         chroot-pit# NEWTZ=US/Pacific
+         chroot-pit# grep TZ /etc/environment
+         ```
+
+         Add only if TZ is not present
+
+         ```bash
+         chroot-pit# echo TZ=${NEWTZ} >> /etc/environment
+         ```
+
+      1. Check for `utc` setting.
+
+         chroot-pit# grep -i utc /srv/cray/scripts/metal/ntp-upgrade-config.sh
+
+         Change only if the grep command shows these lines set to UTC.
+
+         ```bash
+         chroot-pit# sed -i "s#^timedatectl set-timezone UTC#timedatectl set-timezone $NEWTZ#" /srv/cray/scripts/metal/ntp-upgrade-config.sh
+         chroot-pit# sed -i 's/--utc/--localtime/' /srv/cray/scripts/metal/ntp-upgrade-config.sh
+         ```
+
+1. Create the new SquashFS artifact.
+
+   ```bash
+   chroot-pit# /srv/cray/scripts/common/create-kis-artifacts.sh
+   ```
+
+1. Exit the chroot environment.
+
+   ```bash
+   chroot-pit# exit
+   ```
+
+1. Clean up the SquashFS creation.
+
+   The Kubernetes image directory is /var/www/ephemeral/data/k8s.
+
+   ```bash
+   pit# umount -v /var/www/ephemeral/data/k8s/squashfs-root/mnt/squashfs
+   ```
+
+1. Move new SquashFS image, kernel, and initrd into place.
+
+   ```bash
+   pit# mv -v squashfs-root/squashfs/* .
+   ```
+
+1. Update file permissions on initrd.
+
+   ```bash
+   pit# chmod -v 644 initrd.img.xz
+   ```
+
+1. Rename the new squashfs, kernel, and initrd to include a new version string.
+
+   If the old name of the squashfs was kubernetes-0.1.69.squashfs, then its version was '0.1.69', so the newly created version should be renamed to include a version of '0.1.69-1' with an additional dash and a build iteration number of 1. This will help to track what base version was used.
+
+   ```bash
+   pit# ls -l old/*squashfs
+   -rw-r--r--  1 root root 5135859712 Aug 19 19:10 kubernetes-0.1.69.squashfs
+   ```
+
+   Set the VERSION variable based on the version string displayed by the above command with an incremented suffix added to show a build iteration.
+
+   ```bash
+   pit# export VERSION=0.1.69-1
+   pit# mv filesystem.squashfs kubernetes-${VERSION}.squashfs
+   pit# mv initrd.img.xz initrd.img-${VERSION}.xz
+   ```
+
+   The kernel file will have a name with the kernel version but not this new $VERSION.
+
+   ```bash
+   pit# ls -l *kernel
+   -rw-r--r--  1 root root    8552768 Aug 19 19:09 5.3.18-24.75-default.kernel
+   ```
+
+   Rename it to include the version string.
+
+   ```bash
+   pit# mv 5.3.18-24.75-default.kernel 5.3.18-24.75-default-${VERSION}.kernel
+   ```
+
+1. Set the boot links.
+
+   ```bash
+   pit# cd
+   pit# set-sqfs-links.sh
+   ```
+
+The Kubernetes image will have the image changes for the next boot.
+
+### Ceph Image
+
+The Ceph image is used by the utility storage nodes.
+
+1. Change to the working directory for the Ceph image.
+
+   ```bash
+   pit# cd /var/www/ephemeral/data/ceph
+   ```
+
+1. Open the image.
+
+   The Ceph image will be of the form "storage-ceph-0.1.69.squashfs" in /var/www/ephemeral/data/ceph, but the version number may be different.
+
+   ```bash
+   pit# unsquashfs storage-ceph-0.1.69.squashfs
+   ```
+
+1. Save the old SquashFS image, kernel, and initrd.
+
+   ```bash
+   pit# mkdir -v old
+   pit# mv -v *squashfs *kernel initrd* old
+   ```
+
+1. Copy the generated public and private ssh keys for the root account into the image.
+
+   This example assumes that an RSA key was generated.
+
+   ```bash
+   pit# cp -p /root/.ssh/id_rsa /root/.ssh/id_rsa.pub squashfs-root/root/.ssh
+   ```
+
+1. Add the public ssh key for the root account to `authorized_keys`.
+
+   This example assumes that an RSA key was generated so it adds the id_rsa.pub file to authorized_keys.
+
+   ```bash
+   pit# cat /root/.ssh/id_rsa.pub >> squashfs-root/root/.ssh/authorized_keys
+   pit# chmod 640 squashfs-root/root/.ssh/authorized_keys
+   ```
+
+1. Change into the image root.
+
+   ```bash
+   pit# chroot ./squashfs-root
+   ```
+
+1. Change the password.
+
+   ```bash
+   chroot-pit# passwd
+   ```
+
+1. If there are any other things to be changed in the image, they could also be done at this point.
+
+   For example, some sites may want to change the timezone.
+
+   1. (Optional) Set default timezone on management nodes.
+
+      1. Check whether TZ variable is already set in `/etc/environment`.  The setting for NEWTZ must be a valid timesone from the set under /usr/share/zoneinfo.
+
+         ```bash
+         chroot-pit# NEWTZ=US/Pacific
+         chroot-pit# grep TZ /etc/environment
+         ```
+
+         Add only if TZ is not present
+
+         ```bash
+         chroot-pit# echo TZ=${NEWTZ} >> /etc/environment
+         ```
+
+      1. Check for `utc` setting.
+
+         chroot-pit# grep -i utc /srv/cray/scripts/metal/ntp-upgrade-config.sh
+
+         Change only if the grep command shows these lines set to UTC.
+
+         ```bash
+         chroot-pit# sed -i "s#^timedatectl set-timezone UTC#timedatectl set-timezone $NEWTZ#" /srv/cray/scripts/metal/ntp-upgrade-config.sh
+         chroot-pit# sed -i 's/--utc/--localtime/' /srv/cray/scripts/metal/ntp-upgrade-config.sh
+         ```
+
+1. Create the new SquashFS artifact.
+
+   ```bash
+   chroot-pit# /srv/cray/scripts/common/create-kis-artifacts.sh
+   ```
+
+1. Exit the chroot environment.
+
+   ```bash
+   chroot-pit# exit
+   ```
+
+1. Clean up the SquashFS creation.
+
+   The Ceph image directory is /var/www/ephemeral/data/ceph.
+
+   ```bash
+   pit# umount -v /var/www/ephemeral/data/ceph/squashfs-root/mnt/squashfs
+   ```
+
+1. Save old SquashFS image.
+
+   ```bash
+   pit# mkdir -v old
+   pit# mv -v *squashfs old
+   ```
+
+1. Move new SquashFS image, kernel, and initrd into place.
+
+   ```bash
+   pit# mv -v squashfs-root/squashfs/* .
+   ```
+
+1. Update file permissions on initrd.
+
+   ```bash
+   pit# chmod -v 644 initrd.img.xz
+   ```
+
+1. Rename the new squashfs, kernel, and initrd to include a new version string.
+
+   If the old name of the squashfs was storage-ceph-0.1.69.squashfs, then its version was '0.1.69', so the newly created version should be renamed to include a version of '0.1.69-1' with an additional dash and a build iteration number of 1. This will help to track what base version was used.
+
+   ```bash
+   pit# ls -l old/*squashfs
+   -rw-r--r--  1 root root 5135859712 Aug 19 19:10 storage-ceph-0.1.69.squashfs
+   ```
+
+   Set the VERSION variable based on the version string displayed by the above command with an incremented suffix added to show a build iteration.
+
+   ```bash
+   pit# VERSION=0.1.69-1
+   pit# mv filesystem.squashfs storage-ceph-${VERSION}.squashfs
+   pit# mv initrd.img.xz initrd.img-${VERSION}.xz
+   ```
+
+   The kernel file will have a name with the kernel version but not this new $VERSION.
+
+   ```bash
+   pit# ls -l *kernel
+   -rw-r--r--  1 root root    8552768 Aug 19 19:09 5.3.18-24.75-default.kernel
+   ```
+
+   Rename it to include the version string.
+
+   ```bash
+   pit# mv 5.3.18-24.75-default.kernel 5.3.18-24.75-default-${VERSION}.kernel
+   ```
+
+1. Set the boot links.
+
+   ```bash
+   pit# cd
+   pit# set-sqfs-links.sh
+   ```
+
+The Ceph image will have the image changes for the next boot.
+
+### Common Cleanup
+
+1. Clean up temporary storage used to prepare images.
+
+   These could be removed now or after verification that the nodes are able to boot successfully with the new images.
+
+   ```bash
+   pit# cd /var/www/ephemeral/data
+   pit# rm -rf ceph/old k8s/old
+   ```

--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md
@@ -98,7 +98,7 @@ The Kubernetes image is used by the master and worker nodes.
          chroot-pit# grep -i utc /srv/cray/scripts/metal/ntp-upgrade-config.sh
          ```
 
-         Change only if the grep command shows these lines set to UTC.
+         Change only if the `grep` command shows these lines set to UTC.
 
          ```bash
          chroot-pit# sed -i "s#^timedatectl set-timezone UTC#timedatectl set-timezone $NEWTZ#" /srv/cray/scripts/metal/ntp-upgrade-config.sh
@@ -253,7 +253,7 @@ The Ceph image is used by the utility storage nodes.
          chroot-pit# grep -i utc /srv/cray/scripts/metal/ntp-upgrade-config.sh
          ```
 
-         Change only if the grep command shows these lines set to UTC.
+         Change only if the `grep` command shows these lines set to UTC.
 
          ```bash
          chroot-pit# sed -i "s#^timedatectl set-timezone UTC#timedatectl set-timezone $NEWTZ#" /srv/cray/scripts/metal/ntp-upgrade-config.sh

--- a/operations/security_and_authentication/Update_NCN_Passwords.md
+++ b/operations/security_and_authentication/Update_NCN_Passwords.md
@@ -1,14 +1,28 @@
 ## Update NCN Passwords
 
-The NCNs deploy with a default password, which are changed during the system
-install. See [Change NCN Image Root Password and SSH Keys](Change_NCN_Image_Root_Password_and_SSH_Keys.md)
+The management nodes deploy with a default password in the image, so it is a recommended best
+practice for system security to change the root password in the image so that it is
+not the documented default password. In addition to the root password in the image, NCN
+personalization should be used to change the password as part of post-boot CFS.  The password
+in the image should be used when console access is desired during the network boot of a management
+node that is being rebuilt, but this password should be different than the one stored in Vault
+that is applied by CFS during post-boot NCN personalization to change the on-disk password. Once
+NCN personalization has been run, then the password in Vault should be used for console access.
+
+Use one of these methods to change the root pasword in the image.
+
+1. If the PIT node is booted, see 
+[Change NCN Image Root Password and SSH Keys on PIT Node](Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_node.md)
 for more information.
 
-It is a recommended best practice for system security to change the root
-password after the install is complete.
+1. If the PIT node is not booted, see 
+[Change NCN Image Root Password and SSH Keys](Change_NCN_Image_Root_Password_and_SSH_Keys.md)
+for more information.
 
-The NCN root user password is stored in the HashiCorp Vault instance, and
-applied with the `csm.password` Ansible role via a CFS session.
+The rest of this procedure describes how to change the root password stored in the HashiCorp
+Vault instance and then apply it immediately to management nodes with the `csm.password` Ansible
+role via a CFS session. The same root password from Vault will be applied anytime that the NCN
+personalization including the CSM layer is run.
 
 ### Procedure: Configure Root Password in Vault
 

--- a/upgrade/1.0.11/Stage_0_Prerequisites.md
+++ b/upgrade/1.0.11/Stage_0_Prerequisites.md
@@ -189,8 +189,6 @@ In the event of a problem during the upgrade which may cause the loss of BSS dat
 
 The resulting file needs to be saved in the event that BSS data needs to be restored in the future.
 
-Once the above steps have been completed, proceed to [Stage 1](Stage_1.md).
-
 ## Stage 0.9 - Modify NCN Images
 
 Any site modifications to the images used to boot the management nodes need to be done again
@@ -239,4 +237,8 @@ of CSM software, but if was not done then, it should be done now. See
 [Update NCN Passwords](../../operations/security_and_authentication/Update_NCN_Passwords.md) and
 [full NCN personalization](../../operations/CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md#set_root_password)
 for more information.
+
+## Stage 0.10 - Continue to Stage 1
+
+Once the above steps have been completed, proceed to [Stage 1](Stage_1.md).
 

--- a/upgrade/1.0.11/Stage_0_Prerequisites.md
+++ b/upgrade/1.0.11/Stage_0_Prerequisites.md
@@ -190,3 +190,53 @@ In the event of a problem during the upgrade which may cause the loss of BSS dat
 The resulting file needs to be saved in the event that BSS data needs to be restored in the future.
 
 Once the above steps have been completed, proceed to [Stage 1](Stage_1.md).
+
+## Stage 0.9 - Modify NCN Images
+
+Any site modifications to the images used to boot the management nodes need to be done again
+as part of this upgrade. These may include changing the root password, adding different ssh
+keys for the root account, or setting a default timezone.
+
+The management nodes deploy with a default password in the image, so it is a recommended best
+practice for system security to change the root password in the image so that it is
+not the documented default password. In addition to the root password in the image, NCN
+personalization should be used to change the password as part of post-boot CFS. The password
+in the image should be used when console access is desired during the network boot of a management
+node that is being rebuilt, but this password should be different than the one stored in Vault
+that is applied by CFS during post-boot NCN personalization to change the on-disk password. Once
+NCN personalization has been run, then the password in Vault should be used for console access.
+
+1. Use this procedure to change the k8s-image used for master nodes and worker nodes and the ceph-image
+used by utility storage nodes. See 
+[Change NCN Image Root Password and SSH Keys](../../operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md)
+for more information.
+
+1. Adjust the version variables used later in the upgrade.
+
+   1. The previous procedure to create the site-customized `k8s-image` and `ceph-image` should have set these variables.
+
+      ```bash
+      ncn-m001# echo $CEPHNEW
+      ncn-m001# echo $K8sNEW
+      ```
+
+    2. Check current versions in `/etc/cray/upgrade/csm/myenv`.
+
+      ```bash
+      ncn-m001# grep CEPH_VERSION /etc/cray/upgrade/csm/myenv
+      ncn-m001# grep KUBERNETES_VERSION /etc/cray/upgrade/csm/myenv
+      ```
+
+    3. If the `CEPH_VERSION` or `KUBERNETES_VERSION` does not match the `CEPHNEW` and `K8SNEW` settings, edit the file.
+
+      ```bash
+      ncn-m001# vi /etc/cray/upgrade/csm/myenv
+      ```
+
+2. Use this procedure to change the root password in Vault and the CSM layer of configuration
+applied during NCN Personalizaion. Usually this configuration is done during the first time installation
+of CSM software, but if was not done then, it should be done now. See
+[Update NCN Passwords](../../operations/security_and_authentication/Update_NCN_Passwords.md) and
+[full NCN personalization](../../operations/CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md#set_root_password)
+for more information.
+


### PR DESCRIPTION
## Summary and Scope

CASMINST-4289-1.0 Revised password, ssh key, and timezone change for k8s-image and ceph-image

Revised procedures to change the NCN images (k8s-image and ceph-image) to be done from PIT node or later when PIT node is not available.  Both procedures will change the root password, ssh keys and authorized_keys for root, and optionally change the timezone.

The install procedure now refers to this procedure as the security best practices recommended method to change the root password from the PIT node before deploying any of the other NCNs.

Added image changing to the Upgrade procedure and changed non-PIT operational procedure to also do a BSS update and recommend a Rolling Rebuild (if not doing a CSM upgrade)

## Issues and Related PRs

This also address timezone procedure issue from [CASMINST-3959](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3959)

And root password change in image issue from [CASMINST-4274](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4274)

## Testing

Tested ssh-keygen commands in isolation since that part of the procedure was incorrect.

Tested timezone change commands as part of draft documentation at customer site for [CASMINST-3959](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3959)

### Tested on:



### Test description:


## Risks and Mitigations


## Pull Request Checklist

