### PR TITLE
CASMPET-5528 1.0 : DOCS: Fix paths to podman and lsscsi RPMS

### DIFF
--- a/install/bootstrap_livecd_usb.md
+++ b/install/bootstrap_livecd_usb.md
@@ -106,8 +106,8 @@ Fetch the base installation CSM tarball, extract it, and install the contained C
      from the `${CSM_PATH}/rpm/embedded` directory.
 
       ```bash
-      linux# rpm -Uvh ${CSM_PATH}/rpm/embedded/suse/SLE-Module-Containers/15-SP2/x86_64/update/x86_64/podman-*.x86_64.rpm
-      linux# rpm -Uvh ${CSM_PATH}/rpm/embedded/suse/SLE-Module-Containers/15-SP2/x86_64/update/noarch/podman-cni-config-*.noarch.rpm
+      linux# rpm -Uvh ${CSM_PATH}/rpm/embedded/suse/SLE-Module-Containers/15-SP2/x86_64/update/podman-*.x86_64.rpm
+      linux# rpm -Uvh ${CSM_PATH}/rpm/embedded/suse/SLE-Module-Containers/15-SP2/x86_64/update/podman-cni-config-*.noarch.rpm
       ```
 
 1. Install `lsscsi` to view attached storage devices.
@@ -125,7 +125,7 @@ Fetch the base installation CSM tarball, extract it, and install the contained C
      from the `${CSM_PATH}/rpm/embedded` directory.
 
       ```bash
-      linux# rpm -Uvh ${CSM_PATH}/rpm/embedded/suse/SLE-Module-Basesystem/15-SP2/x86_64/product/x86_64/lsscsi-*.x86_64.rpm
+      linux# rpm -Uvh ${CSM_PATH}/rpm/embedded/suse/SLE-Module-Basesystem/15-SP2/x86_64/product/lsscsi-*.x86_64.rpm
       ```
 
 1. Although not strictly required, the procedures for setting up the


### PR DESCRIPTION
## Summary and Scope

Seen during fanta 1.2 fresh install.
Paths to install or upgrade podman and lsscsi RPMS need correcting

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5528](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5528)
* Change will also be needed in 1.0, 1.2, 1.2.5 and main
* Future work required by NA
* Documentation changes required in NA
* Merge with/before/after NA

## Testing

_List the environments in which these changes were tested._

### Tested on:

* fanta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

None

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
