### PR TITLE
CASMCMS-7927: Document known Gitea/VCS 401 issue; some linting

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -176,3 +176,4 @@ and many more...
 * Intermittently, storage nodes have clock skew during fresh install.
 * Kube-multus pods may fail to restart due to ImagePullBackOff. For more information see [Kube-multus pod is in ImagePullBackOff](troubleshooting/known_issues/kube_multus_pod_in_ImagePullBackOff.md).
 * Power capping Olympus and River compute hardware via CAPMC is not supported.
+* On fresh install, API calls to Gitea/VCS may give 401 Errors. See [Gitea/VCS 401 Errors](troubleshooting/known_issues/gitea_vcs_401_errors.md) for more information.

--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -36,6 +36,7 @@ The areas should be tested in the order they are listed on this page. Errors in 
   - [3 Software Management Services Health Checks](#sms-health-checks)
     - [3.1 SMS Test Execution](#sms-checks)
     - [3.2 Interpreting cmsdev Results](#cmsdev-results)
+    - [3.3 Known Issues](#sms-checks-known-issues)
   - [4. Booting CSM Barebones Image](#booting-csm-barebones-image)
     - [4.1 Locate CSM Barebones Image in IMS](#locate-csm-barebones-image-in-ims)
     - [4.2 Create a BOS Session Template for the CSM Barebones Image](#csm-bos-session-template)
@@ -666,6 +667,19 @@ If one or more checks failed:
         ```
 
 Additional test execution details can be found in `/opt/cray/tests/cmsdev.log`.
+
+<a name="sms-checks-known-issues"></a>
+### 3.3 Known Issues
+
+#### Failed To Create VCS Organization
+
+On a fresh install, it is possible that `cmsdev` reports an error similar to the following:
+```text
+ERROR (run tag zl7ak-vcs): POST https://api-gw-service-nmn.local/vcs/api/v1/orgs: expected status code 201, got 401
+ERROR (run tag zl7ak-vcs): Failed to create vcs organization
+```
+
+In this case, follow the [Gitea/VCS 401 Errors](../troubleshooting/known_issues/gitea_vcs_401_errors.md) troubleshooting procedure.
 
 <a name="booting-csm-barebones-image"></a>
 ## 4. Booting CSM Barebones Image

--- a/troubleshooting/index.md
+++ b/troubleshooting/index.md
@@ -7,6 +7,7 @@ This document provides troubleshooting information for services and functionalit
     * [Hardware Discovery](#known-issues-hardware-discovery)
     * [initrd.img.xz not found](#initrd-not-found)
     * [Power Capping](#power-capping)
+    * [Gitea/VCS 401 Errors](known_issues/gitea_vcs_401_errors.md)
     * [SAT/HSM/CAPMC Component Power State Mismatch](known_issues/component_power_state_mismatch.md)
     * [BOS/BOA Incorrect command is output to rerun a failed operation.](known_issues/incorrect_output_for_bos_command_rerun.md)
     * [CFS Sessions are Stuck in a Pending State](known_issues/cfs_sessions_stuck_in_pending.md)

--- a/troubleshooting/known_issues/Gigabye_Missing_Redfish_Data.md
+++ b/troubleshooting/known_issues/Gigabye_Missing_Redfish_Data.md
@@ -1,4 +1,4 @@
-### Gigabyte BMC Missing Redfish Data
+# Gigabyte BMC Missing Redfish Data
 
 Follow this procedure if you notice data from Gigabyte nodes is missing from Hardware State Manager (HSM) or other CSM tools.
 
@@ -11,16 +11,15 @@ If the data is present in the Redfish, a rediscovery of the BMC may populate the
 **Prerequisite:**
 * Make sure the firmware and BIOS of the Gigabyte node is at the latest supported level.
 
-###### Reset the Gigabyte BMC
+## Reset the Gigabyte BMC
 
 Run the command: `ipmitool -I lanplus -U admin -P password -H <target bmc ip> mc reset cold`
 * `password` is the admin password
 * `<target bmc ip>` is the IP address of the BMC
 
 After 5 minutes, check to Redfish endpoint once again to verify the data is present.
-Rediscover the BMC.
 
-###### Rediscover the Gigabyte BMC
+## Rediscover the Gigabyte BMC
 
-To rediscover the BMC run the command: `cray hsm inventory discover create --xnames <xname of BMC> --force true`
-* `<xname of BMC>` is the BMC xname, example: `x3000c0s1b0`
+To rediscover the BMC, run the command: `cray hsm inventory discover create --xnames <xname of BMC> --force true`
+* `<xname of BMC>` is the BMC xname, for example: `x3000c0s1b0`

--- a/troubleshooting/known_issues/cfs_sessions_stuck_in_pending.md
+++ b/troubleshooting/known_issues/cfs_sessions_stuck_in_pending.md
@@ -2,8 +2,8 @@
 In rare cases it is possible that a CFS session can be stuck in a `pending` state. Sessions should only enter the `pending` state briefly, for no more than a few seconds while the corresponding Kubernetes job is being scheduled. If any sessions are in this state for more than a minute, they can safely be deleted. If the sessions were created automatically and retires are enabled, the sessions should be recreated automatically.
 
 Pending sessions can be found with the following command:
-```
-cray cfs sessions list --status pending
+```bash
+ncn# cray cfs sessions list --status pending
 ```
 
-Stuck sessions that were created by the cfs-batcher can block further sessions from being scheduled against the same components. In the event that sessions are not being scheduled against some components, check the list of pending sessions to see if any are stuck and targeting the same component.
+Stuck sessions that were created by the `cfs-batcher` can block further sessions from being scheduled against the same components. In the event that sessions are not being scheduled against some components, check the list of pending sessions to see if any are stuck and targeting the same component.

--- a/troubleshooting/known_issues/component_power_state_mismatch.md
+++ b/troubleshooting/known_issues/component_power_state_mismatch.md
@@ -1,11 +1,11 @@
 # SAT/HSM/CAPMC Component Power State Mismatch
-Because of various hardware or communication issues, the node state reported by SAT and HSM (Hardware State Manager) may become out of sync with the actual hardware state reported by CAPMC or via redfish. In most cases this will be noticed when trying to power on or off nodes with BOS/BOA and will present as SAT or HSM reporting nodes are 'On' while CAPMC reports them as 'Off' (or vice versa).
+Because of various hardware or communication issues, the node state reported by SAT and HSM (Hardware State Manager) may become out of sync with the actual hardware state reported by CAPMC or via redfish. In most cases this will be noticed when trying to power on or off nodes with BOS/BOA and will present as SAT or HSM reporting nodes are `On` while CAPMC reports them as `Off` (or vice versa).
 
 ## Possible Causes
 Possible reasons the power state got out of sync include but are not limited to:
 * A known issue with Gigabyte nodes where power Redfish events can get sent out of order when rebooting nodes.
 * Network issues preventing the flow of Redfish events (telemetry will also be affected)
-* Issues with the cray-hms-hmcollector pod
+* Issues with the `cray-hms-hmcollector` pod
 
 ## Fix
 In most cases, once the underlying cause has been corrected, this should correct itself when the node boots OS, starts heartbeating, and goes to the 'Ready' state. If not, the power state for the affected nodes can be re-synced by kicking off HSM re-discovery of those nodes' BMCs.

--- a/troubleshooting/known_issues/craycli_403_forbidden_errors.md
+++ b/troubleshooting/known_issues/craycli_403_forbidden_errors.md
@@ -1,48 +1,53 @@
 # Cray CLI 403 Forbidden Errors 
 
-There is a known issue where the keycloak configuration obtained from LDAP is incomplete causing the keycloak-users-localize job to fail to complete. This, in turn, causes 403 Forbidden errors when trying to use the craycli. This can also cause a keycloak test to fail during CSM health validation.
+There is a known issue where the Keycloak configuration obtained from LDAP is incomplete causing the `keycloak-users-localize` job to fail to complete. This, in turn, causes `403 Forbidden` errors when trying to use the Cray CLI. This can also cause a Keycloak test to fail during CSM health validation.
 
 ## Fix
 To recover from this situation, the following can be done. 
 
 1. Log into the Keycloak admin console. See [Access the Keycloak User Management UI](../../operations/security_and_authentication/Access_the_Keycloak_User_Management_UI.md)
-1. Delete the shasta-user-federation-ldap entry from the "User Federation" page.
+1. Delete the `shasta-user-federation-ldap` entry from the `User Federation` page.
 1. Wait three minutes for the configuration to resync.
-1. Re-run the keycloak localize job.
+1. Re-run the Keycloak localize job.
    ```bash
     ncn# kubectl get job -n services -l app.kubernetes.io/name=cray-keycloak-users-localize \
-    -ojson | jq '.items[0]' > keycloak-users-localize-job.json
-
+           -ojson | jq '.items[0]' > keycloak-users-localize-job.json
     ncn# cat keycloak-users-localize-job.json | jq 'del(.spec.selector)' | \
-    jq 'del(.spec.template.metadata.labels)' | kubectl replace --force -f -
+           jq 'del(.spec.template.metadata.labels)' | kubectl replace --force -f -
+    ```
+    
+    Expected output looks similar to:
+    ```text
     job.batch "keycloak-users-localize-1" deleted
     job.batch/keycloak-users-localize-1 replaced
-   ```
-1. Check to see if the keycloak-users-localize job has completed.
-   ```bash
-   ncn# kubectl -n services wait --for=condition=complete --timeout=10s job/`kubectl -n services get jobs | grep users-localize | awk '{print $1}'`
-   ```
+    ```
+1. Check to see if the `keycloak-users-localize` job has completed.
+    ```bash
+    ncn# kubectl -n services wait --for=condition=complete --timeout=10s job/`kubectl -n services get jobs | grep users-localize | awk '{print $1}'`
+    ```
 1. If the above command returns output containing `condition met` then the issue is resolved and you can skip the rest of the steps.
-1. If the above command returns output containing `error: timed out waiting for the condition` then check the logs of the keycloak-users-localize pod.
-   ```bash
-   ncn# kubectl -n services logs `kubectl -n services get pods | grep users-localize | awk '{print $1}'` keycloak-localize
-   ```
+1. If the above command returns output containing `error: timed out waiting for the condition` then check the logs of the `keycloak-users-localize` pod.
+    ```bash
+    ncn# kubectl -n services logs `kubectl -n services get pods | grep users-localize | awk '{print $1}'` keycloak-localize
+    ```
 1. If you see an error showing that there is a duplicate group, complete the next step. 
-1. Go to the Groups page in the Keycloak admin console and delete the groups. 
+1. Go to the `Groups` page in the Keycloak admin console and delete the groups. 
 1. Wait three minutes for the configuration to resync. 
-1. Re-run the keycloak localize job.
+1. Re-run the Keycloak localize job.
    ```bash
     ncn# kubectl get job -n services -l app.kubernetes.io/name=cray-keycloak-users-localize \
-    -ojson | jq '.items[0]' > keycloak-users-localize-job.json
-
+           -ojson | jq '.items[0]' > keycloak-users-localize-job.json
     ncn# cat keycloak-users-localize-job.json | jq 'del(.spec.selector)' | \
-    jq 'del(.spec.template.metadata.labels)' | kubectl replace --force -f -
+           jq 'del(.spec.template.metadata.labels)' | kubectl replace --force -f -
+    ```
+    
+    Expected output looks similar to:
+    ```text
     job.batch "keycloak-users-localize-1" deleted
     job.batch/keycloak-users-localize-1 replaced
-   ```
+    ```
 1. Check again to make sure the job has now completed.
-   ```bash
-   ncn# kubectl -n services wait --for=condition=complete --timeout=10s job/`kubectl -n services get jobs | grep users-localize | awk '{print $1}'`
-   ```
-   You should see output containing `condition met`
-
+    ```bash
+    ncn# kubectl -n services wait --for=condition=complete --timeout=10s job/`kubectl -n services get jobs | grep users-localize | awk '{print $1}'`
+    ```
+    You should see output containing `condition met`

--- a/troubleshooting/known_issues/discovery_aruba_snmp_issue.md
+++ b/troubleshooting/known_issues/discovery_aruba_snmp_issue.md
@@ -1,11 +1,12 @@
-# Air cooled hardware is not getting properly discovered with Aruba leaf switches.
+# Air-cooled hardware is not getting properly discovered with Aruba leaf switches.
 
 ## Symptoms:
    - The System has Aruba leaf switches.
-   - Air cooled hardware is reported to not be present under State Components and Inventory Redfish Endpoints in Hardware State Manager by the hsm_discovery_verify.sh script.
+   - Air-cooled hardware is reported to not be present under State Components and Inventory Redfish Endpoints in Hardware State Manager by the `hsm_discovery_verify.sh` script.
    - BMCs have IP addresses given out by DHCP, but in DNS their xname hostname does not resolve.
 
 ## Procedure to determine if you affected by this known issue:
+
 1. Determine the name of the last HSM discovery job that ran.
    ```bash
    ncn# HMS_DISCOVERY_POD=$(kubectl -n services get pods -l app=hms-discovery | tail -n 1 | awk '{ print $1 }')
@@ -13,7 +14,7 @@
    hms-discovery-1624314420-r8c49
    ```
 
-2. Look at the logs of the HMS discovery job to find the MAC addresses associated with instances of the `MAC address in HSM not found in any switch!` error messages. The following command will parse the logs are report these MAC addresses.
+1. Look at the logs of the HMS discovery job to find the MAC addresses associated with instances of the `MAC address in HSM not found in any switch!` error messages. The following command will parse the logs are report these MAC addresses.
    > Each of the following MAC address does not contain a ComponentID in Hardware State Manager in the Ethernet interfaces table, which can be viewed with: `cray hsm inventory ethernetInterfaces list`.
    ```bash
    ncn# UNKNOWN_MACS=$(kubectl -n services logs $HMS_DISCOVERY_POD hms-discovery | jq 'select(.msg == "MAC address in HSM not found in any switch!").unknownComponent.ID' -r -c)
@@ -26,14 +27,14 @@
    b42e99dfec49
    ```
 
-3. Look at the logs of the HMS discovery job to find the MAC address associated with instances of the `Found MAC address in switch.` log messages. The following command will parse the logs are report these MAC addresses.
+1. Look at the logs of the HMS discovery job to find the MAC address associated with instances of the `Found MAC address in switch.` log messages. The following command will parse the logs are report these MAC addresses.
    ```bash
    ncn# FOUND_IN_SWITCH_MACS=$(kubectl -n services logs $HMS_DISCOVERY_POD hms-discovery | jq 'select(.msg == "Found MAC address in switch.").macWithoutPunctuation' -r)
    ncn# echo "$FOUND_IN_SWITCH_MACS"
    b42e99bdd255
    ```
 
-4. Perform a diff between the 2 sets of collected MAC addresses to see if the Aruba leaf switches in the system are affected by a known SNMP issues with Aruba switches.
+1. Perform a `diff` between the 2 sets of collected MAC addresses to see if the Aruba leaf switches in the system are affected by a known SNMP issues with Aruba switches.
    ```bash
    ncn# diff -y <(echo "$UNKNOWN_MACS" | sort -u) <(echo "$FOUND_IN_SWITCH_MACS" | sort -u)
    9440c9376780                                                  <

--- a/troubleshooting/known_issues/gitea_vcs_401_errors.md
+++ b/troubleshooting/known_issues/gitea_vcs_401_errors.md
@@ -1,0 +1,81 @@
+# Gitea/VCS 401 Errors
+
+## Summary
+
+During fresh installs of csm-1.0.x, creation of the main admin user for gitea/VCS (Version Control Service) may fail. In this case, calls to the gitea/VCS API that require authentication will return `401` status codes with a message of `token is required`. The workaround is to manually create the admin user.
+
+## Symptoms
+
+During a fresh install, if this problem occurs, it will typically be noticed during the first run of the [Validate CSM Health](../../operations/validate_csm_health.md) procedure when the [SMS Health Checks](../../operations/validate_csm_health.md#sms-health-checks) are performed. The `cmsdev` command will include output similar to the following:
+```text
+ERROR (run tag zl7ak-vcs): POST https://api-gw-service-nmn.local/vcs/api/v1/orgs: expected status code 201, got 401
+ERROR (run tag zl7ak-vcs): Failed to create vcs organization
+```
+
+If you see the above, first verify that this is due to the user creation issue documented on this page. To do so, perform the following steps on any Kubernetes master or worker node.
+
+1. Identify the Gitea/VCS pod:
+
+    ```bash
+    ncn-mw# GITEA_VCS_POD=$(
+                kubectl get pods -n services | 
+                grep "^gitea-vcs-" | 
+                grep -v "^gitea-vcs-postgres-" | 
+                grep -w Running | 
+                awk '{ print $1 }')
+    ncn-mw# echo $GITEA_VCS_POD
+    ```
+    
+    The output should look similar to the following:
+    ```text
+    gitea-vcs-7c6f5b5c45-4wjcl
+    ```
+
+1. Search the Gitea setup log using the following command:
+    ```bash
+    ncn-mw# kubectl exec -n services $GITEA_VCS_POD -c vcs -- \
+                grep -o "^Incorrect Usage: flag provided but not defined:" /data/gitea/setup
+    ```
+
+    * `command terminated with exit code 1`
+        
+        If the command gives this output, it means that the problem being investigated is **NOT** the problem documented on this page.
+
+    * `Incorrect Usage: flag provided but not defined:`
+
+        If the command gives this output, then the problem being investigated **IS** the problem documented on this page. In this case, 
+        complete the following remediation steps to manually create the admin user.
+
+## Remediation
+
+1. Manually create the admin user by running the following command:
+
+    > **NOTE**: This command uses the `$GITEA_VCS_POD` variable defined by one
+    > of the commands in the previous section.
+
+    ```bash
+    ncn-mw# kubectl exec -n services $GITEA_VCS_POD -c vcs -- su -l git -c '
+                set -eo pipefail
+                cd /data/gitea
+                echo "Manually creating admin user; Running in `pwd`" >> /data/gitea/setup
+                CRAYVCS_USER=$(</mnt/crayvcs-credentials/vcs_username)
+                CRAYVCS_PASSWORD=$(</mnt/crayvcs-credentials/vcs_password)
+                CRAYVCS_USER_EMAIL="${CRAYVCS_USER}@mgmt-plane-nmn.local"
+                /app/gitea/gitea admin create-user \
+                    --config /data/gitea/conf/app.ini \
+                    --name ${CRAYVCS_USER} \
+                    --admin \
+                    --must-change-password=false \
+                    --email "${CRAYVCS_USER_EMAIL}" \
+                    --password "${CRAYVCS_PASSWORD}" 2>&1 | 
+                        tee -a /data/gitea/setup'
+    ```
+
+    On success, the output will look similar to the following:
+    ```text
+    --name flag is deprecated. Use --username instead.
+    2022/03/22 17:50:54 ...dules/setting/git.go:93:newGit() [I] Git Version: 2.24.4, Wire Protocol Version 2 Enabled
+    New user 'crayvcs' has been successfully created!
+    ```
+
+1. Re-run the [SMS Health Checks](../../operations/validate_csm_health.md#sms-health-checks) to validate that the problem has been resolved.

--- a/troubleshooting/known_issues/incorrect_output_for_bos_command_rerun.md
+++ b/troubleshooting/known_issues/incorrect_output_for_bos_command_rerun.md
@@ -4,24 +4,24 @@ When the Boot Orchestration Agent (BOA), an agent of the Boot Orchestration Serv
 The faulty command includes squiggly braces around a comma separated list of quoted nodes. These squiggly braces, single quotes, and the spaces separating the individual nodes all need to be removed. Then, this reformatted command can be run.
 
 Example of a faulty command in the BOA log:
-```
+```text
 ERROR   - cray.boa.agent - You can attempt to boot these nodes by issuing the command:
 cray bos v1 session create --template-uuid shasta-1.4-csm-bare-bones-image --operation boot --limit {'x3000c0s25b3n0', 'x3000c0s23b4n0', 'x3000c0s20b4n0', 'x3000c0s37b2n0', 'x1000c0s7b0n0', 'x1000c3s3b0n0', 'x1000c1s1b1n1', 'x1000c0s7b1n0', 'x1000c2s3b1n1', 'x3000c0s20b3n0', 'x3000c0s25b1n0', 'x3000c0s20b1n0', 'x3000c0s20b2n0', 'x3000c0s25b2n0', 'x3000c0s23b3n0', 'x3000c0s25b4n0', 'x1000c1s1b1n0', 'x3000c0s37b1n0', 'x3000c0s37b4n0', 'x1000c2s3b1n0', 'x3000c0s23b2n0', 'x3000c0s23b1n0', 'x1000c0s7b1n1', 'x3000c0s37b3n0', 'x1000c0s7b0n1'}
 ```
 
 Example of the correct command:
-```
+```text
 cray bos v1 session create --template-uuid shasta-1.4-csm-bare-bones-image --operation boot --limit x3000c0s25b3n0,x3000c0s23b4n0,x3000c0s20b4n0,x3000c0s37b2n0,x1000c0s7b0n0,x1000c3s3b0n0,x1000c1s1b1n1,x1000c0s7b1n0,x1000c2s3b1n1,x3000c0s20b3n0,x3000c0s25b1n0,x3000c0s20b1n0,x3000c0s20b2n0,x3000c0s25b2n0,x3000c0s23b3n0,x3000c0s25b4n0,x1000c1s1b1n0,x3000c0s37b1n0,x3000c0s37b4n0,x1000c2s3b1n0,x3000c0s23b2n0,x3000c0s23b1n0,x1000c0s7b1n1,x3000c0s37b3n0,x1000c0s7b0n1
 ```
 
 Cut and paste the faulty command and assign to an environment variable.
-```
-# CMD="cray bos v1 session create --template-uuid shasta-1.4-csm-bare-bones-image --operation boot --limit {'x3000c0s25b3n0', 'x3000c0s23b4n0', 'x3000c0s20b4n0', 'x3000c0s37b2n0', 'x1000c0s7b0n0', 'x1000c3s3b0n0', 'x1000c1s1b1n1', 'x1000c0s7b1n0', 'x1000c2s3b1n1', 'x3000c0s20\
+```bash
+linux# CMD="cray bos v1 session create --template-uuid shasta-1.4-csm-bare-bones-image --operation boot --limit {'x3000c0s25b3n0', 'x3000c0s23b4n0', 'x3000c0s20b4n0', 'x3000c0s37b2n0', 'x1000c0s7b0n0', 'x1000c3s3b0n0', 'x1000c1s1b1n1', 'x1000c0s7b1n0', 'x1000c2s3b1n1', 'x3000c0s20\
 b3n0', 'x3000c0s25b1n0', 'x3000c0s20b1n0', 'x3000c0s20b2n0', 'x3000c0s25b2n0', 'x3000c0s23b3n0', 'x3000c0s25b4n0', 'x1000c1s1b1n0', 'x3000c0s37b1n0', 'x3000c0s37b4n0', 'x1000c2s3b1n0', 'x3000c0s23b2n0', 'x3000c0s23b1n0', 'x1000c0s7b1n1', 'x3000c0s37b3n0', 'x1000c0s7b0n\
 1'}"
 ```
 
 Then, paste this command to get the corrected output.
-```
-# echo $CMD |sed s/,\ /,/g|sed s/{//g|sed s/}//g|sed s/\'//g
+```bash
+linux# echo $CMD |sed s/,\ /,/g|sed s/{//g|sed s/}//g|sed s/\'//g
 ```

--- a/troubleshooting/known_issues/kube_multus_pod_in_ImagePullBackOff.md
+++ b/troubleshooting/known_issues/kube_multus_pod_in_ImagePullBackOff.md
@@ -1,34 +1,33 @@
-# Kube-multus pod is in ImagePullBackOff
+# `kube-multus` pod is in `ImagePullBackOff`
 
 ## Description
 
-There is a known problem where kube-multus pods may fail to re-start due to an ImagePullBackOff error. The multus:v3.1 image will need to be re-tagged in Nexus and the kube-multus pod will need to be restarted.
+There is a known problem where `kube-multus` pods may fail to restart due to an `ImagePullBackOff` error. The `multus:v3.1` image will need to be re-tagged in Nexus and the `kube-multus` pod will need to be restarted.
 
-* Run the following command to determine if any kube-multus pods are failing due to this issue. If any pods are in ImagePullBackOff, proceed with the fix.
+Run the following command to determine if any `kube-multus` pods are failing due to this issue. If any pods are in `ImagePullBackOff`, proceed with the fix.
 
-    ```bash
-    ncn# kubectl get pods -n kube-system -l app=multus | grep ImagePullBackOff
+```bash
+ncn# kubectl get pods -n kube-system -l app=multus | grep ImagePullBackOff
 
-    kube-multus-ds-amd64-4wkb5   0/1    ImagePullBackOff    0          18h
-    ```
+kube-multus-ds-amd64-4wkb5   0/1    ImagePullBackOff    0          18h
+```
 
 ## Fix
 
-1. Re-tag the multus image in Nexus.
+1. Re-tag the `multus` image in Nexus.
 
    ```bash
    ncn# podman run --rm --network host quay.io/skopeo/stable copy --src-tls-verify=false --dest-tls-verify=false docker://registry.local/docker.io/nfvpe/multus:v3.1 docker://registry.local/nfvpe/multus:v3.1
    ```
 
-1. Restart the kube-multus pod that was found above to be in ImagePullBackOff.
+1. Restart the `kube-multus` pod that was found above to be in `ImagePullBackOff`.
 
    ```bash
-   ncn# kubectl delete pod <KUBE-MULTUS-POD> -n kube-system
+   ncn# kubectl delete pod <KUBE-MULTUS-POD-NAME> -n kube-system
    ```
 
-1. Verify all kube-multus pods are now Running.
+1. Verify all `kube-multus` pods are now `Running`.
 
    ```bash
    ncn# kubectl get pods -n kube-system -l app=multus
    ```
-

--- a/troubleshooting/known_issues/kubernetes_node_rootFS_out_of_space.md
+++ b/troubleshooting/known_issues/kubernetes_node_rootFS_out_of_space.md
@@ -2,7 +2,7 @@
 
 ## Description
 
- There is a known bug in Kubernetes 1.19.9 where movement of a pod with an attached volume may not complete in time and cause the kubelet service to stream error messages to the /var/log/messages log file.  If this goes unchecked, it will fill up the root file system.
+There is a known bug in Kubernetes 1.19.9 where movement of a pod with an attached volume may not complete in time and cause the `kubelet` service to stream error messages to the `/var/log/messages` log file. If this goes unchecked, it will fill up the root file system.
 
 ## Fix
 
@@ -10,27 +10,28 @@
 1. Verify that you have a large messages file in `/var/log/`.
 
    ```bash
-   ncn-m/w:/var/log # ls -lh messages-20211212
+   ncn-mw# cd /var/log
+   ncn-mw# ls -lh messages-20211212
    -rw-r----- 1 root root 67G Dec 13 12:24 messages-20211212
    ```
 
 1. Remove the file.
-1. Restart kubelet to address the streaming log entries.
+1. Restart `kubelet` to address the streaming log entries.
 
    ```bash
-   ncn-m/w# systemctl restart kubelet.service
+   ncn-mw# systemctl restart kubelet.service
    ```
 
-1. Restart the syslog service.
+1. Restart the `syslog` service.
 
    ```bash
-   ncn-m/w# systemctl restart rsyslog
+   ncn-mw# systemctl restart rsyslog
    ```
 
 1. Verify that the space issue is resolved
 
    ```bash
-   ncn-m/w# df -h /
+   ncn-mw# df -h /
    Filesystem      Size  Used Avail Use% Mounted on
    LiveOS_rootfs   280G  933M  279G   1% /
    ```

--- a/troubleshooting/known_issues/orphaned_cfs_pods.md
+++ b/troubleshooting/known_issues/orphaned_cfs_pods.md
@@ -1,14 +1,14 @@
 # Orphaned CFS Pods After Booting or Rebooting
 
-After a boot or reboot a few CFS pods may continue running even after they have
-finished and never go away.
-The state of these pod is that the only container still running in the pod is
+After a boot or reboot, a few CFS pods may continue running even after they have
+finished, and never go away.
+The state of these pods is that the only container still running in the pod is
 `istio-proxy` and the pod does not have a `metadata.ownerReference`.
 
 If `kubectl get pods -n services | grep cfs` is run after a boot or reboot, the
 orphaned CFS pods look like this:
 
-```
+```text
 services         cfs-257e0f3f-f677-4a0f-908a-aede6e6cc2fb-tbwgp                    1/8     NotReady           0          24m
 services         cfs-9818f756-8486-49f1-ab7c-0bea733bdbf8-mp296                    1/8     NotReady           0          24m
 services         cfs-e8e827c2-9cf0-4a52-9257-e93e275ec394-d8d9z                    1/8     NotReady           0          24m
@@ -24,10 +24,10 @@ no more pods will be able to be scheduled by the system because there is a limit
 The orphaned CFS pods can be cleaned up manually by deleting them, for example,
 using the pods above run the following command:
 
-```
-# kubectl delete pods -n services cfs-257e0f3f-f677-4a0f-908a-aede6e6cc2fb-tbwgp \
-    cfs-9818f756-8486-49f1-ab7c-0bea733bdbf8-mp296 \
-    cfs-e8e827c2-9cf0-4a52-9257-e93e275ec394-d8d9z
+```bash
+ncn# kubectl delete pods -n services cfs-257e0f3f-f677-4a0f-908a-aede6e6cc2fb-tbwgp \
+       cfs-9818f756-8486-49f1-ab7c-0bea733bdbf8-mp296 \
+       cfs-e8e827c2-9cf0-4a52-9257-e93e275ec394-d8d9z
 ```
 
 A fix will be provided in a follow-on release such that these orphaned CFS pods

--- a/troubleshooting/known_issues/unbound_clbo.md
+++ b/troubleshooting/known_issues/unbound_clbo.md
@@ -1,11 +1,12 @@
-#Unbound in CrashLoopBackOff After Deployment Restart
+# Unbound in CrashLoopBackOff After Deployment Restart
 
-* There is a known race condition that can cause cray-dns-unbound to go into CLBO after running:
+* There is a known race condition that can cause `cray-dns-unbound` to go into CLBO (`CrashLoopBackOff`) after running the following command:
     ```bash
-    kubectl rollout restart deployment -n services cray-dns-unbound
-     ```
+    ncn# kubectl rollout restart deployment -n services cray-dns-unbound
+    ```
 * This can impact csm-1.0.10 or older.
-* Run the following command to get cray-dns-unbound out of CLBO
-  ```bash
-  kubectl patch deployment -n services cray-dns-unbound --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/command", "value": ["sh", "-c", "touch /etc/unbound/records.conf;/srv/unbound/entrypoint.sh"]}]'
-  ```
+* Run the following command to get `cray-dns-unbound` out of CLBO:
+    ```bash
+    ncn# kubectl patch deployment -n services cray-dns-unbound --type='json' \
+           -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/command", "value": ["sh", "-c", "touch /etc/unbound/records.conf;/srv/unbound/entrypoint.sh"]}]'
+    ```

--- a/troubleshooting/known_issues/wait_for_unbound_hang.md
+++ b/troubleshooting/known_issues/wait_for_unbound_hang.md
@@ -36,7 +36,7 @@ The hung jobs should be deleted using one of the following options:
         echo $job_id
         job_status=$(echo $job_entry| awk '{ print $2 }')
         echo $job_status
-    	if [[ "$job_status" -eq "0/1" ]];then
+    	if [[ "$job_status" == "0/1" ]];then
             echo "deleting stale job"
     		kubectl delete jobs -n services $job_id
             echo "kubectl delete jobs -n services $job_id"

--- a/troubleshooting/known_issues/wait_for_unbound_hang.md
+++ b/troubleshooting/known_issues/wait_for_unbound_hang.md
@@ -1,40 +1,41 @@
-#Wait_for_unbound or cray-dns-unbound-manager hangs
+# `wait_for_unbound` or `cray-dns-unbound-manager` hangs
 
+Run the following command:
 
+```bash
+ncn# kubectl get jobs -n services | grep cray-dns-unbound-manager
+```
 
-* Run the following command:
+The output should look similar to the following:
+```text
+services            cray-dns-unbound-manager-1635352560                  0/1           26h        26h
+services            cray-dns-unbound-manager-1635448680                  1/1           35s        8m37s
+services            cray-dns-unbound-manager-1635448860                  1/1           51s        5m36s
+services            cray-dns-unbound-manager-1635449040                  1/1           61s        2m35s
+```
 
-    ```bash
-    kubectl get jobs -n services | grep cray-dns-unbound-manager
+If one of the jobs shows `0/1` for more than 10 minutes and there are others with `1/1`, then that means the `0/1` job is hung. 
+
+The hung jobs should be deleted using one of the following options:
+
+* Delete the hung job with the following command:
+
+	```bash
+	ncn# kubectl delete jobs -n services <name-of-hung-job>
     ```
-	
-	
-	```bash
-    services            cray-dns-unbound-manager-1635352560                  0/1           26h        26h
-    services            cray-dns-unbound-manager-1635448680                  1/1           35s        8m37s
-    services            cray-dns-unbound-manager-1635448860                  1/1           51s        5m36s
-    services            cray-dns-unbound-manager-1635449040                  1/1           61s        2m35s
-	```
 
-* If you see one of the jobs show `0/1` for more than 10 minutes and there are other runs with `1/1`.  That means that job is hung.  You can delete the job with:
-
-
-	```bash
-	kubectl delete jobs -n services $job_with_0/1
-	```
-
-* Alternative is copy and paste following code block:
+* An alternative is to run the following code block that will find and delete all hung jobs:
 
 	```bash
     unbound_manager_jobs=$(kubectl get jobs -n services |awk '{ print $1 }'|grep unbound-manager)
 
     for job in $unbound_manager_jobs; do
         job_entry=$(kubectl get jobs -n services $job|sed 1d)
-            echo $job_entry
+        echo $job_entry
         job_id=$(echo $job_entry| awk '{ print $1 }')
-            echo $job_id
-            job_status=$(echo $job_entry| awk '{ print $2 }')
-            echo $job_status
+        echo $job_id
+        job_status=$(echo $job_entry| awk '{ print $2 }')
+        echo $job_status
     	if [[ "$job_status" -eq "0/1" ]];then
             echo "deleting stale job"
     		kubectl delete jobs -n services $job_id


### PR DESCRIPTION
Most of this PR just documents how to identify and correct a known issue with Gitea/VCS on fresh installs. The details are all in a new page in the troubleshooting/known_issues folder. This issue is linked to both from the main release notes and from the CSM health validation page (as this is where the problem is most likely to be initially detected).

In addition to the above, I did some linting of some of the other known issues pages. I didn't mean to, I just couldn't help myself.