### PR TITLE
CASMINST-4447 - Adding Ceph upgrade restart if image pull failed

### DIFF
--- a/upgrade/1.2/Stage_4.md
+++ b/upgrade/1.2/Stage_4.md
@@ -54,6 +54,47 @@
    ncn-s# watch "ceph -s; ceph orch ps"
    ```
 
+**IMPORTANT:** If the `ceph -s` has a warning with "UPGRADE_FAILED_PULL: Upgrade: failed to pull target image" as the description, then follow the below procedure.
+
+**Perform the below steps from one of these nodes (ncn-s001/2/3):**
+ 1. check the upgrade status.
+
+    ```bash
+    ceph orch upgrade status
+    ```
+    ***Sample Output***
+    ```bash
+    {
+       "target_image": "registry.local/artifactory.algol60.net/csm-docker/stable/quay.io/ceph/ceph:v15.2.15",
+       "in_progress": true,
+       "services_complete": [],
+       "message": "Error: UPGRADE_FAILED_PULL: Upgrade: failed to pull target image"
+     }
+     ```
+ 2. Pause and resume the upgrade.
+   
+    ```bash
+    ceph orch upgrade pause
+    ceph orch upgrade resume
+    ```
+
+1.  Watch cephadm
+
+    ```bash
+    ceph -W cephadm
+    ```
+
+    ***Note:*** This will watch the cephadm logs and if the occurence occurs again it will give you more detail as to which node may be having an issue.
+
+2. If the issue occurs again then log into each of the storage nodes and perform a podman pull of the image.
+
+    ```bash
+    podman pull registry.local/artifactory.algol60.net/csm-docker/stable/quay.io/ceph/ceph:v15.2.15
+    ```
+
+    * If a node cannot pulled from any of the nodes then please contact support for further assistance.  
+
+
 Expected Warnings:
 
 From `ceph -s`


### PR DESCRIPTION
## Summary and Scope

We have seen this occur once, but adding it as it is good documentation to have.

## Issues and Related PRs

* Resolves CASMINST-4447


## Testing

### Tested on:

  * drax

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

