### PR TITLE
CASMPET-5427-1.2.5: Fix docs relating to Nexus Keycloak integration

### DIFF
--- a/operations/package_repository_management/Manage_Repositories_with_Nexus.md
+++ b/operations/package_repository_management/Manage_Repositories_with_Nexus.md
@@ -2,41 +2,33 @@
 
 This section describes how to connect to Nexus with the Web UI, as well as how to access the REST API from non-compute nodes \(NCNs\) or compute nodes to manage repositories.
 
-### Using Keycloak to Create and Manage Accounts
-
-In order to log into the Web UI or authenticate with the REST API, a user account with appropriate permissions must be created.
-Accounts are managed in Keycloak (see [Configure Keycloak Accounts](../CSM_product_management/Configure_Keycloak_Account.md)).
-To add administrator permissions for Nexus, add the `nx-admin` role binding to the user from the `system-nexus-client` 
-client (see below).
-To add an anonymous user, add the `nx-anonymous` role binding to the user from the `system-nexus-client` client (see below).
-
-    ![Nexus Admin Account](../../img/operations/Nexus_Admin_Account.png "Nexus Admin Account")
-
-    ![Nexus Anonymous Account](../../img/operations/Nexus_Anonymous_Account.png "Nexus Anonymous Account")
-
-### Using the Local Nexus Admin Account
-
-During the deployment or update of Nexus, a local admin account is created. To access the local admin account for Nexus
-on any NCN, run the following commands:
-
-```bash
-ncn# kubectl -n nexus get secret nexus-admin-credential --template {{.data.username}} | base64 -d; echo
-```
-
-```bash
-ncn# kubectl -n nexus get secret nexus-admin-credential --template {{.data.password}} | base64 -d; echo
-```
-
-The first command will print the username of the local admin account. The second command will print the 
-password for the local admin account. (Note that the secret will not update or stay in sync if the username
-or password of the local account is changed.). This account has the same permissions as an account created
-in Keycloak with the `nx-admin` role.
-
 ### Access Nexus with the Web UI
 
 Use the hostname set in `istio.ingress.hosts.ui.authority` (see below) to connect to Nexus over the Customer Access Network (CAN) using a web browser. For example:
 
-`https://nexus.{{network.dns.external}}/`
+```bash
+https://nexus.{{network.dns.external}}/
+```
+
+### Use Keycloak to Create and Manage Accounts
+
+In order to log into the Web UI or authenticate with the REST API, a user account with appropriate permissions must be created. Accounts are managed in Keycloak (see [Configure Keycloak Accounts](../CSM_product_management/Configure_Keycloak_Account.md)). To add administrator permissions for Nexus, add the `nx-admin` role binding to the user from the `system-nexus-client` client (see below). To add an anonymous user, add the `nx-anonymous` role binding to the user from the `system-nexus-client` client (see below).
+
+  ![Nexus Admin Account](../../img/operations/Nexus_Admin_Account.png "Nexus Admin Account")
+
+  ![Nexus Anonymous Account](../../img/operations/Nexus_Anonymous_Account.png "Nexus Anonymous Account")
+
+### Use the Local Nexus Admin Account
+
+During the deployment or update of Nexus, a local admin account is created. To access the local admin account for Nexus on any NCN, run the following commands:
+
+```bash
+ncn# kubectl -n nexus get secret nexus-admin-credential --template {{.data.username}} | base64 -d; echo
+
+ncn# kubectl -n nexus get secret nexus-admin-credential --template {{.data.password}} | base64 -d; echo
+```
+
+The first command will print the username of the local admin account. The second command will print the password for the local admin account. (Note that the secret will not update or stay in sync if the username or password of the local account is changed.). This account has the same permissions as an account created in Keycloak with the `nx-admin` role.
 
 ### Access Nexus with the REST API
 

--- a/operations/package_repository_management/Repair_Yum_Repository_Metadata.md
+++ b/operations/package_repository_management/Repair_Yum_Repository_Metadata.md
@@ -22,7 +22,7 @@ The system is fully installed.
     https://nexus.{{network.dns.external}}/
     ```
     
-    Users will need to login through nexus UI. The account is configured through Keycloak with a role mapping for Nexus authentication. The role needed for admin permissions is nx-admin in the system-nexus-client role. Scripts may connect by using a username and password in the request.
+    Users will need to login through Nexus UI. The account is configured through Keycloak with a role mapping for Nexus authentication. The role needed for admin permissions is nx-admin in the system-nexus-client role. Scripts may connect by using a username and password in the request.
     
     ![Keycloak Adding Permissions](../../img/operations/Keycloak_add_nexus_permission.png "Keycloak Adding Permissions")
 


### PR DESCRIPTION
## Summary and Scope

Fixes the missed commit from previous merge on 1.2 that got transferred to 1.2.5. This does not change any documentation only syntax errors, capitalization and formatting.

## Issues and Related PRs

* Resolves [CASMPET-5427](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5427)