### PR TITLE
MTL-1663 remove default pool during deploy to prevent contention issues

### DIFF
--- a/install/deploy_final_ncn.md
+++ b/install/deploy_final_ncn.md
@@ -16,6 +16,7 @@ Topics:
       * [Start Hand-Off](#start-hand-off)
    * [Reboot](#reboot)
    * [Enable NCN Disk Wiping Safeguard](#enable-ncn-disk-wiping-safeguard)
+   * [Remove the default NTP pool](#remove-the-default-ntp-pool)
    * [Configure DNS and NTP on each BMC](#configure-dns-and-ntp-on-each-bmc)
    * [Next Topic](#next-topic)
 
@@ -528,8 +529,18 @@ the Kubernetes cluster as the final of three master nodes forming a quorum.
 
 > **`CSI NOTE`** `/tmp/csi` will delete itself on the next reboot. The `/tmp` directory is `tmpfs` and runs in memory, it normally will not persist on restarts.
 
+<a name="remove-the-default-ntp-pool"></a>
+
+### 6. Remove the default NTP pool
+
+Run the following commands on ncn-m001 to remove the default pool, which can cause contention issues with NTP.
+
+```
+ncn-m001# sed -i "s/^! pool pool\.ntp\.org.*//" /etc/chrony.conf
+```
+
 <a name="configure-dns-and-ntp-on-each-bmc"></a>
-### 6. Configure DNS and NTP on each BMC
+### 7. Configure DNS and NTP on each BMC
 
  > **NOTE:** If the system uses Gigabyte or Intel hardware, skip this section.
 
@@ -579,7 +590,7 @@ However, the commands in this section are all run **on** `ncn-m001`.
     ```
 
 <a name="next-topic"></a>
-### 7. Next Topic
+### 8. Next Topic
 
    After completing this procedure, the next step is to configure administrative access.
 

--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -32,6 +32,7 @@ the number of storage and worker nodes.
    1. [Configure after Management Node Deployment](#configure_after_management_node_deployment)
       1. [LiveCD Cluster Authentication](#livecd-cluster-authentication)
       1. [Install Tests and Test Server on NCNs](#install-tests)
+      1. [Remove the default NTP pool](#remove-the-default-ntp-pool)
    1. [Validate Management Node Deployment](#validate_management_node_deployment)
       1. [Validation](#validation)
       1. [Optional Validation](#optional-validation)
@@ -726,6 +727,15 @@ pit# export CSM_RELEASE=csm-x.y.z
 pit# pushd /var/www/ephemeral
 pit# ${CSM_RELEASE}/lib/install-goss-tests.sh
 pit# popd
+```
+
+<a name="remove-default-ntp-pool"></a>
+### 4.5 Remove the default NTP pool
+
+Run the following command on the PIT node to remove the default pool, which can cause contention issues with NTP.
+
+```bash
+pit# pdsh -b -S -w "$(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u |  tr -t '\n' ',')" 'sed -i "s/^! pool pool\.ntp\.org.*//" /etc/chrony.conf'
 ```
 
 <a name="validate_management_node_deployment"></a>


### PR DESCRIPTION
Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>

## Summary and Scope

Adds a step to remove the default NTP pool since code for it will be removed in MTL-1662

## Issues and Related PRs

* Resolves MTL-1663


## Testing

Validated the sed and pdsh commands run.

### Tested on:

  * `#wasp`
  * Local development environment


## Risks and Mitigations

Low.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

