### PR TITLE
Change storage node deployment into a single command

### DIFF
--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -339,18 +339,11 @@ The configuration workflow described here is intended to help understand the exp
 <a name="boot-the-storage-nodes"></a>
 1. Boot the **Storage Nodes**
 
-    1. Boot all storage nodes except `ncn-s001`:
+    Boot all the storage nodes. `ncn-s001` will start 1 minute after the other storage nodes.
 
         ```bash
-        pit# grep -oP $stoken /etc/dnsmasq.d/statics.conf | grep -v "ncn-s001-" | sort -u | xargs -t -i ipmitool -I lanplus -U $USERNAME -E -H {} power on
-        ```
-
-    1. Wait approximately 1 minute.
-
-    1. Boot `ncn-s001`:
-
-        ```bash
-        pit# ipmitool -I lanplus -U $USERNAME -E -H ncn-s001-mgmt power on
+        pit# grep -oP $stoken /etc/dnsmasq.d/statics.conf | grep -v "ncn-s001-" | sort -u | xargs -t -i ipmitool -I lanplus -U $USERNAME -E -H {} power on; \
+                 sleep 60; ipmitool -I lanplus -U $USERNAME -E -H ncn-s001-mgmt power on
         ```
 
 1. Wait. Observe the installation through `ncn-s001-mgmt`'s console:


### PR DESCRIPTION
## Summary and Scope

Change in the documentation for the deployment of the storage NCNs with a single compound command rather than three steps.

## Issues and Related PRs

* Resolves [CASMINST-4270](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4270)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * surtur

### Test description:

I've performed this command on numerous installs. The only difference between this approach on the three step approach this replaces is the preciseness of the delay between the booting of the other storage nodes and ncn-s001.

## Risks and Mitigations

This is a low risk change, plus I've used this same approach on numerous installs.


