### PR TITLE
CASMPET-5082 Add spire int ca regen steps

### DIFF
--- a/operations/index.md
+++ b/operations/index.md
@@ -643,6 +643,7 @@ Spire provides the ability to authenticate nodes and workloads, and to securely 
 
   * [Restore Spire Postgres without a Backup](spire/Restore_Spire_Postgres_without_a_Backup.md)
   * [Troubleshoot Spire Failing to Start on NCNs](spire/Troubleshoot_Spire_Failing_to_Start_on_NCNs.md)
+  * [Update Spire Intermediate CA Certificate](spire/Update_Spire_Intermediate_CA_Certificate.md)
 
 
 <a name="update-firmware-with-fas"></a>

--- a/operations/spire/Update_Spire_Intermediate_CA_Certificate.md
+++ b/operations/spire/Update_Spire_Intermediate_CA_Certificate.md
@@ -17,7 +17,7 @@ kubectl get secret -n spire spire.spire.ca-tls -o json | jq -r '.data."tls.crt" 
 
 ## Replace the Spire Intermediate CA Certificate
 
-1. Delete the secret that stores the certificate
+1. Delete the secret that stores the certificate.
 
    ```bash
    SPIRE_INTERMEDIATE_JOB=$(kubectl get job -n vault -o name| grep 'spire-intermediate' | tail -n1)
@@ -25,7 +25,7 @@ kubectl get secret -n spire spire.spire.ca-tls -o json | jq -r '.data."tls.crt" 
    kubectl delete secret -n spire spire.spire.ca-tls
    ```
 
-1. Rerun the job that obtains the secret and creates the certificate
+1. Re-run the job that obtains the secret and creates the certificate.
 
    ```bash
    kubectl get -n vault "$SPIRE_INTERMEDIATE_JOB" -o json | jq 'del(.spec.selector,.spec.template.metadata.labels)' | kubectl replace --force -f -
@@ -45,7 +45,7 @@ kubectl get secret -n spire spire.spire.ca-tls -o json | jq -r '.data."tls.crt" 
    one to start up in its place.
 
 1. Re-run the command to get the certificate's expiration date to verify that
-   it's been updated
+   it's been updated.
 
    ```bash
    kubectl get secret -n spire spire.spire.ca-tls -o json | jq -r '.data."tls.crt" | @base64d' | openssl x509 -noout -enddate

--- a/operations/spire/Update_Spire_Intermediate_CA_Certificate.md
+++ b/operations/spire/Update_Spire_Intermediate_CA_Certificate.md
@@ -2,7 +2,7 @@
 
 Starting with CSM 1.2.5, there is a cronjob in the `vault` namespace named
 `spire-intermediate` that runs once a week. If the Spire intermediate CA
-certificate is set to expire in less than a month when that job runs then it
+certificate is set to expire in less than a month when that job runs, then it
 will replace the certificate with a new one. If this process fails you can
 take the manual steps listed below in order to update the certificate.
 

--- a/operations/spire/Update_Spire_Intermediate_CA_Certificate.md
+++ b/operations/spire/Update_Spire_Intermediate_CA_Certificate.md
@@ -6,7 +6,7 @@ certificate is set to expire in less than a month when that job runs, then it
 will replace the certificate with a new one. If this process fails you can
 take the manual steps listed below in order to update the certificate.
 
-## How to obtain the expiration date for the Spire intermediate CA
+## Obtain the Expiration Date for the Spire Intermediate CA
 
 To obtain the expiration date of the Spire intermediate CA certificate, run the
 following command on a node that has access to kubectl (Such as ncn-m001)

--- a/operations/spire/Update_Spire_Intermediate_CA_Certificate.md
+++ b/operations/spire/Update_Spire_Intermediate_CA_Certificate.md
@@ -15,7 +15,7 @@ following command on a node that has access to `kubectl` (such as `ncn-m001`):
 kubectl get secret -n spire spire.spire.ca-tls -o json | jq -r '.data."tls.crt" | @base64d' | openssl x509 -noout -enddate
 ```
 
-## How to replace the Spire intermediate CA certificate with a new one
+## Replace the Spire Intermediate CA Certificate
 
 In order to replace the expired or soon to expire Spire intermediate CA
 certificate you need to delete the secret that stores the certificate and then

--- a/operations/spire/Update_Spire_Intermediate_CA_Certificate.md
+++ b/operations/spire/Update_Spire_Intermediate_CA_Certificate.md
@@ -1,0 +1,49 @@
+# Update Spire intermediate CA certificate
+
+Starting with CSM 1.2.5, there is a cronjob in the `vault` namespace named
+`spire-intermediate` that runs once a week. If the Spire intermediate CA
+certificate is set to expire in less than a month when that job runs then it
+will replace the certificate with a new one. If this process fails you can
+take the manual steps listed below in order to update the certificate.
+
+## How to obtain the expiration date for the Spire intermediate CA
+
+To obtain the expiration date of the Spire intermediate CA certificate, run the
+following command on a node that has access to kubectl (Such as ncn-m001)
+
+```bash
+kubectl get secret -n spire spire.spire.ca-tls -o json | jq -r '.data."tls.crt" | @base64d' | openssl x509 -noout -enddate
+```
+
+## How to replace the Spire intermediate CA certificate with a new one
+
+In order to replace the expired or soon to expire Spire intermediate CA
+certificate you need to delete the secret that stores the certificate and then
+re-run the job that obtains the certificate and creates the secret.
+
+```bash
+SPIRE_INTERMEDIATE_JOB=$(kubectl get job -n vault -o name| grep 'spire-intermediate' | tail -n1)
+kubectl get secrets -n spire spire.spire.ca-tls -o yaml > spire.spire.ca-tls.yaml.bak
+kubectl delete secret -n spire spire.spire.ca-tls
+kubectl get -n vault "$SPIRE_INTERMEDIATE_JOB" -o json | jq 'del(.spec.selector,.spec.template.metadata.labels)' | kubectl replace --force -f -
+```
+
+After the `spire.spire.ca-tls` secret in the `spire` namespace has been
+repopulated you should roll the spire-server to make sure all of them pick up
+the new CA.
+
+```bash
+kubectl rollout restart -n spire statefulset spire-server
+```
+
+Any spire-agents in the CLBO state should come back into a Running state the
+next time they're started. If you don't wish to wait for them to be restarted
+automatically then you can delete the spire-agent pod, which will cause a new
+one to start up in its place.
+
+After this is done you can then rerun the command to get the certificate's
+expiration date to verify that it's been updated.
+
+```bash
+kubectl get secret -n spire spire.spire.ca-tls -o json | jq -r '.data."tls.crt" | @base64d' | openssl x509 -noout -enddate
+```

--- a/operations/spire/Update_Spire_Intermediate_CA_Certificate.md
+++ b/operations/spire/Update_Spire_Intermediate_CA_Certificate.md
@@ -17,33 +17,36 @@ kubectl get secret -n spire spire.spire.ca-tls -o json | jq -r '.data."tls.crt" 
 
 ## Replace the Spire Intermediate CA Certificate
 
-In order to replace the expired or soon to expire Spire intermediate CA
-certificate you need to delete the secret that stores the certificate and then
-re-run the job that obtains the certificate and creates the secret.
+1. Delete the secret that stores the certificate
 
-```bash
-SPIRE_INTERMEDIATE_JOB=$(kubectl get job -n vault -o name| grep 'spire-intermediate' | tail -n1)
-kubectl get secrets -n spire spire.spire.ca-tls -o yaml > spire.spire.ca-tls.yaml.bak
-kubectl delete secret -n spire spire.spire.ca-tls
-kubectl get -n vault "$SPIRE_INTERMEDIATE_JOB" -o json | jq 'del(.spec.selector,.spec.template.metadata.labels)' | kubectl replace --force -f -
-```
+   ```bash
+   SPIRE_INTERMEDIATE_JOB=$(kubectl get job -n vault -o name| grep 'spire-intermediate' | tail -n1)
+   kubectl get secrets -n spire spire.spire.ca-tls -o yaml > spire.spire.ca-tls.yaml.bak
+   kubectl delete secret -n spire spire.spire.ca-tls
+   ```
 
-After the `spire.spire.ca-tls` secret in the `spire` namespace has been
-repopulated you should roll the spire-server to make sure all of them pick up
-the new CA.
+1. Rerun the job that obtains the secret and creates the certificate
 
-```bash
-kubectl rollout restart -n spire statefulset spire-server
-```
+   ```bash
+   kubectl get -n vault "$SPIRE_INTERMEDIATE_JOB" -o json | jq 'del(.spec.selector,.spec.template.metadata.labels)' | kubectl replace --force -f -
+   ```
 
-Any spire-agents in the CLBO state should come back into a Running state the
-next time they're started. If you don't wish to wait for them to be restarted
-automatically then you can delete the spire-agent pod, which will cause a new
-one to start up in its place.
+1. After the `spire.spire.ca-tls` secret in the `spire` namespace has been
+   repopulated you should roll the spire-server to make sure all of them pick up
+   the new CA.
 
-After this is done you can then rerun the command to get the certificate's
-expiration date to verify that it's been updated.
+   ```bash
+   kubectl rollout restart -n spire statefulset spire-server
+   ```
 
-```bash
-kubectl get secret -n spire spire.spire.ca-tls -o json | jq -r '.data."tls.crt" | @base64d' | openssl x509 -noout -enddate
-```
+   Any spire-agents in the CLBO state should come back into a Running state the
+   next time they're started. If you don't wish to wait for them to be restarted
+   automatically then you can delete the spire-agent pod, which will cause a new
+   one to start up in its place.
+
+1. Re-run the command to get the certificate's expiration date to verify that
+   it's been updated
+
+   ```bash
+   kubectl get secret -n spire spire.spire.ca-tls -o json | jq -r '.data."tls.crt" | @base64d' | openssl x509 -noout -enddate
+   ```

--- a/operations/spire/Update_Spire_Intermediate_CA_Certificate.md
+++ b/operations/spire/Update_Spire_Intermediate_CA_Certificate.md
@@ -1,4 +1,4 @@
-# Update Spire intermediate CA certificate
+# Update Spire Intermediate CA Certificate
 
 Starting with CSM 1.2.5, there is a cronjob in the `vault` namespace named
 `spire-intermediate` that runs once a week. If the Spire intermediate CA

--- a/operations/spire/Update_Spire_Intermediate_CA_Certificate.md
+++ b/operations/spire/Update_Spire_Intermediate_CA_Certificate.md
@@ -9,7 +9,7 @@ take the manual steps listed below in order to update the certificate.
 ## Obtain the Expiration Date for the Spire Intermediate CA
 
 To obtain the expiration date of the Spire intermediate CA certificate, run the
-following command on a node that has access to kubectl (Such as ncn-m001)
+following command on a node that has access to `kubectl` (such as `ncn-m001`):
 
 ```bash
 kubectl get secret -n spire spire.spire.ca-tls -o json | jq -r '.data."tls.crt" | @base64d' | openssl x509 -noout -enddate


### PR DESCRIPTION
This adds documentation on how to replace the Spire intermediate CA cert if it's expired or close to becoming expired. This was the method used to Fix Odin in [CASMTRIAGE-3127](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3127).