### PR TITLE
Add retries to etcd add/remove member csi calls

### DIFF
--- a/upgrade/1.2/scripts/common/ncn-common.sh
+++ b/upgrade/1.2/scripts/common/ncn-common.sh
@@ -124,3 +124,24 @@ function wait_for_kubernetes() {
       echo "====> ${state_name} has been completed"
   fi
 }
+
+function run_csi_etcd_retry() {
+  local etcd_action=$1
+  local target_ncn=$2
+  local etcd_cmd="csi automate ncn etcd --action $etcd_action --ncn $target_ncn --kubeconfig /etc/kubernetes/admin.conf"
+
+  local count=0
+  while [ true ]; do
+    if ! $etcd_cmd; then
+      if [[ $count -ge 3 ]]; then
+        echo "ERROR: Command still failing after retries: ${etcd_cmd}"
+        exit 1
+      fi
+      echo "Command failed: ${etcd_cmd}; retrying in 5 seconds"
+      sleep 5
+      let count+=1
+      continue
+    fi
+    break
+  done
+}

--- a/upgrade/1.2/scripts/upgrade/ncn-upgrade-master-nodes.sh
+++ b/upgrade/1.2/scripts/upgrade/ncn-upgrade-master-nodes.sh
@@ -120,10 +120,10 @@ state_name="PREPARE_ETCD"
 state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
 if [[ $state_recorded == "0" ]]; then
     echo "====> ${state_name} ..."
-    csi automate ncn etcd --action remove-member --ncn $target_ncn --kubeconfig /etc/kubernetes/admin.conf
+    run_csi_etcd_retry "remove-member" "${target_ncn}"
     ssh $target_ncn 'systemctl daemon-reload'
     ssh $target_ncn 'systemctl stop etcd.service'
-    csi automate ncn etcd --action add-member --ncn $target_ncn --kubeconfig /etc/kubernetes/admin.conf
+    run_csi_etcd_retry "add-member" "${target_ncn}"
     record_state "${state_name}" ${target_ncn}
 else
     echo "====> ${state_name} has been completed"


### PR DESCRIPTION
## Summary and Scope

The csi command occassionally warrants a retry when adding or removing a member from the etcd cluster.  This will be fixed in 1.3 with retries in the csi command proper, but for 1.2 we'll retry calling csi from the upgrade script.

## Issues and Related PRs

* Resolves [CASMINST-4210](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4210)

## Testing

Tested the retry function with csi on wasp.

### Tested on:

  * `wasp`

### Test description:

Tested the retry function with csi on wasp.

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

