### PR TITLE
CASMPET-5319 1.2 : DOC : Add to spire postgres restore steps

### DIFF
--- a/operations/kubernetes/Restore_Postgres.md
+++ b/operations/kubernetes/Restore_Postgres.md
@@ -205,7 +205,19 @@ In the event that the Spire Postgres cluster is in a state that the cluster must
     ncn-w001# while [ $(kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/name="${CLIENT}" | grep -v NAME | wc -l) != 3 ] ; do echo "  waiting for pods to start"; sleep 2; done
     ```
 
-11. Restart the `spire-agent` on all the nodes.
+11. Restart the `spire-agent` daemonset and the `spire-jwks` service.
+
+    ```bash
+    ncn-w001# kubectl rollout restart daemonset spire-agent -n ${NAMESPACE}
+    # Wait for the restart to complete
+    ncn-w001# kubectl rollout status daemonset spire-agent -n ${NAMESPACE}
+
+    ncn-w001# kubectl rollout restart deployment spire-jwks -n ${NAMESPACE}
+    # Wait for the restart to complete
+    ncn-w001# kubectl rollout status deployment spire-jwks -n ${NAMESPACE}
+    ```
+
+12. Restart the `spire-agent` on all the nodes.
 
     ```bash
     ncn-w001# pdsh -w ncn-m00[1-3] 'systemctl restart spire-agent'
@@ -213,7 +225,7 @@ In the event that the Spire Postgres cluster is in a state that the cluster must
     ncn-w001# pdsh -w ncn-s00[1-3] 'systemctl restart spire-agent'
     ```
 
-12. Verify the service is working. The following should return a token.
+13. Verify the service is working. The following should return a token.
 
     ```bash
     ncn-w001:# /usr/bin/heartbeat-spire-agent api fetch jwt -socketPath=/root/spire/agent.sock -audience test


### PR DESCRIPTION
## Summary and Scope

An additional step was needed during restore of spire postgres at archer2 to ensure spire-jwks was healthy.

## Issues and Related PRs

* Resolves [CASMPET-5319](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5319)
* Change will also be needed in 1.0, 1.2, 1.2.5, main
* Future work required by NA
* Documentation changes required in NA
* Merge with/before/after NA

## Testing
archer2

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
