### PR TITLE
MTL-1666 fix ports 1.2.5

### DIFF
--- a/install/cable_management_network_servers.md
+++ b/install/cable_management_network_servers.md
@@ -75,9 +75,9 @@ The table below describes the cabling of dual card configurations. Also read not
 | Device | Port | Linux Device | Destination | Name | VLAN | LAG |
 |:-------|------|:------|:-------------------------|:--------------|:--------------------|:-----|
 | OCP        | 1 | mgmt0  | primary      |  N/A |  HMN, NMN, CAN  |  MLAG-LACP |
-| OCP        | 2 | mgmt1  | N/A          |  N/A |  N/A            |  N/A       |
-| PCIE-SLOT1 | 1 | mgmt2  | secondary    |  N/A |  HMN, NMN, CAN  |  MLAG-LACP |
-| PCIE-SLOT1 | 2 | mgmt3  | N/A          |  N/A |  N/A  |  N/A    |
+| OCP        | 2 | sun0   | N/A          |  N/A |  N/A            |  N/A       |
+| PCIE-SLOT1 | 1 | mgmt1  | secondary    |  N/A |  HMN, NMN, CAN  |  MLAG-LACP |
+| PCIE-SLOT1 | 2 | sun1   | N/A          |  N/A |  N/A  |  N/A    |
 | ILO        | 1 | None   | HMN leaf-bmc |  N/A |  HMN  |  N/A    |
 
 <br>
@@ -110,9 +110,9 @@ NOTES:
 | Device | Port | Linux Device | Destination | Name | VLAN | LAG |
 |:-------|------|:------|:-------------------------|:--------------|:--------------------|:-----|
 | OCP        | 1 |  mgmt0 | primary      |  N/A |  HMN, NMN, CAN  |  MLAG-LACP |
-| OCP        | 2 |  mgmt1 | primary      |  N/A |  SUN            |  MLAG-LACP |
-| PCIE-SLOT1 | 1 |  mgmt2 | secondary    |  N/A |  HMN, NMN, CAN  |  MLAG-LACP |
-| PCIE-SLOT1 | 2 |  mgmt3 | secondary    |  N/A |  SUN            |  MLAG-LACP |
+| OCP        | 2 |  sun0  | primary      |  N/A |  SUN            |  MLAG-LACP |
+| PCIE-SLOT1 | 1 |  mgmt1 | secondary    |  N/A |  HMN, NMN, CAN  |  MLAG-LACP |
+| PCIE-SLOT1 | 2 |  sun1  | secondary    |  N/A |  SUN            |  MLAG-LACP |
 | ILO        | 1 |  None  | HMN leaf-bmc |  N/A |  HMN            |  N/A       |
 
 <br>

--- a/install/cable_management_network_servers.md
+++ b/install/cable_management_network_servers.md
@@ -45,9 +45,9 @@ ports on the nodes and how to cable the nodes to the management network switches
 
 | Device | Port | Linux Device | Destination | Name | VLAN | LAG |
 |:-------|------|:------|:-------------------------|:--------------|:--------------------|:-----|
-| OCP | 1 |  mgmt0 | primary |  N/A |  HMN, NMN, CAN  |  MLAG-LACP |
-| OCP | 2 |  mgmt1 | secondary |  N/A |  HMN, NMN, CAN  |  MLAG-LACP |
-| ILO | 1 |  None | HMN leaf-bmc |  N/A |  HMN  |  N/A |
+| OCP | 1 |  mgmt0  | primary      |  N/A  |  HMN, NMN, CAN  |  MLAG-LACP  |
+| OCP | 2 |  mgmt1  | secondary    |  N/A  |  HMN, NMN, CAN  |  MLAG-LACP  |
+| ILO | 1 |  None   | HMN leaf-bmc |  N/A  |  HMN            |  N/A        |
 
 <br>
 NOTES:
@@ -60,8 +60,8 @@ NOTES:
 
 |hostname|Source         |Destination   |Destination |
 |--------|---------------|--------------|------------|
-| wn01	 | x3000u04ocp-j1 | x3000u12-j7 | sw-25g01   |
-| wn01	 | x3000u04ocp-j2 | x3000u13-j7	| sw-25g02   |
+| wn01	 | x3000u04ocp-j1 | x3000u12-j7 | sw-25g01 |
+| wn01	 | x3000u04ocp-j2 | x3000u13-j7	| sw-25g02 |
 
 ![Diagram of HPE Worker Node Cabling](../img/network/HPE_Worker.png)
 
@@ -74,11 +74,11 @@ The table below describes the cabling of dual card configurations. Also read not
 
 | Device | Port | Linux Device | Destination | Name | VLAN | LAG |
 |:-------|------|:------|:-------------------------|:--------------|:--------------------|:-----|
-| OCP | 1 |  mgmt0 | primary |  N/A |  HMN, NMN, CAN  |  MLAG-LACP |
-| OCP | 2 |  mgmt1 | site |  N/A |  N/A  |  N/A |
-| PCIE-SLOT1 | 1 |  mgmt2 | secondary |  N/A |  HMN, NMN, CAN  |  MLAG-LACP |
-| PCIE-SLOT1 | 2 |  mgmt3 | None |  N/A |  N/A  |  N/A |
-| ILO | 1 |  None | HMN leaf-bmc |  N/A |  HMN  |  N/A |
+| OCP        | 1 | mgmt0  | primary      |  N/A |  HMN, NMN, CAN  |  MLAG-LACP |
+| OCP        | 2 | mgmt1  | N/A          |  N/A |  N/A            |  N/A       |
+| PCIE-SLOT1 | 1 | mgmt2  | secondary    |  N/A |  HMN, NMN, CAN  |  MLAG-LACP |
+| PCIE-SLOT1 | 2 | mgmt3  | N/A          |  N/A |  N/A  |  N/A    |
+| ILO        | 1 | None   | HMN leaf-bmc |  N/A |  HMN  |  N/A    |
 
 <br>
 NOTES:
@@ -109,11 +109,11 @@ NOTES:
 
 | Device | Port | Linux Device | Destination | Name | VLAN | LAG |
 |:-------|------|:------|:-------------------------|:--------------|:--------------------|:-----|
-| OCP | 1 |  mgmt0 | primary |  N/A |  HMN, NMN, CAN  |  MLAG-LACP |
-| OCP | 2 |  mgmt1 | primary |  N/A |  SUN  |  MLAG-LACP |
-| PCIE-SLOT1 | 1 |  mgmt2 | secondary |  N/A |  HMN, NMN, CAN  |  MLAG-LACP |
-| PCIE-SLOT1 | 2 |  mgmt3 | secondary |  N/A |  SUN  |  MLAG-LACP |
-| ILO | 1 |  None | HMN leaf-bmc |  N/A |  HMN  |  N/A |
+| OCP        | 1 |  mgmt0 | primary      |  N/A |  HMN, NMN, CAN  |  MLAG-LACP |
+| OCP        | 2 |  mgmt1 | primary      |  N/A |  SUN            |  MLAG-LACP |
+| PCIE-SLOT1 | 1 |  mgmt2 | secondary    |  N/A |  HMN, NMN, CAN  |  MLAG-LACP |
+| PCIE-SLOT1 | 2 |  mgmt3 | secondary    |  N/A |  SUN            |  MLAG-LACP |
+| ILO        | 1 |  None  | HMN leaf-bmc |  N/A |  HMN            |  N/A       |
 
 <br>
 NOTES:
@@ -152,11 +152,11 @@ For systems that include 4 leaf switches the cabling will look like the followin
 
 | Device | Port | Linux Device | Destination | Name | VLAN | LAG |
 |:-------|------|:------|:-------------------------|:--------------|:--------------------|:-----|
-| OCP | 1 |  mgmt0 | primary |  N/A |  NMN  |  N/A |
-| OCP | 2 |  mgmt1 | primary |  N/A |  CAN  |  MLAG-LACP |
-| PCIE-SLOT1 | 1 |  mgmt2 | secondary |  N/A |  N/A  |  N/A |
-| PCIE-SLOT1 | 2 |  mgmt3 | secondary |  N/A |  CAN  |  MLAG-LACP |
-| ILO | 1 |  None | HMN leaf-bmc |  N/A |  HMN  |  N/A |
+| OCP        | 1 |  mgmt0 | primary      |  N/A |  NMN  |  N/A       |
+| OCP        | 2 |  mgmt1 | primary      |  N/A |  CAN  |  MLAG-LACP |
+| PCIE-SLOT1 | 1 |  mgmt2 | secondary    |  N/A |  N/A  |  N/A       |
+| PCIE-SLOT1 | 2 |  mgmt3 | secondary    |  N/A |  CAN  |  MLAG-LACP |
+| ILO        | 1 |  None  | HMN leaf-bmc |  N/A |  HMN  |  N/A       |
 
 <br>
 NOTES:


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

This corrects the interface names for CSM 1.2+

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

No, the interface names changed to remove the extraneous mgmt2 and mgmt3 NICs

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [MTL-1666](https://jira-pro.its.hpecorp.net:8443/browse/MTL-1666)
* Change will also be needed in `release/1.2.5` and `main`

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

