### PR TITLE
CASMPET-5450 1.0 : kube-etcdbackup jobs fail when NCN ncn-s001 is removed

### DIFF
--- a/operations/node_management/Add_Remove_Replace_NCNs/Boot_NCN.md
+++ b/operations/node_management/Add_Remove_Replace_NCNs/Boot_NCN.md
@@ -64,7 +64,7 @@ Boot a master, worker, or storage non-compute node (NCN) that is to be added to 
 
 1. Within several minutes, the node should begin to boot. This can be viewed from the ConMan console window. Eventually, there will be a `NBP file...` message in the console output. This indicates that the PXE boot has started the TFTP download of the `ipxe` program. Later messages will appear as the Linux kernel loads and the scripts in the `initrd` begin to run, including `cloud-init`.
 
-1. Wait until `cloud-init` displays messages similar to these on the console. This indicates that `cloud-init` has finished with the module called `modules:final`.
+1. Wait until `cloud-init` displays messages similar to these on the console. This indicates that `cloud-init` has finished with the module called `modules-final`.
 
     ```screen
     [  300.390000] cloud-init[7110]: 2022-03-16 18:30:59,449 - util.py[DEBUG]: cloud-init mode 'modules' took 244.143 seconds (198.87)

--- a/operations/utility_storage/Add_Ceph_Node.md
+++ b/operations/utility_storage/Add_Ceph_Node.md
@@ -29,7 +29,7 @@
     ncn-s# /usr/share/doc/csm/scripts/join_ceph_cluster.sh
     ```
 
-    **IMPORTANT:** In the output from `watch ceph -s` the health should go to a `HEALTH_WARN` state. This is expected. Most commonly you will see an alert about `failed to probe daemons or devices`, but this should clear on its own.
+    **IMPORTANT:** In the output from `watch ceph -s` the health should go to a `HEALTH_WARN` state. This is expected. Most commonly you will see an alert about `failed to probe daemons or devices`, but this should clear on its own. In addition, it may take up to 5 minutes for the added OSDs to report as `up`.  This is dependent on the Ceph Orchestrator performing an inventory and completing batch processing to add the OSDs.
 
 ## Zapping OSDs
 
@@ -136,10 +136,10 @@
      10.252.1.13
      ```
 
-     Update the existing HAproxy config on `ncn-s001` to include the added node.
+     Update the HAproxy config to include the added node. Select a storage node `ncn-s00x` from `ncn-s001`, `ncn-s002`, or `ncn-s003`. This cannot be done from the added node.
 
      ```
-     ncn-s001# vi /etc/haproxy/haproxy.cfg
+     ncn-s00x# vi /etc/haproxy/haproxy.cfg
      ```
 
      This example adds or updates `ncn-s004` with the IP address `10.252.1.13` to `backend rgw-backend`.
@@ -157,10 +157,10 @@
      ...
      ```
 
-     Copy the HAproxy config from `ncn-s001` to all the storage nodes. Adjust the command based on the number of storage nodes.
+     Copy the updated HAproxy config to all the storage nodes. Adjust the command based on the number of storage nodes.
 
      ```bash
-     ncn-s001# pdcp -w ncn-s00[2-(end node number)] /etc/haproxy/haproxy.cfg /etc/haproxy/haproxy.cfg
+     ncn-s00x# pdcp -w ncn-s00[1-(end node number)] /etc/haproxy/haproxy.cfg /etc/haproxy/haproxy.cfg
      ```
       
      Configure `apparmor` and KeepAlived **on the added node** and restart the services across all the storage nodes.


### PR DESCRIPTION
## Summary and Scope

* CASMPET-5450 : kube-etcdbackup jobs fail when NCN ncn-s001 is removed
Added `systemctl stop keepalived.service` to removed storage node otherwise rgw-vip may stop working and cause things like kube-etcdbackup to start failing.

* CASMPET-5449 : NCN Storage replace 
Minor doc improvements

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5450](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5450) and [CASMPET-5449](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5449)
* Change will also be needed in NA
* Future work required by NA
* Documentation changes required in NA
* Merge with/before/after NA

## Testing

fanta

### Tested on:

  * dev system

### Test description:

Replace storage node by swapping identity ncn-s001 (sn0 slot13)->(sn4 slot36) and ncn-s004 (sn4 slot36)->(sn0 slot13). And back to the original identity for ncn-s001

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

