### PR TITLE
CASMINST-4394 add preflight check after csm service upgrade

### DIFF
--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -24,23 +24,39 @@
 
    - Internet Connected
 
-     ```bash
-     ncn-m001# wget https://storage.googleapis.com/csm-release-public/csm-1.2/docs-csm/docs-csm-latest.noarch.rpm -P /root
+     1. Set the ENDPOINT variable to the URL of the directory containing the CSM release tarball.
 
-     ncn-m001# rpm -Uvh --force /root/docs-csm-latest.noarch.rpm
+        In other words, the full URL to the CSM release tarball will be ${ENDPOINT}${CSM_RELEASE}.tar.gz
 
-     ncn-m001# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version [CSM_RELEASE] --endpoint [ENDPOINT]
-     ```
+        **NOTE** This step is optional for Cray/HPE internal installs.
+
+        ```bash
+        ncn-m001# ENDPOINT=https://put.the/url/here/
+        ```
+
+     1. Run the script
+
+        ```bash
+        ncn-m001# wget https://storage.googleapis.com/csm-release-public/csm-1.2/docs-csm/docs-csm-latest.noarch.rpm -P /root
+
+        ncn-m001# rpm -Uvh --force /root/docs-csm-latest.noarch.rpm
+
+        ncn-m001# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version [CSM_RELEASE] --endpoint [ENDPOINT]
+        ```
 
    - Air Gapped (replace the PATH_TO below with the location of the rpm)
 
-     ```bash
-     ncn-m001# cp [PATH_TO_docs-csm-*.noarch.rpm] /root
+     1. Copy the docs-csm RPM package and CSM release tarball to `ncn-m001`.
+     
+     1. Run the script
 
-     ncn-m001# rpm -Uvh --force /root/docs-csm-*.noarch.rpm
+        ```bash
+        ncn-m001# cp [PATH_TO_docs-csm-*.noarch.rpm] /root
 
-     ncn-m001# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version [CSM_RELEASE] --tarball-file [PATH_TO_CSM_TARBALL_FILE]
-     ```
+        ncn-m001# rpm -Uvh --force /root/docs-csm-*.noarch.rpm
+
+        ncn-m001# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version [CSM_RELEASE] --tarball-file [PATH_TO_CSM_TARBALL_FILE]
+        ```
 
 <a name="reduce-cpu-limits"></a>
 

--- a/upgrade/1.2/Stage_3.md
+++ b/upgrade/1.2/Stage_3.md
@@ -1,13 +1,40 @@
 # Stage 3 - CSM Service Upgrades
 
-**IMPORTANT:**
+1. Install latest document RPM package and prepare assets:
 
-> During this stage there will be a brief (approximately 5 minutes) window where pods with PVCs will not be able to migrate between nodes. This is due to a redeployment of the Ceph csi provisioners into namespaces to accommodate the newer charts and a better upgrade strategy.
+   > The install scripts will look for the RPM in `/root`, so it is important that you copy it there.
 
-Run `csm-upgrade.sh` to deploy upgraded CSM applications and services:
+   ```bash
+    ncn-m002# CSM_RELEASE=csm-1.2.0
+   ```
 
-```bash
-ncn-m002# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/csm-upgrade.sh
-```
+   - Internet Connected
+
+     ```bash
+     ncn-m002# wget https://storage.googleapis.com/csm-release-public/csm-1.2/docs-csm/docs-csm-latest.noarch.rpm -P /root
+
+     ncn-m002# rpm -Uvh --force /root/docs-csm-latest.noarch.rpm
+
+     ncn-m002# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version [CSM_RELEASE] --endpoint [ENDPOINT]
+     ```
+
+   - Air Gapped (replace the PATH_TO below with the location of the rpm)
+
+     ```bash
+     ncn-m002# cp [PATH_TO_docs-csm-*.noarch.rpm] /root
+
+     ncn-m002# rpm -Uvh --force /root/docs-csm-*.noarch.rpm
+
+     ncn-m002# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version [CSM_RELEASE] --tarball-file [PATH_TO_CSM_TARBALL_FILE]
+     ```
+
+1. Run `csm-upgrade.sh` to deploy upgraded CSM applications and services:
+    **IMPORTANT:**
+
+    > During this stage there will be a brief (approximately 5 minutes) window where pods with PVCs will not be able to migrate between nodes. This is due to a redeployment of the Ceph csi provisioners into namespaces to accommodate the newer charts and a better upgrade strategy.
+
+    ```bash
+    ncn-m002# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/csm-upgrade.sh
+    ```
 
 Once `Stage 3` is completed, proceed to [Stage 4](Stage_4.md)

--- a/upgrade/1.2/Stage_3.md
+++ b/upgrade/1.2/Stage_3.md
@@ -2,36 +2,51 @@
 
 1. Prepare assets:
 
-
    ```bash
     ncn-m002# CSM_RELEASE=csm-1.2.0
    ```
 
-   - Internet connected:
+   - Internet Connected
 
-     ```bash
-     ncn-m002# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version ${CSM_RELEASE} --endpoint [ENDPOINT]
-     ```
+     1. Set the ENDPOINT variable to the URL of the directory containing the CSM release tarball.
 
-   - Air gapped (replace the PATH_TO below with the location of the RPM):
+        In other words, the full URL to the CSM release tarball will be ${ENDPOINT}${CSM_RELEASE}.tar.gz
 
-     ```bash
-     ncn-m002# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version ${CSM_RELEASE} --tarball-file [PATH_TO_CSM_TARBALL_FILE]
-     ```
+        **NOTE** This step is optional for Cray/HPE internal installs.
+
+        ```bash
+        ncn-m002# ENDPOINT=https://put.the/url/here/
+        ```
+
+     1. Run the script
+
+        ```bash
+        ncn-m002# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version [CSM_RELEASE] --endpoint [ENDPOINT]
+        ```
+
+   - Air Gapped (replace the PATH_TO below with the location of the CSM release tarball)
+
+     1. Copy CSM release tarball to `ncn-m002`.
+
+     1. Run the script
+
+        ```bash
+        ncn-m002# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version [CSM_RELEASE] --tarball-file [PATH_TO_CSM_TARBALL_FILE]
+        ```
 
 1. Run `csm-upgrade.sh` to deploy upgraded CSM applications and services:
-    **IMPORTANT:**
+   **IMPORTANT:**
 
-    > During this stage there will be a brief (approximately 5 minutes) window where pods with PVCs will not be able to migrate between nodes. This is due to a redeployment of the Ceph csi provisioners into namespaces to accommodate the newer charts and a better upgrade strategy.
+   > During this stage there will be a brief (approximately 5 minutes) window where pods with PVCs will not be able to migrate between nodes. This is due to a redeployment of the Ceph csi provisioners into namespaces to accommodate the newer charts and a better upgrade strategy.
 
-    > Set the `SW_ADMIN_PASSWORD` environment variable to the admin password for the switches. This is needed for post upgrade tests.
+   > Set the `SW_ADMIN_PASSWORD` environment variable to the admin password for the switches. This is needed for post upgrade tests.
 
-    ```bash
-    ncn-m002# export SW_ADMIN_PASSWORD=sw1tCH@DM1Np4s5w0rd
-    ```
+   ```bash
+   ncn-m002# export SW_ADMIN_PASSWORD=sw1tCH@DM1Np4s5w0rd
+   ```
 
-    ```bash
-    ncn-m002# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/csm-upgrade.sh
-    ```
+   ```bash
+   ncn-m002# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/csm-upgrade.sh
+   ```
 
 Once `Stage 3` is completed, proceed to [Stage 4](Stage_4.md)

--- a/upgrade/1.2/Stage_3.md
+++ b/upgrade/1.2/Stage_3.md
@@ -7,7 +7,7 @@
     ncn-m002# CSM_RELEASE=csm-1.2.0
    ```
 
-   - Internet Connected
+   - Internet connected:
 
      ```bash
      ncn-m002# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version ${CSM_RELEASE} --endpoint [ENDPOINT]

--- a/upgrade/1.2/Stage_3.md
+++ b/upgrade/1.2/Stage_3.md
@@ -2,7 +2,6 @@
 
 1. Prepare assets:
 
-   > The install scripts will look for the RPM in `/root`, so it is important that you copy it there.
 
    ```bash
     ncn-m002# CSM_RELEASE=csm-1.2.0

--- a/upgrade/1.2/Stage_3.md
+++ b/upgrade/1.2/Stage_3.md
@@ -1,6 +1,6 @@
 # Stage 3 - CSM Service Upgrades
 
-1. Install latest document RPM package and prepare assets:
+1. Prepare assets:
 
    > The install scripts will look for the RPM in `/root`, so it is important that you copy it there.
 
@@ -11,21 +11,13 @@
    - Internet Connected
 
      ```bash
-     ncn-m002# wget https://storage.googleapis.com/csm-release-public/csm-1.2/docs-csm/docs-csm-latest.noarch.rpm -P /root
-
-     ncn-m002# rpm -Uvh --force /root/docs-csm-latest.noarch.rpm
-
-     ncn-m002# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version [CSM_RELEASE] --endpoint [ENDPOINT]
+     ncn-m002# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version ${CSM_RELEASE} --endpoint [ENDPOINT]
      ```
 
    - Air Gapped (replace the PATH_TO below with the location of the rpm)
 
      ```bash
-     ncn-m002# cp [PATH_TO_docs-csm-*.noarch.rpm] /root
-
-     ncn-m002# rpm -Uvh --force /root/docs-csm-*.noarch.rpm
-
-     ncn-m002# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version [CSM_RELEASE] --tarball-file [PATH_TO_CSM_TARBALL_FILE]
+     ncn-m002# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version ${CSM_RELEASE} --tarball-file [PATH_TO_CSM_TARBALL_FILE]
      ```
 
 1. Run `csm-upgrade.sh` to deploy upgraded CSM applications and services:

--- a/upgrade/1.2/Stage_3.md
+++ b/upgrade/1.2/Stage_3.md
@@ -24,6 +24,12 @@
 
     > During this stage there will be a brief (approximately 5 minutes) window where pods with PVCs will not be able to migrate between nodes. This is due to a redeployment of the Ceph csi provisioners into namespaces to accommodate the newer charts and a better upgrade strategy.
 
+    > Set the `SW_ADMIN_PASSWORD` environment variable to the admin password for the switches. This is needed for post upgrade tests.
+
+    ```bash
+    ncn-m002# export SW_ADMIN_PASSWORD=sw1tCH@DM1Np4s5w0rd
+    ```
+
     ```bash
     ncn-m002# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/csm-upgrade.sh
     ```

--- a/upgrade/1.2/Stage_3.md
+++ b/upgrade/1.2/Stage_3.md
@@ -13,7 +13,7 @@
      ncn-m002# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version ${CSM_RELEASE} --endpoint [ENDPOINT]
      ```
 
-   - Air Gapped (replace the PATH_TO below with the location of the rpm)
+   - Air gapped (replace the PATH_TO below with the location of the RPM):
 
      ```bash
      ncn-m002# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version ${CSM_RELEASE} --tarball-file [PATH_TO_CSM_TARBALL_FILE]

--- a/upgrade/1.2/scripts/common/ncn-common.sh
+++ b/upgrade/1.2/scripts/common/ncn-common.sh
@@ -88,6 +88,7 @@ function drain_node() {
 }
 
 function ssh_keygen_keyscan() {
+    set +e
     local target_ncn ncn_ip known_hosts
     known_hosts="/root/.ssh/known_hosts"
     sed -i 's@pdsh.*@@' $known_hosts
@@ -101,8 +102,10 @@ function ssh_keygen_keyscan() {
     [ $? -ne 0 ] && return 1
     ssh-keygen -R "${ncn_ip}" -f "${known_hosts}" > /dev/null 2>&1
     [ $? -ne 0 ] && return 1
-    ssh-keyscan -H "${target_ncn},${ncn_ip}" >> "${known_hosts}"
-    return $?
+    ssh-keyscan -H "${target_ncn},${ncn_ip}" >> "${known_hosts}"  > /dev/null 2>&1
+    res=$?
+    set -e
+    return $res
 }
 
 function wait_for_kubernetes() {

--- a/upgrade/1.2/scripts/common/ncn-common.sh
+++ b/upgrade/1.2/scripts/common/ncn-common.sh
@@ -30,6 +30,17 @@ trap 'err_report' ERR
 touch /etc/cray/upgrade/csm/myenv
 . /etc/cray/upgrade/csm/myenv
 
+if [[ -z ${LOG_FILE} ]]; then
+    LOG_FILE="$(pwd)/output.log"
+    echo
+    echo
+    echo " ************"
+    echo " *** NOTE ***"
+    echo " ************"
+    echo "LOG_FILE is not specified; use default location: ${LOG_FILE}"
+    echo
+fi
+
 # make an array of all the csm versions that are installed
 IFS=$'\n' \
   read -r -d '' \

--- a/upgrade/1.2/scripts/common/ncn-common.sh
+++ b/upgrade/1.2/scripts/common/ncn-common.sh
@@ -76,7 +76,9 @@ function drain_node() {
    state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
    if [[ $state_recorded == "0" ]]; then
       echo "====> ${state_name} ..."
+      {
       csi automate ncn kubernetes --action delete-ncn --ncn ${target_ncn} --kubeconfig /etc/kubernetes/admin.conf
+      } >> ${LOG_FILE} 2>&1
 
       record_state "${state_name}" ${target_ncn}
       echo
@@ -109,6 +111,7 @@ function wait_for_kubernetes() {
   state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
   if [[ $state_recorded == "0" ]]; then
       echo "====> ${state_name} ..."
+      {
       set +e
       echo "waiting for k8s: $target_ncn ..."
       until csi automate ncn kubernetes --action is-member --ncn $target_ncn --kubeconfig /etc/kubernetes/admin.conf
@@ -118,6 +121,7 @@ function wait_for_kubernetes() {
       # Restore set -e
       set -e
       echo "$target_ncn joined k8s"
+      } >> ${LOG_FILE} 2>&1
 
       record_state "${state_name}" ${target_ncn}
   else

--- a/upgrade/1.2/scripts/common/ncn-common.sh
+++ b/upgrade/1.2/scripts/common/ncn-common.sh
@@ -31,7 +31,7 @@ touch /etc/cray/upgrade/csm/myenv
 . /etc/cray/upgrade/csm/myenv
 
 if [[ -z ${LOG_FILE} ]]; then
-    LOG_FILE="$(pwd)/output.log"
+    export LOG_FILE="$(pwd)/output.log"
     echo
     echo
     echo " ************"

--- a/upgrade/1.2/scripts/common/ncn-rebuild-common.sh
+++ b/upgrade/1.2/scripts/common/ncn-rebuild-common.sh
@@ -54,10 +54,10 @@ if [[ $state_recorded == "0" ]]; then
     echo "====> ${state_name} ..."
     {
     if [[ -z $NONINTERACTIVE ]]; then
-        echo " ****** DATA LOSS ON ${target_ncn} - FRESH OS INSTALL UPON REBOOT ******"
-        echo " ****** BACKUP DATA ON ${target_ncn} TO USB OR OTHER SAFE LOCATION ******"
-        echo " ****** DATA MANAGED BY K8S/CEPH WILL BE BACKED UP/RESTORED AUTOMATICALLY ******"
-        echo "Read and act on above steps. Press Enter key to continue ..."
+        echo " ****** DATA LOSS ON ${target_ncn} - FRESH OS INSTALL UPON REBOOT ******"  >/dev/tty
+        echo " ****** BACKUP DATA ON ${target_ncn} TO USB OR OTHER SAFE LOCATION ******" >/dev/tty
+        echo " ****** DATA MANAGED BY K8S/CEPH WILL BE BACKED UP/RESTORED AUTOMATICALLY ******" >/dev/tty
+        echo "Read and act on above steps. Press Enter key to continue ..." >/dev/tty
         read
     fi
 

--- a/upgrade/1.2/scripts/common/ncn-rebuild-common.sh
+++ b/upgrade/1.2/scripts/common/ncn-rebuild-common.sh
@@ -174,7 +174,7 @@ fi
 bootscript_last_epoch=$(curl -s -k -H "Content-Type: application/json" \
             -H "Authorization: Bearer ${TOKEN}" \
             "https://api-gw-service-nmn.local/apis/bss/boot/v1/endpoint-history?name=$TARGET_XNAME" \
-            | jq '.[]| select(.endpoint=="bootscript")|.last_epoch')
+            | jq '.[]| select(.endpoint=="bootscript")|.last_epoch' 2> /dev/null)
 
 state_name="POWER_CYCLE_NCN"
 state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
@@ -212,7 +212,7 @@ EOF
             tmp_bootscript_last_epoch=$(curl -s -k -H "Content-Type: application/json" \
                 -H "Authorization: Bearer ${TOKEN}" \
                 "https://api-gw-service-nmn.local/apis/bss/boot/v1/endpoint-history?name=$TARGET_XNAME" \
-                | jq '.[]| select(.endpoint=="bootscript")|.last_epoch')
+                | jq '.[]| select(.endpoint=="bootscript")|.last_epoch' 2> /dev/null)
             if [[ $? -eq 0 ]]; then
                 break
             fi

--- a/upgrade/1.2/scripts/common/ncn-rebuild-common.sh
+++ b/upgrade/1.2/scripts/common/ncn-rebuild-common.sh
@@ -199,7 +199,6 @@ state_name="WAIT_FOR_NCN_BOOT"
 state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
 if [[ $state_recorded == "0" ]]; then
     echo "====> ${state_name} ..."
-    {
     # inline tips for watching boot logs
     cat <<EOF
 TIPS:
@@ -210,6 +209,7 @@ EOF
     printf "%s" "waiting for boot: $target_ncn ..."
     while true
     do
+        {
         set +e
         while true
         do
@@ -222,7 +222,7 @@ EOF
             fi
         done
         set -e
-
+        } >> ${LOG_FILE} 2>&1
         if [[ $tmp_bootscript_last_epoch -ne $bootscript_last_epoch ]]; then
             echo "bootscript fetched"
             break
@@ -238,7 +238,7 @@ EOF
         sleep 2
     done
     printf "\n%s\n" "$target_ncn is booted and online"
-    } >> ${LOG_FILE} 2>&1
+    
     record_state "${state_name}" ${target_ncn}
 else
     echo "====> ${state_name} has been completed"
@@ -248,7 +248,7 @@ state_name="WAIT_FOR_CLOUD_INIT"
 state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
 if [[ $state_recorded == "0" ]]; then
     echo "====> ${state_name} ..."
-    {
+    
     sleep 60
     # wait for cloud-init
     # ssh commands are expected to fail for a while, so we temporarily disable set -e
@@ -265,7 +265,7 @@ if [[ $state_recorded == "0" ]]; then
     # Restore set -e
     set -e
     printf "\n%s\n"  "$target_ncn finished cloud-init"
-    } >> ${LOG_FILE} 2>&1
+    
     record_state "${state_name}" ${target_ncn}
 else
     echo "====> ${state_name} has been completed"

--- a/upgrade/1.2/scripts/common/ncn-rebuild-common.sh
+++ b/upgrade/1.2/scripts/common/ncn-rebuild-common.sh
@@ -35,6 +35,7 @@ state_name="CSI_VALIDATE_BSS_NTP"
 state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
 if [[ $state_recorded == "0" && $2 != "--rebuild" ]]; then
     echo "====> ${state_name} ..."
+    {
 
     if ! cray bss bootparameters list --hosts $TARGET_XNAME --format json | jq '.[] |."cloud-init"."user-data".ntp' | grep -q '/etc/chrony.d/cray.conf'; then
         echo "${target_ncn} is missing NTP data in BSS. Please see the procedure which can be found in the 'Known Issues and Bugs' section titled 'Fix BSS Metadata' on the 'Configure NTP on NCNs' page of the CSM documentation."
@@ -42,6 +43,7 @@ if [[ $state_recorded == "0" && $2 != "--rebuild" ]]; then
     else
         record_state "${state_name}" ${target_ncn}
     fi
+    } >> ${LOG_FILE} 2>&1
 else
     echo "====> ${state_name} has been completed"
 fi
@@ -50,12 +52,13 @@ state_name="WIPE_NODE_DISK"
 state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
 if [[ $state_recorded == "0" ]]; then
     echo "====> ${state_name} ..."
-
+    {
     if [[ -z $NONINTERACTIVE ]]; then
         echo " ****** DATA LOSS ON ${target_ncn} - FRESH OS INSTALL UPON REBOOT ******"
         echo " ****** BACKUP DATA ON ${target_ncn} TO USB OR OTHER SAFE LOCATION ******"
         echo " ****** DATA MANAGED BY K8S/CEPH WILL BE BACKED UP/RESTORED AUTOMATICALLY ******"
-        read -p "Read and act on above steps. Press Enter key to continue ..."
+        echo "Read and act on above steps. Press Enter key to continue ..."
+        read
     fi
 
     if [[ $target_ncn == ncn-s* ]]; then
@@ -120,52 +123,52 @@ EOF
     chmod +x wipe_disk.sh
     scp wipe_disk.sh $target_ncn:/tmp/wipe_disk.sh
     ssh $target_ncn '/tmp/wipe_disk.sh'
-
+    } >> ${LOG_FILE} 2>&1
     record_state "${state_name}" ${target_ncn}
 else
     echo "====> ${state_name} has been completed"
 fi
+{
+    target_ncn_mgmt_host="${target_ncn}-mgmt"
+    if [[ ${target_ncn} == "ncn-m001" ]]; then
+        target_ncn_mgmt_host=$(ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ncn-m001 "ipmitool lan print | grep 'IP Address' | grep -v 'Source'"  | awk -F ": " '{print $2}')
+    fi
+    echo "mgmt IP/Host: ${target_ncn_mgmt_host}"
 
-target_ncn_mgmt_host="${target_ncn}-mgmt"
-if [[ ${target_ncn} == "ncn-m001" ]]; then
-    target_ncn_mgmt_host=$(ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ncn-m001 "ipmitool lan print | grep 'IP Address' | grep -v 'Source'"  | awk -F ": " '{print $2}')
-fi
-echo "mgmt IP/Host: ${target_ncn_mgmt_host}"
+    # retrieve IPMI username/password from vault
+    VAULT_TOKEN=$(kubectl get secrets cray-vault-unseal-keys -n vault -o jsonpath={.data.vault-root} | base64 -d)
+    # Make sure we got a vault token
+    [[ -n ${VAULT_TOKEN} ]]
 
-# retrieve IPMI username/password from vault
-VAULT_TOKEN=$(kubectl get secrets cray-vault-unseal-keys -n vault -o jsonpath={.data.vault-root} | base64 -d)
-# Make sure we got a vault token
-[[ -n ${VAULT_TOKEN} ]]
-
-# During worker upgrades, one vault pod might be offline, so we look for one that works.
-# List names of all Running vault pods, grep for just the cray-vault-# pods, and try them in
-# turn until one of them has the IPMI credentials.
-IPMI_USERNAME=""
-IPMI_PASSWORD=""
-for VAULT_POD in $(kubectl get pods -n vault --field-selector status.phase=Running --no-headers \
-                    -o custom-columns=:.metadata.name | grep -E "^cray-vault-(0|[1-9][0-9]*)$") ; do
-    IPMI_USERNAME=$(kubectl exec -it -n vault -c vault ${VAULT_POD} -- sh -c \
-        "export VAULT_ADDR=http://localhost:8200; export VAULT_TOKEN=`echo $VAULT_TOKEN`; \
-        vault kv get -format=json secret/hms-creds/$TARGET_MGMT_XNAME" | 
-        jq -r '.data.Username')
-    # If we are not able to get the username, no need to try and get the password.
-    [[ -n ${IPMI_USERNAME} ]] || continue
-    export IPMI_PASSWORD=$(kubectl exec -it -n vault -c vault ${VAULT_POD} -- sh -c \
-        "export VAULT_ADDR=http://localhost:8200; export VAULT_TOKEN=`echo $VAULT_TOKEN`; \
-        vault kv get -format=json secret/hms-creds/$TARGET_MGMT_XNAME" | 
-        jq -r '.data.Password')
-    break
-done
-# Make sure we found a pod that worked
-[[ -n ${IPMI_USERNAME} ]]
-
+    # During worker upgrades, one vault pod might be offline, so we look for one that works.
+    # List names of all Running vault pods, grep for just the cray-vault-# pods, and try them in
+    # turn until one of them has the IPMI credentials.
+    IPMI_USERNAME=""
+    IPMI_PASSWORD=""
+    for VAULT_POD in $(kubectl get pods -n vault --field-selector status.phase=Running --no-headers \
+                        -o custom-columns=:.metadata.name | grep -E "^cray-vault-(0|[1-9][0-9]*)$") ; do
+        IPMI_USERNAME=$(kubectl exec -it -n vault -c vault ${VAULT_POD} -- sh -c \
+            "export VAULT_ADDR=http://localhost:8200; export VAULT_TOKEN=`echo $VAULT_TOKEN`; \
+            vault kv get -format=json secret/hms-creds/$TARGET_MGMT_XNAME" | 
+            jq -r '.data.Username')
+        # If we are not able to get the username, no need to try and get the password.
+        [[ -n ${IPMI_USERNAME} ]] || continue
+        export IPMI_PASSWORD=$(kubectl exec -it -n vault -c vault ${VAULT_POD} -- sh -c \
+            "export VAULT_ADDR=http://localhost:8200; export VAULT_TOKEN=`echo $VAULT_TOKEN`; \
+            vault kv get -format=json secret/hms-creds/$TARGET_MGMT_XNAME" | 
+            jq -r '.data.Password')
+        break
+    done
+    # Make sure we found a pod that worked
+    [[ -n ${IPMI_USERNAME} ]]
+} >> ${LOG_FILE} 2>&1
 state_name="SET_PXE_BOOT"
 state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
 if [[ $state_recorded == "0" ]]; then
     echo "====> ${state_name} ..."
-    
-    ipmitool -I lanplus -U ${IPMI_USERNAME} -E -H $target_ncn_mgmt_host chassis bootdev pxe options=efiboot
-
+    {
+        ipmitool -I lanplus -U ${IPMI_USERNAME} -E -H $target_ncn_mgmt_host chassis bootdev pxe options=efiboot
+    } >> ${LOG_FILE} 2>&1
     record_state "${state_name}" ${target_ncn}
 else
     echo "====> ${state_name} has been completed"
@@ -180,13 +183,13 @@ state_name="POWER_CYCLE_NCN"
 state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
 if [[ $state_recorded == "0" ]]; then
     echo "====> ${state_name} ..."
-
-    # power cycle node
-    ipmitool -I lanplus -U ${IPMI_USERNAME} -E -H $target_ncn_mgmt_host chassis power off
-    sleep 20
-    ipmitool -I lanplus -U ${IPMI_USERNAME} -E -H $target_ncn_mgmt_host chassis power status
-    ipmitool -I lanplus -U ${IPMI_USERNAME} -E -H $target_ncn_mgmt_host chassis power on
-
+    {
+        # power cycle node
+        ipmitool -I lanplus -U ${IPMI_USERNAME} -E -H $target_ncn_mgmt_host chassis power off
+        sleep 20
+        ipmitool -I lanplus -U ${IPMI_USERNAME} -E -H $target_ncn_mgmt_host chassis power status
+        ipmitool -I lanplus -U ${IPMI_USERNAME} -E -H $target_ncn_mgmt_host chassis power on
+    } >> ${LOG_FILE} 2>&1
     record_state "${state_name}" ${target_ncn}
 else
     echo "====> ${state_name} has been completed"
@@ -196,6 +199,7 @@ state_name="WAIT_FOR_NCN_BOOT"
 state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
 if [[ $state_recorded == "0" ]]; then
     echo "====> ${state_name} ..."
+    {
     # inline tips for watching boot logs
     cat <<EOF
 TIPS:
@@ -234,7 +238,7 @@ EOF
         sleep 2
     done
     printf "\n%s\n" "$target_ncn is booted and online"
-
+    } >> ${LOG_FILE} 2>&1
     record_state "${state_name}" ${target_ncn}
 else
     echo "====> ${state_name} has been completed"
@@ -244,6 +248,7 @@ state_name="WAIT_FOR_CLOUD_INIT"
 state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
 if [[ $state_recorded == "0" ]]; then
     echo "====> ${state_name} ..."
+    {
     sleep 60
     # wait for cloud-init
     # ssh commands are expected to fail for a while, so we temporarily disable set -e
@@ -260,39 +265,44 @@ if [[ $state_recorded == "0" ]]; then
     # Restore set -e
     set -e
     printf "\n%s\n"  "$target_ncn finished cloud-init"
-
+    } >> ${LOG_FILE} 2>&1
     record_state "${state_name}" ${target_ncn}
 else
     echo "====> ${state_name} has been completed"
 fi
 
 if [[ $target_ncn != ncn-s* ]]; then
-    wait_for_kubernetes $target_ncn
+    {
+        wait_for_kubernetes $target_ncn
+    } >> ${LOG_FILE} 2>&1
 fi 
 
-set +e
-while true ; do    
-    csi handoff bss-update-param --set metal.no-wipe=1 --limit $TARGET_XNAME
-    if [[ $? -eq 0 ]]; then
-        break
-    else
-        sleep 5
-    fi
-done
-set -e
+{
+    set +e
+    while true ; do    
+        csi handoff bss-update-param --set metal.no-wipe=1 --limit $TARGET_XNAME
+        if [[ $? -eq 0 ]]; then
+            break
+        else
+            sleep 5
+        fi
+    done
+    set -e
+} >> ${LOG_FILE} 2>&1
 
 if [[ ${target_ncn} == "ncn-m001" ]]; then
     state_name="RESTORE_M001_NET_CONFIG"
     state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
     if [[ $state_recorded == "0" ]]; then
         echo "====> ${state_name} ..."
-
-        if [[ $ssh_keys_done == "0" ]]; then
-            ssh_keygen_keyscan "${target_ncn}"
-            ssh_keys_done=1
-        fi
-        scp ifcfg-lan0 root@ncn-m001:/etc/sysconfig/network/
-        ssh root@ncn-m001 'wicked ifreload lan0'
+        {
+            if [[ $ssh_keys_done == "0" ]]; then
+                ssh_keygen_keyscan "${target_ncn}"
+                ssh_keys_done=1
+            fi
+            scp ifcfg-lan0 root@ncn-m001:/etc/sysconfig/network/
+            ssh root@ncn-m001 'wicked ifreload lan0'
+        } >> ${LOG_FILE} 2>&1
         record_state "${state_name}" ${target_ncn}
     else
         echo "====> ${state_name} has been completed"
@@ -304,13 +314,13 @@ if [[ ${target_ncn} != ncn-s* ]]; then
     state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
     if [[ $state_recorded == "0" ]]; then
         echo "====> ${state_name} ..."
-
+        {
         if [[ $ssh_keys_done == "0" ]]; then
             ssh_keygen_keyscan "${target_ncn}"
             ssh_keys_done=1
         fi
         ssh ${TARGET_NCN} 'cray init --no-auth --overwrite --hostname https://api-gw-service-nmn.local'
-
+        } >> ${LOG_FILE} 2>&1
         record_state "${state_name}" ${target_ncn}
     else
         echo "====> ${state_name} has been completed"

--- a/upgrade/1.2/scripts/common/upgrade-state.sh
+++ b/upgrade/1.2/scripts/common/upgrade-state.sh
@@ -43,6 +43,7 @@ function record_state () {
     if [[ $state_recorded == "0" ]]; then
         printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "${state_name}" >> /etc/cray/upgrade/csm/$CSM_RELEASE/$target_ncn/state
     fi
+    echo "====> ${state_name} has been completed"
 }
 
 function is_state_recorded () {

--- a/upgrade/1.2/scripts/common/upgrade-state.sh
+++ b/upgrade/1.2/scripts/common/upgrade-state.sh
@@ -74,11 +74,13 @@ function move_state_file () {
 }
 
 function err_report() {
-    echo
-    echo "[ERROR] - Unexpected errors, check output above"
+    # force output to console regardless of redirection
+    echo >/dev/tty 
+    echo "[ERROR] - Unexpected errors, check logs: ${LOG_FILE}" >/dev/tty 
 }
 
 function ok_report() {
-    echo
-    echo "[OK] - Successfully completed"
+    # force output to console regardless of redirection
+    echo >/dev/tty 
+    echo "[OK] - Successfully completed" >/dev/tty
 }

--- a/upgrade/1.2/scripts/upgrade/csm-upgrade.sh
+++ b/upgrade/1.2/scripts/upgrade/csm-upgrade.sh
@@ -121,5 +121,6 @@ else
     echo "====> ${state_name} has been completed"
 fi
 
+ GOSS_BASE=/opt/cray/tests/install/ncn goss -g /opt/cray/tests/install/ncn/suites/ncn-upgrade-preflight-tests.yaml --vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml validate
 
 ok_report

--- a/upgrade/1.2/scripts/upgrade/csm-upgrade.sh
+++ b/upgrade/1.2/scripts/upgrade/csm-upgrade.sh
@@ -34,9 +34,9 @@ state_name="VERIFY_K8S_NODES_UPGRADED"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" ]]; then
     echo "====> ${state_name} ..."
-
+    {
     /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/util/verify-k8s-nodes-upgraded.sh
-
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"
@@ -46,6 +46,7 @@ state_name="PRE_CEPH_CSI_TARGET_REQUIREMENTS"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" ]]; then
     echo "====> ${state_name} ..."
+    {
     scp ncn-s001:/srv/cray/scripts/common/csi-configuration.sh /tmp/csi-configuration.sh
     mkdir -p /srv/cray/tmp
     . /tmp/csi-configuration.sh
@@ -57,7 +58,7 @@ if [[ $state_recorded == "0" ]]; then
     create_k8s_1.2_storage_class
     create_sma_1.2_storage_class
     create_cephfs_1.2_storage_class
-
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"
@@ -67,11 +68,11 @@ state_name="PRE_STRIMZI_UPGRADE"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" ]]; then
     echo "====> ${state_name} ..."
-
+    {
     pushd /usr/share/doc/csm/upgrade/1.2/scripts/strimzi
     ./kafka-prereq.sh
     popd +0
-
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"
@@ -81,11 +82,11 @@ state_name="CSM_SERVICE_UPGRADE"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" ]]; then
     echo "====> ${state_name} ..."
-
+    {
     pushd ${CSM_ARTI_DIR}
     ./upgrade.sh
     popd +0
-
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"
@@ -95,7 +96,9 @@ state_name="POST_CSM_ENABLE_PSP"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" ]]; then
     echo "====> ${state_name} ..."
+    {
     /usr/share/doc/csm/upgrade/1.2/scripts/k8s/enable-psp.sh
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"
@@ -105,7 +108,9 @@ state_name="POST_STRIMZI_UPGRADE"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" ]]; then
     echo "====> ${state_name} ..."
+    {
     /usr/share/doc/csm/upgrade/1.2/scripts/strimzi/kafka-restart.sh
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"
@@ -115,7 +120,9 @@ state_name="FIX_SPIRE_ON_STORAGE"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" ]]; then
     echo "====> ${state_name} ..."
+    {
     /opt/cray/platform-utils/spire/fix-spire-on-storage.sh
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"

--- a/upgrade/1.2/scripts/upgrade/csm-upgrade.sh
+++ b/upgrade/1.2/scripts/upgrade/csm-upgrade.sh
@@ -121,6 +121,9 @@ else
     echo "====> ${state_name} has been completed"
 fi
 
- GOSS_BASE=/opt/cray/tests/install/ncn goss -g /opt/cray/tests/install/ncn/suites/ncn-upgrade-preflight-tests.yaml --vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml validate
+state_name="POST CSM Upgrade Validation"
+echo "====> ${state_name} ..."
+GOSS_BASE=/opt/cray/tests/install/ncn goss -g /opt/cray/tests/install/ncn/suites/ncn-upgrade-preflight-tests.yaml --vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml validate
+echo "====> ${state_name} has been completed"
 
 ok_report

--- a/upgrade/1.2/scripts/upgrade/csm-upgrade.sh
+++ b/upgrade/1.2/scripts/upgrade/csm-upgrade.sh
@@ -130,7 +130,7 @@ fi
 
 state_name="POST CSM Upgrade Validation"
 echo "====> ${state_name} ..."
-GOSS_BASE=/opt/cray/tests/install/ncn goss -g /opt/cray/tests/install/ncn/suites/ncn-upgrade-preflight-tests.yaml --vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml validate
+GOSS_BASE=/opt/cray/tests/install/ncn goss -g /opt/cray/tests/install/ncn/suites/ncn-post-csm-service-upgrade-tests.yaml --vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml validate
 echo "====> ${state_name} has been completed"
 
 ok_report

--- a/upgrade/1.2/scripts/upgrade/prerequisites.sh
+++ b/upgrade/1.2/scripts/upgrade/prerequisites.sh
@@ -92,6 +92,7 @@ if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     do
         echo "Node: $host"
         counter=0
+        ssh_keygen_keyscan $host
         until ssh $host test -f /run/cloud-init/instance-data.json
         do
             ssh $host cloud-init init 2>&1 >/dev/null
@@ -110,6 +111,7 @@ if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     do
         echo "Node: $host"
         counter=0
+        ssh_keygen_keyscan $host
         until ssh $host test -f /run/cloud-init/instance-data.json
         do
             ssh $host cloud-init init 2>&1 >/dev/null

--- a/upgrade/1.2/scripts/upgrade/prerequisites.sh
+++ b/upgrade/1.2/scripts/upgrade/prerequisites.sh
@@ -48,17 +48,6 @@ case $key in
 esac
 done
 
-if [[ -z ${LOG_FILE} ]]; then
-    LOG_FILE="$(pwd)/output.log"
-    echo
-    echo
-    echo " ************"
-    echo " *** NOTE ***"
-    echo " ************"
-    echo "LOG_FILE is not specified; use default location: ${LOG_FILE}"
-    echo
-fi
-
 if [[ -z ${CSM_RELEASE} ]]; then
     echo "CSM RELEASE is not specified"
     exit 1

--- a/upgrade/1.2/scripts/upgrade/prerequisites.sh
+++ b/upgrade/1.2/scripts/upgrade/prerequisites.sh
@@ -102,12 +102,11 @@ if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     for host in $(kubectl get nodes -o json |jq -r '.items[].metadata.name')
     do
         echo "Node: $host"
-        (( counter=0 ))
-        ssh_keygen_keyscan $host
+        counter=0
         until ssh $host test -f /run/cloud-init/instance-data.json
         do
             ssh $host cloud-init init 2>&1 >/dev/null
-            (( counter++ ))
+            counter=$((counter+1))
             sleep 10
             if [[ $counter > 5 ]]
             then
@@ -120,19 +119,18 @@ if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     ## Ceph nodes
     for host in $(ceph node ls|jq -r '.osd|keys[]')
     do
-    echo "Node: $host"
-    (( counter=0 ))
-    ssh_keygen_keyscan $host
-    until ssh $host test -f /run/cloud-init/instance-data.json
-    do
-        ssh $host cloud-init init 2>&1 >/dev/null
-        (( counter++ ))
-        sleep 10
-        if [[ $counter > 5 ]]
-        then
-            echo "Cloud init data is missing and cannot be recreated. Existing upgrade.."
-        fi
-    done
+        echo "Node: $host"
+        counter=0
+        until ssh $host test -f /run/cloud-init/instance-data.json
+        do
+            ssh $host cloud-init init 2>&1 >/dev/null
+            counter=$((counter+1))
+            sleep 10
+            if [[ $counter > 5 ]]
+            then
+                echo "Cloud init data is missing and cannot be recreated. Existing upgrade.."
+            fi
+        done
     done
 
     set -e

--- a/upgrade/1.2/scripts/upgrade/prerequisites.sh
+++ b/upgrade/1.2/scripts/upgrade/prerequisites.sh
@@ -468,7 +468,7 @@ if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
 
     backupBucket="config-data"
     set +e
-    cray artifacts list config-data
+    cray artifacts list config-data 2> /dev/null
     if [[ $? -ne 0 ]]; then
         backupBucket="vbis"
     fi

--- a/upgrade/1.2/scripts/upgrade/prerequisites.sh
+++ b/upgrade/1.2/scripts/upgrade/prerequisites.sh
@@ -48,6 +48,17 @@ case $key in
 esac
 done
 
+if [[ -z ${LOG_FILE} ]]; then
+    LOG_FILE="$(pwd)/output.log"
+    echo
+    echo
+    echo " ************"
+    echo " *** NOTE ***"
+    echo " ************"
+    echo "LOG_FILE is not specified; use default location: ${LOG_FILE}"
+    echo
+fi
+
 if [[ -z ${CSM_RELEASE} ]]; then
     echo "CSM RELEASE is not specified"
     exit 1
@@ -68,10 +79,13 @@ state_name="UPDATE_SSH_KEYS"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" ]]; then
     echo "====> ${state_name} ..."
-     grep -oP "(ncn-\w+)" /etc/hosts | sort -u | xargs -t -i ssh {} 'truncate --size=0 ~/.ssh/known_hosts'
+    {
 
-     grep -oP "(ncn-\w+)" /etc/hosts | sort -u | xargs -t -i ssh {} 'grep -oP "(ncn-s\w+|ncn-m\w+|ncn-w\w+)" /etc/hosts | sort -u | xargs -t -i ssh-keyscan -H \{\} >> /root/.ssh/known_hosts'
+    grep -oP "(ncn-\w+)" /etc/hosts | sort -u | xargs -t -i ssh {} 'truncate --size=0 ~/.ssh/known_hosts'
 
+    grep -oP "(ncn-\w+)" /etc/hosts | sort -u | xargs -t -i ssh {} 'grep -oP "(ncn-s\w+|ncn-m\w+|ncn-w\w+)" /etc/hosts | sort -u | xargs -t -i ssh-keyscan -H \{\} >> /root/.ssh/known_hosts'
+
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"
@@ -81,6 +95,7 @@ state_name="CHECK_CLOUD_INIT_PREREQ"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     echo "====> ${state_name} ..."
+    {
     echo "Ensuring cloud-init is healthy"
     set +e
     # K8s nodes
@@ -121,6 +136,7 @@ if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     done
 
     set -e
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"
@@ -130,11 +146,13 @@ state_name="UPDATE_DOC_RPM"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" ]]; then
     echo "====> ${state_name} ..."
+    {
     if [[ ! -f /root/docs-csm-latest.noarch.rpm ]]; then
         echo "ERROR: docs-csm-latest.noarch.rpm is missing under: /root -- halting..."
         exit 1
     fi
     cp /root/docs-csm-latest.noarch.rpm ${CSM_ARTI_DIR}/rpm/cray/csm/sle-15sp2/
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"
@@ -144,6 +162,7 @@ state_name="UPDATE_CUSTOMIZATIONS"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     echo "====> ${state_name} ..."
+    {
     
     # update podman config
     sed -i 's/.*mount_program =.*/mount_program = "\/usr\/bin\/fuse-overlayfs"/' /etc/containers/storage.conf
@@ -168,6 +187,7 @@ if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     kubectl delete secret -n loftsman site-init
     kubectl create secret -n loftsman generic site-init --from-file=./customizations.yaml
     popd
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"
@@ -177,8 +197,10 @@ state_name="SETUP_NEXUS"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     echo "====> ${state_name} ..."
+    {
     ${CSM_ARTI_DIR}/lib/setup-nexus.sh
 
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"
@@ -188,11 +210,13 @@ state_name="DISABLE_SERVICE_REPOS"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     echo "====> ${state_name} ..."
+    {
     NCNS=$(${CSM_ARTI_DIR}/lib/list-ncns.sh | paste -sd,)
     pdsh -w "$NCNS" 'zypper ms -d Basesystem_Module_15_SP2_x86_64'
     pdsh -w "$NCNS" 'zypper ms -d Public_Cloud_Module_15_SP2_x86_64'
     pdsh -w "$NCNS" 'zypper ms -d SUSE_Linux_Enterprise_Server_15_SP2_x86_64'
     pdsh -w "$NCNS" 'zypper ms -d Server_Applications_Module_15_SP2_x86_64'
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"
@@ -202,7 +226,9 @@ state_name="UPGRADE_BSS"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     echo "====> ${state_name} ..."
+    {
     helm -n services upgrade cray-hms-bss ${CSM_ARTI_DIR}/helm/cray-hms-bss-*.tgz
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"
@@ -212,7 +238,9 @@ state_name="UPGRADE_KEA"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     echo "====> ${state_name} ..."
+    {
     helm -n services upgrade cray-dhcp-kea ${CSM_ARTI_DIR}/helm/cray-dhcp-kea-*.tgz
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"
@@ -222,6 +250,7 @@ state_name="UPLOAD_NEW_NCN_IMAGE"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     echo "====> ${state_name} ..."
+    {
     temp_file=$(mktemp)
     artdir=${CSM_ARTI_DIR}/images
 
@@ -249,6 +278,7 @@ if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     echo "export CEPH_VERSION=${CEPH_VERSION}" >> /etc/cray/upgrade/csm/myenv
     echo "export KUBERNETES_VERSION=${KUBERNETES_VERSION}" >> /etc/cray/upgrade/csm/myenv
 
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"
@@ -258,6 +288,7 @@ state_name="UPDATE_CLOUD_INIT_RECORDS"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     echo "====> ${state_name} ..."
+    {
 
     # get bss cloud-init data with host_records
     curl -k -H "Authorization: Bearer $TOKEN" https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters?name=Global|jq .[] > cloud-init-global.json
@@ -289,6 +320,7 @@ if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
         --k8s-version ${KUBERNETES_VERSION} \
         --storage-version ${CEPH_VERSION}
 
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
     echo
 else
@@ -299,6 +331,7 @@ state_name="PREFLIGHT_CHECK"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" ]]; then
     echo "====> ${state_name} ..."
+    {
     export PDSH_SSH_ARGS_APPEND="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
     rpm --force -Uvh $(find $CSM_ARTI_DIR/rpm/cray/csm/ -name \*csm-testing\*.rpm | sort -V | tail -1)
     /opt/cray/tests/install/ncn/scripts/validate-bootraid-artifacts.sh
@@ -316,6 +349,7 @@ if [[ $state_recorded == "0" ]]; then
 
     GOSS_BASE=/opt/cray/tests/install/ncn goss -g /opt/cray/tests/install/ncn/suites/ncn-upgrade-preflight-tests.yaml --vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml validate
 
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"
@@ -325,6 +359,7 @@ state_name="PRECACHE_NEXUS_IMAGES"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     echo "====> ${state_name} ..."
+    {
 
     images=$(kubectl get configmap -n nexus cray-precache-images -o json | jq -r '.data.images_to_cache' | grep "sonatype\|proxy\|busybox")
     export PDSH_SSH_ARGS_APPEND="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
@@ -337,6 +372,7 @@ if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
       exit 1
     fi
 
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"
@@ -346,6 +382,7 @@ state_name="POD_ANTI_AFFINITY"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     echo "====> ${state_name} ..."
+    {
 
     kubectl patch deployment -n spire spire-jwks -p '{
         "spec": {
@@ -370,6 +407,7 @@ if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
         }
     }}'
 
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"
@@ -381,6 +419,7 @@ state_name="ADD_MTL_ROUTES"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     echo "====> ${state_name} ..."
+    {
 
     export PDSH_SSH_ARGS_APPEND="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
     NCNS=$(grep -oP 'ncn-w\w\d+|ncn-s\w\d+' /etc/hosts | sort -u)
@@ -408,6 +447,7 @@ if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
         exit 1
     fi
 
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"
@@ -417,9 +457,11 @@ state_name="CREATE_CEPH_RO_KEY"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     echo "====> ${state_name} ..."
+    {
     ceph-authtool -C /etc/ceph/ceph.client.ro.keyring -n client.ro --cap mon 'allow r' --cap mds 'allow r' --cap osd 'allow r' --cap mgr 'allow r' --gen-key
     ceph auth import -i /etc/ceph/ceph.client.ro.keyring
     for node in $(ceph orch host ls --format=json|jq -r '.[].hostname'); do scp /etc/ceph/ceph.client.ro.keyring $node:/etc/ceph/ceph.client.ro.keyring; done
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"
@@ -429,6 +471,7 @@ state_name="BACKUP_BSS_DATA"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     echo "====> ${state_name} ..."
+    {
     
     cray bss bootparameters list --format=json > bss-backup-$(date +%Y-%m-%d).json
 
@@ -442,6 +485,7 @@ if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
 
     cray artifacts create ${backupBucket} bss-backup-$(date +%Y-%m-%d).json bss-backup-$(date +%Y-%m-%d).json
     
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"
@@ -451,6 +495,7 @@ state_name="BACKUP_VCS_DATA"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     echo "====> ${state_name} ..."
+    {
     
     pgLeaderPod=$(kubectl exec gitea-vcs-postgres-0 -n services -c postgres -it -- patronictl list | grep Leader | awk -F'|' '{print $2}')
     kubectl exec -it ${pgLeaderPod} -n services -c postgres -- pg_dumpall -c -U postgres > gitea-vcs-postgres.sql
@@ -478,6 +523,7 @@ if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     cray artifacts create ${backupBucket} gitea-vcs-postgres.manifest gitea-vcs-postgres.manifest
     cray artifacts create ${backupBucket} vcs.tar vcs.tar
     
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"
@@ -487,6 +533,7 @@ state_name="TDS_LOWER_CPU_REQUEST"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     echo "====> ${state_name} ..."
+    {
     
     numOfActiveWokers=$(kubectl get nodes | grep "ncn-w" | grep "Ready" | wc -l)
     minimal_count=4
@@ -496,6 +543,7 @@ if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
         echo "==> TDS: false"
     fi
     
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"
@@ -505,6 +553,7 @@ state_name="SUSPEND_NCN_CONFIGURATION"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     echo "====> ${state_name} ..."
+    {
     
     export CRAY_FORMAT=json
     for xname in $(cray hsm state components list --role Management --type node | jq -r .Components[].ID)
@@ -512,6 +561,7 @@ if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
         cray cfs components update --enabled false --desired-config "" $xname
     done
     
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"

--- a/upgrade/1.2/scripts/upgrade/util/update-customizations.sh
+++ b/upgrade/1.2/scripts/upgrade/util/update-customizations.sh
@@ -54,7 +54,6 @@ set -- "${args[@]}"
 
 [[ $# -eq 1 ]] || usage
 
-set -o xtrace
 
 customizations="$1"
 
@@ -480,4 +479,3 @@ else
     cat "$c"
 fi
 
-ok_report


### PR DESCRIPTION

## Summary and Scope

- Redirect all output except for long running process to log files (wait for boot, wait for cloud-init)
- add validation after csm service upgrade
- add back doc to download tarball before csm services upgrade

## Issues and Related PRs
- CASMINST-4388
- CASMINST-4389
- CASMINST-4391

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

