### PR TITLE
MTL-1647: adjust docs to account for no default root password/keys

### DIFF
--- a/install/deploy_final_ncn.md
+++ b/install/deploy_final_ncn.md
@@ -125,23 +125,9 @@ the Kubernetes cluster as the final of three master nodes forming a quorum.
 
     1. Set the variables.
 
-        **IMPORTANT:** The variables you set depend on whether you customized the default NCN images. The most
-        common procedures that involve customizing the images are
-        [Configuring NCN Images to Use Local Timezone](../operations/node_management/Configure_NTP_on_NCNs.md#configure_ncn_images_to_use_local_timezone) and
-        [Changing NCN Image Root Password and SSH Keys on PIT Node](../operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md).
-        The two paths forward are listed below:
-
-        * If the NCN images were customized, set the following variables:
-
-            ```bash
-            pit# artdir=/var/www/ephemeral/data ; k8sdir=$artdir/k8s ; cephdir=$artdir/ceph
-            ```
-
-        * If the NCN images were **not** customized, set the following variables:
-
-            ```bash
-            pit# artdir=${CSM_PATH}/images ; k8sdir=$artdir/kubernetes ; cephdir=$artdir/storage-ceph
-            ```
+        ```bash
+        pit# artdir=/var/www/ephemeral/data ; k8sdir=$artdir/k8s ; cephdir=$artdir/ceph
+        ```
 
     1. Run the following command.
 

--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -263,13 +263,11 @@ The configuration workflow described here is intended to help understand the exp
 <a name="deploy"></a>
 ### 3.2 Deploy
 
-1. Change the default root password and SSH keys
+1. Set the default root password and SSH keys and optionally change the timezone
 
-   The management nodes deploy with a default password in the image, so it is a recommended best
-   practice for system security to change the root password in the image so that it is
-   not the documented default password.
+   The management nodes images do not contain a default password or default ssh keys.
 
-   It is **strongly encouraged** to change the default root password and SSH keys in the images used to boot the management nodes.
+   It is **required** to set the default root password and SSH keys in the images used to boot the management nodes.
    Follow the NCN image customization steps in [Change NCN Image Root Password and SSH Keys on PIT Node](../operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md)
 
 1. Create boot directories for any NCN in DNS This will create folders for each host in `/var/www`, allowing each host to have their own unique set of artifacts; kernel, initrd, SquashFS, and `script.ipxe` bootscript.

--- a/operations/node_management/Configure_NTP_on_NCNs.md
+++ b/operations/node_management/Configure_NTP_on_NCNs.md
@@ -344,7 +344,6 @@ Adjust the node images so that they also boot in the local timezone. This is acc
 [Change NCN Image Root Password and SSH Keys on PIT Node](../security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md)
 for more information.
 
-   **Note:** Make a note that when performing the [csi handoff of NCN boot artifacts in Deploy Final NCN](../../install/deploy_final_ncn.md#ncn-boot-artifacts-hand-off), you must be sure to specify these new images. Otherwise ncn-m001 will use the default timezone when it boots, and subsequent reboots of the other NCNs will also lose the customized timezone changes.
 1. If the PIT node is not booted, see
 [Change NCN Image Root Password and SSH Keys](../security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md)
 for more information.

--- a/operations/security_and_authentication/Update_NCN_Passwords.md
+++ b/operations/security_and_authentication/Update_NCN_Passwords.md
@@ -1,15 +1,8 @@
-# Update NCN User Passwords
+# Set NCN User Passwords
 
-The management nodes deploy with a default password in the image, so it is a recommended best
-practice for system security to change the root password in the image so that it is
-not the documented default password. In addition to the root password in the image, NCN
-personalization should be used to change the password as part of post-boot CFS.  The password
-in the image should be used when console access is desired during the network boot of a management
-node that is being rebuilt, but this password should be different than the one stored in Vault
-that is applied by CFS during post-boot NCN personalization to change the on-disk password. Once
-NCN personalization has been run, then the password in Vault should be used for console access.
+The management node image do not contain a default root password or default ssh keys.
 
-Use one of these methods to change the root pasword in the image.
+Use one of these methods to change or set the root pasword in the image.
 
 1. If the PIT node is booted, see
 [Change NCN Image Root Password and SSH Keys on PIT Node](Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md)

--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -255,17 +255,11 @@ To prevent any possibility of losing Workload Manager configuration data or file
 ## Stage 0.9 - Modify NCN Images
 
 Any site modifications to the images used to boot the management nodes need to be done again
-as part of this upgrade. These may include changing the root password, adding different ssh
-keys for the root account, or setting a default timezone.
+as part of this upgrade. This include setting the root password, adding ssh keys for the root
+account, and setting a default timezone.
 
-The management nodes deploy with a default password in the image, so it is a recommended best
-practice for system security to change the root password in the image so that it is
-not the documented default password. In addition to the root password in the image, NCN
-personalization should be used to change the password as part of post-boot CFS. The password
-in the image should be used when console access is desired during the network boot of a management
-node that is being rebuilt, but this password should be different than the one stored in Vault
-that is applied by CFS during post-boot NCN personalization to change the on-disk password. Once
-NCN personalization has been run, then the password in Vault should be used for console access.
+The management nodes images do not contain a default password or ssh keys, so it is a requirement
+that they be set and added at this time.
 
 1. Use this procedure to change the k8s-image used for master nodes and worker nodes and the ceph-image
 used by utility storage nodes. See


### PR DESCRIPTION
## Summary and Scope

Adjust docs to account for no default root password/keys