### PR TITLE
CASMTRIAGE-3149: Provide special character handling when changing SNMP, Air-cooled Node BMC, ServerTech PDU, and CEC password change procedures.

### DIFF
--- a/operations/security_and_authentication/Change_Air-Cooled_Node_BMC_Credentials.md
+++ b/operations/security_and_authentication/Change_Air-Cooled_Node_BMC_Credentials.md
@@ -13,9 +13,19 @@ All air-cooled and liquid-cooled BMCs share the same global credentials. The air
 
 ### Procedure
 
-1.  Create an SCSD payload file to change all air-cooled node BMCs to the same global credential:
+1.  Set the `NEW_BMC_CREDENTIAL` to specify the new root user password for air-cooled node BMCs:
     ```bash
-    ncn-m001# export NEW_BMC_CREDENTIAL=new.root.password
+    ncn-m001# read -s NEW_BMC_CREDENTIAL
+    ncn-m001# echo $NEW_BMC_CREDENTIAL
+    ```
+
+    Expected output:
+    ```
+    new.root.password
+    ```
+
+2.  Create an SCSD payload file to change all air-cooled node BMCs to the same global credential:
+    ```bash
     ncn-m001# cat > bmc_creds_glb.json <<DATA
     {
         "Force":false,
@@ -32,19 +42,19 @@ All air-cooled and liquid-cooled BMCs share the same global credentials. The air
     ncn-m001# cat bmc_creds_glb.json | jq
     ```
 
-2.  Apply the new BMC credentials:
+3.  Apply the new BMC credentials:
     ```bash
     ncn-m001# cray scsd bmc globalcreds create ./bmc_creds_glb.json
     ```
 
     **Troubleshooting:** If the above command has any components that do not have the status of OK, they must be retried until they work, or the retries are exhausted and noted as failures. Failed modules need to be taken out of the system until they are fixed.
 
-3.  Perform a rediscovery on the BMCs that had their credentials changed:
+4.  Perform a rediscovery on the BMCs that had their credentials changed:
     ```bash
     ncn-m001# cray hsm inventory discover create --xnames $(cat bmc_creds_glb.json | jq '.Targets | join(",")' -r)
     ```
 
-4.  Wait for DiscoverOK for all of the BMCs that had their credentials changed. You may need to re-run the command below until all BMCs are DiscoverOK:
+5.  Wait for DiscoverOK for all of the BMCs that had their credentials changed. You may need to re-run the command below until all BMCs are DiscoverOK:
     ```bash
     ncn-m001# for bmc in $(cat bmc_creds_glb.json | jq '.Targets[]' -r); do
         echo "Checking Discovery Status for $bmc"

--- a/operations/security_and_authentication/Change_Credentials_on_ServerTech_PDUs.md
+++ b/operations/security_and_authentication/Change_Credentials_on_ServerTech_PDUs.md
@@ -22,12 +22,24 @@ This procedure changes password used by the `admn` user on ServerTech PDUs. Eith
 
 2.  Specify the existing password for the `admn` user:
     ```bash
-    ncn-m001# OLD_PDU_PASSWORD=secret
+    ncn-m001# read -s OLD_PDU_PASSWORD
+    ncn-m001# echo $OLD_PDU_PASSWORD
+    ```
+
+    Expected output:
+    ```
+    secret
     ```
 
 3.  Specify the new desired password for the `admn` user. The new password must between 1 and 32 characters.
     ```bash
-    ncn-m001# NEW_PDU_PASSWORD=supersecret
+    ncn-m001# read -s NEW_PDU_PASSWORD
+    ncn-m001# echo $NEW_PDU_PASSWORD
+    ```
+
+    Expected output:
+    ```
+    supersecret
     ```
 
 4.  Change password for the `admn` user on the ServerTech PDU.
@@ -36,8 +48,8 @@ This procedure changes password used by the `admn` user on ServerTech PDUs. Eith
     -   To update the password on a single ServerTech PDU in the system:
         ```bash
         ncn-m001# PDU=x3000m0
-        ncn-m001# curl -i -k -u admn:$OLD_PDU_PASSWORD -X PATCH https://$PDU/jaws/config/users/local/admn \
-            -d "{ \"password\": \"$NEW_PDU_PASSWORD\" }"
+        ncn-m001# curl -i -k -u "admn:$OLD_PDU_PASSWORD" -X PATCH https://$PDU/jaws/config/users/local/admn \
+            -d $(jq --arg PASSWORD "$NEW_PDU_PASSWORD" -nc '{password: $PASSWORD}')
         ```
 
         Expected output upon a successful password change:
@@ -56,8 +68,8 @@ This procedure changes password used by the `admn` user on ServerTech PDUs. Eith
         ncn-m001# for PDU in $(cray hsm inventory redfishEndpoints list --type CabinetPDUController --format json |
           jq -r '.RedfishEndpoints[] | select(.FQDN | contains("rts")).ID'); do
             echo "Updating password on $PDU"
-            curl -i -k -u admn:$OLD_PDU_PASSWORD -X PATCH https://$PDU/jaws/config/users/local/admn \
-                -d "{ \"password\": \"$NEW_PDU_PASSWORD\" }"
+            curl -i -k -u "admn:$OLD_PDU_PASSWORD" -X PATCH https://$PDU/jaws/config/users/local/admn \
+                -d $(jq --arg PASSWORD "$NEW_PDU_PASSWORD" -nc '{password: $PASSWORD}')
         done
         ```
 

--- a/operations/security_and_authentication/Change_SNMP_Credentials_on_Leaf_Switches.md
+++ b/operations/security_and_authentication/Change_SNMP_Credentials_on_Leaf_Switches.md
@@ -56,11 +56,34 @@ This procedure changes the SNMP credentials on management leaf switches in the s
         sw-leaf-001# exit
         ```
 
-3.  Update Vault with new SNMP credentials:
+3.  Set environment variables containing the new SNMP credentials:
+    > `read -s` is used to prevent the password from appearing in the command history.
+
+    1.  Set the SNMP auth password environment variable:
+        ```bash
+        ncn-m001# read -s SNMP_AUTH_PASS 
+        ncn-m001# echo $SNMP_AUTH_PASS
+        ```
+
+        Expected output:
+        ```
+        foobar01
+        ```
+
+    2.  Set the SNMP priv password environment variable:
+        ```bash
+        ncn-m001# read -s SNMP_PRIV_PASS
+        ncn-m001# echo $SNMP_PRIV_PASS
+        ```
+
+        Expected output:
+        ```
+        foobar02
+        ```
+
+4.  Update Vault with new SNMP credentials:
 
     ```bash
-    ncn-m001# SNMP_AUTH_PASS=foobar01
-    ncn-m001# SNMP_PRIV_PASS=foobar02
     ncn-m001# VAULT_PASSWD=$(kubectl -n vault get secrets cray-vault-unseal-keys -o json | jq -r '.data["vault-root"]' |  base64 -d)
     ncn-m001# alias vault='kubectl -n vault exec -i cray-vault-0 -c vault -- env VAULT_TOKEN=$VAULT_PASSWD VAULT_ADDR=http://127.0.0.1:8200 VAULT_FORMAT=json vault'
     ```
@@ -89,20 +112,20 @@ This procedure changes the SNMP credentials on management leaf switches in the s
         done
         ```
 
-4.  Restart the River Endpoint Discovery Service (REDS) to pickup the new SNMP credentials:
+5.  Restart the River Endpoint Discovery Service (REDS) to pickup the new SNMP credentials:
 
     ```bash
     ncn-m001# kubectl -n services rollout restart deployment cray-reds
     ncn-m001# kubectl -n services rollout status deployment cray-reds
     ```
 
-5.  Wait for REDS to initialize itself:
+6.  Wait for REDS to initialize itself:
 
     ```bash
     ncn-m001# sleep 2m
     ```
 
-6.  Verify REDS was able to communicate with the leaf switches with the updated credentials:
+7.  Verify REDS was able to communicate with the leaf switches with the updated credentials:
 
     Determine the name of the REDS pods:
 

--- a/operations/security_and_authentication/Updating_the_Liquid-Cooled_EX_Cabinet_Default_Credentials_after_a_CEC_Password_Change.md
+++ b/operations/security_and_authentication/Updating_the_Liquid-Cooled_EX_Cabinet_Default_Credentials_after_a_CEC_Password_Change.md
@@ -176,7 +176,13 @@ Before redeploying MEDS, update the `customizations.yaml` file in the `site-init
 ### 2. Update credentials for existing EX hardware in the system
 1. Set `CRED_PASSWORD` to the new updated password:
     ```bash
-    ncn-m001# CRED_PASSWORD=foobar
+    ncn-m001# read -s CRED_PASSWORD
+    ncn-m001# echo $CRED_PASSWORD
+    ```
+
+    Expected output:
+    ```
+    foobar
     ```
 
 2. Update the credentials used by CSM services for all previously discovered EX cabinet BMCs to the new global default:


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
Provide special character handling when changing SNMP, Air-cooled Node BMC, ServerTech PDU, and CEC password change procedures.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMTRIAGE-3149

## Testing

_List the environments in which these changes were tested._

### Tested on:
  * Surtur
  * Fanta
 
### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

Ran through the read-only steps of these procedures to verify that environment variables can correctly contain passwords with special characters. 

Changed the credentials of a ServerTech PDU using the updated curl command utilizing jq for handling special characters in the payload.

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
Low risk. 

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

