### PR TITLE
CASMINST-4423: Linting

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -55,20 +55,20 @@ CSM 1.2 contains approximately 2000 changes spanning bug fixes, new feature deve
 ### Base Platform Component Upgrades
 * istio V1.8 from istio V1.7
 * Release of Loftsman V1.2.0-1
-* K8S V1.20.13 from K8S V1.19.9
+* Kubernetes V1.20.13 from Kubernetes V1.19.9
 * Ceph V15.2.15 from V15.2.8
 
 ### Security Improvements
-* Switch to non-root containers - A significant number of root user container images have been removed - the remainder have been identified for a future release
-* Verification of signed RPMS
-* CVE Remediation - A significant number of CVE's have been addressed, including a majority of the critical and High CVEs like polkit and log4j
+* Switch to non-root containers - A significant number of root user container images have been removed. The remainder have been identified for a future release
+* Verification of signed RPMs
+* CVE Remediation - A significant number of CVEs have been addressed, including a majority of the critical and High CVEs like `polkit` and `log4j`
 * Updates to Nexus require authentication
-* Remove of code injection vulnerability in CFS configuration API commit and cloneURL fields
+* Remove of code injection vulnerability in `commit` and `cloneURL` fields of CFS configuration API
 * Further restrictions on allowed HTTP verbs in API requests coming from compute nodes
 * Option to restrict compute to only call URIs by machine identity
 
 ### Customer Requested Enhancements
-* Ability to turn off slots without hms-discovery powering them on
+* Ability to turn off slots without `hms-discovery` powering them on
 * Resilient way to reboot a compute node into its current configuration with a single API call
 
 ## Bug Fixes

--- a/background/ncn_plan_of_record.md
+++ b/background/ncn_plan_of_record.md
@@ -1,6 +1,6 @@
 # Plan of Record
 
-This document outlines the hardware necessary to meet CSM's Plan of Record (PoR). This serves the **minimum, necessary** pieces required per each server in the management plane.
+This document outlines the hardware necessary to meet CSM's Plan of Record (PoR). This serves as the **minimum, necessary** pieces required per each server in the management plane.
 
 1. If the system's NICs do not align to the PoR NICs outlined below (e.g. Onboard NICs are used instead of PCIe), then follow [Customize PCIe Hardware](../operations/node_management/customize_pcie_hardware.md) before booting the NCN(s).
 1. If there are more disks than what is listed below in the PoR for disks, then follow [Customize Disk Hardware](../operations/node_management/customize_disk_hardware.md) before booting the NCN(s).
@@ -52,7 +52,7 @@ This document outlines the hardware necessary to meet CSM's Plan of Record (PoR)
 <a name="worker-nics"></a>
 #### Worker NICs 
 
-> **`NOTE:`** There is no PCIe redundancy for the mangement network for worker NCNs. The only redundancy set up for workers is port redundancy.
+> **`NOTE:`** There is no PCIe redundancy for the management network for worker NCNs. The only redundancy set up for workers is port redundancy.
 
 - _Management Network:_ 1x PCIe card with 2 heads/ports for a total of 2 ports dedicated to a single PCIe card
 - _High-Speed Network:_ 1x PCIe card capable of 100Gbps (e.g. ConnectX-5 or Cassini), with 1 or 2 heads/ports
@@ -66,7 +66,7 @@ This document outlines the hardware necessary to meet CSM's Plan of Record (PoR)
 - _Operating System:_ 2x SSDs of equal size, and less than 500GiB (524288000000 bytes)
 - _CEPH:_ 8x SSDs of any size 
 
-> **`NOTE:`** Any available disk that isn't consumed by the operating system will be used for CEPH, but a node needs a minimum of 8 disks for making an ideal CEPH pool for CSM.
+> **`NOTE:`** Any available disk that is not consumed by the operating system will be used for CEPH, but a node needs a minimum of 8 disks for making an ideal CEPH pool for CSM.
 
 <a name="storage-nics"></a>
 #### Storage NICs

--- a/install/bootstrap_livecd_remote_iso.md
+++ b/install/bootstrap_livecd_remote_iso.md
@@ -1,7 +1,7 @@
 # Bootstrap PIT Node from LiveCD Remote ISO
 
-The Pre-Install Toolkit (PIT) node needs to be bootstrapped from the LiveCD. There are two media available
-to bootstrap the PIT node--the RemoteISO or a bootable USB device. This procedure describes using the
+The Pre-Install Toolkit (PIT) node needs to be bootstrapped from the LiveCD. There are two install medias available
+to bootstrap the PIT node: the RemoteISO or a bootable USB device. This procedure describes using the
 RemoteISO. If not using the RemoteISO, see [Bootstrap PIT Node from LiveCD USB](bootstrap_livecd_usb.md)
 
 The installation process is similar to the USB based installation with adjustments to account for the
@@ -122,7 +122,8 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
    ```
 
 1. <a name="set-up-site-link"></a>Set up the site-link, enabling SSH to work. You can reconnect with SSH after this step.
-   > **`NOTICE REGARDING DHCP`** If your site's network authority or network administrator has already provisioned an IPv4 address for your master node(s) external NIC(s), **then skip this step**.
+   > **`Note:`** If your site's network authority or network administrator has already provisioned a DHCP given IPv4 address for your master node(s) external NIC(s), **then skip this step**.
+
 
    1. Setup Variables.
 
@@ -137,8 +138,8 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
       pit# site_nics=em1
       ```
 
-   1. Run the link setup script.
-      > **`NOTE : USAGE`** All of the `/root/bin/csi-*` scripts are harmless to run without parameters, doing so will dump usage statements.
+   1. Run the site-link setup script.
+      > **`Note:`** All of the `/root/bin/csi-*` scripts are harmless to run without parameters, doing so will dump usage statements.
 
       ```bash
       pit# /root/bin/csi-setup-lan0.sh $site_ip $site_gw $site_dns $site_nics
@@ -169,7 +170,7 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
       ```bash
       pit# hostnamectl
       ```
-      > **`NOTE`** If the hostname returned by the `hostnamectl` command is still `pit`, then re-run the above script with the same parameters. Otherwise an administrator should feel free to set the hostname by hand with `hostnamectl`, please continue to use the `-pit` suffix to prevent masquerading a PIT node as a real NCN to administrators and automation.
+      > **`Note:`** If the hostname returned by the `hostnamectl` command is still `pit`, then re-run the above csi-set-hostname.sh script with the same parameters. Otherwise an administrator should feel free to set the hostname by hand with `hostnamectl`, please continue to use the `-pit` suffix to prevent masquerading a PIT node as a real NCN to administrators and automation.
 
 1. Find a local disk for storing product installers.
 
@@ -204,7 +205,7 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
 
 1. Mount local disk, check the output of each command as it goes.
 
-   > **`NOTE`** The FSLabel `PITDATA` is already in `/etc/fstab`, so the path is omitted in the following calls to `mount`.
+   > **`Note:`** The FSLabel `PITDATA` is already in `/etc/fstab`, so the path is omitted in the following calls to `mount`.
 
     ```bash
     pit# mount -v -L PITDATA
@@ -225,7 +226,7 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
 1. Download the CSM software release to the PIT node.
 
    **Important:** In an earlier step, the CSM release plus any patches or hotfixes
-   was downloaded to a system using the instructions in [Update CSM Product Stream](../update_product_stream/index.md)
+   was downloaded to a system using the instructions in [Update CSM Product Stream](../update_product_stream/index.md).
    Either copy from that system to the PIT node or set the ENDPOINT variable to URL and use `wget`.
 
    1. Set helper variables
@@ -270,7 +271,7 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
             rsync -a -P --delete ${CSM_PATH}/images/storage-ceph/ /var/www/ephemeral/data/ceph/
       ```
 
-   > The PIT ISO, Helm charts/images, and bootstrap RPMs are now available in the extracted CSM tar.
+   > **`Note:`** The PIT ISO, Helm charts/images, and bootstrap RPMs are now available in the extracted CSM tar.
 
 1. Install/upgrade CSI; check if a newer version was included in the tar-ball.
 
@@ -312,12 +313,12 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
 <a name="generate-installation-files"></a>
 #### 4.1 Generate Installation Files
 
-Some files are needed for generating the configuration payload. See these topics in [Prepare Configuration Payload](prepare_configuration_payload.md) if one has not already prepared the information for this system.
+Some files are needed for generating the configuration payload. See the [Command Line Configuration Payload](prepare_configuration_payload.md#command_line_configuration_payload) and [Configuration Payload Files](prepare_configuration_payload.md#configuration_payload_files) topics if one has not already prepared the information for this system.
 
 * [Command Line Configuration Payload](prepare_configuration_payload.md#command_line_configuration_payload)
 * [Configuration Payload Files](prepare_configuration_payload.md#configuration_payload_files)
 
-1. At this time see [Create HMN Connections JSON](create_hmn_connections_json.md) for instructions about creating the `hmn_connections.json`.
+1. Create the `hmn_connections.json` file by following the [Create HMN Connections JSON](create_hmn_connections_json.md)  procedure. Return to this section when completed.
 
 1. Change into the preparation directory plus necessary PIT directories (for later):
 
@@ -347,7 +348,7 @@ Some files are needed for generating the configuration payload. See these topics
 
 1. **For subsequent fresh-installs (re-installs) where the `system_config.yaml` parameter file is available**, generate the updated system configuration (see [Cray Site Init Files](../background/index.md#cray_site_init_files)).
 
-   > **`SKIP STEP IF`** if the `system_config.yaml` file is unavailable please skip this step and move onto the next one in order to generate the first configuration payload.
+   > **`Warning:`** If the `system_config.yaml` file is unavailable, please skip this step and move onto the next one in step 4.1.b to generate the first configuration payload.
 
    1. Check for the configuration files. The needed files should be in the current directory.
 
@@ -374,7 +375,7 @@ Some files are needed for generating the configuration payload. See these topics
 
    1. Generate the system configuration
 
-      > **`NOTE`** for those more familiar with a CSM Install, this step may be skipped entirely by simple invoking pit-intas detailed in the [#first time](#bring---up-the-pit-services-and-validate-pit-health) section.
+      > **`Note:`** For those more familiar with a CSM install, this step may be skipped entirely by simple invoking `pit-intas` detailed in the [#first time](#bring---up-the-pit-services-and-validate-pit-health) section.
 
       > **NOTE:** Ensure to select a reachable NTP pool/server passed in via the `--ntp-pools`/`--ntp-servers` flags, respectively. Adding an unreachable server can cause clock skew as chrony tries to continually reach out to a server it can never reach.
 
@@ -382,14 +383,14 @@ Some files are needed for generating the configuration payload. See these topics
       pit:/var/www/ephemeral/prep/# csi config init
 
       # Verify the newly generated configuration payload's `system_config.yaml` matches the current version of CSI.
-      # NOTE: Keep this new system_config.yaml somewhere safe to facilitate re-installs.
+      # Note: Keep this new system_config.yaml somewhere safe to facilitate re-installs.
       pit:/var/www/ephemeral/prep/# cat ${SYSTEM_NAME}/system_config.yaml
       pit:/var/www/ephemeral/prep/# csi version
       ```
 
       A new directory matching your `--system-name` argument will now exist in your working directory.
 
-      > **`NOTE`** These warnings from `csi config init` for issues in `hmn_connections.json` can be ignored.
+      > **`Note:`** These warnings from `csi config init` for issues in `hmn_connections.json` can be ignored.
       >
       > 1. The node with the external connection (`ncn-m001`) will have a warning similar to this because its BMC is connected to the site and not the HMN like the other management NCNs. It can be ignored.
       >   ```bash
@@ -419,21 +420,21 @@ Some files are needed for generating the configuration payload. See these topics
 
    1. Check for the configuration files. The needed files should be in the current directory.
 
-      > **`NOTE`** for those more familiar with a CSM Install, this step may be skipped entirely by simple invoking pit-intas detailed in the [#first time](#bring---up-the-pit-services-and-validate-pit-health) section.
+      > **`Note:`** for those more familiar with a CSM Install, this step may be skipped entirely by simple invoking pit-intas detailed in the [#first time](#bring---up-the-pit-services-and-validate-pit-health) section.
 
       ```bash
       pit:/var/www/ephemeral/prep/# ls -1
       ```
 
-   Expected output looks similar to the following:
+       1. Expected output looks similar to the following:
 
-      ```
-      application_node_config.yaml
-      cabinets.yaml
-      hmn_connections.json
-      ncn_metadata.csv
-      switch_metadata.csv
-      ```
+          ```
+          application_node_config.yaml
+          cabinets.yaml
+          hmn_connections.json
+          ncn_metadata.csv
+          switch_metadata.csv
+          ```
 
    1. Verify that the `SYSTEM_NAME` variable is set.
 
@@ -442,7 +443,7 @@ Some files are needed for generating the configuration payload. See these topics
       ```
 
    1. Generate the system config:
-      > **`NOTE`** the provided command below is an **example only**, run `csi config init --help` to print a full list of parameters that must be set. These will vary significatnly depending on ones system and site configuration.
+      > **`Note:`** The following command is an **example only**, run `csi config init --help` to print a full list of parameters that must be set. These will vary significantly depending on the system and site configuration in use.
 
       ```bash
       pit:/var/www/ephemeral/prep/# csi config init \
@@ -521,28 +522,28 @@ Some files are needed for generating the configuration payload. See these topics
 <a name="prepare-site-init"></a>
 #### 4.2 Prepare Site Init
 
-First, prepare a shim to facilitate going through the site-init guide:
+1. First, prepare a shim to facilitate going through the site-init guide:
 
- ```bash
- pit# mkdir -vp /mnt/pitdata
- pit# mount -v --bind /var/www/ephemeral/ /mnt/pitdata/
- ```
+    ```bash
+    pit# mkdir -vp /mnt/pitdata
+    pit# mount -v --bind /var/www/ephemeral/ /mnt/pitdata/
+    ```
 
-Follow the procedures to [Prepare Site Init](prepare_site_init.md) directory for your system.
+1. Follow the procedures to [Prepare Site Init](prepare_site_init.md) directory for your system.
 
-Finally, cleanup the shim:
- ```bash
- pit# cd ~
- # this uses `rmdir` to safely remove the directory, preventing accidental removal if one does not notice a `umount` command failure.
- pit# umount -v /mnt/pitdata/
- pit# rmdir -v /mnt/pitdata
- ```
+1. Clean-up the shim:
+    ```bash
+    pit# cd ~
+    # this uses `rmdir` to safely remove the directory, preventing accidental removal if one does not notice a `umount` command failure.
+     pit# umount -v /mnt/pitdata/
+     pit# rmdir -v /mnt/pitdata
+     ```
 
 <a name="bring---up-the-pit-services-and-validate-pit-health"></a>
 ### 5. Bring-up the PIT Services and Validate PIT Health
 
 1. Set the same variables from the `csi config init` step from earlier, and then invoke "PIT init" to setup the PIT server for deploying NCNs.
-   > **`NOTE`** `pit-init` will re-run `csi config init`, copy all generated files into place, apply the CA patch, and finally restart daemons. This will also re-print the `metalid.sh` content in case it was skipped in the previous step. **Re-installs** can skip running `csi config init` entirely and simply run `pit-init.sh` after gathering CSI input files into `/var/www/ephemeral/prep`.
+   > **`Note`** `pit-init` will re-run `csi config init`, copy all generated files into place, apply the CA patch, and finally restart daemons. This will also re-print the `metalid.sh` content in case it was skipped in the previous step. **Re-installs** can skip running `csi config init` entirely and simply run `pit-init.sh` after gathering CSI input files into `/var/www/ephemeral/prep`.
 
     ```bash
     pit# export USERNAME=root

--- a/install/bootstrap_livecd_remote_iso.md
+++ b/install/bootstrap_livecd_remote_iso.md
@@ -10,7 +10,7 @@ lack of removable storage.
 **Important:** Before starting this procedure be sure to complete the procedure to
 [Prepare Configuration Payload](prepare_configuration_payload.md) for the relevant installation scenario.
 
-### Topics:
+## Topics
    1. [Known Compatibility Issues](#known-compatibility-issues)
    1. [Attaching and Booting the LiveCD with the BMC](#attaching-and-booting-the-livecd-with-the-bmc)
    1. [First Login](#first-login)
@@ -23,7 +23,7 @@ lack of removable storage.
    1. [Next Topic](#next-topic)
 
 <a name="known-compatibility-issues"></a>
-### 1. Known Compatibility Issues
+## 1. Known Compatibility Issues
 
 The LiveCD Remote ISO has known compatibility issues for nodes from certain vendors.
 
@@ -31,7 +31,7 @@ The LiveCD Remote ISO has known compatibility issues for nodes from certain vend
    * Gigabyte nodes should not attempt to bootstrap using the LiveCD Remote ISO method. Instead use [Bootstrap PIT Node from LiveCD USB](bootstrap_livecd_usb.md)
 
 <a name="attaching-and-booting-the-livecd-with-the-bmc"></a>
-### 2. Attaching and Booting the LiveCD with the BMC
+## 2. Attaching and Booting the LiveCD with the BMC
 
 > **Warning:** If this is a re-installation on a system that still has a USB device from a prior
 > installation, then that USB device must be wiped before continuing. Failing to wipe the USB, if present, may result in confusion.
@@ -52,9 +52,7 @@ the instructions for attaching to the BMC will differ.
 1. Prepare a server on the network to host the cray-pre-install-toolkit ISO.
 
    This release of CSM software, the cray-pre-install-toolkit ISO should be placed on a server which the PIT node
-   will be able to contact via http or https.
-
-      * HPE nodes can use http or https.
+   will be able to contact using HTTP or HTTPS.
 
    **Note:** A shorter path name is better than a long path name on the webserver.
 
@@ -70,7 +68,7 @@ the instructions for attaching to the BMC will differ.
 1. The chosen procedure should have rebooted the server. Observe the server boot into the LiveCD.
 
 <a name="first-login"></a>
-### 3. First Login
+## 3. First Login
 
 On first login (over SSH or at local console) the LiveCD will prompt the administrator to change the password.
 
@@ -93,7 +91,7 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
    ```
 
 <a name="configure-the-running-livecd"></a>
-### 4. Configure the Running LiveCD
+## 4. Configure the Running LiveCD
 
 1. Set up the Typescript directory as well as the initial typescript. This directory will be returned to for every typescript in the entire CSM installation.
 
@@ -103,6 +101,10 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
    pit# script -af csm-install-remoteiso.$(date +%Y-%m-%d).txt
    pit# export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
    pit# /root/bin/metalid.sh
+   ```
+   
+   Expected output of the last command looks similar to the following:
+   ```
    = PIT Identification = COPY/CUT START =======================================
    VERSION=1.5.7
    TIMESTAMP=20211028194247
@@ -124,8 +126,7 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
 1. <a name="set-up-site-link"></a>Set up the site-link, enabling SSH to work. You can reconnect with SSH after this step.
    > **`Note:`** If your site's network authority or network administrator has already provisioned a DHCP given IPv4 address for your master node(s) external NIC(s), **then skip this step**.
 
-
-   1. Setup Variables.
+   1. Setup variables.
 
       ```bash
       # The IPv4 Address for the nodes external interface(s); this will be provided if not already by the site's network administrator or network authority.
@@ -205,7 +206,7 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
 
 1. Mount local disk, check the output of each command as it goes.
 
-   > **`Note:`** The FSLabel `PITDATA` is already in `/etc/fstab`, so the path is omitted in the following calls to `mount`.
+    > **`Note:`** The FSLabel `PITDATA` is already in `/etc/fstab`, so the path is omitted in the following calls to `mount`.
 
     ```bash
     pit# mount -v -L PITDATA
@@ -232,16 +233,18 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
    1. Set helper variables
 
       ```bash
-      pit# export ENDPOINT=https://arti.dev.cray.com/artifactory/shasta-distribution-stable-local/csm
+      pit# ENDPOINT=https://arti.dev.cray.com/artifactory/shasta-distribution-stable-local/csm
       pit# export CSM_RELEASE=csm-x.y.z
       pit# export SYSTEM_NAME=eniac
       ```
 
-   1. Save the `CSM_RELEASE` and `SYSTEM_NAME` variable for usage later; all subsequent shell sessions will have this var set.
+   1. Save the `CSM_RELEASE` for usage later; all subsequent shell sessions will have this variable set.
 
-      ```bash
-      # Prepend a new line to assure we add on a unique line and not at the end of another.
-      pit# echo -e "\nCSM_RELEASE=$CSM_RELEASE\nSYSTEM_NAME=$SYSTEM_NAME" >>/etc/environment
+      > The `echo` prepends a newline to ensure that the variable assignment occurs on a unique line,
+      > and not at the end of another.
+
+      ```bash      
+      pit# echo -e "\nCSM_RELEASE=$CSM_RELEASE" >>/etc/environment
       ```
 
    1. Fetch the release tarball.
@@ -253,7 +256,6 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
    1. Expand the tarball on the PIT node.
 
       > Note: Expansion of the tarball may take more than 45 minutes.
-
 
       ```bash
       pit# tar -C /var/www/ephemeral -zxvf /var/www/ephemeral/${CSM_RELEASE}.tar.gz
@@ -311,7 +313,7 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
    ```
 
 <a name="generate-installation-files"></a>
-#### 4.1 Generate Installation Files
+### 4.1 Generate Installation Files
 
 Some files are needed for generating the configuration payload. See the [Command Line Configuration Payload](prepare_configuration_payload.md#command_line_configuration_payload) and [Configuration Payload Files](prepare_configuration_payload.md#configuration_payload_files) topics if one has not already prepared the information for this system.
 
@@ -344,7 +346,7 @@ Some files are needed for generating the configuration payload. See the [Command
    After gathering the files into this working directory, move on to [Subsequent Fresh-Installs (Re-Installs)](#subsequent-fresh-installs-re-installs).
 
 <a name="subsequent-fresh-installs-re-installs"></a>
-##### 4.1.a Subsequent Fresh-Installs (Re-Installs)
+#### 4.1.a Subsequent Fresh-Installs (Re-Installs)
 
 1. **For subsequent fresh-installs (re-installs) where the `system_config.yaml` parameter file is available**, generate the updated system configuration (see [Cray Site Init Files](../background/index.md#cray_site_init_files)).
 
@@ -375,9 +377,9 @@ Some files are needed for generating the configuration payload. See the [Command
 
    1. Generate the system configuration
 
-      > **`Note:`** For those more familiar with a CSM install, this step may be skipped entirely by simple invoking `pit-intas` detailed in the [#first time](#bring---up-the-pit-services-and-validate-pit-health) section.
+      > **`Note:`** For those more familiar with a CSM install, this step may be skipped entirely by using `pit-init.sh`, as detailed in the [Bring-up the PIT Services and Validate PIT Health](#bring---up-the-pit-services-and-validate-pit-health) section.
 
-      > **NOTE:** Ensure to select a reachable NTP pool/server passed in via the `--ntp-pools`/`--ntp-servers` flags, respectively. Adding an unreachable server can cause clock skew as chrony tries to continually reach out to a server it can never reach.
+      > **`Note:`** Make sure to select a reachable NTP pool/server (passed in via the `--ntp-pools`/`--ntp-servers` flags, respectively). Adding an unreachable server can cause clock skew as `chrony` tries to continually reach out to a server it can never reach.
 
       ```bash
       pit:/var/www/ephemeral/prep/# csi config init
@@ -414,13 +416,13 @@ Some files are needed for generating the configuration payload. See the [Command
    1. Skip the next step and continue to [prepare site init](#prepare-site-init).
 
 <a name="first-timeinitial-installs-bare-metal"></a>
-##### 4.1.b First-Time/Initial Installs (bare-metal)
+#### 4.1.b First-Time/Initial Installs (bare-metal)
 
 1. **For first-time/initial installs (without a `system_config.yaml`file)**, generate the system configuration. See below for an explanation of the command line parameters and some common settings.
 
    1. Check for the configuration files. The needed files should be in the current directory.
 
-      > **`Note:`** for those more familiar with a CSM Install, this step may be skipped entirely by simple invoking pit-intas detailed in the [#first time](#bring---up-the-pit-services-and-validate-pit-health) section.
+      > **`Note:`** For those more familiar with a CSM install, this step may be skipped entirely by using `pit-init.sh`, as detailed in the [Bring-up the PIT Services and Validate PIT Health](#bring---up-the-pit-services-and-validate-pit-health) section.
 
       ```bash
       pit:/var/www/ephemeral/prep/# ls -1
@@ -483,34 +485,34 @@ Some files are needed for generating the configuration payload. See the [Command
 
       > **`SPECIAL NOTES`** Certain parameters to `csi config init` may be hard to grasp on first-time configuration generations:
       >
-      > 1. The `application_node_config.yaml` file is optional, but if one has one describing the mapping between prefixes in `hmn_connections.csv` that should be mapped to HSM subroles, one needs to include a command line option to have it used. See [Create Application Node YAML](create_application_node_config_yaml.md).
-      > 1. The `bootstrap-ncn-bmc-user` and `bootstrap-ncn-bmc-pass` must match what is used for the BMC account and its password for the management NCNs.
-      > 1. Set site parameters (`site-domain`, `site-ip`, `site-gw`, `site-nic`, `site-dns`) for the information which connects `ncn-m001` (the PIT node) to the site. The `site-nic` is the interface on this node connected to the site.
-      > 1. There are other interfaces possible, but the `install-ncn-bond-members` are typically:
+      > * The `application_node_config.yaml` file is optional, but if one has one describing the mapping between prefixes in `hmn_connections.csv` that should be mapped to HSM subroles, one needs to include a command line option to have it used. See [Create Application Node YAML](create_application_node_config_yaml.md).
+      > * The `bootstrap-ncn-bmc-user` and `bootstrap-ncn-bmc-pass` must match what is used for the BMC account and its password for the management NCNs.
+      > * Set site parameters (`site-domain`, `site-ip`, `site-gw`, `site-nic`, `site-dns`) for the information which connects `ncn-m001` (the PIT node) to the site. The `site-nic` is the interface on this node connected to the site.
+      > * There are other interfaces possible, but the `install-ncn-bond-members` are typically:
       >    * `p1p1,p10p1` for HPE nodes
       >    * `p1p1,p1p2` for Gigabyte nodes
       >    * `p801p1,p801p2` for Intel nodes
-      > 1. If one are not using a `cabinets-yaml` file, set the three cabinet parameters (`mountain-cabinets`, `hill-cabinets`, and `river-cabinets`) to the number of each cabinet which are part of this system.
-      > 1. The starting cabinet number for each type of cabinet (for example, `starting-mountain-cabinet`) has a default that can be overridden. See the `csi config init --help`
-      > 1. For systems that use non-sequential cabinet ID numbers, use `cabinets-yaml` to include the `cabinets.yaml` file. This file can include information about the starting ID for each cabinet type and number of cabinets which have separate command line options, but is a way to specify explicitly the id of every cabinet in the system. If one are using a `cabinets-yaml` file, flags specified on the `csi` command-line related to cabinets will be ignored. See [Create Cabinets YAML](create_cabinets_yaml.md).
-      > 1. An override to default cabinet IPv4 subnets can be made with the `hmn-mtn-cidr` and `nmn-mtn-cidr` parameters.
+      > * If one are not using a `cabinets-yaml` file, set the three cabinet parameters (`mountain-cabinets`, `hill-cabinets`, and `river-cabinets`) to the number of each cabinet which are part of this system.
+      > * The starting cabinet number for each type of cabinet (for example, `starting-mountain-cabinet`) has a default that can be overridden. See the `csi config init --help`
+      > * For systems that use non-sequential cabinet ID numbers, use `cabinets-yaml` to include the `cabinets.yaml` file. This file can include information about the starting ID for each cabinet type and number of cabinets which have separate command line options, but is a way to specify explicitly the id of every cabinet in the system. If one are using a `cabinets-yaml` file, flags specified on the `csi` command-line related to cabinets will be ignored. See [Create Cabinets YAML](create_cabinets_yaml.md).
+      > * An override to default cabinet IPv4 subnets can be made with the `hmn-mtn-cidr` and `nmn-mtn-cidr` parameters.
 
       > **`SPECIAL/IGNORABLE WARNINGS`** These warnings from `csi config init` for issues in `hmn_connections.json` can be ignored:
       >
-      > 1. The node with the external connection (`ncn-m001`) will have a warning similar to this because its BMC is connected to the site and not the HMN like the other management NCNs. It can be ignored.
+      > * The node with the external connection (`ncn-m001`) will have a warning similar to this because its BMC is connected to the site and not the HMN like the other management NCNs. It can be ignored.
       >
       >    ```
       >    "Couldn't find switch port for NCN: x3000c0s1b0"
       >    ```
       >
-      > 1. An unexpected component may have this message. If this component is an application node with an unusual prefix, it should be added to the `application_node_config.yaml` file. Then rerun `csi config init`. See the procedure to [Create Application Node Config YAML](create_application_node_config_yaml.md).
+      > * An unexpected component may have this message. If this component is an application node with an unusual prefix, it should be added to the `application_node_config.yaml` file. Then rerun `csi config init`. See the procedure to [Create Application Node Config YAML](create_application_node_config_yaml.md).
       >
       >    ```json
       >    {"level":"warn","ts":1610405168.8705149,"msg":"Found unknown source prefix! If this is expected to be an Application node, please update application_node_config.yaml","row":
       >    {"Source":"gateway01","SourceRack":"x3000","SourceLocation":"u33","DestinationRack":"x3002","DestinationLocation":"u48","DestinationPort":"j29"}}
       >    ```
       >
-      > 1. If a cooling door is found in `hmn_connections.json`, there may be a message like the following. It can be safely ignored.
+      > * If a cooling door is found in `hmn_connections.json`, there may be a message like the following. It can be safely ignored.
       >
       >    ```json
       >    {"level":"warn","ts":1612552159.2962296,"msg":"Cooling door found, but xname does not yet exist for cooling doors!","row":
@@ -520,30 +522,30 @@ Some files are needed for generating the configuration payload. See the [Command
    1. Continue with the next step to [prepare site init](#prepare-site-init).
 
 <a name="prepare-site-init"></a>
-#### 4.2 Prepare Site Init
+### 4.2 Prepare Site Init
 
 1. First, prepare a shim to facilitate going through the site-init guide:
 
     ```bash
-    pit# mkdir -vp /mnt/pitdata
-    pit# mount -v --bind /var/www/ephemeral/ /mnt/pitdata/
+    pit# mkdir -vp /mnt/pitdata &&
+         mount -v --bind /var/www/ephemeral/ /mnt/pitdata/
     ```
 
 1. Follow the procedures to [Prepare Site Init](prepare_site_init.md) directory for your system.
 
-1. Clean-up the shim:
+1. Remove the shim:
+
+    > This uses `rmdir` to safely remove the directory, preventing accidental removal if one does not notice a `umount` command failure.
+
     ```bash
-    pit# cd ~
-    # this uses `rmdir` to safely remove the directory, preventing accidental removal if one does not notice a `umount` command failure.
-     pit# umount -v /mnt/pitdata/
-     pit# rmdir -v /mnt/pitdata
-     ```
+    pit# cd ~ && umount -v /mnt/pitdata/ && rmdir -v /mnt/pitdata
+    ```
 
 <a name="bring---up-the-pit-services-and-validate-pit-health"></a>
-### 5. Bring-up the PIT Services and Validate PIT Health
+## 5. Bring-up the PIT Services and Validate PIT Health
 
-1. Set the same variables from the `csi config init` step from earlier, and then invoke "PIT init" to setup the PIT server for deploying NCNs.
-   > **`Note`** `pit-init` will re-run `csi config init`, copy all generated files into place, apply the CA patch, and finally restart daemons. This will also re-print the `metalid.sh` content in case it was skipped in the previous step. **Re-installs** can skip running `csi config init` entirely and simply run `pit-init.sh` after gathering CSI input files into `/var/www/ephemeral/prep`.
+1. Set the same variables from the `csi config init` step from earlier, and then invoke `pit-init.sh` to set up the PIT server for deploying NCNs.
+   > **`Note:`** `pit-init.sh` will re-run `csi config init`, copy all generated files into place, apply the CA patch, and finally restart daemons. This will also re-print the `metalid.sh` content in case it was skipped in the previous step. **Re-installs** can skip running `csi config init` entirely and simply run `pit-init.sh` after gathering CSI input files into `/var/www/ephemeral/prep`.
 
     ```bash
     pit# export USERNAME=root
@@ -559,7 +561,7 @@ Some files are needed for generating the configuration payload. See the [Command
 
 1. Install Goss Tests and Server
 
-   The following assumes the CSM_PATH environment variable is set to the absolute path of the unpacked CSM release.
+   The following assumes the `CSM_PATH` environment variable is set to the absolute path of the unpacked CSM release.
 
    ```bash
    pit# rpm -Uvh --force $(find ${CSM_PATH}/rpm/ -name "goss-servers*.rpm" | sort -V | tail -1)
@@ -567,9 +569,8 @@ Some files are needed for generating the configuration payload. See the [Command
    ```
 
 <a name="next-topic"></a>
-# Next Topic
+## Next Topic
 
-After completing this procedure the next step is to configure the management network switches.
+After completing this procedure, proceed to configure the management network switches.
 
-* See [Configure Management Network Switches](index.md#configure_management_network)
-
+See [Configure Management Network Switches](index.md#configure_management_network)

--- a/install/bootstrap_livecd_usb.md
+++ b/install/bootstrap_livecd_usb.md
@@ -284,7 +284,7 @@ Some files are needed for generating the configuration payload. See these topics
 
    > **`NOTE`** if it is desirable to expedite booting into the USB, this step may be skipped. Instead, after logging into the PIT for [#first time](#51-first-login) and running `pit-init` the USB will gain connectivity and SSH. As long as the required files are present then one may continue to the first time boot.
 
-   > **`NOTE`** ensure you select a reachable NTP pool/server passed in via the `--ntp-pools`/`--ntp-servers` flags, respectively.  Adding an unreachable server can cause clock skew as chrony tries to continually reach out to a server it can never reach.
+   > **`NOTE`** ensure you select a reachable NTP pool/server passed in via the `--ntp-pools`/`--ntp-servers` flags, respectively. Adding an unreachable server can cause clock skew as chrony tries to continually reach out to a server it can never reach.
 
 
       ```bash

--- a/install/bootstrap_livecd_usb.md
+++ b/install/bootstrap_livecd_usb.md
@@ -20,7 +20,7 @@ There are 5 overall steps that provide a bootable USB with SSH enabled, capable 
    1. [Next Topic](#next-topic)
 
 <a name="download-and-expand-the-csm-release"></a>
-### 1. Download and Expand the CSM Release
+## 1. Download and Expand the CSM Release
 
 Fetch the base installation CSM tarball, extract it, and install the contained CSI tool.
 
@@ -38,7 +38,7 @@ Fetch the base installation CSM tarball, extract it, and install the contained C
    linux# export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
    ```
 
-1. The CSM software release should be downloaded and expanded for use.
+1. Download and expand the CSM software release.
 
    **Important:** In order to ensure that the CSM release plus any patches, documentation updates,
    or hotfixes are included, follow the instructions in [Update CSM Product Stream](../update_product_stream/index.md)
@@ -133,7 +133,7 @@ Fetch the base installation CSM tarball, extract it, and install the contained C
       ```
 
 <a name="create-the-bootable-media"></a>
-### 2. Create the Bootable Media
+## 2. Create the Bootable Media
 
 Cray Site Init will create the bootable LiveCD. Before creating the media, identify
 which device will be used for it.
@@ -207,7 +207,7 @@ which device will be used for it.
 The USB device is now bootable and contains the CSM artifacts. This may be useful for internal or quick usage. Administrators seeking a Shasta installation must continue onto the [configuration payload](#configuration-payload).
 
 <a name="configuration-payload"></a>
-### 3. Configuration Payload
+## 3. Configuration Payload
 
 The SHASTA-CFG structure and other configuration files will be prepared, then `csi` will generate system-unique configuration payload used for the rest of the CSM installation on the USB device.
 
@@ -215,7 +215,7 @@ The SHASTA-CFG structure and other configuration files will be prepared, then `c
 * [Prepare Site Init](#prepare-site-init)
 
 <a name="generate-installation-files"></a>
-#### 3.1 Generate Installation Files
+### 3.1 Generate Installation Files
 
 Some files are needed for generating the configuration payload. See these topics in [Prepare Configuration Payload](prepare_configuration_payload.md) if one has not already prepared the information for this system.
 
@@ -251,7 +251,7 @@ Some files are needed for generating the configuration payload. See these topics
    After gathering the files into this working directory, move on to [Subsequent Fresh-Installs (Re-Installs)](#subsequent-fresh-installs-re-installs).
 
 <a name="subsequent-fresh-installs-re-installs"></a>
-##### 3.1.a Subsequent Fresh-Installs (Re-Installs)
+#### 3.1.a Subsequent Fresh-Installs (Re-Installs)
 
 1. **For subsequent fresh-installs (re-installs) where the `system_config.yaml` parameter file is available**, generate the updated system configuration (see [Cray Site Init Files](../background/index.md#cray_site_init_files)).
 
@@ -300,29 +300,29 @@ Some files are needed for generating the configuration payload. See these topics
 
       > **`NOTE`** These warnings from `csi config init` for issues in `hmn_connections.json` can be ignored.
       >
-      > 1. The node with the external connection (`ncn-m001`) will have a warning similar to this because its BMC is connected to the site and not the HMN like the other management NCNs. It can be ignored.
-      >   ```bash
-      >   "Couldn't find switch port for NCN: x3000c0s1b0"
-      >   ```
+      > * The node with the external connection (`ncn-m001`) will have a warning similar to this because its BMC is connected to the site and not the HMN like the other management NCNs. It can be ignored.
+      >    ```
+       >   "Couldn't find switch port for NCN: x3000c0s1b0"
+      >    ```
       >
-      > 1. An unexpected component may have this message. If this component is an application node with an unusual prefix, it should be added to the `application_node_config.yaml` file. Then rerun `csi config init`. See the procedure to [Create Application Node Config YAML](create_application_node_config_yaml.md)
+      > * An unexpected component may have this message. If this component is an application node with an unusual prefix, it should be added to the `application_node_config.yaml` file. Then rerun `csi config init`. See the procedure to [Create Application Node Config YAML](create_application_node_config_yaml.md)
       >
-      >   ```json
-      >   {"level":"warn","ts":1610405168.8705149,"msg":"Found unknown source prefix! If this is expected to be an Application node, please update application_node_config.yaml","row":
-      >   {"Source":"gateway01","SourceRack":"x3000","SourceLocation":"u33","DestinationRack":"x3002","DestinationLocation":"u48","DestinationPort":"j29"}}
-      >   ```
+      >    ```json
+      >    {"level":"warn","ts":1610405168.8705149,"msg":"Found unknown source prefix! If this is expected to be an Application node, please update application_node_config.yaml","row":
+      >    {"Source":"gateway01","SourceRack":"x3000","SourceLocation":"u33","DestinationRack":"x3002","DestinationLocation":"u48","DestinationPort":"j29"}}
+      >    ```
       >
-      > 1. If a cooling door is found in `hmn_connections.json`, there may be a message like the following. It can be safely ignored.
+      > * If a cooling door is found in `hmn_connections.json`, there may be a message like the following. It can be safely ignored.
       >
-      >   ```json
-      >   {"level":"warn","ts":1612552159.2962296,"msg":"Cooling door found, but xname does not yet exist for cooling doors!","row":
-      >   {"Source":"x3000door-Motiv","SourceRack":"x3000","SourceLocation":" ","DestinationRack":"x3000","DestinationLocation":"u36","DestinationPort":"j27"}}
-      >   ```
+      >    ```json
+      >    {"level":"warn","ts":1612552159.2962296,"msg":"Cooling door found, but xname does not yet exist for cooling doors!","row":
+      >    {"Source":"x3000door-Motiv","SourceRack":"x3000","SourceLocation":" ","DestinationRack":"x3000","DestinationLocation":"u36","DestinationPort":"j27"}}
+      >    ```
 
    1. Skip the next step and continue to [prepare site init](#prepare-site-init).
 
 <a name="first-timeinitial-installs-bare-metal"></a>
-##### 3.1.b First-Time/Initial Installs (bare-metal)
+#### 3.1.b First-Time/Initial Installs (bare-metal)
 
 1. **For first-time/initial installs (without a `system_config.yaml`file)**, generate the system configuration. See below for an explanation of the command line parameters and some common settings.
 
@@ -391,34 +391,34 @@ Some files are needed for generating the configuration payload. See these topics
 
       > **`SPECIAL NOTES`** Certain parameters to `csi config init` may be hard to grasp on first-time configuration generations:
       >
-      > 1. The `application_node_config.yaml` file is optional, but if one has one describing the mapping between prefixes in `hmn_connections.csv` that should be mapped to HSM subroles, one needs to include a command line option to have it used. See [Create Application Node YAML](create_application_node_config_yaml.md).
-      > 1. The `bootstrap-ncn-bmc-user` and `bootstrap-ncn-bmc-pass` must match what is used for the BMC account and its password for the management NCNs.
-      > 1. Set site parameters (`site-domain`, `site-ip`, `site-gw`, `site-nic`, `site-dns`) for the information which connects `ncn-m001` (the PIT node) to the site. The `site-nic` is the interface on this node connected to the site.
-      > 1. There are other interfaces possible, but the `install-ncn-bond-members` are typically:
+      > * The `application_node_config.yaml` file is optional, but if one has one describing the mapping between prefixes in `hmn_connections.csv` that should be mapped to HSM subroles, one needs to include a command line option to have it used. See [Create Application Node YAML](create_application_node_config_yaml.md).
+      > * The `bootstrap-ncn-bmc-user` and `bootstrap-ncn-bmc-pass` must match what is used for the BMC account and its password for the management NCNs.
+      > * Set site parameters (`site-domain`, `site-ip`, `site-gw`, `site-nic`, `site-dns`) for the information which connects `ncn-m001` (the PIT node) to the site. The `site-nic` is the interface on this node connected to the site.
+      > * There are other interfaces possible, but the `install-ncn-bond-members` are typically:
       >    * `p1p1,p10p1` for HPE nodes
       >    * `p1p1,p1p2` for Gigabyte nodes
       >    * `p801p1,p801p2` for Intel nodes
-      > 1. If one are not using a `cabinets-yaml` file, set the three cabinet parameters (`mountain-cabinets`, `hill-cabinets`, and `river-cabinets`) to the number of each cabinet which are part of this system.
-      > 1. The starting cabinet number for each type of cabinet (for example, `starting-mountain-cabinet`) has a default that can be overridden. See the `csi config init --help`
-      > 1. For systems that use non-sequential cabinet ID numbers, use `cabinets-yaml` to include the `cabinets.yaml` file. This file can include information about the starting ID for each cabinet type and number of cabinets which have separate command line options, but is a way to specify explicitly the id of every cabinet in the system. If one are using a `cabinets-yaml` file, flags specified on the `csi` command-line related to cabinets will be ignored. See [Create Cabinets YAML](create_cabinets_yaml.md).
-      > 1. An override to default cabinet IPv4 subnets can be made with the `hmn-mtn-cidr` and `nmn-mtn-cidr` parameters.
+      > * If not using a `cabinets-yaml` file, set the three cabinet parameters (`mountain-cabinets`, `hill-cabinets`, and `river-cabinets`) to the number of each cabinet which are part of this system.
+      > * The starting cabinet number for each type of cabinet (for example, `starting-mountain-cabinet`) has a default that can be overridden. See the `csi config init --help`
+      > * For systems that use non-sequential cabinet ID numbers, use `cabinets-yaml` to include the `cabinets.yaml` file. This file can include information about the starting ID for each cabinet type and number of cabinets which have separate command line options, but is a way to specify explicitly the id of every cabinet in the system. If one are using a `cabinets-yaml` file, flags specified on the `csi` command-line related to cabinets will be ignored. See [Create Cabinets YAML](create_cabinets_yaml.md).
+      > * An override to default cabinet IPv4 subnets can be made with the `hmn-mtn-cidr` and `nmn-mtn-cidr` parameters.
 
       > **`SPECIAL/IGNORABLE WARNINGS`** These warnings from `csi config init` for issues in `hmn_connections.json` can be ignored:
       >
-      > 1. The node with the external connection (`ncn-m001`) will have a warning similar to this because its BMC is connected to the site and not the HMN like the other management NCNs. It can be ignored.
+      > * The node with the external connection (`ncn-m001`) will have a warning similar to this because its BMC is connected to the site and not the HMN like the other management NCNs. It can be ignored.
       >
       >    ```
       >    "Couldn't find switch port for NCN: x3000c0s1b0"
       >    ```
       >
-      > 1. An unexpected component may have this message. If this component is an application node with an unusual prefix, it should be added to the `application_node_config.yaml` file. Then rerun `csi config init`. See the procedure to [Create Application Node Config YAML](create_application_node_config_yaml.md).
+      > * An unexpected component may have this message. If this component is an application node with an unusual prefix, it should be added to the `application_node_config.yaml` file. Then rerun `csi config init`. See the procedure to [Create Application Node Config YAML](create_application_node_config_yaml.md)
       >
       >    ```json
       >    {"level":"warn","ts":1610405168.8705149,"msg":"Found unknown source prefix! If this is expected to be an Application node, please update application_node_config.yaml","row":
       >    {"Source":"gateway01","SourceRack":"x3000","SourceLocation":"u33","DestinationRack":"x3002","DestinationLocation":"u48","DestinationPort":"j29"}}
       >    ```
       >
-      > 1. If a cooling door is found in `hmn_connections.json`, there may be a message like the following. It can be safely ignored.
+      > * If a cooling door is found in `hmn_connections.json`, there may be a message like the following. It can be safely ignored.
       >
       >    ```json
       >    {"level":"warn","ts":1612552159.2962296,"msg":"Cooling door found, but xname does not yet exist for cooling doors!","row":
@@ -428,7 +428,7 @@ Some files are needed for generating the configuration payload. See these topics
    1. Continue to the next step to [prepare site init](#prepare-site-init).
 
 <a name="prepare-site-init"></a>
-#### 3.2 Prepare Site Init
+### 3.2 Prepare Site Init
 
 > **`NOTE`**: It is assumed at this point that `/mnt/pitdata` is still mounted on the linux system, this is important as the following procedure depends on that mount existing.
 
@@ -441,7 +441,7 @@ Some files are needed for generating the configuration payload. See these topics
 1. Follow all of the [Prepare Site Init](prepare_site_init.md) procedures.
 
 <a name="prepopulate-livecd-daemons-configuration-and-ncn-artifacts"></a>
-### 4. Prepopulate LiveCD Daemons Configuration and NCN Artifacts
+## 4. Prepopulate LiveCD Daemons Configuration and NCN Artifacts
 
 Now that the configuration is generated, we can populate the LiveCD with the generated files.
 
@@ -545,7 +545,7 @@ Now the USB device may be reattached to the management node, or if it was made o
 reboot into the LiveCD.
 
 <a name="boot-the-livecd"></a>
-### 5. Boot the LiveCD
+## 5. Boot the LiveCD
 
 Some systems will boot the USB device automatically if no other OS exists (bare-metal). Otherwise the
 administrator may need to use the BIOS Boot Selection menu to choose the USB device.
@@ -589,7 +589,7 @@ The typescript can be discarded, otherwise if issues arise then it should be sub
 > **An integrity check** runs before Linux starts by default, it can be skipped by selecting "OK" in its prompt.
 
 <a name="first-login"></a>
-#### 5.1 First Login
+### 5.1 First Login
 
 On first login (over SSH or at local console) the LiveCD will prompt the administrator to change the password.
 
@@ -646,7 +646,7 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
    Note: The hostname should be similar to `eniac-ncn-m001-pit` when booted from the LiveCD, but it will be shown as `pit#` in the command prompts from this point onward.
 
 <a name="configure-the-running-livecd"></a>
-### 6. Configure the Running LiveCD
+## 6. Configure the Running LiveCD
 
 1. Start a typescript to record this section of activities done on `ncn-m001` while booted from the LiveCD.
 
@@ -696,9 +696,8 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
    ```
 
 <a name="next-topic"></a>
-# Next Topic
+## Next Topic
 
-After completing this procedure the next step is to configure the management network switches.
+After completing this procedure, proceed to configure the management network switches.
 
-* See [Configure Management Network Switches](index.md#configure_management_network)
-
+See [Configure Management Network Switches](index.md#configure_management_network).

--- a/install/collect_mac_addresses_for_ncns.md
+++ b/install/collect_mac_addresses_for_ncns.md
@@ -13,27 +13,25 @@ this topic could be skipped and instead move to [Deploy Management Nodes](index.
 file already had valid MAC addresses for both BMC and node interfaces before `csi config init` was run, then this
 topic could be skipped and instead move to [Deploy Management Nodes](index.md#deploy_management_nodes).
 
-### Topics
+## Topics
 
-   1. [Collect the BMC MAC addresses](#collect_the_bmc_mac_addresses)
-   1. [Restart Services after BMC MAC Addresses Collected](#restart_services_after_bmc_mac_addresses_collected)
-   1. [Collect the NCN MAC addresses](#collect_the_ncn_mac_addresses)
-   1. [Restart Services after NCN MAC Addresses Collected](#restart_services_after_ncn_mac_addresses_collected)
-   1. [Next Topic](#next-topic)
-
-## Details
+1. [Collect the BMC MAC addresses](#collect_the_bmc_mac_addresses)
+1. [Restart Services after BMC MAC Addresses Collected](#restart_services_after_bmc_mac_addresses_collected)
+1. [Collect the NCN MAC addresses](#collect_the_ncn_mac_addresses)
+1. [Restart Services after NCN MAC Addresses Collected](#restart_services_after_ncn_mac_addresses_collected)
+1. [Next Topic](#next-topic)
 
 <a name="collect_the_bmc_mac_addresses"></a>
-### 1. Collect the BMC MAC addresses
+## 1. Collect the BMC MAC addresses
 
 The BMC MAC address can be collected from the switches using knowledge about the cabling of the NMN from the SHCD.
 
 See [Collecting BMC MAC Addresses](collecting_bmc_mac_addresses.md).
 
 <a name="restart_services_after_bmc_mac_addresses_collected"></a>
-### 2. Restart Services after BMC MAC Addresses Collected
+## 2. Restart Services after BMC MAC Addresses Collected
 
-The previous step updated `ncn_metadata.csv` with the BMC MAC Addresses, so several earlier steps need to be repeated.
+The previous step updated `ncn_metadata.csv` with the BMC MAC addresses, so several earlier steps need to be repeated.
 
 1. Change into the preparation directory.
 
@@ -42,14 +40,14 @@ The previous step updated `ncn_metadata.csv` with the BMC MAC Addresses, so seve
    ```
 
 1. Confirm that the `ncn_metadata.csv` file in this directory has the new information.
-   There should be no remaining dummy data (de:ad:be:ef:00:00) for the BMC MAC column in the file, but that string may
-   be present for the Bootstrap MAC, Bond0 MAC0, and Bond0 MAC1 columns.
+   There should be no remaining dummy data (`de:ad:be:ef:00:00`) for the `BMC MAC` column in the file, but that string may
+   be present for the `Bootstrap MAC`, `Bond0 MAC0`, and `Bond0 MAC1` columns.
 
    ```bash
    pit# cat ncn_metadata.csv
    ```
 
-1. Remove the incorrectly generated configs. Before deleting the incorrectly generated configs consider
+1. Remove the incorrectly generated configurations. Before deleting the incorrectly generated configurations, consider
 making a backup of them, in case they need to be examined at a later time.
 
    > **`Warning`** Ensure that the `SYSTEM_NAME` environment variable is correctly set.
@@ -130,44 +128,44 @@ making a backup of them, in case they need to be examined at a later time.
 
 1. Check that IP addresses are set for each interface and investigate any failures.
 
-    > **`Note:`** The bond0.can0 interface is optional in CSM 1.2+
+    > **`Note:`** The `bond0.can0` interface is optional in CSM 1.2+
+
+    Check IP addresses. Do not run tests if these are missing and instead triage the issue.
 
     ```bash
-    Check IP addresses. Do not run tests if these are missing and instead start triaging the issue.
+    pit# wicked show bond0 bond0.nmn0 bond0.hmn0 bond0.can0
+    bond0           up
+    link:     #7, state up, mtu 1500
+    type:     bond, mode ieee802-3ad, hwaddr b8:59:9f:fe:49:d4
+    config:   compat:suse:/etc/sysconfig/network/ifcfg-bond0
+    leases:   ipv4 static granted
+    addr:     ipv4 10.1.1.2/16 [static]
 
-       pit# wicked show bond0 bond0.nmn0 bond0.hmn0 bond0.can0
-       bond0           up
-       link:     #7, state up, mtu 1500
-       type:     bond, mode ieee802-3ad, hwaddr b8:59:9f:fe:49:d4
-       config:   compat:suse:/etc/sysconfig/network/ifcfg-bond0
-       leases:   ipv4 static granted
-       addr:     ipv4 10.1.1.2/16 [static]
+    bond0.nmn0      up
+    link:     #8, state up, mtu 1500
+    type:     vlan bond0[2], hwaddr b8:59:9f:fe:49:d4
+    config:   compat:suse:/etc/sysconfig/network/ifcfg-bond0.nmn0
+    leases:   ipv4 static granted
+    addr:     ipv4 10.252.1.4/17 [static]
+    route:    ipv4 10.92.100.0/24 via 10.252.0.1 proto boot
 
-       bond0.nmn0      up
-       link:     #8, state up, mtu 1500
-       type:     vlan bond0[2], hwaddr b8:59:9f:fe:49:d4
-       config:   compat:suse:/etc/sysconfig/network/ifcfg-bond0.nmn0
-       leases:   ipv4 static granted
-       addr:     ipv4 10.252.1.4/17 [static]
-       route:    ipv4 10.92.100.0/24 via 10.252.0.1 proto boot
+    bond0.can0      up
+    link:     #9, state up, mtu 1500
+    type:     vlan bond0[7], hwaddr b8:59:9f:fe:49:d4
+    config:   compat:suse:/etc/sysconfig/network/ifcfg-bond0.can0
+    leases:   ipv4 static granted
+    addr:     ipv4 10.102.9.5/24 [static]
 
-       bond0.can0      up
-       link:     #9, state up, mtu 1500
-       type:     vlan bond0[7], hwaddr b8:59:9f:fe:49:d4
-       config:   compat:suse:/etc/sysconfig/network/ifcfg-bond0.can0
-       leases:   ipv4 static granted
-       addr:     ipv4 10.102.9.5/24 [static]
-
-       bond0.hmn0      up
-       link:     #10, state up, mtu 1500
-       type:     vlan bond0[4], hwaddr b8:59:9f:fe:49:d4
-       config:   compat:suse:/etc/sysconfig/network/ifcfg-bond0.hmn0
-       leases:   ipv4 static granted
-       addr:     ipv4 10.254.1.4/17 [static]
+    bond0.hmn0      up
+    link:     #10, state up, mtu 1500
+    type:     vlan bond0[4], hwaddr b8:59:9f:fe:49:d4
+    config:   compat:suse:/etc/sysconfig/network/ifcfg-bond0.hmn0
+    leases:   ipv4 static granted
+    addr:     ipv4 10.254.1.4/17 [static]
     ```
 
-1. Copy the service config files generated earlier by `csi config init` for DNSMasq, Metal
-   Basecamp (cloud-init), and Conman.
+1. Copy the service configuration files generated earlier by `csi config init` for DNSMasq, Metal
+   Basecamp (cloud-init), and ConMan.
 
     1. Copy files (files only, `-r` is expressly not used).
 
@@ -198,7 +196,7 @@ making a backup of them, in case they need to be examined at a later time.
    ```
 
 <a name="collect_the_ncn_mac_addresses"></a>
-### 3. Collect the NCN MAC addresses
+## 3. Collect the NCN MAC addresses
 
 Now that the BMC MAC addresses are correct in `ncn_metadata.csv` and the PIT node services have been restarted,
 a partial boot of the management nodes can be done to collect the remaining information from the conman console
@@ -304,9 +302,9 @@ making a backup of them, in case they need to be examined at a later time.
          ```json
          {"level":"warn","ts":1612552159.2962296,"msg":"Cooling door found, but xname does not yet exist for cooling doors!","row":
          {"Source":"x3000door-Motiv","SourceRack":"x3000","SourceLocation":" ","DestinationRack":"x3000","DestinationLocation":"u36","DestinationPort":"j27"}}
+         ```
 
-
-1. Copy the interface config files generated earlier by `csi config init` into `/etc/sysconfig/network/`.
+1. Copy the interface configuration files generated earlier by `csi config init` into `/etc/sysconfig/network/`.
 
    ```bash
    pit# cp -pv /var/www/ephemeral/prep/${SYSTEM_NAME}/pit-files/* /etc/sysconfig/network/
@@ -316,44 +314,44 @@ making a backup of them, in case they need to be examined at a later time.
 
 1. Check that IP addresses are set for each interface and investigate any failures.
 
-    > **`Note:`** The bond0.can0 interface is optional in CSM 1.2+
+    > **`Note:`** The `bond0.can0` interface is optional in CSM 1.2+
+
+    Check IP addresses. Do not run tests if these are missing and instead triage the issue.
 
     ```bash
-    Check IP addresses. Do not run tests if these are missing and instead start triaging the issue.
+    pit# wicked show bond0 bond0.nmn0 bond0.hmn0 bond0.can0
+    bond0           up
+    link:     #7, state up, mtu 1500
+    type:     bond, mode ieee802-3ad, hwaddr b8:59:9f:fe:49:d4
+    config:   compat:suse:/etc/sysconfig/network/ifcfg-bond0
+    leases:   ipv4 static granted
+    addr:     ipv4 10.1.1.2/16 [static]
 
-       pit# wicked show bond0 bond0.nmn0 bond0.hmn0 bond0.can0
-       bond0           up
-       link:     #7, state up, mtu 1500
-       type:     bond, mode ieee802-3ad, hwaddr b8:59:9f:fe:49:d4
-       config:   compat:suse:/etc/sysconfig/network/ifcfg-bond0
-       leases:   ipv4 static granted
-       addr:     ipv4 10.1.1.2/16 [static]
+    bond0.nmn0      up
+    link:     #8, state up, mtu 1500
+    type:     vlan bond0[2], hwaddr b8:59:9f:fe:49:d4
+    config:   compat:suse:/etc/sysconfig/network/ifcfg-bond0.nmn0
+    leases:   ipv4 static granted
+    addr:     ipv4 10.252.1.4/17 [static]
+    route:    ipv4 10.92.100.0/24 via 10.252.0.1 proto boot
 
-       bond0.nmn0      up
-       link:     #8, state up, mtu 1500
-       type:     vlan bond0[2], hwaddr b8:59:9f:fe:49:d4
-       config:   compat:suse:/etc/sysconfig/network/ifcfg-bond0.nmn0
-       leases:   ipv4 static granted
-       addr:     ipv4 10.252.1.4/17 [static]
-       route:    ipv4 10.92.100.0/24 via 10.252.0.1 proto boot
+    bond0.can0      up
+    link:     #9, state up, mtu 1500
+    type:     vlan bond0[7], hwaddr b8:59:9f:fe:49:d4
+    config:   compat:suse:/etc/sysconfig/network/ifcfg-bond0.can0
+    leases:   ipv4 static granted
+    addr:     ipv4 10.102.9.5/24 [static]
 
-       bond0.can       up
-       link:     #9, state up, mtu 1500
-       type:     vlan bond0[7], hwaddr b8:59:9f:fe:49:d4
-       config:   compat:suse:/etc/sysconfig/network/ifcfg-bond0.can0
-       leases:   ipv4 static granted
-       addr:     ipv4 10.102.9.5/24 [static]
-
-       bond0.hmn0      up
-       link:     #10, state up, mtu 1500
-       type:     vlan bond0[4], hwaddr b8:59:9f:fe:49:d4
-       config:   compat:suse:/etc/sysconfig/network/ifcfg-bond0.hmn0
-       leases:   ipv4 static granted
-       addr:     ipv4 10.254.1.4/17 [static]
+    bond0.hmn0      up
+    link:     #10, state up, mtu 1500
+    type:     vlan bond0[4], hwaddr b8:59:9f:fe:49:d4
+    config:   compat:suse:/etc/sysconfig/network/ifcfg-bond0.hmn0
+    leases:   ipv4 static granted
+    addr:     ipv4 10.254.1.4/17 [static]
     ```
 
-1. Copy the service config files generated earlier by `csi config init` for DNSMasq, Metal
-   Basecamp (cloud-init), and Conman.
+1. Copy the service configuration files generated earlier by `csi config init` for DNSMasq, Metal
+   Basecamp (cloud-init), and ConMan.
 
     1. Copy files (files only, `-r` is expressly not used).
 
@@ -378,19 +376,18 @@ making a backup of them, in case they need to be examined at a later time.
         pit# systemctl restart basecamp nexus dnsmasq conman
         ```
 
-1. Ensure system-specific settings generated by CSI are merged into `customizations.yaml`:
-   > The `yq` tool used in the following procedures is available under `/var/www/ephemeral/prep/site-init/utils/bin` once the SHASTA-CFG repo has been cloned.
+1. Ensure system-specific settings generated by CSI are merged into `customizations.yaml`.
+    > The `yq` tool used in the following procedures is available under `/var/www/ephemeral/prep/site-init/utils/bin` once the SHASTA-CFG repo has been cloned.
 
-   ```bash
-   pit# alias yq="/var/www/ephemeral/prep/site-init/utils/bin/$(uname | awk '{print tolower($0)}')/yq"
-   pit# yq merge -xP -i /var/www/ephemeral/prep/site-init/customizations.yaml <(yq prefix -P "/var/www/ephemeral/prep/${SYSTEM_NAME}/customizations.yaml" spec)
-   ```
+    ```bash
+    pit# alias yq="/var/www/ephemeral/prep/site-init/utils/bin/$(uname | awk '{print tolower($0)}')/yq"
+    pit# yq merge -xP -i /var/www/ephemeral/prep/site-init/customizations.yaml <(yq prefix -P "/var/www/ephemeral/prep/${SYSTEM_NAME}/customizations.yaml" spec)
+    ```
 
 <a name="next-topic"></a>
-# Next Topic
+## Next Topic
 
-   After completing the collection of BMC MAC addresses and NCN MAC address to update `ncn_metadata.csv` and restarting
-   the services dependent on correct data in `ncn_metadata.csv`, the next step is deployment of the management nodes.
+After completing the collection of BMC MAC addresses and NCN MAC addresses in order to update `ncn_metadata.csv`, and after restarting
+the services dependent on correct data in `ncn_metadata.csv`, the next step is deployment of the management nodes.
 
-   See [Deploy Management Nodes](index.md#deploy_management_nodes)
-
+See [Deploy Management Nodes](index.md#deploy_management_nodes)

--- a/install/collect_mac_addresses_for_ncns.md
+++ b/install/collect_mac_addresses_for_ncns.md
@@ -52,7 +52,7 @@ The previous step updated `ncn_metadata.csv` with the BMC MAC Addresses, so seve
 1. Remove the incorrectly generated configs. Before deleting the incorrectly generated configs consider
 making a backup of them, in case they need to be examined at a later time.
 
-   > **`WARNING`** Ensure that the `SYSTEM_NAME` environment variable is correctly set.
+   > **`Warning`** Ensure that the `SYSTEM_NAME` environment variable is correctly set.
 
    ```bash
    pit# export SYSTEM_NAME=eniac
@@ -130,11 +130,11 @@ making a backup of them, in case they need to be examined at a later time.
 
 1. Check that IP addresses are set for each interface and investigate any failures.
 
-  > Note that bond0.can0 is optional in CSM 1.2+
+    > **`Note:`** The bond0.can0 interface is optional in CSM 1.2+
 
-    1. Check IP addresses. Do not run tests if these are missing and instead start triaging the issue.
+    ```bash
+    Check IP addresses. Do not run tests if these are missing and instead start triaging the issue.
 
-       ```bash
        pit# wicked show bond0 bond0.nmn0 bond0.hmn0 bond0.can0
        bond0           up
        link:     #7, state up, mtu 1500
@@ -164,7 +164,7 @@ making a backup of them, in case they need to be examined at a later time.
        config:   compat:suse:/etc/sysconfig/network/ifcfg-bond0.hmn0
        leases:   ipv4 static granted
        addr:     ipv4 10.254.1.4/17 [static]
-       ```
+    ```
 
 1. Copy the service config files generated earlier by `csi config init` for DNSMasq, Metal
    Basecamp (cloud-init), and Conman.
@@ -278,7 +278,7 @@ making a backup of them, in case they need to be examined at a later time.
    system_config.yaml
    ```
 
-   Regenerate the system configuration. The `system_config.yaml` file contains all of the options that where used to generate the initial system configuration, and can be used in place of specifying CLI flags to CSI.
+   Regenerate the system configuration. The `system_config.yaml` file contains all of the options that were used to generate the initial system configuration, and can be used in place of specifying CLI flags to CSI.
    ```bash
    pit# csi config init
    ```
@@ -316,11 +316,11 @@ making a backup of them, in case they need to be examined at a later time.
 
 1. Check that IP addresses are set for each interface and investigate any failures.
 
-  > Note that bond0.can0 is optional in CSM 1.2+
+    > **`Note:`** The bond0.can0 interface is optional in CSM 1.2+
 
-    1. Check IP addresses. Do not run tests if these are missing and instead start triaging the issue.
+    ```bash
+    Check IP addresses. Do not run tests if these are missing and instead start triaging the issue.
 
-       ```bash
        pit# wicked show bond0 bond0.nmn0 bond0.hmn0 bond0.can0
        bond0           up
        link:     #7, state up, mtu 1500
@@ -350,7 +350,7 @@ making a backup of them, in case they need to be examined at a later time.
        config:   compat:suse:/etc/sysconfig/network/ifcfg-bond0.hmn0
        leases:   ipv4 static granted
        addr:     ipv4 10.254.1.4/17 [static]
-       ```
+    ```
 
 1. Copy the service config files generated earlier by `csi config init` for DNSMasq, Metal
    Basecamp (cloud-init), and Conman.

--- a/install/create_cabinets_yaml.md
+++ b/install/create_cabinets_yaml.md
@@ -2,7 +2,7 @@
 
 This page provides directions on constructing the optional `cabinets.yaml` file. This file lists cabinet IDs for any systems with non-contiguous cabinet ID numbers and controls how the `csi config init` command treats cabinet IDs.
 
-The following example file is manually created and follows this format. Eeach "type" of cabinet can have several fields: `total_number` of cabinets of this type, `starting_id` for this cabinet type, and a list of the IDs.
+The following example file is manually created and follows this format. Each "type" of cabinet can have several fields: `total_number` of cabinets of this type, `starting_id` for this cabinet type, and a list of the IDs.
 
 ```yaml
 ---

--- a/install/create_hmn_connections_json.md
+++ b/install/create_hmn_connections_json.md
@@ -1,27 +1,27 @@
-# Create HMN Connections JSON
+# Create HMN Connections JSON File
 
-### About this task
+Use this procedure to generate the `hmn_connections.json` from the system's SHCD Excel document. This process is typically needed when generating the `hmn_connections.json` file for a new system, or regenerating it when a system's SHCD file is changed (specifically the `HMN` tab). The `hms-shcd-parser` tool can be used to generate the `hmn_connections.json` file.
 
-Use this procedure shows to generate the `hmn_connections.json` from the system's SHCD Excel document. This process is typically needed when generating the `hmn_connections.json` file for a new system, or regenerating it when system's SHCD is changed (specifically the HMN tab). The `hms-shcd-parser` tool can be used to generate the `hmn_connections.json` file.
+The [SHCD/HMN Connections Rules](shcd_hmn_connections_rules.md) document explains the expected naming conventions and rules for the `HMN` tab of the SHCD file, and for the `hmn_connections.json` file.
 
-The [SHCD/HMN Connections Rules document](shcd_hmn_connections_rules.md) explains the expected naming conventions and rules for the HMN tab of the SHCD, and the `hmn_connections.json` file.
-
-### Prerequisites
+## Prerequisites
 
 * SHCD Excel file for the system
 * Podman is available
 
     > Podman is available on the CSM LiveCD, and is installed onto an NCN when being used as an environment to create the CSM PIT in the [Bootstrap PIT Node from LiveCD USB](bootstrap_livecd_usb.md) or [Bootstrap Pit Node from LiveCD Remote ISO](bootstrap_livecd_remote_iso.md) procedures.
 
-### Procedure
+## Procedure
 
-1. Inspect the HMN tab of the SHCD to verify that it does not have unexpected data in columns J through U in row 20 or below. If any unexpected data is present in this region of the HMN tab it will end up in the generated `hmn_connections.json`, and needs to be removed before generating the `hmn_connections.json` file. Unexpected data is anything other than HMN cabling information, such as another table placed below the HMN cabling information. Any data above row 20 will not interfere when generating `hmn_connections.json`.
+1. Inspect the `HMN` tab of the SHCD file.
+
+    Verify that it does not have unexpected data in columns `J` through `U` in rows 20 or below. If any unexpected data is present in this region of the `HMN` tab, then it will end up in the generated `hmn_connections.json`. Therefore, it must be removed before generating the `hmn_connections.json` file. Unexpected data is anything other than HMN cabling information, such as another table placed below the HMN cabling information. Any data above row 20 will not interfere when generating `hmn_connections.json`.
 
     For example, the following image shows an unexpected table present underneath HMN cabling information in rows 26 to 29. The HMN cabling information in this example is truncated for brevity.
 
-    ![Screen Shot of unexpected data in the HMN tab of a SHCD](../img/install/shcd-hmn-tab-unexpected-data.png)
+    ![Screen Shot of unexpected data in the `HMN` tab of an SHCD file](../img/install/shcd-hmn-tab-unexpected-data.png)
 
-2. Load the `hms-shcd-parser` container image from the CSM release distribution into Podman.
+1. Load the `hms-shcd-parser` container image from the CSM release distribution into Podman.
 
     > The `CSM_RELEASE` environment variable is expected to to be set from the [Bootstrap PIT Node from LiveCD USB](bootstrap_livecd_usb.md) or [Bootstrap PIT Node from LiveCD Remote ISO](bootstrap_livecd_remote_iso.md) procedures.
     >
@@ -40,19 +40,20 @@ The [SHCD/HMN Connections Rules document](shcd_hmn_connections_rules.md) explain
     linux# ./${CSM_RELEASE}/hack/load-container-image.sh artifactory.algol60.net/csm-docker/stable/hms-shcd-parser:$SHCD_PARSER_VERSION
     ```
 
-3. Copy the system's SHCD over the machine being used to prepare the `hmn_connections.json` file.
+1. Copy the system's SHCD file to the machine being used to prepare the `hmn_connections.json` file.
 
-4. Set environment to point to the system's SHCD Excel file:
+1. Set a variable to point to the system's SHCD Excel file.
 
-    > **NOTE:** Make sure to quote the SHCD file path if there are spaces in the document's filename.
+    > **NOTE:** Make sure to quote the SHCD file path if there is whitespace in the document's path or filename.
 
     ```bash
-    linux# export SHCD_FILE="/path/to/systems/SHCD.xlsx"
+    linux# SHCD_FILE="/path/to/systems/SHCD.xlsx"
     ```
 
-5. Generate the hmn_connections.json file from the SHCD. This will either create or overwrite the `hmn_connections.json` file in the current directory:
+1. Generate the `hmn_connections.json` file from the SHCD file.
+
+    > This will create the `hmn_connections.json` file in the current directory. If it already exists, it will be overwritten.
 
     ```bash
     linux# podman run --rm -it --name hms-shcd-parser -v "$(realpath "$SHCD_FILE")":/input/shcd_file.xlsx -v "$(pwd)":/output artifactory.algol60.net/csm-docker/stable/hms-shcd-parser:$SHCD_PARSER_VERSION
     ```
-

--- a/install/deploy_final_ncn.md
+++ b/install/deploy_final_ncn.md
@@ -519,7 +519,7 @@ the Kubernetes cluster as the final of three master nodes forming a quorum.
 
 ### 6. Remove the default NTP pool
 
-Run the following commands on ncn-m001 to remove the default pool, which can cause contention issues with NTP.
+Run the following commands on `ncn-m001` to remove the default pool, which can cause contention issues with NTP.
 
 ```
 ncn-m001# sed -i "s/^! pool pool\.ntp\.org.*//" /etc/chrony.conf

--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -158,8 +158,8 @@ proceed to step 2.
       >
       > For HPE NCNs the date configuration menu can be found at the following path: `System Configuration -> BIOS/Platform Configuration (RBSU) -> Date and Time`
       >
-      > Alternatively for HPE NCNs you can log in to the BMC's web interface and access the HTML5 console for the node to interact with the graphical BIOS.
-      > From the administrators own machine create a SSH tunnel (-L creates the tunnel, and -N prevents a shell and stubs the connection):
+      > Alternatively, for HPE NCNs you can log in to the BMC's web interface and access the HTML5 console for the node, in order to interact with the graphical BIOS.
+      > From the administrator's own machine, create an SSH tunnel (`-L` creates the tunnel; `-N` prevents a shell and stubs the connection):
       >
       > ```bash
       > linux# bmc=ncn-w001-mgmt # Change this to be each node in turn.
@@ -185,12 +185,12 @@ firmware requirement before starting.
    the firmware because that service has not yet been installed. However, at this point, it would be possible to use
    the HPE Cray EX HPC Firmware Pack (HFP) product on the PIT node to learn about the firmware versions available in HFP.
 
-   If the firmware is not updated at this point in the installation workflow, it can be done with FAS after CSM and HFP have
-   both been installed and configured, however, at that point a rolling reboot procedure for the management nodes will be needed
+   If the firmware is not updated at this point in the installation workflow, then it can be done with FAS after CSM and HFP have
+   both been installed and configured. However, at that point a rolling reboot procedure for the management nodes will be needed,
    after the firmware has been updated.
 
    See the 1.5 _HPE Cray EX System Software Getting Started Guide S-8000_
-   on the HPE Customer Support Center at https://www.hpe.com/support/ex-gsg for more information about the HPE Cray EX HPC Firmware Pack (HFP) product.
+   on the [HPE Customer Support Center](https://www.hpe.com/support/ex-gsg) for information about the _HPE Cray EX HPC Firmware Pack_ (HFP) product.
 
    In the HFP documentation there is information about the recommended firmware packages to be installed.
    See "Product Details" in the HPE Cray EX HPC Firmware Pack Installation Guide.
@@ -343,10 +343,11 @@ The configuration workflow described here is intended to help understand the exp
 
     Boot all the storage nodes. `ncn-s001` will start 1 minute after the other storage nodes.
 
-        ```bash
-        pit# grep -oP $stoken /etc/dnsmasq.d/statics.conf | grep -v "ncn-s001-" | sort -u | xargs -t -i ipmitool -I lanplus -U $USERNAME -E -H {} power on; \
-                 sleep 60; ipmitool -I lanplus -U $USERNAME -E -H ncn-s001-mgmt power on
-        ```
+    ```bash
+    pit# grep -oP $stoken /etc/dnsmasq.d/statics.conf | grep -v "ncn-s001-" | sort -u |
+            xargs -t -i ipmitool -I lanplus -U $USERNAME -E -H {} power on; \
+         sleep 60; ipmitool -I lanplus -U $USERNAME -E -H ncn-s001-mgmt power on
+    ```
 
 1. Wait. Observe the installation through `ncn-s001-mgmt`'s console:
 
@@ -526,9 +527,8 @@ If there are LVM check failures, then the problem must be resolved before contin
 <a name="check-for-unused-drives-on-utility-storage-nodes"></a>
 ### 3.4 Check for Unused Drives on Utility Storage Nodes
 
- > **`IMPORTANT:`** Do the following if NCNs are Gigabyte hardware.
- > **`IMPORTANT:`** the cephadm may output this warning "WARNING: The same type, major and minor should not be used for multiple devices.". You can ignore this warning.
-
+> **`IMPORTANT:`** Do the following if NCNs are Gigabyte hardware. It is suggested (but optional) for HPE NCNs.
+>
 > **`IMPORTANT:`** Estimate the expected number of OSDs using the following table and using this equation:
 >
 >  total_osds = (num of utility storage/ceph nodes) * (OSD count from table below for the appropriate hardware)
@@ -630,7 +630,7 @@ If there are LVM check failures, then the problem must be resolved before contin
     **`IMPORTANT:`** The `cephadm` command may output this warning `WARNING: The same type, major and minor should not be used for multiple devices.`. You can ignore this warning.
 
     The field `available` would be `True` if Ceph sees the drive as empty and can
-    be used, e.g.:
+    be used. For example:
 
     ```text
     Device Path               Size         rotates available Model name
@@ -761,7 +761,7 @@ Observe the output of the checks and note any failures, then remediate them.
    Total Tests: 7, Total Passed: 7, Total Failed: 0, Total Execution Time: 1.4226 seconds
    ```
 
-   If the test total line reports any failed tests, look through the full output of the test in csi-pit-validate-ceph.log to see which node had the failed test and what the details are for that test.
+   If the test total line reports any failed tests, look through the full output of the test in `csi-pit-validate-ceph.log` to see which node had the failed test and what the details are for that test.
 
    **`Note`**: Please see [Utility Storage](../operations/utility_storage/Utility_Storage.md) to help resolve any failed tests.
 
@@ -789,7 +789,7 @@ Observe the output of the checks and note any failures, then remediate them.
 
    If these total lines report any failed tests, look through the full output of the test to see which node had the failed test and what the details are for that test.
 
-   > **`WARNING`** If there are failures for tests with names like "Worker Node CONLIB FS Label", then manual tests should be run on the node which reported the failure. See [Manual LVM Check Procedure](#manual-lvm-check-procedure). If the manual tests fail, then the problem must be resolved before continuing to the next step. See [LVM Check Failure Recovery](#lvm-check-failure-recovery).
+   > **`WARNING`** If there are failures for tests with names like `Worker Node CONLIB FS Label`, then manual tests should be run on the node which reported the failure. See [Manual LVM Check Procedure](#manual-lvm-check-procedure). If the manual tests fail, then the problem must be resolved before continuing to the next step. See [LVM Check Failure Recovery](#lvm-check-failure-recovery).
 
 1. Ensure that weave has not become split-brained.
 
@@ -843,6 +843,6 @@ Observe the output of the checks and note any failures, then remediate them.
 <a name="next-topic"></a>
 # Next Topic
 
-   After completing the deployment of the management nodes, the next step is to install the CSM services.
+After completing the deployment of the management nodes, the next step is to install the CSM services.
 
-   See [Install CSM Services](index.md#install_csm_services)
+See [Install CSM Services](index.md#install_csm_services)

--- a/install/index.md
+++ b/install/index.md
@@ -16,25 +16,25 @@ like the checking and updating of firmware on system components or the preparati
 
 Once the CSM installation has completed, other product streams for the HPE Cray EX system can be installed.
 
-### Topics:
+## Topics
 
-   1. [Validate SHCD](../operations/network/management_network/validate_shcd.md)
-   1. [Prepare Configuration Payload](#prepare_configuration_payload)
-   1. [Prepare Management Nodes](#prepare_management_nodes)
-   1. [Bootstrap PIT Node](#bootstrap_pit_node)
-   1. [Configure Management Network Switches](#configure_management_network)
-   1. [Collect MAC Addresses for NCNs](#collect_mac_addresses_for_ncns)
-   1. [Deploy Management Nodes](#deploy_management_nodes)
-   1. [Install CSM Services](#install_csm_services)
-   1. [Validate CSM Health Before Final NCN Deployment](#validate_csm_health_before_final_ncn_deploy)
-   1. [Deploy Final NCN](#deploy_final_ncn)
-   1. [Configure Administrative Access](#configure_administrative_access)
-   1. [Validate CSM Health](#validate_csm_health)
-   1. [Configure Prometheus Alert Notifications](#configure_prometheus_alert_notifications)
-   1. [Update Firmware with FAS](#update_firmware_with_fas)
-   1. [Prepare Compute Nodes](#prepare_compute_nodes)
-   1. [Next Topic](#next_topic)
-   1. [Troubleshooting Installation Problems](#troubleshooting_installation)
+1. [Validate SHCD](../operations/network/management_network/validate_shcd.md)
+1. [Prepare Configuration Payload](#prepare_configuration_payload)
+1. [Prepare Management Nodes](#prepare_management_nodes)
+1. [Bootstrap PIT Node](#bootstrap_pit_node)
+1. [Configure Management Network Switches](#configure_management_network)
+1. [Collect MAC Addresses for NCNs](#collect_mac_addresses_for_ncns)
+1. [Deploy Management Nodes](#deploy_management_nodes)
+1. [Install CSM Services](#install_csm_services)
+1. [Validate CSM Health Before Final NCN Deployment](#validate_csm_health_before_final_ncn_deploy)
+1. [Deploy Final NCN](#deploy_final_ncn)
+1. [Configure Administrative Access](#configure_administrative_access)
+1. [Validate CSM Health](#validate_csm_health)
+1. [Configure Prometheus Alert Notifications](#configure_prometheus_alert_notifications)
+1. [Update Firmware with FAS](#update_firmware_with_fas)
+1. [Prepare Compute Nodes](#prepare_compute_nodes)
+1. [Next Topic](#next_topic)
+1. [Troubleshooting Installation Problems](#troubleshooting_installation)
 
 The topics in this chapter need to be done as part of an ordered procedure so are shown here with numbered topics.
 

--- a/install/index.md
+++ b/install/index.md
@@ -1,14 +1,19 @@
 # Install CSM
 
+## Abstract
+
 Installation of the CSM product stream has many steps in multiple procedures which should be done in a
 specific order. Information about the HPE Cray EX system and the site is used to prepare the configuration
 payload. The initial node used to bootstrap the installation process is called the PIT node because the
-Pre-Install Toolkit (PIT) is installed there. Once the management network switches have been configured, the other
+Pre-Install Toolkit (PIT) is installed there.
+
+Once the management network switches have been configured, the other
 management nodes can be deployed with an operating system and the software to create a Kubernetes cluster
 utilizing Ceph storage. The CSM services provide essential software infrastructure including the API gateway
 and many micro-services with REST APIs for managing the system. Once administrative access has been configured,
 the installation of CSM software can be validated with health checks before doing operational tasks
-like the checking and updating of firmware on system components or the preparation of compute nodes.
+like the checking and updating of firmware on system components or the preparation of compute nodes. 
+
 Once the CSM installation has completed, other product streams for the HPE Cray EX system can be installed.
 
 ### Topics:
@@ -33,7 +38,7 @@ Once the CSM installation has completed, other product streams for the HPE Cray 
 
 The topics in this chapter need to be done as part of an ordered procedure so are shown here with numbered topics.
 
-**Note**: If problems are encountered during the installation, some topics have their own troubleshooting
+**`Note`**: If problems are encountered during the installation, some topics have their own [troubleshooting sections found in the operations index](../operations/index.md).
 sections, but there is also a general troubleshooting topic.
 
 ## Details
@@ -94,7 +99,9 @@ sections, but there is also a general troubleshooting topic.
 
       Now that the PIT node has been booted with the LiveCD environment and CSI has generated the switch IP addresses,
       the management network switches can be configured.
-      [Management Net Docs](../operations/network/management_network/index.md)
+
+      See [Management Network User Guide](../operations/network/management_network/index.md)
+
 
       **Note**: If a reinstall of this software release is being done on this system and the management network switches
       have already been configured, then this topic could be skipped and instead move to

--- a/install/prepare_configuration_payload.md
+++ b/install/prepare_configuration_payload.md
@@ -6,9 +6,9 @@ can be passed to the `csi` (Cray Site Init) program during the CSM installation 
 Information gathered from a site survey is needed to feed into the CSM installation process, such as system name, system size, site network information for the CAN, site DNS configuration, site NTP configuration, network information for the node used to bootstrap the installation. More detailed component level information about the system hardware is encapsulated in the SHCD (Shasta Cabling Diagram), which is a spreadsheet prepared by HPE Cray Manufacturing to assemble the components of the system and connect appropriately labeled cables.
 
 How the configuration payload is prepared depends on whether this is a first time installation of CSM
-software on this system or the CSM software is being reinstalled. The reinstall scenario has the
+software on this system or the CSM software is being reinstalled. The *reinstall scenario* has the
 advantage of being able to use the configuration payload from the previous CSM installation
-and an extra configuration file which that installation generated.
+and an additional configuration file which that installation generated. The *first time* install scenario requires using the csi config tool to pass arguments to CSI as well as the creation of a number of [Configuration Payload Files}(#configuration-payload-files).
 
 
 ### Topics
@@ -24,14 +24,14 @@ and an extra configuration file which that installation generated.
 <a name="command_line_configuration_payload"></a>
 ### Command Line Configuration Payload
 
-This information from a site survey can be given to the `csi` command as command line arguments.
-The information is shown here to explain what data is needed. It will not be used until moving
+The information from a site survey can be given to the `csi` command as command line arguments.
+The information and options shown below are to explain what data is needed. It will not be used until moving
 to the [Bootstrap PIT Node](index.md#bootstrap_pit_node) procedure.
 
 The air-cooled cabinet is known to `csi` as a `river` cabinet. The liquid-cooled cabinets are either
 `mountain` or `hill` (if a TDS system).
 
-For more description of these settings and the default values, see [Default IP Address Ranges](../introduction/csm_overview.md#default_ip_address_ranges) and the other topics in [CSM Overview](../introduction/csm_overview.md).
+For more description of these settings and the default values, see [Default IP Address Ranges](../introduction/csm_overview.md#default_ip_address_ranges) and the other topics in [CSM Overview](../introduction/csm_overview.md). There are additional options not shown on this page that can be seen by running `csi config init --help`.
 
 | CSI option | Information |
 | --- | --- |

--- a/install/prepare_management_nodes.md
+++ b/install/prepare_management_nodes.md
@@ -1,6 +1,6 @@
 # Prepare Management Nodes
 
-The procedures described on this page are being done before any node is booted with the Cray Pre-Install Toolkit. When the PIT node is referenced during these procedures, it means the node that will be be booted as the PIT node.
+The procedures described on this page must be completed before any node is booted with the Cray Pre-Install Toolkit (PIT), which is performed in a later document. When the PIT node is referenced during these procedures, it means the node that will be booted as the PIT node.
 
 ## Topics
 

--- a/introduction/csm_overview.md
+++ b/introduction/csm_overview.md
@@ -4,7 +4,7 @@ This CSM Overview describes the Cray System Management ecosystem with its hardwa
 
 The CSM installation prepares and deploys a distributed system across a group of management nodes organized into a Kubernetes cluster which uses Ceph for utility storage. These nodes perform their function as Kubernetes master nodes, Kubernetes worker nodes, or utility storage nodes with the Ceph storage.
 
-System services on these nodes are provided as containerized micro-services packaged for deployment via Helm charts. Kubernetes orchestrates these services and schedules them on Kubernetes worker nodes with horizontal scaling. Horizontal scales increases or decreases the number of services instances demand for them varies, such as when booting many compute nodes or application nodes.
+System services on these nodes are provided as containerized micro-services packaged for deployment via Helm charts. Kubernetes orchestrates these services and schedules them on Kubernetes worker nodes with horizontal scaling. Horizontal scaling increases or decreases the number of services' instances as demand for them varies, such as when booting many compute nodes or application nodes.
 
 ### Topics:
    1. [System Nodes and Networks](#system_nodes_and_networks)
@@ -139,8 +139,8 @@ is no single point of failure. The design of the system allows for resiliency in
    the total balance of pods. It is less significant to lose one of the worker nodes if the system has more
    than three worker nodes because there are more worker nodes able to handle the pod load.
    * The state and configuration of the Kubernetes cluster are stored in an etcd cluster distributed across the
-   Kubernetes master nodes. This cluster is also backed up on an interval, and backups are pushed to Ceph
-   Rados Gateway (S3).
+   Kubernetes master nodes. This cluster is also backed up on an interval, and backups are pushed to the
+   local cluster's Ceph Rados Gateway (S3).
    * A micro-service can run on any node that meets the requirements for that micro-service, such as appropriate
    hardware attributes, which are indicated by Kubernetes labels and taints.
    * All micro-services have shared persistent storage so that they can be restarted on any worker node in the Kubernetes

--- a/introduction/index.md
+++ b/introduction/index.md
@@ -23,7 +23,7 @@ for an HPE Cray EX system.
 
    System services on these nodes are provided as containerized micro-services packaged for deployment
    via Helm charts. Kubernetes orchestrates these services and schedules them on Kubernetes worker
-   nodes with horizontal scaling. Horizontal scales increases or decreases the number of services instances
+   nodes with horizontal scaling. Horizontal scaling increases or decreases the number of services' instances as
    demand for them varies, such as when booting many compute nodes or application nodes.
 
    There is much more information available in the [CSM Overview](csm_overview.md) about the hardware,
@@ -55,9 +55,8 @@ See [Scenarios for Shasta v1.5](scenarios.md)
 <a name="operations"></a>
 ## CSM Operational Activities
 
-   Procedures which are used during either installation or upgrading of software or in both, but which
-   may also be used for general operation of the system reside here. They are referenced in the context
-   of the installation workflow. For example, updating firmware with FAS or running the CSM health checks.
+   Procedures which are used during either installation, upgrading or general operation of the system reside here. They are referenced in the context
+   of the specific workflow. For example, updating firmware with FAS or running the CSM health checks.
 
    See [CSM Operational Activities](../operations/index.md)
 

--- a/operations/boot_orchestration/Troubleshoot_Compute_Node_Boot_Issues_Related_to_Unified_Extensible_Firmware_Interface_UEFI.md
+++ b/operations/boot_orchestration/Troubleshoot_Compute_Node_Boot_Issues_Related_to_Unified_Extensible_Firmware_Interface_UEFI.md
@@ -35,5 +35,5 @@ Encryption of compute node logs is not enabled, so the passwords may be passed i
 3.  Use one of the following options to resolve the issue:
 
     -   Contact the system administrator or someone who is knowledgeable about UEFI if the node is stuck in the UEFI shell.
-    -   Reseat the node if it is suspected that this may be a hardware related issue. To reseat a node, pull the power cable off the back end of the box. Wait a few seconds, then reconnect the power cable and push the power button on the front of the box. Reseating a node must be done on site. Contact customer support for more information.
+    -   Reseat the node if it is suspected that this may be a hardware-related issue. To reseat a node, pull the power cable off the back end of the box. Wait a few seconds, then reconnect the power cable and push the power button on the front of the box. Reseating a node must be done on site. Contact customer support for more information.
 

--- a/operations/hpe_pdu/hpe_pdu_admin_procedures.md
+++ b/operations/hpe_pdu/hpe_pdu_admin_procedures.md
@@ -109,7 +109,7 @@ The firmware will be updated and the PDU management processor will restart.
     ```bash
     ncn# cray hsm inventory ethernetInterfaces delete {ID}
     ```
-1. On the next `hms-discovery` job run, it should locate the PDU and discover it correctly as a HPE PDU.
+1. On the next `hms-discovery` job run, it should locate the PDU and discover it correctly as an HPE PDU.
     After waiting 5 minutes, verify the Ethernet interfaces that were previously deleted are now present:
     ```bash
     ncn# cray hsm inventory ethernetInterfaces list --type CabinetPDUController

--- a/operations/image_management/Configure_IMS_to_validate_rpms.md
+++ b/operations/image_management/Configure_IMS_to_validate_rpms.md
@@ -1,4 +1,4 @@
-# Configure IMS to validate RPMS
+# Configure IMS to Validate RPMs
 
 Configuring IMS to validate the GPG signatures of RPMs during IMS Build operations involves two steps.
 

--- a/operations/image_management/Create_UAN_Boot_Images.md
+++ b/operations/image_management/Create_UAN_Boot_Images.md
@@ -339,7 +339,7 @@ This guide only details how to apply UAN-specific configuration to the UAN image
 
     10. Verify that there is only one subdirectory in the lib/modules directory of the image.
 
-        The existence of more than one subdirectory indicates a mismatch between the kernel of the image and the DVS RPMS that were installed in the previous step.
+        The existence of more than one subdirectory indicates a mismatch between the kernel of the image and the DVS RPMs that were installed in the previous step.
 
         ```bash
         ncn-m001# la UAN-1.4.0-day-zero/lib/modules/

--- a/operations/index.md
+++ b/operations/index.md
@@ -77,7 +77,7 @@ Build and customize image recipes with the Image Management Service (IMS).
      * [Create UAN Boot Images](image_management/Create_UAN_Boot_Images.md)
      * [Convert TGZ Archives to SquashFS Images](image_management/Convert_TGZ_Archives_to_SquashFS_Images.md)
    * [Delete or Recover Deleted IMS Content](image_management/Delete_or_Recover_Deleted_IMS_Content.md)
-   * [Configure IMS to validate RPMS](image_management/Configure_IMS_to_validate_rpms.md)
+   * [Configure IMS to Validate RPMs](image_management/Configure_IMS_to_validate_rpms.md)
 
 <a name="boot-orchestration"></a>
 
@@ -333,7 +333,7 @@ Mechanisms used by the system to ensure the security and authentication of inter
        * [Change the LDAP Server IP Address for New LDAP Server Content](security_and_authentication/Change_the_LDAP_Server_IP_Address_for_New_LDAP_Server_Content.md)
        * [Remove the LDAP User Federation from Keycloak](security_and_authentication/Remove_the_LDAP_User_Federation_from_Keycloak.md)
        * [Add LDAP User Federation](security_and_authentication/Add_LDAP_User_Federation.md)
-       * [Keycloak User Management with kcadm.sh](security_and_authentication/Keycloak_User_Management_with_Kcadm.md)
+       * [Keycloak User Management with `kcadm.sh`](security_and_authentication/Keycloak_User_Management_with_Kcadm.md)
    * [Public Key Infrastructure \(PKI\)](security_and_authentication/Public_Key_Infrastructure_PKI.md)
        * [PKI Certificate Authority \(CA\)](security_and_authentication/PKI_Certificate_Authority_CA.md)
        * [Make HTTPS Requests from Sources Outside the Management Kubernetes Cluster](security_and_authentication/Make_HTTPS_Requests_from_Sources_Outside_the_Management_Kubernetes_Cluster.md)

--- a/operations/index.md
+++ b/operations/index.md
@@ -426,7 +426,7 @@ Enable system administrators to assess the health of their system. Operators nee
   * [System Management Health Checks and Alerts](system_management_health/System_Management_Health_Checks_and_Alerts.md)
   * [Access System Management Health Services](system_management_health/Access_System_Management_Health_Services.md)
   * [Configure Prometheus Email Alert Notifications](system_management_health/Configure_Prometheus_Email_Alert_Notifications.md)
-
+  * [Troubleshoot Grafana Dashboard](system_management_health/Troubleshoot_Grafana_Dashboard.md)
 
 <a name="system-layout-service-sls"></a>
 

--- a/operations/kubernetes/Recover_from_Postgres_WAL_Event.md
+++ b/operations/kubernetes/Recover_from_Postgres_WAL_Event.md
@@ -1,6 +1,6 @@
 # Recover from Postgres WAL Event
 
-A WAL event can occur because of lag, network communication, or bandwidth issues. This can cause the PVC hosted by Ceph and mounted inside the container on /home/postgres/pgdata to fill and the database to stop running. If no database dump exists, the disk space issue needs to be fixed so that a dump can be taken. Then the dump can be restored to a newly created postgresql cluster. If a dump already exists, skip to [Rebuild the Cluster and Restore the Data](#rebuild-restore).
+A WAL event can occur because of lag, network communication, or bandwidth issues. This can cause the PVC hosted by Ceph and mounted inside the container on `/home/postgres/pgdata` to fill and the database to stop running. If no database dump exists, the disk space issue needs to be fixed so that a dump can be taken. Then the dump can be restored to a newly created postgresql cluster. If a dump already exists, skip to [Rebuild the cluster and Restore the data](#rebuild-restore).
 
 If no database dump exists and neither option results in a successful dump, then services specific [Disaster Recovery for Postgres](Disaster_Recovery_Postgres.md) will be required.
 
@@ -13,202 +13,187 @@ The Recovery Workflow:
  - [Rebuild the Cluster and Restore the Data](#rebuild-restore)
 
 <a name="recover-database"></a>
-### Attempt to Recover to a Running Database
+## Attempt to Recover to a Running Database
 
 A running database is needed to be able to dump the current data.
 
 The following example is based on `cray-smd-postgres`.
 
-1. Confirm that the database is down (no endpoint exists) and that the disk is full on one or more postgresql cluster member.
+Confirm that the database is down (no endpoint exists) and that the disk is full on one or more postgresql cluster member.
 
-    ```bash
-    ncn-w001# POSTGRESQL=cray-smd-postgres
-    $ NAMESPACE=services
+```bash
+ncn-mw# POSTGRESQL=cray-smd-postgres
+ncn-mw# NAMESPACE=services
+ncn-mw# kubectl get endpoints ${POSTGRESQL} -n ${NAMESPACE}
+```
+    
+Expected output looks similar to:
+```
+NAME                ENDPOINTS         AGE
+cray-smd-postgres                     3d22h
+```
 
-    ncn-w001# kubectl get endpoints ${POSTGRESQL} -n ${NAMESPACE}
-    NAME                ENDPOINTS         AGE
-    cray-smd-postgres                     3d22h
-    ```
+```bash
+ncn-mw# for i in {0..2}; do 
+            echo "${POSTGRESQL}-${i}:"
+            kubectl exec ${POSTGRESQL}-${i} -n ${NAMESPACE} -c postgres -- df -h pgdata
+        done
+```
+    
+Expected output looks similar to:
+```
+cray-smd-postgres-0:
+Filesystem      Size  Used Avail Use% Mounted on
+/dev/rbd8        30G   28G  1.6G  95% /home/postgres/pgdata
+cray-smd-postgres-1:
+Filesystem      Size  Used Avail Use% Mounted on
+/dev/rbd15       30G   30G     0 100% /home/postgres/pgdata
+cray-smd-postgres-2:
+Filesystem      Size  Used Avail Use% Mounted on
+/dev/rbd6        30G  383M   30G   2% /home/postgres/pgdata
+```
 
-    ```bash
-    ncn-w001# for i in {0..2}; do echo "${POSTGRESQL}-${i}:"; kubectl exec ${POSTGRESQL}-${i} -n ${NAMESPACE} -c postgres -- df -h pgdata; done
-    ```
-
-    Example output:
-
-    ```
-    cray-smd-postgres-0:
-    Filesystem      Size  Used Avail Use% Mounted on
-    /dev/rbd8        30G   28G  1.6G  95% /home/postgres/pgdata
-    cray-smd-postgres-1:
-    Filesystem      Size  Used Avail Use% Mounted on
-    /dev/rbd15       30G   30G     0 100% /home/postgres/pgdata
-    cray-smd-postgres-2:
-    Filesystem      Size  Used Avail Use% Mounted on
-    /dev/rbd6        30G  383M   30G   2% /home/postgres/pgdata
-    ```
-
-    If the database is down and the disk is full because of replication issues, there are two ways to attempt to get back to a running database: either delete files or resize the Postgres PVCs until the database is able to start running again.
+If the database is down and the disk is full because of replication issues, there are two ways to attempt to get back to a running database: either delete files or resize the Postgres PVCs until the database is able to start running again.
 
 <a name="option1"></a>
-#### Option 1: Clear Logs and/or WAL Files
+### Option 1 : Clear logs and/or WAL files
 
 The following example is based on `cray-smd-postgres`.
 
-1. Clear files from /home/postgres/pgdata/pgroot/pg_log/ until the database is running again and you can successfully connect. For example, if the disk space is at 100%, exec into that pod, copy the logs off (optional) and then clear the logs to recover some disk space.
+1. Clear files from `/home/postgres/pgdata/pgroot/pg_log/` until the database is running again and you can successfully connect. For example, if the disk space is at 100%, exec into that pod, copy the logs off (optional) and then clear the logs to recover some disk space.
 
-    ```
-    ncn-w001# kubectl cp "${POSTGRESQL}-1":/home/postgres/pgdata/pgroot/pg_log /tmp -c postgres -n ${NAMESPACE}
-    ncn-w001# kubectl exec "${POSTGRESQL}-1" -n ${NAMESPACE} -c postgres -it -- bash
+    ```bash
+    ncn-mw# kubectl cp "${POSTGRESQL}-1":/home/postgres/pgdata/pgroot/pg_log /tmp -c postgres -n ${NAMESPACE}
+    ncn-mw# kubectl exec "${POSTGRESQL}-1" -n ${NAMESPACE} -c postgres -it -- bash
     root@cray-smd-postgres-1:/home/postgres# for i in {0..7}; do > /home/postgres/pgdata/pgroot/pg_log/postgresql-$i.csv; done
     ```
 
-2. Restart the Postgres cluster and postgres-operator.
+1. Restart the Postgres cluster and `postgres-operator`.
 
+    ```bash
+    ncn-mw# kubectl delete pod -n ${NAMESPACE} "${POSTGRESQL}-0" "${POSTGRESQL}-1" "${POSTGRESQL}-2"
+    ncn-mw# kubectl delete pod -n services -l app.kubernetes.io/name=postgres-operator
     ```
-    ncn-w001# kubectl delete pod -n ${NAMESPACE} "${POSTGRESQL}-0" "${POSTGRESQL}-1" "${POSTGRESQL}-2"
-    ncn-w001# kubectl delete pod -n services -l app.kubernetes.io/name=postgres-operator
-    ```
+    
+1. Check if the database is running. If it is running, then continue with [Dumping the data](#dump).
 
-3. Check if the database is running. If it is running, continue with [Dump the Data](#dump).
-
-    ```
-    ncn-w001# kubectl exec "${POSTGRESQL}-1" -n ${NAMESPACE} -c postgres -it -- psql -U postgres
+    ```bash
+    ncn-mw# kubectl exec "${POSTGRESQL}-1" -n ${NAMESPACE} -c postgres -it -- psql -U postgres
     psql (12.2 (Ubuntu 12.2-1.pgdg18.04+1), server 11.7 (Ubuntu 11.7-1.pgdg18.04+1))
     Type "help" for help.
 
     postgres=#   <----- success!!  Type \q
     ```
+    
+1. If the database is still not running, then delete files from `/home/postgres/pgdata/pgroot/data/pg_wal/`.
 
-4. If the database is still not running, delete files from /home/postgres/pgdata/pgroot/data/pg\_wal/.
+    > CAUTION: This method could result in unintended consequences for the Postgres database and long service downtime; do not use unless there is a known [Disaster Recovery for Postgres](Disaster_Recovery_Postgres.md) procedure for repopulating the Postgres cluster.
 
-    > **CAUTION:** This method could result in unintended consequences for the Postgres database and long service downtime; do not use unless there is a known [Disaster Recovery for Postgres](Disaster_Recovery_Postgres.md) procedure for repopulating the Postgres cluster.
-
-    ```
-    ncn-w001# kubectl exec "${POSTGRESQL}-1" -n ${NAMESPACE} -c postgres -it -- bash
+    ```bash
+    ncn-mw# kubectl exec "${POSTGRESQL}-1" -n ${NAMESPACE} -c postgres -it -- bash
     root@cray-smd-postgres-1:/home/postgres# rm pgdata/pgroot/data/pg_wal/0*
     ```
 
-5. Restart the Postgres cluster and postgres-operator.
+1. Restart the Postgres cluster and `postgres-operator`.
 
+    ```bash
+    ncn-mw# kubectl delete pod -n ${NAMESPACE} "${POSTGRESQL}-0" "${POSTGRESQL}-1" "${POSTGRESQL}-2"
+    ncn-mw# kubectl delete pod -n services -l app.kubernetes.io/name=postgres-operator
     ```
-    ncn-w001# kubectl delete pod -n ${NAMESPACE} "${POSTGRESQL}-0" "${POSTGRESQL}-1" "${POSTGRESQL}-2"
-    ncn-w001# kubectl delete pod -n services -l app.kubernetes.io/name=postgres-operator
+    
+1. Check if the database is running.
     ```
-
-6. Check if the database is running.
-
-    ```
-    ncn-w001# kubectl exec "${POSTGRESQL}-1" -n ${NAMESPACE} -c postgres -it -- psql -U postgres
+    ncn-mw# kubectl exec "${POSTGRESQL}-1" -n ${NAMESPACE} -c postgres -it -- psql -U postgres
     psql (12.2 (Ubuntu 12.2-1.pgdg18.04+1), server 11.7 (Ubuntu 11.7-1.pgdg18.04+1))
     Type "help" for help.
 
     postgres=#   <----- success!!  Type \q
     ```
 
-7. If the database is still not running, try recovering using the other option listed in this document.
+1. If the database is still not running, then try recovering using the other option listed in this document.
 
 <a name="option2"></a>
-#### Option 2: Resize the Postgres PVCs
+### Option 2 : Resize the Postgres PVCs
 
 The following example is based on `cray-smd-postgres`, where the postgresql `cray-smd-postgres` resource and the `pgdata-cray-smd-postgres` PVCs will be resized from `100Gi` to `120Gi`.
 
-1. Determine the current size of the Postgres PVCs and set PGRESIZE to the desired new size (it must be larger than the current size).
+1. Determine the current size of the Postgres PVCs and set `PGRESIZE` to the desired new size (it must be larger than the current size).
 
-    ```
-    ncn-w001# kubectl get postgresql -A | grep "smd\|NAME"
+    ```bash
+    ncn-mw# kubectl get postgresql -A | grep "smd\|NAME"
     NAMESPACE   NAME                         TEAM                VERSION   PODS   VOLUME   CPU-REQUEST   MEMORY-REQUEST   AGE   STATUS
     services    cray-smd-postgres            cray-smd            11        3      100Gi    4             8Gi              18h   Running
 
-    ncn-w001# kubectl get pvc -A | grep "cray-smd-postgres\|NAME"
+    ncn-mw# kubectl get pvc -A | grep "cray-smd-postgres\|NAME"
     NAMESPACE      NAME                         STATUS    VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS           AGE
     services       pgdata-cray-smd-postgres-0   Bound     pvc-c86859f4-a57f-4694-a66a-8120e96a1ab4   100Gi      RWO            k8s-block-replicated   18h
     services       pgdata-cray-smd-postgres-1   Bound     pvc-300f52e4-f88d-47ef-9a1e-e598fd919047   100Gi      RWO            k8s-block-replicated   18h
     services       pgdata-cray-smd-postgres-2   Bound     pvc-f33879f3-0e99-4299-b796-210fbb693a2f   100Gi      RWO            k8s-block-replicated   18h
 
-    ncn-w001# PGRESIZE=120Gi
-    ncn-w001# POSTGRESQL=cray-smd-postgres
-    ncn-w001# PGDATA=pgdata-cray-smd-postgres
-    ncn-w001# NAMESPACE=services
+    ncn-mw# PGRESIZE=120Gi
+    ncn-mw# POSTGRESQL=cray-smd-postgres
+    ncn-mw# PGDATA=pgdata-cray-smd-postgres
+    ncn-mw# NAMESPACE=services
     ```
 
-2. Edit numberOfInstances in the postgresql resource from 3 to 1.
+1. Edit `numberOfInstances` in the `postgresql` resource from 3 to 1.
 
-    ```
-    ncn-w001# kubectl patch postgresql ${POSTGRESQL} -n ${NAMESPACE} --type=json -p='[{"op" : "replace", "path":"/spec/numberOfInstances", "value" : 1}]'
+    ```bash
+    ncn-mw# kubectl patch postgresql ${POSTGRESQL} -n ${NAMESPACE} --type=json -p='[{"op" : "replace", "path":"/spec/numberOfInstances", "value" : 1}]'
     postgresql.acid.zalan.do/cray-smd-postgres patched
     ```
 
-3. Wait for 2 of the 3 postgresql pods to terminate.
+1. Wait for 2 of the 3 postgresql pods to terminate.
 
     ```
-    ncn-w001# while [ $(kubectl get pods -l "application=spilo,cluster-name=${POSTGRESQL}" -n ${NAMESPACE} | grep -v NAME | wc -l) != 1 ] ; do echo "  waiting for pods to terminate"; sleep 2; done
+    ncn-mw# while [ $(kubectl get pods -l "application=spilo,cluster-name=${POSTGRESQL}" -n ${NAMESPACE} | grep -v NAME | wc -l) != 1 ] ; do
+                echo "  waiting for pods to terminate"
+                sleep 2
+            done
     ```
 
-4. Delete the PVCs from the non-running Postgres pods.
+1. Delete the PVCs from the non-running Postgres pods.
 
-    ```
-    ncn-w001# kubectl delete pvc "${PGDATA}-1" "${PGDATA}-2" -n ${NAMESPACE}
-    ```
-
-    Example output:
-
-    ```
+    ```bash
+    ncn-mw# kubectl delete pvc "${PGDATA}-1" "${PGDATA}-2" -n ${NAMESPACE}
     persistentvolumeclaim "pgdata-cray-smd-postgres-1" deleted
     persistentvolumeclaim "pgdata-cray-smd-postgres-2" deleted
     ```
 
-5. Resize the remaining Postgres PVC resources.requests.storage to $PGRESIZE.
+1. Resize the remaining Postgres PVC `resources.requests.storage` to `$PGRESIZE`.
 
-    ```
-    ncn-w001# kubectl patch -p '{"spec": {"resources": {"requests": {"storage": "'${PGRESIZE}'"}}}}' "pvc/${PGDATA}-0" -n ${NAMESPACE}
-    ```
-
-    Example output:
-
-    ```
+    ```bash
+    ncn-mw# kubectl patch -p '{"spec": {"resources": {"requests": {"storage": "'${PGRESIZE}'"}}}}' "pvc/${PGDATA}-0" -n ${NAMESPACE}
     persistentvolumeclaim/pgdata-cray-smd-postgres-0 patched
     ```
 
-6. Wait for the PVC to resize.
+1. Wait for the PVC to resize.
 
-    ```
-    ncn-w001# while [ -z '$(kubectl describe pvc "${PGDATA}-0" -n ${NAMESPACE} | grep FileSystemResizeSuccessful' ] ; do echo "  waiting for PVC to resize"; sleep 2; done
-    ```
-
-7. Update the postgresql resource spec.volume.size to $PGRESIZE.
-
-    ```
-    ncn-w001# kubectl get "postgresql/${POSTGRESQL}" -n ${NAMESPACE} -o json | jq '.spec.volume = {"size": "'${PGRESIZE}'"}' | kubectl apply -f -
+    ```bash
+    ncn-mw# while [ -z '$(kubectl describe pvc "${PGDATA}-0" -n ${NAMESPACE} | grep FileSystemResizeSuccessful' ] ; do
+                echo "  waiting for PVC to resize"
+                sleep 2
+            done
     ```
 
-    Example output:
+1. Update the `postgresql` resource `spec.volume.size` to `$PGRESIZE`.
 
-    ```
+    ```bash
+    ncn-mw# kubectl get "postgresql/${POSTGRESQL}" -n ${NAMESPACE} -o json | jq '.spec.volume = {"size": "'${PGRESIZE}'"}' | kubectl apply -f -
     postgresql.acid.zalan.do/cray-smd-postgres configured
     ```
 
-8. Restart the existing postgresql pod.
+1. Restart the existing `postgresql` pod.
 
-    ```
-    ncn-w001# kubectl delete pod "${POSTGRESQL}-0" -n services
-    ```
-
-    Example output:
-
-    ```
+    ```bash
+    ncn-mw# kubectl delete pod "${POSTGRESQL}-0" -n services
     pod "cray-smd-postgres-0" deleted
     ```
 
-9. Check that the single instance pod is Running with 3/3 Ready, patronictl reports the member is Running and postgresql resource is Running with new volume size ($PGRESIZE).
+1. Verify that the single instance pod is `Running` with `3/3` `Ready`, `patronictl` reports the member is running, and the `postgresql` resource is `Running` with new volume size (`$PGRESIZE`).
 
-    ```
-    ncn-w001# kubectl get pods -l "application=spilo,cluster-name=${POSTGRESQL}" -n ${NAMESPACE}
-    ```
-
-    Example output:
-
-    ```
+    ```bash
+    ncn-mw# kubectl get pods -l "application=spilo,cluster-name=${POSTGRESQL}" -n ${NAMESPACE}
     NAME                  READY   STATUS    RESTARTS   AGE
     cray-smd-postgres-0   3/3     Running   0          14s
 
@@ -219,82 +204,71 @@ The following example is based on `cray-smd-postgres`, where the postgresql `cra
     | cray-smd-postgres | cray-smd-postgres-0 | 10.44.0.38 | Leader | running |  2 |           |
     +-------------------+---------------------+------------+--------+---------+----+-----------+
 
-    ```
-    ncn-w001# kubectl get postgresql ${POSTGRESQL} -n ${NAMESPACE}
-    ```
-
-    Example output:
-
-    ```
+    ncn-mw# kubectl get postgresql ${POSTGRESQL} -n ${NAMESPACE}
     NAME                TEAM       VERSION   PODS   VOLUME   CPU-REQUEST   MEMORY-REQUEST   AGE   STATUS
     cray-smd-postgres   cray-smd   11        1      120Gi    500m          100Mi            11m   Running
     ```
 
-10. Check that the database is running.
+1. Verify that the database is running.
 
-    ```
-    ncn-w001# kubectl exec "${POSTGRESQL}-0" -n services -c postgres -it -- psql -U postgres
-    ```
-
-    Example output:
-
-    ```
+    ```bash
+    ncn-mw# kubectl exec "${POSTGRESQL}-0" -n services -c postgres -it -- psql -U postgres
     psql (12.2 (Ubuntu 12.2-1.pgdg18.04+1), server 11.7 (Ubuntu 11.7-1.pgdg18.04+1))
     Type "help" for help.
 
     postgres=#   <----- success!!  Type \q
     ```
 
-11. Scale numberOfInstances in postgresql resource from 1 back to 3.
+1. Scale `numberOfInstances` in `postgresql` resource from 1 back to 3.
 
-    ```
-    ncn-w001# kubectl patch postgresql "${POSTGRESQL}" -n "${NAMESPACE}" --type='json' -p='[{"op" : "replace", "path":"/spec/numberOfInstances", "value" : 3}]'
-    ```
-
-    Example output:
-
-    ```
+    ```bash
+    ncn-mw# kubectl patch postgresql "${POSTGRESQL}" -n "${NAMESPACE}" --type='json' -p='[{"op" : "replace", "path":"/spec/numberOfInstances", "value" : 3}]'
     postgresql.acid.zalan.do/cray-smd-postgres patched
     ```
 
-12. Logs may indicate WAL error such as the following, but a dump can be taken at this point.
+1. Logs may indicate WAL error such as the following, but a dump can be taken at this point.
 
-    ```
-    ncn-w001# kubectl logs "${POSTGRESQL}-0" -n ${NAMESPACE} -c postgres | grep -i error
-    ncn-w001# kubectl logs "${POSTGRESQL}-1" -n ${NAMESPACE} -c postgres | grep -i error
-    ncn-w001# kubectl logs "${POSTGRESQL}-2" -n ${NAMESPACE} -c postgres | grep -i error
+    ```bash
+    ncn-mw# kubectl logs "${POSTGRESQL}-0" -n ${NAMESPACE} -c postgres | grep -i error
+    ncn-mw# kubectl logs "${POSTGRESQL}-1" -n ${NAMESPACE} -c postgres | grep -i error
+    ncn-mw# kubectl logs "${POSTGRESQL}-2" -n ${NAMESPACE} -c postgres | grep -i error
     error: could not get write-ahead log end position from server: ERROR:  invalid segment number
     ```
 
-13. In order to persist any Postgres PVC storage volume size changes, it is necessary that this change also be made to the customer-managed customizations.yaml file. See the Postgres PVC resize information in the [Post Install Customizations](../CSM_product_management/Post_Install_Customizations.md#postgres_pvc_resize).
+1. In order to persist any Postgres PVC storage volume size changes, it is necessary that this change also be made to the 
+   customer-managed `customizations.yaml` file. See the Postgres PVC Resize information in the 
+   [Post Install Customizations](../CSM_product_management/Post_Install_Customizations.md#postgres_pvc_resize).
 
 <a name="dump"></a>
-### Dump the Data
+## Dump the data
 
 If the recovery was successful such that the database is now running, then continue with the following steps to dump the data.
 
 <a name="scale"></a>
 1. Scale the client service to 0.
 
-    The following example is based on `cray-smd`. The `cray-smd` client service is deployed as a deployment. Other services may differ; e.g. statefulset.
+    The following example is based on `cray-smd`. The `cray-smd` client service is deployed as a deployment. Other services may differ; e.g. `statefulset`.
 
-    ```
-    ncn-w001# CLIENT=cray-smd
-    ncn-w001# POSTGRESQL=cray-smd-postgres
-    ncn-w001# NAMESPACE=services
+    ```bash
+    ncn-mw# CLIENT=cray-smd
+    ncn-mw# POSTGRESQL=cray-smd-postgres
+    ncn-mw# NAMESPACE=services
 
-    ncn-w001# kubectl scale deployment ${CLIENT} -n ${NAMESPACE} --replicas=0
+    ncn-mw# kubectl scale deployment ${CLIENT} -n ${NAMESPACE} --replicas=0
     deployment.apps/cray-smd scaled
 
-    ncn-w001# while [ $(kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/name="${CLIENT}" | grep -v NAME | wc -l) != 0 ] ; do echo "  waiting for pods to terminate"; sleep 2; done
+    ncn-mw# while [ $(kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/name="${CLIENT}" | grep -v NAME | wc -l) != 0 ] ; do
+                echo "  waiting for pods to terminate"
+                sleep 2
+            done
     ```
 
-2. Dump all of the data.
+1. Dump all the data.
 
-    Determine which Postgres member is the leader and exec into the leader pod to dump the data to a local file:
+    Determine which Postgres member is the leader and `kubectl exec` into the leader pod in order to dump the data to a local file:
 
-    ```
-    ncn-w001# kubectl exec "${POSTGRESQL}-0" -n ${NAMESPACE} -c postgres -it -- patronictl list
+    ```bash
+    ncn-mw# kubectl exec "${POSTGRESQL}-0" -n ${NAMESPACE} -c postgres -it -- patronictl list
     +-------------------+---------------------+------------+--------+---------+----+-----------+
     |      Cluster      |        Member       |    Host    |  Role  |  State  | TL | Lag in MB |
     +-------------------+---------------------+------------+--------+---------+----+-----------+
@@ -302,17 +276,14 @@ If the recovery was successful such that the database is now running, then conti
     | cray-smd-postgres | cray-smd-postgres-1 | 10.44.0.34 |        | running |    |         0 |
     | cray-smd-postgres | cray-smd-postgres-2 | 10.36.0.44 |        | running |    |         0 |
     +-------------------+---------------------+------------+--------+---------+----+-----------+
-
-    ncn-w001# POSTGRES_LEADER=cray-smd-postgres-0
-
-    ncn-w001# kubectl exec -it ${POSTGRES_LEADER} -n ${NAMESPACE} -c postgres -- pg_dumpall -c -U postgres > "${POSTGRESQL}-dumpall.sql"
-
-    ncn-w001# ls "${POSTGRESQL}-dumpall.sql"
+    ncn-mw# POSTGRES_LEADER=cray-smd-postgres-0
+    ncn-mw# kubectl exec -it ${POSTGRES_LEADER} -n ${NAMESPACE} -c postgres -- pg_dumpall -c -U postgres > "${POSTGRESQL}-dumpall.sql"
+    ncn-mw# ls "${POSTGRESQL}-dumpall.sql"
     cray-smd-postgres-dumpall.sql
     ```
 
 <a name="rebuild-restore"></a>
-### Rebuild the Cluster and Restore the Data
+## Rebuild the cluster and restore the data
 
 If recovery was successful such that a dump could be taken or a dump already exists, then continue with the following steps to rebuild the postgresql cluster and restore the data.
 
@@ -320,30 +291,39 @@ The following example restores the dump to the `cray-smd-postgres` cluster.
 
 1. If the client service is not yet scaled to 0, follow the step above to [scale the client service to 0](#scale).
 
-2. Delete and re-create the postgresql resource (which includes the PVCs).
+1. Delete and re-create the `postgresql` resource (which includes the PVCs).
 
-    ```
-    ncn-w001# CLIENT=cray-smd
-    ncn-w001# POSTGRESQL=cray-smd-postgres
-    ncn-w001# NAMESPACE=services
+    ```bash
+    ncn-mw# CLIENT=cray-smd
+    ncn-mw# POSTGRESQL=cray-smd-postgres
+    ncn-mw# NAMESPACE=services
 
-    ncn-w001# kubectl get postgresql ${POSTGRESQL} -n ${NAMESPACE} -o json | jq 'del(.spec.selector)' | jq 'del(.spec.template.metadata.labels."controller-uid")' | jq 'del(.status)' > postgres-cr.yaml
+    ncn-mw# kubectl get postgresql ${POSTGRESQL} -n ${NAMESPACE} -o json |
+                jq 'del(.spec.selector)' |
+                jq 'del(.spec.template.metadata.labels."controller-uid")' |
+                jq 'del(.status)' > postgres-cr.yaml
 
-    ncn-w001# kubectl delete -f postgres-cr.yaml
+    ncn-mw# kubectl delete -f postgres-cr.yaml
     postgresql.acid.zalan.do "cray-smd-postgres" deleted
 
-    ncn-w001# while [ $(kubectl get pods -l "application=spilo,cluster-name=${POSTGRESQL}" -n ${NAMESPACE} | grep -v NAME | wc -l) != 0 ] ; do echo "  waiting for pods to terminate"; sleep 2; done
+    ncn-mw# while [ $(kubectl get pods -l "application=spilo,cluster-name=${POSTGRESQL}" -n ${NAMESPACE} | grep -v NAME | wc -l) != 0 ] ; do
+                echo "  waiting for pods to terminate"
+                sleep 2
+            done
 
-    ncn-w001# kubectl create -f postgres-cr.yaml
+    ncn-mw# kubectl create -f postgres-cr.yaml
     postgresql.acid.zalan.do/cray-smd-postgres created
 
-    ncn-w001# while [ $(kubectl get pods -l "application=spilo,cluster-name=${POSTGRESQL}" -n ${NAMESPACE} | grep -v NAME | wc -l) != 3 ] ; do echo "  waiting for pods to start running"; sleep 2; done
+    ncn-mw# while [ $(kubectl get pods -l "application=spilo,cluster-name=${POSTGRESQL}" -n ${NAMESPACE} | grep -v NAME | wc -l) != 3 ] ; do
+        echo "  waiting for pods to start running"
+        sleep 2
+    done
     ```
 
-3. Determine which Postgres member is the leader.
+1. Determine which Postgres member is the leader.
 
-    ```
-    ncn-w001# kubectl exec "${POSTGRESQL}-0" -n ${NAMESPACE} -c postgres -it -- patronictl list
+    ```bash
+    ncn-mw# kubectl exec "${POSTGRESQL}-0" -n ${NAMESPACE} -c postgres -it -- patronictl list
     +-------------------+---------------------+------------+--------+---------+----+-----------+
     |      Cluster      |        Member       |    Host    |  Role  |  State  | TL | Lag in MB |
     +-------------------+---------------------+------------+--------+---------+----+-----------+
@@ -352,90 +332,74 @@ The following example restores the dump to the `cray-smd-postgres` cluster.
     | cray-smd-postgres | cray-smd-postgres-2 | 10.36.0.44 |        | running |    |         0 |
     +-------------------+---------------------+------------+--------+---------+----+-----------+
 
-    ncn-w001# POSTGRES_LEADER=cray-smd-postgres-0
+    ncn-mw# POSTGRES_LEADER=cray-smd-postgres-0
     ```
 
-4. Copy the dump taken above to the Postgres leader pod and restore the data.
+1. Copy the dump taken above to the Postgres leader pod and restore the data.
 
     If the dump exists in a different location, adjust this example as needed.
 
+    ```bash
+    ncn-mw# kubectl cp ./cray-smd-postgres-dumpall.sql ${POSTGRES_LEADER}:/home/postgres/cray-smd-postgres-dumpall.sql -c postgres -n ${NAMESPACE}
+
+    ncn-mw# kubectl exec ${POSTGRES_LEADER} -c postgres -n ${NAMESPACE} -it -- psql -U postgres < cray-smd-postgres-dumpall.sql
     ```
-    ncn-w001# kubectl cp ./cray-smd-postgres-dumpall.sql ${POSTGRES_LEADER}:/home/postgres/cray-smd-postgres-dumpall.sql -c postgres -n ${NAMESPACE}
 
-    ncn-w001# kubectl exec ${POSTGRES_LEADER} -c postgres -n ${NAMESPACE} -it -- psql -U postgres < cray-smd-postgres-dumpall.sql
-    ```
+1. Restore the secrets.
 
-5. Restore the secrets.
+    Once the dump has been restored onto the newly built postgresql cluster, the current Kubernetes secrets need to be updated in the 
+    postgresql cluster, otherwise the service will experience readiness and liveness probe failures because it will be unable to 
+    authenticate to the database.
 
-    Once the dump has been restored onto the newly built postgresql cluster, the current Kubernetes secrets need to be updated in the postgresql cluster, otherwise the service will experience readiness and liveness probe failures because it will be unable to authenticate to the database.
+    1. Determine what secrets are associated with the postgresql credentials.
 
-    1. Determine which Postgres member is the leader.
-
-        ```
-        ncn-w001# kubectl exec "${POSTGRESQL}-0" -n ${NAMESPACE} -c postgres -it -- patronictl list
-        +-------------------+---------------------+------------+--------+---------+----+-----------+
-        |      Cluster      |        Member       |    Host    |  Role  |  State  | TL | Lag in MB |
-        +-------------------+---------------------+------------+--------+---------+----+-----------+
-        | cray-smd-postgres | cray-smd-postgres-0 | 10.42.0.25 | Leader | running |  1 |           |
-        | cray-smd-postgres | cray-smd-postgres-1 | 10.44.0.34 |        | running |    |         0 |
-        | cray-smd-postgres | cray-smd-postgres-2 | 10.36.0.44 |        | running |    |         0 |
-        +-------------------+---------------------+------------+--------+---------+----+-----------+
-
-        ncn-w001# POSTGRES_LEADER=cray-smd-postgres-0
-        ```
-
-    2. Determine what secrets are associated with the postgresql credentials.
-
-        ```
-        ncn-w001# kubectl get secrets -n ${NAMESPACE} | grep "${POSTGRESQL}.credentials"
-        ```
-
-        Example output:
-
-        ```
+        ```bash
+        ncn-mw# kubectl get secrets -n ${NAMESPACE} | grep "${POSTGRESQL}.credentials"
         services            hmsdsuser.cray-smd-postgres.credentials                       Opaque                                2      31m
         services            postgres.cray-smd-postgres.credentials                        Opaque                                2      31m
         services            service-account.cray-smd-postgres.credentials                 Opaque                                2      31m
         services            standby.cray-smd-postgres.credentials                         Opaque                                2      31m
         ```
 
-    3. For each secret above, get the username and password from Kubernetes and update the Postgres database with this information.
+    1. For each secret above, get the username and password from Kubernetes and update the Postgres database with this information.
 
-        For example (hmsdsuser.cray-smd-postgres.credentials):
+        For example (`hmsdsuser.cray-smd-postgres.credentials`):
 
-        ```
-        ncn-w001# kubectl get secret hmsdsuser.cray-smd-postgres.credentials -n ${NAMESPACE} -ojsonpath='{.data.username}' | base64 -d
+        ```bash
+        ncn-mw# kubectl get secret hmsdsuser.cray-smd-postgres.credentials -n ${NAMESPACE} -ojsonpath='{.data.username}' | base64 -d
         hmsdsuser
-
-        ncn-w001# kubectl get secret hmsdsuser.cray-smd-postgres.credentials -n ${NAMESPACE} -ojsonpath='{.data.password}'| base64 -d
+        ncn-mw# kubectl get secret hmsdsuser.cray-smd-postgres.credentials -n ${NAMESPACE} -ojsonpath='{.data.password}'| base64 -d
         ABCXYZ
         ```
 
-    4. Exec into the leader pod to reset the user's password:
+    1. `kubectl exec` into the leader pod to reset the user's password:
 
-        ```
-        ncn-w001# kubectl exec ${POSTGRES_LEADER} -n ${NAMESPACE} -c postgres -it -- bash
+        ```bash
+        ncn-mw# kubectl exec ${POSTGRES_LEADER} -n ${NAMESPACE} -c postgres -it -- bash
         root@cray-smd-postgres-0:/home/postgres# /usr/bin/psql postgres postgres
         postgres=# ALTER USER hmsdsuser WITH PASSWORD 'ABCXYZ';
         ALTER ROLE
         postgres=#
         ```
 
-    5. Repeat the previous sub-steps until all ${POSTGRESQL}.credentials secrets have been updated in the database.
+    1. Continue the above process until all `${POSTGRESQL}.credentials` secrets have been updated in the database.
 
-6. Restart the postgresql cluster.
+1. Restart the postgresql cluster
 
-    ```
-    ncn-w001# kubectl delete pod "${POSTGRESQL}-0" "${POSTGRESQL}-1" "${POSTGRESQL}-2" -n ${NAMESPACE}
-
-    ncn-w001# while [ $(kubectl get postgresql ${POSTGRESQL} -n ${NAMESPACE} -o json | jq -r '.status.PostgresClusterStatus') != "Running" ]; do echo "waiting for ${POSTGRESQL} to start running"; sleep 2; done
-    ```
-
-7. Scale the client service back to 3.
-
-    ```
-    ncn-w001# kubectl scale deployment ${CLIENT} -n ${NAMESPACE} --replicas=3
-
-    ncn-w001# while [ $(kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/name="${CLIENT}" | grep -v NAME | wc -l) != 3 ] ; do echo "  waiting for pods to start running"; sleep 2; done
+    ```bash
+    ncn-mw# kubectl delete pod "${POSTGRESQL}-0" "${POSTGRESQL}-1" "${POSTGRESQL}-2" -n ${NAMESPACE}
+    ncn-mw# while [ $(kubectl get postgresql ${POSTGRESQL} -n ${NAMESPACE} -o json |jq -r '.status.PostgresClusterStatus') != "Running" ]; do
+                echo "waiting for ${POSTGRESQL} to start running"
+                sleep 2
+            done
     ```
 
+1. Scale the client service back to 3
+
+    ```bash
+    ncn-mw# kubectl scale deployment ${CLIENT} -n ${NAMESPACE} --replicas=3
+    ncn-mw# while [ $(kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/name="${CLIENT}" | grep -v NAME | wc -l) != 3 ] ; do
+        echo "  waiting for pods to start running"
+        sleep 2
+    done
+    ```

--- a/operations/kubernetes/TDS_Lower_CPU_Requests.md
+++ b/operations/kubernetes/TDS_Lower_CPU_Requests.md
@@ -1,6 +1,6 @@
 # TDS Lower CPU Requests
 
-TDS systems with three worker nodes will encounter pod scheduling issues when worker nodes are taken out of the Kubernetes cluster and being upgraded.  _*For systems with only three worker nodes*_, the following script should be executed to reduce the CPU request for some services with high CPU requests in order to allow critical upgrade related services to be successfully scheduled on two worker nodes:
+TDS systems with three worker nodes will encounter pod scheduling issues when worker nodes are taken out of the Kubernetes cluster and being upgraded.  _*For systems with only three worker nodes*_, the following script should be executed to reduce the CPU request for some services with high CPU requests in order to allow critical upgrade-related services to be successfully scheduled on two worker nodes:
 
 >
 >```bash

--- a/operations/kubernetes/Troubleshoot_Postgres_Database.md
+++ b/operations/kubernetes/Troubleshoot_Postgres_Database.md
@@ -1,6 +1,7 @@
 # Troubleshoot Postgres Database
 
 General Postgres Troubleshooting Topics
+- [The `patronictl` Tool](#patronictl)
 - [Is the Database Unavailable?](#unavailable)
 - [Is the Database Disk Full?](#diskfull)
 - [Is Replication Lagging?](#lag)
@@ -8,14 +9,15 @@ General Postgres Troubleshooting Topics
 - [Is a Cluster Member missing?](#missing)
 - [Is the Postgres Leader missing?](#leader)
 
-## The patronictl Tool
+<a name="patronictl"></a>
+## The `patronictl` Tool
 
-The patronictl tool is used to call a REST API that interacts with Postgres databases. It handles a variety of tasks, such as listing cluster members and the replication status, configuring and restarting databases, and more.
+The `patronictl` tool is used to call a REST API that interacts with Postgres databases. It handles a variety of tasks, such as listing cluster members and the replication status, configuring and restarting databases, and more.
 
 The tool is installed in the database containers:
 
 ```bash
-ncn-w001# kubectl exec -it -n services keycloak-postgres-0 -c postgres -- su postgres
+ncn-mw# kubectl exec -it -n services keycloak-postgres-0 -c postgres -- su postgres
 ```
 
 Use the following command for more information on the `patronictl` command:
@@ -23,14 +25,16 @@ Use the following command for more information on the `patronictl` command:
 ```bash
 postgres@keycloak-postgres-0:~$ patronictl --help
 ```
+
 <a name="unavailable"></a>
 ## Is the Database Unavailable?
+
 If there are no endpoints for the main service, Patroni will mark the database as unavailable.
 
 The following is an example for `keycloak-postgres` where no endpoints are listed, which means the database is unavailable.
 
 ```bash
-ncn-w001# kubectl get endpoints keycloak-postgres -n services
+ncn-mw# kubectl get endpoints keycloak-postgres -n services
 ```
 
 Example output:
@@ -40,21 +44,21 @@ NAME                ENDPOINTS         AGE
 keycloak-postgres   <none>            3d22h
 ```
 
-If the database is unavailable, check if the [Disk Full](#diskfull) is the cause of the issue. Otherwise, check the `postgres-operator` logs for errors.
+If the database is unavailable, check if [Disk Full](#diskfull) is the cause of the issue. Otherwise, check the `postgres-operator` logs for errors.
 
 ```bash
-ncn-w001# kubectl logs -l app.kubernetes.io/name=postgres-operator -n services
+ncn-mw# kubectl logs -l app.kubernetes.io/name=postgres-operator -n services
 ```
 
 <a name="diskfull"></a>
 ## Is the Database Disk Full?
 
-The following is an example for `keycloak-postgres`. One cluster member is failing to start because of a full pgdata disk. This was likely due to replication issues which caused the pg_wal files to grow.
+The following is an example for `keycloak-postgres`. One cluster member is failing to start because of a full `pgdata` disk. This was likely due to replication issues, which caused the `pg_wal` files to grow.
 
 ```bash
-ncn-w001# POSTGRESQL=keycloak-postgres
-ncn-w001# NAMESPACE=services
-ncn-w001# kubectl exec "${POSTGRESQL}-1" -c postgres -it -n ${NAMESPACE} -- patronictl list
+ncn-mw# POSTGRESQL=keycloak-postgres
+ncn-mw# NAMESPACE=services
+ncn-mw# kubectl exec "${POSTGRESQL}-1" -c postgres -it -n ${NAMESPACE} -- patronictl list
 +-------------------+---------------------+------------+--------+--------------+----+-----------+
 |      Cluster      |        Member       |    Host    |  Role  |    State     | TL | Lag in MB |
 +-------------------+---------------------+------------+--------+--------------+----+-----------+
@@ -63,7 +67,7 @@ ncn-w001# kubectl exec "${POSTGRESQL}-1" -c postgres -it -n ${NAMESPACE} -- patr
 | keycloak-postgres | keycloak-postgres-2 | 10.36.0.40 | Leader |   running    |  4 |           |
 +-------------------+---------------------+------------+--------+--------------+----+-----------+
 
-ncn-w001# for i in {0..2}; do echo "${POSTGRESQL}-${i}:"; kubectl exec "${POSTGRESQL}-${i}" -n ${NAMESPACE} -c postgres -- df -h pgdata; done;
+ncn-mw# for i in {0..2}; do echo "${POSTGRESQL}-${i}:"; kubectl exec "${POSTGRESQL}-${i}" -n ${NAMESPACE} -c postgres -- df -h pgdata; done;
 keycloak-postgres-0:
 Filesystem      Size  Used Avail Use% Mounted on
 /dev/sde        976M  960M     0 100% /home/postgres/pgdata
@@ -74,24 +78,25 @@ keycloak-postgres-2:
 Filesystem      Size  Used Avail Use% Mounted on
 /dev/rbd3       976M  136M  825M  15% /home/postgres/pgdata
 
-ncn-w001#  kubectl logs "${POSTGRESQL}-0" -n ${NAMESPACE} -c postgres | grep FATAL
+ncn-mw#  kubectl logs "${POSTGRESQL}-0" -n ${NAMESPACE} -c postgres | grep FATAL
 2021-07-14 17:52:48 UTC [30495]: [1-1] 60ef2470.771f 0     FATAL:  could not write lock file "postmaster.pid": No space left on device
 
-ncn-w001# kubectl exec "${POSTGRESQL}-0" -n ${NAMESPACE} -c postgres -it -- du -h --max-depth 1 /home/postgres/pgdata/pgroot/data/pg_wal
-
+ncn-mw# kubectl exec "${POSTGRESQL}-0" -n ${NAMESPACE} -c postgres -it -- du -h --max-depth 1 /home/postgres/pgdata/pgroot/data/pg_wal
 ```
-To recover the cluster member that had failed to start because of disk pressure, attempt to reclaim some space on the pgdata disk.
 
-Exec into that pod, copy the logs off (optional) and then clear the logs to recover some disk space. Then restart the Postgres cluster and postgres-operator.
-```
-ncn-w001# kubectl cp "${POSTGRESQL}-1":/home/postgres/pgdata/pgroot/pg_log /tmp -c postgres -n ${NAMESPACE}
-ncn-w001# kubectl exec "${POSTGRESQL}-1" -n ${NAMESPACE} -c postgres -it -- bash
+To recover the cluster member that had failed to start because of disk pressure, attempt to reclaim some space on the `pgdata` disk.
+
+`kubectl exec` into that pod, copy the logs off (optional), and then clear the logs in order to recover some disk space. Finally, restart the Postgres cluster and `postgres-operator`.
+
+```bash
+ncn-mw# kubectl cp "${POSTGRESQL}-1":/home/postgres/pgdata/pgroot/pg_log /tmp -c postgres -n ${NAMESPACE}
+ncn-mw# kubectl exec "${POSTGRESQL}-1" -n ${NAMESPACE} -c postgres -it -- bash
 root@cray-smd-postgres-1:/home/postgres# for i in {0..7}; do > /home/postgres/pgdata/pgroot/pg_log/postgresql-$i.csv; done
 ```
 
-```
-ncn-w001# kubectl delete pod "${POSTGRESQL}-0" "${POSTGRESQL}-1" "${POSTGRESQL}-2" -n ${NAMESPACE}
-ncn-w001# kubectl delete pod -l app.kubernetes.io/name=postgres-operator -n services
+```bash
+ncn-mw# kubectl delete pod "${POSTGRESQL}-0" "${POSTGRESQL}-1" "${POSTGRESQL}-2" -n ${NAMESPACE}
+ncn-mw# kubectl delete pod -l app.kubernetes.io/name=postgres-operator -n services
 ```
 
 If disk issues persist or exist on multiple nodes and the above does not resolve the issue, see the [Recover from Postgres WAL Event](Recover_from_Postgres_WAL_Event.md) procedure.
@@ -99,7 +104,7 @@ If disk issues persist or exist on multiple nodes and the above does not resolve
 <a name="lag"></a>
 ## Is Replication Lagging?
 
-Postgres replication lag can be detected with Prometheus alerts and alert notifications (See [Configure Prometheus Email Alert Notifications](../system_management_health/Configure_Prometheus_Email_Alert_Notifications.md)). If replication lag is not caught early, it can cause the disk mounted on /home/postgres/pgdata to fill up and the database to stop running. If this issue is caught before the database stops, it can be easily remediated using a partonictl command to reinitialize the lagging cluster member.
+Postgres replication lag can be detected with Prometheus alerts and alert notifications (See [Configure Prometheus Email Alert Notifications](../system_management_health/Configure_Prometheus_Email_Alert_Notifications.md)). If replication lag is not caught early, it can cause the disk mounted on `/home/postgres/pgdata` to fill up and the database to stop running. If this issue is caught before the database stops, it can be easily remediated using a patronictl command to reinitialize the lagging cluster member.
 
 ### Check if Replication is Working
 
@@ -108,7 +113,7 @@ When services have a Postgres cluster of pods, they need to be able to replicate
 The following is an example where replication is working:
 
 ```bash
-ncn-w001# kubectl exec keycloak-postgres-0 -c postgres -n services -it -- patronictl list
+ncn-mw# kubectl exec keycloak-postgres-0 -c postgres -n services -it -- patronictl list
 ```
 
 Example output:
@@ -125,7 +130,7 @@ Example output:
 
 The following is an example where replication is broken:
 
-```bash
+```
 +-------------------+---------------------+--------------+--------+----------+----+-----------+
 |      Cluster      |        Member       |     Host     |  Role  |  State   | TL | Lag in MB |
 +-------------------+---------------------+--------------+--------+----------+----+-----------+
@@ -139,10 +144,10 @@ The following is an example where replication is broken:
 
 In the event that a state of broken Postgres replication persists and the space allocated for the WAL files fills up, the affected database will likely shut down and create a state where it can be very difficult to recover. This can impact the reliability of the related service and may require that it be redeployed with data repopulation procedures. If replication lag is caught and remediated before the database shuts down, replication can be recovered using `patronictl reinit`.
 
-A reinitialize will get the lagging replica member re-synced and replicating again. This should be done as soon as replication lag is detected. In the preceding example, `keycloak-postgres-0` and `keycloak-postgres-2` were not replicating properly (Lag>0 or unknown). To remediate, `kubectl exec` into the leader pod and use `patronictl reinit <cluster> <lagging cluster member>` to reinitialize the lagging member(s). For example:
+A reinitialize will get the lagging replica member re-synced and replicating again. This should be done as soon as replication lag is detected. In the preceding example, `keycloak-postgres-0` and `keycloak-postgres-2` were not replicating properly (Lag>0 or `unknown`). To remediate, `kubectl exec` into the leader pod and use `patronictl reinit <cluster> <lagging cluster member>` to reinitialize the lagging member(s). For example:
 
 ```bash
-ncn-w001# kubectl exec keycloak-postgres-1 -n services -it -- bash
+ncn-mw# kubectl exec keycloak-postgres-1 -n services -it -- bash
 root@keycloak-postgres-1:/home/postgres# patronictl reinit keycloak-postgres keycloak-postgres-0
 ```
 
@@ -171,7 +176,7 @@ Success: reinitialize for member keycloak-postgres-2
 Verify that replication has recovered:
 
 ```bash
-ncn-w001# kubectl exec keycloak-postgres-0 -c postgres -n services -it -- patronictl list
+ncn-mw# kubectl exec keycloak-postgres-0 -c postgres -n services -it -- patronictl list
 ```
 
 Example output:
@@ -193,7 +198,7 @@ Example output:
     For example:
 
     ```bash
-    ncn-w001# kubectl exec cray-console-data-postgres-0 -n services -- bash
+    ncn-mw# kubectl exec cray-console-data-postgres-0 -n services -- bash
     root@cray-console-data-postgres-0:~# patronictl reinit cray-console-data-postgres cray-console-data-postgres-1
     ```
 
@@ -211,14 +216,14 @@ Example output:
     Failed: reinitialize for member cray-console-data-postgres-1, status code=503, (Cluster has no leader, can not reinitialize)
     ```
  
-    1. Delete the postgres leader pod and wait for the leader to restart.
+    1. Delete the Postgres leader pod and wait for the leader to restart.
     
         ```bash
-        ncn-w001# kubectl delete pod cray-console-data-postgres-0 -n services
+        ncn-mw# kubectl delete pod cray-console-data-postgres-0 -n services
         ```
     
         ```bash
-        ncn-w001# kubectl exec cray-console-postgres-0 -c postgres -n services -it -- patronictl list
+        ncn-mw# kubectl exec keycloak-postgres-0 -c postgres -n services -it -- patronictl list
         ```
     
         Example output:
@@ -233,12 +238,12 @@ Example output:
         +------------------------------+------------+--------+---------+----+-----------+
         ```
 
-    2. Re-run [Is Replication Lagging?](#lag) to `reinit` any lagging members.
+    1. Re-run [Is Replication Lagging?](#lag) to `reinit` any lagging members.
 
-    3. If the `reinit` still fails, then delete member pods that are still reporting lag. This should clear up any remaining lag.
+    1. If the `reinit` still fails, then delete member pods that are still reporting lag. This should clear up any remaining lag.
 
        ```bash
-        ncn-w001# kubectl exec cray-console-postgres-0 -c postgres -n services -it -- patronictl list
+        ncn-mw# kubectl exec cray-console-postgres-0 -c postgres -n services -it -- patronictl list
         ```
 
         Example output:
@@ -254,10 +259,10 @@ Example output:
         ```
 
         ```bash
-        ncn-w001# kubectl delete pod cray-console-data-postgres-1 cray-console-data-postgres-2 -n services
+        ncn-mw# kubectl delete pod cray-console-data-postgres-1 cray-console-data-postgres-2 -n services
         ```
 
-        Once the pods restart, check that the lag has resolved:
+        Once the pods restart, verify that the lag has resolved:
 
         Example output:
 
@@ -271,10 +276,10 @@ Example output:
         +------------------------------+------------+--------+---------+----+-----------+
         ```
 
-- If a cluster member is `stopped` after a successful reinitialization, check for pg_internal.init.* files that may need to be cleaned up. This can occur if the pgdata disk was full prior to the reinitialization, leaving truncated pg_internal.init.* files in the pgdata directory.
+- If a cluster member is `stopped` after a successful reinitialization, check for `pg_internal.init.*` files that may need to be cleaned up. This can occur if the `pgdata` disk was full prior to the reinitialization, leaving truncated `pg_internal.init.*` files in the `pgdata` directory.
 
     ```bash
-    ncn-w001# kubectl exec keycloak-postgres-0 -c postgres -n services -it -- patronictl list
+    ncn-mw# kubectl exec keycloak-postgres-0 -c postgres -n services -it -- patronictl list
     ```
 
     Example output:
@@ -289,10 +294,10 @@ Example output:
     +-------------------+---------------------+--------------+--------+---------+----+-----------+
     ```
  
-    Exec into that pod that is `stopped` and check the most recent postgres log for any `invalid segment number 0` errors relating to pg_internal.init.* files.
+    `kubectl exec` into that pod that is `stopped` and check the most recent Postgres log for any `invalid segment number 0` errors relating to `pg_internal.init.*` files.
 
     ```bash
-    ncn-w001# kubectl exec keycloak-postgres-2 -n services -it -- bash
+    ncn-mw# kubectl exec keycloak-postgres-2 -n services -it -- bash
     postgres@keycloak-postgres-2:~$ export LOG=`ls -t /home/postgres/pgdata/pgroot/pg_log/*.csv | head -1`
     postgres@keycloak-postgres-2:~$ grep pg_internal.init $LOG | grep "invalid segment number 0" | tail -1
     ```
@@ -303,7 +308,7 @@ Example output:
     2022-02-01 16:59:35.529 UTC,"standby","",227600,"127.0.0.1:42264",61f966f7.37910,3,"sending backup ""pg_basebackup base backup""",2022-02-01 16:59:35 UTC,7/0,0,ERROR,XX000,"invalid segment number 0 in file ""pg_internal.init.2239188""",,,,,,,,,"pg_basebackup"
     ```
 
-    If the check above finds such files, first find any zero length pg_internal.init.* files.
+    If the check above finds such files, first find any zero length `pg_internal.init.*` files.
 
     ```bash
     postgres@keycloak-postgres-2:~$ find /home/postgres/pgdata -name pg_internal.init.* -size 0 
@@ -317,13 +322,13 @@ Example output:
     ./pgroot/data/base/16622/pg_internal.init.2239010
     ```
 
-    Then delete the zero length pg_internal.init.* files. Double check the syntax of the command in this step before executing it `-size 0 -exec rm {} \;`.
+    Then delete the zero length `pg_internal.init.*` files. Double check the syntax of the command in this step before executing it.
 
     ```bash
     postgres@keycloak-postgres-2:~$ find /home/postgres/pgdata -name pg_internal.init.* -size 0 -exec rm {} \;
     ```
 
-    Next find any non-zero length pg_internal.init.* files that were truncated when the file system filled up.
+    Next find any non-zero length `pg_internal.init.*` files that were truncated when the file system filled up.
 
     ```bash
     postgres@keycloak-postgres-2:~$ grep pg_internal.init $LOG | grep "invalid segment number 0" | tail -1
@@ -335,7 +340,7 @@ Example output:
     2022-02-01 16:59:35.529 UTC,"standby","",227600,"127.0.0.1:42264",61f966f7.37910,3,"sending backup ""pg_basebackup base backup""",2022-02-01 16:59:35 UTC,7/0,0,ERROR,XX000,"invalid segment number 0 in file ""pg_internal.init.2239188""",,,,,,,,,"pg_basebackup"
     ```
 
-    Locate the non-zero length pg_internal.init.* file.
+    Locate the non-zero length `pg_internal.init.*` file.
 
     ```bash
     postgres@keycloak-postgres-2:~$ find ~/pgdata -name pg_internal.init.2239188
@@ -347,16 +352,16 @@ Example output:
     /home/postgres/pgdata/pgroot/data/base/16622/pg_internal.init.2239188
     ```
 
-    Then delete (or move to a different location) the non-zero length pg_internal.init.* file.
+    Then delete (or move to a different location) the non-zero length `pg_internal.init.*` file.
 
     ```bash
     postgres@keycloak-postgres-2:~$ rm /home/postgres/pgdata/pgroot/data/base/16622/pg_internal.init.2239188
     ```
 
-    Iterate over the above steps to find, locate and delete non-zero length pg_internal.init.* files until there are no more new `invalid segment number 0` messages. At this point, verify that the cluster member has started.
+    Iterate over the above steps to find, locate, and delete non-zero length `pg_internal.init.*` files until there are no more new `invalid segment number 0` messages. At this point, verify that the cluster member has started.
 
     ```bash
-    ncn-w001# kubectl exec keycloak-postgres-0 -c postgres -n services -it -- patronictl list
+    ncn-mw# kubectl exec keycloak-postgres-0 -c postgres -n services -it -- patronictl list
     ```
 
     Example output:
@@ -373,28 +378,28 @@ Example output:
 
 ### Setup Alerts for Replication Lag
 
-Alerts exist in prometheus for the following:
+Alerts exist in Prometheus for the following:
 
-- PostgresqlReplicationLagSMA
-- PostgresqlReplicationLagServices
-- PostgresqlFollowerReplicationLagSMA
-- PostgresqlFollowerReplicationLagServices
+- `PostgresqlReplicationLagSMA`
+- `PostgresqlReplicationLagServices`
+- `PostgresqlFollowerReplicationLagSMA`
+- `PostgresqlFollowerReplicationLagServices`
 
 When alert notifications are configured, replication issues can be detected quickly. If the replication issue persists such that the database becomes unavailable, recovery will likely be much more involved. Catching such issues as soon as possible is desired. See [Configure Prometheus Email Alert Notifications](../system_management_health/Configure_Prometheus_Email_Alert_Notifications.md).
 
 <a name="syncfailed"></a>
 ## Is the Postgres status `SyncFailed`?
 
-### Check all the postgresql resources
+### Check all the `postgresql` resources
 
-Check for any postgresql resource that has a `STATUS` of `SyncFailed`. `SyncFailed` generally means that there is something between the `postgres-operator` and the Postgres cluster that is out of sync. This does not always mean that the cluster is unhealthy. To determine the underlying sync issue, check the `postgres-operator` logs for messages to further root cause the issue.
+Check for any `postgresql` resource that has a `STATUS` of `SyncFailed`. `SyncFailed` generally means that there is something between the `postgres-operator` and the Postgres cluster that is out of sync. This does not always mean that the cluster is unhealthy. To determine the underlying sync issue, check the `postgres-operator` logs for messages to further root cause the issue.
 
-Other `STATUS` values such as `Updating` are a non issue. It is expected that this will eventually change to `Running` or possibly `SyncFailed` if the `postgres-operator` encounters issues syncing updates to the postgresql cluster.
+Other `STATUS` values such as `Updating` are a non-issue. It is expected that this will eventually change to `Running` or possibly `SyncFailed` if the `postgres-operator` encounters issues syncing updates to the `postgresql` cluster.
 
-1. Check for any postgresql resource that has a `STATUS` of `SyncFailed`.
+1. Check for any `postgresql` resource that has a `STATUS` of `SyncFailed`.
 
     ```bash
-    ncn-w001# kubectl get postgresql -A
+    ncn-mw# kubectl get postgresql -A
     ```
 
     Example output:
@@ -412,7 +417,7 @@ Other `STATUS` values such as `Updating` are a non issue. It is expected that th
 1. Find the the `postgres-operator` pod name.
 
     ```bash
-    ncn-w001# kubectl get pods -l app.kubernetes.io/name=postgres-operator -n services
+    ncn-mw# kubectl get pods -l app.kubernetes.io/name=postgres-operator -n services
     ```
 
     Example output:
@@ -425,27 +430,28 @@ Other `STATUS` values such as `Updating` are a non issue. It is expected that th
 1. Check the logs for the `postgres-operator`.
 
     ```
-    ncn-w001# kubectl logs cray-postgres-operator-6fffc48b4c-mqz7z -n services \
+    ncn-mw# kubectl logs cray-postgres-operator-6fffc48b4c-mqz7z -n services \
     -c postgres-operator | grep -i sync | grep -i msg
     ```
 
-#### Case 1 : msg="could not sync cluster: could not sync persistent volumes: could not sync volumes: could not resize EBS volumes: some persistent volumes are not compatible with existing resizing providers"
+#### Case 1 : `msg="could not sync cluster: could not sync persistent volumes: could not sync volumes: could not resize EBS volumes: some persistent volumes are not compatible with existing resizing providers"`
 
-This generally means that the postgresql resource was updated to change the volume size from the Postgres operator's perspective, but the additional step to resize the actual PVCs was not done so the operator and the Postgres cluster are not able to sync the resize change. The cluster is still healthy, but to complete the resize of the underlying Postgres PVCs, additional steps are needed.
+This generally means that the `postgresql` resource was updated to change the volume size from the Postgres operator's perspective, but the additional step to resize the actual PVCs was not done so the operator and the Postgres cluster are not able to sync the resize change. The cluster is still healthy, but to complete the resize of the underlying Postgres PVCs, additional steps are needed.
 
-The example below assumes that `cray-smd-postgres` is in `SyncFailed` and the volume size was recently increased to `100Gi` (possibly by editing the volume size of postgresql `cray-smd-postgres` resource), but the `pgdata-cray-smd-postgres` PVC's storage capacity was not updated to align with the change. To confirm this is the case:
+The example below assumes that `cray-smd-postgres` is in `SyncFailed` and the volume size was recently increased to `100Gi` (possibly by editing the volume size of `postgresql` `cray-smd-postgres` resource), but the `pgdata-cray-smd-postgres` PVC's storage capacity was not updated to align with the change. To confirm this is the case:
 
 ```bash
-ncn-w001# kubectl get postgresql cray-smd-postgres -n services -o jsonpath="{.spec.volume.size}"
+ncn-mw# kubectl get postgresql cray-smd-postgres -n services -o jsonpath="{.spec.volume.size}"
 100Gi
 
-ncn-w001# kubectl get pvc -n services -l application=spilo,cluster-name=cray-smd-postgres
+ncn-mw# kubectl get pvc -n services -l application=spilo,cluster-name=cray-smd-postgres
 NAME                         STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS           AGE
 pgdata-cray-smd-postgres-0   Bound    pvc-020cf339-e372-46ae-bc37-de2b55320e88   30Gi       RWO            k8s-block-replicated   70m
 pgdata-cray-smd-postgres-1   Bound    pvc-3d42598a-188e-4301-a58e-0f0ce3944c89   30Gi       RWO            k8s-block-replicated   27m
 pgdata-cray-smd-postgres-2   Bound    pvc-0d659080-7d39-409a-9ee5-1a1806971054   30Gi       RWO            k8s-block-replicated   27m
 ```
-To resolve this `SyncFailed` case, resize the `pgdata` PVCs for the selected Postgres cluster. Create the following function in the shell and execute the function by calling it with the appropriate arguments. For this example the `pgdata-cray-smd-postgres` PVCs will be resized to `100Gi` to match that of the postgresql `cray-smd-postgres` volume size.
+
+To resolve this `SyncFailed` case, resize the `pgdata` PVCs for the selected Postgres cluster. Create the following function in the shell and execute the function by calling it with the appropriate arguments. For this example the `pgdata-cray-smd-postgres` PVCs will be resized to `100Gi` to match that of the `postgresql` `cray-smd-postgres` volume size.
 
 ```bash
 function resize-postgresql-pvc
@@ -457,11 +463,11 @@ function resize-postgresql-pvc
 
     # Check for required arguments
     if [ $# -ne 4 ]; then
-        echo "Illegal number of parameters"
+        echo "Illegal number of parameters ($#). Function requires exactly 4 arguments."
         exit 2
     fi
 
-    ## Check PGRESIZE matches current postgresql volume size
+    ## Check that PGRESIZE matches current postgresql volume size
     postgresql_volume_size=$(kubectl get postgresql "${POSTGRESQL}" -n "${NAMESPACE}" -o jsonpath="{.spec.volume.size}")
     if [ "${postgresql_volume_size}" != "${PGRESIZE}" ]; then
          echo "Invalid resize ${PGRESIZE}, expected ${postgresql_volume_size}"
@@ -470,112 +476,154 @@ function resize-postgresql-pvc
 
     ## Scale the postgres cluster to 1 member
     kubectl patch postgresql "${POSTGRESQL}" -n "${NAMESPACE}" --type='json' -p='[{"op" : "replace", "path":"/spec/numberOfInstances", "value" : 1}]'
-    while [ $(kubectl get pods -l "application=spilo,cluster-name=${POSTGRESQL}" -n "${NAMESPACE}" | grep -v NAME | wc -l) != 1 ] ; do echo "  waiting for pods to terminate"; sleep 2; done
+    while [ $(kubectl get pods -l "application=spilo,cluster-name=${POSTGRESQL}" -n "${NAMESPACE}" | grep -v NAME | wc -l) != 1 ] ; do
+        echo "  waiting for pods to terminate"
+        sleep 2
+    done
 
-    ## Delete the inactive PVCs, resize the active PVC and wait for the resize to complete
+    ## Delete the inactive PVCs, resize the active PVC, and wait for the resize to complete
     kubectl delete pvc "${PGDATA}-1" "${PGDATA}-2" -n "${NAMESPACE}"
     kubectl patch -p '{"spec": {"resources": {"requests": {"storage": "'${PGRESIZE}'"}}}}' "pvc/${PGDATA}-0" -n "${NAMESPACE}"
-    while [ -z '$(kubectl describe pvc "{PGDATA}-0" -n "${NAMESPACE}" | grep FileSystemResizeSuccessful' ] ; do echo "  waiting for PVC to resize"; sleep 2; done
+    while [ -z '$(kubectl describe pvc "{PGDATA}-0" -n "${NAMESPACE}" | grep FileSystemResizeSuccessful' ] ; do
+        echo "  waiting for PVC to resize"
+        sleep 2
+    done
 
     ## Scale the postgres cluster back to 3 members
     kubectl patch postgresql "${POSTGRESQL}" -n "${NAMESPACE}" --type='json' -p='[{"op" : "replace", "path":"/spec/numberOfInstances", "value" : 3}]'
-    while [ $(kubectl get pods -l "application=spilo,cluster-name=${POSTGRESQL}" -n "${NAMESPACE}" | grep -v NAME | grep -c "Running") != 3 ] ; do echo "  waiting for pods to restart"; sleep 2; done
+    while [ $(kubectl get pods -l "application=spilo,cluster-name=${POSTGRESQL}" -n "${NAMESPACE}" | grep -v NAME | grep -c "Running") != 3 ] ; do
+        echo "  waiting for pods to restart"
+        sleep 2
+    done
 }
 ```
+
 ```bash
-ncn-w001# resize-postgresql-pvc cray-smd-postgres pgdata-cray-smd-postgres services 100Gi
+ncn-mw# resize-postgresql-pvc cray-smd-postgres pgdata-cray-smd-postgres services 100Gi
 ```
 
-In order to persist any Postgres PVC storage volume size changes, it is necessary that this change also be made to the customer-managed customizations.yaml file. See the Postgres PVC Resize information in the [Post Install Customizations](../CSM_product_management/Post_Install_Customizations.md#postgres_pvc_resize).
+In order to persist any Postgres PVC storage volume size changes, it is necessary that this change also be made to the customer-managed `customizations.yaml` file. See the Postgres PVC Resize information in the [Post Install Customizations](../CSM_product_management/Post_Install_Customizations.md#postgres_pvc_resize) document.
 
-#### Case 2: msg="could not sync cluster: could not sync roles: could not init db connection: could not init db connection: still failing after 8 retries"
+#### Case 2: `msg="could not sync cluster: could not sync roles: could not init db connection: could not init db connection: still failing after 8 retries"`
 
-This generally means that some state in the Postgres operator is out of sync with that of the postgresql cluster, resulting in database connection issues. To resolve this `SyncFailed` case, restarting the Postgres operator by deleting the pod may clear up the issue.
+This generally means that some state in the Postgres operator is out of sync with that of the `postgresql` cluster, resulting in database connection issues. To resolve this `SyncFailed` case, restarting the Postgres operator by deleting the pod may clear up the issue.
 
 ```bash
-ncn-w001# kubectl delete pod -l app.kubernetes.io/name=postgres-operator -n services
+ncn-mw# kubectl delete pod -l app.kubernetes.io/name=postgres-operator -n services
+```
 
-## Wait for the `postgres-operator` to restart
-ncn-w001# kubectl get pods -l app.kubernetes.io/name=postgres-operator -n services
+Wait for the `postgres-operator` to restart
+
+```bash
+ncn-mw# kubectl get pods -l app.kubernetes.io/name=postgres-operator -n services
 NAME                                      READY   STATUS    RESTARTS   AGE
 cray-postgres-operator-6fffc48b4c-mqz7z   2/2     Running   0           6m
 ```
 
 If the database connection has been down for a long period of time and the `SyncFailed` persists after the above steps, a restart of the cluster and the `postgres-operator` may be needed for the service to reconnect to the Postgres cluster. For example, if the `cray-gitea` service is not able to connect to the Postgres database and the connection has been failing for many hours, restart the cluster and operator.
 
+Scale the service to 0
 ```bash
-ncn-w001# CLIENT=gitea-vcs
-ncn-w001# POSTGRESQL=gitea-vcs-postgres
-ncn-w001# NAMESPACE=services
-
-## Scale the service to 0
-ncn-w001# kubectl scale deployment ${CLIENT} -n ${NAMESPACE} --replicas=0
-
-## Restart the Postgres cluster and the postgres-operator
-ncn-w001# kubectl delete pod "${POSTGRESQL}-0" "${POSTGRESQL}-1" "${POSTGRESQL}-2" -n ${NAMESPACE}
-ncn-w001# kubectl delete pods -n services -lapp.kubernetes.io/name=postgres-operator
-ncn-w001# while [ $(kubectl get postgresql ${POSTGRESQL} -n ${NAMESPACE} -o json | jq -r '.status.PostgresClusterStatus') != "Running" ]; do echo "waiting for ${POSTGRESQL} to start running"; sleep 2; done
-
-
-## Scale the service back to 1 (for different services this may be to 3)
-ncn-w001# kubectl scale deployment ${CLIENT} -n ${NAMESPACE} --replicas=1
+ncn-mw# CLIENT=gitea-vcs
+ncn-mw# POSTGRESQL=gitea-vcs-postgres
+ncn-mw# NAMESPACE=services
+ncn-mw# kubectl scale deployment ${CLIENT} -n ${NAMESPACE} --replicas=0
 ```
 
-#### Case 3: msg="error while syncing cluster state: could not sync roles: could not init db connection: could not init db connection: pq: password authentication failed for user \<username\>"
-
-This generally means that the password for the given user is not the same as that specified in the Kubernetes secret. This can occur if the postgresql cluster was rebuilt and the data was restored, leaving the Kubernetes secrets out of sync with the Postgres cluster. To resolve this `SyncFailed` case, gather the username and password for the credential from Kubernetes, and update the database with these values. For example, if the user `postgres` is failing to authenticate between the `cray-smd` services and the `cray-smd-postgres` cluster, get the password for the `postgres` user from the Kubernetes secret and update the password in the database.
+Restart the Postgres cluster and the `postgres-operator`
 
 ```bash
-ncn-w001# CLIENT=cray-smd
-ncn-w001# POSTGRESQL=cray-smd-postgres
-ncn-w001# NAMESPACE=services
+ncn-mw# kubectl delete pod "${POSTGRESQL}-0" "${POSTGRESQL}-1" "${POSTGRESQL}-2" -n ${NAMESPACE}
+ncn-mw# kubectl delete pods -n services -lapp.kubernetes.io/name=postgres-operator
+ncn-mw# while [ $(kubectl get postgresql ${POSTGRESQL} -n ${NAMESPACE} -o json | jq -r '.status.PostgresClusterStatus') != "Running" ]; do echo "waiting for ${POSTGRESQL} to start running"; sleep 2; done
+``
 
-## Scale the service to 0
-ncn-w001# kubectl scale deployment ${CLIENT} -n ${NAMESPACE} --replicas=0
-ncn-w001# while [ $(kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/name="${CLIENT}" | grep -v NAME | wc -l) != 0 ] ; do echo "  waiting for pods to terminate"; sleep 2; done
+Scale the service back to 1 (for different services this may be to 3)
 
-## Determine what secrets are associated with the postgresql credentials
-ncn-w001# kubectl get secrets -n ${NAMESPACE} | grep "${POSTGRESQL}.credentials"
-services            hmsdsuser.cray-smd-postgres.credentials                       Opaque                                2      31m
-services            postgres.cray-smd-postgres.credentials                        Opaque                                2      31m
-services            service-account.cray-smd-postgres.credentials                 Opaque                                2      31m
-services            standby.cray-smd-postgres.credentials                         Opaque                                2      31m
-
-
-## Gather the decoded username and password for the user that is failing to authenticate - for example postgres.cray-smd-postgres.credentials :
-ncn-w001# kubectl get secret postgres.cray-smd-postgres.credentials -n ${NAMESPACE} -ojsonpath='{.data.username}' | base64 -d
-postgres
-
-ncn-w001# kubectl get secret postgres.cray-smd-postgres.credentials -n ${NAMESPACE} -ojsonpath='{.data.password}'| base64 -d
-ABCXYZ
-
-## Exec into the postgres leader, and update the username and password in the database
-ncn-w001# kubectl exec "${POSTGRESQL}-0" -n ${NAMESPACE} -c postgres -it -- patronictl list
-+-------------------+---------------------+------------+--------+---------+----+-----------+
-|      Cluster      |        Member       |    Host    |  Role  |  State  | TL | Lag in MB |
-+-------------------+---------------------+------------+--------+---------+----+-----------+
-| cray-smd-postgres | cray-smd-postgres-0 | 10.42.0.25 | Leader | running |  1 |           |
-| cray-smd-postgres | cray-smd-postgres-1 | 10.44.0.34 |        | running |    |         0 |
-| cray-smd-postgres | cray-smd-postgres-2 | 10.36.0.44 |        | running |    |         0 |
-+-------------------+---------------------+------------+--------+---------+----+-----------+
-ncn-w001# POSTGRES_LEADER=cray-smd-postgres-0
-
-ncn-w001# kubectl exec ${POSTGRES_LEADER} -n ${NAMESPACE} -c postgres -it -- bash
-root@cray-smd-postgres-0:/home/postgres# /usr/bin/psql postgres postgres
-postgres=# ALTER USER postgres WITH PASSWORD 'ABCXYZ';
-ALTER ROLE
-postgres=#
-
-## Restart the postgresql cluster
-ncn-w001# kubectl delete pod "${POSTGRESQL}-0" "${POSTGRESQL}-1" "${POSTGRESQL}-2" -n ${NAMESPACE}
-
-ncn-w001# while [ $(kubectl get postgresql ${POSTGRESQL} -n ${NAMESPACE} -o json | jq -r '.status.PostgresClusterStatus') != "Running" ]; do echo "waiting for ${POSTGRESQL} to start running"; sleep 2; done
-
-## Scale the service back to 3
-ncn-w001# kubectl scale deployment ${CLIENT} -n ${NAMESPACE} --replicas=3
-
-ncn-w001# while [ $(kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/name="${CLIENT}" | grep -v NAME | wc -l) != 3 ] ; do echo "  waiting for pods to start running"; sleep 2; done
+```bash
+ncn-mw# kubectl scale deployment ${CLIENT} -n ${NAMESPACE} --replicas=1
 ```
+
+#### Case 3: `msg="error while syncing cluster state: could not sync roles: could not init db connection: could not init db connection: pq: password authentication failed for user \<username\>"`
+
+This generally means that the password for the given user is not the same as that specified in the Kubernetes secret. This can occur if the `postgresql` cluster was rebuilt and the data was restored, leaving the Kubernetes secrets out of sync with the Postgres cluster. To resolve this `SyncFailed` case, gather the username and password for the credential from Kubernetes, and update the database with these values. For example, if the user `postgres` is failing to authenticate between the `cray-smd` services and the `cray-smd-postgres` cluster, then get the password for the `postgres` user from the Kubernetes secret and update the password in the database.
+
+1. Set necessary variables.
+
+    ```bash
+    ncn-mw# CLIENT=cray-smd
+    ncn-mw# POSTGRESQL=cray-smd-postgres
+    ncn-mw# NAMESPACE=services
+    ```
+
+1. Scale the service to 0
+
+    ```bash
+    ncn-mw# kubectl scale deployment ${CLIENT} -n ${NAMESPACE} --replicas=0
+    ncn-mw# while [ $(kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/name="${CLIENT}" | grep -v NAME | wc -l) != 0 ] ; do
+                echo "  waiting for pods to terminate"
+                sleep 2
+            done
+    ```
+
+1. Determine what secrets are associated with the `postgresql` credentials.
+
+    ```bash
+    ncn-mw# kubectl get secrets -n ${NAMESPACE} | grep "${POSTGRESQL}.credentials"
+    services            hmsdsuser.cray-smd-postgres.credentials                       Opaque                                2      31m
+    services            postgres.cray-smd-postgres.credentials                        Opaque                                2      31m
+    services            service-account.cray-smd-postgres.credentials                 Opaque                                2      31m
+    services            standby.cray-smd-postgres.credentials                         Opaque                                2      31m
+    ```
+
+1. Gather the decoded username and password for the user that is failing to authenticate - for example:
+
+    `postgres.cray-smd-postgres.credentials`:
+    ```bash
+    ncn-mw# kubectl get secret postgres.cray-smd-postgres.credentials -n ${NAMESPACE} -ojsonpath='{.data.username}' | base64 -d
+    postgres
+    ncn-mw# kubectl get secret postgres.cray-smd-postgres.credentials -n ${NAMESPACE} -ojsonpath='{.data.password}'| base64 -d
+    ABCXYZ
+    ```
+
+1. `kubectl exec` into the postgres leader, and update the username and password in the database.
+
+    ```bash
+    ncn-mw# kubectl exec "${POSTGRESQL}-0" -n ${NAMESPACE} -c postgres -it -- patronictl list
+    +-------------------+---------------------+------------+--------+---------+----+-----------+
+    |      Cluster      |        Member       |    Host    |  Role  |  State  | TL | Lag in MB |
+    +-------------------+---------------------+------------+--------+---------+----+-----------+
+    | cray-smd-postgres | cray-smd-postgres-0 | 10.42.0.25 | Leader | running |  1 |           |
+    | cray-smd-postgres | cray-smd-postgres-1 | 10.44.0.34 |        | running |    |         0 |
+    | cray-smd-postgres | cray-smd-postgres-2 | 10.36.0.44 |        | running |    |         0 |
+    +-------------------+---------------------+------------+--------+---------+----+-----------+
+    ncn-mw# POSTGRES_LEADER=cray-smd-postgres-0
+    ncn-mw# kubectl exec ${POSTGRES_LEADER} -n ${NAMESPACE} -c postgres -it -- bash
+    root@cray-smd-postgres-0:/home/postgres# /usr/bin/psql postgres postgres
+    postgres=# ALTER USER postgres WITH PASSWORD 'ABCXYZ';
+    ALTER ROLE
+    postgres=#
+    ```
+
+1. Restart the `postgresql` cluster.
+
+    ```bash
+    ncn-mw# kubectl delete pod "${POSTGRESQL}-0" "${POSTGRESQL}-1" "${POSTGRESQL}-2" -n ${NAMESPACE}
+    ncn-mw# while [ $(kubectl get postgresql ${POSTGRESQL} -n ${NAMESPACE} -o json | jq -r '.status.PostgresClusterStatus') != "Running" ]; do
+                echo "waiting for ${POSTGRESQL} to start running"
+                sleep 2
+            done
+    ```
+
+1. Scale the service back to 3
+
+    ```bash
+    ncn-mw# kubectl scale deployment ${CLIENT} -n ${NAMESPACE} --replicas=3
+    ncn-mw# while [ $(kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/name="${CLIENT}" | grep -v NAME | wc -l) != 3 ] ; do
+                echo "  waiting for pods to start running"
+                sleep 2
+            done
+    ```
 
 <a name="missing"></a>
 ## Is a Cluster Member missing?
@@ -587,43 +635,43 @@ Most services expect to maintain a Postgres cluster consisting of three pods for
 For a given Postgres cluster, check how many pods are running.
 
 ```bash
-ncn-w001# POSTGRESQL=keycloak-postgres
-ncn-w001# NAMESPACE=services
-ncn-w001# kubectl get pods -A -l "application=spilo,cluster-name=${POSTGRESQL}"
+ncn-mw# POSTGRESQL=keycloak-postgres
+ncn-mw# NAMESPACE=services
+ncn-mw# kubectl get pods -A -l "application=spilo,cluster-name=${POSTGRESQL}"
 ```
 
 ### Recover from a missing member
 
-If the number of Postgres pods for the given cluster is more or less than expected, increase or decrease as needed. This example will patch the keycloak-postgres cluster resource so that three pods should be running.
+If the number of Postgres pods for the given cluster is more or less than expected, increase or decrease as needed. This example will patch the `keycloak-postgres` cluster resource so that three pods should be running.
 
-1. Set the POSTGRESQL and NAMESPACE variables.
+1. Set the `POSTGRESQL` and `NAMESPACE` variables.
 
     ```bash
-    ncn-w001# POSTGRESQL=keycloak-postgres
-    ncn-w001# NAMESPACE=services
+    ncn-mw# POSTGRESQL=keycloak-postgres
+    ncn-mw# NAMESPACE=services
     ```
 
-1. Patch the keycloak-postgres cluster resource to ensure three pods are running.
+1. Patch the `keycloak-postgres` cluster resource to ensure three pods are running.
 
     ```bash
-    ncn-w001# kubectl patch postgresql "${POSTGRESQL}" -n "${NAMESPACE}" --type='json' \
+    ncn-mw# kubectl patch postgresql "${POSTGRESQL}" -n "${NAMESPACE}" --type='json' \
     -p='[{"op" : "replace", "path":"/spec/numberOfInstances", "value" : 3}]'
     ```
 
-1. Confirm the number of cluster members, otherwise known as pods, by checking the postgresql resource.
+1. Confirm the number of cluster members, otherwise known as pods, by checking the `postgresql` resource.
 
     ```bash
-    ncn-w001# kubectl get postgresql ${POSTGRESQL} -n ${NAMESPACE}
+    ncn-mw# kubectl get postgresql ${POSTGRESQL} -n ${NAMESPACE}
     NAME                TEAM       VERSION   PODS   VOLUME   CPU-REQUEST   MEMORY-REQUEST   AGE   STATUS
     keycloak-postgres   keycloak   11        3      10Gi                                    29m   Running
     ```
 
-1. If a pod is starting but remains in Pending, CrashLoopBackOff, ImagePullBackOff or other non Running states, describe the pod and/or get logs from the pod for further analysis.
+1. If a pod is starting but remains in `Pending`, `CrashLoopBackOff`, `ImagePullBackOff`, or other non-`Running` states, describe the pod and/or get logs from the pod for further analysis.
 
     1. Find the pod name.
 
         ```bash
-        ncn-w001# kubectl get pods -A -l "application=spilo,cluster-name=${POSTGRESQL}"
+        ncn-mw# kubectl get pods -A -l "application=spilo,cluster-name=${POSTGRESQL}"
         ```
 
         Example output:
@@ -638,13 +686,13 @@ If the number of Postgres pods for the given cluster is more or less than expect
     1. Describe the pod.
 
         ```
-        ncn-w001# kubectl describe pod "${POSTGRESQL}-0" -n ${NAMESPACE}
+        ncn-mw# kubectl describe pod "${POSTGRESQL}-0" -n ${NAMESPACE}
         ```
 
     1. View the pod logs.
 
         ```
-        ncn-w001# kubectl logs "${POSTGRESQL}-0" -c postgres -n ${NAMESPACE}
+        ncn-mw# kubectl logs "${POSTGRESQL}-0" -c postgres -n ${NAMESPACE}
         ```
 
 <a name="leader"></a>
@@ -654,17 +702,17 @@ If a Postgres cluster no longer has a leader, the database will need to be recov
 
 ### Determine if the Postgres Leader is missing
 
-1. Set the POSTGRESQL and NAMESPACE variables.
+1. Set the `POSTGRESQL` and `NAMESPACE` variables.
 
     ```bash
-    ncn-w001# POSTGRESQL=cray-smd-postgres
-    ncn-w001# NAMESPACE=services
+    ncn-mw# POSTGRESQL=cray-smd-postgres
+    ncn-mw# NAMESPACE=services
     ```
 
 1. Check if the leader is missing.
 
     ```
-    ncn-w001# kubectl exec ${POSTGRESQL}-0 -n ${NAMESPACE} -c postgres -- patronictl list
+    ncn-mw# kubectl exec ${POSTGRESQL}-0 -n ${NAMESPACE} -c postgres -- patronictl list
     ```
 
     Example output:
@@ -682,4 +730,3 @@ If a Postgres cluster no longer has a leader, the database will need to be recov
 ### Recover from a missing Postgres Leader
 
 See the [Recover from Postgres WAL Event](Recover_from_Postgres_WAL_Event.md) procedure.
-

--- a/operations/network/management_network/added_hardware.md
+++ b/operations/network/management_network/added_hardware.md
@@ -6,18 +6,18 @@ Follow this procedure when new hardware is added to the system.
 
 1. Validate the SHCD.
 
-   The SHCD defines the topology of a Shasta system, this is needed when generating switch configs.
+   The SHCD defines the topology of a Shasta system, this is needed when generating switch configurations.
 
    Refer to [Validate the SHCD](validate_shcd.md).
 
-2. Generate the switch configuration file(s).
+1. Generate the switch configuration file(s).
 
    Refer to [Generate Switch Configs](generate_switch_configs.md).
 
-3. Check the differences between the generated configs and the configs on the system.
+1. Check the differences between the generated configurations and the configurations on the system.
 
    Refer to [Validate Switch Configs](validate_switch_configs.md).
 
-4. Run a suite of tests against the management network switches.
+1. Run a suite of tests against the management network switches.
 
    Refer to [Network Tests](network_tests.md).

--- a/operations/network/management_network/apply_switch_configs.md
+++ b/operations/network/management_network/apply_switch_configs.md
@@ -43,7 +43,7 @@ There are some caveats that are mentioned below.
 1. Paste in the generated config.
 
     - When pasting in the config be sure that all the commands were accepted. In some cases you will need to back out of the current config context and back to global configuration for the commands to work as intended.
-    - `banner motd` will need to be manually applied.
+    - `banner exec` will need to be manually applied.
 
       For example:
 

--- a/operations/network/management_network/aruba/vsf.md
+++ b/operations/network/management_network/aruba/vsf.md
@@ -2,21 +2,21 @@
 
 Virtual Switching Framework (VSF) defines a virtual switch comprised of multiple individual physical switches, inter-connected through standard Ethernet links. These physical switches will operate with one control plane, thereby visible to the peers as a virtual switch stack.
 
-Within the stack, one switch is the "Master" switch, which runs all the control plane software and manages the ASICs of all the stack members. A second switch can be configured as the "Standby" switch, which will take over as Master if the master fails.
+Within the stack, one switch is the "Master" switch, which runs all the control plane software and manages the ASICs of all the stack members. A second switch can be configured as the "Standby" switch, which will take over as master if the master fails.
 
 Each stack member must have a unique member number. While deploying a stack, the user must ensure that each member has a distinct member number by renumbering the switches to desired member numbers. Stack formation will fail if there is a member number conflict.
 
-A primary member will become Master under normal circumstances (no member / link failures). The secondary member will become standby member under normal circumstances.
+A primary member will become master under normal circumstances (no member / link failures). The secondary member will become standby member under normal circumstances.
 
-The primary member is member number "1". This is not configurable. Also note that "1" is the default member number. A factory-default switch boots up as a VSF enabled switch, with member number "1". a it behaves as a 1-member stack, of which it is master.
+The primary member is member number `1`. This is not configurable. Also note that `1` is the default member number. A factory-default switch boots up as a VSF-enabled switch, with member number "1". It behaves as a 1-member stack, of which it is master.
 
-The secondary member number is user configurable, and there is no default secondary member. It is strongly recommended that the customer configure a secondary member in the stack, since a stack with a standby offers resiliency and high-availability.
+The secondary member number is user configurable, and there is no default secondary member. It is strongly recommended that the customer configure a secondary member in the stack, because a stack with a standby offers resiliency and high-availability.
 
 Other than the primary and secondary members, no members can ever become master / standby of the stack.
 
 ## Configuration Commands
 
-Create a VSF Member:
+Create a VSF member:
 
 ```text
 switch(config)# vsf member <ID>

--- a/operations/network/management_network/load_saved_switch_config.md
+++ b/operations/network/management_network/load_saved_switch_config.md
@@ -1,39 +1,49 @@
 # Load Saved Switch Configuration
 
-This procedures shows how to switch between saved switch configurations.
+This procedure shows how to switch between already saved switch configurations.
 
 To save switch configurations, refer to the [Configuration Management](config_management.md) procedure.
 
-## Aruba
+This procedure is intended for internal use only. It is used to quickly switch between configurations that are already loaded on the switches.
 
-1. View the checkpoints.
+This procedure needs to be done on all mgmt switches.
 
-    Ensure that `CSM1_0` and `CSM1_2` exist. If they exist, proceed to the next step.
+-  Spine switches will have three total configuration files/checkpoints.
+    -  1.2 fresh install
+    -  1.2 upgrade
+    -  1.0
+  
+-  Leaf-BMC switches will have have two configuration files/checkpoints.
+    - 1.2
+    - 1.0
+  
+### Aruba
+
+1. View the checkpoints. 
+   
+    Ensure that the proper checkpoints exist. `CSM1_0` and `CSM1_2` are used in this example.
+
+
+    Example:
 
     ```
-    sw-spine-001# show checkpoint
-    ```
-
-    Example output:
-
-    ```
-    NAME TYPE WRITER DATE(YYYY/MM/DD) IMAGE VERSION
-    CSM1_0 latest User 2022-01-13T16:51:37Z GL.10.08.1021
-    CSM1_2 latest User 2022-01-13T16:51:48Z GL.10.08.1021
-    startup-config startup User 2021-12-20T17:35:58Z GL.10.08.1021
+    sw-spine-001# show checkpoint | include CSM
+    CSM1_2_FRESH_INSTALL_CANU_1_3_2                     latest      User    2022-04-01T20:11:57Z  GL.10.09.0010
+    CSM1_2_UPGRADE_CANU_1_3_2                           checkpoint  User    2022-04-01T18:57:06Z  GL.10.09.0010
+    CSM1_0_CANU_1_2_4                                   checkpoint  User    2022-03-15T21:37:11Z  GL.10.09.0010
     ```
 
 1. Rollback to desired checkpoint.
 
     ```
-    sw-spine-001# checkpoint rollback CSM1_0
+    sw-spine-001# checkpoint rollback CSM1_2_UPGRADE_CANU_1_3_2    
     ```
 
 ## Dell
 
-1. View the configuration files.
 
-    Ensure that `csm1.0` and `csm1.2` exist. If they exist, proceed to the next step.
+    Ensure that the proper config files exist. `CSM1_0` and `CSM1_2` are used in this example.
+
 
     ```
     sw-leaf-001# dir config
@@ -68,8 +78,9 @@ To save switch configurations, refer to the [Configuration Management](config_ma
 ## Mellanox
 
 1. View the configuration files.
+   
+    Ensure that the proper checkpoints exist. `CSM1_0` and `CSM1_2` are used in this example.
 
-    Ensure that `csm1.0` and `csm1.2` exist. If they exist, proceed to the next step.
 
     ```
     sw-spine-001 [standalone: master] (config) # show configuration files
@@ -78,21 +89,25 @@ To save switch configurations, refer to the [Configuration Management](config_ma
     Example output:
 
     ```
-    csm1.0 (active)
-    csm1.0.bak
-    csm1.2
-    csm1.2.bak
+    sw-spine-001 [mlag-domain: master] # show configuration files
+
+    csm1.0.canu1.1.21 (active)
+    csm1.0.canu1.1.21.bak
+    csm1.2.fresh_install_canu1.1.21
+    csm1.2.fresh_install_canu1.1.21.bak
+    csm1.2.upgrade_canu1.1.21
+    csm1.2.upgrade_canu1.1.21.bak
     initial
     initial.bak
 
-    Active configuration: csm1.0
+    Active configuration: csm1.0.canu1.1.21
     Unsaved changes     : yes
     ```
 
 1. Switch to desired configuration.
 
     ```
-    sw-spine-001 [standalone: master] (config) # configuration switch-to csm1.0
+    sw-spine-001 [standalone: master] (config) # configuration switch-to csm1.2.upgrade_canu1.1.21
     ```
 
     Example output:

--- a/operations/network/management_network/saving_config.md
+++ b/operations/network/management_network/saving_config.md
@@ -58,10 +58,11 @@ To keep track of what configuration version is running on the switch, create a n
 
 ### Aruba
 
-1. Get the CSM and CANU versions from the MOTD banner.
+1. Get the CSM and CANU versions from the EXEC banner.
 
     ```
-    sw-leaf-bmc-001(config)# show banner motd
+    sw-leaf-bmc-001(config)# show banner exec
+
     ```
 
     Example output:

--- a/operations/network/management_network/snmp_exporter_configs.md
+++ b/operations/network/management_network/snmp_exporter_configs.md
@@ -1,81 +1,82 @@
 # Prometheus SNMP Exporter
+
 The Prometheus SNMP Exporter is deployed by the the `cray-sysmgmt-health` chart to the `sysmgmt-health` namespace as part of the Cray System Management \(CSM\) release.
 
-### Configuration
+## Configuration
 
-In order to provide data to the Grafana SNMP dashboards the SNMP Exporter must be configured with a list of management network switches to scrape metrics from.
+In order to provide data to the Grafana SNMP dashboards, the SNMP Exporter must be configured with a list of management network switches to scrape metrics from.
 
 1. Set the `SYSTEM_NAME` variable if not already set.
 
-```bash
-linux# SYSTEM_NAME=eniac
-```
+    ```bash
+    linux# SYSTEM_NAME=eniac
+    ```
 
 1. Obtain the list of switches to use as targets using CSM Automatic Network Utility (CANU).
 
-```bash
-linux# canu init --sls-file /var/www/ephemeral/prep/${SYSTEM_NAME}/sls_input_file.json --out -
-10.252.0.2
-10.252.0.3
-10.252.0.4
-10.252.0.5
-4 IP addresses saved to <stdout>
-```
+    ```bash
+    linux# canu init --sls-file /var/www/ephemeral/prep/${SYSTEM_NAME}/sls_input_file.json --out -
+    10.252.0.2
+    10.252.0.3
+    10.252.0.4
+    10.252.0.5
+    4 IP addresses saved to <stdout>
+    ```
 
-1. Update customizations.yaml with the list of switches.
+1. Update `customizations.yaml` with the list of switches.
 
-```bash
-linux# yq write -s - -i /mnt/pitdata/prep/site-init/customizations.yaml <<EOF
-- command: update
-  path: spec.kubernetes.services.cray-sysmgmt-health.prometheus-snmp-exporter
-  value:
-          serviceMonitor:
-            enabled: true
-            params:
-              enabled: true
-              conf:
-                module:
-                - if_mib
-                target:
-                - 127.0.0.1
-                - 10.252.0.2
-                - 10.252.0.3
-                - 10.252.0.4
-                - 10.252.0.5
-EOF
-```
+    ```bash
+    linux# yq write -s - -i /mnt/pitdata/prep/site-init/customizations.yaml <<EOF
+    - command: update
+      path: spec.kubernetes.services.cray-sysmgmt-health.prometheus-snmp-exporter
+      value:
+              serviceMonitor:
+                enabled: true
+                params:
+                  enabled: true
+                  conf:
+                    module:
+                    - if_mib
+                    target:
+                    - 127.0.0.1
+                    - 10.252.0.2
+                    - 10.252.0.3
+                    - 10.252.0.4
+                    - 10.252.0.5
+    EOF
+    ```
 
 1. Review the SNMP Exporter configuration.
 
-```bash
-linux# yq r /mnt/pitdata/prep/site-init/customizations.yaml spec.kubernetes.services.cray-sysmgmt-health.prometheus-snmp-exporter
-```
+    ```bash
+    linux# yq r /mnt/pitdata/prep/site-init/customizations.yaml spec.kubernetes.services.cray-sysmgmt-health.prometheus-snmp-exporter
+    ```
 
-The expected output looks similar to
+    The expected output looks similar to
 
-```
-serviceMonitor:
-  enabled: true
-  params:
-    enabled: true
-    conf:
-      module:
-        - if_mib
-      target:
-        - 127.0.0.1
-        - 10.252.0.2
-        - 10.252.0.3
-        - 10.252.0.4
-        - 10.252.0.5
-```
+    ```yaml
+    serviceMonitor:
+      enabled: true
+      params:
+        enabled: true
+        conf:
+          module:
+            - if_mib
+          target:
+            - 127.0.0.1
+            - 10.252.0.2
+            - 10.252.0.3
+            - 10.252.0.4
+            - 10.252.0.5
+    ```
 
-The most common configuration parameters are specified in the following table. They must be set in the customizations.yaml file under the `spec.kubernetes.services.cray-sysmgmt-health.prometheus-snmp-exporter` service definition.
+The most common configuration parameters are specified in the following table. They must be set in the `customizations.yaml` file under the `spec.kubernetes.services.cray-sysmgmt-health.prometheus-snmp-exporter` service definition.
 
 |Customization|Default|Description|
 |-------------|-------|-----------|
-|`serviceMonitor.enabled`|`true`|Enables serviceMonitor for snmp exporter \(default chart value is `true`\)|
+|`serviceMonitor.enabled`|`true`|Enables `serviceMonitor` for snmp exporter \(default chart value is `true`\)|
 |`params.enabled`|`false`|Sets the snmp exporter params change to true \(default chart value is `false`\)|
 |`params.conf.module`|`if_mib`| snmp exporter to select which module \(default chart value is `if_mib`\)|
 |`params.conf.target`|`127.0.0.1`| add list of switch targets to snmp exporter to monitor \(default chart value is `127.0.0.1`\)|
 
-For a complete set of available parameters, consult the values.yaml file for the `cray-sysmgmt-health` chart.
+For a complete set of available parameters, consult the `values.yaml` file for the `cray-sysmgmt-health` chart.

--- a/operations/network/management_network/upgrade.md
+++ b/operations/network/management_network/upgrade.md
@@ -1,6 +1,6 @@
-# Upgrade Switches From 1.0 to 1.0 Preconfig
+# Upgrade Switches From 1.0 to 1.2 Preconfig
 
-Use the following procedure to upgrade switches from 1.0 to 1.0 preconfig.
+Use the following procedure to upgrade switches from 1.0 to 1.2 preconfig.
 
 To check if the management network is using generated switch configs, log onto a management switch and check for a banner with a `CANU version`. This indicates the switch config has been generated.
 
@@ -18,6 +18,8 @@ If the configs have not been generated, follow the procedure below.
 ## Procedure
 
 > **CAUTION:** All of these steps should be done using an out-of-band connection. This process is disruptive and will require downtime.
+> 
+> **CAUTION:** This procedure must be done in coordination with the CSM network team.
 
 1. Collect system data.
 

--- a/operations/network/management_network/validate_shcd.md
+++ b/operations/network/management_network/validate_shcd.md
@@ -1,6 +1,14 @@
-# Validate the SHCD
+# Validate the SHCD 
 
 Use the CSM Automated Network Utility (CANU) to validate the SHCD. SHCD validation is required to ensure Plan-of-Record network configurations are generated. This is an iterative process to create a model of the entire network topology connection-by-connection.
+
+## Topics
+
+   * [Prerequisites before validating the SHCD](#prerequisites)
+   * [Begin validation in the following order](#begin-validation-in-the-following-order)
+   * [Checks and Validations](#checks-and-validations)
+   * [Logging and Updates](#logging-and-updates)
+   * [Output SHD to JSON](#output-shcd-to-json)
 
 ## Prerequisites
 
@@ -35,7 +43,7 @@ The SHCD must be validated in the following order:
 
    ![](./img/shcd_example.png)
 
-   In this example, the 10G_25G_40G_100G worksheet has the upper left and lower right corners of I37 and T107 respectively.
+   In this example above, the 10G_25G_40G_100G worksheet has the upper left and lower right corners of I37 and T107 respectively. Note, the above screenshot is trimmed and only the first full 68 rows are shown.
 
 1. Use CANU to validate this worksheet.
 
@@ -65,9 +73,15 @@ A worksheet that runs "cleanly" will have checked that:
 
    * No overlapping ports specified.
 
-   * Node connections can be made at the appropriate speeds.
+A worksheet that runs *cleanly* will have checked that: 
 
-A clean run will have the following sections:
+* Nodes are *architecturally allowed* to connect to each other. 
+
+	* No overlapping ports specified. 
+
+	* Node connections can be made at the appropriate speeds. 
+
+In addition, a clean run will have the following sections: 
 
   * SHCD Node Connections – A high level list of all node connections on the system.
 
@@ -77,13 +91,13 @@ A clean run will have the following sections:
 
     * A list of nodes found that are not categorized on the system.
 
-      **NOTE:** This list is important as it could include misspellings of nodes that should be included!
+      **`Note`:** This list is important as it could include misspellings of nodes that should be included!
 
     * A list of cell-by-cell warnings of misspellings and other nit-picking items that CANU has autocorrected on the system.
 
 #### Check Warnings
 
-***Critically***, the Warnings output will contain a section headed "Node type could not be determined for the following". This needs to be carefully reviewed because it may contain site uplinks that are not tracked by CANU, but may also contain mis-spelled or miscategorized nodes.
+***Critical:*** The Warnings output will contain a section headed "Node type could not be determined for the following".  This needs to be carefully reviewed because it may contain site uplinks that are not tracked by CANU but may also contain mis-spelled or mis-categorized nodes. As an example: 
 
 For example:
 
@@ -114,7 +128,7 @@ Cell: P16      Name: SITE
 
 ***From the above example, two important observations can be made:***
 
-1. CAN and SITE uplinks are not in the "clean run" model. This means that these ports will not be configured.
+1. CAN and SITE uplinks are not in the *clean run* model. This means that these ports will not be configured. 
 
 1. Critically, Cell I38 has a name of "sw-spinx-002". This should be noted as a misspelling of "sw-spine-002" and corrected.
 
@@ -131,11 +145,11 @@ Today CANU validates many things, but a future feature is full cable specificati
 
 * Switch-to-switch cabling is appropriate for LAG formation.
 
-* "Other" nodes on the network seem sane.
+* *Other* nodes on the network seem sane. 
 
 ## Logging and Updates
 
-Once the SHCD has run cleanly through CANU and CANU output has been manually validated, changes to the SHCD should be "committed" so that work is not lost, and other users can take advantage of the CANU changes.
+Once the SHCD has run cleanly through CANU and CANU output has been manually validated, changes to the SHCD should be *committed* so that work is not lost, and other users can take advantage of the CANU changes.
 
 1. Add an entry to the changelog Config. Summary first worksheet.
 
@@ -154,9 +168,8 @@ Once the SHCD has run cleanly through CANU and CANU output has been manually val
 
 ## Output SHCD to JSON
 
-Once the SHCD is fully validate, the user will be able to output all the connection details to a `json` file.
-
-This is used to generate switch configurations.
+- Once the SHCD is fully validated, the user will be able to output all the connection details to a `json` file.
+- This output `json` file is used to generate switch configs.
 
 ```bash
 ncn# canu validate shcd -a v1 --shcd ./test.xlsx --tabs 40G_10G,NMN,HMN --corners I12,S37,I9,S20,I20,S31  --json --out cabling.json

--- a/operations/network/management_network/validate_shcd.md
+++ b/operations/network/management_network/validate_shcd.md
@@ -69,29 +69,28 @@ The SHCD must be validated in the following order:
 
 A worksheet that runs "cleanly" will have checked that:
 
-   * Nodes are "architecturally allowed" to connect to each other.
+* Nodes are "architecturally allowed" to connect to each other.
 
-   * No overlapping ports specified.
+* No overlapping ports specified.
 
 A worksheet that runs *cleanly* will have checked that: 
 
 * Nodes are *architecturally allowed* to connect to each other. 
 
-	* No overlapping ports specified. 
+* No overlapping ports specified. 
 
-	* Node connections can be made at the appropriate speeds. 
+* Node connections can be made at the appropriate speeds. 
 
 In addition, a clean run will have the following sections: 
 
-  * SHCD Node Connections – A high level list of all node connections on the system.
+* SHCD Node Connections – A high level list of all node connections on the system.
 
-  * SHCD Port Usage – A Port-by-port detailed listing of all node connections on the system.
+* SHCD Port Usage – A Port-by-port detailed listing of all node connections on the system.
 
-  * Warnings:
-
+* Warnings:
     * A list of nodes found that are not categorized on the system.
 
-      **`Note`:** This list is important as it could include misspellings of nodes that should be included!
+        **`Note`:** This list is important as it could include misspellings of nodes that should be included!
 
     * A list of cell-by-cell warnings of misspellings and other nit-picking items that CANU has autocorrected on the system.
 
@@ -132,7 +131,6 @@ Cell: P16      Name: SITE
 
 1. Critically, Cell I38 has a name of "sw-spinx-002". This should be noted as a misspelling of "sw-spine-002" and corrected.
 
-
 ## Check SHCD Port Usage
 
 Today CANU validates many things, but a future feature is full cable specification checking of nodes (e.g. what NCN ports go to which switches to properly form bonds).  There are several CANU roadmap items, but today a manual review of the "SHCD Port Usage" connections list is vital. Specifically, check:
@@ -145,7 +143,7 @@ Today CANU validates many things, but a future feature is full cable specificati
 
 * Switch-to-switch cabling is appropriate for LAG formation.
 
-* *Other* nodes on the network seem sane. 
+* **Other** nodes on the network seem sane. 
 
 ## Logging and Updates
 
@@ -163,13 +161,13 @@ Once the SHCD has run cleanly through CANU and CANU output has been manually val
 
    Either of the following options can be used:
 
-   * customer communication (CAST ticket for customers)
+   * `customer communication` (CAST ticket for customers)
    * SharePoint (internal systems and sometimes customer systems)
 
 ## Output SHCD to JSON
 
 - Once the SHCD is fully validated, the user will be able to output all the connection details to a `json` file.
-- This output `json` file is used to generate switch configs.
+- This output `json` file is used to generate switch configurations.
 
 ```bash
 ncn# canu validate shcd -a v1 --shcd ./test.xlsx --tabs 40G_10G,NMN,HMN --corners I12,S37,I9,S20,I20,S31  --json --out cabling.json

--- a/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System.md
+++ b/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System.md
@@ -1,6 +1,6 @@
 # Adding a Liquid-cooled blade to a System
 
-This procedure will add a liquid-cooled blades from a HPE Cray EX system.
+This procedure will add a liquid-cooled blades from an HPE Cray EX system.
 
 ## Perquisites
 -   The Cray command line interface \(CLI\) tool is initialized and configured on the system.

--- a/operations/node_management/Check_the_BMC_Failover_Mode.md
+++ b/operations/node_management/Check_the_BMC_Failover_Mode.md
@@ -4,16 +4,16 @@ Gigabyte BMCs must have their failover mode disabled to prevent incorrect networ
 
 If Gigabyte BMC failover mode is not disabled, some BMCs may receive incorrect IP addresses. Specifically, a BMC may request an IP address on the wrong subnet and be unable to re-acquire a new IP address on the correct subnet. If this occurs, administrators should ensure that the impacted BMC has its failover feature disabled.
 
-### Procedure
+## Procedure
 
 1.  Check the failover setting on a Gigabyte BMC.
 
     For example:
 
     ```bash
-    ncn-m001# export USERNAME=root
-    ncn-m001# export IPMI_PASSWORD=changeme
-    ncn-m001# ipmitool -I lanplus -U $USERNAME -E -H 172.30.52.247 raw 0x0c 0x02 0x01 210 0 0
+    ncn# export USERNAME=root
+    ncn# export IPMI_PASSWORD=changeme
+    ncn# ipmitool -I lanplus -U $USERNAME -E -H 172.30.52.247 raw 0x0c 0x02 0x01 210 0 0
     11 00 00
     ```
 
@@ -22,5 +22,4 @@ If Gigabyte BMC failover mode is not disabled, some BMCs may receive incorrect I
     - `11 00 01` - failover mode is enabled.
     - `11 00 00` – failover mode is disabled \(this is the desired state\).
 
-    Please note that if a Gigabyte BMC is reset to defaults for any reason, or upgraded, the failover mode will need to be disabled again to switch the BMC to manual mode as the default setting is for failover mode to be enabled.
-
+    > Note: On Gigabyte BMCs, the default setting is for failover mode to be enabled. Therefore, if a Gigabyte BMC is reset to defaults for any reason, or upgraded, then failover mode must be disabled again in order to switch the BMC to manual mode.

--- a/operations/node_management/Move_a_liquid-cooled_blade_within_a_System.md
+++ b/operations/node_management/Move_a_liquid-cooled_blade_within_a_System.md
@@ -1,5 +1,5 @@
 # Move a liquid-cooled blade within a System
-This top level procedure outlines common scenarios for moving blades around within a HPE Cray EX system.
+This top level procedure outlines common scenarios for moving blades around within an HPE Cray EX system.
 
 Blade movement scenarios:
 * [Scenario 1: Swap locations of two blades](#swap-locations-of-two-blades)

--- a/operations/node_management/Removing_a_Liquid-cooled_blade_from_a_System.md
+++ b/operations/node_management/Removing_a_Liquid-cooled_blade_from_a_System.md
@@ -1,6 +1,6 @@
 # Removing a Liquid-cooled blade from a System
 
-This procedure will remove a liquid-cooled blades from a HPE Cray EX system.
+This procedure will remove a liquid-cooled blades from an HPE Cray EX system.
 
 ## Perquisites
 -   The Cray command line interface \(CLI\) tool is initialized and configured on the system.

--- a/operations/node_management/Reset_Credentials_on_Redfish_Devices_for_Reinstallation.md
+++ b/operations/node_management/Reset_Credentials_on_Redfish_Devices_for_Reinstallation.md
@@ -8,7 +8,7 @@ Administrative privileges are required.
 
 ### Procedure
 
-1.  Create a SCSD payload file with the default credentials for the Redfish devices that have been changed from the defaults.
+1.  Create an SCSD payload file with the default credentials for the Redfish devices that have been changed from the defaults.
 
     The following example shows a payload file that will set the devices \`x0c0s0b0\` and \`x0c0s1b0\` back to the default Redfish credentials.
 

--- a/operations/node_management/Swap_a_Compute_Blade_with_a_Different_System.md
+++ b/operations/node_management/Swap_a_Compute_Blade_with_a_Different_System.md
@@ -4,69 +4,64 @@ Swap an HPE Cray EX liquid-cooled compute blade between two systems.
 
 - The two systems in this example are:
 
-  - Source system - Cray EX TDS cabinet x9000 with a healthy EX425 blade (Windom dual-injection) in chassis 3, slot 0
-  - Destination system - Cray EX cabinet x1005 with a defective EX425 blade (Windom dual-injection) in chassis 3, slot 0
+    - Source system - Cray EX TDS cabinet x9000 with a healthy EX425 blade (Windom dual-injection) in chassis 3, slot 0
+    - Destination system - Cray EX cabinet x1005 with a defective EX425 blade (Windom dual-injection) in chassis 3, slot 0
 
 - Substitute the correct component names (xnames) or other parameters in the command examples that follow.
 
 - All the nodes in the blade must be specified using a comma-separated list. For example, EX425 compute blades include two node cards, each with two logical nodes (4 nodes).
 
-
-
-### Prerequisites
+## Prerequisites
 
 - The Slingshot fabric must be configured with the desired topology for both blades.
 
 - The System Layout Service (SLS) must have the desired HSN configuration.
 
-- The blade that is removed from the source system must be installed in the empty slot left by the blade removed from destination system and visa-versa.
+- The blade that is removed from the source system must be installed in the empty slot left by the blade removed from destination system, and vice-versa.
 
 - Check the status of the high-speed network (HSN) and record link status before the procedure.
 
 - Review the following command examples. The commands can be used to capture the required values from the HSM `ethernetInterfaces` table and write the values to a file. The file then can be used to automate subsequent commands in this procedure, for example:
 
-  ```bash
-  ncn-m001# mkdir blade_swap_scripts; cd blade_swap_scripts
-  ncn-m001# cat blade_query.sh
+    ```bash
+    ncn-m001:# mkdir blade_swap_scripts; cd blade_swap_scripts
+    ncn-m001:# cat blade_query.sh
+    #!/bin/bash
+    BLADE=$1
+    OUTFILE=$2
 
-  #!/bin/bash
-  BLADE=$1
-  OUTFILE=$2
+    BLADE_DOT=$BLADE.
 
-  BLADE_DOT=$BLADE.
+    cray hsm inventory ethernetInterfaces list --format json | jq -c --arg BLADE "$BLADE_DOT" 'map(select(.ComponentID|test($BLADE))) | map(select(.Description == "Node Maintenance Network")) | .[] | {xname: .ComponentID, ID: .ID,MAC: .MACAddress, IP: .IPAddresses[0].IPAddress,Desc: .Description}' > $OUTFILE
+    ```
 
-  cray hsm inventory ethernetInterfaces list --format json | jq -c --arg BLADE "$BLADE_DOT" 'map(select(.ComponentID|test($BLADE))) | map(select(.Description == "Node Maintenance Network")) | .[] | {xname: .ComponentID, ID: .ID,MAC: .MACAddress, IP: .IPAddresses[0].IPAddress,Desc: .Description}' > $OUTFILE
-  ```
+    ```bash
+    ncn-m001:# ./blade_query.sh x1000c0s1 x1000c0s1.json
+    ncn-m001:# cat x1000c0s1.json
+    {"xname":"x9000c3s1b0n0","ID":"0040a6836339","MAC":"00:40:a6:83:63:39","IP":"10.100.0.10","Desc":"Node Maintenance Network"}
+    {"xname":"x9000c3s1b0n1","ID":"0040a683633a","MAC":"00:40:a6:83:63:3a","IP":"10.100.0.98","Desc":"Node Maintenance Network"}
+    {"xname":"x9000c3s1b1n0","ID":"0040a68362e2","MAC":"00:40:a6:83:62:e2","IP":"10.100.0.123","Desc":"Node Maintenance Network"}
+    {"xname":"x9000c3s1b1n1","ID":"0040a68362e3","MAC":"00:40:a6:83:62:e3","IP":"10.100.0.122","Desc":"Node Maintenance Network"}
+    ```
 
-  ```bash
-  ncn-m001# ./blade_query.sh x1000c0s1 x1000c0s1.json
-  ncn-m001# cat x1000c0s1.json
-  {"xname":"x9000c3s1b0n0","ID":"0040a6836339","MAC":"00:40:a6:83:63:39","IP":"10.100.0.10","Desc":"Node Maintenance Network"}
-  {"xname":"x9000c3s1b0n1","ID":"0040a683633a","MAC":"00:40:a6:83:63:3a","IP":"10.100.0.98","Desc":"Node Maintenance Network"}
-  {"xname":"x9000c3s1b1n0","ID":"0040a68362e2","MAC":"00:40:a6:83:62:e2","IP":"10.100.0.123","Desc":"Node Maintenance Network"}
-  {"xname":"x9000c3s1b1n1","ID":"0040a68362e3","MAC":"00:40:a6:83:62:e3","IP":"10.100.0.122","Desc":"Node Maintenance Network"}
-  ```
+    To delete an `ethernetInterfaces` entry using `curl`:
 
-  To delete an `ethernetInterfaces` entry using curl:
+    ```bash
+    ncn-m001:# for ID in $(cat x9000c3s1.json | jq -r '.ID'); do cray hsm inventory ethernetInterfaces delete $ID; done
+    ```
 
-  ```bash
-  ncn-m001# for ID in $(cat x9000c3s1.json | jq -r '.ID'); do cray hsm inventory ethernetInterfaces delete $ID; done
-  ```
+    To insert an `ethernetInterfaces` entry using `curl`:
 
-  To insert an `ethernetInterfaces` entry using curl:
-
-  ```bash
-  ncn-m001:# while read PAYLOAD ; do curl -H "Authorization: Bearer $MY_TOKEN" -L -X POST 'https://api-gw-service-nmn.local/apis/smd/hsm/v1/Inventory/EthernetInterfaces' -H 'Content-Type: application/json' --data-raw "$(echo $PAYLOAD | jq -c '{ComponentID: .xname,Description: .Desc,MACAddress: .MAC,IPAddress: .IP}')";sleep 5; done < x9000c3s1.json
-  ```
+    ```bash
+    ncn-m001:# while read PAYLOAD ; do curl -H "Authorization: Bearer $MY_TOKEN" -L -X POST 'https://api-gw-service-nmn.local/apis/smd/hsm/v1/Inventory/EthernetInterfaces' -H 'Content-Type: application/json' --data-raw "$(echo $PAYLOAD | jq -c '{ComponentID: .xname,Description: .Desc,MACAddress: .MAC,IPAddress: .IP}')";sleep 5; done < x9000c3s1.json
+    ```
 
 - The blades must have the coolant drained and filled during the swap to minimize cross-contamination of cooling systems.
 
-  - Review procedures in *HPE Cray EX Coolant Service Procedures H-6199*
-  - Review the *HPE Cray EX Hand Pump User Guide H-6200*
+    - Review procedures in *HPE Cray EX Coolant Service Procedures H-6199*
+    - Review the *HPE Cray EX Hand Pump User Guide H-6200*
 
-
-
-### Prepare the source system blade for removal
+## Prepare the source system blade for removal
 
 1. Using the work load manager (WLM), drain running jobs from the affected nodes on the blade. Refer to the vendor documentation for the WLM for more information.
 
@@ -77,9 +72,7 @@ Swap an HPE Cray EX liquid-cooled compute blade between two systems.
    ncn-m001# cray bos session create --template-uuid $BOS_TEMPLATE --operation shutdown --limit x9000c3s0b0n0,x9000c3s0b0n1,x9000c3s0b1n0,x9000c3s0b1n1
    ```
 
-
-
-#### Disable the Redfish endpoints for the nodes
+### Disable the Redfish endpoints for the nodes
 
 3. Temporarily disable the Redfish endpoints for each compute node NodeBMC.
 
@@ -88,9 +81,7 @@ Swap an HPE Cray EX liquid-cooled compute blade between two systems.
    ncn-m001# cray hsm inventory redfishEndpoints update --enabled false x9000c3s0b1
    ```
 
-
-
-#### Clear the node controller settings
+### Clear the node controller settings
 
 4. Remove the system specific settings from each node controller on the blade.
 
@@ -105,9 +96,7 @@ Swap an HPE Cray EX liquid-cooled compute blade between two systems.
    ```
    Use Ctrl-C to return to the prompt if command does not return.
 
-
-
-#### Power off the chassis slot
+### Power off the chassis slot
 
 5. Suspend the hms-discovery cron job.
 
@@ -135,19 +124,15 @@ Swap an HPE Cray EX liquid-cooled compute blade between two systems.
       ncn-m001# cray capmc component name (xname)_off create --xnames x9000c3s0 --recursive true
       ```
 
+### Disable the chassis slot
 
-
-#### Disable the chassis slot
-
-6. Disable the chassis slot. Disabling the slot prevents hms-discovery from automatically powering on the slot. This example disables slot 0, chassis 3, in cabinet 9000.
+6. Disable the chassis slot. Disabling the slot prevents `hms-discovery` from automatically powering on the slot. This example disables slot 0, chassis 3, in cabinet 9000.
 
    ```bash
    ncn-m001# cray hsm state components enabled update --enabled false x9000c3s0
    ```
 
-
-
-#### Record MAC and IP addresses for nodes
+### Record MAC and IP addresses for nodes
 
 **IMPORTANT**: Record the node management network (NMN) MAC and IP addresses for each node in the blade (labeled `Node Maintenance Network`). To prevent disruption in the data virtualization service (DVS), these addresses must be maintained in the HSM when the blade is swapped and discovered.
 
@@ -207,7 +192,7 @@ The hardware management network MAC and IP addresses are assigned algorithmicall
 
 
 
-#### Remove the blade
+### Remove the blade
 
 8. Remove the blade from the source system.
    - Review the *Remove a Compute Blade Using the Lift* procedure in *HPE Cray EX Hardware Replacement Procedures H-6173* for detailed instructions for replacing liquid-cooled blades (https://internal.support.hpe.com/).
@@ -215,9 +200,7 @@ The hardware management network MAC and IP addresses are assigned algorithmicall
    - Review *HPE Cray EX Coolant Service Procedures H-6199*. If using the hand pump, review procedures in the *HPE Cray EX Hand Pump User Guide H-6200* (https://internal.support.hpe.com/).
 10. Install the blade from the source system in a storage rack or leave it on the cart.
 
-
-
-### Prepare the blade in the destination system for removal
+## Prepare the blade in the destination system for removal
 
 11. Use WLM to drain jobs from the affected nodes on the blade.
 
@@ -229,9 +212,7 @@ The hardware management network MAC and IP addresses are assigned algorithmicall
     --limit x1005c3s0b0n0,x1005c3s0b0n1,x1005c3s0b1n0,x1005c3s0b1n1
     ```
 
-
-
-#### Disable the Redfish endpoints for the nodes
+### Disable the Redfish endpoints for the nodes
 
 13. When nodes are `Off`, temporarily disable endpoint discovery service (MEDS) for the compute nodes(s).
     Disabling chassis slot prevents hms-discovery from attempting to power them back on.
@@ -241,9 +222,7 @@ The hardware management network MAC and IP addresses are assigned algorithmicall
     ncn-m001# cray hsm inventory redfishEndpoints update --enabled false x1005c3s0b1
     ```
 
-
-
-#### Clear the node controller settings
+### Clear the node controller settings
 
 14. Remove system specific settings from each node controller on the blade.
 
@@ -257,9 +236,7 @@ The hardware management network MAC and IP addresses are assigned algorithmicall
       https://x1005c3s0b1/redfish/v1/Managers/BMC/Actions/Manager.Reset
     ```
 
-
-
-#### Power off the chassis slot
+### Power off the chassis slot
 
 15. Suspend the hms-discovery cron job.
 
@@ -287,9 +264,7 @@ The hardware management network MAC and IP addresses are assigned algorithmicall
     ncn-m001# cray capmc component name (xname)_off create --xnames x1005c3s0 --recursive true
     ```
 
-
-
-#### Disable the chassis slot
+### Disable the chassis slot
 
 18. Disable the chassis slot. This example disables slot 0, chassis 3, in cabinet 1005.
 
@@ -297,9 +272,7 @@ The hardware management network MAC and IP addresses are assigned algorithmicall
     ncn-m001# cray hsm state components enabled update --enabled false x1005c3s0
     ```
 
-
-
-#### Record the NIC MAC and IP addresses
+### Record the NIC MAC and IP addresses
 
 **IMPORTANT**: Record the ComponentID, MAC, and IP addresses for each node in the blade in the destination system. To prevent disruption in the data virtualization service (DVS), these addresses must be maintained in the HSM when the replacement blade is swapped and discovered.
 
@@ -355,17 +328,13 @@ The hardware management network NIC MAC addresses for liquid-cooled blades are a
     ncn-m001# cray hsm inventory redfishEndpoints delete x1005c3s0b1
     ```
 
-
-
-#### Swap the blade hardware
+### Swap the blade hardware
 
 24. Remove the blade from destination system install it in a storage cart.
 
 25. Install the blade from the source system into the destination system.
 
-
-
-#### Bring up the blade in the destination system
+### Bring up the blade in the destination system
 
 26. Obtain an authentication token to access the API gateway. In the example below, replace `myuser`, `mypass`, and `shasta` in the cURL command with site-specific values. Note the value of `access_token`. Review [Retrieve an Authentication Token](../security_and_authentication/Retrieve_an_Authentication_Token.md) for more information. The example is a script to secure a token and set it to the variable MY_TOKEN.
 
@@ -444,9 +413,7 @@ The hardware management network NIC MAC addresses for liquid-cooled blades are a
 
 29. Repeat the preceding command for each node in the blade.
 
-
-
-#### Enable and power on the chassis slot
+### Enable and power on the chassis slot
 
 30. Enable the chassis slot. The example enables slot 0, chassis 3, in cabinet 1005.
 
@@ -460,11 +427,9 @@ The hardware management network NIC MAC addresses for liquid-cooled blades are a
     ncn-m001# cray capmc component name (xname)_on create --xnames x1005c3s0 --recursive true
     ```
 
+### Enable discovery
 
-
-#### Enable discovery
-
-32. Verify the hms-discovery cronjob is not suspended in k8s (`ACTIVE` = `1` and `SUSPEND` = `False`).
+32. Verify the `hms-discovery` cronjob is not suspended in Kubernetes (`ACTIVE` = `1` and `SUSPEND` = `False`).
 
     ```bash
     ncn-m001# kubectl -n services patch cronjobs hms-discovery \
@@ -489,9 +454,7 @@ The hardware management network NIC MAC addresses for liquid-cooled blades are a
     ncn-m001# sleep 180
     ```
 
-
-
-#### Verify discovery has completed
+### Verify discovery has completed
 
 34. To verify the BMC(s) have been discovered by the HSM, run this command for each BMC in the blade.
 
@@ -503,21 +466,21 @@ The hardware management network NIC MAC addresses for liquid-cooled blades are a
 
     ```
     {
-    	"ID": "x1005c3s0b0",
-    	"Type": "NodeBMC",
-    	"Hostname": "x1005c3s0b0",
-    	"Domain": "",
-    	"FQDN": "x1005c3s0b0",
-    	"Enabled": true,
-    	"User": "root",
-    	"Password": "",
-    	"MACAddr": "02:03:E8:00:31:00",
-    	"RediscoverOnUpdate": true,
-    	"DiscoveryInfo": {
-    		"LastDiscoveryAttempt": "2021-06-10T18:01:59.920850Z",
-    		"LastDiscoveryStatus": "DiscoverOK",
-    		"RedfishVersion": "1.2.0"
-    	}
+        "ID": "x1005c3s0b0",
+        "Type": "NodeBMC",
+        "Hostname": "x1005c3s0b0",
+        "Domain": "",
+        "FQDN": "x1005c3s0b0",
+        "Enabled": true,
+        "User": "root",
+        "Password": "",
+        "MACAddr": "02:03:E8:00:31:00",
+        "RediscoverOnUpdate": true,
+        "DiscoveryInfo": {
+            "LastDiscoveryAttempt": "2021-06-10T18:01:59.920850Z",
+            "LastDiscoveryStatus": "DiscoverOK",
+            "RedfishVersion": "1.2.0"
+        }
     }
     ```
 
@@ -591,9 +554,7 @@ The hardware management network NIC MAC addresses for liquid-cooled blades are a
     . . .
     ```
 
-
-
-#### Power on and boot the nodes
+### Power on and boot the nodes
 
 39. Use boot orchestration to power on and boot the nodes. Specify the appropriate BOS template for the node type.
 
@@ -603,9 +564,7 @@ The hardware management network NIC MAC addresses for liquid-cooled blades are a
       --operation reboot --limit x1005c3s0b0n0,x1005c3s0b0n1,x1005c3s0b1n0,x1005c3s0b1n1
     ```
 
-
-
-#### Check firmware
+### Check firmware
 
 40. Verify that the correct firmware versions for node BIOS, node controller (nC), NIC mezzanine card (NMC), GPUs, and so on.
 
@@ -615,11 +574,9 @@ The hardware management network NIC MAC addresses for liquid-cooled blades are a
     ncn-m001# cray fas actions create CUSTOM_DEVICE_PARAMETERS.json
     ```
 
+### Check DVS
 
-
-#### Check DVS
-
-There should be a cray-cps pod (the broker), three cray-cps-etcd pods and their waiter, and at least one cray-cps-cm-pm pod. Usually there are two cray-cps-cm-pm pods, one on ncn-w002 and one on ncn-w003 and other worker nodes
+There should be a `cray-cps` pod (the broker), three `cray-cps-etcd` pods and their waiter, and at least one `cray-cps-cm-pm` pod. Usually there are two `cray-cps-cm-pm` pods, one on `ncn-w002`, and one on `ncn-w003` and other worker nodes
 
 42. Check the cray-cps pods on worker nodes and verify they are `Running`.
 
@@ -665,9 +622,7 @@ There should be a cray-cps pod (the broker), three cray-cps-etcd pods and their 
     rootfs
     ```
 
-
-
-#### Check the HSN for the affected nodes
+### Check the HSN for the affected nodes
 
 46. Determine the pod name for the Slingshot fabric manager pod and check the status of the fabric.
 
@@ -677,9 +632,7 @@ There should be a cray-cps pod (the broker), three cray-cps-etcd pods and their 
       -- fmn_status
     ```
 
-
-
-#### Check DNS
+### Check DNS
 
 Check for duplicate IP address entries in the State Management Database (SMD). Duplicate entries will cause DNS operations to fail.
 
@@ -700,7 +653,7 @@ Config reload failed
 ncn-m001#
 ```
 
-47. Use the following example curl command to check for active DHCP leases. If there are 0 DHCP leases, there is a configuration error.
+47. Use the following example `curl` command to check for active DHCP leases. If there are 0 DHCP leases, there is a configuration error.
 
     ```bash
     ncn-m001# curl -H "Authorization: Bearer ${MY_TOKEN}" -X POST -H "Content-Type: application/json" -d '{ "command": "lease4-get-all", "service": [ "dhcp4" ] }' https://api-gw-service-nmn.local/apis/dhcp-kea | jq
@@ -796,9 +749,7 @@ ncn-m001#
     Last login: Tue Aug 31 10:45:49 2021 from 10.252.1.9
     ```
 
-
-
-#### Bring up the blade in the source system
+### Bring up the blade in the source system
 
 51. To minimize cross-contamination of cooling systems, drain the coolant from the blade removed from destination system and fill with fresh coolant .
 
@@ -809,4 +760,3 @@ ncn-m001#
 - Review the *Remove a Compute Blade Using the Lift* procedure in *HPE Cray EX Hardware Replacement Procedures H-6173* for detailed instructions for replacing liquid-cooled blades (https://internal.support.hpe.com/).
 
 53. Repeat steps 26 through 50 to power on the nodes in the source system.
-

--- a/operations/node_management/customize_disk_hardware.md
+++ b/operations/node_management/customize_disk_hardware.md
@@ -2,7 +2,7 @@
 
 This page will assist an admin with changing the kernel parameters for NCNs that have extra disks.
 
-> **`NOTE:`** If a system's hardware is Plan of Record (PoR) then this page is not needed.
+> **`NOTE:`** If a system's hardware is Plan of Record (PoR), then this page is not needed.
 
 For any procedure below, it is assumed that the extra disks are going to be utilized. If they are undesired, then the only action item to do is to yank/remove/pull the disks from the NCN.
 

--- a/operations/power_management/Cray_Advanced_Platform_Monitoring_and_Control_CAPMC.md
+++ b/operations/power_management/Cray_Advanced_Platform_Monitoring_and_Control_CAPMC.md
@@ -12,7 +12,7 @@ has HTTPS access to the
 [System Management Services](../network/Access_to_System_Management_Services.md).
 
 Third party software can access the API directly. Refer to the
-[CAPMC API](https://github.com/Cray-HPE/hms-capmc/blob/release/csm-1.0/api/swagger.yaml)
+[CAPMC API](https://github.com/Cray-HPE/hms-capmc/blob/v1.31.0/api/swagger.yaml)
 documentation for detailed information about API options and features.
 
 The `cray capmc` command (see `--help`) can be used to control power to

--- a/operations/security_and_authentication/Add_LDAP_User_Federation.md
+++ b/operations/security_and_authentication/Add_LDAP_User_Federation.md
@@ -2,268 +2,264 @@
 
 Add LDAP user federation using the Keycloak localization tool.
 
-
-### Prerequisites
+## Prerequisites
 
 LDAP user federation is not currently configured in Keycloak. For example, if it was not configured in Keycloak when the system was initially installed or the LDAP user federation was removed.
 
+## Procedure
 
-### Procedure
+1. Prepare to edit the `customizations.yaml` file.
 
-1. Prepare to customize the customizations.yaml file.
-
-   If the customizations.yaml file is managed in an external Git repository (as recommended), then clone a local working tree. Replace the `<URL>` value in the following command before running it.
+   If the `customizations.yaml` file is managed in an external Git repository (as recommended), then clone a local working tree. Replace the `<URL>` value in the following command before running it.
 
    ```bash
    ncn-m001# git clone <URL> /root/site-init
    ncn-m001# cd /root/site-init
    ```
 
-   If there is not a backup of site-init, perform the following steps to create a new one using the values stored in the Kubernetes cluster.
+   If there is not a backup of `site-init`, perform the following steps to create a new one using the values stored in the Kubernetes cluster.
 
-   1. Create a new site-init directory using the CSM tarball.
+   1. Create a new `site-init` directory using the CSM tarball.
 
-      Determine the location of the initial unpacked install tarball and set ${CSM_DISTDIR} accordingly.
+      Determine the location of the initial unpacked install tarball and set `${CSM_DISTDIR}` accordingly.
 
-      > **NOTE:** If the unpacked set of CSM directories was copied, no untar action is required. If the tarball tgz file was copied, the command to unpack it is `tar -zxvf CSM_RELEASE.tar.gz`. Replace the *CSM_RELEASE* value before running the command to unpack the tarball.
+      > **NOTE:** If the unpacked set of CSM directories was copied, no untar action is required. If the tarball `.tgz` file was copied, the command to unpack it is `tar -zxvf CSM_RELEASE.tar.gz`. Replace the `CSM_RELEASE` value before running the command to unpack the tarball.
 
       ```bash
       ncn-m001# cp -r ${CSM_DISTDIR}/shasta-cfg/* /root/site-init
       ncn-m001# cd /root/site-init
       ```
 
-   2. Extract customizations.yaml from the site-init secret.
+   1. Extract `customizations.yaml` from the `site-init` Kubernetes secret.
 
       ```bash
       ncn-m001# kubectl -n loftsman get secret site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d - > customizations.yaml
       ```
 
-   3. Extract the certificate and key used to create the sealed secrets.
+   1. Extract the certificate and key used to create the sealed secrets.
 
       ```bash
       ncn-m001# kubectl -n kube-system get secret sealed-secrets-key -o jsonpath='{.data.tls\.crt}' | base64 -d - > certs/sealed_secrets.crt
       ncn-m001# kubectl -n kube-system get secret sealed-secrets-key -o jsonpath='{.data.tls\.key}' | base64 -d - > certs/sealed_secrets.key
       ```
 
-  > **NOTE:** All subsequent steps of this procedure should be performed within the `/root/site-init` directory created in this step.
+   > **NOTE:** All subsequent steps of this procedure should be performed within the `/root/site-init` directory created in this step.
 
-2. Repopulate the keycloak_users_localize and cray-keycloak Sealed Secrets in the customizations.yaml file with the desired configuration.
+1. Repopulate the `keycloak_users_localize` and `cray-keycloak` sealed secrets in the `customizations.yaml` file with the desired configuration.
 
    Update the LDAP settings with the desired configuration. LDAP connection information
-   is stored in the keycloak-users-localize Secret in the customizations.yaml file.
+   is stored in the `keycloak-users-localize` secret in the `customizations.yaml` file.
 
-   -   The ldap_connection_url key is required and is set to an LDAP URL.
-   -   The ldap_bind_dn and ldap_bind_credentials keys are optional.
-   -   If the LDAP server requires authentication. then the bind DN and credentials are set in these keys respectively.
+   - The `ldap_connection_url` key is required and is set to an LDAP URL.
+   - The `ldap_bind_dn` and `ldap_bind_credentials` keys are optional.
+      - If the LDAP server requires authentication. then the bind DN and credentials are set in these keys respectively.
 
    For example:
 
-      ```bash
-            cray-keycloak:
-                generate:
-                  name: keycloak-certs
-                  data:
-                    - type: static_b64
-                      args:
-                        name: certs.jks
-                        value: /u3+7QAAAAIAAAAA5yXvSDt11bGXyBA9M2iy0/5i1Tg=
+   ```yaml
+         cray-keycloak:
+             generate:
+               name: keycloak-certs
+               data:
+                 - type: static_b64
+                   args:
+                     name: certs.jks
+                     value: /u3+7QAAAAIAAAAA5yXvSDt11bGXyBA9M2iy0/5i1Tg=
 
-            keycloak_users_localize:
-                generate:
-                  name: keycloak-users-localize
-                  data:
-                    - type: static
-                      args:
-                        name: ldap_connection_url
-                        value: "ldaps://my_ldap.my_org.test"
-                    - type: static
-                      args:
-                        name: ldap_bind_dn
-                        value: "cn=my_admin"
-                    - type: static
-                      args:
-                        name: ldap_bind_credentials
-                        value: "my_ldap_admin_password"
-      ```
+         keycloak_users_localize:
+             generate:
+               name: keycloak-users-localize
+               data:
+                 - type: static
+                   args:
+                     name: ldap_connection_url
+                     value: "ldaps://my_ldap.my_org.test"
+                 - type: static
+                   args:
+                     name: ldap_bind_dn
+                     value: "cn=my_admin"
+                 - type: static
+                   args:
+                     name: ldap_bind_credentials
+                     value: "my_ldap_admin_password"
+   ```
 
-     The example above puts an empty certs.jks in the cray-keycloak Sealed Secret.
-     The next step will generate certs.jks.
+   The example above puts an empty `certs.jks` in the `cray-keycloak` sealed secret.
+   The next step will generate `certs.jks`.
 
-     Other LDAP configuration settings are set in the spec.kubernetes.services.cray-keycloak-users-localize field in the customizations.yaml file.
+   Other LDAP configuration settings are set in the `spec.kubernetes.services.cray-keycloak-users-localize` field in the `customizations.yaml` file.
 
-     The fields are as follows:
+   A list of the fields follows. The format of the entries in this list is:
+   ```
+     * <cray-keycloak-users-localize chart option name> : <description>
+       - default: <the default value if not overridden in customizations.yaml
+       - type: <type that the value in customizations.yaml has to be. e.g., if type is string and a number is entered then you need to quote it>
+       - allowed values: <if only certain values are allowed they are listed here>
+   ```
 
-      ```
-      (
-      Notes for the following table: format is
+   The fields are:
+   ```yaml
+     * ldapProviderId : The Keycloak provider ID for the component. This must be "ldap"
+       - default: ldap
+       - type: string
+     * ldapFederationName : The name of the LDAP provider in Keycloak. If a provider with this name already exists then this tool will not create a new provider.
+       - default: shasta-user-federation-ldap
+       - type: string
+     * ldapPriority : The priority of this provider when looking up users or adding a user.
+       - default: 1
+       - type: string
+     * ldapEditMode : If you want to be able to create or change users in Keycloak and have them created or modified in the LDAP server, and the LDAP server allows it, then this can be changed.
+       - default: READ_ONLY
+       - type: string
+       - allowed values: `READ_ONLY`, `WRITEABLE`, or `UNSYNCED`
+     * ldapSyncRegistrations : If true, then newly created users will be created in the LDAP server.
+       - default: false
+       - type: string
+       - allowed values: true or false
+     * ldapVendor: This determines some defaults for what mappers are created by default.
+       - default: other
+       - type: string
+       - allowed values: Active Directory, Red Hat Directory Server, Tivoli, Novell eDirectory, or other
+     * ldapUsernameLDAPAttribute: The LDAP attribute to map to the username in Keycloak.
+       - default: uid
+       - type: string
+     * ldapRdnLDAPAttribute: The LDAP attribute being used as the users RDN.
+       - default: uid
+       - type: string
+     * ldapUuidLDAPAttribute: The LDAP attribute being used as a unique ID.
+       - default: uid
+       - type: string
+     * ldapUserObjectClasses: The object classes for user entries.
+       - default: posixAccount
+       - type: comma-separated string
+     * ldapAuthType: Set to "none" if the LDAP server allows anonymous search for users and groups, otherwise set to "simple" to bind.
+       - default: none
+       - type: string
+       - allowed values: none or simple
+     * ldapSearchBase: The DN for the base entry to search for users and groups.
+       - default: cn=default
+       - type: string
+     * ldapSearchScope: The search scope to use when searching for users or groups: 2 for subtree, 1 for onelevel
+       - default: 2
+       - type: string
+       - allowed values: 1 or 2
+     * ldapUseTruststoreSpi: Determines if the truststore is used to validate the server certificate when connecting to the server.
+       - default: ldapsOnly
+       - type: string
+       - allowed values: ldapsOnly, always, never
+     * ldapConnectionPooling: If true then Keycloak will use a connection pool of LDAP connections.
+       - default: true
+       - type: string
+       - allowed values: true or false
+     * ldapPagination: Set to true if the LDAP server supports or requires use of the paging extension.
+       - default: true
+       - type: string
+       - allowed values: true or false
+     * ldapAllowKerberosAuthentication:
+       - Set to true to enable HTTP authentication of users with SPNEGO/Kerberos tokens.
+       - default: false
+       - type: string
+     * ldapBatchSizeForSync: Count of LDAP users to be imported from LDAP to Keycloak in a single transaction.
+       - default: 4000
+       - type: string
+     * ldapFullSyncPeriod: If a positive number, this is the number of seconds between automatic full user synchronization operations; if negative then full user synchronization operations will not be done automatically.
+       - default: -1
+       - type: string
+     * ldapChangedSyncPeriod: f a positive number, this is the number of seconds between automatic changed user synchronization operations; if negative then changed user synchronization operations will not be done automatically.
+       - default: -1
+       - type: string
+     * ldapDebug: Set to true to enable extra logging of LDAP operations.
+       - default: true
+       - allowed values: true or false
+     * ldapUserAttributeMappers: Extra attribute mappers to create so that users have attributes required by Shasta software. The Keycloak attribute that the LDAP attribute maps to will be the same.
+       - default: [uidNumber, gidNumber, loginShell, homeDirectory]
+       - type: list of strings
+     * ldapUserAttributeMappersToRemove: These attribute mappers will be removed, to be used in the case where the default attribute mappers are not appropriate. For example, this could be used to remove the email mapper if email addresses are not unique.
+       - default: []
+       - type: list of strings
+     * ldapGroupNameLDAPAttribute: The LDAP attribute to map to the group name in Keycloak.
+       - default: cn
+       - type: string
+     * ldapGroupObjectClass: The object classes for group entries.
+       - default: posixGroup
+       - type: comma-separated string
+     * ldapPreserveGroupInheritance: Whether group inheritance should be propagated to Keycloak or not.
+       - default: false
+       - type: string
+       - allowed values: true or false
+     * ldapMembershipLDAPAttribute: Name of the LDAP attribute that refers to the group members.
+       - default: memberUid
+       - type: string
+     * ldapMembershipAttributeType: If the member attribute contains the DN for the user, then set this to DN. If the member attribute is the UID of the entry then set this to UID.
+       - default: UID
+       - type: string
+       - allowed values: UID or DN
+     * ldapMembershipUserLDAPAttribute: If the ldapMembershipAttributeType is UID then this is the LDAP attribute containing the UID value, otherwise this is ignored.
+       - default: uid
+       - type: string
+     * ldapGroupsLDAPFilter: Extra filter to include when searching for group entries. If this is not the empty string the value must start with the ( character and end with ).
+       - default: ""
+       - type: string
+     * ldapUserRolesRetrieveStrategy: Defines how to retrieve groups for a user.
+       - default: LOAD_GROUPS_BY_MEMBER_ATTRIBUTE
+       - type: string
+       - allowed values: LOAD_GROUPS_BY_MEMBER_ATTRIBUTE, GET_GROUPS_FROM_USER_MEMBEROF_ATTRIBUTE, LOAD_GROUPS_BY_MEMBER_ATTRIBUTE_RECURSIVELY
+     * ldapMappedGroupAttributes: Attributes of the group that will be added as attributes of the user. Some Shasta REST API operations require the user to have a gidNumber and this adds that attribute from the LDAP group.
+       - default: cn,gidNumber,memberUid
+       - type: comma-separated string
+     * ldapDropNonExistingGroupsDuringSync: If true, groups that are not in LDAP will be deleted when synchronizing.
+       - default: false
+       - type: string
+       - allowed values: true or false
+     * ldapDoFullSync: Tells the HPE Cray EX Keycloak localization tool to perform an immediate full user synchronization after configuring the LDAP integration.
+       - default: true
+       - type: string
+     * ldapRoleMapperDn: If this is an empty string then a role mapper is not created, otherwise this the the DN used as the search base to find role entries.
+       - default: ""
+       - type: string
+     * ldapRoleMapperRoleNameLDAPAttribute: The LDAP attribute to map to the role name in Keycloak.
+       - default: cn
+       - type: string
+     * ldapRoleMapperRoleObjectClasses: The object classes for role entries.
+       - default: groupOfNames
+       - type: string
+     * ldapRoleMapperLDAPAttribute: Name of the LDAP attribute that refers to the group members.
+       - default: member
+       - type: string
+     * ldapRoleMapperMemberAttributeType: If the member attribute contains the DN for the user, then set this to DN. If the member attribute is the UID of the entry then set this to UID.
+       - default: DN
+       - type: string
+       - allowed values: UID or DN
+     * ldapRoleMapperUserLDAPAttribute: If the ldapRoleMapperMemberAttributeType is UID then this is the LDAP attribute containing the UID value, otherwise this is ignored.
+       - default: sAMAccountName
+       - type: string
+     * ldapRoleMapperRolesLDAPFilter: Extra filter to include when searching for group entries. If this is not the empty string the value must start with the ( character and end with ).
+       - default: ""
+       - type: string
+     * ldapRoleMapperMode: Specifies how to retrieve roles for the user.
+       - default: READ_ONLY
+       - allowed values: READ_ONLY, LDAP_ONLY, or IMPORT
+     * ldapRoleMapperStrategy: Defines how to retrieve roles for a user.
+       - default: LOAD_ROLES_BY_MEMBER_ATTRIBUTE
+       - type: string
+       - allowed values: LOAD_ROLES_BY_MEMBER_ATTRIBUTE, GET_ROLES_FROM_MEMBEROF_ATTRIBUTE, or LOAD_ROLES_BY_MEMBER_ATTRIBUTE_RECURSIVELY
+     * ldapRoleMapperMemberOfLDAPAttribute: Only used when ldapRoleMapperStrategy is GET_ROLES_FROM_MEMBEROF_ATTRIBUTE where it is the LDAP attribute in the user entry that contains the roles that the user has.
+       - default: memberOf
+       - type: string
+     * ldapRoleMapperUseRealmRolesMapping: If true then LDAP role mappings will be mapped to realm role mappings in Keycloak, otherwise the LDAP role mappings will be mapped to client role mappings.
+       - default: false
+       - type: string
+       - allowed values: true or false
+     * ldapRoleMapperClientId: If ldapRoleMapperUseRealmRolesMapping is false then this is the client ID to apply the roles to.
+         - default: shasta
+         - type: string
+   ```
 
-        * <cray-keycloak-users-localize chart option name> : <description>
-          - default: <the default value if not overridden in customizations.yaml
-          - type: <type that the value in customizations.yaml has to be. e.g., if type is string and a number is entered then you need to quote it>
-          - allowed values: <if only certain values are allowed they are listed here>
-        )
+1. (Optional) Add the LDAP CA certificate in the `certs.jks` section of `customizations.yaml`.
 
-        * ldapProviderId : The Keycloak provider ID for the component. This must be "ldap"
-          - default: ldap
-          - type: string
-        * ldapFederationName : The name of the LDAP provider in Keycloak. If a provider with this name already exists then this tool will not create a new provider.
-          - default: shasta-user-federation-ldap
-          - type: string
-        * ldapPriority : The priority of this provider when looking up users or adding a user.
-          - default: 1
-          - type: string
-        * ldapEditMode : If you want to be able to create or change users in Keycloak and have them created or modified in the LDAP server, and the LDAP server allows it, then this can be changed.
-          - default: READ_ONLY
-          - type: string
-          - allowed values: `READ_ONLY`, `WRITEABLE`, or `UNSYNCED`
-        * ldapSyncRegistrations : If true, then newly created users will be created in the LDAP server.
-          - default: false
-          - type: string
-          - allowed values: true or false
-        * ldapVendor: This determines some defaults for what mappers are created by default.
-          - default: other
-          - type: string
-          - allowed values: Active Directory, Red Hat Directory Server, Tivoli, Novell eDirectory, or other
-        * ldapUsernameLDAPAttribute: The LDAP attribute to map to the username in Keycloak.
-          - default: uid
-          - type: string
-        * ldapRdnLDAPAttribute: The LDAP attribute being used as the users RDN.
-          - default: uid
-          - type: string
-        * ldapUuidLDAPAttribute: The LDAP attribute being used as a unique ID.
-          - default: uid
-          - type: string
-        * ldapUserObjectClasses: The object classes for user entries.
-          - default: posixAccount
-          - type: comma-separated string
-        * ldapAuthType: Set to "none" if the LDAP server allows anonymous search for users and groups, otherwise set to "simple" to bind.
-          - default: none
-          - type: string
-          - allowed values: none or simple
-        * ldapSearchBase: The DN for the base entry to search for users and groups.
-          - default: cn=default
-          - type: string
-        * ldapSearchScope: The search scope to use when searching for users or groups: 2 for subtree, 1 for onelevel
-          - default: 2
-          - type: string
-          - allowed values: 1 or 2
-        * ldapUseTruststoreSpi: Determines if the truststore is used to validate the server certificate when connecting to the server.
-          - default: ldapsOnly
-          - type: string
-          - allowed values: ldapsOnly, always, never
-        * ldapConnectionPooling: If true then Keycloak will use a connection pool of LDAP connections.
-          - default: true
-          - type: string
-          - allowed values: true or false
-        * ldapPagination: Set to true if the LDAP server supports or requires use of the paging extension.
-          - default: true
-          - type: string
-          - allowed values: true or false
-        * ldapAllowKerberosAuthentication:
-          - Set to true to enable HTTP authentication of users with SPNEGO/Kerberos tokens.
-          - default: false
-          - type: string
-        * ldapBatchSizeForSync: Count of LDAP users to be imported from LDAP to Keycloak in a single transaction.
-          - default: 4000
-          - type: string
-        * ldapFullSyncPeriod: If a positive number, this is the number of seconds between automatic full user synchronization operations; if negative then full user synchronization operations will not be done automatically.
-          - default: -1
-          - type: string
-        * ldapChangedSyncPeriod: f a positive number, this is the number of seconds between automatic changed user synchronization operations; if negative then changed user synchronization operations will not be done automatically.
-          - default: -1
-          - type: string
-        * ldapDebug: Set to true to enable extra logging of LDAP operations.
-          - default: true
-          - allowed values: true or false
-        * ldapUserAttributeMappers: Extra attribute mappers to create so that users have attributes required by Shasta software. The Keycloak attribute that the LDAP attribute maps to will be the same.
-          - default: [uidNumber, gidNumber, loginShell, homeDirectory]
-          - type: list of strings
-        * ldapUserAttributeMappersToRemove: These attribute mappers will be removed, to be used in the case where the default attribute mappers are not appropriate. For example, this could be used to remove the email mapper if email addresses are not unique.
-          - default: []
-          - type: list of strings
-        * ldapGroupNameLDAPAttribute: The LDAP attribute to map to the group name in Keycloak.
-          - default: cn
-          - type: string
-        * ldapGroupObjectClass: The object classes for group entries.
-          - default: posixGroup
-          - type: comma-separated string
-        * ldapPreserveGroupInheritance: Whether group inheritance should be propagated to Keycloak or not.
-          - default: false
-          - type: string
-          - allowed values: true or false
-        * ldapMembershipLDAPAttribute: Name of the LDAP attribute that refers to the group members.
-          - default: memberUid
-          - type: string
-        * ldapMembershipAttributeType: If the member attribute contains the DN for the user, then set this to DN. If the member attribute is the UID of the entry then set this to UID.
-          - default: UID
-          - type: string
-          - allowed values: UID or DN
-        * ldapMembershipUserLDAPAttribute: If the ldapMembershipAttributeType is UID then this is the LDAP attribute containing the UID value, otherwise this is ignored.
-          - default: uid
-          - type: string
-        * ldapGroupsLDAPFilter: Extra filter to include when searching for group entries. If this is not the empty string the value must start with the ( character and end with ).
-          - default: ""
-          - type: string
-        * ldapUserRolesRetrieveStrategy: Defines how to retrieve groups for a user.
-          - default: LOAD_GROUPS_BY_MEMBER_ATTRIBUTE
-          - type: string
-          - allowed values: LOAD_GROUPS_BY_MEMBER_ATTRIBUTE, GET_GROUPS_FROM_USER_MEMBEROF_ATTRIBUTE, LOAD_GROUPS_BY_MEMBER_ATTRIBUTE_RECURSIVELY
-        * ldapMappedGroupAttributes: Attributes of the group that will be added as attributes of the user. Some Shasta REST API operations require the user to have a gidNumber and this adds that attribute from the LDAP group.
-          - default: cn,gidNumber,memberUid
-          - type: comma-separated string
-        * ldapDropNonExistingGroupsDuringSync: If true, groups that are not in LDAP will be deleted when synchronizing.
-          - default: false
-          - type: string
-          - allowed values: true or false
-        * ldapDoFullSync: Tells the HPE Cray EX Keycloak localization tool to perform an immediate full user synchronization after configuring the LDAP integration.
-          - default: true
-          - type: string
-        * ldapRoleMapperDn: If this is an empty string then a role mapper is not created, otherwise this the the DN used as the search base to find role entries.
-          - default: ""
-          - type: string
-        * ldapRoleMapperRoleNameLDAPAttribute: The LDAP attribute to map to the role name in Keycloak.
-          - default: cn
-          - type: string
-        * ldapRoleMapperRoleObjectClasses: The object classes for role entries.
-          - default: groupOfNames
-          - type: string
-        * ldapRoleMapperLDAPAttribute: Name of the LDAP attribute that refers to the group members.
-          - default: member
-          - type: string
-        * ldapRoleMapperMemberAttributeType: If the member attribute contains the DN for the user, then set this to DN. If the member attribute is the UID of the entry then set this to UID.
-          - default: DN
-          - type: string
-          - allowed values: UID or DN
-        * ldapRoleMapperUserLDAPAttribute: If the ldapRoleMapperMemberAttributeType is UID then this is the LDAP attribute containing the UID value, otherwise this is ignored.
-          - default: sAMAccountName
-          - type: string
-        * ldapRoleMapperRolesLDAPFilter: Extra filter to include when searching for group entries. If this is not the empty string the value must start with the ( character and end with ).
-          - default: ""
-          - type: string
-        * ldapRoleMapperMode: Specifies how to retrieve roles for the user.
-          - default: READ_ONLY
-          - allowed values: READ_ONLY, LDAP_ONLY, or IMPORT
-        * ldapRoleMapperStrategy: Defines how to retrieve roles for a user.
-          - default: LOAD_ROLES_BY_MEMBER_ATTRIBUTE
-          - type: string
-          - allowed values: LOAD_ROLES_BY_MEMBER_ATTRIBUTE, GET_ROLES_FROM_MEMBEROF_ATTRIBUTE, or LOAD_ROLES_BY_MEMBER_ATTRIBUTE_RECURSIVELY
-        * ldapRoleMapperMemberOfLDAPAttribute: Only used when ldapRoleMapperStrategy is GET_ROLES_FROM_MEMBEROF_ATTRIBUTE where it is the LDAP attribute in the user entry that contains the roles that the user has.
-          - default: memberOf
-          - type: string
-        * ldapRoleMapperUseRealmRolesMapping: If true then LDAP role mappings will be mapped to realm role mappings in Keycloak, otherwise the LDAP role mappings will be mapped to client role mappings.
-          - default: false
-          - type: string
-          - allowed values: true or false
-        * ldapRoleMapperClientId: If ldapRoleMapperUseRealmRolesMapping is false then this is the client ID to apply the roles to.
-            - default: shasta
-            - type: string
-      ```
-
-3. (Optional) Add the LDAP CA certificate in the certs.jks section of customizations.yaml.
-
-   If LDAP requires TLS (recommended), update the `cray-keycloak` Sealed
-   Secret value by supplying a base64 encoded Java KeyStore (JKS) that
-   contains the CA certificate that signed the LDAP server's host key. The
+   If LDAP requires TLS (recommended), update the `cray-keycloak` sealed
+   secret value by supplying a base-64-encoded Java KeyStore (JKS) that
+   contains the CA certificate that signed with the LDAP server's host key. The
    password for the JKS file must be `password`.
 
    Administrators may use the `keytool` command from the `openjdk:11-jre-slim` container image
@@ -272,189 +268,192 @@ LDAP user federation is not currently configured in Keycloak. For example, if it
 
    1. Load the `openjdk` container image.
 
-        > **NOTE:** Requires a properly configured Docker or Podman environment.
+      > **NOTE:** Requires a properly configured Docker or Podman environment.
 
-        ```bash
-        ncn-m001# ${CSM_DISTDIR}/hack/load-container-image.sh dtr.dev.cray.com/library/openjdk:11-jre-slim
-        ```
+      ```bash
+      ncn-m001# ${CSM_DISTDIR}/hack/load-container-image.sh dtr.dev.cray.com/library/openjdk:11-jre-slim
+      ```
 
-        **Troubleshooting:**
+      **Troubleshooting:**
 
-        * If the output shows the skopeo.tar file cannot be found, ensure that the $CSM_DISTDIR directory looks correct, and contains the `dtr.dev.cray.com` directory that includes the originally installed docker images.
+      * If the output shows the `skopeo.tar` file cannot be found, then ensure that the `$CSM_DISTDIR` directory looks contains the `dtr.dev.cray.com` directory which includes the originally installed docker images.
 
-          The following is an example of the skopeo.tar file not being found:
+         The following is an example of the skopeo.tar file not being found:
 
-          ```bash
-          ++ podman load -q -i ./hack/../vendor/skopeo.tar
-          ++ sed -e 's/^.*: //'
-          + SKOPEO_IMAGE=
-          ```
+         ```bash
+         ++ podman load -q -i ./hack/../vendor/skopeo.tar
+         ++ sed -e 's/^.*: //'
+         + SKOPEO_IMAGE=
+         ```
 
-        * If the following overlay error is returned, it could be caused by an earlier podman invocation using a different configuration:
+      * If the following overlay error is returned, it could be caused by an earlier podman invocation using a different configuration:
 
-          ```
-          "ERRO[0000] [graphdriver] prior storage driver overlay failed: 'overlay' is not supported over overlayfs, a mount_program is required: backing file system is unsupported for this graph driver"
-          ```
+         ```
+         "ERRO[0000] [graphdriver] prior storage driver overlay failed: 'overlay' is not supported over overlayfs, a mount_program is required: backing file system is unsupported for this graph driver"
+         ```
 
-          To recover podman, move the overlay directories to a backup folder as follows:
+         To recover podman, move the overlay directories to a backup folder as follows:
 
-          ```bash
-          ncn-m001# mkdir /var/lib/containers/storage/backup
-          ncn-m001# mv /var/lib/containers/storage/overlay* /var/lib/containers/storage/backup
-          ```
+         ```bash
+         ncn-m001# mkdir /var/lib/containers/storage/backup
+         ncn-m001# mv /var/lib/containers/storage/overlay* /var/lib/containers/storage/backup
+         ```
 
-          This should allow load-container-images.sh to succeed.
+         This should allow `load-container-images.sh` to succeed.
 
-   2. Create (or update) `cert.jks` with the PEM-encoded CA certificate for an LDAP host.
+   1. Create (or update) `cert.jks` with the PEM-encoded CA certificate for an LDAP host.
 
-        > **IMPORTANT:** Replace `<ca-cert.pem>` and `<alias>` before running the command.
+      > **IMPORTANT:** Replace `<ca-cert.pem>` and `<alias>` before running the command.
 
-        ```bash
-        ncn-m001# podman run --rm -v "$(pwd):/data" dtr.dev.cray.com/library/openjdk:11-jre-slim keytool \
-        -importcert -trustcacerts -file /data/<ca-cert.pem> -alias <alias> -keystore /data/certs.jks \
-        -storepass password -noprompt
-        ```
+      ```bash
+      ncn-m001# podman run --rm -v "$(pwd):/data" dtr.dev.cray.com/library/openjdk:11-jre-slim keytool \
+                -importcert -trustcacerts -file /data/<ca-cert.pem> -alias <alias> -keystore /data/certs.jks \
+                -storepass password -noprompt
+      ```
 
-   3. Set variables for the LDAP server.
+   1. Set variables for the LDAP server.
 
-        In the following example, the LDAP server has the hostname `dcldap2.us.cray.com` and is using the port 636.
+      In the following example, the LDAP server has the hostname `dcldap2.us.cray.com` and is using the port `636`.
 
-        ```bash
-        ncn-m001# export LDAP=dcldap2.us.cray.com
-        ncn-m001# export PORT=636
-        ```
+      ```bash
+      ncn-m001# export LDAP=dcldap2.us.cray.com
+      ncn-m001# export PORT=636
+      ```
 
-   4. Get the issuer certificate for the LDAP server at port 636. Use `openssl s_client` to connect
+   1. Get the issuer certificate for the LDAP server at port `636`. Use `openssl s_client` to connect
       and show the certificate chain returned by the LDAP host.
 
-        ```bash
-        ncn-m001# openssl s_client -showcerts -connect $LDAP:${PORT} </dev/null
-        ```
+      ```bash
+      ncn-m001# openssl s_client -showcerts -connect $LDAP:${PORT} </dev/null
+      ```
 
-        Either manually extract (cut/paste) the issuer's
-        certificate into `cacert.pem`, or try the following commands to
-        create it automatically.
+   1. Generate `cacert.pem` containing the issuer's certificate.
 
-        > **NOTE:** The following commands were verified using OpenSSL
-        > version 1.1.1d and use the `-nameopt RFC2253` option to ensure
-        > consistent formatting of distinguished names (DNs).
-        > Unfortunately, older versions of OpenSSL may not support
-        > `-nameopt` on the `s_client` command or may use a different
-        > default format. As a result, mileage may vary; however,
-        > administrators should be able to extract the issuer certificate manually
-        > from the output of the above `openssl s_client` example if the
-        > following commands are unsuccessful.
+      Either manually extract (cut/paste) the issuer's
+      certificate into `cacert.pem`, or try the following commands to
+      create it automatically.
 
-        Observe the issuer's DN.
+      > **NOTE:** The following commands were verified using OpenSSL
+      > version 1.1.1d and use the `-nameopt RFC2253` option to ensure
+      > consistent formatting of distinguished names (DNs).
+      > Unfortunately, older versions of OpenSSL may not support
+      > `-nameopt` on the `s_client` command or may use a different
+      > default format. As a result, mileage may vary; however,
+      > administrators should be able to extract the issuer certificate manually
+      > from the output of the above `openssl s_client` example if the
+      > following commands are unsuccessful.
 
-        For example:
+      1. Observe the issuer's DN.
 
-        ```bash
-        ncn-m001# openssl s_client -showcerts -nameopt RFC2253 -connect $LDAP:${PORT} </dev/null 2>/dev/null | grep issuer= | sed -e 's/^issuer=//'
+         For example:
 
-        emailAddress=dcops@hpe.com,CN=Data Center,OU=HPC/MCS,O=HPE,ST=WI,C=US
-        ```
+         ```bash
+         ncn-m001# openssl s_client -showcerts -nameopt RFC2253 -connect $LDAP:${PORT} </dev/null 2>/dev/null | grep issuer= | sed -e 's/^issuer=//'
 
-        Then, extract the issuer's certificate using the `awk` command:
+         emailAddress=dcops@hpe.com,CN=Data Center,OU=HPC/MCS,O=HPE,ST=WI,C=US
+         ```
 
-        > **NOTE:** The issuer DN is properly escaped as part of the
-        > `awk` pattern below. If the value being used is
-        > different, be sure to escape it properly!
+      1. Extract the issuer's certificate using the `awk` command.
 
-        ```bash
-        ncn-m001# openssl s_client -showcerts -nameopt RFC2253 -connect $LDAP:${PORT} </dev/null 2>/dev/null | \
-                awk '/s:emailAddress=dcops@hpe.com,CN=Data Center,OU=HPC\/MCS,O=HPE,ST=WI,C=US/,/END CERTIFICATE/' | \
-                awk '/BEGIN CERTIFICATE/,/END CERTIFICATE/' > cacert.pem
-        ```
+         > **NOTE:** The issuer DN is properly escaped as part of the
+         > `awk` pattern below. If the value being used is
+         > different, be sure to escape it properly!
 
-    5. Verify the issuer's certificate was properly extracted and saved in `cacert.pem`.
+         ```bash
+         ncn-m001# openssl s_client -showcerts -nameopt RFC2253 -connect $LDAP:${PORT} </dev/null 2>/dev/null |
+                    awk '/s:emailAddress=dcops@hpe.com,CN=Data Center,OU=HPC\/MCS,O=HPE,ST=WI,C=US/,/END CERTIFICATE/' |
+                    awk '/BEGIN CERTIFICATE/,/END CERTIFICATE/' > cacert.pem
+         ```
 
-        ```bash
-        ncn-m001# cat cacert.pem
-        ```
+   1. Verify the issuer's certificate was properly extracted and saved in `cacert.pem`.
 
-        Expected output looks similar to the following:
+      ```bash
+      ncn-m001# cat cacert.pem
+      ```
 
-        ```
-        -----BEGIN CERTIFICATE-----
-        MIIDvTCCAqWgAwIBAgIUYxrG/PrMcmIzDuJ+U1Gh8hpsU8cwDQYJKoZIhvcNAQEL
-        BQAwbjELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAldJMQwwCgYDVQQKDANIUEUxEDAO
-        BgNVBAsMB0hQQy9NQ1MxFDASBgNVBAMMC0RhdGEgQ2VudGVyMRwwGgYJKoZIhvcN
-        AQkBFg1kY29wc0BocGUuY29tMB4XDTIwMTEyNDIwMzM0MVoXDTMwMTEyMjIwMzM0
-        MVowbjELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAldJMQwwCgYDVQQKDANIUEUxEDAO
-        BgNVBAsMB0hQQy9NQ1MxFDASBgNVBAMMC0RhdGEgQ2VudGVyMRwwGgYJKoZIhvcN
-        AQkBFg1kY29wc0BocGUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKC
-        AQEAuBIZkKitHHVQHymtaQt4D8ZhG4qNJ0cTsLhODPMtVtBjPZp59e+PWzbc9Rj5
-        +wfjLGteK6/fNJsJctWlS/ar4jw/xBIPMk5pg0dnkMT2s7lkSCmyd9Uib7u6y6E8
-        yeGoGcb7I+4ZI+E3FQV7zPact6b17xmajNyKrzhBGEjYucYJUL5iTgZ6a7HOZU2O
-        aQSXe7ctiHBxe7p7RhHCuKRrqJnxoohakloKwgHHzDLFQzX/5ADp1hdJcduWpaXY
-        RMBu6b1mhmwo5vmc+fDnfUpl5/X4i109r9VN7JC7DQ5+JX8u9SHDGLggBWkrhpvl
-        bNXMVCnwnSFfb/rnmGO7rdJSpwIDAQABo1MwUTAdBgNVHQ4EFgQUVg3VYExUAdn2
-        WE3e8Xc8HONy/+4wHwYDVR0jBBgwFoAUVg3VYExUAdn2WE3e8Xc8HONy/+4wDwYD
-        VR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAWLDQLB6rrmK+gwUY+4B7
-        0USbQK0JkLWuc0tCfjTxNQTzFb75PeH+GH21QsjUI8VC6QOAAJ4uzIEV85VpOQPp
-        qjz+LI/Ej1xXfz5ostZQu9rCMnPtVu7JT0B+NV7HvgqidTfa2M2dw9yUYS2surZO
-        8S0Dq3Bi6IEhtGU3T8ZpbAmAp+nNsaJWdUNjD4ECO5rAkyA/Vu+WyMz6F3ZDBmRr
-        ipWM1B16vx8rSpQpygY+FNX4e1RqslKhoyuzXfUGzyXux5yhs/ufOaqORCw3rJIx
-        v4sTWGsSBLXDsFM3lBgljSAHfmDuKdO+Qv7EqGzCRMpgSciZihnbQoRrPZkOHUxr
-        NA==
-        -----END CERTIFICATE-----
-        ```
+      Expected output looks similar to the following:
 
-    6. Create `certs.jks`.
+      ```
+      -----BEGIN CERTIFICATE-----
+      MIIDvTCCAqWgAwIBAgIUYxrG/PrMcmIzDuJ+U1Gh8hpsU8cwDQYJKoZIhvcNAQEL
+      BQAwbjELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAldJMQwwCgYDVQQKDANIUEUxEDAO
+      BgNVBAsMB0hQQy9NQ1MxFDASBgNVBAMMC0RhdGEgQ2VudGVyMRwwGgYJKoZIhvcN
+      AQkBFg1kY29wc0BocGUuY29tMB4XDTIwMTEyNDIwMzM0MVoXDTMwMTEyMjIwMzM0
+      MVowbjELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAldJMQwwCgYDVQQKDANIUEUxEDAO
+      BgNVBAsMB0hQQy9NQ1MxFDASBgNVBAMMC0RhdGEgQ2VudGVyMRwwGgYJKoZIhvcN
+      AQkBFg1kY29wc0BocGUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKC
+      AQEAuBIZkKitHHVQHymtaQt4D8ZhG4qNJ0cTsLhODPMtVtBjPZp59e+PWzbc9Rj5
+      +wfjLGteK6/fNJsJctWlS/ar4jw/xBIPMk5pg0dnkMT2s7lkSCmyd9Uib7u6y6E8
+      yeGoGcb7I+4ZI+E3FQV7zPact6b17xmajNyKrzhBGEjYucYJUL5iTgZ6a7HOZU2O
+      aQSXe7ctiHBxe7p7RhHCuKRrqJnxoohakloKwgHHzDLFQzX/5ADp1hdJcduWpaXY
+      RMBu6b1mhmwo5vmc+fDnfUpl5/X4i109r9VN7JC7DQ5+JX8u9SHDGLggBWkrhpvl
+      bNXMVCnwnSFfb/rnmGO7rdJSpwIDAQABo1MwUTAdBgNVHQ4EFgQUVg3VYExUAdn2
+      WE3e8Xc8HONy/+4wHwYDVR0jBBgwFoAUVg3VYExUAdn2WE3e8Xc8HONy/+4wDwYD
+      VR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAWLDQLB6rrmK+gwUY+4B7
+      0USbQK0JkLWuc0tCfjTxNQTzFb75PeH+GH21QsjUI8VC6QOAAJ4uzIEV85VpOQPp
+      qjz+LI/Ej1xXfz5ostZQu9rCMnPtVu7JT0B+NV7HvgqidTfa2M2dw9yUYS2surZO
+      8S0Dq3Bi6IEhtGU3T8ZpbAmAp+nNsaJWdUNjD4ECO5rAkyA/Vu+WyMz6F3ZDBmRr
+      ipWM1B16vx8rSpQpygY+FNX4e1RqslKhoyuzXfUGzyXux5yhs/ufOaqORCw3rJIx
+      v4sTWGsSBLXDsFM3lBgljSAHfmDuKdO+Qv7EqGzCRMpgSciZihnbQoRrPZkOHUxr
+      NA==
+      -----END CERTIFICATE-----
+      ```
 
-        ```bash
-        ncn-m001# podman run --rm -v "$(pwd):/data" dtr.dev.cray.com/library/openjdk:11-jre-slim keytool -importcert \
-        -trustcacerts -file /data/cacert.pem -alias cray-data-center-ca -keystore /data/certs.jks \
-        -storepass password -noprompt
-        ```
+   1. Create `certs.jks`.
 
-    7. Create `certs.jks.b64` by base-64 encoding `certs.jks`.
+      ```bash
+      ncn-m001# podman run --rm -v "$(pwd):/data" dtr.dev.cray.com/library/openjdk:11-jre-slim keytool -importcert \
+                    -trustcacerts -file /data/cacert.pem -alias cray-data-center-ca -keystore /data/certs.jks \
+                    -storepass password -noprompt
+      ```
 
-        ```bash
-        ncn-m001# base64 certs.jks > certs.jks.b64
-        ```
+   1. Create `certs.jks.b64` by base-64 encoding `certs.jks`.
 
-    8.  Inject and encrypt `certs.jks.b64` into `customizations.yaml`.
+      ```bash
+      ncn-m001# base64 certs.jks > certs.jks.b64
+      ```
 
-        ```bash
-        ncn-m001# cat <<EOF | yq w - 'data."certs.jks"' "$(<certs.jks.b64)" | \
-        yq r -j - | /root/site-init/utils/secrets-encrypt.sh | \
-        yq w -f - -i /root/site-init/customizations.yaml 'spec.kubernetes.sealed_secrets.cray-keycloak'
-        {
-            "kind": "Secret",
-            "apiVersion": "v1",
-            "metadata": {
-            "name": "keycloak-certs",
-            "namespace": "services",
-            "creationTimestamp": null
-            },
-            "data": {}
-        }
-        EOF
-        ```
+   1. Inject and encrypt `certs.jks.b64` into `customizations.yaml`.
 
-4. Upload the modified customizations.yaml file to Kubernetes.
+      ```bash
+      ncn-m001# cat <<EOF | yq w - 'data."certs.jks"' "$(<certs.jks.b64)" |
+                    yq r -j - | /root/site-init/utils/secrets-encrypt.sh |
+                    yq w -f - -i /root/site-init/customizations.yaml \
+                    spec.kubernetes.sealed_secrets.cray-keycloak
+      {
+          "kind": "Secret",
+          "apiVersion": "v1",
+          "metadata": {
+          "name": "keycloak-certs",
+          "namespace": "services",
+          "creationTimestamp": null
+          },
+          "data": {}
+      }
+      EOF
+      ```
+
+1. Upload the modified `customizations.yaml` file to Kubernetes.
 
    ```bash
    ncn-m001# kubectl delete secret -n loftsman site-init
    ncn-m001# kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
    ```
 
-5. Prepare to generate Sealed Secrets.
+1. Prepare to generate sealed secrets.
 
-   Secrets are stored in customizations.yaml as `SealedSecret` resources
+   Secrets are stored in `customizations.yaml` as `SealedSecret` resources
    (encrypted secrets), which are deployed by specific charts and decrypted by the
-   Sealed Secrets operator. But first, those Secrets must be seeded, generated, and
-   encrypted.
+   sealed secrets operator. In order for that to happen, those Secrets must first be seeded,
+   generated, and encrypted.
 
    ```bash
    ncn-m001# ./utils/secrets-reencrypt.sh customizations.yaml ./certs/sealed_secrets.key ./certs/sealed_secrets.crt
    ```
 
-6. Encrypt the static values in the customizations.yaml file after making changes.
+1. Encrypt the static values in the `customizations.yaml` file after making changes.
 
-   The following command must be run within the site-init directory.
+   The following command must be run within the `site-init` directory.
 
    ```bash
    ncn-m001# ./utils/secrets-seed-customizations.sh customizations.yaml
@@ -462,280 +461,277 @@ LDAP user federation is not currently configured in Keycloak. For example, if it
 
    Expected output looks similar to:
 
-      ```bash
-      Creating Sealed Secret keycloak-certs
-      Generating type static_b64...
-      Creating Sealed Secret keycloak-master-admin-auth
-      Generating type static...
-      Generating type static...
-      Generating type randstr...
-      Generating type static...
-      Creating Sealed Secret cray_reds_credentials
-      Generating type static...
-      Generating type static...
-      Creating Sealed Secret cray_meds_credentials
-      Generating type static...
-      Creating Sealed Secret cray_hms_rts_credentials
-      Generating type static...
-      Generating type static...
-      Creating Sealed Secret vcs-user-credentials
-      Generating type randstr...
-      Generating type static...
-      Creating Sealed Secret generated-platform-ca-1
-      Generating type platform_ca...
-      Creating Sealed Secret pals-config
-      Generating type zmq_curve...
-      Generating type zmq_curve...
-      Creating Sealed Secret munge-secret
-      Generating type randstr...
-      Creating Sealed Secret slurmdb-secret
-      Generating type static...
-      Generating type static...
-      Generating type randstr...
-      Generating type randstr...
-      Creating Sealed Secret keycloak-users-localize
-      Generating type static...
-      ```
+   ```
+   Creating Sealed Secret keycloak-certs
+   Generating type static_b64...
+   Creating Sealed Secret keycloak-master-admin-auth
+   Generating type static...
+   Generating type static...
+   Generating type randstr...
+   Generating type static...
+   Creating Sealed Secret cray_reds_credentials
+   Generating type static...
+   Generating type static...
+   Creating Sealed Secret cray_meds_credentials
+   Generating type static...
+   Creating Sealed Secret cray_hms_rts_credentials
+   Generating type static...
+   Generating type static...
+   Creating Sealed Secret vcs-user-credentials
+   Generating type randstr...
+   Generating type static...
+   Creating Sealed Secret generated-platform-ca-1
+   Generating type platform_ca...
+   Creating Sealed Secret pals-config
+   Generating type zmq_curve...
+   Generating type zmq_curve...
+   Creating Sealed Secret munge-secret
+   Generating type randstr...
+   Creating Sealed Secret slurmdb-secret
+   Generating type static...
+   Generating type static...
+   Generating type randstr...
+   Generating type randstr...
+   Creating Sealed Secret keycloak-users-localize
+   Generating type static...
+   ```
 
-7. Decrypt the Sealed Secret to verify it was generated correctly.
+1. Decrypt the sealed secret to verify it was generated correctly.
 
    ```bash
    ncn-m001# ./utils/secrets-decrypt.sh keycloak_users_localize | jq -r '.data.ldap_connection_url' | base64 --decode
+   ```
+   
+   Expected output looks similar to the following:
+   ```
    ldaps://my_ldap.my_org.test
    ```
 
-8. Re-apply the cray-keycloak Helm chart with the updated customizations.yaml file.
+1. Re-apply the `cray-keycloak` Helm chart with the updated `customizations.yaml` file.
 
-    1. Retrieve the current platform.yaml manifest.
+   1. Retrieve the current `platform.yaml` manifest.
 
-       ```bash
-       ncn-m001# kubectl -n loftsman get cm loftsman-platform -o jsonpath='{.data.manifest\.yaml}' > platform.yaml
-       ```
+      ```bash
+      ncn-m001# kubectl -n loftsman get cm loftsman-platform -o jsonpath='{.data.manifest\.yaml}' > platform.yaml
+      ```
 
-    2. Remove all charts from the platform.yaml except for cray-keycloak.
+   1. Remove all charts from the `platform.yaml` manifest except for `cray-keycloak`.
 
-       Edit the platform.yaml file and delete all sections starting with `-name: <chart_name>`, except for the cray-keycloak section.
+      Edit the `platform.yaml` file and delete all sections starting with `-name: <chart_name>`, except for the `cray-keycloak` section.
 
-       Then, change the name of the manifest being deployed from platform to cray-keycloak:
+   1. Change the name of the manifest being deployed from `platform` to `cray-keycloak`.
 
-       ```bash
-       ncn-m001# sed -i 's/name: platform/name: cray-keycloak/' platform.yaml
-       ```
+      ```bash
+      ncn-m001# sed -i 's/name: platform/name: cray-keycloak/' platform.yaml
+      ```
 
-    3. Populate the platform manifest with data from the customizations.yaml file.
+   1. Populate the platform manifest with data from the `customizations.yaml` file.
 
-       ```bash
-       ncn-m001# manifestgen -i platform.yaml -c customizations.yaml -o new-platform.yaml
-       ```
+      ```bash
+      ncn-m001# manifestgen -i platform.yaml -c customizations.yaml -o new-platform.yaml
+      ```
 
-    4. Re-apply the platform manifest with the updated cray-keycloak chart.
+   1. Re-apply the platform manifest with the updated `cray-keycloak` chart.
 
-       ```bash
-       ncn-m001# loftsman ship --manifest-path ./new-platform.yaml --charts-repo https://packages.local/repository/charts
-       ```
+      ```bash
+      ncn-m001# loftsman ship --manifest-path ./new-platform.yaml --charts-repo https://packages.local/repository/charts
+      ```
 
-    5. Wait for the keycloak-certs secret to reflect the new `cert.jks`.
+   1. Wait for the `keycloak-certs` secret to reflect the new `cert.jks`.
 
-       Run the following command until there is a non-empty value in the secret (this can take a minute or two):
+      Run the following command until there is a non-empty value in the secret (this can take a minute or two):
 
-       ```bash
-       ncn-m001# kubectl get secret -n services keycloak-certs -o yaml | grep certs.jks
-         certs.jks: <REDACTED>
-       ```
+      ```bash
+      ncn-m001# kubectl get secret -n services keycloak-certs -o yaml | grep certs.jks
+        certs.jks: <REDACTED>
+      ```
 
-    6. Restart the `cray-keycloak-[012]` pods.
+   1. Restart the `cray-keycloak-` pods.
 
-       ```bash
-       ncn-m001# kubectl rollout restart statefulset -n services cray-keycloak
-       ```
+      ```bash
+      ncn-m001# kubectl rollout restart statefulset -n services cray-keycloak
+      ```
 
-    7. Wait for the Keycloak pods to restart before moving on to the next step.
+   1. Wait for the Keycloak pods to restart.
 
-       Once the `cray-keycloak-[012]` pods have restarted, proceed to the next step.
+      ```bash
+      ncn-m001# kubectl rollout status statefulset -n services cray-keycloak
+      ```
 
-       ```bash
-       ncn-m001# kubectl get po -n services | grep cray-keycloak
-       ```
+1.  Re-apply the `cray-keycloak-users-localize` Helm chart with the updated `customizations.yaml` file.
 
-9.  Re-apply the cray-keycloak-users-localize Helm chart with the updated customizations.yaml file.
+   1.  Determine the `cray-keycloak-users-localize` chart version that is currently deployed.
 
-    1.  Determine the cray-keycloak-users-localize chart version that is currently deployed.
+      ```bash
+      ncn-m001# helm ls -A -a | grep cray-keycloak-users-localize | awk '{print $(NF-1)}'
+      cray-keycloak-users-localize-1.5.6
+      ```
 
-        ```bash
-        ncn-m001# helm ls -A -a | grep cray-keycloak-users-localize | awk '{print $(NF-1)}'
-        cray-keycloak-users-localize-1.5.6
-        ```
+   1.  Create a manifest file that will be used to reapply the same chart version.
 
-    2.  Create a manifest file that will be used to reapply the same chart version.
+      ```bash
+      ncn-m001# cat << EOF > ./cray-keycloak-users-localize-manifest.yaml
+      apiVersion: manifests/v1beta1
+      metadata:
+        name: reapply-cray-keycloak-users-localize
+      spec:
+        charts:
+          - name: cray-keycloak-users-localize
+            namespace: services
+            version: 1.5.6
+      EOF
+      ```
 
-        ```bash
-        ncn-m001# cat << EOF > ./cray-keycloak-users-localize-manifest.yaml
-        apiVersion: manifests/v1beta1
-        metadata:
-          name: reapply-cray-keycloak-users-localize
-        spec:
-          charts:
-            - name: cray-keycloak-users-localize
-              namespace: services
-              version: 1.5.6
-        EOF
-        ```
+   1. Uninstall the current `cray-keycloak-users-localize` chart.
 
-    3. Uninstall the current cray-keycloak-users-localize chart.
+      ```bash
+      ncn-m001# helm del cray-keycloak-users-localize -n services
+      ```
 
-        ```bash
-        ncn-m001# helm del cray-keycloak-users-localize -n services
-        ```
+   1. Populate the deployment manifest with data from the `customizations.yaml` file.
 
-    4. Populate the deployment manifest with data from the customizations.yaml file.
+      ```bash
+      ncn-m001# manifestgen -i cray-keycloak-users-localize-manifest.yaml -c customizations.yaml -o deploy.yaml
+      ```
 
-        ```bash
-        ncn-m001# manifestgen -i cray-keycloak-users-localize-manifest.yaml -c customizations.yaml -o deploy.yaml
-        ```
+   1. Reapply the `cray-keycloak-users-localize` chart.
 
-    5. Reapply the cray-keycloak-users-localize chart.
+      ```bash
+      ncn-m001# loftsman ship --manifest-path ./deploy.yaml \
+                --charts-repo https://packages.local/repository/charts
+      ```
 
-        ```bash
-        ncn-m001# loftsman ship --manifest-path ./deploy.yaml \
-        --charts-repo https://packages.local/repository/charts
-        ```
+   1. Watch the pod to check the status of the job.
 
-    6. Watch the pod to check the status of the job.
+      The pod will go through the normal Kubernetes states. It will stay in a `Running` state for a while, and then it will go to `Completed`.
 
-        The pod will go through the normal Kubernetes states. It will stay in a Running state for a while, and then it will go to Completed.
+      ```bash
+      ncn-m001# kubectl get pods -n services | grep keycloak-users-localize
+      keycloak-users-localize-1-sk2hn                                0/2     Completed   0          2m35s
+      ```
 
-        ```bash
-        ncn-m001# kubectl get pods -n services | grep keycloak-users-localize
-        keycloak-users-localize-1-sk2hn                                0/2     Completed   0          2m35s
-        ```
+   1.  Check the pod's logs.
 
-    7.  Check the pod's logs.
+      Replace the `KEYCLOAK_POD_NAME` value with the pod name from the previous step.
 
-        Replace the `KEYCLOAK_POD_NAME` value with the pod name from the previous step.
+      ```bash
+      ncn-m001# kubectl logs -n services KEYCLOAK_POD_NAME keycloak-localize
+      <logs showing it has updated the "s3" objects and ConfigMaps>
+      2020-07-20 18:26:15,774 - INFO    - keycloak_localize - keycloak-localize complete
+      ```
 
-        ```bash
-        ncn-m001# kubectl logs -n services KEYCLOAK_POD_NAME keycloak-localize
-        <logs showing it has updated the "s3" objects and ConfigMaps>
-        2020-07-20 18:26:15,774 - INFO    - keycloak_localize - keycloak-localize complete
-        ```
+1. Sync the users and groups from Keycloak to the compute nodes.
 
-10. Sync the users and groups from Keycloak to the compute nodes.
+   1. Get the `crayvcs` password.
 
-    1. Get the crayvcs password for pushing the changes.
+      ```bash
+      ncn-m001# kubectl get secret -n services vcs-user-credentials \
+                    --template={{.data.vcs_password}} | base64 --decode
+      ```
 
-        ```bash
-        ncn-m001# kubectl get secret -n services vcs-user-credentials \
-        --template={{.data.vcs_password}} | base64 --decode
-        ```
+   1. Checkout content from the `cos-config-management` VCS repository.
 
-    2. Checkout content from the cos-config-management VCS repository.
+      ```bash
+      ncn-m001# git clone https://api-gw-service-nmn.local/vcs/cray/cos-config-management.git
+      ncn-m001# cd cos-config-management
+      ncn-m001# git checkout integration
+      ```
 
-        ```bash
-        ncn-m001# git clone https://api-gw-service-nmn.local/vcs/cray/cos-config-management.git
-        ncn-m001# cd cos-config-management
-        ncn-m001# git checkout integration
-        ```
+   1. Create the `group_vars/Compute/keycloak.yaml` file.
 
-    3. Create the group_vars/Compute/keycloak.yaml file.
+      The file should contain the following values:
 
-        The file should contain the following values:
+      ```bash
+      ---
+      keycloak_config_computes: True
+      ```
 
-        ```bash
-        ---
-        keycloak_config_computes: True
-        ```
+   1. Push the changes to VCS with the `crayvcs` username.
 
-    4. Push the changes to VCS with the crayvcs username.
+      ```bash
+      ncn-m001# git add group_vars/Compute/keycloak.yaml
+      ncn-m001# git commit -m "Configure keycloak on computes"
+      ncn-m001# git push origin integration
+      ```
 
-        ```bash
-        ncn-m001# git add group_vars/Compute/keycloak.yaml
-        ncn-m001# git commit -m "Configure keycloak on computes"
-        ncn-m001# git push origin integration
-        ```
+   1. Update the Configuration Framework Service (CFS) configuration.
 
-    5. Update the Configuration Framework Service (CFS) configuration.
-
-        ```bash
-        ncn-m001# cray cfs configurations update configurations-example \
+      ```bash
+      ncn-m001# cray cfs configurations update configurations-example \
         --file ./configurations-example.json --format json
-        {
-          "lastUpdated": "2021-07-28T03:26:30:37Z",
-          "layers": [
-             {
-              "cloneUrl": "https://api-gw-service-nmn.local/vcs/cray/example-repo.git",
-              "commit": "<git commit id>",
-              "name": "configurations-layer-example-1",
-              "playbook": "site.yml"
-             }
-           ],
-           "name": "configurations-example"
-        }
-        ```
+      {
+        "lastUpdated": "2021-07-28T03:26:30:37Z",
+        "layers": [
+           {
+            "cloneUrl": "https://api-gw-service-nmn.local/vcs/cray/example-repo.git",
+            "commit": "<git commit id>",
+            "name": "configurations-layer-example-1",
+            "playbook": "site.yml"
+           }
+         ],
+         "name": "configurations-example"
+      }
+      ```
 
-    6. Reboot with the Boot Orchestration Service (BOS).
+   1. Reboot with the Boot Orchestration Service (BOS).
 
-        ```bash
-        ncn-m001# cray bos session create --template-uuid BOS_TEMPLATE --operation reboot
-        ```
+      ```bash
+      ncn-m001# cray bos session create --template-uuid BOS_TEMPLATE --operation reboot
+      ```
 
-11. Validate that LDAP integration was added successfully.
+1. Validate that LDAP integration was added successfully.
 
-    1. Retrieve the admin password for Keycloak.
+   1. Retrieve the `admin` user's password for Keycloak.
 
-       ```bash
-       ncn-m001# kubectl get secrets -n services keycloak-master-admin-auth -ojsonpath='{.data.password}' | base64 -d
-       ```
+      ```bash
+      ncn-m001# kubectl get secrets -n services keycloak-master-admin-auth -ojsonpath='{.data.password}' | base64 -d
+      ```
 
-    2. Login to the Keycloak UI using the `admin` user and the password obtained in the previous step.
+   1. Login to the Keycloak UI using the `admin` user and the password obtained in the previous step.
 
-       The Keycloak UI URL is typically similar to the following:
+      The Keycloak UI URL is typically similar to the following: `https://auth.cmn.<system_name>/keycloak`
 
-       ```
-       https://auth.cmn.<system_name>/keycloak
-       ```
+   1. Click on the `Users` tab in the navigation pane on the left.
 
-    3. Click on the "Users" tab in the navigation pane on the left.
+   1. Click on the `View all users` button and verify that the LDAP users appear in the table.
 
-    4. Click on the "View all users" button and verify the LDAP users appear in the table.
+   1. Verify that a token can be retrieved from Keycloak using an LDAP user/password.
 
-    5. Verify a token can be retrieved from Keycloak using an LDAP user/password.
+      In the example below, replace `myuser`, `mypass`, and `shasta` in the cURL command with
+      site-specific values. The shasta client is created during the SMS install process.
 
-       In the example below, replace myuser, mypass, and shasta in the cURL command with
-       site-specific values. The shasta client is created during the SMS install process.
+      In the following example, the `python -mjson.tool` is not required; it is simply used to
+      format the output for readability.
 
-       In the following example, the `python -mjson.tool` is not required; it is simply used to
-       format the output for readability.
-
-       ```bash
-       ncn-w001# curl -s \
+      ```bash
+      ncn-w001# curl -s \
          -d grant_type=password \
          -d client_id=shasta \
          -d username=myuser \
          -d password=mypass \
          https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token |
          python -mjson.tool
-       ```
+      ```
 
-       Expected output:
+      Expected output:
 
-       ```bash
-       {
-           "access_token": "ey...IA", <<-- NOTE this value, used in the following step
-           "expires_in": 300,
-           "not-before-policy": 0,
-           "refresh_expires_in": 1800,
-           "refresh_token": "ey...qg",
-           "scope": "profile email",
-           "session_state": "10c7d2f7-8921-4652-ad1e-10138ec6fbc3",
-           "token_type": "bearer"
-       }
-       ```
+      ```json
+      {
+          "access_token": "ey...IA", <<-- NOTE this value, used in the following step
+          "expires_in": 300,
+          "not-before-policy": 0,
+          "refresh_expires_in": 1800,
+          "refresh_token": "ey...qg",
+          "scope": "profile email",
+          "session_state": "10c7d2f7-8921-4652-ad1e-10138ec6fbc3",
+          "token_type": "bearer"
+      }
+      ```
 
-    6. Validate that the `access_token` looks correct.
+   1. Validate that the `access_token` looks correct.
 
-       Copy the `access_token` from the previous step and open a browser window.
-       Navigate to http://jwt.io, and paste the token in the "Encoded" field.
+      Copy the `access_token` from the previous step and open a browser window.
+      Navigate to http://jwt.io and paste the token in the `Encoded` field.
 
-       Verify the `preferred_username` is the expected LDAP user and the
-       role is `admin` (or other role based on the user).
-
+      Verify that the `preferred_username` is the expected LDAP user, and that the
+      role is `admin` (or other role appropriate for the user).

--- a/operations/security_and_authentication/Change_Air-Cooled_Node_BMC_Credentials.md
+++ b/operations/security_and_authentication/Change_Air-Cooled_Node_BMC_Credentials.md
@@ -13,7 +13,7 @@ All air-cooled and liquid-cooled BMCs share the same global credentials. The air
 
 ### Procedure
 
-1.  Create a SCSD payload file to change all air-cooled node BMCs to the same global credential:
+1.  Create an SCSD payload file to change all air-cooled node BMCs to the same global credential:
     ```bash
     ncn-m001# export NEW_BMC_CREDENTIAL=new.root.password
     ncn-m001# cat > bmc_creds_glb.json <<DATA

--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
@@ -151,7 +151,7 @@ The Ceph image `ceph-image` is used by the utility storage nodes.
                                     -d ~/.ssh/
    ```
 
-   In the above example, the timezone in the Squashfs is being changed to Americas/Chicago.
+   In the above example, the timezone in the squashfs is being changed to `Americas/Chicago`.
    The root password will **not** be changed because `-p` was not provided on the command line.
    It will copy the existing keys in `~/.ssh/` into the image.
 
@@ -174,7 +174,7 @@ The Ceph image `ceph-image` is used by the utility storage nodes.
 
 1. Put the new squashfs, kernel, and initrd into S3
 
-   1. If not already available, get this sript which will put a file into S3 with public read setting.
+   1. If not already available, get this script which will put a file into S3 with public read setting.
 
    ```bash
    ncn-m# wget https://github.com/Cray-HPE/s3_examples/blob/main/no_STS/ceph-upload-file-public-read.py
@@ -192,10 +192,9 @@ The Ceph image `ceph-image` is used by the utility storage nodes.
       "temp_url_keys": [],
       ```
 
-   1. Using the access_key and secret_key, construct a `credentials.json` file with contents similar to this.
+   1. Using the `access_key` and `secret_key`, construct a `credentials.json` file with contents similar to this.
 
-      ```bash
-      ncn-m# cat credentials.json
+      ```json
       {
           "access_key": "KJ1B22VP2MBKYPALP8VW",
           "secret_key": "EJbDkvoaHEcMfhkMeDSA3tEM6DwBSmuGzVYkuUOv",

--- a/operations/security_and_authentication/Keycloak_User_Management_with_Kcadm.md
+++ b/operations/security_and_authentication/Keycloak_User_Management_with_Kcadm.md
@@ -1,40 +1,62 @@
 # Keycloak User Management with kcadm.sh
 
-The Cray CLI requires a valid Keycloak JWT token. If the token is not present it must be obtained by supplying valid user credentials at the time of CLI initialization. During the installation or upgrade of a Shasta system the Keycloak user LDAP federation state or credentials may not be known or the external LDAP system for which the user may have been federated may not be available. These scenarios make it impossible to initialize the Cray CLI with a previously valid Keycloak user or LDAP federated Keycloak user. If for whatever reason the Keycloak UI is not available to the admin to verify the state of the user, using Keycloak's kcadm.sh utility from the command line will be required.
+## Overview
 
-The `kcadm.sh` utility is included with the Shasta Keycloak container image and can be used as described below to perform troubleshooting operations that can verify the existence of a user, determine if the user is federated, change the user credential (for a keycloak-local account only) or create a new local Keycloak user that is compatible (has the correct role mappings) with the Cray CLI. All the operations described below must be run as root from the `ncn-m001` node.
+The Cray CLI requires a valid Keycloak JWT token. If the token is not present it must be obtained by supplying valid user credentials at the time of CLI initialization. During the installation or upgrade of a Shasta system, the Keycloak user LDAP federation state or credentials may not be known, or the external LDAP system for which the user may have been federated may not be available. These scenarios make it impossible to initialize the Cray CLI with a previously valid Keycloak user or LDAP federated Keycloak user. If for any reason the Keycloak UI is not available for the administrator to verify the state of the user, using Keycloak's `kcadm.sh` utility from the command line will be required.
 
-Usage of the bash function(s) provided below will require making additions to the Linux environment. This can be accomplished by pasting the function(s) into your shell or pasting the function(s) into a file and then sourcing the file before running the indicated function(s).
+The `kcadm.sh` utility is included with the Shasta Keycloak container image and can be used as described below to:
+    * Perform troubleshooting operations that can verify the existence of a user.
+    * Determine if a user is federated.
+    * Change a user credential (for a keycloak-local account only).
+    * Create a new local Keycloak user that is compatible (has the correct role mappings) with the Cray CLI.
+    
+All of the operations described below must be run as `root` from the `ncn-m001` node.
 
+Usage of Bash functions provided below will require making additions to the Linux environment. This can be accomplished by pasting the function into the shell, or pasting the function into a file and then sourcing the file, before running the indicated function.
+
+### Topics
+
+* [Check the Status of a Keycloak User](#check-the-status-of-a-keycloak-user)
+* [Update a Local Keycloak User Credential](#update-a-local-keycloak-user-credential)
+* [Create a Local Keycloak Cray CLI User](#create-a-local-keycloak-cray-cli-user)
+* [Delete a Local Keycloak User](#delete-a-local-keycloak-user)
+
+<a name="check-the-status-of-a-keycloak-user"></a>
 ## Check the Status of a Keycloak User
 
-Use this procedure to determine if a user both exists in Keycloak and if the user is LDAP federated or not.  If the user is LDAP federated and the credential is not known, update the user credential in LDAP. It will not be possible to use a federated user account to initialize the Cray CLI if LDAP is not available. In this case, create a local Keycloak user for use with the Cray CLI by following the procedure below for creating a local Keycloak Cray CLI user. The credential for a local account may be updated if needed by following the procedure below for updating a local Keycloak account credential.
+This procedure determines whether or not a user exists in Keycloak and whether or not that user is LDAP federated.
 
-Add the following bash function to your environment:
+If a user is LDAP federated and the credential is not known, then that user credential must be updated in LDAP.
+
+Add the following Bash function to your environment:
 
 ```bash
 kc-find-user(){
-  # Note that filtering doesn’t use exact matching. For example, the below would match the value of username attribute against "*$1*" pattern.
+  # Note that filtering does not use exact matching. For example, the below would
+  # match the value of username attribute against "*$1*" pattern.
 
   if [ $# -eq 0 ]; then
     echo "Usage: ${FUNCNAME[0]} userName"
     return 1
   fi
 
-  MAA=$(kubectl get secret -n services keycloak-master-admin-auth --template={{.data.password}} | base64 --decode)
+  local MAA
+  MAA=$(kubectl get secret -n services keycloak-master-admin-auth --template={{.data.password}} | 
+        base64 --decode)
   if [ -z "$MAA" ]; then
     echo "Unable to get the master admin authentication credential"
     return 1
   fi
   
-  kubectl -n services exec cray-keycloak-0 -c keycloak -- sh -c " \
-    export MAA=$MAA && \
-    echo 'Looking for the Keycloak user: "$1"' && \
-    ./opt/jboss/keycloak/bin/kcadm.sh get users -r shasta -q username=$1 --no-config --server http://localhost:8080/keycloak --realm master --user admin --client admin-cli --password $MAA"
+  kubectl -n services exec cray-keycloak-0 -c keycloak -- sh -c "
+    echo 'Looking for the Keycloak user: $1' &&
+    ./opt/jboss/keycloak/bin/kcadm.sh get users -r shasta -q username='$1' --no-config \
+        --server http://localhost:8080/keycloak --realm master --user admin \
+        --client admin-cli --password '$MAA'"
 }
 ```
 
-Example when the user account is LDAP federated as indicated by the presence of the 'federationLink' attribute:
+Example when the user account is LDAP federated, as indicated by the presence of the `federationLink` attribute:
 
 ```bash
 ncn-m001# kc-find-user vers
@@ -74,9 +96,9 @@ Logging into http://localhost:8080/keycloak as user admin of realm master
 } ]
 ```
 
-If the user is a local Keycloak user and the credential is not known, follow the procedure to update a local Keycloak user credential.
+If the user is a local Keycloak user and the credential is not known, then see [Update a Local Keycloak User Credential](#update-a-local-keycloak-user-credential).
 
-Example when the user account is a local Keycloak user (no 'federationLink' attribute):
+Example when the user account is a local Keycloak user (no `federationLink` attribute):
 
 ```bash
 ncn-m001# kc-find-user localcli
@@ -102,7 +124,7 @@ Logging into http://localhost:8080/keycloak as user admin of realm master
 } ]
 ```
 
-If the user does not exist and it is necessary to create a local Keycloak user for use with the Cray CLI, you may follow the procedure below for creating a local Keycloak Cray CLI user.
+If the user does not exist and it is necessary to create a local Keycloak user for use with the Cray CLI, then see [Create a Local Keycloak Cray CLI User](#create-a-local-keycloak-cray-cli-user).
 
 Example when the user account is not known to Keycloak:
 
@@ -114,11 +136,12 @@ Logging into http://localhost:8080/keycloak as user admin of realm master
 [ ]ncn-m001#
 ```
 
+<a name="update-a-local-keycloak-user-credential"></a>
 ## Update a Local Keycloak User Credential
 
-Use this procedure to reset the credential for a local Keycloak user. This procedure will not work if the user is LDAP federated. You may set KC_USER_PASSWORD to override the default before calling the function.
+This procedure resets the credential for a local Keycloak user. This procedure will not work if the user is LDAP federated.
 
-Add the following bash function to your environment:
+Add the following Bash function to your environment:
 
 ```bash
 kc-set-local-user-password(){
@@ -128,7 +151,9 @@ kc-set-local-user-password(){
     return 1
   fi
 
-  MAA=$(kubectl get secret -n services keycloak-master-admin-auth --template={{.data.password}} | base64 --decode)
+  local MAA
+  MAA=$(kubectl get secret -n services keycloak-master-admin-auth --template={{.data.password}} | 
+        base64 --decode)
   if [ -z "$MAA" ]; then
     echo "Unable to get the master admin authentication credential"
     return 1
@@ -137,26 +162,28 @@ kc-set-local-user-password(){
   # Specify a new default password.
   # Set KC_USER_NEWPASSWD to a specific password override the default
   # before calling this function.
-  # i.e.: export KC_USER_NEWPASSWD=someNewPassword 
+  # i.e.: KC_USER_NEWPASSWD=someNewPassword 
   : ${KC_USER_NEWPASSWD:=changeme1}
 
-  kubectl -n services exec cray-keycloak-0 -c keycloak -- sh -c " \
-    export MAA=$MAA && \
-    export KC_USER_NEWPASSWD=$KC_USER_NEWPASSWD && \
-    echo 'Resetting password for the Keycloak user: "$1"' && \
-    ./opt/jboss/keycloak/bin/kcadm.sh set-password -r shasta --username "$1" --new-password $KC_USER_NEWPASSWD --no-config --server http://localhost:8080/keycloak --realm master --user admin --client admin-cli --password $MAA"
+  kubectl -n services exec cray-keycloak-0 -c keycloak -- sh -c "
+    echo 'Resetting password for the Keycloak user: $1' &&
+    ./opt/jboss/keycloak/bin/kcadm.sh set-password -r shasta --username '$1' \
+        --new-password '$KC_USER_NEWPASSWD' --no-config --server http://localhost:8080/keycloak \
+        --realm master --user admin --client admin-cli --password '$MAA'"
 }
 ```
+
+> If desired, set the `KC_USER_NEWPASSWD` variable to override the default before calling the function.
 
 Example of updating the credential with an overridden password:
 
 ```bash
-ncn-m001# KC_USER_NEWPASSWD=wax0nwax0ff && kc-set-local-user-password localcli
+ncn-m001# KC_USER_NEWPASSWD=wax0nwax0ff kc-set-local-user-password localcli
 Resetting password for the Keycloak user: localcli
 Logging into http://localhost:8080/keycloak as user admin of realm master
 ```
 
-If the user can not be found by username, the account credential will not be updated as in this example:
+If the user cannot be found by username, then the account credential will not be updated, as in this example:
 
 ```bash
 ncn-m001# kc-set-local-user-password localc
@@ -166,7 +193,7 @@ User not found for username: localc
 command terminated with exit code 1
 ```
 
-If the user is LDAP federated, the account credential will not be updated as in this example:
+If the user is LDAP federated, then the account credential will not be updated, as in this example:
 
 ```bash
 ncn-m001# KC_USER_NEWPASSWD=wax0nwax0ff && kc-set-local-user-password vers
@@ -176,11 +203,12 @@ null [Can't reset password as account is read only]
 command terminated with exit code 1
 ```
 
+<a name="create-a-local-keycloak-cray-cli-user"></a>
 ## Create a Local Keycloak Cray CLI User
 
-Use this procedure to create a new local Keycloak user that is compatible with the Cray CLI. You may set KC_USER_PASSWORD to override the default before calling the function.
+This procedure creates a new local Keycloak user that is compatible with the Cray CLI. This may be needed because it is not possible to use a federated user account to initialize the Cray CLI if LDAP is not available.
 
-Add the following bash function to your environment:
+Add the following Bash function to your environment:
 
 ```bash
 kc-create-local-cli-user(){
@@ -189,7 +217,9 @@ kc-create-local-cli-user(){
     return 1
   fi
 
-  MAA=$(kubectl get secret -n services keycloak-master-admin-auth --template={{.data.password}} | base64 --decode)
+  local MAA
+  MAA=$(kubectl get secret -n services keycloak-master-admin-auth --template={{.data.password}} | 
+        base64 --decode)
   if [ -z "$MAA" ]; then
     echo "Unable to get the master admin authentication credential"
     return 1
@@ -198,27 +228,35 @@ kc-create-local-cli-user(){
   # Specify a new default password.
   # Set KC_USER_NEWPASSWD to a specific password to override the default
   # before calling this function.
-  # i.e.: export KC_USER_NEWPASSWD=someNewPassword 
+  # i.e.: KC_USER_NEWPASSWD=someNewPassword 
   : ${KC_USER_NEWPASSWD:=changeme1}
 
-  kubectl -n services exec cray-keycloak-0 -c keycloak -- sh -c " \
-    export MAA=$MAA && \
-    export KC_USER_NEWPASSWD=$KC_USER_NEWPASSWD && \
-    echo 'Creating the Keycloak user: "$1"' && \
-    ./opt/jboss/keycloak/bin/kcadm.sh create users -r shasta -s enabled=true -s username="$1" --no-config --server http://localhost:8080/keycloak --realm master --user admin --client admin-cli --password $MAA && \
-    echo 'Resetting password for the Keycloak user: "$1"' && \
-    ./opt/jboss/keycloak/bin/kcadm.sh set-password -r shasta --username "$1" --new-password $KC_USER_NEWPASSWD --no-config --server http://localhost:8080/keycloak --realm master --user admin --client admin-cli --password $MAA && \
-    echo 'Adding the Cray client admin role to the user: "$1"' && \
-    ./opt/jboss/keycloak/bin/kcadm.sh add-roles -r shasta --uusername "$1" --cclientid cray --rolename admin --no-config --server http://localhost:8080/keycloak --realm master --user admin --client admin-cli --password $MAA && \
-    echo 'Adding the Shasta client admin role to the user: "$1"' && \
-    ./opt/jboss/keycloak/bin/kcadm.sh add-roles -r shasta --uusername "$1" --cclientid shasta --rolename admin --no-config --server http://localhost:8080/keycloak --realm master --user admin --client admin-cli --password $MAA"
+  kubectl -n services exec cray-keycloak-0 -c keycloak -- sh -c "
+    echo 'Creating the Keycloak user: $1' &&
+    ./opt/jboss/keycloak/bin/kcadm.sh create users -r shasta -s enabled=true -s username='$1' \
+        --no-config --server http://localhost:8080/keycloak --realm master --user admin \
+        --client admin-cli --password '$MAA' &&
+    echo 'Resetting password for the Keycloak user: $1' &&
+    ./opt/jboss/keycloak/bin/kcadm.sh set-password -r shasta --username '$1' \
+        --new-password '$KC_USER_NEWPASSWD' --no-config --server http://localhost:8080/keycloak \
+        --realm master --user admin --client admin-cli --password '$MAA' &&
+    echo 'Adding the Cray client admin role to the user: $1' &&
+    ./opt/jboss/keycloak/bin/kcadm.sh add-roles -r shasta --uusername '$1' --cclientid cray \
+        --rolename admin --no-config --server http://localhost:8080/keycloak --realm master \
+        --user admin --client admin-cli --password '$MAA' &&
+    echo 'Adding the Shasta client admin role to the user: $1' &&
+    ./opt/jboss/keycloak/bin/kcadm.sh add-roles -r shasta --uusername '$1' --cclientid shasta \
+        --rolename admin --no-config --server http://localhost:8080/keycloak --realm master \
+        --user admin --client admin-cli --password '$MAA'"
 }
 ```
+
+> If desired, set the `KC_USER_NEWPASSWD` variable to override the default before calling the function.
 
 Example of creating a user:
 
 ```bash
-ncn-m001# kc-create-local-cli-user localcli
+ncn-m001# KC_USER_NEWPASSWD=wax0ffwax0n kc-create-local-cli-user localcli
 Creating the Keycloak user: localcli
 Logging into http://localhost:8080/keycloak as user admin of realm master
 Created new user with id 'b49abdcc-a314-4355-89d7-44f4d8d33ab8'
@@ -230,9 +268,11 @@ Adding the Shasta client admin role to the user: localcli
 Logging into http://localhost:8080/keycloak as user admin of realm master
 ```
 
-You can optionally search for the user using `kc-find-user` to check that the user has been created. It will also be possible to initialize the Cray CLI using this new user and credential. Refer to the Cray CLI documentation for details.
+If desired, the user creation may be verified by checking the status of the new user. See [Check the Status of a Keycloak User](#check-the-status-of-a-keycloak-user).
 
-If the user exists, the function will just exit as in this example:
+Initializing the Cray CLI is possible using this new user and credential. See [Configure the Cray CLI](../configure_cray_cli.md).
+
+If the user to be created already exists, then the function will just exit, as in this example:
 
 ```bash
 ncn-m001# kc-create-local-cli-user localcli
@@ -242,11 +282,12 @@ User exists with same username
 command terminated with exit code 1
 ```
 
+<a name="delete-a-local-keycloak-user"></a>
 ## Delete a Local Keycloak User
 
-Use this procedure if it is necessary to delete a local Keycloak user. This procedure will not work if the user is LDAP federated.
+This procedure deletes a local Keycloak user. This will not work if the user is LDAP federated.
 
-Add the following bash function to your environment:
+Add the following Bash function to your environment:
 
 ```bash
 kc-delete-local-user(){
@@ -256,18 +297,23 @@ kc-delete-local-user(){
     return 1
   fi
 
-  read -p "This will delete the Keycloak userID $1. Continue? (y/N): " confirm && [[ $confirm == [yY] ]] || return 1
+  local confirm
+  read -p "This will delete the Keycloak userID $1. Continue? (y/N): " \
+        confirm && [[ $confirm == [yY] ]] || return 1
 
-  MAA=$(kubectl get secret -n services keycloak-master-admin-auth --template={{.data.password}} | base64 --decode)
+  local MAA
+  MAA=$(kubectl get secret -n services keycloak-master-admin-auth --template={{.data.password}} | 
+        base64 --decode)
   if [ -z "$MAA" ]; then
     echo "Unable to get the master admin authentication credential"
     return 1
   fi
 
-  kubectl -n services exec cray-keycloak-0 -c keycloak -- sh -c " \
-    export MAA=$MAA && \
-    echo 'Deleting the Keycloak user UUID: "$1"' && \
-    ./opt/jboss/keycloak/bin/kcadm.sh delete users/"$1" -r shasta --no-config --server http://localhost:8080/keycloak --realm master --user admin --client admin-cli --password $MAA"
+  kubectl -n services exec cray-keycloak-0 -c keycloak -- sh -c "
+    echo 'Deleting the Keycloak user UUID: $1' &&
+    ./opt/jboss/keycloak/bin/kcadm.sh delete 'users/$1' -r shasta --no-config \
+        --server http://localhost:8080/keycloak --realm master --user admin \
+        --client admin-cli --password '$MAA'"
 }
 ```
 
@@ -306,7 +352,7 @@ Logging into http://localhost:8080/keycloak as user admin of realm master
 [ ]
 ```
 
-If the user can not be found by ID, it will not be removed as in this example:
+If the user can not be found by ID, then it will not be removed, as in this example:
 
 ```bash
 ncn-m001# kc-delete-local-user b49abdcc-a314-4355-89d7-44f4d8d33ab8

--- a/operations/system_layout_service/Add_Liquid-Cooled_Cabinets_To_SLS.md
+++ b/operations/system_layout_service/Add_Liquid-Cooled_Cabinets_To_SLS.md
@@ -12,33 +12,35 @@ This procedure adds one or more liquid-cooled cabinets and associated CDU manage
     * Hardware Management Network (HMN) VLAN ID configured on the CEC (for example `3004`)
     * Node Management Network (NMN) VLAN ID configured on the CEC (for example `2004`)
     * Starting compute node ID (NID) (for example `2025`)
-    * Cabinet Type: Mountain (8 Chassis) or Hill (2 Chassis)
+    * Cabinet Type: Mountain (8 chassis) or Hill (2 chassis)
 
--   Collect information for the CDU Switches (if any) being added to the system. For each CDU Management Switch collect:
-    - CDU Switch component name (xname) (for example `d1w1`)
-    - CDU Switch brand (for example Dell or Aruba)
-    - CDU Switch Alias (for example `sw-cdu-004`)
+-   Collect information for the CDU switches (if any) being added to the system. For each CDU management switch, collect:
+    - CDU switch component name (xname) (for example `d1w1`)
+    - CDU switch brand (for example Dell or Aruba)
+    - CDU switch alias (for example `sw-cdu-004`)
 
 ## Procedure
 
-1.  Perform a SLS dump state operation:
+1.  Perform an SLS dump state operation:
+
     ```bash
     ncn# cray sls dumpstate list --format json > sls_dump.json
     ncn# cp sls_dump.json sls_dump.original.json
     ```
 
-2.  **For each** new liquid-cooled cabinet being added to the system collect the following information about each cabinet:
+1.  **For each** new liquid-cooled cabinet being added to the system, collect the following information about each cabinet:
+
     * Cabinet component name (xname) (for example `x1004`)
     * Hardware Management Network (HMN) VLAN ID configured on the CEC (for example `3004`)
     * Node Management Network (NMN) VLAN ID configured on the CEC (for example `2004`)
     * Starting compute node ID (NID) (for example `2025`)
     * Cabinet Type (Mountain (8 Chassis) or Hill (2 Chassis))
 
-    > The inspect_sls_cabinets.py script can be used to help display information about existing cabinets present in the system:
+    > The `inspect_sls_cabinets.py` script can be used to help display information about existing cabinets present in the system:
     > ```bash
     > ncn# /usr/share/doc/csm/scripts/operations/system_layout_service/inspect_sls_cabinets.py sls_dump.json
     > ```
-    > Example Output with a system with 1 Air-cooled cabinet and 4 liquid-cooled cabinets:
+    > Example output on a system with 1 air-cooled cabinet and 4 liquid-cooled cabinets:
     > ```
     > =================================
     > Cabinet NID Allocations
@@ -63,7 +65,7 @@ This procedure adds one or more liquid-cooled cabinets and associated CDU manage
     > x3000 (River)       | 1513      | 10.107.0.0/22       | 1770      | 10.106.0.0/22
     > ```
 
-3.  **For each** new liquid-cooled cabinet add it to the previously taken SLS state dump in __ascending order__:
+1.  **For each** new liquid-cooled cabinet, add it to the previously taken SLS state dump in __ascending order__:
 
     Command line flags for `add_liquid_cooled_cabinet.py`:
     | Argument             | Description                                                       | Example value        |
@@ -72,7 +74,7 @@ This procedure adds one or more liquid-cooled cabinets and associated CDU manage
     | `--cabinet-type`     | Type of liquid-cooled cabinet to add                              | `Mountain` or `Hill` |
     | `--cabinet-vlan-hmn` | Hardware Management Network (HMN) VLAN ID configured on the CEC   | `3004`               |
     | `--cabinet-vlan-nmn` | Node Management Network (NMN) VLAN ID configured on the CEC       | `2004`               |
-    | `--starting-nid`     | Starting NID for new cabinet. Each cabinet is allocated 256 NIDs. | `2024`               |
+    | `--starting-nid`     | Starting NID for new cabinet. Each cabinet is allocated 256 NIDs  | `2024`               |
 
     ```bash
     ncn# /usr/share/doc/csm/scripts/operations/system_layout_service/add_liquid_cooled_cabinet.py sls_dump.json \
@@ -126,7 +128,7 @@ This procedure adds one or more liquid-cooled cabinets and associated CDU manage
     Writing updated SLS state to sls_dump.json
     ```
 
-    **Note** if adding more than one cabinet and contiguous NIDs are desired the value of the `Next available NID 2280` can be used as the value to the `--start-nid` argument when adding the next cabinet.
+    **Note**: If adding more than one cabinet and contiguous NIDs are desired, the value of the `Next available NID 2280` can be used as the value for the `--start-nid` argument when adding the next cabinet.
 
     Possible Errors:
     | Problem                        | Error Message                                                         | Resolution |
@@ -136,7 +138,8 @@ This procedure adds one or more liquid-cooled cabinets and associated CDU manage
     | Duplicate Cabinet HMN VLAN ID: | `Error found duplicate VLAN 3022 with subnet cabinet_1001 in HMN_MTN` | Ensure that the this new cabinet has an unique HMN VLAN ID. |
     | Duplicate Cabinet NMN VLAN ID  | `Error found duplicate VLAN 3023 with subnet cabinet_1001 in NMN_MTN` | Ensure that the this new cabinet has an unique NMN VLAN ID. |
 
-4.  Inspect cabinet subnet and VLAN allocations in the system after adding the new cabinets cabinets:
+1.  Inspect cabinet subnet and VLAN allocations in the system after adding the new cabinets.
+
     ```bash
     ncn# /usr/share/doc/csm/scripts/operations/system_layout_service/inspect_sls_cabinets.py sls_dump.json
     ```
@@ -168,13 +171,14 @@ This procedure adds one or more liquid-cooled cabinets and associated CDU manage
     x3000 (River)       | 1513      | 10.107.0.0/22       | 1770      | 10.106.0.0/22
     ```
 
-5.  **For each** new CDU Switch being added to the system collect the following information about each switch:
-    - CDU Switch component name (xname) (for example `d1w1`)
-    - CDU Switch brand (for example Dell or Aruba)
-    - CDU Switch Alias (for example `sw-cdu-004` )
+1.  **For each** new CDU switch being added to the system, collect the following information about it:
 
+    - CDU switch component name (xname) (for example `d1w1`)
+    - CDU switch brand (for example Dell or Aruba)
+    - CDU switch alias (for example `sw-cdu-004` )
 
-6.  **For each** new CDU Switch add it to the SLS state dump taken in step 1 in __ascending order__ based on the switch alias:
+1.  **For each** new CDU switch, add it to the SLS state dump taken in step 1 in __ascending order__ based on the switch alias:
+
     ```bash
     ncn# /usr/share/doc/csm/scripts/operations/system_layout_service/add_cdu_switch.py sls_dump.json \
         --cdu-switch d1w1 \
@@ -226,12 +230,14 @@ This procedure adds one or more liquid-cooled cabinets and associated CDU manage
 
     Writing updated SLS state to sls_dump.json
     ```
-7. Inspect the differences between the original SLS state file and the modified one:
+
+1. Inspect the differences between the original SLS state file and the modified one.
+
     ```bash
     ncn# diff sls_dump.original.json sls_dump.json
     ```
 
-8.  Perform a SLS load state operation to replace the contents of SLS with the data from the `sls_dump.json` file.
+1.  Perform an SLS load state operation to replace the contents of SLS with the data from the `sls_dump.json` file.
 
     Get an API Token:
     ```bash
@@ -247,6 +253,6 @@ This procedure adds one or more liquid-cooled cabinets and associated CDU manage
         https://api-gw-service-nmn.local/apis/sls/v1/loadstate
     ```
 
-9.  MEDS will automatically start looking for potential hardware in the newly added liquid-cooled cabinets.
+1.  MEDS will automatically start looking for potential hardware in the newly added liquid-cooled cabinets.
 
-    **Note**: No hardware in these new cabinets will be discovered until the management network has been reconfigured to support the new cabinets, and routes has been added to the management NCNs in the system.
+    **Note**: No hardware in these new cabinets will be discovered until the management network has been reconfigured to support the new cabinets, and routes have been added to the management NCNs in the system.

--- a/operations/system_layout_service/Restore_SLS_Postgres_without_an_Existing_Backup.md
+++ b/operations/system_layout_service/Restore_SLS_Postgres_without_an_Existing_Backup.md
@@ -29,7 +29,7 @@ This procedure is intended to repopulate SLS in the event when no Postgres backu
     ncn# cray artifacts get sls sls_input_file.json sls_input_file.json
     ```
 
-2. Perform a SLS load state operation to replace the contents of SLS with the data from the `sls_input_file.json` file.
+2. Perform an SLS load state operation to replace the contents of SLS with the data from the `sls_input_file.json` file.
 
     Get an API Token:
     ```bash

--- a/operations/system_management_health/Troubleshoot_Grafana_Dashboard.md
+++ b/operations/system_management_health/Troubleshoot_Grafana_Dashboard.md
@@ -1,0 +1,70 @@
+# Troubleshoot Grafana Dashboard
+
+General Grafana dashboard troubleshooting topics
+  - [Ceph - OSD Overview Dashboard](#ceph-osd-overview-dashboard)
+  - [Ceph - RBD Overview Dashboard](#ceph-rbd-overview-dashboard)
+  - [Ceph - RGW Instance Detail Dashboard](#ceph-rgw-instance-detail-dashboard)
+  - [Ceph - RGW Overview Dashboard](#ceph-rgw-overview-dashboard)
+
+<a name="ceph-osd-overview-dashboard"></a>
+## Ceph - OSD Overview Dashboard: 3 panels not found
+
+Currently skipping cray-sysmgmt-health pie chart plugin installation for airgapped systems. If the system is non airgapped then comment out or remove plugins property in customizations.yaml.
+This will be fixed in a future release.
+
+Command to extract customizations.yaml from the site-init secret.
+
+```bash
+ncn-m001# kubectl -n loftsman get secret site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d - > customizations.yaml
+```
+
+Example for airgapped systems (please uncomment plugins property):
+
+```bash
+cray-sysmgmt-health:
+          grafana:
+            externalAuthority: grafana.cmn.{{ network.dns.external }}
+            # Skip plugin installation for airgapped systems.
+            # If the system is non airgapped then you can comment out or remove plugins property.
+            plugins: ""
+```
+
+Example for non-airgapped systems (please comment out plugins property):
+
+```bash
+cray-sysmgmt-health:
+          grafana:
+            externalAuthority: grafana.cmn.{{ network.dns.external }}
+            # Skip plugin installation for airgapped systems.
+            # If the system is non airgapped then you can comment out or remove plugins property.
+            # plugins: ""
+```
+
+Commands to reupload customizations.yaml file to Kubernetes so that the changes persist.
+
+```bash
+ncn-m001# kubectl delete secret -n loftsman site-init 
+ncn-m001# kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
+```
+
+
+<a name="ceph-rbd-overview-dashboard"></a>
+## Ceph - RBD Overview Dashboard: No Data 
+
+Grafana dashboard not getting any ceph_rbd_* metrics from ceph exporter.
+Currently, either ceph exporter or node exporter not collecting ceph_rbd* metrics (RBD rados block device) which are using in this dashboard. This will be fixed in a future release.
+
+
+<a name="ceph-rgw-instance-detail-dashboard"></a>
+## Ceph - RGW Instance Detail Dashboard: Panel missing and no data
+
+Currenlty Ceph - RGW Instance Detail Dashboard using 30 seconds time range in queries which is very short duration. Due to this the dashboard is unable to load the data. 
+The Grafana dashboard will be fixed in future release and before that pie chart plugin issue for workload breakdown panel need to be fixed. This will also be fixed in future release.
+
+
+<a name="ceph-rgw-overview-dashboard"></a>
+## Ceph - RGW Overview Dashboard: No data
+
+Currenlty Ceph - RGW overview Dashboard using 30 seconds time range in queries which is very short duration. Due to this the dashboard is unable to load the data. 
+The Grafana dashboard will be fixed in future release.
+

--- a/operations/system_management_health/Troubleshoot_Prometheus_Alerts.md
+++ b/operations/system_management_health/Troubleshoot_Prometheus_Alerts.md
@@ -1,17 +1,15 @@
 # Troubleshoot Prometheus Alerts
 
 General Prometheus Alert Troubleshooting Topics
-- [Troubleshoot Prometheus Alerts](#troubleshoot-prometheus-alerts)
-  - [CephMgrIsAbsent and CephMgrIsMissingReplicas](#cephmgrisabsent-and-cephmgrismissingreplicas)
-  - [CephNetworkPacketsDropped](#cephnetworkpacketsdropped)
-  - [CPUThrottlingHigh](#cputhrottlinghigh)
-  - [KubePodNotReady](#kubepodnotready)
-  - [PostgresqlFollowerReplicationLagSMA](#postgresqlfollowerreplicationlagsma)
-  - [PostgresqlHighRollbackRate](#postgresqlhighrollbackrate)
-  - [PostgresqlInactiveReplicationSlot](#postgresqlinactivereplicationslot)
-  - [PostgresqlNotEnoughConnections](#postgresqlnotenoughconnections)
-  - [CephNetworkPacketsDropped](#cephnetworkpacketsdropped)
-  - [TargetDown](#targetdown)
+- [`CephMgrIsAbsent` and `CephMgrIsMissingReplicas`](#cephmgrisabsent-and-cephmgrismissingreplicas)
+- [`CephNetworkPacketsDropped`](#cephnetworkpacketsdropped)
+- [`CPUThrottlingHigh`](#cputhrottlinghigh)
+- [`KubePodNotReady`](#kubepodnotready)
+- [`PostgresqlFollowerReplicationLagSMA`](#postgresqlfollowerreplicationlagsma)
+- [`PostgresqlHighRollbackRate`](#postgresqlhighrollbackrate)
+- [`PostgresqlInactiveReplicationSlot`](#postgresqlinactivereplicationslot)
+- [`PostgresqlNotEnoughConnections`](#postgresqlnotenoughconnections)
+- [`TargetDown`](#targetdown)
 
 <a name="cephmgrmissing"></a>
 ## `CephMgrIsAbsent` and `CephMgrIsMissingReplicas`
@@ -57,20 +55,19 @@ Example output:
 
 The `CephMgrIsAbsent` and `CephMgrIsMissingReplicas` alerts should now clear in Prometheus.
 
-
 <a name="networkpacketsdropped"></a>
 ## `CephNetworkPacketsDropped`
 
-The `CephNetworkPacketsDropped` alert does not necessarily indicate there are packets being dropped on an interface on a storage node. In a future release this alert will be renamed to be more generic. If this alert fires, inspect the IP address in the details of the alert to determine the node in question (it can be storage, master, or worker node). If the interface in question is determined to be healthy, this alert can be ignored.
+The `CephNetworkPacketsDropped` alert does not necessarily indicate there are packets being dropped on an interface on a storage node. In a future release this alert will be renamed to be more generic. If this alert fires, inspect the IP address in the details of the alert to determine the node in question (it can be storage, master, or worker node). If the interface in question is determined to be healthy, then this alert can be ignored.
 
 <a name="cputhrottlinghigh"></a>
 ## `CPUThrottlingHigh`
 
 Alerts for `CPUThrottlingHigh` on `gatekeeper-audit` can be ignored. This pod is not utilized in this release.
 
-Alerts for `CPUThrottlingHigh` on `gatekeeper-controller-manager` can be ignored. This has low CPU requests, and it is normal for it to spike when it is in use.
+Alerts for `CPUThrottlingHigh` on `gatekeeper-controller-manager` can be ignored. These have low CPU requests, and it is normal for resource usage to spike when it is in use.
 
-Alerts for CPUThrottlingHigh on smartmon pods can be ignored. It is normal for smartmon pods resource usage to spike when it is polling. This will be fixed in a future release.
+Alerts for `CPUThrottlingHigh` on `smartmon` pods can be ignored. It is normal for `smartmon` pods' resource usage to spike when it is polling. This will be fixed in a future release.
 
 Alerts for `CPUThrottlingHigh` on CFS services such as `cfs-batcher` and `cfs-trust` can be ignored. Because CFS is idle most of the time, these services have low CPU requests, and it is normal for CFS service resource usage to spike when it is in use.
 
@@ -99,12 +96,7 @@ Alerts for `PostgresqlInactiveReplicationSlot` on `sma-postgres-cluster` pods wi
 
 Alerts for `PostgresqlNotEnoughConnections` for `datname="foo"` and `datname="bar"` can be ignored. These databases are not used and will be removed in a future release.
 
-<a name="networkpacketsdropped"></a>
-## `CephNetworkPacketsDropped`
-
-The `CephNetworkPacketsDropped` alert does not necessarily indicate there are packets being dropped on an interface on a storage node. In a future release this alert will be renamed to be more generic. If this alert fires, inspect the IP address in the details of the alert to determine the node in question (it can be storage, master or worker node). If the interface in question is determined to be healthy, this alert can be ignored.
-
 <a name="targetdown"></a>
-## TargetDown
+## `TargetDown`
 
-Many of the Alerts for Target Down for sysmgmt-health/cray-sysmgmt-health-kubernetes-pods/0 are due to job pods that have Completed and no longer have an active endpoint that can be scraped. If the target that is down is from a job pods that has completed, the target down alert for that pod can be ignored. This is being fixed in a future release.
+Many of the alerts for `TargetDown` for `sysmgmt-health/cray-sysmgmt-health-kubernetes-pods/0` are due to job pods that have `Completed` and no longer have an active endpoint that can be scraped. If the target that is down is from a job pod that has completed, the `TargetDown` alert for that pod can be ignored. This is being fixed in a future release.

--- a/operations/system_management_health/Troubleshoot_Prometheus_Alerts.md
+++ b/operations/system_management_health/Troubleshoot_Prometheus_Alerts.md
@@ -10,7 +10,8 @@ General Prometheus Alert Troubleshooting Topics
   - [PostgresqlHighRollbackRate](#postgresqlhighrollbackrate)
   - [PostgresqlInactiveReplicationSlot](#postgresqlinactivereplicationslot)
   - [PostgresqlNotEnoughConnections](#postgresqlnotenoughconnections)
-  - [CephNetworkPacketsDropped](#cephnetworkpacketsdropped-1)
+  - [CephNetworkPacketsDropped](#cephnetworkpacketsdropped)
+  - [TargetDown](#targetdown)
 
 <a name="cephmgrmissing"></a>
 ## `CephMgrIsAbsent` and `CephMgrIsMissingReplicas`
@@ -69,6 +70,8 @@ Alerts for `CPUThrottlingHigh` on `gatekeeper-audit` can be ignored. This pod is
 
 Alerts for `CPUThrottlingHigh` on `gatekeeper-controller-manager` can be ignored. This has low CPU requests, and it is normal for it to spike when it is in use.
 
+Alerts for CPUThrottlingHigh on smartmon pods can be ignored. It is normal for smartmon pods resource usage to spike when it is polling. This will be fixed in a future release.
+
 Alerts for `CPUThrottlingHigh` on CFS services such as `cfs-batcher` and `cfs-trust` can be ignored. Because CFS is idle most of the time, these services have low CPU requests, and it is normal for CFS service resource usage to spike when it is in use.
 
 <a name="kubepodnotready"></a>
@@ -100,3 +103,8 @@ Alerts for `PostgresqlNotEnoughConnections` for `datname="foo"` and `datname="ba
 ## `CephNetworkPacketsDropped`
 
 The `CephNetworkPacketsDropped` alert does not necessarily indicate there are packets being dropped on an interface on a storage node. In a future release this alert will be renamed to be more generic. If this alert fires, inspect the IP address in the details of the alert to determine the node in question (it can be storage, master or worker node). If the interface in question is determined to be healthy, this alert can be ignored.
+
+<a name="targetdown"></a>
+## TargetDown
+
+Many of the Alerts for Target Down for sysmgmt-health/cray-sysmgmt-health-kubernetes-pods/0 are due to job pods that have Completed and no longer have an active endpoint that can be scraped. If the target that is down is from a job pods that has completed, the target down alert for that pod can be ignored. This is being fixed in a future release.

--- a/operations/utility_storage/Identify_Ceph_Latency_Issues.md
+++ b/operations/utility_storage/Identify_Ceph_Latency_Issues.md
@@ -64,16 +64,16 @@ This procedure requires admin privileges.
 Based on the output from `ceph -s` (using our example above) we can correlate some information to help determine our bottleneck.
 
 1. When reporting slow ops for OSDs, then it is good to find out if those OSDs are on the same node or different nodes.
-    1. If on the same node, then look at networking or other hardware related issues on that node.
-    2. If the osds are on different nodes, then networking issues should be investigated.
+    1. If the OSDs are on the same node, then look at networking or other hardware-related issues on that node.
+    1. If the OSDs are on different nodes, then investigate networking issues.
        1. As an initial step, restart the OSDs, if the slow ops go away and do not return, then we can investigate the logs for possible software bugs or memory issues.
-       2. If the slow ops come right back, then there is an issue with replication between the 2 OSDs which tends to be network related.
+       1. If the slow ops come right back, then there is an issue with replication between the 2 OSDs which tends to be network-related.
 
-2. When reporting slow ops for `MONs`, then it is typically an issue with the process.
+1. When reporting slow ops for `MONs`, then it is typically an issue with the process.
    1. The most common cause here is either an abrupt clock skew or a hung mon/mgr process.
       1. The recommended remediation is to do a rolling restart of the Ceph `MON` and `MGR` daemons.
 
-3. When reporting slow ops for `MDS`, then it could be due to a couple of different reasons.
-   1. If listed in addition to `OSDs`, then the root cause for this will typically be the `OSDs` and the process above should be used followed by restarting the `MDS` daemons.
-   2. If it is only listing `MDS`, then restart the MDS daemons. If the problem persists, then the logs will have to be investigated for the root cause.
-   3. See [Troubleshoot_Ceph_MDS_reporting_slow_requests_and_failure_on_client](Troubleshoot_Ceph_MDS_reporting_slow_requests_and_failure_on_client.md) for additional steps to help identify MDS slow ops.
+1. When reporting slow ops for MDS, then are multiple possible causes.
+   1. If listed in addition to OSDs, then the root cause for this is typically the OSDs, and the process above should be used, followed by restarting the `MDS` daemons.
+   1. If it is only listing MDS, then restart the MDS daemons. If the problem persists, then examine the logs in order to determine the root cause.
+   1. See [Troubleshoot_Ceph_MDS_reporting_slow_requests_and_failure_on_client](Troubleshoot_Ceph_MDS_reporting_slow_requests_and_failure_on_client.md) for additional steps to help identify MDS slow ops

--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -301,7 +301,7 @@ BMC can be safely ignored or needs to be addressed before proceeding.
 * The node BMCs for HPE Apollo XL645D nodes may report as a mismatch depending on the state of the system when the `hsm_discovery_verify.sh` script is run. If the system is currently going through the process of installation, then this is an expected mismatch as the [Prepare Compute Nodes](../install/prepare_compute_nodes.md) procedure required to configure the BMC of the HPE Apollo 6500 XL645D node may not have been completed yet.
    > For more information refer to [Configure HPE Apollo 6500 XL645d Gen10 Plus Compute Nodes](../install/prepare_compute_nodes.md#configure-hpe-apollo-6500-x645d-gen10-plus-compute-nodes) for additional required configuration for this type of BMC.
 
-   Example mismatch for the BMC of a HPE Apollo XL654D:
+   Example mismatch for the BMC of an HPE Apollo XL654D:
    ```bash
    ...
      Nodes: FAIL

--- a/scripts/operations/system_layout_service/backup_sls_postgres.sh
+++ b/scripts/operations/system_layout_service/backup_sls_postgres.sh
@@ -80,7 +80,7 @@ for secret in ${secrets[@]}; do
 done
 echo "Secret manifest is located at ${BACKUP_FOLDER}/${BACKUP_NAME}.manifest"
 
-# Perform a SLS dumpstate. Does not hurt to take one.
+# Perform an SLS dumpstate. Does not hurt to take one.
 echo "Performing SLS dumpstate..."
 export TOKEN=$(curl -s -S -d grant_type=client_credentials \
                           -d client_id=admin-client \

--- a/update_product_stream/index.md
+++ b/update_product_stream/index.md
@@ -14,18 +14,9 @@ After the RPM has been installed, the documentation will be available at `/usr/s
 <a name="download-and-extract"></a>
 ## Download and Extract CSM Product Release
 
-### About this task
-
-#### Role
-System installer
-
-#### Objective
 Acquire a CSM software release tarball for installation on the HPE Cray EX supercomputer.
 
-#### Limitations
-None.
-
-### Procedure
+### Details 
 
    1. Download the CSM software release tarball for the HPE Cray EX system to a Linux system.
 
@@ -48,18 +39,9 @@ None.
 <a name="patch"></a>
 ## Apply Patch to CSM Release
 
-### About this task
-
-#### Role
-System installer
-
-#### Objective
 Apply a CSM update patch to the release tarball. This ensures that the latest CSM product artifacts are installed on the HPE Cray EX supercomputer.
 
-#### Limitations
-None.
-
-### Procedure
+### Details
 
    1. Verify that the Git version is at least 2.16.5 on the Linux system which will apply the patch.
 
@@ -121,18 +103,9 @@ This tarball can now be used in place of the original CSM software release tarba
 <a name="documentation"></a>
 ## Check for Latest Documentation
 
-### About this task
-
-#### Role
-System installer
-
-#### Objective
 Acquire the latest documentation RPM. This may include updates, corrections, and enhancements that were not available until after the software release.
 
-#### Limitations
-None.
-
-### Procedure
+### Details
 
 1. Check the version of the currently installed CSM documentation.
 
@@ -160,18 +133,9 @@ None.
 <a name="hotfixes"></a>
 ## Check for Field Notices about Hotfixes
 
-### About this task
-
-#### Role
-System installer
-
-#### Objective
 Collect all available Field Notices about Hotfixes which should be applied to this CSM software release.
 
-#### Limitations
-None.
-
-### Procedure
+### Details
 
 Check with HPE Cray service for any Field Notices about Hotfixes which should be applied to this CSM software release.
 

--- a/upgrade/1.2/README.md
+++ b/upgrade/1.2/README.md
@@ -35,7 +35,7 @@ For more information about modifying `customizations.yaml` and tuning based on s
 
 **`Important:`** Please take note of the below content for troubleshooting purposes in the case that you encounter issues.
 
-## Relevant Troubleshooting Links for Upgrade Related Issues
+## Relevant Troubleshooting Links for Upgrade-Related Issues
 
 ### General Kubernetes Commands for Troubleshooting
 

--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -1,20 +1,25 @@
 # Stage 0 - Prerequisites and Preflight Checks
 
-> **NOTE:** CSM-1.0.1 or higher is required in order to upgrade to CSM-1.2.0
+> **`Note`:** CSM-1.0.1 or higher is required in order to upgrade to CSM-1.2.0
 
+## Abstract
+
+Stage 0 has several critical procedures which prepares and verify if the environment is ready for upgrade. First, the latest docs RPM is installed; it includes critical install scripts used in the upgrade procedure. Next, the current configuration of the System Layout Service (SLS) is updated to have necessary information for CSM 1.2. The management network configuration is also upgraded. Towards the end, prerequisite checks are performed to ensure that the upgrade is ready to proceed. Finally, a backup of Workload Manager configuration data and files is created. Once complete, the upgrade proceeds to Stage 1.
+
+**Stages**
 - [Stage 0.1 - Install latest docs RPM](#install-latest-docs)
 - [Stage 0.2 - Update SLS](#update-sls)
 - [Stage 0.3 - Upgrade Management Network](#update-management-network)
 - [Stage 0.4 - Prerequisites Check](#prerequisites-check)
 - [Stage 0.5 - Backup Workload Manager Data](#backup_workload_manager)
 - [Stage 0.6 - Modify NCN Images](#modify_ncn_images)
-- [Stage 0.7 - Continue to Stage 1](#continue_to_stage1)
+- [Stage Completed](#stage_completed)
 
 <a name="install-latest-docs"></a>
 
-## Stage 0.1 - Install latest docs RPM
+## Stage 0.1 - Install latest documentation RPM
 
-1. Install latest document RPM package and prepare assets:
+1. Install latest documentation RPM package and prepare assets:
 
    > The install scripts will look for the RPM in `/root`, so it is important that you copy it there.
 
@@ -24,43 +29,44 @@
 
    - Internet Connected
 
-     1. Set the ENDPOINT variable to the URL of the directory containing the CSM release tarball.
+      1. Set the ENDPOINT variable to the URL of the directory containing the CSM release tarball.
 
-        In other words, the full URL to the CSM release tarball will be ${ENDPOINT}${CSM_RELEASE}.tar.gz
+         In other words, the full URL to the CSM release tarball will be ${ENDPOINT}${CSM_RELEASE}.tar.gz
 
-        **NOTE** This step is optional for Cray/HPE internal installs.
+         **Note:** This step is optional for Cray/HPE internal installs.
 
-        ```bash
-        ncn-m001# ENDPOINT=https://put.the/url/here/
-        ```
+         ```bash
+         ncn-m001# ENDPOINT=https://put.the/url/here/
+         ```
 
-     1. Run the script
+      1. Run the script
 
-        ```bash
-        ncn-m001# wget https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/docs-csm/1.2/noarch/docs-csm-latest.noarch.rpm -P /root
+         ```bash
+         ncn-m001# wget https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/docs-csm/1.2/noarch/docs-csm-latest.noarch.rpm -P /root &&
+                   rpm -Uvh --force /root/docs-csm-latest.noarch.rpm
 
-        ncn-m001# rpm -Uvh --force /root/docs-csm-latest.noarch.rpm
-
-        ncn-m001# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version [CSM_RELEASE] --endpoint [ENDPOINT]
-        ```
+         ncn-m001# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version [CSM_RELEASE] --endpoint [ENDPOINT]
+         ```
 
    - Air Gapped (replace the PATH_TO below with the location of the rpm)
 
-     1. Copy the docs-csm RPM package and CSM release tarball to `ncn-m001`.
+      1. Copy the docs-csm RPM package and CSM release tarball to `ncn-m001`.
      
-     1. Run the script
+      1. Run the script
 
-        ```bash
-        ncn-m001# cp [PATH_TO_docs-csm-*.noarch.rpm] /root
+         ```bash
+         ncn-m001# cp [PATH_TO_docs-csm-*.noarch.rpm] /root
 
-        ncn-m001# rpm -Uvh --force /root/docs-csm-*.noarch.rpm
+         ncn-m001# rpm -Uvh --force /root/docs-csm-*.noarch.rpm
 
-        ncn-m001# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version [CSM_RELEASE] --tarball-file [PATH_TO_CSM_TARBALL_FILE]
-        ```
+         ncn-m001# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version [CSM_RELEASE] --tarball-file [PATH_TO_CSM_TARBALL_FILE]
+         ```
 
 <a name="reduce-cpu-limits"></a>
 
 ## Stage 0.2 - Update SLS
+
+### Abstract
 
 CSM 1.2 introduces the bifurcated CAN as well as network configuration controlled by data in SLS. An offline upgrade of SLS data is performed. More details on the upgrade and its sequence of events can be found in the [README.SLS_upgrade.md](./scripts/sls/README.SLS_Upgrade.md).
 
@@ -68,65 +74,16 @@ The SLS data upgrade is a critical step in moving to CSM 1.2. Upgraded SLS data 
 
 One detail which must not be overlooked is that the existing Customer Access Network (CAN) will be migrated or retrofitted into the new Customer Management Network (CMN) while minimizing changes. A new CAN, (or CHN) network is then created. Pivoting the existing CAN to the new CMN allows administrative traffic (already on the CAN) to remain as-is while moving standard user traffic to a new site-routable network.
 
-### Prerequisites
-
-At a minimum, answers to the following questions must be known prior to upgrading:
-
-1. _Will user traffic (non-administrative) come in via the CAN, CHN or is the site Air-gapped?_
-2. _What is the internal VLAN and the site-routable IP subnet for the new CAN or CHN?_
-3. _Is there a need to preserve any existing IP address(es) during the CAN-to-CMN migration?_
-   1. One example would be the `external-dns` IP address used for DNS lookups of system resources from site DNS servers. Changes to `external-dns` often require changes to site resources with requisite process and timeframes from other groups. For preserving `external-dns` IP addresses, the flag is `--preserve-existing-subnet-for-cmn external-dns`. WARNING: It is up to the user to compare pre-upgraded and post-upgraded SLS files for sanity. Specifically, in the case of preserving `external-dns` values, to prevent site-networking changes that might result in NCN IP addresses overlapping during the upgrade process. This requires network subnetting expertise and EXPERT mode below.
-   2. Another, mutually exclusive example is the need to preserve all NCN IP addresses related to the old CAN whilst migrating the new CMN. This preservation is not often needed as the transition of NCN IP addresses for the CAN-to-CMN is automatically handled during the upgrade. The flag to preserve CAN-to-CMN NCN IP addresses is mutually exclusive with other preservations and the flag is `--preserve-existing-subnet-for-cmn ncns`.
-   3. Should no preservation flag be set, the default behavior is to recalculate every IP address on the existing CAN while migrating to the CMN. The behavior in this case is to calculate the subnet sizes based on number of devices (with a bit of spare room), while maximizing IP address pool sizes for (dynamic) services.
-   4. An EXPERT mode of flags also exists whereby manually subnetted allocations can be assigned to the new CMN, bypassing several expectations, but not essential subnetting math. As a note for experts the "Remaining subnets" list from a run using `--preserve-existing-subnet-for-cmn` can be used as an aid in selecting subnets to override with `--cmn-subnet-override` or `--can-subnet-override` values and used to seed another run of the upgrader.
-
-Several other flags in the migration script allow for user input, overrides and guidance to the upgrade process. Taking time to review these options is important. All current options can be seen by running:
-
-```bash
-ncn-m001# export DOCDIR=/usr/share/doc/csm/upgrade/1.2/scripts/sls
-ncn-m001# ${DOCDIR}/sls_updater_csm_1.2.py --help
-```
-
-Example output:
-
-```text
-Usage: sls_updater_csm_1.2.py [OPTIONS]
-
-  Upgrade a system SLS file from CSM 1.0 to CSM 1.2.
-
-   1. Migrate switch naming (in order):  leaf to leaf-bmc and agg to leaf.
-   2. Remove api-gateway entries from HMLB subnets for CSM 1.2 security.
-   3. Remove kubeapi-vip reservations for all networks except NMN.
-   4. Create the new BICAN "toggle" network.
-   5. Migrate the existing CAN to CMN.
-   7. Create the CHN network.
-   7. Convert IP addresses of the CAN network.
-   8. Create MetalLB Pools Names and ASN entries on CMN and NMN networks.
-   9. Update uai_macvlan in NMN dhcp ranges and uai_macvlan VLAN.
-  10. Remove unused user networks (CAN or CHN).
-
-Options:
-  --sls-input-file FILENAME - Input SLS JSON file  [required]
-  --sls-output-file FILENAME - Upgraded SLS JSON file name
-  --bican-user-network-name [CAN|CHN|HSN] - Name of the network over which non-admin users access the system  [required]
-  --customer-access-network <INTEGER RANGE IPV4NETWORK>... - CAN - VLAN and IPv4 network CIDR block [default: 6, 10.103.6.0/24]
-  --customer-highspeed-network <INTEGER RANGE IPV4NETWORK>... - CHN - VLAN and IPv4 network CIDR block [default: 5, 10.104.7.0/24]
-  --bgp-asn INTEGER RANGE - The autonomous system number for BGP router [default: 65533;64512<=x<=65534]
-  --bgp-chn-asn INTEGER RANGE - The autonomous system number for CHN BGP clients  [default: 65530;64512<=x<=65534]
-  --bgp-cmn-asn INTEGER RANGE - The autonomous system number for CMN BGP clients  [default: 65532;64512<=x<=65534]
-  --bgp-nmn-asn INTEGER RANGE - The autonomous system number for NMN BGP clients  [default: 65531;64512<=x<=65534]
-  --preserve-existing-subnet-for-cmn [external-dns|ncns] -  When creating the CMN from the CAN, preserve the metallb_static_pool for external-dns IP, or bootstrap_dhcp for NCN IP addresses. By default no subnet IP addresses from CAN will be preserved.
-  --can-subnet-override <CHOICE IPV4NETWORK>... - [EXPERT] Manually/Statically assign CAN subnets to your choice of network_hardware bootstrap_dhcp, can_metallb_address_pool, and/or can_metallb_static_pool subnets.
-  --cmn-subnet-override <CHOICE IPV4NETWORK>... - [EXPERT] Manually/Statically assign CMN subnets to your choice of network_hardware, bootstrap_dhcp, cmn_metallb_address_pool, and/or cmn_metallb_static_pool subnets.
-  --help - Show this message and exit.
-```
+> **`Important:`** If this is the first time performing the SLS update to CSM 1.2, you should review the [README.SLS_upgrade.md](./scripts/sls/README.SLS_Upgrade.md) to ensure you use all the correct options for your environment. Two examples are given below. To see all options from the update script run `./sls_updater_csm_1.2.py --help`
 
 ### Retrieve SLS data as JSON
 
 1. Obtain a token:
 
    ```bash
-   ncn-m001# export TOKEN=$(curl -s -k -S -d grant_type=client_credentials -d client_id=admin-client -d client_secret=`kubectl get secrets admin-client-auth -o    jsonpath='{.data.client-secret}' | base64 -d` https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
+   ncn-m001# export TOKEN=$(curl -s -k -S -d grant_type=client_credentials -d client_id=admin-client \
+                                -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
+                                https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
    ```
 
 1. Create a working directory:
@@ -146,105 +103,114 @@ Options:
 
 - Example 1: The CHN as the system default route (will by default output to `migrated_sls_file.json`).
 
-```bash
-ncn-m001# export DOCDIR=/usr/share/doc/csm/upgrade/1.2/scripts/sls
-ncn-m001# ${DOCDIR}/sls_updater_csm_1.2.py --sls-input-file sls_input_file.json \
+   ```bash
+   ncn-m001# export DOCDIR=/usr/share/doc/csm/upgrade/1.2/scripts/sls
+   ncn-m001# ${DOCDIR}/sls_updater_csm_1.2.py --sls-input-file sls_input_file.json \
                          --bican-user-network-name CHN \
                          --customer-highspeed-network 5 10.103.11.192/26
-```
+   ```
 
 - Example 2: The CAN as the system default route, keep the generated CHN (for testing), and preserve the existing `external-dns` entry.
 
-```bash
-ncn-m001# export DOCDIR=/usr/share/doc/csm/upgrade/1.2/scripts/sls
-ncn-m001# ${DOCDIR}/sls_updater_csm_1.2.py --sls-input-file sls_input_file.json \
+   ```bash
+   ncn-m001# export DOCDIR=/usr/share/doc/csm/upgrade/1.2/scripts/sls
+   ncn-m001# ${DOCDIR}/sls_updater_csm_1.2.py --sls-input-file sls_input_file.json \
                          --bican-user-network-name CAN \
                          --customer-access-network 6 10.103.15.192/26 \
                          --preserve-existing-subnet-for-cmn external-dns
-```
+   ```
 
-- NOTE: A detailed review of the migrated/upgraded data (using `vimdiff` or otherwise) for production systems and for systems which have many add-on components (UAN, login nodes, storage integration points, etc.) is strongly recommended. Particularly, ensure that subnet reservations are correct in order to prevent any data mismatches.
+- **`Note:`**: A detailed review of the migrated/upgraded data (using `vimdiff` or otherwise) for production systems and for systems which have many add-on components (UAN, login nodes, storage integration points, etc.) is strongly recommended. Particularly, ensure that subnet reservations are correct in order to prevent any data mismatches.
 
-Upload migrated SLS file to SLS service:
+### Upload migrated SLS file to SLS service
 
-```bash
-ncn-m001# curl -H "Authorization: Bearer ${TOKEN}" -k -L -X POST 'https://api-gw-service-nmn.local/apis/sls/v1/loadstate' -F 'sls_dump=@migrated_sls_file.json'
-```
+   ```bash
+   ncn-m001# curl -H "Authorization: Bearer ${TOKEN}" -k -L -X POST 'https://api-gw-service-nmn.local/apis/sls/v1/loadstate' -F 'sls_dump=@migrated_sls_file.json'
+   ```
 
 <a name="update-management-network"></a>
 
 ## Stage 0.3 - Upgrade Management Network
 
-#### Verify if Switches have 1.2 Configuration in place.
+### Verify if switches have 1.2 configuration in place
 
-  1. Login to each management switch `ssh admin@1.2.3.4`
-
-  1. After logging into each switch, you will see output like the below in your prompt if the switches have a CANU generated config for CSM 1.2 in place.
-
-   ```
-##################################################################################
-    # CSM version:  1.2
-    # CANU version: 1.3.2
-##################################################################################
+1. Log in to each management switch 
+   ```bash
+   linux# ssh admin@1.2.3.4
    ```
 
-  3. If the switch does show the banner like the above, then follow the steps in the [Management Network 1.0 (1.2 Preconfig) to 1.2
-](https://github.com/Cray-HPE/docs-csm/blob/release/1.2/operations/network/management_network/1.0_to_1.2_upgrade.md). If the banner does NOT show like the above, then please reach out to support to get the 1.2 preconfigs applied to the system.
+1. Examine the text displayed when logging in to the switch. Specifically, look for output similar to the following:
 
+   ```
+   ##################################################################################
+   # CSM version:  1.2
+   # CANU version: 1.3.2
+   ##################################################################################
+   ```
 
-- See the [Management Network User Guide](../../operations/network/management_network/index.md) for more information on the management network.
+   - If you see text like the above, then it means that the switches have a CANU-generated configuration for CSM 1.2 in place. In this case, follow the steps in the [Management Network 1.0 (1.2 Preconfig) to 1.2](https://github.com/Cray-HPE/docs-csm/blob/release/1.2/operations/network/management_network/1.0_to_1.2_upgrade.md).
+
+   - If the banner does NOT contain text like the above, then contact support in order to get the 1.2 preconfigs applied to the system.
+
+   - See the [Management Network User Guide](../../operations/network/management_network/index.md) for more information on the management network.
 
 <a name="prerequisites-check"></a>
 
 ## Stage 0.4 - Prerequisites Check
 
-Run check script:
+1. Set the `SW_ADMIN_PASSWORD` environment variable.
 
-Set the `SW_ADMIN_PASSWORD` environment variable to the admin password for the switches. This is needed for preflight tests within the check script.
+   Set it to the password for `admin` user on the switches. This is needed for preflight tests within the check script.
 
-```bash
-ncn-m001# export SW_ADMIN_PASSWORD=PutYourOwnPasswordHere
-```
+   ```bash
+   ncn-m001# export SW_ADMIN_PASSWORD=changeme
+   ```
 
-> **`IMPORTANT:`** If the password for the local Nexus `admin` account has
-> been changed from the default `admin123` (not typical), then set the
-> `NEXUS_PASSWORD` environment variable to the correct `admin` password
-> before running prerequisites.sh!
->
-> For example:
->
-> ```bash
-> ncn-m001# export NEXUS_PASSWORD=PutYourOwnPasswordHered
-> ```
->
-> Otherwise, a random 32-character base64-encoded string will be generated
-> and updated as the default `admin` password when Nexus is upgraded.
+1. Set the `NEXUS_PASSWORD` variable **only if needed**.
 
-- ```bash
-  ncn-m001# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prerequisites.sh --csm-version [CSM_RELEASE]
-  ```
+   > **`IMPORTANT:`** If the password for the local Nexus `admin` account has
+   > been changed from the default `admin123` (not typical), then set the
+   > `NEXUS_PASSWORD` environment variable to the correct `admin` password
+   > before running `prerequisites.sh`!
+   >
+   > For example:
+   >
+   > ```bash
+   > ncn-m001# export NEXUS_PASSWORD=changeme
+   > ```
+   >
+   > Otherwise, a random 32-character base-64-encoded string will be generated
+   > and updated as the default `admin` password when Nexus is upgraded.
 
-**`IMPORTANT:`** If any errors are encountered, then potential fixes should be displayed where the error occurred. **IF** the upgrade `prerequisites.sh` script fails and does not provide guidance, then try rerunning it. If the failure persists, then open a support ticket for guidance before proceeding.
+1. Run the script.
 
-**`IMPORTANT:`** If the `NEXUS_PASSWORD` environment variable was set as previously mentioned, then remove it before continuing:
+   ```bash
+   ncn-m001# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prerequisites.sh --csm-version [CSM_RELEASE]
+   ```
 
-```bash
-ncn-m001# unset NEXUS_PASSWORD
-```
+   **`IMPORTANT:`** If any errors are encountered, then potential fixes should be displayed where the error occurred. **IF** the upgrade `prerequisites.sh` script fails and does not provide guidance, then try rerunning it. If the failure persists, then open a support ticket for guidance before proceeding.
 
-**`OPTIONAL:`** `customizations.yaml` has been updated in this step. If [using an external Git repository for managing customizations](../../install/prepare_site_init.md#version-control-site-init-files) as recommended,
-clone a local working tree and commit appropriate changes to `customizations.yaml`.
+1. Unset the `NEXUS_PASSWORD` variable, if it was set in the earlier step.
 
-For example:
+   ```bash
+   ncn-m001# unset NEXUS_PASSWORD
+   ```
 
-```bash
-ncn-m001# git clone <URL> site-init
-ncn-m001# cd site-init
-ncn-m001# kubectl -n loftsman get secret site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d - > customizations.yaml
-ncn-m001# git add customizations.yaml
-ncn-m001# git commit -m 'CSM 1.2 upgrade - customizations.yaml'
-ncn-m001# git push
-```
+1. Commit changes to `customizations.yaml` (optional).
+
+   `customizations.yaml` has been updated in this procedure. If [using an external Git repository for managing customizations](../../install/prepare_site_init.md#version-control-site-init-files) as recommended,
+then clone a local working tree and commit appropriate changes to `customizations.yaml`.
+
+   For example:
+
+   ```bash
+   ncn-m001# git clone <URL> site-init
+   ncn-m001# cd site-init
+   ncn-m001# kubectl -n loftsman get secret site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d - > customizations.yaml
+   ncn-m001# git add customizations.yaml
+   ncn-m001# git commit -m 'CSM 1.2 upgrade - customizations.yaml'
+   ncn-m001# git push
+   ```
 
 <a name="backup_workload_manager"></a>
 
@@ -297,7 +263,8 @@ for more information.
     [full NCN personalization](../../operations/CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md#set_root_password)
     for more information.
 
-<a name="continue_to_stage1"></a>
+<a name="stage_completed"></a>
 
-## Stage 0.7 - Continue to Stage 1
-Continue on to [Stage 1 - Ceph image upgrade](https://github.com/Cray-HPE/docs-csm/blob/release/1.2/upgrade/1.2/Stage_1.md).
+## Stage Completed
+
+Continue to [Stage 1 - Ceph image upgrade](https://github.com/Cray-HPE/docs-csm/blob/release/1.2/upgrade/1.2/Stage_1.md).

--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -24,23 +24,39 @@
 
    - Internet Connected
 
-     ```bash
-     ncn-m001# wget https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/docs-csm/1.2/noarch/docs-csm-latest.noarch.rpm -P /root
+     1. Set the ENDPOINT variable to the URL of the directory containing the CSM release tarball.
 
-     ncn-m001# rpm -Uvh --force /root/docs-csm-latest.noarch.rpm
+        In other words, the full URL to the CSM release tarball will be ${ENDPOINT}${CSM_RELEASE}.tar.gz
 
-     ncn-m001# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version [CSM_RELEASE] --endpoint [ENDPOINT]
-     ```
+        **NOTE** This step is optional for Cray/HPE internal installs.
+
+        ```bash
+        ncn-m001# ENDPOINT=https://put.the/url/here/
+        ```
+
+     1. Run the script
+
+        ```bash
+        ncn-m001# wget https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/docs-csm/1.2/noarch/docs-csm-latest.noarch.rpm -P /root
+
+        ncn-m001# rpm -Uvh --force /root/docs-csm-latest.noarch.rpm
+
+        ncn-m001# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version [CSM_RELEASE] --endpoint [ENDPOINT]
+        ```
 
    - Air Gapped (replace the PATH_TO below with the location of the rpm)
 
-     ```bash
-     ncn-m001# cp [PATH_TO_docs-csm-*.noarch.rpm] /root
+     1. Copy the docs-csm RPM package and CSM release tarball to `ncn-m001`.
+     
+     1. Run the script
 
-     ncn-m001# rpm -Uvh --force /root/docs-csm-*.noarch.rpm
+        ```bash
+        ncn-m001# cp [PATH_TO_docs-csm-*.noarch.rpm] /root
 
-     ncn-m001# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version [CSM_RELEASE] --tarball-file [PATH_TO_CSM_TARBALL_FILE]
-     ```
+        ncn-m001# rpm -Uvh --force /root/docs-csm-*.noarch.rpm
+
+        ncn-m001# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version [CSM_RELEASE] --tarball-file [PATH_TO_CSM_TARBALL_FILE]
+        ```
 
 <a name="reduce-cpu-limits"></a>
 
@@ -159,6 +175,23 @@ ncn-m001# curl -H "Authorization: Bearer ${TOKEN}" -k -L -X POST 'https://api-gw
 
 ## Stage 0.3 - Upgrade Management Network
 
+#### Verify if Switches have 1.2 Configuration in place.
+
+  1. Login to each management switch `ssh admin@1.2.3.4`
+
+  1. After logging into each switch, you will see output like the below in your prompt if the switches have a CANU generated config for CSM 1.2 in place.
+
+   ```
+##################################################################################
+    # CSM version:  1.2
+    # CANU version: 1.3.2
+##################################################################################
+   ```
+
+  3. If the switch does show the banner like the above, then follow the steps in the [Management Network 1.0 (1.2 Preconfig) to 1.2
+](https://github.com/Cray-HPE/docs-csm/blob/release/1.2/operations/network/management_network/1.0_to_1.2_upgrade.md). If the banner does NOT show like the above, then please reach out to support to get the 1.2 preconfigs applied to the system.
+
+
 - See the [Management Network User Guide](../../operations/network/management_network/index.md) for more information on the management network.
 
 <a name="prerequisites-check"></a>
@@ -170,7 +203,7 @@ Run check script:
 Set the `SW_ADMIN_PASSWORD` environment variable to the admin password for the switches. This is needed for preflight tests within the check script.
 
 ```bash
-ncn-m001# export SW_ADMIN_PASSWORD=sw1tCH@DM1Np4s5w0rd
+ncn-m001# export SW_ADMIN_PASSWORD=PutYourOwnPasswordHere
 ```
 
 > **`IMPORTANT:`** If the password for the local Nexus `admin` account has
@@ -181,7 +214,7 @@ ncn-m001# export SW_ADMIN_PASSWORD=sw1tCH@DM1Np4s5w0rd
 > For example:
 >
 > ```bash
-> ncn-m001# export NEXUS_PASSWORD=cu$t0m@DM1Np4s5w0rd
+> ncn-m001# export NEXUS_PASSWORD=PutYourOwnPasswordHered
 > ```
 >
 > Otherwise, a random 32-character base64-encoded string will be generated

--- a/upgrade/1.2/Stage_1.md
+++ b/upgrade/1.2/Stage_1.md
@@ -16,7 +16,7 @@
       /usr/bin/ssh-copy-id: INFO: Source of key(s) to be installed: "/root/ceph.pub"Number of key(s) added: 1Now try logging into the machine, with:   "ssh 'root@ncn-s003'"
       and check to make sure that only the key(s) you wanted were added.Error EINVAL: Traceback (most recent call last):
       ```
-    * During the storage node rebuild, it is possible that Ceph health may report ***HEALTH_WARN 1 daemons have recently crashed***.  This can occur occasionally as part of the shutdown process of the node being rebuilt. Please refer to the [Dump Ceph Crash Data](operations/../../../operations/utility_storage/Dump_Ceph_Crash_Data.md) procedure for more information.
+    * During the storage node rebuild, it is possible that ceph health may report ***HEALTH_WARN 1 daemons have recently crashed***.  This can occur occasionally as part of the shutdown process of the node being rebuilt.  Please refer to the [Dump Ceph Crash Data](operations/../../../operations/utility_storage/Dump_Ceph_Crash_Data.md) located in the Operations/Utility Storage section of the guide.
 
 **IMPORTANT:** Ensure the Ceph cluster is healthy prior to continuing. If you have processes not running, then refer to [Utility Storage Operations](../../operations/utility_storage/Utility_Storage.md) for operational and troubleshooting procedures.
 

--- a/upgrade/1.2/Stage_1.md
+++ b/upgrade/1.2/Stage_1.md
@@ -9,20 +9,22 @@
     > NOTE: You may need to reset the root password for each node after it is rebooted
 
     **Known Issues:**
-    * It is possible to encounter an error like shown below.  If this is the case, just re-run the same command for the node upgrade and it will pick up at that point and conitune.
+    * It is possible to encounter an error like shown below. If this is the case, then re-run the same command for the node upgrade. It will pick up at that point and continue.
 
-      ```text
-      ====> REDEPLOY_CEPH ...
-      /usr/bin/ssh-copy-id: INFO: Source of key(s) to be installed: "/root/ceph.pub"Number of key(s) added: 1Now try logging into the machine, with:   "ssh 'root@ncn-s003'"
-      and check to make sure that only the key(s) you wanted were added.Error EINVAL: Traceback (most recent call last):
-      ```
-    * During the storage node rebuild, it is possible that ceph health may report ***HEALTH_WARN 1 daemons have recently crashed***.  This can occur occasionally as part of the shutdown process of the node being rebuilt.  Please refer to the [Dump Ceph Crash Data](operations/../../../operations/utility_storage/Dump_Ceph_Crash_Data.md) located in the Operations/Utility Storage section of the guide.
+        ```text
+        ====> REDEPLOY_CEPH ...
+        /usr/bin/ssh-copy-id: INFO: Source of key(s) to be installed: "/root/ceph.pub"Number of key(s) added: 1Now try logging into the machine, with:   "ssh 'root@ncn-s003'"
+        and check to make sure that only the key(s) you wanted were added.Error EINVAL: Traceback (most recent call last):
+        ```
+    * During the storage node rebuild, it is possible that Ceph health may report `HEALTH_WARN 1 daemons have recently crashed`. This can occur occasionally as part of the shutdown process of the node being rebuilt. Refer to [Dump Ceph Crash Data](../../operations/utility_storage/Dump_Ceph_Crash_Data.md), located in the Operations/Utility Storage section of the CSM documentation.
 
-**IMPORTANT:** Ensure the Ceph cluster is healthy prior to continuing. If you have processes not running, then refer to [Utility Storage Operations](../../operations/utility_storage/Utility_Storage.md) for operational and troubleshooting procedures.
+1. **IMPORTANT:** Ensure the Ceph cluster is healthy prior to continuing.
 
-1. Repeat the previous step for each other storage node, one at a time.
+    If you have processes not running, then refer to [Utility Storage Operations](../../operations/utility_storage/Utility_Storage.md) for operational and troubleshooting procedures.
 
-2. After `ncn-upgrade-ceph-nodes.sh` has successfully run for all storage nodes, rescan SSH keys on all storage nodes
+1. Repeat the previous steps for each other storage node, one at a time.
+
+1. After `ncn-upgrade-ceph-nodes.sh` has successfully run for all storage nodes, rescan the SSH keys on all storage nodes.
 
     ```bash
     ncn-m001# grep -oP "(ncn-s\w+)" /etc/hosts | sort -u | xargs -t -i ssh {} 'truncate --size=0 ~/.ssh/known_hosts'
@@ -30,41 +32,57 @@
     ncn-m001# grep -oP "(ncn-s\w+)" /etc/hosts | sort -u | xargs -t -i ssh {} 'grep -oP "(ncn-s\w+|ncn-m\w+|ncn-w\w+)" /etc/hosts | sort -u | xargs -t -i ssh-keyscan -H \{\} >> /root/.ssh/known_hosts'
     ```
 
-3. Deploy `node-exporter` and `alertmanager`.
+1. Deploy `node-exporter` and `alertmanager`.
 
-    **NOTE:** This process will need to run on a node running `ceph-mon`, which in most cases will be `ncn-s001`, `ncn-s002`, and `ncn-s003`. It only needs to be run once, not on every one of these nodes.
+    **NOTE:** This procedure will need to run on a node running `ceph-mon`, which in most cases will be `ncn-s001`, `ncn-s002`, and `ncn-s003`. It only needs to be run once, not on every one of these nodes.
 
-    1. Deploy `node-exporter` and `alertmanager`:
+    1. Deploy `node-exporter` and `alertmanager`.
 
         ```bash
-        ncn-s# ceph orch apply node-exporter
+        ncn-s# ceph orch apply node-exporter && ceph orch apply alertmanager
+        ```
+        
+        Expected output should look similar to the following:
+        ```
         Scheduled node-exporter update...
-
-        ncn-s# ceph orch apply alertmanager
         Scheduled alertmanager update...
         ```
 
-    2. Verify `node-exporter` and `alertmanager` are running:
+    1. Verify that `node-exporter` is running.
+
+        > **IMPORTANT:** There should be a `node-exporter` container per Ceph node.
 
         ```bash
         ncn-s# ceph orch ps --daemon_type node-exporter
+        ```
+        
+        Expected output on a system with three Ceph nodes should look similar to the following:
+        ```
         NAME                    HOST      STATUS         REFRESHED  AGE  VERSION  IMAGE NAME                                       IMAGE ID           CONTAINER ID
         node-exporter.ncn-s001  ncn-s001  running (57m)  3m ago     67m  0.18.1   docker.io/prom/node-exporter:v0.18.1             e5a616e4b9cf       3465eade21da
         node-exporter.ncn-s002  ncn-s002  running (57m)  3m ago     67m  0.18.1   registry.local/prometheus/node-exporter:v0.18.1  e5a616e4b9cf       7ed9b6cc9991
         node-exporter.ncn-s003  ncn-s003  running (57m)  3m ago     67m  0.18.1   registry.local/prometheus/node-exporter:v0.18.1  e5a616e4b9cf       1078d9e555e4
+        ```
 
+    1. Verify that `alertmanager` is running.
+
+        > **IMPORTANT:** There should be a single `alertmanager` container for the cluster.
+
+        ```bash
         ncn-s# ceph orch ps --daemon_type alertmanager
+        ```
+        
+        Expected output should look similar to the following:
+        ```
         NAME                   HOST      STATUS         REFRESHED  AGE  VERSION  IMAGE NAME                                      IMAGE ID           CONTAINER ID
         alertmanager.ncn-s001  ncn-s001  running (66m)  3m ago     68m  0.20.0   registry.local/prometheus/alertmanager:v0.20.0  0881eb8f169f       775aa53f938f
         ```
 
-        **IMPORTANT:** There should be a `node-exporter` container per Ceph node and a single `alertmanager` container for the cluster.
-
-4. Update BSS to ensure the Ceph images are loaded if a node is rebuilt.
+1. Update BSS to ensure that the Ceph images are loaded if a node is rebuilt.
 
     ```bash
     ncn-m001# . /usr/share/doc/csm/upgrade/1.2/scripts/ceph/lib/update_bss_metadata.sh
     ncn-m001# update_bss_storage
     ```
 
- Once `Stage 1` is successfully completed, all the Ceph nodes have been rebooted into the new image. Now proceed to [Stage 2](Stage_2.md).
+ Once `Stage 1` is successfully completed, all the Ceph nodes have been rebooted into the new image. Proceed to [Stage 2](Stage_2.md).

--- a/upgrade/1.2/Stage_3.md
+++ b/upgrade/1.2/Stage_3.md
@@ -1,13 +1,52 @@
 # Stage 3 - CSM Service Upgrades
 
-**IMPORTANT:**
+1. Prepare assets:
 
-> During this stage there will be a brief (approximately 5 minutes) window where pods with PVCs will not be able to migrate between nodes. This is due to a redeployment of the Ceph csi provisioners into namespaces to accommodate the newer charts and a better upgrade strategy.
+   ```bash
+    ncn-m002# CSM_RELEASE=csm-1.2.0
+   ```
 
-Run `csm-upgrade.sh` to deploy upgraded CSM applications and services:
+   - Internet Connected
 
-```bash
-ncn-m002# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/csm-upgrade.sh
-```
+     1. Set the ENDPOINT variable to the URL of the directory containing the CSM release tarball.
+
+        In other words, the full URL to the CSM release tarball will be ${ENDPOINT}${CSM_RELEASE}.tar.gz
+
+        **NOTE** This step is optional for Cray/HPE internal installs.
+
+        ```bash
+        ncn-m002# ENDPOINT=https://put.the/url/here/
+        ```
+
+     1. Run the script
+
+        ```bash
+        ncn-m002# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version [CSM_RELEASE] --endpoint [ENDPOINT]
+        ```
+
+   - Air Gapped (replace the PATH_TO below with the location of the CSM release tarball)
+
+     1. Copy CSM release tarball to `ncn-m002`.
+
+     1. Run the script
+
+        ```bash
+        ncn-m002# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version [CSM_RELEASE] --tarball-file [PATH_TO_CSM_TARBALL_FILE]
+        ```
+
+1. Run `csm-upgrade.sh` to deploy upgraded CSM applications and services:
+   **IMPORTANT:**
+
+   > During this stage there will be a brief (approximately 5 minutes) window where pods with PVCs will not be able to migrate between nodes. This is due to a redeployment of the Ceph csi provisioners into namespaces to accommodate the newer charts and a better upgrade strategy.
+
+   > Set the `SW_ADMIN_PASSWORD` environment variable to the admin password for the switches. This is needed for post upgrade tests.
+
+   ```bash
+   ncn-m002# export SW_ADMIN_PASSWORD=sw1tCH@DM1Np4s5w0rd
+   ```
+
+   ```bash
+   ncn-m002# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/csm-upgrade.sh
+   ```
 
 Once `Stage 3` is completed, proceed to [Stage 4](Stage_4.md)

--- a/upgrade/1.2/Stage_4.md
+++ b/upgrade/1.2/Stage_4.md
@@ -195,7 +195,7 @@ Only processes running the v15.2.8 image will be upgraded. This will include `MO
 ceph orch upgrade stop
 ```
 
-> DO NOT proceed past this point if the upgrade has not completed and been verified.  Contact support for indepth troubleshooting.
+> DO NOT proceed past this point if the upgrade has not completed and been verified. Contact support for indepth troubleshooting.
 
 1. Disable `auth_allow_insecure_global_id_reclaim`
 

--- a/upgrade/1.2/Stage_4.md
+++ b/upgrade/1.2/Stage_4.md
@@ -161,7 +161,7 @@ Only processes running the v15.2.8 image will be upgraded. This will include `MO
             mons are allowing insecure global_id reclaim
    ```
 
-   `ceph orch ps` should show `MON`, `MGR`, `MDS`, `RGW`, and `OSD` processes running version `v15.2.15`.  There should be **NO** processes running version `v15.2.8`.
+   `ceph orch ps` should show `MON`, `MGR`, `MDS`, `RGW`, and `OSD` processes running version `v15.2.15`. There should be **NO** processes running version `v15.2.8`.
 
    A handy command to verify you are not running any older versions of ceph:
 
@@ -171,7 +171,7 @@ Only processes running the v15.2.8 image will be upgraded. This will include `MO
    ceph orch ps -f json-pretty|jq -r '.[]|select(.version=="15.2.8")|.version'|wc -l
    ```
 
-   > If the above command shows any number other than 0, then the upgrade is not complete.  You can refer to [Ceph_Orchestrator_Usage.md](../operation/../../operations/utility_storage/Ceph_Orchestrator_Usage.md) for additional usage and troubleshooting. 
+   > If the above command shows any number other than 0, then the upgrade is not complete. Refer to [Ceph_Orchestrator_Usage.md](../operation/../../operations/utility_storage/Ceph_Orchestrator_Usage.md) for additional usage and troubleshooting. 
 
    Some addtional commands to run to check the ceph upgrade:
 
@@ -187,7 +187,7 @@ Only processes running the v15.2.8 image will be upgraded. This will include `MO
    ceph -W cephadm
    ```
 
-   > This will watch the cephadm process.  This will be the most helpful, but can be slow as events will have to retry in order to see which part failed and why.  
+   > This will watch the `cephadm` process. This is the most helpful, but can be slow as events will have to retry in order to see which part failed and why.  
 
 **IMPORTANT:** If you have any ceph mon/mgr/mds/osd/rgw processes still running 15.2.8 then do the following:
 
@@ -195,7 +195,7 @@ Only processes running the v15.2.8 image will be upgraded. This will include `MO
 ceph orch upgrade stop
 ```
 
-> DO NOT proceed past this point if the upgrade has not completed and been verified. Contact support for indepth troubleshooting.
+> DO NOT proceed past this point if the upgrade has not completed and been verified. Contact support for in-depth troubleshooting.
 
 1. Disable `auth_allow_insecure_global_id_reclaim`
 

--- a/upgrade/1.2/scripts/k8s/determine-worker-order.sh
+++ b/upgrade/1.2/scripts/k8s/determine-worker-order.sh
@@ -32,7 +32,7 @@ conman_node=$(kubectl get po -n services -l 'app.kubernetes.io/name=cray-conman'
 conman_pod=$(kubectl get po -n services -l 'app.kubernetes.io/name=cray-conman' -o wide | grep -v NAME | awk '{print $1}')
 
 echo ""
-echo "Boot related pod locations:"
+echo "Boot-related pod locations:"
 echo ""
 echo "  kea pod is running on:    $kea_node ($kea_pod)"
 echo "  nexus pod is running on:  $nexus_node ($nexus_pod)"

--- a/upgrade/1.2/scripts/upgrade/prerequisites.sh
+++ b/upgrade/1.2/scripts/upgrade/prerequisites.sh
@@ -68,10 +68,13 @@ state_name="UPDATE_SSH_KEYS"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" ]]; then
     echo "====> ${state_name} ..."
-     grep -oP "(ncn-\w+)" /etc/hosts | sort -u | xargs -t -i ssh {} 'truncate --size=0 ~/.ssh/known_hosts'
+    {
 
-     grep -oP "(ncn-\w+)" /etc/hosts | sort -u | xargs -t -i ssh {} 'grep -oP "(ncn-s\w+|ncn-m\w+|ncn-w\w+)" /etc/hosts | sort -u | xargs -t -i ssh-keyscan -H \{\} >> /root/.ssh/known_hosts'
+    grep -oP "(ncn-\w+)" /etc/hosts | sort -u | xargs -t -i ssh {} 'truncate --size=0 ~/.ssh/known_hosts'
 
+    grep -oP "(ncn-\w+)" /etc/hosts | sort -u | xargs -t -i ssh {} 'grep -oP "(ncn-s\w+|ncn-m\w+|ncn-w\w+)" /etc/hosts | sort -u | xargs -t -i ssh-keyscan -H \{\} >> /root/.ssh/known_hosts'
+
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"
@@ -81,18 +84,19 @@ state_name="CHECK_CLOUD_INIT_PREREQ"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     echo "====> ${state_name} ..."
+    {
     echo "Ensuring cloud-init is healthy"
     set +e
     # K8s nodes
     for host in $(kubectl get nodes -o json |jq -r '.items[].metadata.name')
     do
         echo "Node: $host"
-        (( counter=0 ))
+        counter=0
         ssh_keygen_keyscan $host
         until ssh $host test -f /run/cloud-init/instance-data.json
         do
             ssh $host cloud-init init 2>&1 >/dev/null
-            (( counter++ ))
+            counter=$((counter+1))
             sleep 10
             if [[ $counter > 5 ]]
             then
@@ -105,22 +109,23 @@ if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     ## Ceph nodes
     for host in $(ceph node ls|jq -r '.osd|keys[]')
     do
-    echo "Node: $host"
-    (( counter=0 ))
-    ssh_keygen_keyscan $host
-    until ssh $host test -f /run/cloud-init/instance-data.json
-    do
-        ssh $host cloud-init init 2>&1 >/dev/null
-        (( counter++ ))
-        sleep 10
-        if [[ $counter > 5 ]]
-        then
-            echo "Cloud init data is missing and cannot be recreated. Existing upgrade.."
-        fi
-    done
+        echo "Node: $host"
+        counter=0
+        ssh_keygen_keyscan $host
+        until ssh $host test -f /run/cloud-init/instance-data.json
+        do
+            ssh $host cloud-init init 2>&1 >/dev/null
+            counter=$((counter+1))
+            sleep 10
+            if [[ $counter > 5 ]]
+            then
+                echo "Cloud init data is missing and cannot be recreated. Existing upgrade.."
+            fi
+        done
     done
 
     set -e
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"
@@ -130,11 +135,13 @@ state_name="UPDATE_DOC_RPM"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" ]]; then
     echo "====> ${state_name} ..."
+    {
     if [[ ! -f /root/docs-csm-latest.noarch.rpm ]]; then
         echo "ERROR: docs-csm-latest.noarch.rpm is missing under: /root -- halting..."
         exit 1
     fi
     cp /root/docs-csm-latest.noarch.rpm ${CSM_ARTI_DIR}/rpm/cray/csm/sle-15sp2/
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"
@@ -144,6 +151,7 @@ state_name="UPDATE_CUSTOMIZATIONS"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     echo "====> ${state_name} ..."
+    {
     
     # update podman config
     sed -i 's/.*mount_program =.*/mount_program = "\/usr\/bin\/fuse-overlayfs"/' /etc/containers/storage.conf
@@ -168,6 +176,7 @@ if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     kubectl delete secret -n loftsman site-init
     kubectl create secret -n loftsman generic site-init --from-file=./customizations.yaml
     popd
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"
@@ -177,8 +186,10 @@ state_name="SETUP_NEXUS"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     echo "====> ${state_name} ..."
+    {
     ${CSM_ARTI_DIR}/lib/setup-nexus.sh
 
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"
@@ -188,11 +199,13 @@ state_name="DISABLE_SERVICE_REPOS"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     echo "====> ${state_name} ..."
+    {
     NCNS=$(${CSM_ARTI_DIR}/lib/list-ncns.sh | paste -sd,)
     pdsh -w "$NCNS" 'zypper ms -d Basesystem_Module_15_SP2_x86_64'
     pdsh -w "$NCNS" 'zypper ms -d Public_Cloud_Module_15_SP2_x86_64'
     pdsh -w "$NCNS" 'zypper ms -d SUSE_Linux_Enterprise_Server_15_SP2_x86_64'
     pdsh -w "$NCNS" 'zypper ms -d Server_Applications_Module_15_SP2_x86_64'
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"
@@ -202,7 +215,9 @@ state_name="UPGRADE_BSS"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     echo "====> ${state_name} ..."
+    {
     helm -n services upgrade cray-hms-bss ${CSM_ARTI_DIR}/helm/cray-hms-bss-*.tgz
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"
@@ -212,7 +227,9 @@ state_name="UPGRADE_KEA"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     echo "====> ${state_name} ..."
+    {
     helm -n services upgrade cray-dhcp-kea ${CSM_ARTI_DIR}/helm/cray-dhcp-kea-*.tgz
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"
@@ -222,6 +239,7 @@ state_name="UPLOAD_NEW_NCN_IMAGE"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     echo "====> ${state_name} ..."
+    {
     temp_file=$(mktemp)
     artdir=${CSM_ARTI_DIR}/images
 
@@ -249,6 +267,7 @@ if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     echo "export CEPH_VERSION=${CEPH_VERSION}" >> /etc/cray/upgrade/csm/myenv
     echo "export KUBERNETES_VERSION=${KUBERNETES_VERSION}" >> /etc/cray/upgrade/csm/myenv
 
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"
@@ -258,6 +277,7 @@ state_name="UPDATE_CLOUD_INIT_RECORDS"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     echo "====> ${state_name} ..."
+    {
 
     # get bss cloud-init data with host_records
     curl -k -H "Authorization: Bearer $TOKEN" https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters?name=Global|jq .[] > cloud-init-global.json
@@ -289,6 +309,7 @@ if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
         --k8s-version ${KUBERNETES_VERSION} \
         --storage-version ${CEPH_VERSION}
 
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
     echo
 else
@@ -299,6 +320,7 @@ state_name="PREFLIGHT_CHECK"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" ]]; then
     echo "====> ${state_name} ..."
+    {
     export PDSH_SSH_ARGS_APPEND="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
     rpm --force -Uvh $(find $CSM_ARTI_DIR/rpm/cray/csm/ -name \*csm-testing\*.rpm | sort -V | tail -1)
     /opt/cray/tests/install/ncn/scripts/validate-bootraid-artifacts.sh
@@ -316,6 +338,7 @@ if [[ $state_recorded == "0" ]]; then
 
     GOSS_BASE=/opt/cray/tests/install/ncn goss -g /opt/cray/tests/install/ncn/suites/ncn-upgrade-preflight-tests.yaml --vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml validate
 
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"
@@ -325,6 +348,7 @@ state_name="PRECACHE_NEXUS_IMAGES"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     echo "====> ${state_name} ..."
+    {
 
     images=$(kubectl get configmap -n nexus cray-precache-images -o json | jq -r '.data.images_to_cache' | grep "sonatype\|proxy\|busybox")
     export PDSH_SSH_ARGS_APPEND="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
@@ -337,6 +361,7 @@ if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
       exit 1
     fi
 
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"
@@ -346,6 +371,7 @@ state_name="POD_ANTI_AFFINITY"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     echo "====> ${state_name} ..."
+    {
 
     kubectl patch deployment -n spire spire-jwks -p '{
         "spec": {
@@ -370,6 +396,7 @@ if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
         }
     }}'
 
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"
@@ -381,6 +408,7 @@ state_name="ADD_MTL_ROUTES"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     echo "====> ${state_name} ..."
+    {
 
     export PDSH_SSH_ARGS_APPEND="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
     NCNS=$(grep -oP 'ncn-w\w\d+|ncn-s\w\d+' /etc/hosts | sort -u)
@@ -408,6 +436,7 @@ if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
         exit 1
     fi
 
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"
@@ -417,9 +446,11 @@ state_name="CREATE_CEPH_RO_KEY"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     echo "====> ${state_name} ..."
+    {
     ceph-authtool -C /etc/ceph/ceph.client.ro.keyring -n client.ro --cap mon 'allow r' --cap mds 'allow r' --cap osd 'allow r' --cap mgr 'allow r' --gen-key
     ceph auth import -i /etc/ceph/ceph.client.ro.keyring
     for node in $(ceph orch host ls --format=json|jq -r '.[].hostname'); do scp /etc/ceph/ceph.client.ro.keyring $node:/etc/ceph/ceph.client.ro.keyring; done
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"
@@ -429,6 +460,7 @@ state_name="BACKUP_BSS_DATA"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     echo "====> ${state_name} ..."
+    {
     
     cray bss bootparameters list --format=json > bss-backup-$(date +%Y-%m-%d).json
 
@@ -442,6 +474,7 @@ if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
 
     cray artifacts create ${backupBucket} bss-backup-$(date +%Y-%m-%d).json bss-backup-$(date +%Y-%m-%d).json
     
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"
@@ -451,6 +484,7 @@ state_name="BACKUP_VCS_DATA"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     echo "====> ${state_name} ..."
+    {
     
     pgLeaderPod=$(kubectl exec gitea-vcs-postgres-0 -n services -c postgres -it -- patronictl list | grep Leader | awk -F'|' '{print $2}')
     kubectl exec -it ${pgLeaderPod} -n services -c postgres -- pg_dumpall -c -U postgres > gitea-vcs-postgres.sql
@@ -478,6 +512,7 @@ if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     cray artifacts create ${backupBucket} gitea-vcs-postgres.manifest gitea-vcs-postgres.manifest
     cray artifacts create ${backupBucket} vcs.tar vcs.tar
     
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"
@@ -487,6 +522,7 @@ state_name="TDS_LOWER_CPU_REQUEST"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     echo "====> ${state_name} ..."
+    {
     
     numOfActiveWokers=$(kubectl get nodes | grep "ncn-w" | grep "Ready" | wc -l)
     minimal_count=4
@@ -496,6 +532,7 @@ if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
         echo "==> TDS: false"
     fi
     
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"
@@ -505,6 +542,7 @@ state_name="SUSPEND_NCN_CONFIGURATION"
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     echo "====> ${state_name} ..."
+    {
     
     export CRAY_FORMAT=json
     for xname in $(cray hsm state components list --role Management --type node | jq -r .Components[].ID)
@@ -512,6 +550,7 @@ if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
         cray cfs components update --enabled false --desired-config "" $xname
     done
     
+    } >> ${LOG_FILE} 2>&1
     record_state ${state_name} $(hostname)
 else
     echo "====> ${state_name} has been completed"

--- a/upgrade/1.2/scripts/upgrade/util/update-customizations.sh
+++ b/upgrade/1.2/scripts/upgrade/util/update-customizations.sh
@@ -54,7 +54,6 @@ set -- "${args[@]}"
 
 [[ $# -eq 1 ]] || usage
 
-set -o xtrace
 
 customizations="$1"
 
@@ -504,4 +503,3 @@ else
     cat "$c"
 fi
 
-ok_report


### PR DESCRIPTION
Ready for review:

1. Backported missing content from release/1.2 into 1.2.5
2. Otherwise, just linting. No content changes, EXCEPT
3. There were a few problems with the Bash functions in the new kcadm page. Specifically, quotes were being used inconsistently and left open some unintentional effects if the function received an argument with whitespace. I tested all of the updated functions to verify that they worked as intended.