### PR TITLE
CASMPET-5082 Add spire int ca regen steps

### DIFF
--- a/operations/index.md
+++ b/operations/index.md
@@ -626,6 +626,7 @@ Spire provides the ability to authenticate nodes and workloads, and to securely 
 
   * [Restore Spire Postgres without a Backup](spire/Restore_Spire_Postgres_without_a_Backup.md)
   * [Troubleshoot Spire Failing to Start on NCNs](spire/Troubleshoot_Spire_Failing_to_Start_on_NCNs.md)
+  * [Update Spire Intermediate CA Certificate](spire/Update_Spire_Intermediate_CA_Certificate.md)
 
 
 <a name="update-firmware-with-fas"></a>

--- a/operations/spire/Update_Spire_Intermediate_CA_Certificate.md
+++ b/operations/spire/Update_Spire_Intermediate_CA_Certificate.md
@@ -16,7 +16,7 @@ kubectl get secret -n spire spire.spire.ca-tls -o json | jq -r '.data."tls.crt" 
 
 ## Replace the Spire Intermediate CA Certificate
 
-1. Delete the secret that stores the certificate
+1. Delete the secret that stores the certificate.
 
    ```bash
    SPIRE_INTERMEDIATE_JOB=$(kubectl get job -n vault -o name| grep 'spire-intermediate' | tail -n1)
@@ -24,7 +24,7 @@ kubectl get secret -n spire spire.spire.ca-tls -o json | jq -r '.data."tls.crt" 
    kubectl delete secret -n spire spire.spire.ca-tls
    ```
 
-1. Rerun the job that obtains the secret and creates the certificate
+1. Re-run the job that obtains the secret and creates the certificate.
 
    ```bash
    kubectl get -n vault "$SPIRE_INTERMEDIATE_JOB" -o json | jq 'del(.spec.selector,.spec.template.metadata.labels)' | kubectl replace --force -f -
@@ -44,7 +44,7 @@ kubectl get secret -n spire spire.spire.ca-tls -o json | jq -r '.data."tls.crt" 
    one to start up in its place.
 
 1. Re-run the command to get the certificate's expiration date to verify that
-   it's been updated
+   it's been updated.
 
    ```bash
    kubectl get secret -n spire spire.spire.ca-tls -o json | jq -r '.data."tls.crt" | @base64d' | openssl x509 -noout -enddate

--- a/operations/spire/Update_Spire_Intermediate_CA_Certificate.md
+++ b/operations/spire/Update_Spire_Intermediate_CA_Certificate.md
@@ -1,48 +1,51 @@
-# Update Spire intermediate CA certificate
+# Update Spire Intermediate CA Certificate
 
 Prior to CSM 1.2.5 there is no mechanism to automatically update the spire
 intermediate CA certificate before it expires. This certificate expires after
 one year. Administrators will want to keep track of when this certificate
 expires and manually update the certificate before it expires.
 
-## How to obtain the expiration date for the Spire intermediate CA
+## Obtain the Expiration Date for the Spire Intermediate CA
 
 To obtain the expiration date of the Spire intermediate CA certificate, run the
-following command on a node that has access to kubectl (Such as ncn-m001)
+following command on a node that has access to `kubectl` (such as `ncn-m001`):
 
 ```bash
 kubectl get secret -n spire spire.spire.ca-tls -o json | jq -r '.data."tls.crt" | @base64d' | openssl x509 -noout -enddate
 ```
 
-## How to replace the Spire intermediate CA certificate with a new one
+## Replace the Spire Intermediate CA Certificate
 
-In order to replace the expired or soon to expire Spire intermediate CA
-certificate you need to delete the secret that stores the certificate and then
-re-run the job that obtains the certificate and creates the secret.
+1. Delete the secret that stores the certificate
 
-```bash
-SPIRE_INTERMEDIATE_JOB=$(kubectl get job -n vault -o name| grep 'spire-intermediate' | tail -n1)
-kubectl get secrets -n spire spire.spire.ca-tls -o yaml > spire.spire.ca-tls.yaml.bak
-kubectl delete secret -n spire spire.spire.ca-tls
-kubectl get -n vault "$SPIRE_INTERMEDIATE_JOB" -o json | jq 'del(.spec.selector,.spec.template.metadata.labels)' | kubectl replace --force -f -
-```
+   ```bash
+   SPIRE_INTERMEDIATE_JOB=$(kubectl get job -n vault -o name| grep 'spire-intermediate' | tail -n1)
+   kubectl get secrets -n spire spire.spire.ca-tls -o yaml > spire.spire.ca-tls.yaml.bak
+   kubectl delete secret -n spire spire.spire.ca-tls
+   ```
 
-After the `spire.spire.ca-tls` secret in the `spire` namespace has been
-repopulated you should roll the spire-server to make sure all of them pick up
-the new CA.
+1. Rerun the job that obtains the secret and creates the certificate
 
-```bash
-kubectl rollout restart -n spire statefulset spire-server
-```
+   ```bash
+   kubectl get -n vault "$SPIRE_INTERMEDIATE_JOB" -o json | jq 'del(.spec.selector,.spec.template.metadata.labels)' | kubectl replace --force -f -
+   ```
 
-Any spire-agents in the CLBO state should come back into a Running state the
-next time they're started. If you don't wish to wait for them to be restarted
-automatically then you can delete the spire-agent pod, which will cause a new
-one to start up in its place.
+1. After the `spire.spire.ca-tls` secret in the `spire` namespace has been
+   repopulated you should roll the spire-server to make sure all of them pick up
+   the new CA.
 
-After this is done you can then rerun the command to get the certificate's
-expiration date to verify that it's been updated.
+   ```bash
+   kubectl rollout restart -n spire statefulset spire-server
+   ```
 
-```bash
-kubectl get secret -n spire spire.spire.ca-tls -o json | jq -r '.data."tls.crt" | @base64d' | openssl x509 -noout -enddate
-```
+   Any spire-agents in the CLBO state should come back into a Running state the
+   next time they're started. If you don't wish to wait for them to be restarted
+   automatically then you can delete the spire-agent pod, which will cause a new
+   one to start up in its place.
+
+1. Re-run the command to get the certificate's expiration date to verify that
+   it's been updated
+
+   ```bash
+   kubectl get secret -n spire spire.spire.ca-tls -o json | jq -r '.data."tls.crt" | @base64d' | openssl x509 -noout -enddate
+   ```

--- a/operations/spire/Update_Spire_Intermediate_CA_Certificate.md
+++ b/operations/spire/Update_Spire_Intermediate_CA_Certificate.md
@@ -1,0 +1,48 @@
+# Update Spire intermediate CA certificate
+
+Prior to CSM 1.2.5 there is no mechanism to automatically update the spire
+intermediate CA certificate before it expires. This certificate expires after
+one year. Administrators will want to keep track of when this certificate
+expires and manually update the certificate before it expires.
+
+## How to obtain the expiration date for the Spire intermediate CA
+
+To obtain the expiration date of the Spire intermediate CA certificate, run the
+following command on a node that has access to kubectl (Such as ncn-m001)
+
+```bash
+kubectl get secret -n spire spire.spire.ca-tls -o json | jq -r '.data."tls.crt" | @base64d' | openssl x509 -noout -enddate
+```
+
+## How to replace the Spire intermediate CA certificate with a new one
+
+In order to replace the expired or soon to expire Spire intermediate CA
+certificate you need to delete the secret that stores the certificate and then
+re-run the job that obtains the certificate and creates the secret.
+
+```bash
+SPIRE_INTERMEDIATE_JOB=$(kubectl get job -n vault -o name| grep 'spire-intermediate' | tail -n1)
+kubectl get secrets -n spire spire.spire.ca-tls -o yaml > spire.spire.ca-tls.yaml.bak
+kubectl delete secret -n spire spire.spire.ca-tls
+kubectl get -n vault "$SPIRE_INTERMEDIATE_JOB" -o json | jq 'del(.spec.selector,.spec.template.metadata.labels)' | kubectl replace --force -f -
+```
+
+After the `spire.spire.ca-tls` secret in the `spire` namespace has been
+repopulated you should roll the spire-server to make sure all of them pick up
+the new CA.
+
+```bash
+kubectl rollout restart -n spire statefulset spire-server
+```
+
+Any spire-agents in the CLBO state should come back into a Running state the
+next time they're started. If you don't wish to wait for them to be restarted
+automatically then you can delete the spire-agent pod, which will cause a new
+one to start up in its place.
+
+After this is done you can then rerun the command to get the certificate's
+expiration date to verify that it's been updated.
+
+```bash
+kubectl get secret -n spire spire.spire.ca-tls -o json | jq -r '.data."tls.crt" | @base64d' | openssl x509 -noout -enddate
+```


### PR DESCRIPTION
This adds documentation on how to replace the Spire intermediate CA cert if it's expired or close to becoming expired. This was the method used to Fix Odin in [CASMTRIAGE-3127](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3127).