### PR TITLE
MTL-1661 add note to use a valid, reachable NTP server

### DIFF
--- a/install/bootstrap_livecd_remote_iso.md
+++ b/install/bootstrap_livecd_remote_iso.md
@@ -376,6 +376,8 @@ Some files are needed for generating the configuration payload. See these topics
 
       > **`NOTE`** for those more familiar with a CSM Install, this step may be skipped entirely by simple invoking pit-intas detailed in the [#first time](#bring---up-the-pit-services-and-validate-pit-health) section.
 
+      > **`NOTE`** ensure you select a reachable NTP pool/server passed in via the `--ntp-pools`/`--ntp-servers` flags, respectively.  Adding an uncreachable server can cause clock skew as chrony tries to continually reach out to a server it can never reach.
+
       ```bash
       pit:/var/www/ephemeral/prep/# csi config init
 

--- a/install/bootstrap_livecd_remote_iso.md
+++ b/install/bootstrap_livecd_remote_iso.md
@@ -376,7 +376,7 @@ Some files are needed for generating the configuration payload. See these topics
 
       > **`NOTE`** for those more familiar with a CSM Install, this step may be skipped entirely by simple invoking pit-intas detailed in the [#first time](#bring---up-the-pit-services-and-validate-pit-health) section.
 
-      > **`NOTE`** ensure you select a reachable NTP pool/server passed in via the `--ntp-pools`/`--ntp-servers` flags, respectively.  Adding an uncreachable server can cause clock skew as chrony tries to continually reach out to a server it can never reach.
+      > **NOTE:** Ensure to select a reachable NTP pool/server passed in via the `--ntp-pools`/`--ntp-servers` flags, respectively. Adding an unreachable server can cause clock skew as chrony tries to continually reach out to a server it can never reach.
 
       ```bash
       pit:/var/www/ephemeral/prep/# csi config init

--- a/install/bootstrap_livecd_usb.md
+++ b/install/bootstrap_livecd_usb.md
@@ -281,6 +281,9 @@ Some files are needed for generating the configuration payload. See these topics
 
    > **`NOTE`** if it is desirable to expedite booting into the USB, this step may be skipped. Instead, after logging into the PIT for [#first time](#51-first-login) and running `pit-init` the USB will gain connectivity and SSH. As long as the required files are present then one may continue to the first time boot.
 
+   > **`NOTE`** ensure you select a reachable NTP pool/server passed in via the `--ntp-pools`/`--ntp-servers` flags, respectively.  Adding an uncreachable server can cause clock skew as chrony tries to continually reach out to a server it can never reach.
+
+
       ```bash
       linux:/mnt/pitdata/prep# csi config init
 

--- a/install/bootstrap_livecd_usb.md
+++ b/install/bootstrap_livecd_usb.md
@@ -281,7 +281,7 @@ Some files are needed for generating the configuration payload. See these topics
 
    > **`NOTE`** if it is desirable to expedite booting into the USB, this step may be skipped. Instead, after logging into the PIT for [#first time](#51-first-login) and running `pit-init` the USB will gain connectivity and SSH. As long as the required files are present then one may continue to the first time boot.
 
-   > **`NOTE`** ensure you select a reachable NTP pool/server passed in via the `--ntp-pools`/`--ntp-servers` flags, respectively.  Adding an uncreachable server can cause clock skew as chrony tries to continually reach out to a server it can never reach.
+   > **`NOTE`** ensure you select a reachable NTP pool/server passed in via the `--ntp-pools`/`--ntp-servers` flags, respectively.  Adding an unreachable server can cause clock skew as chrony tries to continually reach out to a server it can never reach.
 
 
       ```bash


### PR DESCRIPTION
Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>

## Summary and Scope

add note to use a valid, reachable NTP server when running `csi config init`

## Issues and Related PRs

* Resolves MTL-1661
* 
## Testing

N/A


## Risks and Mitigations

Low.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

