### PR TITLE
Fixes to remove storage-ceph-cloudinit from being put back into runcmds

### DIFF
--- a/upgrade/1.0.1/scripts/upgrade/ncn-upgrade-cloud-init.sh
+++ b/upgrade/1.0.1/scripts/upgrade/ncn-upgrade-cloud-init.sh
@@ -274,8 +274,7 @@ cat <<EOF>first-ceph-runcmd-user-data.json
           "/srv/cray/scripts/metal/disable-cloud-init.sh",
           "/srv/cray/scripts/common/update_ca_certs.py",
           "/srv/cray/scripts/metal/install-rpms.sh",
-          "/srv/cray/scripts/common/pre-load-images.sh",
-          "/srv/cray/scripts/common/storage-ceph-cloudinit.sh"
+          "/srv/cray/scripts/common/pre-load-images.sh"
       ]
   }
 }

--- a/upgrade/1.0.11/scripts/upgrade/ncn-upgrade-cloud-init.sh
+++ b/upgrade/1.0.11/scripts/upgrade/ncn-upgrade-cloud-init.sh
@@ -274,8 +274,7 @@ cat <<EOF>first-ceph-runcmd-user-data.json
           "/srv/cray/scripts/metal/disable-cloud-init.sh",
           "/srv/cray/scripts/common/update_ca_certs.py",
           "/srv/cray/scripts/metal/install-rpms.sh",
-          "/srv/cray/scripts/common/pre-load-images.sh",
-          "/srv/cray/scripts/common/storage-ceph-cloudinit.sh"
+          "/srv/cray/scripts/common/pre-load-images.sh"
       ]
   }
 }


### PR DESCRIPTION
## Summary and Scope

This addresses an issue where we remove the cloud init call from runcmds in
prequisites, but the upgrade script comes in afterwards and puts it back.

It can cause some issues if the cloud-init is run and re-creates some csi references

## Issues and Related PRs

* Resolves CASMTRIAGE-3157


## Testing


### Tested on:

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

