### PR TITLE
CASMINST-4330: Update 1.2 upgrade stage 0 for disabling CFS

### DIFF
--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -235,14 +235,16 @@ To prevent any possibility of losing configuration data, backup the VCS data and
 ## Stage 0.7 - Suspend NCN Configuration
 
 Suspend automatic reconfiguration on NCNs to ensure that previous CSM version
-configuration is not applied during the upgrade. Automatic reconfiguration
-will be re-enabled in [Stage 5](Stage_5.md).
+configuration is not applied during the upgrade. The desired configuration is
+also unset so that actions that re-enable CFS, such as rebooting nodes, do 
+not trigger configuration early.  Automatic reconfiguration will be re-enabled,
+and the desired configuration will be set again in [Stage 5](Stage_5.md).
 
    ```bash
    ncn# export CRAY_FORMAT=json
    ncn# for xname in $(cray hsm state components list --role Management --type node | jq -r .Components[].ID)
    do
-       cray cfs components update --enabled false $xname
+       cray cfs components update --enabled false --desired-config "" $xname
    done
 ```
 


### PR DESCRIPTION
## Summary and Scope

Just disabling components in CFS is not sufficient, since steps taken between stage 0 and stage 5 reboot nodes and cause CFS to become re-enabled.  This updates the documentation to unset the desired configuration in stage 0 as well.

Stage 5 already includes steps to set the desired configuration, so no changes are needed there.

## Issues and Related PRs

* Resolves CASMINST-4330

## Testing

### Tested on:

  * Mug

### Test description:

- Tested the updated command on mug.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

