### PR TITLE
CASMINST-3781 war if bootraid artifacts script fails 

### DIFF
--- a/install/redeploy_pit_node.md
+++ b/install/redeploy_pit_node.md
@@ -606,6 +606,14 @@ Perform the following steps **on `ncn-m001`**.
     ncn-m001# /opt/cray/tests/install/ncn/scripts/validate-bootraid-artifacts.sh
     ```
 
+1. If the above fails with messages about ` Host key verification failed`, clear them from the `known_hosts`:
+
+    This script will perform the check on all NCNs, including `ncn-m001`.
+
+    ```
+    ncn-m001# for ncn in $(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u); do ssh-keygen -R $ncn;done
+    ```
+
 <a name="next-topic"></a>
 # Next Topic
 


### PR DESCRIPTION

Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>

## Summary and Scope

Removes the offending `known_hosts` after a rebuild.

## Issues and Related PRs

* Resolves CASMINST-3781

## Testing

Verified the command to get the NCN names worked.

### Tested on:

  * `redbull`

## Risks and Mitigations
 
Low. WAR

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

