### PR TITLE
CASMINST-4468: invoke the cleanup function on more signals

### DIFF
--- a/upgrade/1.2/scripts/upgrade/prerequisites.sh
+++ b/upgrade/1.2/scripts/upgrade/prerequisites.sh
@@ -27,7 +27,7 @@ set -e
 locOfScript=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 . ${locOfScript}/../common/upgrade-state.sh
 . ${locOfScript}/../common/ncn-common.sh $(hostname)
-trap 'err_report' ERR
+trap 'err_report' ERR INT TERM HUP
 # array for paths to unmount after chrooting images
 declare -a UNMOUNTS=()
 


### PR DESCRIPTION
## Summary and Scope

We want the cleanup function to run in the case of a kill or a control-C as well.