### PR TITLE
CASMINST-4283: Add CMN route to net attach defs

### DIFF
--- a/background/ncn_plan_of_record.md
+++ b/background/ncn_plan_of_record.md
@@ -2,8 +2,8 @@
 
 This document outlines the hardware necessary to meet CSM's Plan of Record (PoR). This serves the **minimum, necessary** pieces required per each server in the management plane.
 
-1. If the system's NICs do not align to the PoR NICs outlined below (e.g. Onboard NICs are used instead of PCIe), then follow [Customize PCIe Hardware](../operations/customize_pcie_hardware.md) before booting the NCN(s).
-1. If there are more disks than what is listed below in the PoR for disks, then follow [Customize Disk Hardware](../operations/customize_disk_hardware.md) before booting the NCN(s).
+1. If the system's NICs do not align to the PoR NICs outlined below (e.g. Onboard NICs are used instead of PCIe), then follow [Customize PCIe Hardware](../operations/node_management/customize_pcie_hardware.md) before booting the NCN(s).
+1. If there are more disks than what is listed below in the PoR for disks, then follow [Customize Disk Hardware](../operations/node_management/customize_disk_hardware.md) before booting the NCN(s).
 
 ## Table of Contents
 

--- a/operations/node_management/customize_pcie_hardware.md
+++ b/operations/node_management/customize_pcie_hardware.md
@@ -90,7 +90,7 @@ Identify the hardware configuration by PXE booting a node.
         -----
         ```
 
-1. Use the information returned in the previous step to compare the `PCI.DeviceID` and `PCI.VendorID` values to what is in [NCN Networking Vendor and Bus ID Identification](../background/ncn_networking.md#vendor-and-bus-id-identification).
+1. Use the information returned in the previous step to compare the `PCI.DeviceID` and `PCI.VendorID` values to what is in [NCN Networking Vendor and Bus ID Identification](../../background/ncn_networking.md#vendor-and-bus-id-identification).
 
 1. Since PoR systems are handled with defaults, at this point one should notice differing `PCI.DeviceID` values than the bolded entries in the Vendor and Bus ID table.
 


### PR DESCRIPTION
#### Summary and Scope
We need prevent UAIs from getting to CMN like we do with NMNLB.   The way this is being accomplished with NMNLB is that a route exists on the UAI that goes to a gateway that it cannot get to.   We are doing the same thing for CMN by adding the CMN subnet to macvlan routes defined in customizations.yaml.  This causes it to be added to the relevant network attachment definitions.

While testing the idempotency, I found that there was still an issue adding `generated` to the cray-oauth2-proxy SealedSecrets when they are already encrypted.   Fixed those as well.

- Fixes #CASMINST-4283

#### Prerequisites

- [x] I tested this `hela`

I pulled the customizations.yaml out of the site-init secret on hela and then ran this new update-customizations.yaml on it.  I checked the diff between the original customizations.yaml and the updated one to verify that only the expected changes were done.  I also ran update-customizations.sh a second and third time to check the idempotency.

```
  macvlansetup:
    nmn_subnet: 10.252.2.0/23
    nmn_supernet: 10.252.0.0/17
    nmn_supernet_gateway: 10.252.0.1
    nmn_vlan: bond0.nmn0
    nmn_reservation_start: 10.252.2.10
    nmn_reservation_end: 10.252.3.254
    routes:
    - dst: 10.100.0.0/17
      gw: 10.252.0.1
    - dst: 10.106.0.0/17
      gw: 10.252.0.1
    - dst: 10.103.0.0/25
      gw: 10.252.0.1
    - dst: 10.92.100.0/24
      gw: 10.252.0.1
```