### PR TITLE
CASMINST-4438 dont run ntp pool workaround for ncn-m001 (PIT)

### DIFF
--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -886,7 +886,7 @@ pit# popd
 Run the following command on the PIT node to remove the default pool, which can cause contention issues with NTP.
 
 ```bash
-pit# pdsh -b -S -w "$(grep -oP 'ncn-\w\d+' /etc/dnsmasq.d/statics.conf | sort -u |  tr -t '\n' ',')" 'sed -i "s/^! pool pool\.ntp\.org.*//" /etc/chrony.conf'
+pit# pdsh -b -S -w "$(grep -oP 'ncn-\w\d+' /etc/dnsmasq.d/statics.conf | grep -v m001 | sort -u |  tr -t '\n' ',')" 'sed -i "s/^! pool pool\.ntp\.org.*//" /etc/chrony.conf'
 ```
 
 <a name="validate_management_node_deployment"></a>


### PR DESCRIPTION
Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>

## Summary and Scope

Omits ncn-m001 from a list of hosts to target for a command that fixes an NTP issue.

## Issues and Related PRs

* Resolves CASMINST-4438

## Testing

### Tested on:

  * `#surtur`

### Test description:

Ran the entire command.

## Risks and Mitigations

Low.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
