### PR TITLE
CASMTRIAGE-3135: Consolidate information on managing VCS passwords

### DIFF
--- a/operations/configuration_management/Version_Control_Service_VCS.md
+++ b/operations/configuration_management/Version_Control_Service_VCS.md
@@ -25,7 +25,7 @@ The initial VCS login credentials for the `crayvcs` user are stored in three pla
 
 -   `vcs-user-credentials` Kubernetes secret: This is used to initialize the other two locations, as well as providing a place where other users can query for the password.
 -   VCS \(Gitea\): These credentials are used when pushing to Git using the default username and password. The password should be changed through the Gitea UI.
--   Keycloak: These credentials are used to access the VCS UI. They must be changed through Keycloak.
+-   Keycloak: These credentials are used to access the VCS UI. They must be changed through Keycloak.  For more information on accessing Keycloak, see [Access the Keycloak User Management UI](../security_and_authentication/Access_the_Keycloak_User_Management_UI.md)
 
 **WARNING:** These three sources of credentials are not synced by any mechanism. Changing the default password requires that is it changed in all three places. Changing only one may result in difficulty determining the password at a later date, or may result in losing access to VCS altogether.
 
@@ -37,7 +37,6 @@ ncn# kubectl create secret generic vcs-user-credentials --save-config \
 --from-literal=vcs_password="NEW_PASSWORD" \
 --dry-run -o yaml | kubectl apply -f -
 ```
-
 The `NEW_PASSWORD` value must be replaced with the updated password.
 
 ### Access the `cray` Gitea Organization

--- a/operations/security_and_authentication/Manage_System_Passwords.md
+++ b/operations/security_and_authentication/Manage_System_Passwords.md
@@ -25,30 +25,15 @@ To create new accounts, refer to [Create Internal User Accounts in the Keycloak 
 
 ### Gitea
 
-The initial Gitea login credentials for the `crayvcs` username are stored in three places:
+The default Gitea user credentials is `crayvcs`. The password is randomly generated at install time
+and can be found in the vcs-user-credentials secret.
 
--   vcs-user-credentials Kubernetes secret - This is used to initialize the other two locations, as well as providing a place where users can query for the password.
+```bash
+ncn-w001# kubectl get secret -n services vcs-user-credentials \
+--template={{.data.vcs_password}} | base64 --decode
+```
 
-    The password can be obtained using this command:
-
-    ```bash
-    ncn-w001# kubectl get secret -n services vcs-user-credentials \
-    --template={{.data.vcs_password}} | base64 --decode
-    ```
-
-    The password can be changed using this command:
-
-    ```bash
-    ncn-w001# kubectl create secret generic vcs-user-credentials \
-    --save-config --from-literal=vcs_username="crayvcs" --from-literal=vcs_password="NEW_PASSWORD" \
-    --dry-run -o yaml | kubectl apply -f -
-    ```
-
--   Gitea - These credentials are used when pushing to Git using the default username and password. The password should be changed through the Gitea UI.
-
--   Keycloak - These credentials are used to allow access to the Gitea UI. They must be changed through Keycloak.
-
-**IMPORTANT:** These three sources of credentials are not currently synced by any mechanism, and so changing the default password requires that it be changed in all three places. Changing only one many result in difficulty determining the password at a later date, or may result in lost access to Gitea.
+For more information on Gitea, including how to change the password, see [Version Control Service VCS](../configuration_management/Version_Control_Service_VCS.md).
 
 ### System Management Health Service
 


### PR DESCRIPTION
## Summary and Scope

Consolidates some information on managing VCS passwords to keep the information near the docs on how to access the VCS UI, and avoid duplicating information.

## Issues and Related PRs

* Resolves CASMTRIAGE-3135

## Testing

### Tested on:

NA - docs only

### Test description:

NA - docs only

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

