### PR TITLE
CASMINST-4265:  Make sure SW_ADMIN_PASSWORD is set before running prerequisites.sh

### DIFF
--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -164,6 +164,12 @@ ncn-m001# curl -H "Authorization: Bearer ${TOKEN}" -k -L -X POST 'https://api-gw
 
 Run check script:
 
+   Set the `SW_ADMIN_PASSWORD` environment variable to the admin password for the switches.   This is needed for preflight tests within the check script.
+
+   ```bash
+   ncn-m001# export SW_ADMIN_PASSWORD=sw1tCH@DM1Np4s5w0rd
+   ```
+
    > **`IMPORTANT:`** If the password for the local Nexus `admin` account has
    > been changed from the default `admin123` (not typical), then set the
    > `NEXUS_PASSWORD` environment variable to the correct `admin` password

--- a/upgrade/1.2/scripts/upgrade/prerequisites.sh
+++ b/upgrade/1.2/scripts/upgrade/prerequisites.sh
@@ -63,6 +63,11 @@ if [[ -z ${CSM_RELEASE} ]]; then
     exit 1
 fi
 
+if [[ -z ${SW_ADMIN_PASSWORD} ]]; then
+    echo "SW_ADMIN_PASSWORD environment variable has not been set"
+    exit 1
+fi
+
 if [[ -z ${TARBALL_FILE} ]]; then
     # Download tarball from internet
 


### PR DESCRIPTION
## Summary and Scope

This adds a step before running prerequisites.sh to set the SW_ADMIN_PASSWORD environment variable.  This variable is needed to run the goss-switch-bgp-neighbor-aruba-or-mellanox.yaml to check the status of the BGP peering sessions before attempting to boot the nodes.

I did this very early in prerequisites.sh so we could catch it right away before any of the other steps have been done.   This avoids having to resume after some of the steps have already been run.

## Issues and Related PRs

* Work required by CASMINST-4265

## Testing


### Tested on:

  * `drax`

### Test description:

I manually applied the change to prerequisites.sh and ran the first part of the script both with and without the environment variable set to test that it properly checks for that variable and exits if it is not set. 

## Risks and Mitigations

Very low.   The test has not been added yet so we can make sure that this process works before it has any impact.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

