### PR TITLE
CASMINST-4325 - adding retry note for rare error during storage node …

### DIFF
--- a/upgrade/1.2/Stage_1.md
+++ b/upgrade/1.2/Stage_1.md
@@ -12,7 +12,7 @@
 
     ```text
     ====> REDEPLOY_CEPH ...
-    /usr/bin/ssh-copy-id: INFO: Source of key(s) to be installed: "/root/ceph.pub"Number of key(s) added: Now try logging into the machine, with:   "ssh 'root@ncn-s003'"
+    /usr/bin/ssh-copy-id: INFO: Source of key(s) to be installed: "/root/ceph.pub"Number of key(s) added: 1 Now try logging into the machine, with:   "ssh 'root@ncn-s003'"
     and check to make sure that only the key(s) you wanted were added.Error EINVAL: Traceback (most recent call last):
     ```
 

--- a/upgrade/1.2/Stage_1.md
+++ b/upgrade/1.2/Stage_1.md
@@ -8,7 +8,7 @@
 
     > NOTE: You may need to reset the root password for each node after it is rebooted
 
-    **IMPORTANT:** You may encounter an error like shown below.  If this is the case, just re-run the same command for the node upgrade and it will pick up at that point and conitune.
+    **IMPORTANT:** You may encounter an error like the one shown below. If this is the case, just re-run the same command for the node upgrade and it will pick up at that point and continue.
 
     ```text
     ====> REDEPLOY_CEPH ...

--- a/upgrade/1.2/Stage_1.md
+++ b/upgrade/1.2/Stage_1.md
@@ -12,7 +12,7 @@
 
     ```text
     ====> REDEPLOY_CEPH ...
-    /usr/bin/ssh-copy-id: INFO: Source of key(s) to be installed: "/root/ceph.pub"Number of key(s) added: 1Now try logging into the machine, with:   "ssh 'root@ncn-s003'"
+    /usr/bin/ssh-copy-id: INFO: Source of key(s) to be installed: "/root/ceph.pub"Number of key(s) added: Now try logging into the machine, with:   "ssh 'root@ncn-s003'"
     and check to make sure that only the key(s) you wanted were added.Error EINVAL: Traceback (most recent call last):
     ```
 

--- a/upgrade/1.2/Stage_1.md
+++ b/upgrade/1.2/Stage_1.md
@@ -8,6 +8,14 @@
 
     > NOTE: You may need to reset the root password for each node after it is rebooted
 
+    **IMPORTANT:** You may encounter an error like shown below.  If this is the case, just re-run the same command for the node upgrade and it will pick up at that point and conitune.
+
+    ```text
+    ====> REDEPLOY_CEPH ...
+    /usr/bin/ssh-copy-id: INFO: Source of key(s) to be installed: "/root/ceph.pub"Number of key(s) added: 1Now try logging into the machine, with:   "ssh 'root@ncn-s003'"
+    and check to make sure that only the key(s) you wanted were added.Error EINVAL: Traceback (most recent call last):
+    ```
+
 **IMPORTANT:** Ensure the Ceph cluster is healthy prior to continuing. If you have processes not running, then refer to [Utility Storage Operations](../../operations/utility_storage/Utility_Storage.md) for operational and troubleshooting procedures.
 
 1. Repeat the previous step for each other storage node, one at a time.


### PR DESCRIPTION
## Summary and Scope

CASMINST-4325 - adding retry note for rare error during storage node upgrade

I was not able to reproduce the error to locate the source and it is very rare that we come across this.


## Issues and Related PRs

* Resolves CASMINST-4325

## Testing

### Tested on:

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
