### PR TITLE
CASMINST-4440: remove duplicate step, clarify another

### DIFF
--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md
@@ -39,13 +39,6 @@ The Kubernetes image is used by the master and worker nodes.
    pit# unsquashfs kubernetes-0.1.69.squashfs
    ```
 
-1. Save the old SquashFS image, kernel, and initrd.
-
-   ```bash
-   pit# mkdir -v old
-   pit# mv -v *squashfs *kernel initrd* old
-   ```
-
 1. Copy the generated public and private SSH keys for the root account into the image.
 
    This example assumes that an RSA key was generated.
@@ -167,7 +160,7 @@ The Kubernetes image is used by the master and worker nodes.
    pit# mv 5.3.18-24.75-default.kernel 5.3.18-24.75-default-${VERSION}.kernel
    ```
 
-1. Set the boot links.
+1. Set the boot links. Skip this step if proceeding to the Ceph Image section below.
 
    ```bash
    pit# cd


### PR DESCRIPTION
## Summary and Scope

Remove the duplicated step of saving the original squashfs images.
Also, clarify that the set-sqfs-links.sh step should be skipped
after modifying the k8s image if you're also modifying the ceph
image.

This verbiage only exists in the `release/1.0` branch.