### PR TITLE
MTL-1645: Add check for NTP data in BSS.

### DIFF
--- a/upgrade/1.0.11/scripts/upgrade/ncn-upgrade-wipe-rebuild.sh
+++ b/upgrade/1.0.11/scripts/upgrade/ncn-upgrade-wipe-rebuild.sh
@@ -67,6 +67,20 @@ else
     echo "====> ${state_name} has been completed"
 fi
 
+state_name="CSI_VALIDATE_BSS_NTP"
+state_recorded=$(is_state_recorded "${state_name}" ${upgrade_ncn})
+if [[ $state_recorded == "0" ]]; then
+    echo "====> ${state_name} ..."
+    if ! cray bss bootparameters list --hosts $UPGRADE_XNAME --format json | jq '.[] |."cloud-init"."user-data".ntp' | grep -q '/etc/chrony.d/cray.conf'; then
+      echo "$(UPGRADE_XNAME) is missing NTP data in BSS. Please see the procedure which can be found in the 'Known Issues and Bugs' section titled 'Fix BSS Metadata' on the 'Configure NTP on NCNs' page of the CSM documentation."
+      exit 1
+    else
+      record_state "${state_name}" ${upgrade_ncn}
+    fi
+else
+    echo "====> ${state_name} has been completed"
+fi
+
 state_name="WIPE_NODE_DISK"
 state_recorded=$(is_state_recorded "${state_name}" ${upgrade_ncn})
 if [[ $state_recorded == "0" ]]; then


### PR DESCRIPTION
## Summary and Scope

This adds a check to the upgrade scripts for 1.0.11 that ensure BSS contains NTP data. The NTP data itself is not validated, it is just tested to exist at all.

## Issues and Related PRs

* Resolves [MTL-1645](https://jira-pro.its.hpecorp.net:8443/browse/MTL-1645)

## Testing

### Tested on:

  * `Rocket`

### Test description:

Tested on Rocket by executing the script for both success paths and failure paths.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

