### PR TITLE
CASMINST-4464: Modify pdsh command to avoid authentication errors

### DIFF
--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -337,7 +337,8 @@ The configuration workflow described here is intended to help understand the exp
     ncn-w003-mgmt
     ```
 
-    > **`NOTE`**: All consoles are located at `/var/log/conman/console*`
+    > **`NOTE`**: All console logs are located at `/var/log/conman/console*`
+
 <a name="boot-the-storage-nodes"></a>
 1. Boot the **Storage Nodes**
 
@@ -349,31 +350,17 @@ The configuration workflow described here is intended to help understand the exp
          sleep 60; ipmitool -I lanplus -U $USERNAME -E -H ncn-s001-mgmt power on
     ```
 
-1. Wait. Observe the installation through `ncn-s001-mgmt`'s console:
-
-    Print the console name:
-
-    ```bash
-    pit# conman -q | grep s001
-    ```
-
-    Expected output looks similar to the following:
-
-    ```text
-    ncn-s001-mgmt
-    ```
-
-    Then join the console:
+1. Observe the installation through the console of `ncn-s001-mgmt`.
 
     ```bash
     pit# conman -j ncn-s001-mgmt
     ```
 
-    From there an administrator can witness console-output for the cloud-init scripts.
+    From there an administrator can witness console output for the `cloud-init` scripts.
 
-    **`NOTE`**: Watch the storage node consoles carefully for error messages. If any are seen, consult [Ceph-CSI Troubleshooting](ceph_csi_troubleshooting.md)
+    **`NOTE`**: Watch the storage node consoles carefully for error messages. If any are seen, consult [Ceph-CSI Troubleshooting](ceph_csi_troubleshooting.md).
 
-    **`NOTE`**: If the nodes have PXE boot issues (e.g. getting PXE errors, not pulling the ipxe.efi binary), see [PXE boot troubleshooting](pxe_boot_troubleshooting.md)
+    **`NOTE`**: If the nodes have PXE boot issues (for example, getting PXE errors, or not pulling the `ipxe.efi` binary), see [PXE boot troubleshooting](pxe_boot_troubleshooting.md).
 
 1. Wait for storage nodes before booting Kubernetes master nodes and worker nodes.
 
@@ -446,7 +433,7 @@ The configuration workflow described here is intended to help understand the exp
 
 #### 3.3.1 Run The Check
 
-Run the following command on the PIT node to validate that the expected LVM labels are present on disks on the master and worker nodes. When it prompts you for a password, enter the password for `ncn-m002`.
+Run the following command on the PIT node to validate that the expected LVM labels are present on disks on the master and worker nodes. When it prompts you for a password, enter the root password for `ncn-m002`.
 
 ```bash
 pit# /usr/share/doc/csm/install/scripts/check_lvm.sh

--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -717,10 +717,27 @@ pit# popd
 <a name="remove-default-ntp-pool"></a>
 ### 4.5 Remove the default NTP pool
 
-Run the following command on the PIT node to remove the default pool, which can cause contention issues with NTP.
+Run the following command on the PIT node to remove the default pool, which can cause contention issues with NTP. When it prompts you for a password, enter the root password for `ncn-m002`.
 
 ```bash
-pit# pdsh -b -S -w "$(grep -oP 'ncn-\w\d+' /etc/dnsmasq.d/statics.conf | grep -v m001 | sort -u |  tr -t '\n' ',')" 'sed -i "s/^! pool pool\.ntp\.org.*//" /etc/chrony.conf'
+pit# ssh ncn-m002 "\
+        PDSH_SSH_ARGS_APPEND='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' \
+        pdsh -b -S -w $(grep -oP 'ncn-\w\d+' /etc/dnsmasq.d/statics.conf | 
+            grep -v m001 | sort -u |  tr -t '\n' ,) \
+        sed -i \'s/^! pool pool[.]ntp[.]org.*//\' /etc/chrony.conf"
+```
+
+Expected output looks similar to the following:
+```
+Password:
+ncn-m002: Warning: Permanently added 'ncn-m002,10.252.1.11' (ECDSA) to the list of known hosts.
+ncn-s001: Warning: Permanently added 'ncn-s001,10.252.1.6' (ECDSA) to the list of known hosts.
+ncn-s002: Warning: Permanently added 'ncn-s002,10.252.1.5' (ECDSA) to the list of known hosts.
+ncn-s003: Warning: Permanently added 'ncn-s003,10.252.1.4' (ECDSA) to the list of known hosts.
+ncn-m003: Warning: Permanently added 'ncn-m003,10.252.1.10' (ECDSA) to the list of known hosts.
+ncn-w002: Warning: Permanently added 'ncn-w002,10.252.1.8' (ECDSA) to the list of known hosts.
+ncn-w001: Warning: Permanently added 'ncn-w001,10.252.1.9' (ECDSA) to the list of known hosts.
+ncn-w003: Warning: Permanently added 'ncn-w003,10.252.1.7' (ECDSA) to the list of known hosts.
 ```
 
 <a name="validate_management_node_deployment"></a>


### PR DESCRIPTION
## Summary and Scope

Recently a step was added to the "Deploy Management Nodes" state of the CSM install (for both csm-1.0 and 1.2). This step edits the NTP configuration on all of the NCNs. However, it tries to do this using a `pdsh` command on the PIT node, and this command fails with SSH authentication issues. This is because passwordless SSH is not configured from the PIT node to the other NCNs, and even if it was configured, the command would still fail because of the lack of entries in the known_hosts file.

This PR modifies the command so that it instead is an `ssh` command to ncn-m002, and from there it uses passwordless SSH to the NCNs via `pdsh`. This does mean that the user is prompted once for the root password for ncn-m002, but that's all.

I tested this during my install of surtur today and the change works as expected. No change was made to the edit being done to the NTP configuration file, only to the commands being used in order to execute that change on the NCNs.

This PR also includes some minor linting of the Deploy Management Nodes page.

## Issues and Related PRs

[csm-1.0 PR](https://github.com/Cray-HPE/docs-csm/pull/1363)
[csm-1.2 PR](https://github.com/Cray-HPE/docs-csm/pull/1362)
[csm-1.2.5 PR](https://github.com/Cray-HPE/docs-csm/pull/1361)

## Testing

I tested this during my csm-1.0.11 install on surtur. This section of the install docs is the same for csm-1.0 and csm-1.2, so I am confident that the new command will work there as well. In any case, the current command definitely does not work for csm-1.2.

## Risks and Mitigations

Fairly low risk -- and as noted previously, the current command won't wok, so even if the new command doesn't work (which it does), it wouldn't make things worse.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable