### PR TITLE
CASMINST-4290 - Add wait for rgw to be started on upgraded node

### DIFF
--- a/upgrade/1.2/scripts/upgrade/ncn-upgrade-ceph-nodes.sh
+++ b/upgrade/1.2/scripts/upgrade/ncn-upgrade-ceph-nodes.sh
@@ -158,6 +158,19 @@ fi
 . /usr/share/doc/csm/upgrade/1.2/scripts/ceph/lib/ceph-health.sh
 wait_for_health_ok
 
+# Wait for rgw to start before executing goss tests
+target_ncn=ncn-s001
+rgw_counter=0
+until [[ $(ceph orch ps --daemon_type rgw ${target_ncn} --format json-pretty|jq -r '.[].status_desc') == "running" ]]
+do
+  sleep 30
+  let rgw_counter+=1
+  if rgw_counter -gt 10
+  then
+    exit 1
+  fi
+done
+
 if [[ ${target_ncn} == "ncn-s001" ]]; then
     state_name="POST_CEPH_IMAGE_UPGRADE_BUCKETS"
     state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})


### PR DESCRIPTION
## Summary and Scope
This will allow the rgw process to start and us not enter a race condition where the goss test is checking for a process that does not get spawned until after the cluster is healthy

## Issues and Related PRs

* Resolves CASMINST-4920

## Testing
tested the logic out on a craystack instance

### Tested on:

  * craystack

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

