### PR TITLE
MTL-1647: adjust docs to account for no default root password/keys

### DIFF
--- a/install/deploy_final_ncn.md
+++ b/install/deploy_final_ncn.md
@@ -126,23 +126,9 @@ the Kubernetes cluster as the final of three master nodes forming a quorum.
 
     1. Set the variables.
 
-        **IMPORTANT:** The variables you set depend on whether you customized the default NCN images. The most
-        common procedures that involve customizing the images are
-        [Configuring NCN Images to Use Local Timezone](../operations/node_management/Configure_NTP_on_NCNs.md#configure_ncn_images_to_use_local_timezone) and
-        [Changing NCN Image Root Password and SSH Keys on PIT Node](../operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md).
-        The two paths forward are listed below:
-
-        * If the NCN images were customized, set the following variables:
-
-            ```bash
-            pit# artdir=/var/www/ephemeral/data ; k8sdir=$artdir/k8s ; cephdir=$artdir/ceph
-            ```
-
-        * If the NCN images were **not** customized, set the following variables:
-
-            ```bash
-            pit# artdir=${CSM_PATH}/images ; k8sdir=$artdir/kubernetes ; cephdir=$artdir/storage-ceph
-            ```
+        ```bash
+        pit# artdir=/var/www/ephemeral/data ; k8sdir=$artdir/k8s ; cephdir=$artdir/ceph
+        ```
 
     1. Run the following command.
 

--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -264,7 +264,7 @@ The configuration workflow described here is intended to help understand the exp
 <a name="deploy"></a>
 ### 3.2 Deploy
 
-1. Set the default root password and SSH keys and optionally change the timezone
+1. Set the default root password and SSH keys and optionally change the timezone.
 
    The management nodes images do not contain a default password or default ssh keys.
 

--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -264,13 +264,11 @@ The configuration workflow described here is intended to help understand the exp
 <a name="deploy"></a>
 ### 3.2 Deploy
 
-1. Change the default root password and SSH keys
+1. Set the default root password and SSH keys and optionally change the timezone
 
-   The management nodes deploy with a default password in the image, so it is a recommended best
-   practice for system security to change the root password in the image so that it is
-   not the documented default password.
+   The management nodes images do not contain a default password or default ssh keys.
 
-   It is **strongly encouraged** to change the default root password and SSH keys in the images used to boot the management nodes.
+   It is **required** to set the default root password and SSH keys in the images used to boot the management nodes.
    Follow the NCN image customization steps in [Change NCN Image Root Password and SSH Keys on PIT Node](../operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md)
 
 1. Create boot directories for any NCN in DNS This will create folders for each host in `/var/www`, allowing each host to have their own unique set of artifacts; kernel, initrd, SquashFS, and `script.ipxe` bootscript.


### PR DESCRIPTION
@heemstra made a PR for MTL-1647 a little while ago which updated the docs to cover the fact that in csm-1.2 the NCN images no longer have a default password or SSH keys. Some of the changes in that PR were reverted, presumably on accident. This PR restores the lost changes.
