### PR TITLE
Adding known issue for test failures for ceph csi k8s reqs

### DIFF
--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -76,25 +76,26 @@ There are multiple Goss test suites available that cover a variety of subsystems
     ncn/pit# export SW_ADMIN_PASSWORD='changeme'
     ```
 
-1. Run the NCN health checks.
+2. Run the NCN health checks.
 
     ```bash
     ncn/pit# /opt/cray/tests/install/ncn/automated/ncn-healthcheck
     ```
 
-1. Run the Kubernetes checks.
+3. Run the Kubernetes checks.
 
     ```bash
     ncn/pit# /opt/cray/tests/install/ncn/automated/ncn-kubernetes-checks
     ```
 
-1. Review results.
+4. Review results.
 
     Review the output for `Result: FAIL` and follow the instructions provided to resolve any such test failures. With the exception of the [Known Test Issues](#autogoss-issues), all health checks are expected to pass.
 
 <a name="autogoss-issues"></a>
 #### 1.1.1 Known Test Issues
 
+* It is possible that the first pass of running these tests may fail due to could-init not being completed on the storage nodes.  In this case please wait 5 minutes and re-run the tests.
 * Kubernetes Query BSS Cloud-init for ca-certs
   - This test may fail immediately after platform install. It should pass after the TrustedCerts Operator has updated BSS (Global cloud-init meta) with CA certificates.
 * Kubernetes Velero No Failed Backups

--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -76,19 +76,19 @@ There are multiple Goss test suites available that cover a variety of subsystems
     ncn/pit# export SW_ADMIN_PASSWORD='changeme'
     ```
 
-2. Run the NCN health checks.
+1. Run the NCN health checks.
 
     ```bash
     ncn/pit# /opt/cray/tests/install/ncn/automated/ncn-healthcheck
     ```
 
-3. Run the Kubernetes checks.
+1. Run the Kubernetes checks.
 
     ```bash
     ncn/pit# /opt/cray/tests/install/ncn/automated/ncn-kubernetes-checks
     ```
 
-4. Review results.
+1. Review results.
 
     Review the output for `Result: FAIL` and follow the instructions provided to resolve any such test failures. With the exception of the [Known Test Issues](#autogoss-issues), all health checks are expected to pass.
 


### PR DESCRIPTION
## Summary and Scope

This is to address known issue where we occasionally run the test
prior to cloud-init being fully completed on the storage nodes

## Issues and Related PRs

* Resolves CASMINST-4356

## Testing

### Tested on:

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

