### PR TITLE
CASMINST-4476: Lint and correct error in Backup Custom Config page

### DIFF
--- a/operations/network/management_network/backup_custom_config.md
+++ b/operations/network/management_network/backup_custom_config.md
@@ -144,7 +144,7 @@ snmpv3 user testuser auth md5 auth-pass plaintext xxxxxx priv des priv-pass plai
 ### Dell
 
 ```
-sw-leaf-001# show running-configuration | include snmp
+sw-leaf-001# show running-configuration | grep snmp
 snmp-server group cray-reds-group 3 noauth read cray-reds-view
 snmp-server user xxxxxx cray-reds-group 3 auth md5 xxxxxx priv des xxxxxx
 snmp-server view cray-reds-view 1.3.6.1.2 included

--- a/operations/network/management_network/backup_custom_config.md
+++ b/operations/network/management_network/backup_custom_config.md
@@ -4,35 +4,35 @@
 
 - Access to the switches.
 
-If your doing a fresh install of CSM but previously had a different version of CSM installed you will need to backup/restore certain switch config after the switch has been wiped.
+If you are doing a fresh install of CSM but previously had a different version of CSM installed, then you will need to backup/restore certain switch configurations after the switch has been wiped.
 
-This needs to be done before wiping the switch.
+The backup needs to be done before wiping the switch.
 
 This includes:
 
-- users and passwords
-- snmp credentials
-- site connections
-- interface speed commands
-- default routes
-- any other customized config for this system
+- Users and passwords
+- SNMP credentials
+- Site connections
+- Interface speed commands
+- Default routes
+- Any other customized configuration for this system
 
 This configuration will likely vary from site to site. This guide will cover the most common site setup.
 
-### Backup site connection configuration
+## Backup site connection configuration
 
-You can find the site connections on the SHCD.
+You can find the site connections in the SHCD file.
 
 ```
 CAN switch	cfcanb6s1	 	 	-	31	sw-25g01	x3000	u39	-	j36
 CAN switch	cfcanb6s1	 	 	-	46	sw-25g02	x3000	u40	-	j36
 ```
 
-With this info we know that we need to back the config on port 36 on both spine switches.
+With this information we know that we need to backup the configuration on port 36 on both spine switches.
 
-log onto the switches and get the configs of the ports and the default route config. Save this output, this will be used after we apply the generated configs.
+Log into the switches. Get the configurationss of the ports and the default route. Save this output; this will be used after we apply the generated configurations.
 
-#### Aruba
+### Aruba
 
 ```
 sw-spine-001# show run int 1/1/36
@@ -102,16 +102,16 @@ sw-spine-002 [mlag-domain: master] # show run | include "ip route"
    ip route 0.0.0.0/0 10.102.255.85
 ```
 
-### Backup users/password
+## Backup users/passwords
 
-#### Aruba
+### Aruba
 
 ```
 sw-leaf-bmc-001# show run | include user
 user admin group administrators password ciphertext xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ```
 
-##### Dell
+### Dell
 
 ```
 sw-leaf-001# show running-configuration | grep user
@@ -119,33 +119,33 @@ system-user linuxadmin password xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 username admin password xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx role sysadmin priv-lvl 15
 ```
 
-##### Mellanox
+### Mellanox
 
 ```
 sw-spine-001 [standalone: master] # show run | include username
    username admin password 7 xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
    username monitor password 7 xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-   ```
+```
 
-#### Backup SNMP credentials
+## Backup SNMP credentials
 
-SNMP is currently only used on sw-leaf-bmc switches, these credentials can be retrieved from vault. More info on SNMP creds can be found on the [Change SNMP Credentials on Leaf-BMC Switches](../../../operations/security_and_authentication/Change_SNMP_Credentials_on_Leaf_BMC_Switches.md) page.
+SNMP is currently only used on sw-leaf-bmc switches. These credentials can be retrieved from Vault. For more information on SNMP credentials, see [Change SNMP Credentials on Leaf-BMC Switches](../../../operations/security_and_authentication/Change_SNMP_Credentials_on_Leaf_BMC_Switches.md).
 
-Once these credentials are retrieved from Vault you can fill in the `xxxxxx` fields below.
+Once these credentials are retrieved from Vault, you can fill in the `xxxxxx` fields below.
 
-##### Aruba
+### Aruba
 
 ```
 sw-leaf-001# show run | include snmp
 snmp-server vrf default
 snmpv3 user testuser auth md5 auth-pass plaintext xxxxxx priv des priv-pass plaintext xxxxxx
- ```
+```
 
-##### Dell
+### Dell
 
 ```
 sw-leaf-001# show running-configuration | include snmp
 snmp-server group cray-reds-group 3 noauth read cray-reds-view
 snmp-server user xxxxxx cray-reds-group 3 auth md5 xxxxxx priv des xxxxxx
 snmp-server view cray-reds-view 1.3.6.1.2 included
- ```
+```


### PR DESCRIPTION
## Summary and Scope

Most of this PR is pure linting. The only non-linting change is correcting one command on a Dell switch. The command used the `include` command, but on Dell switches that should be the `grep` command.

## Issues and Related PRs

* [csm-1.2 backport](https://github.com/Cray-HPE/docs-csm/pull/1390)
* This page does not exist prior to 1.2

## Testing

I tested the updated Dell command on a switch on mug.

## Risks and Mitigations

Very low risk.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
