### PR TITLE
MTL-1647: adjust docs to account for no default root password/keys

### DIFF
--- a/install/deploy_final_ncn.md
+++ b/install/deploy_final_ncn.md
@@ -126,23 +126,9 @@ the Kubernetes cluster as the final of three master nodes forming a quorum.
 
     1. Set the variables.
 
-        **IMPORTANT:** The variables you set depend on whether you customized the default NCN images. The most
-        common procedures that involve customizing the images are
-        [Configuring NCN Images to Use Local Timezone](../operations/node_management/Configure_NTP_on_NCNs.md#configure_ncn_images_to_use_local_timezone) and
-        [Changing NCN Image Root Password and SSH Keys on PIT Node](../operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md).
-        The two paths forward are listed below:
-
-        * If the NCN images were customized, set the following variables:
-
-            ```bash
-            pit# artdir=/var/www/ephemeral/data ; k8sdir=$artdir/k8s ; cephdir=$artdir/ceph
-            ```
-
-        * If the NCN images were **not** customized, set the following variables:
-
-            ```bash
-            pit# artdir=${CSM_PATH}/images ; k8sdir=$artdir/kubernetes ; cephdir=$artdir/storage-ceph
-            ```
+        ```bash
+        pit# artdir=/var/www/ephemeral/data ; k8sdir=$artdir/k8s ; cephdir=$artdir/ceph
+        ```
 
     1. Run the following command.
 

--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -264,7 +264,7 @@ The configuration workflow described here is intended to help understand the exp
 <a name="deploy"></a>
 ### 3.2 Deploy
 
-1. Set the default root password and SSH keys and optionally change the timezone
+1. Set the default root password and SSH keys and optionally change the timezone.
 
    The management nodes images do not contain a default password or default ssh keys.
 

--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -264,13 +264,11 @@ The configuration workflow described here is intended to help understand the exp
 <a name="deploy"></a>
 ### 3.2 Deploy
 
-1. Change the default root password and SSH keys
+1. Set the default root password and SSH keys and optionally change the timezone
 
-   The management nodes deploy with a default password in the image, so it is a recommended best
-   practice for system security to change the root password in the image so that it is
-   not the documented default password.
+   The management nodes images do not contain a default password or default ssh keys.
 
-   It is **strongly encouraged** to change the default root password and SSH keys in the images used to boot the management nodes.
+   It is **required** to set the default root password and SSH keys in the images used to boot the management nodes.
    Follow the NCN image customization steps in [Change NCN Image Root Password and SSH Keys on PIT Node](../operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md)
 
 1. Create boot directories for any NCN in DNS This will create folders for each host in `/var/www`, allowing each host to have their own unique set of artifacts; kernel, initrd, SquashFS, and `script.ipxe` bootscript.

--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -7,7 +7,8 @@
 - [Stage 0.3 - Upgrade Management Network](#update-management-network)
 - [Stage 0.4 - Prerequisites Check](#prerequisites-check)
 - [Stage 0.5 - Backup Workload Manager Data](#backup_workload_manager)
-- [Stage 0.6 - Continue to Stage 1](#continue_to_stage1)
+- [Stage 0.6 - Modify NCN Images](#modify_ncn_images)
+- [Stage 0.7 - Continue to Stage 1](#continue_to_stage1)
 
 <a name="install-latest-docs"></a>
 
@@ -218,6 +219,52 @@ ncn-m001# git push
 
 To prevent any possibility of losing Workload Manager configuration data or files, a back-up is required. Please execute all Backup procedures (for the Workload Manager in use) located in the `Troubleshooting and Administrative Tasks` sub-section of the `Install a Workload Manager` section of the `HPE Cray Programming Environment Installation Guide: CSM on HPE Cray EX`. The resulting backup data should be stored in a safe location off of the system.
 
+<a name="modify_ncn_images"></a>
+## Stage 0.6 - Modify NCN Images
+
+Any site modifications to the images used to boot the management nodes need to be done again
+as part of this upgrade. This includes setting the root password, adding SSH keys for the root
+account, and setting a default timezone.
+
+The management nodes images **do not** contain a default password or SSH keys, so **it is a requirement**
+that they be set and added at this time.
+
+1. Use this procedure to change the `k8s-image` used for master nodes and worker nodes, and the `ceph-image`
+used by utility storage nodes. See
+[Change NCN Image Root Password and SSH Keys](../../operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md)
+for more information.
+
+1. Adjust the version variables used later in the upgrade.
+
+    1. The previous procedure to create the site-customized `k8s-image` and `ceph-image` should have set these variables.
+
+      ```bash
+      ncn-m001# echo $CEPHNEW
+      ncn-m001# echo $K8sNEW
+      ```
+
+    1. Check current versions in `/etc/cray/upgrade/csm/myenv`.
+
+        ```bash
+        ncn-m001# grep CEPH_VERSION /etc/cray/upgrade/csm/myenv
+        ncn-m001# grep KUBERNETES_VERSION /etc/cray/upgrade/csm/myenv
+        ```
+
+    1. If the `CEPH_VERSION` or `KUBERNETES_VERSION` does not match the `CEPHNEW` and `K8SNEW` values, edit the file.
+
+        ```bash
+        ncn-m001# vi /etc/cray/upgrade/csm/myenv
+        ```
+
+1. Change the root password in Vault and the CSM layer of configuration applied during NCN personalizaion, if not done previously.
+
+    Usually this configuration is done during the first time installation of CSM software, but if was not 
+    done at that time, then it should be done now. See
+    [Update NCN Passwords](../../operations/security_and_authentication/Update_NCN_Passwords.md) and
+    [full NCN personalization](../../operations/CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md#set_root_password)
+    for more information.
+
 <a name="continue_to_stage1"></a>
 
-## Stage 0.6 - Continue to Stage 1
+## Stage 0.7 - Continue to Stage 1
+Continue on to [Stage 1 - Ceph image upgrade](https://github.com/Cray-HPE/docs-csm/blob/release/1.2/upgrade/1.2/Stage_1.md).


### PR DESCRIPTION
@heemstra made a PR for MTL-1647 a little while ago which updated the docs to cover the fact that in csm-1.2 the NCN images no longer have a default password or SSH keys. Some of the changes in that PR were reverted, presumably on accident. This PR restores the lost changes.
