### PR TITLE
CASMINST-4468: use an ssh config to ignore unknown hosts

### DIFF
--- a/upgrade/1.2/scripts/common/upgrade-state.sh
+++ b/upgrade/1.2/scripts/common/upgrade-state.sh
@@ -80,6 +80,10 @@ function err_report() {
     echo "$BASH_COMMAND"
     local cmd="$BASH_COMMAND"
 
+    # restore previous ssh config if there was one, remove ours
+    rm -f /root/.ssh/config
+    test -f /root/.ssh/config.bak && mv /root/.ssh/config.bak /root/.ssh/config
+
     # ignore some internal expected errors
     local ignoreCmd="cray artifacts list config-data"
     shouldIgnore=$(echo "$cmd" | grep "${ignoreCmd}" | wc -l)

--- a/upgrade/1.2/scripts/upgrade/prerequisites.sh
+++ b/upgrade/1.2/scripts/upgrade/prerequisites.sh
@@ -70,6 +70,12 @@ if [[ $state_recorded == "0" ]]; then
     echo "====> ${state_name} ..."
     {
 
+    test -f /root/.ssh/config && mv /root/.ssh/config /root/.ssh/config.bak
+    cat <<EOF> /root/.ssh/config
+Host *
+    StrictHostKeyChecking no
+EOF
+
     grep -oP "(ncn-\w+)" /etc/hosts | sort -u | xargs -t -i ssh {} 'truncate --size=0 ~/.ssh/known_hosts'
 
     grep -oP "(ncn-\w+)" /etc/hosts | sort -u | xargs -t -i ssh {} 'grep -oP "(ncn-s\w+|ncn-m\w+|ncn-w\w+)" /etc/hosts | sort -u | xargs -t -i ssh-keyscan -H \{\} >> /root/.ssh/known_hosts'
@@ -610,6 +616,10 @@ if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
 else
     echo "====> ${state_name} has been completed"
 fi
+
+# restore previous ssh config if there was one, remove ours
+rm -f /root/.ssh/config
+test -f /root/.ssh/config.bak && mv /root/.ssh/config.bak /root/.ssh/config
 
 ok_report
 

--- a/upgrade/1.2/scripts/upgrade/prerequisites.sh
+++ b/upgrade/1.2/scripts/upgrade/prerequisites.sh
@@ -104,7 +104,7 @@ if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
             ssh $host cloud-init init 2>&1 >/dev/null
             counter=$((counter+1))
             sleep 10
-            if [[ $counter > 5 ]]
+            if [[ $counter -gt 5 ]]
             then
             echo "Cloud init data is missing and cannot be recreated. Existing upgrade.."
             fi


### PR DESCRIPTION
## Summary and Scope

Add a .ssh/config file that will ignore host key issues for
unknown hosts.  On error, Remove it and restore the original
one that existed.

While here, fix another bug:

Use -gt for numerical comparison.

`>` is for comparing strings and does not work like you'd expect
for numbers.
```
C02YR1QYLVCJ:~ heemstra$ counter=10
C02YR1QYLVCJ:~ heemstra$ if [[ $counter > 5 ]]; then echo "larger"; fi
C02YR1QYLVCJ:~ heemstra$ if [[ $counter -gt 5 ]]; then echo "larger"; fi
larger
C02YR1QYLVCJ:~ heemstra$
```