### PR TITLE
CASMINST-4387 Add markdown linter to docs-csm [1.0]

### DIFF
--- a/.github/workflows/markdown-lint.yaml
+++ b/.github/workflows/markdown-lint.yaml
@@ -1,0 +1,35 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+name: Check Markdown Style
+
+on: push
+
+jobs:
+  markdown-style-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: docker://ghcr.io/igorshubovych/markdownlint-cli:v0.31.1
+      with:
+        args: "--config /github/workspace/.markdownlint.yaml /github/workspace/**/*.md"

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,76 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# * Please refer to https://github.com/DavidAnson/markdownlint/blob/main/schema/.markdownlint.yaml for full description.
+# * Rules listed below can use numeric (MD013) or mnemonic (line-length) section names.
+# * If section value is a scalar set to "false", rule is disabled.
+# * If section value is a scalar set to "true", rule is enabled, with default settings.
+# * If section value is not a scalar, rule is enabled, with settings defined by respective fields.
+# * Linter can be executed locally using the following command:
+#
+#        docker run -v $PWD:/workdir ghcr.io/igorshubovych/markdownlint-cli:latest "**/*.md"
+#
+# * Some violations (marked as "can be fixed automatically") can be fixed automatically, by running linter in fix mode:
+#
+#        docker run -v $PWD:/workdir ghcr.io/igorshubovych/markdownlint-cli:latest --fix "**/*.md"
+#
+default: true
+blanks-around-fences: false
+blanks-around-headings: false
+blanks-around-lists: false
+code-block-style: false
+commands-show-output: false         # can be fixed automatically
+emphasis-style: false
+fenced-code-language: false
+first-line-heading: false
+heading-increment: false
+heading-start-left: false
+heading-style: true
+hr-style: true
+line-length:
+    line_length: 1600
+list-indent: false
+list-marker-space: false
+no-alt-text: false
+no-bare-urls: false
+no-blanks-blockquote: false
+no-duplicate-heading: false
+no-emphasis-as-heading: false
+no-empty-links: false
+no-hard-tabs: false                 # can be fixed automatically
+no-inline-html: false
+no-missing-space-atx: false         # can be fixed automatically
+no-multiple-blanks: false
+no-multiple-space-atx: false        # can be fixed automatically
+no-multiple-space-blockquote: false # can be fixed automatically
+no-space-in-code: false             # can be fixed automatically
+no-space-in-emphasis: false         # can be fixed automatically
+no-space-in-links: false
+no-trailing-punctuation: false      # can be fixed automatically
+no-trailing-spaces: false
+ol-prefix: false
+single-title: false
+single-trailing-newline: false      # can be fixed automatically
+strong-style: false                 # can be fixed automatically
+ul-indent: false
+ul-style: false


### PR DESCRIPTION
## Summary and Scope

Adds markdown linter. Initial configuration very permissive. The plan is to tighten restrictions one by one, by turning them on in configuration file and fixing violations.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMINST-4387

## Testing
Successful run:
https://github.com/Cray-HPE/docs-csm/runs/5762333785?check_suite_focus=true

Unsuccessful run to exclude false positive (line length limit is temporarily decreased to 999 chars):
https://github.com/Cray-HPE/docs-csm/runs/5762323018?check_suite_focus=true

### Tested on:

  * github runners

### Test description:

Performed run with current configuration (successful) and temporarily tightened configuration (unsuccessfull).

## Risks and Mitigations

Minimal - optional CI/CD check

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

