### PR TITLE
STP-3185: added step for NCNs to rejoin Spire

### DIFF
--- a/operations/spire/Update_Spire_Intermediate_CA_Certificate.md
+++ b/operations/spire/Update_Spire_Intermediate_CA_Certificate.md
@@ -31,17 +31,23 @@ ncn# kubectl get secret -n spire spire.spire.ca-tls -o json | jq -r '.data."tls.
    ```
 
 1. After the `spire.spire.ca-tls` secret in the `spire` namespace has been
-   repopulated you should roll the spire-server to make sure all of them pick up
+   repopulated, roll the spire-server to make sure all of them pick up
    the new CA.
 
    ```bash
    ncn# kubectl rollout restart -n spire statefulset spire-server
    ```
 
-   Any `spire-agent`s in the `CrashLoopBackOff` state should come back into a `Running` state the
+   Any `spire-agent` in the `CrashLoopBackOff` state should come back into a `Running` state the
    next time they are started. If you do not wish to wait for them to be restarted
    automatically, then you can delete the `spire-agent` pod, which will cause a new
    one to start up in its place.
+
+1. Enable the NCNs to rejoin Spire.
+   
+   ```bash
+   ncn# kubectl rollout restart -n spire daemonset request-ncn-join-token 
+   ```
 
 1. Re-run the command to get the certificate's expiration date to verify that
    it has been updated.


### PR DESCRIPTION
## Summary and Scope

After updating the Spire intermediate certificate, it is necessary to have NCNs rejoin Spire.

The following command was added:

`ncn# kubectl rollout restart -n spire daemonset request-ncn-join-token `

## Issues and Related PRs

* Resolves [STP-3185](https://jira-pro.its.hpecorp.net:8443/browse/STP-3185) and [CAST-29620](https://jira-pro.its.hpecorp.net:8443/browse/CAST-29620)
* Change will also be needed in `release/1.2`, `release/1.2.5`, and `main`

## Testing

N/A

### Tested on:

N/A

### Test description:

N/A

## Risks and Mitigations

None.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

