### PR TITLE
CASMINST-4283: Add CMN route to net attach defs

### DIFF
--- a/operations/node_management/customize_pcie_hardware.md
+++ b/operations/node_management/customize_pcie_hardware.md
@@ -90,7 +90,7 @@ Identify the hardware configuration by PXE booting a node.
         -----
         ```
 
-1. Use the information returned in the previous step to compare the `PCI.DeviceID` and `PCI.VendorID` values to what is in [Vendor and Bus ID Identification](../../background/ncn_networking.md#vendor-and-bus-id-identification).
+1. Use the information returned in the previous step to compare the `PCI.DeviceID` and `PCI.VendorID` values to what is in [NCN Networking Vendor and Bus ID Identification](../../background/ncn_networking.md#vendor-and-bus-id-identification).
 
 1. Since PoR systems are handled with defaults, at this point one should notice differing `PCI.DeviceID` values than the bolded entries in the Vendor and Bus ID table.
 

--- a/upgrade/1.2/scripts/upgrade/util/update-customizations.sh
+++ b/upgrade/1.2/scripts/upgrade/util/update-customizations.sh
@@ -221,6 +221,24 @@ if [ $errors -gt 0 ]; then
     exit 1
 fi
 
+NMN_GW=$(echo "${NETWORKSJSON}" | jq -r '.[] | select(.Name == "NMN") | .ExtraProperties.Subnets[0].Gateway')
+if [ -z $NMN_GW ]; then
+    echo >&2 "error:  Could not find NMN Gateway"
+    exit 1
+fi
+
+CMN_CIDR=$(echo "${NETWORKSJSON}" | jq -r '.[] | select(.Name == "CMN") | .ExtraProperties.CIDR')
+if [ -z $CMN_CIDR ]; then
+    echo >&2 "error:  Could not find CMN CIDR"
+    exit 1
+fi
+
+# Add the CMN route to macvlan routes if it is not already there
+if [[ -z "$(yq r "$c" "spec.wlm.macvlansetup.routes.(dst==${CMN_CIDR})")" ]]; then
+    yq w -i "$c" "spec.wlm.macvlansetup.routes[+].dst" "${CMN_CIDR}"
+    yq w -i "$c" "spec.wlm.macvlansetup.routes.(dst==${CMN_CIDR}).gw" "${NMN_GW}"
+fi
+
 # Ensure Gitea's PVC configuration has been removed (stop gap for potential upgrades from CSM 0.9.4)
 yq d -i "$c" 'spec.kubernetes.services.gitea.cray-service.persistentVolumeClaims'
 
@@ -413,26 +431,32 @@ fi
 yq d -i "$c" 'spec.kubernetes.services.cray-keycloak-gatekeeper'
 
 # Add oauth2-proxies
-yq w -i "$c" 'spec.kubernetes.sealed_secrets.cray-oauth2-proxy-customer-management.generate.name' 'cray-oauth2-proxy-customer-management'
-yq w -i "$c" 'spec.kubernetes.sealed_secrets.cray-oauth2-proxy-customer-management.generate.data[0].type' randstr
-yq w -i "$c" 'spec.kubernetes.sealed_secrets.cray-oauth2-proxy-customer-management.generate.data[0].args.name' cookie-secret
-yq w -i "$c" 'spec.kubernetes.sealed_secrets.cray-oauth2-proxy-customer-management.generate.data[0].args.length' 32
-yq w -i "$c" 'spec.kubernetes.sealed_secrets.cray-oauth2-proxy-customer-management.generate.data[0].args.encoding' base64
-yq w -i "$c" 'spec.kubernetes.sealed_secrets.cray-oauth2-proxy-customer-management.generate.data[0].args.url_safe' yes
+if [[ -z "$(yq r "$c" 'spec.kubernetes.sealed_secrets.cray-oauth2-proxy-customer-management')" ]]; then
+    yq w -i "$c" 'spec.kubernetes.sealed_secrets.cray-oauth2-proxy-customer-management.generate.name' 'cray-oauth2-proxy-customer-management'
+    yq w -i "$c" 'spec.kubernetes.sealed_secrets.cray-oauth2-proxy-customer-management.generate.data[0].type' randstr
+    yq w -i "$c" 'spec.kubernetes.sealed_secrets.cray-oauth2-proxy-customer-management.generate.data[0].args.name' cookie-secret
+    yq w -i "$c" 'spec.kubernetes.sealed_secrets.cray-oauth2-proxy-customer-management.generate.data[0].args.length' 32
+    yq w -i "$c" 'spec.kubernetes.sealed_secrets.cray-oauth2-proxy-customer-management.generate.data[0].args.encoding' base64
+    yq w -i "$c" 'spec.kubernetes.sealed_secrets.cray-oauth2-proxy-customer-management.generate.data[0].args.url_safe' yes
+fi
 
-yq w -i "$c" 'spec.kubernetes.sealed_secrets.cray-oauth2-proxy-customer-access.generate.name' 'cray-oauth2-proxy-customer-access'
-yq w -i "$c" 'spec.kubernetes.sealed_secrets.cray-oauth2-proxy-customer-access.generate.data[0].type' randstr
-yq w -i "$c" 'spec.kubernetes.sealed_secrets.cray-oauth2-proxy-customer-access.generate.data[0].args.name' cookie-secret
-yq w -i "$c" 'spec.kubernetes.sealed_secrets.cray-oauth2-proxy-customer-access.generate.data[0].args.length' 32
-yq w -i "$c" 'spec.kubernetes.sealed_secrets.cray-oauth2-proxy-customer-access.generate.data[0].args.encoding' base64
-yq w -i "$c" 'spec.kubernetes.sealed_secrets.cray-oauth2-proxy-customer-access.generate.data[0].args.url_safe' yes
+if [[ -z "$(yq r "$c" 'spec.kubernetes.sealed_secrets.cray-oauth2-proxy-customer-access')" ]]; then
+    yq w -i "$c" 'spec.kubernetes.sealed_secrets.cray-oauth2-proxy-customer-access.generate.name' 'cray-oauth2-proxy-customer-access'
+    yq w -i "$c" 'spec.kubernetes.sealed_secrets.cray-oauth2-proxy-customer-access.generate.data[0].type' randstr
+    yq w -i "$c" 'spec.kubernetes.sealed_secrets.cray-oauth2-proxy-customer-access.generate.data[0].args.name' cookie-secret
+    yq w -i "$c" 'spec.kubernetes.sealed_secrets.cray-oauth2-proxy-customer-access.generate.data[0].args.length' 32
+    yq w -i "$c" 'spec.kubernetes.sealed_secrets.cray-oauth2-proxy-customer-access.generate.data[0].args.encoding' base64
+    yq w -i "$c" 'spec.kubernetes.sealed_secrets.cray-oauth2-proxy-customer-access.generate.data[0].args.url_safe' yes
+fi
 
-yq w -i "$c" 'spec.kubernetes.sealed_secrets.cray-oauth2-proxy-customer-high-speed.generate.name' 'cray-oauth2-proxy-customer-high-speed'
-yq w -i "$c" 'spec.kubernetes.sealed_secrets.cray-oauth2-proxy-customer-high-speed.generate.data[0].type' randstr
-yq w -i "$c" 'spec.kubernetes.sealed_secrets.cray-oauth2-proxy-customer-high-speed.generate.data[0].args.name' cookie-secret
-yq w -i "$c" 'spec.kubernetes.sealed_secrets.cray-oauth2-proxy-customer-high-speed.generate.data[0].args.length' 32
-yq w -i "$c" 'spec.kubernetes.sealed_secrets.cray-oauth2-proxy-customer-high-speed.generate.data[0].args.encoding' base64
-yq w -i "$c" 'spec.kubernetes.sealed_secrets.cray-oauth2-proxy-customer-high-speed.generate.data[0].args.url_safe' yes
+if [[ -z "$(yq r "$c" 'spec.kubernetes.sealed_secrets.cray-oauth2-proxy-customer-high-speed')" ]]; then
+    yq w -i "$c" 'spec.kubernetes.sealed_secrets.cray-oauth2-proxy-customer-high-speed.generate.name' 'cray-oauth2-proxy-customer-high-speed'
+    yq w -i "$c" 'spec.kubernetes.sealed_secrets.cray-oauth2-proxy-customer-high-speed.generate.data[0].type' randstr
+    yq w -i "$c" 'spec.kubernetes.sealed_secrets.cray-oauth2-proxy-customer-high-speed.generate.data[0].args.name' cookie-secret
+    yq w -i "$c" 'spec.kubernetes.sealed_secrets.cray-oauth2-proxy-customer-high-speed.generate.data[0].args.length' 32
+    yq w -i "$c" 'spec.kubernetes.sealed_secrets.cray-oauth2-proxy-customer-high-speed.generate.data[0].args.encoding' base64
+    yq w -i "$c" 'spec.kubernetes.sealed_secrets.cray-oauth2-proxy-customer-high-speed.generate.data[0].args.url_safe' yes
+fi
 
 yq w -i --style=single "$c" 'spec.kubernetes.services.cray-oauth2-proxies.customer-management.sealedSecrets[0]'  "{{ kubernetes.sealed_secrets['cray-oauth2-proxy-customer-management'] | toYaml }}"
 yq w -i --style=single "$c" 'spec.kubernetes.services.cray-oauth2-proxies.customer-management.hostAliases[0].ip' '{{ network.netstaticips.nmn_api_gw }}'


### PR DESCRIPTION
#### Summary and Scope
We need prevent UAIs from getting to CMN like we do with NMNLB.   The way this is being accomplished with NMNLB is that a route exists on the UAI that goes to a gateway that it cannot get to.   We are doing the same thing for CMN by adding the CMN subnet to macvlan routes defined in customizations.yaml.  This causes it to be added to the relevant network attachment definitions.

While testing the idempotency, I found that there was still an issue adding `generated` to the cray-oauth2-proxy SealedSecrets when they are already encrypted.   Fixed those as well.

- Fixes #CASMINST-4283

#### Prerequisites

- [x] I tested this `hela`

I pulled the customizations.yaml out of the site-init secret on hela and then ran this new update-customizations.yaml on it.  I checked the diff between the original customizations.yaml and the updated one to verify that only the expected changes were done.  I also ran update-customizations.sh a second and third time to check the idempotency.

```
  macvlansetup:
    nmn_subnet: 10.252.2.0/23
    nmn_supernet: 10.252.0.0/17
    nmn_supernet_gateway: 10.252.0.1
    nmn_vlan: bond0.nmn0
    nmn_reservation_start: 10.252.2.10
    nmn_reservation_end: 10.252.3.254
    routes:
    - dst: 10.100.0.0/17
      gw: 10.252.0.1
    - dst: 10.106.0.0/17
      gw: 10.252.0.1
    - dst: 10.103.0.0/25
      gw: 10.252.0.1
    - dst: 10.92.100.0/24
      gw: 10.252.0.1
```