### PR TITLE
always set metal.no-wipe=1 during rerun

### DIFF
--- a/upgrade/1.2/scripts/common/ncn-rebuild-common.sh
+++ b/upgrade/1.2/scripts/common/ncn-rebuild-common.sh
@@ -270,17 +270,16 @@ if [[ $target_ncn != ncn-s* ]]; then
     wait_for_kubernetes $target_ncn
 fi 
 
-state_name="SET_BSS_NO_WIPE"
-state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
-if [[ $state_recorded == "0" ]]; then
-    echo "====> ${state_name} ..."
-
+set +e
+while true ; do    
     csi handoff bss-update-param --set metal.no-wipe=1 --limit $TARGET_XNAME
-
-    record_state "${state_name}" ${target_ncn}
-else
-    echo "====> ${state_name} has been completed"
-fi
+    if [[ $? -eq 0 ]]; then
+        break
+    else
+        sleep 5
+    fi
+done
+set -e
 
 if [[ ${target_ncn} == "ncn-m001" ]]; then
     state_name="RESTORE_M001_NET_CONFIG"


### PR DESCRIPTION
## Summary and Scope
because of refactoring, metal.no-wipe=0 is not in a state wrapper so when it reruns, it always flip back to metal.no-wipe=0. the fix is to move metal.no-wipe=1 out of a state wrapper so we make sure rerun will always set metal.no-wipe=1

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

