### PR TITLE
Casminst 4289 1.2 Revised password, ssh key, and timezone change for k8s-image and ceph-image

### DIFF
--- a/install/deploy_final_ncn.md
+++ b/install/deploy_final_ncn.md
@@ -128,19 +128,19 @@ the Kubernetes cluster as the final of three master nodes forming a quorum.
         **IMPORTANT:** The variables you set depend on whether you customized the default NCN images. The most
         common procedures that involve customizing the images are
         [Configuring NCN Images to Use Local Timezone](../operations/node_management/Configure_NTP_on_NCNs.md#configure_ncn_images_to_use_local_timezone) and
-        [Changing NCN Image Root Password and SSH Keys](../operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md).
+        [Changing NCN Image Root Password and SSH Keys on PIT Node](../operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md).
         The two paths forward are listed below:
-
-        * If the NCN images were **not** customized, set the following variables (this is the default path):
-
-            ```bash
-            pit# artdir=${CSM_PATH}/images ; k8sdir=$artdir/kubernetes ; cephdir=$artdir/storage-ceph
-            ```
 
         * If the NCN images were customized, set the following variables:
 
             ```bash
             pit# artdir=/var/www/ephemeral/data ; k8sdir=$artdir/k8s ; cephdir=$artdir/ceph
+            ```
+
+        * If the NCN images were **not** customized, set the following variables:
+
+            ```bash
+            pit# artdir=${CSM_PATH}/images ; k8sdir=$artdir/kubernetes ; cephdir=$artdir/storage-ceph
             ```
 
     1. Run the following command.

--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -264,10 +264,13 @@ The configuration workflow described here is intended to help understand the exp
 ### 3.2 Deploy
 
 1. Change the default root password and SSH keys
-   > If you want to avoid using the default install root password and SSH keys for the NCNs, follow the
-   > NCN image customization steps in [Change NCN Image Root Password and SSH Keys](../operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md)
 
-   This step is **strongly encouraged** for all systems.
+   The management nodes deploy with a default password in the image, so it is a recommended best
+   practice for system security to change the root password in the image so that it is
+   not the documented default password.
+
+   It is **strongly encouraged** to change the default root password and SSH keys in the images used to boot the management nodes.
+   Follow the NCN image customization steps in [Change NCN Image Root Password and SSH Keys on PIT Node](../operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md)
 
 1. Create boot directories for any NCN in DNS This will create folders for each host in `/var/www`, allowing each host to have their own unique set of artifacts; kernel, initrd, SquashFS, and `script.ipxe` bootscript.
 

--- a/operations/index.md
+++ b/operations/index.md
@@ -295,6 +295,7 @@ Mechanisms used by the system to ensure the security and authentication of inter
    * [Manage System Passwords](security_and_authentication/Manage_System_Passwords.md)
      * [Update NCN Passwords](security_and_authentication/Update_NCN_Passwords.md)
      * [Change Root Passwords for Compute Nodes](security_and_authentication/Change_Root_Passwords_for_Compute_Nodes.md)
+     * [Change NCN Image Root Password and SSH Keys on Pit Node](security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md)
      * [Change NCN Image Root Password and SSH Keys](security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md)
      * [Change EX Liquid-Cooled Cabinet Global Default Password](security_and_authentication/Change_EX_Liquid-Cooled_Cabinet_Global_Default_Password.md)
      * [Provisioning a Liquid-Cooled EX Cabinet CEC with Default Credentials](security_and_authentication/Provisioning_a_Liquid-Cooled_EX_Cabinet_CEC_with_Default_Credentials.md)

--- a/operations/node_management/Configure_NTP_on_NCNs.md
+++ b/operations/node_management/Configure_NTP_on_NCNs.md
@@ -338,108 +338,14 @@ there. You can find a list of timezones to use in the commands below by running 
 <a name="configure_ncn_images_to_use_local_timezone"></a>
 #### Configure NCN Images to Use Local Timezone
 
-You need to adjust the node images so that they also boot in the local timezone. This is accomplished by `chroot`ing into the unsquashed images, making some modifications, and then squashing it back up and moving the new images into place.
+Adjust the node images so that they also boot in the local timezone. This is accomplished by `chroot`ing into the unsquashed images, making some modifications, and then squashing it back up and moving the new images into place.  This is included as an optional image modification step in the two procedures below.
 
-1. Set some variables.
+1. If the PIT node is booted, see
+[Change NCN Image Root Password and SSH Keys on PIT Node](Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_node.md)
+for more information.
 
-   This example uses `IMGTYPE=ceph` for the utility storage nodes, but the same process should also be done
-   with `IMGTYPE=k8s` for the Kubernetes master and worker nodes.
+   **Note:** Make a note that when performing the [csi handoff of NCN boot artifacts in Deploy Final NCN](../../install/deploy_final_ncn.md#ncn-boot-artifacts-hand-off), you must be sure to specify these new images. Otherwise ncn-m001 will use the default timezone when it boots, and subsequent reboots of the other NCNs will also lose the customized timezone changes.
+1. If the PIT node is not booted, see
+[Change NCN Image Root Password and SSH Keys](Change_NCN_Image_Root_Password_and_SSH_Keys.md)
+for more information.
 
-   ```bash
-   pit# export NEWTZ=America/Chicago
-   pit# export IMGTYPE=ceph
-   pit# export IMGDIR=/var/www/ephemeral/data/${IMGTYPE}
-   ```
-
-1. Go to the Ceph image directory and unsquash the image.
-
-    ```bash
-    pit# cd ${IMGDIR}
-    pit# unsquashfs *.squashfs
-    ```
-
-1. Start a chroot session inside the unsquashed image. Your prompt may change to reflect that you are now in the root directory of the image.
-
-    ```bash
-    pit# chroot ./squashfs-root
-    ```
-
-1. Inside the chroot session, you will modify a few files by running the following commands, and then exit from the chroot session.
-
-    ```bash
-    pit-chroot# echo TZ=${NEWTZ} >> /etc/environment
-    pit-chroot# sed -i "s#^timedatectl set-timezone UTC#timedatectl set-timezone $NEWTZ#" /srv/cray/scripts/metal/set-ntp-config.sh
-    pit-chroot# /srv/cray/scripts/common/create-kis-artifacts.sh
-    pit-chroot# exit
-    pit#
-    ```
-
-1. Back outside the chroot session, you will now back up the original images and copy the new ones into place.
-
-    ```bash
-    pit# mkdir -v ${IMGDIR}/orig
-    pit# mv -v *.kernel *.xz *.squashfs ${IMGDIR}/orig/
-    pit# cp -v squashfs-root/squashfs/* .
-    pit# chmod -v 644 ${IMGDIR}/initrd.img.xz
-    ```
-
-1. Unmount the squashfs mount (which was mounted by the earlier unsquashfs command).
-
-    ```bash
-    pit# umount -v ${IMGDIR}/squashfs-root/mnt/squashfs
-    ```
-
-1. Repeat all of the previous steps, with this change to the IMGTYPE variable.
-
-   This example uses `IMGTYPE=k8s` for the Kubernetes master and worker nodes.
-
-   ```bash
-   pit# export IMGTYPE=k8s
-   pit# export IMGDIR=/var/www/ephemeral/data/${IMGTYPE}
-   ```
-
-1. Go to the k8s image directory and unsquash the image.
-
-    ```bash
-    pit# cd ${IMGDIR}
-    pit# unsquashfs *.squashfs
-    ```
-
-1. Start a chroot session inside the unsquashed image. Your prompt may change to reflect that you are now in the root directory of the image.
-
-    ```bash
-    pit# chroot ./squashfs-root
-    ```
-
-1. Inside the chroot session, you will modify a few files by running the following commands, and then exit from the chroot session.
-
-    ```bash
-    pit-chroot# echo TZ=${NEWTZ} >> /etc/environment
-    pit-chroot# sed -i "s#^timedatectl set-timezone UTC#timedatectl set-timezone $NEWTZ#" /srv/cray/scripts/metal/set-ntp-config.sh
-    pit-chroot# /srv/cray/scripts/common/create-kis-artifacts.sh
-    pit-chroot# exit
-    pit#
-    ```
-
-1. Back outside the chroot session, you will now back up the original images and copy the new ones into place.
-
-    ```bash
-    pit# mkdir -v ${IMGDIR}/orig
-    pit# mv -v *.kernel *.xz *.squashfs ${IMGDIR}/orig/
-    pit# cp -v squashfs-root/squashfs/* .
-    pit# chmod -v 644 ${IMGDIR}/initrd.img.xz
-    ```
-
-1. Unmount the squashfs mount (which was mounted by the earlier unsquashfs command)
-
-    ```bash
-    pit# umount -v ${IMGDIR}/squashfs-root/mnt/squashfs
-    ```
-
-1. Now link the new images so that the NCNs will get them from the LiveCD node when they boot.
-
-    ```bash
-    pit# set-sqfs-links.sh
-    ```
-
-1. Make a note that when performing the [csi handoff of NCN boot artifacts in Deploy Final NCN](../../install/deploy_final_ncn.md#ncn-boot-artifacts-hand-off), you must be sure to specify these new images. Otherwise ncn-m001 will use the default timezone when it boots, and subsequent reboots of the other NCNs will also lose the customized timezone changes.

--- a/operations/node_management/Configure_NTP_on_NCNs.md
+++ b/operations/node_management/Configure_NTP_on_NCNs.md
@@ -341,11 +341,11 @@ there. You can find a list of timezones to use in the commands below by running 
 Adjust the node images so that they also boot in the local timezone. This is accomplished by `chroot`ing into the unsquashed images, making some modifications, and then squashing it back up and moving the new images into place.  This is included as an optional image modification step in the two procedures below.
 
 1. If the PIT node is booted, see
-[Change NCN Image Root Password and SSH Keys on PIT Node](Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_node.md)
+[Change NCN Image Root Password and SSH Keys on PIT Node](../security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_node.md)
 for more information.
 
    **Note:** Make a note that when performing the [csi handoff of NCN boot artifacts in Deploy Final NCN](../../install/deploy_final_ncn.md#ncn-boot-artifacts-hand-off), you must be sure to specify these new images. Otherwise ncn-m001 will use the default timezone when it boots, and subsequent reboots of the other NCNs will also lose the customized timezone changes.
 1. If the PIT node is not booted, see
-[Change NCN Image Root Password and SSH Keys](Change_NCN_Image_Root_Password_and_SSH_Keys.md)
+[Change NCN Image Root Password and SSH Keys](../security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md)
 for more information.
 

--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
@@ -1,174 +1,432 @@
-## Change NCN Image Root Password and SSH Keys
+## Change NCN Image Root Password and SSH Keys 
 
-Customize the NCN image by changing the root password or adding different ssh keys for the root account.
-This procedure shows this process being done on the PIT node during a first time installation of the CSM
-software.
+Customize the NCN images by changing the root password or adding different ssh keys for the root account.
+This procedure shows this process being done any time after the first time installation of the CSM
+software has been completed and the PIT node is booted as a regular master node. To change the NCN image
+during an installation while the PIT node is booted as the PIT node,
+see [Change_NCN_Image_Root_Password_and_SSH_Keys_PIT](#Change_NCN_Image_Root_Password_and_SSH_Keys_PIT.md).
 
-This process should be done for the "Kubernetes" image used by master and worker nodes and then repeated for the "ceph" image used by the utility storage nodes.
+There is some common preparation before making the Kubernetes image for master nodes and worker nodes, making the Ceph image for utility storage nodes, and then some common cleanup afterwards.
+
+***Note:*** This procedure can only be done after the PIT node is rebuilt to become a normal master node.
+
+### Common Preparation
+
+1. Prepare new ssh keys for the root account in advance. The same key information will be added to both k8s-image and ceph-image.
+
+   Either replace the root public and private ssh keys with your own previously generated keys or generate a new pair with `ssh-keygen(1)`. By default `ssh-keygen` will create an RSA key, but other types could be chosen and different filenames would need to be substituted in later steps.
+
+   ```bash
+   ncn-m# mkdir /root/.ssh
+   ncn-m# ssh-keygen -f /root/.ssh/id_rsa -t rsa
+   ncn-m# ls -l /root/.ssh/id_rsa*
+   ncn-m# chmod 600 /root/.ssh/id_rsa
+   ```
+
+1. Change to a working directory with enough space to hold the images once they have been expanded.
+
+   ```bash
+   ncn-m# cd /run/initramfs/overlayfs
+   ncn-m# mkdir workingarea
+   ncn-m# cd workingarea
+   ```
 
 ### Kubernetes Image
 
-The Kubernetes image is used by the master and worker nodes.
+The Kubernetes image ```k8s-image``` is used by the master and worker nodes.
+
+1. Decide which k8s-image is to be modified
+
+   ```bash
+   ncn-m# cray artifacts list ncn-images --format json | jq '.artifacts[] .Key' | grep k8s | grep squashfs
+   "k8s-filesystem.squashfs"
+   "k8s/0.1.107/filesystem.squashfs"
+   "k8s/0.1.109/filesystem.squashfs"
+   "k8s/0.1.48/filesystem.squashfs"
+   ```
+
+   This example uses k8s/0.1.109 for the current version and adds a suffix for the new version.
+
+   ncn-m# export K8SVERSION=0.1.109
+   ncn-m# export K8SNEW=0.1.109-2
+
+1. Make a temporary directory for the k8s-image using the current version string.
+
+   ```bash
+   ncn-m# mkdir -p k8s/${K8SVERSION}
+   ```
+
+1. Get the image.
+
+   ```bash
+   ncn-m# cray artifacts get ncn-images k8s/${K8SVERSION}/filesystem.squashfs k8s/${K8SVERSION}/filesystem.squashfs.orig
+   ```
 
 1. Open the image.
 
-   The Kubernetes image will be of the form "kubernetes-0.1.69.squashfs" in /var/www/ephemeral/data/k8s, but the version number may be different.
-
    ```bash
-   pit# cd /var/www/ephemeral/data/k8s
-   pit# unsquashfs kubernetes-0.1.69.squashfs
-   ```
-1. Chroot into the image root
-
-   ```bash
-   pit# chroot ./squashfs-root
+   ncn-m# unsquashfs -d k8s/${K8SVERSION}/filesystem.squashfs k8s/${K8SVERSION}/filesystem.squashfs.orig
    ```
 
-1. Change the password
+1. Copy the generated public and private ssh keys for the root account into the image.
+
+   This example assumes that an RSA key was generated.
 
    ```bash
-   chroot-pit# passwd
+   ncn-m# cp -p /root/.ssh/id_rsa /root/.ssh/id_rsa.pub k8s/${K8SVERSION}/filesystem.squashfs/root/.ssh
    ```
 
-1. Replace the ssh keys
+1. Add the public ssh key for the root account to `authorized_keys`.
+
+   This example assumes that an RSA key was generated so it adds the id_rsa.pub file to authorized_keys.
 
    ```bash
-   chroot-pit# cd root
+   ncn-m# cat /root/.ssh/id_rsa.pub >> k8s/${K8SVERSION}/filesystem.squashfs/root/.ssh/authorized_keys
+   ncn-m# chmod 640 k8s/${K8SVERSION}/filesystem.squashfs/root/.ssh/authorized_keys
    ```
 
-1. Replace the default root public and private ssh keys with your own or generate a new pair with `ssh-keygen(1)`
+1. Change into the image root.
 
    ```bash
-   chroot-pit# mknod /dev/urandom c 1 9
-   chroot-pit# ssh-keygen <options>
-   chroot-pit# rm /dev/urandom
+   ncn-m# chroot k8s/${K8SVERSION}/filesystem.squashfs
    ```
 
-1. Create the new SquashFS artifact
+1. Change the password.
 
    ```bash
-   chroot-pit# /srv/cray/scripts/common/create-kis-artifacts.sh
+   chroot-ncn-m# passwd
    ```
 
-1. Exit the chroot
+1. (Optional) If there are any other things to be changed in the image, they could also be done at this point.
+
+   1. (Optional) Set default timezone on management nodes.
+
+      1. Check whether TZ variable is already set in `/etc/environment`. The setting for NEWTZ must be a valid timezone from the set under `/usr/share/zoneinfo`.
+
+         ```bash
+         chroot-ncn-m# NEWTZ=US/Pacific
+         chroot-ncn-m# grep TZ /etc/environment
+         ```
+
+         Add only if TZ is not present.
+
+         ```bash
+         chroot-ncn-m# echo TZ=${NEWTZ} >> /etc/environment
+         ```
+
+      1. Check for `utc` setting.
+
+         ```bash
+         chroot-ncn-m# grep -i utc /srv/cray/scripts/metal/ntp-upgrade-config.sh
+         ```
+
+         Change only if the `grep` command shows these lines set to UTC.
+
+         ```bash
+         chroot-ncn-m# sed -i "s#^timedatectl set-timezone UTC#timedatectl set-timezone $NEWTZ#" /srv/cray/scripts/metal/ntp-upgrade-config.sh
+         chroot-ncn-m# sed -i 's/--utc/--localtime/' /srv/cray/scripts/metal/ntp-upgrade-config.sh
+         ```
+
+1. Create the new SquashFS artifact.
 
    ```bash
-   chroot-pit# exit
+   chroot-ncn-m# /srv/cray/scripts/common/create-kis-artifacts.sh
    ```
 
-1. Clean up the SquashFS creation
-
-   The Kubernetes image directory is /var/www/ephemeral/data/k8s.
+1. Exit the chroot environment.
 
    ```bash
-   pit# umount -v /var/www/ephemeral/data/k8s/squashfs-root/mnt/squashfs
+   chroot-ncn-m# exit
    ```
 
-1. Save old SquashFS image.
+1. Clean up the SquashFS creation.
 
    ```bash
-   pit# mkdir -v old
-   pit# mv -v *squashfs old
+   ncn-m# umount -v k8s/${K8SVERSION}/filesystem.squashfs/mnt/squashfs
    ```
 
 1. Move new SquashFS image, kernel, and initrd into place.
 
    ```bash
-   pit# mv -v squashfs-root/squashfs/* .
+   ncn-m# mkdir k8s/${K8SNEW}
+   ncn-m# mv -v k8s/${K8SVERSION}/filesystem.squashfs/squashfs/* k8s/${K8SNEW}
    ```
 
-1. Update file permissions on initrd
+1. Update file permissions on initrd.
 
    ```bash
-   pit# chmod -v 644 initrd.img.xz
+   ncn-m# chmod -v 644 k8s/${K8SNEW}/initrd.img.xz
    ```
 
-1. Set the boot links.
+1. Put the new squashfs, kernel, and initrd into S3
+
+   1. If not already available, get this sript which will put a file into S3 with public read setting.
 
    ```bash
-   pit# cd
-   pit# set-sqfs-links.sh
+   ncn-m# wget https://github.com/Cray-HPE/s3_examples/blob/main/no_STS/ceph-upload-file-public-read.py
+   ncn-m# chmod +x ceph-upload-file-public-read.py
    ```
 
-The Kubernetes image will have the new password for the next boot.
+   1. Get info to add to credentials.json for the SDS user
+
+      ```bash
+      ncn-m# ssh ncn-s001 radosgw-admin user info --uid SDS | grep key
+      "keys": [
+              "access_key": "FKZWSIY92VBC4LPGXW9I",
+              "secret_key": "mYcViYWwXDT7PAR5JOwzsT5vjkKhWHUb8MGJpjsm"
+      "swift_keys": [],
+      "temp_url_keys": [],
+      ```
+
+   1. Using the access_key and secret_key, construct a `credentials.json` file with contents similar to this.
+
+      ```bash
+      ncn-m# cat credentials.json
+      {
+          "access_key": "KJ1B22VP2MBKYPALP8VW",
+          "secret_key": "EJbDkvoaHEcMfhkMeDSA3tEM6DwBSmuGzVYkuUOv",
+          "endpoint_url": "http://10.252.1.11:8080"
+      }
+      ```
+
+   1. Upload the boot artifacts to S3.
+
+      ```bash
+      ncn-m# cp -p credentials.json ceph-upload-file-public-read.py. k8s/${K8SNEW}
+      cd k8s/${K8SNEW}
+      ./ceph-upload-file-public-read.py --bucket-name ncn-images --key-name 'k8s/${K8SNEW}/filesystem.squashfs' --file-name filesystem.squashfs
+      ./ceph-upload-file-public-read.py --bucket-name ncn-images --key-name 'k8s/${K8SNEW}/initrd' --file-name initrd.img.xz
+      ./ceph-upload-file-public-read.py --bucket-name ncn-images --key-name 'k8s/${K8SNEW}/kernel' --file-name 5.3.18-24.75-default.kernel
+      ```
+
+1. The Kubernetes image now has the image changes.
+
+1. Update BSS with the new image for the master nodes and worker nodes.
+
+   **WARNING:** If doing a CSM software upgrade, skip this section to continue with Ceph Image.
+
+   > If not doing a CSM software upgrade, this process will update the entries in BSS for the master nodes and worker nodes to use the new `k8s-image`.
+   > 
+   > 1. Set all master nodes and worker nodes to use newly created k8s-image.
+   >
+   >     This will use the K8SVERSION and K8SNEW variables defined earlier.
+   >
+   >     ```bash
+   >     ncn-m# for node in $(grep -oP "(ncn-[mw]\w+)" /etc/hosts | sort -u) 
+   >     do
+   >       echo $node
+   >       xname=$(ssh $node cat /etc/cray/xname)
+   >       echo $xname
+   >       cray bss bootparameters list --name $xname --format json > bss_$xname.json
+   >       sed -i.old "s@k8s/${K8SVERSION}@k8s/${K8SNEW}@g" bss_$xname.json 
+   >       kernel=$(cat bss_$xname.json | jq '.[]  .kernel')
+   >       initrd=$(cat bss_$xname.json | jq '.[]  .initrd')
+   >       params=$(cat bss_$xname.json | jq '.[]  .params')
+   >       cray bss bootparameters update --initrd $initrd --kernel $kernel --params $params --name $xname --format json
+   >     done
+   >     ```
 
 ### Ceph Image
 
-The Ceph image is used by the utility storage nodes.
+The Ceph image `ceph-image` is used by the utility storage nodes.
+
+1. Decide which ceph-image is to be modified
+
+   ```bash
+   ncn-m# cray artifacts list ncn-images --format json | jq '.artifacts[] .Key' | grep ceph | grep squashfs
+   "ceph-filesystem.squashfs"
+   "ceph/0.1.107/filesystem.squashfs"
+   "ceph/0.1.113/filesystem.squashfs"
+   "ceph/0.1.48/filesystem.squashfs"
+   ```
+
+   This example uses ceph/0.1.113 for the current version and adds a suffix for the new version.
+
+   ncn-m# export CEPHVERSION=0.1.113
+   ncn-m# export CEPHNEW=0.1.113-2
+
+1. Make a temporary directory for the ceph-image using the current version string.
+
+   ```bash
+   ncn-m# mkdir -p ceph/${CEPHVERSION}
+   ```
+
+1. Get the image.
+
+   ```bash
+   ncn-m# cray artifacts get ncn-images ceph/${CEPHVERSION}/filesystem.squashfs ceph/${CEPHVERSION}/filesystem.squashfs.orig
+   ```
 
 1. Open the image.
 
-   The Ceph image will be of the form "storage-ceph-0.1.69.squashfs" in /var/www/ephemeral/data/ceph, but the version number may be different.
-
    ```bash
-   pit# cd /var/www/ephemeral/data/ceph
-   pit# unsquashfs storage-ceph-0.1.69.squashfs
+   ncn-m# unsquashfs -d ceph/${CEPHVERSION}/filesystem.squashfs ceph/${CEPHVERSION}/filesystem.squashfs.orig
    ```
 
-1. Change into the image root
+1. Copy the generated public and private ssh keys for the root account into the image.
+
+   This example assumes that an RSA key was generated.
 
    ```bash
-   pit# chroot ./squashfs-root
+   ncn-m# cp -p /root/.ssh/id_rsa /root/.ssh/id_rsa.pub ceph/${CEPHVERSION}/filesystem.squashfs/root/.ssh
    ```
 
-1. Change the password
+1. Add the public ssh key for the root account to `authorized_keys`.
+
+   This example assumes that an RSA key was generated so it adds the id_rsa.pub file to authorized_keys.
 
    ```bash
-   chroot-pit# passwd
+   ncn-m# cat /root/.ssh/id_rsa.pub >> ceph/${CEPHVERSION}/filesystem.squashfs/root/.ssh/authorized_keys
+   ncn-m# chmod 640 ceph/${CEPHVERSION}/filesystem.squashfs/root/.ssh/authorized_keys
    ```
 
-1. Replace the ssh keys
+1. Change into the image root.
 
    ```bash
-   chroot-pit# cd root
+   ncn-m# chroot ceph/${CEPHVERSION}/filesystem.squashfs
    ```
 
-1. Replace the default root public and private ssh keys with your own or generate a new pair with `ssh-keygen(1)`
-
-1. Create the new SquashFS artifact
+1. Change the password.
 
    ```bash
-   chroot-pit# /srv/cray/scripts/common/create-kis-artifacts.sh
+   chroot-ncn-m# passwd
    ```
 
-1. Exit the chroot
+1. (Optional) If there are any other things to be changed in the image, they could also be done at this point.
+
+   1. (Optional) Set default timezone on management nodes.
+
+      1. Check whether TZ variable is already set in `/etc/environment`. The setting for NEWTZ must be a valid timezone from the set under `/usr/share/zoneinfo`.
+
+         ```bash
+         chroot-ncn-m# NEWTZ=US/Pacific
+         chroot-ncn-m# grep TZ /etc/environment
+         ```
+
+         Add only if TZ is not present.
+
+         ```bash
+         chroot-ncn-m# echo TZ=${NEWTZ} >> /etc/environment
+         ```
+
+      1. Check for `utc` setting.
+
+         ```bash
+         chroot-ncn-m# grep -i utc /srv/cray/scripts/metal/ntp-upgrade-config.sh
+         ```
+
+         Change only if the `grep` command shows these lines set to UTC.
+
+         ```bash
+         chroot-ncn-m# sed -i "s#^timedatectl set-timezone UTC#timedatectl set-timezone $NEWTZ#" /srv/cray/scripts/metal/ntp-upgrade-config.sh
+         chroot-ncn-m# sed -i 's/--utc/--localtime/' /srv/cray/scripts/metal/ntp-upgrade-config.sh
+         ```
+
+1. Create the new SquashFS artifact.
 
    ```bash
-   chroot-pit# exit
+   chroot-ncn-m# /srv/cray/scripts/common/create-kis-artifacts.sh
    ```
 
-1. Clean up the SquashFS creation
-
-   The Ceph image directory is /var/www/ephemeral/data/ceph.
+1. Exit the chroot environment.
 
    ```bash
-   pit# umount -v /var/www/ephemeral/data/ceph/squashfs-root/mnt/squashfs
+   chroot-ncn-m# exit
    ```
 
-1. Save old SquashFS image.
+1. Clean up the SquashFS creation.
 
    ```bash
-   pit# mkdir -v old
-   pit# mv -v *squashfs old
+   ncn-m# umount -v ceph/${CEPHVERSION}/filesystem.squashfs/mnt/squashfs
    ```
 
-1. Move new SquashFS image, kernel, and initrd into place.
+1. Update file permissions on initrd.
 
    ```bash
-   pit# mv -v squashfs-root/squashfs/* .
+   ncn-m# chmod -v 644 ceph/${CEPHNEW}/initrd.img.xz
    ```
 
-1. Update file permissions on initrd
+1. Put the new initrd.img.xz, kernel, and squashfs into S3
+
+   1. If not already available, get this sript which will put a file into S3 with public read setting.
 
    ```bash
-   pit# chmod -v 644 initrd.img.xz
+   ncn-m# wget https://github.com/Cray-HPE/s3_examples/blob/main/no_STS/ceph-upload-file-public-read.py
+   ncn-m# chmod +x ceph-upload-file-public-read.py
    ```
 
-1. Set the boot links.
+   1. Get info to add to credentials.json for the SDS user
+
+      ```bash
+      ncn-m# ssh ncn-s001 radosgw-admin user info --uid SDS | grep key
+      "keys": [
+              "access_key": "FKZWSIY92VBC4LPGXW9I",
+              "secret_key": "mYcViYWwXDT7PAR5JOwzsT5vjkKhWHUb8MGJpjsm"
+      "swift_keys": [],
+      "temp_url_keys": [],
+      ```
+
+   1. Using the `access_key` and `secret_key`, construct a `credentials.json` file with contents similar to this.
+
+      ```bash
+      ncn-m# cat credentials.json
+      {
+          "access_key": "KJ1B22VP2MBKYPALP8VW",
+          "secret_key": "EJbDkvoaHEcMfhkMeDSA3tEM6DwBSmuGzVYkuUOv",
+          "endpoint_url": "http://10.252.1.11:8080"
+      }
+      ```
+
+   1. Upload the boot artifacts to S3.
+
+      ***Note:*** The version string for the kernel file may be different.
+
+      ```bash
+      ncn-m# cp -p credentials.json ceph-upload-file-public-read.py. ceph/${CEPHNEW}
+      cd ceph/${CEPHNEW}
+      ./ceph-upload-file-public-read.py --bucket-name ncn-images --key-name 'ceph/${CEPHNEW}/filesystem.squashfs' --file-name filesystem.squashfs
+      ./ceph-upload-file-public-read.py --bucket-name ncn-images --key-name 'ceph/${CEPHNEW}/initrd' --file-name initrd.img.xz
+      ./ceph-upload-file-public-read.py --bucket-name ncn-images --key-name 'ceph/${CEPHNEW}/kernel' --file-name 5.3.18-24.75-default.kernel
+      cd ../..
+      ```
+
+1. The Ceph image now has the image changes.
+
+1. Update BSS with the new image for utility storage nodes.
+
+   **WARNING:** If doing a CSM software upgrade, skip this section to continue with Common Cleanup.
+
+   > If not doing a CSM software upgrade, this process will update the entries in BSS for the utiltity storage nodes to use the new `ceph-image`.
+   > 
+   > 1. Set all utility storage nodes to use newly created ceph-image.
+   >
+   >     This will use the CEPHVERSION and CEPHNEW variables defined earlier.
+   >
+   >     ```bash
+   >     ncn-m# for node in $(grep -oP "(ncn-s\w+)" /etc/hosts | sort -u) 
+   >     do
+   >       echo $node
+   >       xname=$(ssh $node cat /etc/cray/xname)
+   >       echo $xname
+   >       cray bss bootparameters list --name $xname --format json > bss_$xname.json
+   >       sed -i.old "s@ceph/${CEPHVERSION}@ceph/${CEPHNEW}@g" bss_$xname.json 
+   >       kernel=$(cat bss_$xname.json | jq '.[]  .kernel')
+   >       initrd=$(cat bss_$xname.json | jq '.[]  .initrd')
+   >       params=$(cat bss_$xname.json | jq '.[]  .params')
+   >       cray bss bootparameters update --initrd $initrd --kernel $kernel --params $params --name $xname --format json
+   >     done
+   >     ```
+
+### Common Cleanup
+
+1. Remove the workarea so the space can be reused.
 
    ```bash
-   pit# cd
-   pit# set-sqfs-links.sh
+   ncn-m# rm -rf /run/initramfs/overlayfs/workingarea
    ```
 
-The Ceph image will have the new password for the next boot.
+1. Rebuild nodes.
+
+   **WARNING:** If doing a CSM software upgrade, skip this step since the upgrade process does a rolling rebuild with some additional steps.
+
+   > If not doing a CSM software upgrade, follow the procedure to do a [Rolling Rebuild](../operations/node_management/Rebuild_NCNs.md) of all management nodes.

--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
@@ -429,4 +429,4 @@ The Ceph image `ceph-image` is used by the utility storage nodes.
 
    **WARNING:** If doing a CSM software upgrade, skip this step since the upgrade process does a rolling rebuild with some additional steps.
 
-   > If not doing a CSM software upgrade, follow the procedure to do a [Rolling Rebuild](../operations/node_management/Rebuild_NCNs.md) of all management nodes.
+   > If not doing a CSM software upgrade, follow the procedure to do a [Rolling Rebuild](../node_management/Rebuild_NCNs.md) of all management nodes.

--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_node.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_node.md
@@ -1,0 +1,350 @@
+## Change NCN Image Root Password and SSH Keys on PIT Node
+
+Customize the NCN images by changing the root password or adding different ssh keys for the root account.
+This procedure shows this process being done on the PIT node during a first time installation of the CSM
+software.
+
+There is some common preparation before making the Kubernetes image for master nodes and worker nodes, making the Ceph image for utility storage nodes, and then some common cleanup afterwards.
+
+***Note:*** This procedure can only be done before the PIT node is rebuilt to become a normal master node.
+
+### Common Preparation
+
+1. Prepare new ssh keys on the PIT node for the root account in advance. The same key information will be added to both k8s-image and ceph-image.
+
+   Either replace the root public and private ssh keys with your own previously generated keys or generate a new pair with `ssh-keygen(1)`. By default `ssh-keygen` will create an RSA key, but other types could be chosen and different filenames would need to be substituted in later steps.
+
+   ```bash
+   pit# mkdir /root/.ssh
+   pit# ssh-keygen -f /root/.ssh/id_rsa -t rsa
+   pit# ls -l /root/.ssh/id_rsa*
+   pit# chmod 600 /root/.ssh/id_rsa
+   ```
+
+### Kubernetes Image
+
+The Kubernetes image is used by the master and worker nodes.
+
+1. Change to the working directory for the Kubernetes image.
+
+   ```bash
+   pit# cd /var/www/ephemeral/data/k8s
+   ```
+
+1. Open the image.
+
+   The Kubernetes image will be of the form "kubernetes-0.1.69.squashfs" in /var/www/ephemeral/data/k8s, but the version number may be different.
+
+   ```bash
+   pit# unsquashfs kubernetes-0.1.69.squashfs
+   ```
+
+1. Save the old SquashFS image, kernel, and initrd.
+
+   ```bash
+   pit# mkdir -v old
+   pit# mv -v *squashfs *kernel initrd* old
+   ```
+
+1. Copy the generated public and private ssh keys for the root account into the image.
+
+   This example assumes that an RSA key was generated.
+
+   ```bash
+   pit# cp -p /root/.ssh/id_rsa /root/.ssh/id_rsa.pub squashfs-root/root/.ssh
+   ```
+
+1. Add the public ssh key for the root account to `authorized_keys`.
+
+   This example assumes that an RSA key was generated so it adds the id_rsa.pub file to authorized_keys.
+
+   ```bash
+   pit# cat /root/.ssh/id_rsa.pub >> squashfs-root/root/.ssh/authorized_keys
+   pit# chmod 640 squashfs-root/root/.ssh/authorized_keys
+   ```
+
+1. Change into the image root.
+
+   ```bash
+   pit# chroot ./squashfs-root
+   ```
+
+1. Change the password.
+
+   ```bash
+   chroot-pit# passwd
+   ```
+
+1. (Optional) If there are any other things to be changed in the image, they could also be done at this point.
+
+   1. (Optional) Set default timezone on management nodes.
+
+      1. Check whether TZ variable is already set in `/etc/environment`. The setting for NEWTZ must be a valid timezone from the set under `/usr/share/zoneinfo`.
+
+         ```bash
+         chroot-pit# NEWTZ=US/Pacific
+         chroot-pit# grep TZ /etc/environment
+         ```
+
+         Add only if TZ is not present.
+
+         ```bash
+         chroot-pit# echo TZ=${NEWTZ} >> /etc/environment
+         ```
+
+      1. Check for `utc` setting.
+
+         ```bash
+         chroot-pit# grep -i utc /srv/cray/scripts/metal/ntp-upgrade-config.sh
+         ```
+
+         Change only if the `grep` command shows these lines set to UTC.
+
+         ```bash
+         chroot-pit# sed -i "s#^timedatectl set-timezone UTC#timedatectl set-timezone $NEWTZ#" /srv/cray/scripts/metal/ntp-upgrade-config.sh
+         chroot-pit# sed -i 's/--utc/--localtime/' /srv/cray/scripts/metal/ntp-upgrade-config.sh
+         ```
+
+1. Create the new SquashFS artifact.
+
+   ```bash
+   chroot-pit# /srv/cray/scripts/common/create-kis-artifacts.sh
+   ```
+
+1. Exit the chroot environment.
+
+   ```bash
+   chroot-pit# exit
+   ```
+
+1. Clean up the SquashFS creation.
+
+   The Kubernetes image directory is /var/www/ephemeral/data/k8s.
+
+   ```bash
+   pit# umount -v /var/www/ephemeral/data/k8s/squashfs-root/mnt/squashfs
+   ```
+
+1. Move new SquashFS image, kernel, and initrd into place.
+
+   ```bash
+   pit# mv -v squashfs-root/squashfs/* .
+   ```
+
+1. Update file permissions on initrd.
+
+   ```bash
+   pit# chmod -v 644 initrd.img.xz
+   ```
+
+1. Rename the new squashfs, kernel, and initrd to include a new version string.
+
+   If the old name of the squashfs was kubernetes-0.1.69.squashfs, then its version was '0.1.69', so the newly created version should be renamed to include a version of '0.1.69-1' with an additional dash and a build iteration number of 1. This will help to track what base version was used.
+
+   ```bash
+   pit# ls -l old/*squashfs
+   -rw-r--r--  1 root root 5135859712 Aug 19 19:10 kubernetes-0.1.69.squashfs
+   ```
+
+   Set the VERSION variable based on the version string displayed by the above command with an incremented suffix added to show a build iteration.
+
+   ```bash
+   pit# export VERSION=0.1.69-1
+   pit# mv filesystem.squashfs kubernetes-${VERSION}.squashfs
+   pit# mv initrd.img.xz initrd.img-${VERSION}.xz
+   ```
+
+   The kernel file will have a name with the kernel version but not this new $VERSION.
+
+   ```bash
+   pit# ls -l *kernel
+   -rw-r--r--  1 root root    8552768 Aug 19 19:09 5.3.18-24.75-default.kernel
+   ```
+
+   Rename it to include the version string.
+
+   ```bash
+   pit# mv 5.3.18-24.75-default.kernel 5.3.18-24.75-default-${VERSION}.kernel
+   ```
+
+1. Set the boot links.
+
+   ```bash
+   pit# cd
+   pit# set-sqfs-links.sh
+   ```
+
+The Kubernetes image will have the image changes for the next boot.
+
+### Ceph Image
+
+The Ceph image is used by the utility storage nodes.
+
+1. Change to the working directory for the Ceph image.
+
+   ```bash
+   pit# cd /var/www/ephemeral/data/ceph
+   ```
+
+1. Open the image.
+
+   The Ceph image will be of the form "storage-ceph-0.1.69.squashfs" in /var/www/ephemeral/data/ceph, but the version number may be different.
+
+   ```bash
+   pit# unsquashfs storage-ceph-0.1.69.squashfs
+   ```
+
+1. Save the old SquashFS image, kernel, and initrd.
+
+   ```bash
+   pit# mkdir -v old
+   pit# mv -v *squashfs *kernel initrd* old
+   ```
+
+1. Copy the generated public and private ssh keys for the root account into the image.
+
+   This example assumes that an RSA key was generated.
+
+   ```bash
+   pit# cp -p /root/.ssh/id_rsa /root/.ssh/id_rsa.pub squashfs-root/root/.ssh
+   ```
+
+1. Add the public ssh key for the root account to `authorized_keys`.
+
+   This example assumes that an RSA key was generated so it adds the id_rsa.pub file to authorized_keys.
+
+   ```bash
+   pit# cat /root/.ssh/id_rsa.pub >> squashfs-root/root/.ssh/authorized_keys
+   pit# chmod 640 squashfs-root/root/.ssh/authorized_keys
+   ```
+
+1. Change into the image root.
+
+   ```bash
+   pit# chroot ./squashfs-root
+   ```
+
+1. Change the password.
+
+   ```bash
+   chroot-pit# passwd
+   ```
+
+1. (Optional) If there are any other things to be changed in the image, they could also be done at this point.
+
+   1. (Optional) Set default timezone on management nodes.
+
+      1. Check whether TZ variable is already set in `/etc/environment`. The setting for NEWTZ must be a valid timezone from the set under `/usr/share/zoneinfo`.
+
+         ```bash
+         chroot-pit# NEWTZ=US/Pacific
+         chroot-pit# grep TZ /etc/environment
+         ```
+
+         Add only if TZ is not present.
+
+         ```bash
+         chroot-pit# echo TZ=${NEWTZ} >> /etc/environment
+         ```
+
+      1. Check for `utc` setting.
+
+         ```bash
+         chroot-pit# grep -i utc /srv/cray/scripts/metal/ntp-upgrade-config.sh
+         ```
+
+         Change only if the `grep` command shows these lines set to UTC.
+
+         ```bash
+         chroot-pit# sed -i "s#^timedatectl set-timezone UTC#timedatectl set-timezone $NEWTZ#" /srv/cray/scripts/metal/ntp-upgrade-config.sh
+         chroot-pit# sed -i 's/--utc/--localtime/' /srv/cray/scripts/metal/ntp-upgrade-config.sh
+         ```
+
+1. Create the new SquashFS artifact.
+
+   ```bash
+   chroot-pit# /srv/cray/scripts/common/create-kis-artifacts.sh
+   ```
+
+1. Exit the chroot environment.
+
+   ```bash
+   chroot-pit# exit
+   ```
+
+1. Clean up the SquashFS creation.
+
+   The Ceph image directory is /var/www/ephemeral/data/ceph.
+
+   ```bash
+   pit# umount -v /var/www/ephemeral/data/ceph/squashfs-root/mnt/squashfs
+   ```
+
+1. Save old SquashFS image.
+
+   ```bash
+   pit# mkdir -v old
+   pit# mv -v *squashfs old
+   ```
+
+1. Move new SquashFS image, kernel, and initrd into place.
+
+   ```bash
+   pit# mv -v squashfs-root/squashfs/* .
+   ```
+
+1. Update file permissions on initrd.
+
+   ```bash
+   pit# chmod -v 644 initrd.img.xz
+   ```
+
+1. Rename the new squashfs, kernel, and initrd to include a new version string.
+
+   If the old name of the squashfs was storage-ceph-0.1.69.squashfs, then its version was '0.1.69', so the newly created version should be renamed to include a version of '0.1.69-1' with an additional dash and a build iteration number of 1. This will help to track what base version was used.
+
+   ```bash
+   pit# ls -l old/*squashfs
+   -rw-r--r--  1 root root 5135859712 Aug 19 19:10 storage-ceph-0.1.69.squashfs
+   ```
+
+   Set the VERSION variable based on the version string displayed by the above command with an incremented suffix added to show a build iteration.
+
+   ```bash
+   pit# VERSION=0.1.69-1
+   pit# mv filesystem.squashfs storage-ceph-${VERSION}.squashfs
+   pit# mv initrd.img.xz initrd.img-${VERSION}.xz
+   ```
+
+   The kernel file will have a name with the kernel version but not this new $VERSION.
+
+   ```bash
+   pit# ls -l *kernel
+   -rw-r--r--  1 root root    8552768 Aug 19 19:09 5.3.18-24.75-default.kernel
+   ```
+
+   Rename it to include the version string.
+
+   ```bash
+   pit# mv 5.3.18-24.75-default.kernel 5.3.18-24.75-default-${VERSION}.kernel
+   ```
+
+1. Set the boot links.
+
+   ```bash
+   pit# cd
+   pit# set-sqfs-links.sh
+   ```
+
+The Ceph image will have the image changes for the next boot.
+
+### Common Cleanup
+
+1. Clean up temporary storage used to prepare images.
+
+   These could be removed now or after verification that the nodes are able to boot successfully with the new images.
+
+   ```bash
+   pit# cd /var/www/ephemeral/data
+   pit# rm -rf ceph/old k8s/old
+   ```

--- a/operations/security_and_authentication/Update_NCN_Passwords.md
+++ b/operations/security_and_authentication/Update_NCN_Passwords.md
@@ -1,16 +1,29 @@
 ## Update NCN User Passwords
 
-The NCNs deploy with a default password, which are changed during the system
-install. See [Change NCN Image Root Password and SSH Keys](Change_NCN_Image_Root_Password_and_SSH_Keys.md)
+The management nodes deploy with a default password in the image, so it is a recommended best
+practice for system security to change the root password in the image so that it is
+not the documented default password. In addition to the root password in the image, NCN
+personalization should be used to change the password as part of post-boot CFS.  The password
+in the image should be used when console access is desired during the network boot of a management
+node that is being rebuilt, but this password should be different than the one stored in Vault
+that is applied by CFS during post-boot NCN personalization to change the on-disk password. Once
+NCN personalization has been run, then the password in Vault should be used for console access.
+
+Use one of these methods to change the root pasword in the image.
+
+1. If the PIT node is booted, see
+[Change NCN Image Root Password and SSH Keys on PIT Node](Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_node.md)
 for more information.
 
-It is a recommended best practice for system security to change the root
-password after the install is complete.
+1. If the PIT node is not booted, see
+[Change NCN Image Root Password and SSH Keys](Change_NCN_Image_Root_Password_and_SSH_Keys.md)
+for more information.
 
-The NCN root user password is stored in the [HashiCorp Vault](HashiCorp_Vault.md)
-instance, and applied with the `csm.password` Ansible role via a CFS session. If
-no password is added to Vault as in the procedure below, this Ansible role will
-skip any password updates.
+The rest of this procedure describes how to change the root password stored in the HashiCorp
+Vault instance and then apply it immediately to management nodes with the `csm.password` Ansible
+role via a CFS session. The same root password from Vault will be applied anytime that the NCN
+personalization including the CSM layer is run.  If no password is added to Vault as in the
+procedure below, this Ansible role will skip any password updates.
 
 ### New in CSM Release 1.2.0
 

--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -9,8 +9,9 @@
 * [Stage 0.5 - Prerequisites Check](#prerequisites-check)
 * [Stage 0.6 - Backup VCS Data](#backup-vcs-data)
 * [Stage 0.7 - Suspend NCN Configuration](#suspend-ncn-config)
-* [Stage 0.8 - Modify NCN Images](#modify_ncn_images)
-* [Stage 0.9 - Continue to Stage 1](#continue_to_stage1)
+* [Stage 0.8 - Backup Workload Manager Data](#backup_workload_manager)
+* [Stage 0.9 - Modify NCN Images](#modify_ncn_images)
+* [Stage 0.10 - Continue to Stage 1](#continue_to_stage1)
 
 <a name="install-latest-docs"></a>
 ## Stage 0.1 - Install latest docs RPM
@@ -245,8 +246,13 @@ will be re-enabled in [Stage 5](Stage_5.md).
    done
 ```
 
+<a name="backup_workload_manager"></a>
+## Stage 0.8 - Backup Workload Manager Data
+
+To prevent any possibility of losing Workload Manager configuration data or files, a back-up is required. Please execute all Backup procedures (for the Workload Manager in use) located in the `Troubleshooting and Administrative Tasks` sub-section of the `Install a Workload Manager` section of the `HPE Cray Programming Environment Installation Guide: CSM on HPE Cray EX`. The resulting back-up data should be stored in a safe location off of the system.
+
 <a name="modify_ncn_images"></a>
-## Stage 0.8 - Modify NCN Images
+## Stage 0.9 - Modify NCN Images
 
 Any site modifications to the images used to boot the management nodes need to be done again
 as part of this upgrade. These may include changing the root password, adding different ssh
@@ -296,6 +302,6 @@ of CSM software, but if was not done then, it should be done now. See
 for more information.
 
 <a name="continue_to_stage1"></a>
-## Stage 0.9 - Continue to Stage 1
+## Stage 0.10 - Continue to Stage 1
 
 Once the above steps have been completed, proceed to [Stage 1](Stage_1.md).

--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -9,6 +9,8 @@
 * [Stage 0.5 - Prerequisites Check](#prerequisites-check)
 * [Stage 0.6 - Backup VCS Data](#backup-vcs-data)
 * [Stage 0.7 - Suspend NCN Configuration](#suspend-ncn-config)
+* [Stage 0.8 - Modify NCN Images](#modify_ncn_images)
+* [Stage 0.9 - Continue to Stage 1](#continue_to_stage1)
 
 <a name="install-latest-docs"></a>
 ## Stage 0.1 - Install latest docs RPM
@@ -242,5 +244,58 @@ will be re-enabled in [Stage 5](Stage_5.md).
        cray cfs components update --enabled false $xname
    done
 ```
+
+<a name="modify_ncn_images"></a>
+## Stage 0.8 - Modify NCN Images
+
+Any site modifications to the images used to boot the management nodes need to be done again
+as part of this upgrade. These may include changing the root password, adding different ssh
+keys for the root account, or setting a default timezone.
+
+The management nodes deploy with a default password in the image, so it is a recommended best
+practice for system security to change the root password in the image so that it is
+not the documented default password. In addition to the root password in the image, NCN
+personalization should be used to change the password as part of post-boot CFS. The password
+in the image should be used when console access is desired during the network boot of a management
+node that is being rebuilt, but this password should be different than the one stored in Vault
+that is applied by CFS during post-boot NCN personalization to change the on-disk password. Once
+NCN personalization has been run, then the password in Vault should be used for console access.
+
+1. Use this procedure to change the k8s-image used for master nodes and worker nodes and the ceph-image
+used by utility storage nodes. See
+[Change NCN Image Root Password and SSH Keys](../../operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md)
+for more information.
+
+1. Adjust the version variables used later in the upgrade.
+
+   1. The previous procedure to create the site-customized `k8s-image` and `ceph-image` should have set these variables.
+
+      ```bash
+      ncn-m001# echo $CEPHNEW
+      ncn-m001# echo $K8sNEW
+      ```
+
+    2. Check current versions in `/etc/cray/upgrade/csm/myenv`.
+
+      ```bash
+      ncn-m001# grep CEPH_VERSION /etc/cray/upgrade/csm/myenv
+      ncn-m001# grep KUBERNETES_VERSION /etc/cray/upgrade/csm/myenv
+      ```
+
+    3. If the `CEPH_VERSION` or `KUBERNETES_VERSION` does not match the `CEPHNEW` and `K8SNEW` settings, edit the file.
+
+      ```bash
+      ncn-m001# vi /etc/cray/upgrade/csm/myenv
+      ```
+
+2. Use this procedure to change the root password in Vault and the CSM layer of configuration
+applied during NCN Personalizaion. Usually this configuration is done during the first time installation
+of CSM software, but if was not done then, it should be done now. See
+[Update NCN Passwords](../../operations/security_and_authentication/Update_NCN_Passwords.md) and
+[full NCN personalization](../../operations/CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md#set_root_password)
+for more information.
+
+<a name="continue_to_stage1"></a>
+## Stage 0.9 - Continue to Stage 1
 
 Once the above steps have been completed, proceed to [Stage 1](Stage_1.md).


### PR DESCRIPTION
## Summary and Scope

[CASMINST-4289](https://jira-pro.its.hpecorp.net:8443/secure/QuickSearch.jspa?searchString=CASMINST-4289)-1.2 Revised password, ssh key, and timezone change for k8s-image and ceph-image

Revised procedures to change the NCN images (k8s-image and ceph-image) to be done from PIT node or later when PIT node is not available. Both procedures will change the root password, ssh keys and authorized_keys for root, and optionally change the timezone.

The install procedure now refers to this procedure as the security best practices recommended method to change the root password from the PIT node before deploying any of the other NCNs.

Added image changing to the Upgrade procedure and changed non-PIT operational procedure to also do a BSS update and recommend a Rolling Rebuild (if not doing a CSM upgrade)

## Issues and Related PRs

This also address timezone procedure issue from [CASMINST-3959](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3959)

And root password change in image issue from [CASMINST-4274](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4274)

## Testing

Tested ssh-keygen commands in isolation since that part of the procedure was incorrect.

Tested timezone change commands as part of draft documentation at customer site for [CASMINST-3959](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3959)

### Tested on:


### Test description:



## Risks and Mitigations



## Pull Request Checklist

