### PR TITLE
CASMTRIAGE-3225 Nexus repo does not exist

### DIFF
--- a/upgrade/1.2/scripts/upgrade/prerequisites.sh
+++ b/upgrade/1.2/scripts/upgrade/prerequisites.sh
@@ -240,7 +240,7 @@ if [[ $state_recorded == "0" ]]; then
         [[ -n ${USERNAME} ]]
 
         # Install our pit-init RPM and pull in any dependencies it has.
-        zypper --no-gpg-checks in -y pit-init
+        zypper --no-gpg-checks --plus-repo=https://packages.local/repository/csm-sle-15sp2 in -y pit-init
         /root/bin/bios-baseline.sh -y
 
         # Remove our pit-init RPM and any dependencies it had.


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

During testing the nexus repo providing the RPMs from the tarball existed on the system, but in reality this is false. This change simply adds the repo for a one-time-use in the CASMINST-4458 function.

The fix allowed the failing step to continue:

```bash
====> UPDATE_SSH_KEYS has been completed
====> CHECK_CLOUD_INIT_PREREQ has been completed
====> UPDATE_DOC_RPM has been completed
====> UPDATE_CUSTOMIZATIONS has been completed
====> SETUP_NEXUS has been completed
====> DISABLE_SERVICE_REPOS has been completed
====> REMOVE_DUPLICATE_BMC_DNS_RECORDS ...
====> REMOVE_DUPLICATE_BMC_DNS_RECORDS has been completed
====> UPGRADE_BSS ...
====> UPGRADE_BSS has been completed
====> UPGRADE_KEA ...
====> UPGRADE_KEA has been completed
====> UPLOAD_NEW_NCN_IMAGE ...
```


_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

N/A

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-3225](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3225)
* Change will also be needed in `main` and `release/1.2`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `surtur`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

This was invoked and the failed step succeeded:

`/usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prerequisites.sh --csm-version csm-1.2.0-beta.106`

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

