### PR TITLE
CASMINST-4384: Remove superfluous manual command; validate df command output

### DIFF
--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -208,7 +208,6 @@ ncn-m001# export SW_ADMIN_PASSWORD=sw1tCH@DM1Np4s5w0rd
 **`IMPORTANT:`** If the `NEXUS_PASSWORD` environment variable was set as previously mentioned, then remove it before continuing:
 
 ```bash
-ncn-m001# export -n NEXUS_PASSWORD
 ncn-m001# unset NEXUS_PASSWORD
 ```
 

--- a/upgrade/1.2/scripts/upgrade/prepare-assets.sh
+++ b/upgrade/1.2/scripts/upgrade/prepare-assets.sh
@@ -75,7 +75,11 @@ if [[ -z ${TARBALL_FILE} ]]; then
     # Ensure we have enough disk space
     reqSpace=80000000 # ~80GB
     availSpace=$(df "$HOME" | awk 'NR==2 { print $4 }')
-    if (( availSpace < reqSpace )); then
+    # Validate that we received a nonnegative integer for the amount of available space
+    if ! [[ $availSpace =~ ^(0|[1-9][0-9]*)$ ]]; then
+        echo "ERROR: Invalid free space reported by df command: $availSpace"
+        exit 1
+    elif (( availSpace < reqSpace )); then
         echo "Not enough space; required: $reqSpace, available space: $availSpace" >&2
         exit 1
     fi


### PR DESCRIPTION
This PR contains two small changes:
1. Remove an unnecessary manual command in the upgrade docs.
2. Add a check of the df command output to an upgrade script

I have tested both to verify that the command is indeed superfluous and to validate that the df output check works as expected.