### PR TITLE
CASMINST-4246:  Add uai-gateway-test.sh

### DIFF
--- a/operations/network/gateway_testing.md
+++ b/operations/network/gateway_testing.md
@@ -7,15 +7,31 @@ This page describes how to run a set of tests to determine if the gateways are f
 
 When the nmnlb network is specified, it will use `api-gw-service-nmn.local` as an override for `nmnlb.<system-domain>` in 1.2. You can set `use-api-gw-override: false` in gateway-test-defn.yaml if you would like to disable that override and use `nmnlb.<system-domain>`.
 
-## Running gateway tests from an NCN
+## Running gateway tests on an NCN
 
-The gateway test script can be found in `/usr/share/doc/csm/scripts/operations/gateway-test`. When `gateway-test.py` is run from an NCN, it has access to the admin client secret using `kubectl`. It will use the admin client secret to get the token for accessing the APIs.
+The gateway test scripts can be found in `/usr/share/doc/csm/scripts/operations/gateway-test`. To test the gateways from an NCN you will need to use gateway-test.py.  When `gateway-test.py` is run from an NCN, it has access to the admin client secret using `kubectl`. It will use the admin client secret to get the token for accessing the APIs.
 
-You can run the test by executing the following command. You will need to specify the system domain (for example, `eniac.dev.cray.com`) and the network you would like to use to obtain the token (for example, `nmnlb`, `can`, `cmn`, or `chn`)
+You can run the test by executing the following command. You will need to specify the system domain (for example, `eniac.dev.cray.com`).
 
 ```bash
-ncn# /usr/share/doc/csm/scripts/operations/gateway-test/gateway-test.py eniac.dev.cray.com nmnlb
+ncn# /usr/share/doc/csm/scripts/operations/gateway-test/gateway-test.py eniac.dev.cray.com
 ```
+
+The test will cycle through all of the test networks specified in gateway-test-defn.yaml.
+
+```bash
+test-networks:
+- name: nmnlb
+  gateway: services-gateway
+- name: cmn
+  gateway: services-gateway
+- name: can
+  gateway: customer-user-gateway
+- name: chn
+  gateway: customer-user-gateway
+```
+
+For each network it will attempt to obtain a token from keycloak.  On an NCN, it should be able to get a token from each of those networks.  It will then use that token to attempt to access each of the services defined in gateway-test-defn.yaml on each of the test-networks.   The test will be able to determine whether it should or should not be able to access the service and it will output a PASS or FAIL for each test depending on the actual results.
 
 ## Running gateway tests from UAN, Compute Node, or a device outside of the cluster
 
@@ -31,49 +47,93 @@ You will then need to set the ADMIN_CLIENT_SECRET environment variable to the ad
 linux# export ADMIN_CLIENT_SECRET=26947343-d4ab-403b-14e937dbd700
 ```
 
-You can run the tests by executing the following the command. You will need to specify the system domain (e.g. eniac.dev.cray.com) and the network you would like to use to obtain the token (e.g. nmnlb, can.cmn, chn).
+You can run the tests by executing the following the command. You will need to specify the system domain (e.g. eniac.dev.cray.com).
 
 ```bash
-linux# /usr/share/doc/csm/scripts/operations/gateway-test/gateway-test.py eniac.dev.cray.com cmn
+linux# /usr/share/doc/csm/scripts/operations/gateway-test/gateway-test.py eniac.dev.cray.com
 ```
 
-## Example results
+## Running gateway tests on a UAI 
+
+To test the gateways from a UAI you will need to run `uai-gateway-test.sh`.  
+
+This script will execute the following steps:
+
+* Create a UAI with a cray-uai-gateway-test image.
+* Pass the system domain, user network, and admin client secret to the test UAI.
+* Execute gateway-test.py on the node
+* Output the results
+* Delete the test UAI
+
+You can run the test by executing the following command.
+
+```bash
+ncn# /usr/share/doc/csm/scripts/operations/gateway-test/uai-gateway-test.sh
+```
+
+The test will find the first UAI gateway-test image to create the test UAI.  If you prefer to specify a different image, you can use the --imagename option.
+
+## Example Results 
 
 The results of running the tests will show the following
 
 * Retrieval of a token on the CMN network in order to get SLS data to determine which networks are defined on the system
-* Retrieval of a token on the network specified on the command line to use for testing the APIs
-* Results from each of the networks defined in `gateway-test-defn.yaml`. It will attempt to access each of the services on the network and check the expected results.
-  * It will show PASS or FAIL depending on the expected response for the service and the token being used.
-  * It will show SKIP for services that are not expected to be installed on the system.
-* The return code of the test will be non-zero if any of the tests fail or we are unable to retrieve a token on any of the networks that are expected to be accessible.
+* For each of the test networks...
+    * Retrieval of a token on the network under test
+    * Results from each of the networks defined in `gateway-test-defn.yaml`. It will attempt to access each of the services with the token and check the expected results.
+    * It will show PASS or FAIL depending on the expected response for the service and the token being used.
+    * It will show SKIP for services that are not expected to be installed on the system.
+* The return code at the end of gateway-test.py will be non-zero if any of the tests within it fail or we are unable to retrieve a token on any of the networks that are expected to be accessible.
 
-NOTE: In this example we are running from a server outside the cluster. It is expected that `api-gw-service-nmn.local` is unreachable from this location.
+### Running from an NCN that is configured with CHN as the user network. 
 
 ```bash
-# export ADMIN_CLIENT_SECRET=26947343-d4ab-403b-14e937dbd700
-# ./gateway-test.py eniac.dev.cray.com cmn
+# ./gateway-test.py eniac.dev.cray.com
+
+ncn-m001# ./gateway-test.py eniac.dev.cray.com
 auth.cmn.eniac.dev.cray.com is reachable
 Token successfully retrieved at https://auth.cmn.eniac.dev.cray.com/keycloak/realms/shasta/protocol/openid-connect/token
 
-auth.cmn.eniac.dev.cray.com is reachable
-Token successfully retrieved at https://auth.cmn.eniac.dev.cray.com/keycloak/realms/shasta/protocol/openid-connect/token
+Getting token for nmnlb
+api-gw-service-nmn.local is reachable
+Token successfully retrieved at https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token
 
 
 ------------- api-gw-service-nmn.local -------------------
-ping: api-gw-service-nmn.local: Name or service not known
-api-gw-service-nmn.local is NOT reachable
+api-gw-service-nmn.local is reachable
+PASS - [cray-bos]: https://api-gw-service-nmn.local/apis/bos/v1/session - 200
+PASS - [cray-bss]: https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters - 200
+PASS - [cray-capmc]: https://api-gw-service-nmn.local/apis/capmc/capmc/get_node_rules - 200
+PASS - [cray-cfs-api]: https://api-gw-service-nmn.local/apis/cfs/v2/sessions - 200
+PASS - [cray-console-data]: https://api-gw-service-nmn.local/apis/consoledata/liveness - 204
+PASS - [cray-console-node]: https://api-gw-service-nmn.local/apis/console-node/console-node/liveness - 204
+PASS - [cray-console-operator]: https://api-gw-service-nmn.local/apis/console-operator/console-operator/liveness - 204
+SKIP - [cray-cps]: https://api-gw-service-nmn.local/apis/v2/cps/contents - virtual service not found
+PASS - [cray-fas]: https://api-gw-service-nmn.local/apis/fas/v1/snapshots - 200
+PASS - [cray-hbtd]: https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/health - 200
+PASS - [cray-hmnfd]: https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/health - 200
+PASS - [cray-ims]: https://api-gw-service-nmn.local/apis/ims/images - 200
+PASS - [cray-powerdns-manager]: https://api-gw-service-nmn.local/apis/powerdns-manager/v1/liveness - 204
+PASS - [cray-reds]: https://api-gw-service-nmn.local/apis/reds/v1/liveness - 204
+PASS - [cray-scsd]: https://api-gw-service-nmn.local/apis/scsd/v1/health - 200
+PASS - [cray-sls]: https://api-gw-service-nmn.local/apis/sls/v1/health - 200
+PASS - [cray-smd]: https://api-gw-service-nmn.local/apis/smd/hsm/v1/service/ready - 200
+PASS - [cray-sts]: https://api-gw-service-nmn.local/apis/sts/healthz - 200
+PASS - [cray-uas-mgr]: https://api-gw-service-nmn.local/apis/uas-mgr/v1/images - 200
+SKIP - [nmdv2-service]: https://api-gw-service-nmn.local/apis/v2/nmd/dumps - virtual service not found
+SKIP - [slingshot-fabric-manager]: https://api-gw-service-nmn.local/apis/fabric-manager/fabric/port-policies - virtual service not found
+SKIP - [sma-telemetry]: https://api-gw-service-nmn.local/apis/sma-telemetry-api/v1/ping - virtual service not found
 
 ------------- api.cmn.eniac.dev.cray.com -------------------
 api.cmn.eniac.dev.cray.com is reachable
 PASS - [cray-bos]: https://api.cmn.eniac.dev.cray.com/apis/bos/v1/session - 200
 PASS - [cray-bss]: https://api.cmn.eniac.dev.cray.com/apis/bss/boot/v1/bootparameters - 200
-FAIL - [cray-capmc]: https://api.cmn.eniac.dev.cray.com/apis/capmc/capmc/get_node_rules - 404
+PASS - [cray-capmc]: https://api.cmn.eniac.dev.cray.com/apis/capmc/capmc/get_node_rules - 200
 PASS - [cray-cfs-api]: https://api.cmn.eniac.dev.cray.com/apis/cfs/v2/sessions - 200
 PASS - [cray-console-data]: https://api.cmn.eniac.dev.cray.com/apis/consoledata/liveness - 204
 PASS - [cray-console-node]: https://api.cmn.eniac.dev.cray.com/apis/console-node/console-node/liveness - 204
 PASS - [cray-console-operator]: https://api.cmn.eniac.dev.cray.com/apis/console-operator/console-operator/liveness - 204
-SKIP - [cray-cps]: https://api.cmn.eniac.dev.cray.com/apis/v2/cps/contents
+SKIP - [cray-cps]: https://api.cmn.eniac.dev.cray.com/apis/v2/cps/contents - virtual service not found
 PASS - [cray-fas]: https://api.cmn.eniac.dev.cray.com/apis/fas/v1/snapshots - 200
 PASS - [cray-hbtd]: https://api.cmn.eniac.dev.cray.com/apis/hbtd/hmi/v1/health - 200
 PASS - [cray-hmnfd]: https://api.cmn.eniac.dev.cray.com/apis/hmnfd/hmi/v2/health - 200
@@ -85,10 +145,248 @@ PASS - [cray-sls]: https://api.cmn.eniac.dev.cray.com/apis/sls/v1/health - 200
 PASS - [cray-smd]: https://api.cmn.eniac.dev.cray.com/apis/smd/hsm/v1/service/ready - 200
 PASS - [cray-sts]: https://api.cmn.eniac.dev.cray.com/apis/sts/healthz - 200
 PASS - [cray-uas-mgr]: https://api.cmn.eniac.dev.cray.com/apis/uas-mgr/v1/images - 200
-PASS - [gitea-vcs-web]: https://api.cmn.eniac.dev.cray.com/vcs - 200
-SKIP - [nmdv2-service]: https://api.cmn.eniac.dev.cray.com/apis/v2/nmd/dumps
-SKIP - [slingshot-fabric-manager]: https://api.cmn.eniac.dev.cray.com/apis/fabric-manager/fabric/port-policies
-SKIP - [sma-telemetry]: https://api.cmn.eniac.dev.cray.com/apis/sma-telemetry-api/v1/ping
+SKIP - [nmdv2-service]: https://api.cmn.eniac.dev.cray.com/apis/v2/nmd/dumps - virtual service not found
+SKIP - [slingshot-fabric-manager]: https://api.cmn.eniac.dev.cray.com/apis/fabric-manager/fabric/port-policies - virtual service not found
+SKIP - [sma-telemetry]: https://api.cmn.eniac.dev.cray.com/apis/sma-telemetry-api/v1/ping - virtual service not found
+
+------------- api.can.eniac.dev.cray.com -------------------
+ping: api.can.eniac.dev.cray.com: Name or service not known
+api.can.eniac.dev.cray.com is NOT reachable
+can is not reachable and is not expected to be
+
+------------- api.chn.eniac.dev.cray.com -------------------
+api.chn.eniac.dev.cray.com is reachable
+PASS - [cray-bos]: https://api.chn.eniac.dev.cray.com/apis/bos/v1/session - 404
+PASS - [cray-bss]: https://api.chn.eniac.dev.cray.com/apis/bss/boot/v1/bootparameters - 404
+PASS - [cray-capmc]: https://api.chn.eniac.dev.cray.com/apis/capmc/capmc/get_node_rules - 404
+PASS - [cray-cfs-api]: https://api.chn.eniac.dev.cray.com/apis/cfs/v2/sessions - 404
+PASS - [cray-console-data]: https://api.chn.eniac.dev.cray.com/apis/consoledata/liveness - 404
+PASS - [cray-console-node]: https://api.chn.eniac.dev.cray.com/apis/console-node/console-node/liveness - 404
+PASS - [cray-console-operator]: https://api.chn.eniac.dev.cray.com/apis/console-operator/console-operator/liveness - 404
+SKIP - [cray-cps]: https://api.chn.eniac.dev.cray.com/apis/v2/cps/contents - virtual service not found
+PASS - [cray-fas]: https://api.chn.eniac.dev.cray.com/apis/fas/v1/snapshots - 404
+PASS - [cray-hbtd]: https://api.chn.eniac.dev.cray.com/apis/hbtd/hmi/v1/health - 404
+PASS - [cray-hmnfd]: https://api.chn.eniac.dev.cray.com/apis/hmnfd/hmi/v2/health - 404
+PASS - [cray-ims]: https://api.chn.eniac.dev.cray.com/apis/ims/images - 404
+PASS - [cray-powerdns-manager]: https://api.chn.eniac.dev.cray.com/apis/powerdns-manager/v1/liveness - 404
+PASS - [cray-reds]: https://api.chn.eniac.dev.cray.com/apis/reds/v1/liveness - 404
+PASS - [cray-scsd]: https://api.chn.eniac.dev.cray.com/apis/scsd/v1/health - 404
+PASS - [cray-sls]: https://api.chn.eniac.dev.cray.com/apis/sls/v1/health - 404
+PASS - [cray-smd]: https://api.chn.eniac.dev.cray.com/apis/smd/hsm/v1/service/ready - 404
+PASS - [cray-sts]: https://api.chn.eniac.dev.cray.com/apis/sts/healthz - 404
+PASS - [cray-uas-mgr]: https://api.chn.eniac.dev.cray.com/apis/uas-mgr/v1/images - 404
+SKIP - [nmdv2-service]: https://api.chn.eniac.dev.cray.com/apis/v2/nmd/dumps - virtual service not found
+SKIP - [slingshot-fabric-manager]: https://api.chn.eniac.dev.cray.com/apis/fabric-manager/fabric/port-policies - virtual service not found
+SKIP - [sma-telemetry]: https://api.chn.eniac.dev.cray.com/apis/sma-telemetry-api/v1/ping - virtual service not found
+
+Getting token for cmn
+auth.cmn.eniac.dev.cray.com is reachable
+Token successfully retrieved at https://auth.cmn.eniac.dev.cray.com/keycloak/realms/shasta/protocol/openid-connect/token
+
+
+------------- api-gw-service-nmn.local -------------------
+api-gw-service-nmn.local is reachable
+PASS - [cray-bos]: https://api-gw-service-nmn.local/apis/bos/v1/session - 200
+PASS - [cray-bss]: https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters - 200
+PASS - [cray-capmc]: https://api-gw-service-nmn.local/apis/capmc/capmc/get_node_rules - 200
+PASS - [cray-cfs-api]: https://api-gw-service-nmn.local/apis/cfs/v2/sessions - 200
+PASS - [cray-console-data]: https://api-gw-service-nmn.local/apis/consoledata/liveness - 204
+PASS - [cray-console-node]: https://api-gw-service-nmn.local/apis/console-node/console-node/liveness - 204
+PASS - [cray-console-operator]: https://api-gw-service-nmn.local/apis/console-operator/console-operator/liveness - 204
+SKIP - [cray-cps]: https://api-gw-service-nmn.local/apis/v2/cps/contents - virtual service not found
+PASS - [cray-fas]: https://api-gw-service-nmn.local/apis/fas/v1/snapshots - 200
+PASS - [cray-hbtd]: https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/health - 200
+PASS - [cray-hmnfd]: https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/health - 200
+PASS - [cray-ims]: https://api-gw-service-nmn.local/apis/ims/images - 200
+PASS - [cray-powerdns-manager]: https://api-gw-service-nmn.local/apis/powerdns-manager/v1/liveness - 204
+PASS - [cray-reds]: https://api-gw-service-nmn.local/apis/reds/v1/liveness - 204
+PASS - [cray-scsd]: https://api-gw-service-nmn.local/apis/scsd/v1/health - 200
+PASS - [cray-sls]: https://api-gw-service-nmn.local/apis/sls/v1/health - 200
+PASS - [cray-smd]: https://api-gw-service-nmn.local/apis/smd/hsm/v1/service/ready - 200
+PASS - [cray-sts]: https://api-gw-service-nmn.local/apis/sts/healthz - 200
+PASS - [cray-uas-mgr]: https://api-gw-service-nmn.local/apis/uas-mgr/v1/images - 200
+SKIP - [nmdv2-service]: https://api-gw-service-nmn.local/apis/v2/nmd/dumps - virtual service not found
+SKIP - [slingshot-fabric-manager]: https://api-gw-service-nmn.local/apis/fabric-manager/fabric/port-policies - virtual service not found
+SKIP - [sma-telemetry]: https://api-gw-service-nmn.local/apis/sma-telemetry-api/v1/ping - virtual service not found
+
+------------- api.cmn.eniac.dev.cray.com -------------------
+api.cmn.eniac.dev.cray.com is reachable
+PASS - [cray-bos]: https://api.cmn.eniac.dev.cray.com/apis/bos/v1/session - 200
+PASS - [cray-bss]: https://api.cmn.eniac.dev.cray.com/apis/bss/boot/v1/bootparameters - 200
+PASS - [cray-capmc]: https://api.cmn.eniac.dev.cray.com/apis/capmc/capmc/get_node_rules - 200
+PASS - [cray-cfs-api]: https://api.cmn.eniac.dev.cray.com/apis/cfs/v2/sessions - 200
+PASS - [cray-console-data]: https://api.cmn.eniac.dev.cray.com/apis/consoledata/liveness - 204
+PASS - [cray-console-node]: https://api.cmn.eniac.dev.cray.com/apis/console-node/console-node/liveness - 204
+PASS - [cray-console-operator]: https://api.cmn.eniac.dev.cray.com/apis/console-operator/console-operator/liveness - 204
+SKIP - [cray-cps]: https://api.cmn.eniac.dev.cray.com/apis/v2/cps/contents - virtual service not found
+PASS - [cray-fas]: https://api.cmn.eniac.dev.cray.com/apis/fas/v1/snapshots - 200
+PASS - [cray-hbtd]: https://api.cmn.eniac.dev.cray.com/apis/hbtd/hmi/v1/health - 200
+PASS - [cray-hmnfd]: https://api.cmn.eniac.dev.cray.com/apis/hmnfd/hmi/v2/health - 200
+PASS - [cray-ims]: https://api.cmn.eniac.dev.cray.com/apis/ims/images - 200
+PASS - [cray-powerdns-manager]: https://api.cmn.eniac.dev.cray.com/apis/powerdns-manager/v1/liveness - 204
+PASS - [cray-reds]: https://api.cmn.eniac.dev.cray.com/apis/reds/v1/liveness - 204
+PASS - [cray-scsd]: https://api.cmn.eniac.dev.cray.com/apis/scsd/v1/health - 200
+PASS - [cray-sls]: https://api.cmn.eniac.dev.cray.com/apis/sls/v1/health - 200
+PASS - [cray-smd]: https://api.cmn.eniac.dev.cray.com/apis/smd/hsm/v1/service/ready - 200
+PASS - [cray-sts]: https://api.cmn.eniac.dev.cray.com/apis/sts/healthz - 200
+PASS - [cray-uas-mgr]: https://api.cmn.eniac.dev.cray.com/apis/uas-mgr/v1/images - 200
+SKIP - [nmdv2-service]: https://api.cmn.eniac.dev.cray.com/apis/v2/nmd/dumps - virtual service not found
+SKIP - [slingshot-fabric-manager]: https://api.cmn.eniac.dev.cray.com/apis/fabric-manager/fabric/port-policies - virtual service not found
+SKIP - [sma-telemetry]: https://api.cmn.eniac.dev.cray.com/apis/sma-telemetry-api/v1/ping - virtual service not found
+
+------------- api.can.eniac.dev.cray.com -------------------
+ping: api.can.eniac.dev.cray.com: Name or service not known
+api.can.eniac.dev.cray.com is NOT reachable
+can is not reachable and is not expected to be
+
+------------- api.chn.eniac.dev.cray.com -------------------
+api.chn.eniac.dev.cray.com is reachable
+PASS - [cray-bos]: https://api.chn.eniac.dev.cray.com/apis/bos/v1/session - 404
+PASS - [cray-bss]: https://api.chn.eniac.dev.cray.com/apis/bss/boot/v1/bootparameters - 404
+PASS - [cray-capmc]: https://api.chn.eniac.dev.cray.com/apis/capmc/capmc/get_node_rules - 404
+PASS - [cray-cfs-api]: https://api.chn.eniac.dev.cray.com/apis/cfs/v2/sessions - 404
+PASS - [cray-console-data]: https://api.chn.eniac.dev.cray.com/apis/consoledata/liveness - 404
+PASS - [cray-console-node]: https://api.chn.eniac.dev.cray.com/apis/console-node/console-node/liveness - 404
+PASS - [cray-console-operator]: https://api.chn.eniac.dev.cray.com/apis/console-operator/console-operator/liveness - 404
+SKIP - [cray-cps]: https://api.chn.eniac.dev.cray.com/apis/v2/cps/contents - virtual service not found
+PASS - [cray-fas]: https://api.chn.eniac.dev.cray.com/apis/fas/v1/snapshots - 404
+PASS - [cray-hbtd]: https://api.chn.eniac.dev.cray.com/apis/hbtd/hmi/v1/health - 404
+PASS - [cray-hmnfd]: https://api.chn.eniac.dev.cray.com/apis/hmnfd/hmi/v2/health - 404
+PASS - [cray-ims]: https://api.chn.eniac.dev.cray.com/apis/ims/images - 404
+PASS - [cray-powerdns-manager]: https://api.chn.eniac.dev.cray.com/apis/powerdns-manager/v1/liveness - 404
+PASS - [cray-reds]: https://api.chn.eniac.dev.cray.com/apis/reds/v1/liveness - 404
+PASS - [cray-scsd]: https://api.chn.eniac.dev.cray.com/apis/scsd/v1/health - 404
+PASS - [cray-sls]: https://api.chn.eniac.dev.cray.com/apis/sls/v1/health - 404
+PASS - [cray-smd]: https://api.chn.eniac.dev.cray.com/apis/smd/hsm/v1/service/ready - 404
+PASS - [cray-sts]: https://api.chn.eniac.dev.cray.com/apis/sts/healthz - 404
+PASS - [cray-uas-mgr]: https://api.chn.eniac.dev.cray.com/apis/uas-mgr/v1/images - 404
+SKIP - [nmdv2-service]: https://api.chn.eniac.dev.cray.com/apis/v2/nmd/dumps - virtual service not found
+SKIP - [slingshot-fabric-manager]: https://api.chn.eniac.dev.cray.com/apis/fabric-manager/fabric/port-policies - virtual service not found
+SKIP - [sma-telemetry]: https://api.chn.eniac.dev.cray.com/apis/sma-telemetry-api/v1/ping - virtual service not found
+
+Getting token for can
+ping: auth.can.eniac.dev.cray.com: Name or service not known
+auth.can.eniac.dev.cray.com is NOT reachable
+
+Getting token for chn
+auth.chn.eniac.dev.cray.com is reachable
+Token successfully retrieved at https://auth.chn.eniac.dev.cray.com/keycloak/realms/shasta/protocol/openid-connect/token
+
+
+------------- api-gw-service-nmn.local -------------------
+api-gw-service-nmn.local is reachable
+PASS - [cray-bos]: https://api-gw-service-nmn.local/apis/bos/v1/session - 403
+PASS - [cray-bss]: https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters - 403
+PASS - [cray-capmc]: https://api-gw-service-nmn.local/apis/capmc/capmc/get_node_rules - 403
+PASS - [cray-cfs-api]: https://api-gw-service-nmn.local/apis/cfs/v2/sessions - 403
+PASS - [cray-console-data]: https://api-gw-service-nmn.local/apis/consoledata/liveness - 403
+PASS - [cray-console-node]: https://api-gw-service-nmn.local/apis/console-node/console-node/liveness - 403
+PASS - [cray-console-operator]: https://api-gw-service-nmn.local/apis/console-operator/console-operator/liveness - 403
+SKIP - [cray-cps]: https://api-gw-service-nmn.local/apis/v2/cps/contents - virtual service not found
+PASS - [cray-fas]: https://api-gw-service-nmn.local/apis/fas/v1/snapshots - 403
+PASS - [cray-hbtd]: https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/health - 403
+PASS - [cray-hmnfd]: https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/health - 403
+PASS - [cray-ims]: https://api-gw-service-nmn.local/apis/ims/images - 403
+PASS - [cray-powerdns-manager]: https://api-gw-service-nmn.local/apis/powerdns-manager/v1/liveness - 403
+PASS - [cray-reds]: https://api-gw-service-nmn.local/apis/reds/v1/liveness - 403
+PASS - [cray-scsd]: https://api-gw-service-nmn.local/apis/scsd/v1/health - 403
+PASS - [cray-sls]: https://api-gw-service-nmn.local/apis/sls/v1/health - 403
+PASS - [cray-smd]: https://api-gw-service-nmn.local/apis/smd/hsm/v1/service/ready - 403
+PASS - [cray-sts]: https://api-gw-service-nmn.local/apis/sts/healthz - 403
+PASS - [cray-uas-mgr]: https://api-gw-service-nmn.local/apis/uas-mgr/v1/images - 403
+SKIP - [nmdv2-service]: https://api-gw-service-nmn.local/apis/v2/nmd/dumps - virtual service not found
+SKIP - [slingshot-fabric-manager]: https://api-gw-service-nmn.local/apis/fabric-manager/fabric/port-policies - virtual service not found
+SKIP - [sma-telemetry]: https://api-gw-service-nmn.local/apis/sma-telemetry-api/v1/ping - virtual service not found
+
+------------- api.cmn.eniac.dev.cray.com -------------------
+api.cmn.eniac.dev.cray.com is reachable
+PASS - [cray-bos]: https://api.cmn.eniac.dev.cray.com/apis/bos/v1/session - 403
+PASS - [cray-bss]: https://api.cmn.eniac.dev.cray.com/apis/bss/boot/v1/bootparameters - 403
+PASS - [cray-capmc]: https://api.cmn.eniac.dev.cray.com/apis/capmc/capmc/get_node_rules - 403
+PASS - [cray-cfs-api]: https://api.cmn.eniac.dev.cray.com/apis/cfs/v2/sessions - 403
+PASS - [cray-console-data]: https://api.cmn.eniac.dev.cray.com/apis/consoledata/liveness - 403
+PASS - [cray-console-node]: https://api.cmn.eniac.dev.cray.com/apis/console-node/console-node/liveness - 403
+PASS - [cray-console-operator]: https://api.cmn.eniac.dev.cray.com/apis/console-operator/console-operator/liveness - 403
+SKIP - [cray-cps]: https://api.cmn.eniac.dev.cray.com/apis/v2/cps/contents - virtual service not found
+PASS - [cray-fas]: https://api.cmn.eniac.dev.cray.com/apis/fas/v1/snapshots - 403
+PASS - [cray-hbtd]: https://api.cmn.eniac.dev.cray.com/apis/hbtd/hmi/v1/health - 403
+PASS - [cray-hmnfd]: https://api.cmn.eniac.dev.cray.com/apis/hmnfd/hmi/v2/health - 403
+PASS - [cray-ims]: https://api.cmn.eniac.dev.cray.com/apis/ims/images - 403
+PASS - [cray-powerdns-manager]: https://api.cmn.eniac.dev.cray.com/apis/powerdns-manager/v1/liveness - 403
+PASS - [cray-reds]: https://api.cmn.eniac.dev.cray.com/apis/reds/v1/liveness - 403
+PASS - [cray-scsd]: https://api.cmn.eniac.dev.cray.com/apis/scsd/v1/health - 403
+PASS - [cray-sls]: https://api.cmn.eniac.dev.cray.com/apis/sls/v1/health - 403
+PASS - [cray-smd]: https://api.cmn.eniac.dev.cray.com/apis/smd/hsm/v1/service/ready - 403
+PASS - [cray-sts]: https://api.cmn.eniac.dev.cray.com/apis/sts/healthz - 403
+PASS - [cray-uas-mgr]: https://api.cmn.eniac.dev.cray.com/apis/uas-mgr/v1/images - 403
+SKIP - [nmdv2-service]: https://api.cmn.eniac.dev.cray.com/apis/v2/nmd/dumps - virtual service not found
+SKIP - [slingshot-fabric-manager]: https://api.cmn.eniac.dev.cray.com/apis/fabric-manager/fabric/port-policies - virtual service not found
+SKIP - [sma-telemetry]: https://api.cmn.eniac.dev.cray.com/apis/sma-telemetry-api/v1/ping - virtual service not found
+
+------------- api.can.eniac.dev.cray.com -------------------
+ping: api.can.eniac.dev.cray.com: Name or service not known
+api.can.eniac.dev.cray.com is NOT reachable
+can is not reachable and is not expected to be
+
+------------- api.chn.eniac.dev.cray.com -------------------
+api.chn.eniac.dev.cray.com is reachable
+PASS - [cray-bos]: https://api.chn.eniac.dev.cray.com/apis/bos/v1/session - 404
+PASS - [cray-bss]: https://api.chn.eniac.dev.cray.com/apis/bss/boot/v1/bootparameters - 404
+PASS - [cray-capmc]: https://api.chn.eniac.dev.cray.com/apis/capmc/capmc/get_node_rules - 404
+PASS - [cray-cfs-api]: https://api.chn.eniac.dev.cray.com/apis/cfs/v2/sessions - 404
+PASS - [cray-console-data]: https://api.chn.eniac.dev.cray.com/apis/consoledata/liveness - 404
+PASS - [cray-console-node]: https://api.chn.eniac.dev.cray.com/apis/console-node/console-node/liveness - 404
+PASS - [cray-console-operator]: https://api.chn.eniac.dev.cray.com/apis/console-operator/console-operator/liveness - 404
+SKIP - [cray-cps]: https://api.chn.eniac.dev.cray.com/apis/v2/cps/contents - virtual service not found
+PASS - [cray-fas]: https://api.chn.eniac.dev.cray.com/apis/fas/v1/snapshots - 404
+PASS - [cray-hbtd]: https://api.chn.eniac.dev.cray.com/apis/hbtd/hmi/v1/health - 404
+PASS - [cray-hmnfd]: https://api.chn.eniac.dev.cray.com/apis/hmnfd/hmi/v2/health - 404
+PASS - [cray-ims]: https://api.chn.eniac.dev.cray.com/apis/ims/images - 404
+PASS - [cray-powerdns-manager]: https://api.chn.eniac.dev.cray.com/apis/powerdns-manager/v1/liveness - 404
+PASS - [cray-reds]: https://api.chn.eniac.dev.cray.com/apis/reds/v1/liveness - 404
+PASS - [cray-scsd]: https://api.chn.eniac.dev.cray.com/apis/scsd/v1/health - 404
+PASS - [cray-sls]: https://api.chn.eniac.dev.cray.com/apis/sls/v1/health - 404
+PASS - [cray-smd]: https://api.chn.eniac.dev.cray.com/apis/smd/hsm/v1/service/ready - 404
+PASS - [cray-sts]: https://api.chn.eniac.dev.cray.com/apis/sts/healthz - 404
+PASS - [cray-uas-mgr]: https://api.chn.eniac.dev.cray.com/apis/uas-mgr/v1/images - 404
+SKIP - [nmdv2-service]: https://api.chn.eniac.dev.cray.com/apis/v2/nmd/dumps - virtual service not found
+SKIP - [slingshot-fabric-manager]: https://api.chn.eniac.dev.cray.com/apis/fabric-manager/fabric/port-policies - virtual service not found
+SKIP - [sma-telemetry]: https://api.chn.eniac.dev.cray.com/apis/sma-telemetry-api/v1/ping - virtual service not found
+
+Overall Gateway Test Status:  PASS
+```
+
+### Running from a UAI
+
+```bash
+ncn-m001# ./uai-gateway-test.sh 
+Creating Gateway Test UAI with image artifactory.algol60.net/csm-docker/stable/cray-gateway_test:1.4.0-20220418215843_786bfac
+Waiting for uai-vers-733eea45 to be ready
+status = Running: Not Ready
+status = Running: Ready
+System domain is eniac.dev.cray.com
+User Network on eniac is chn
+Got admin client secret
+Running gateway tests on the UAI...(this may take 1-2 minutes)
+
+Getting token for nmnlb
+api-gw-service-nmn.local is NOT reachable
+
+Getting token for cmn
+auth.cmn.eniac.dev.cray.com is NOT reachable
+
+Getting token for can
+auth.can.eniac.dev.cray.com is reachable
+Token successfully retrieved at https://auth.can.eniac.dev.cray.com/keycloak/realms/shasta/protocol/openid-connect/token
+
+
+------------- api-gw-service-nmn.local -------------------
+api-gw-service-nmn.local is NOT reachable
+nmnlb is not reachable and is not expected to be
+
+------------- api.cmn.eniac.dev.cray.com -------------------
+api.cmn.eniac.dev.cray.com is NOT reachable
+cmn is not reachable and is not expected to be
 
 ------------- api.can.eniac.dev.cray.com -------------------
 api.can.eniac.dev.cray.com is reachable
@@ -111,7 +409,6 @@ PASS - [cray-sls]: https://api.can.eniac.dev.cray.com/apis/sls/v1/health - 404
 PASS - [cray-smd]: https://api.can.eniac.dev.cray.com/apis/smd/hsm/v1/service/ready - 404
 PASS - [cray-sts]: https://api.can.eniac.dev.cray.com/apis/sts/healthz - 404
 PASS - [cray-uas-mgr]: https://api.can.eniac.dev.cray.com/apis/uas-mgr/v1/images - 404
-PASS - [gitea-vcs-web]: https://api.can.eniac.dev.cray.com/vcs - 404
 SKIP - [nmdv2-service]: https://api.can.eniac.dev.cray.com/apis/v2/nmd/dumps
 SKIP - [slingshot-fabric-manager]: https://api.can.eniac.dev.cray.com/apis/fabric-manager/fabric/port-policies
 SKIP - [sma-telemetry]: https://api.can.eniac.dev.cray.com/apis/sma-telemetry-api/v1/ping
@@ -137,10 +434,75 @@ PASS - [cray-sls]: https://api.chn.eniac.dev.cray.com/apis/sls/v1/health - 404
 PASS - [cray-smd]: https://api.chn.eniac.dev.cray.com/apis/smd/hsm/v1/service/ready - 404
 PASS - [cray-sts]: https://api.chn.eniac.dev.cray.com/apis/sts/healthz - 404
 PASS - [cray-uas-mgr]: https://api.chn.eniac.dev.cray.com/apis/uas-mgr/v1/images - 404
-PASS - [gitea-vcs-web]: https://api.chn.eniac.dev.cray.com/vcs - 404
 SKIP - [nmdv2-service]: https://api.chn.eniac.dev.cray.com/apis/v2/nmd/dumps
 SKIP - [slingshot-fabric-manager]: https://api.chn.eniac.dev.cray.com/apis/fabric-manager/fabric/port-policies
 SKIP - [sma-telemetry]: https://api.chn.eniac.dev.cray.com/apis/sma-telemetry-api/v1/ping
- # echo $?
-1
+
+Getting token for chn
+auth.chn.eniac.dev.cray.com is reachable
+Token successfully retrieved at https://auth.chn.eniac.dev.cray.com/keycloak/realms/shasta/protocol/openid-connect/token
+
+
+------------- api-gw-service-nmn.local -------------------
+api-gw-service-nmn.local is NOT reachable
+nmnlb is not reachable and is not expected to be
+
+------------- api.cmn.eniac.dev.cray.com -------------------
+api.cmn.eniac.dev.cray.com is NOT reachable
+cmn is not reachable and is not expected to be
+
+------------- api.can.eniac.dev.cray.com -------------------
+api.can.eniac.dev.cray.com is reachable
+PASS - [cray-bos]: https://api.can.eniac.dev.cray.com/apis/bos/v1/session - 404
+PASS - [cray-bss]: https://api.can.eniac.dev.cray.com/apis/bss/boot/v1/bootparameters - 404
+PASS - [cray-capmc]: https://api.can.eniac.dev.cray.com/apis/capmc/capmc/get_node_rules - 404
+PASS - [cray-cfs-api]: https://api.can.eniac.dev.cray.com/apis/cfs/v2/sessions - 404
+PASS - [cray-console-data]: https://api.can.eniac.dev.cray.com/apis/consoledata/liveness - 404
+PASS - [cray-console-node]: https://api.can.eniac.dev.cray.com/apis/console-node/console-node/liveness - 404
+PASS - [cray-console-operator]: https://api.can.eniac.dev.cray.com/apis/console-operator/console-operator/liveness - 404
+SKIP - [cray-cps]: https://api.can.eniac.dev.cray.com/apis/v2/cps/contents
+PASS - [cray-fas]: https://api.can.eniac.dev.cray.com/apis/fas/v1/snapshots - 404
+PASS - [cray-hbtd]: https://api.can.eniac.dev.cray.com/apis/hbtd/hmi/v1/health - 404
+PASS - [cray-hmnfd]: https://api.can.eniac.dev.cray.com/apis/hmnfd/hmi/v2/health - 404
+PASS - [cray-ims]: https://api.can.eniac.dev.cray.com/apis/ims/images - 404
+PASS - [cray-powerdns-manager]: https://api.can.eniac.dev.cray.com/apis/powerdns-manager/v1/liveness - 404
+PASS - [cray-reds]: https://api.can.eniac.dev.cray.com/apis/reds/v1/liveness - 404
+PASS - [cray-scsd]: https://api.can.eniac.dev.cray.com/apis/scsd/v1/health - 404
+PASS - [cray-sls]: https://api.can.eniac.dev.cray.com/apis/sls/v1/health - 404
+PASS - [cray-smd]: https://api.can.eniac.dev.cray.com/apis/smd/hsm/v1/service/ready - 404
+PASS - [cray-sts]: https://api.can.eniac.dev.cray.com/apis/sts/healthz - 404
+PASS - [cray-uas-mgr]: https://api.can.eniac.dev.cray.com/apis/uas-mgr/v1/images - 404
+SKIP - [nmdv2-service]: https://api.can.eniac.dev.cray.com/apis/v2/nmd/dumps
+SKIP - [slingshot-fabric-manager]: https://api.can.eniac.dev.cray.com/apis/fabric-manager/fabric/port-policies
+SKIP - [sma-telemetry]: https://api.can.eniac.dev.cray.com/apis/sma-telemetry-api/v1/ping
+
+------------- api.chn.eniac.dev.cray.com -------------------
+api.chn.eniac.dev.cray.com is reachable
+PASS - [cray-bos]: https://api.chn.eniac.dev.cray.com/apis/bos/v1/session - 404
+PASS - [cray-bss]: https://api.chn.eniac.dev.cray.com/apis/bss/boot/v1/bootparameters - 404
+PASS - [cray-capmc]: https://api.chn.eniac.dev.cray.com/apis/capmc/capmc/get_node_rules - 404
+PASS - [cray-cfs-api]: https://api.chn.eniac.dev.cray.com/apis/cfs/v2/sessions - 404
+PASS - [cray-console-data]: https://api.chn.eniac.dev.cray.com/apis/consoledata/liveness - 404
+PASS - [cray-console-node]: https://api.chn.eniac.dev.cray.com/apis/console-node/console-node/liveness - 404
+PASS - [cray-console-operator]: https://api.chn.eniac.dev.cray.com/apis/console-operator/console-operator/liveness - 404
+SKIP - [cray-cps]: https://api.chn.eniac.dev.cray.com/apis/v2/cps/contents
+PASS - [cray-fas]: https://api.chn.eniac.dev.cray.com/apis/fas/v1/snapshots - 404
+PASS - [cray-hbtd]: https://api.chn.eniac.dev.cray.com/apis/hbtd/hmi/v1/health - 404
+PASS - [cray-hmnfd]: https://api.chn.eniac.dev.cray.com/apis/hmnfd/hmi/v2/health - 404
+PASS - [cray-ims]: https://api.chn.eniac.dev.cray.com/apis/ims/images - 404
+PASS - [cray-powerdns-manager]: https://api.chn.eniac.dev.cray.com/apis/powerdns-manager/v1/liveness - 404
+PASS - [cray-reds]: https://api.chn.eniac.dev.cray.com/apis/reds/v1/liveness - 404
+PASS - [cray-scsd]: https://api.chn.eniac.dev.cray.com/apis/scsd/v1/health - 404
+PASS - [cray-sls]: https://api.chn.eniac.dev.cray.com/apis/sls/v1/health - 404
+PASS - [cray-smd]: https://api.chn.eniac.dev.cray.com/apis/smd/hsm/v1/service/ready - 404
+PASS - [cray-sts]: https://api.chn.eniac.dev.cray.com/apis/sts/healthz - 404
+PASS - [cray-uas-mgr]: https://api.chn.eniac.dev.cray.com/apis/uas-mgr/v1/images - 404
+SKIP - [nmdv2-service]: https://api.chn.eniac.dev.cray.com/apis/v2/nmd/dumps
+SKIP - [slingshot-fabric-manager]: https://api.chn.eniac.dev.cray.com/apis/fabric-manager/fabric/port-policies
+SKIP - [sma-telemetry]: https://api.chn.eniac.dev.cray.com/apis/sma-telemetry-api/v1/ping
+
+Overall Gateway Test Status:  PASS
+
+Deleting UAI uai-vers-733eea45
+results = [ "Successfully deleted uai-vers-733eea45",]
 ```

--- a/operations/network/gateway_testing.md
+++ b/operations/network/gateway_testing.md
@@ -5,11 +5,11 @@ The services are accessed via three different ingress gateways using a token tha
 
 This page describes how to run a set of tests to determine if the gateways are functioning properly. The gateway test will obtain an API token from Keycloak and then use that token to attempt to access a set of service APIs on one or more networks as defined in the gateway test definition file (`gateway-test-defn.yaml`). The test will check the return code to make sure it gets the expected response.
 
-When the nmnlb network is specified, it will use `api-gw-service-nmn.local` as an override for `nmnlb.<system-domain>` in 1.2. You can set `use-api-gw-override: false` in gateway-test-defn.yaml if you would like to disable that override and use `nmnlb.<system-domain>`.
+When the nmnlb network is specified, it will use `api-gw-service-nmn.local` as an override for `nmnlb.<system-domain>` in 1.2. You can set `use-api-gw-override: false` in `gateway-test-defn.yaml` if you would like to disable that override and use `nmnlb.<system-domain>`.
 
 ## Running gateway tests on an NCN
 
-The gateway test scripts can be found in `/usr/share/doc/csm/scripts/operations/gateway-test`. To test the gateways from an NCN you will need to use gateway-test.py.  When `gateway-test.py` is run from an NCN, it has access to the admin client secret using `kubectl`. It will use the admin client secret to get the token for accessing the APIs.
+The gateway test scripts can be found in `/usr/share/doc/csm/scripts/operations/gateway-test`. To test the gateways from an NCN, use `gateway-test.py`. When `gateway-test.py` is run from an NCN, it has access to the admin client secret using `kubectl`. It will use the admin client secret to get the token for accessing the APIs.
 
 You can run the test by executing the following command. You will need to specify the system domain (for example, `eniac.dev.cray.com`).
 
@@ -17,9 +17,9 @@ You can run the test by executing the following command. You will need to specif
 ncn# /usr/share/doc/csm/scripts/operations/gateway-test/gateway-test.py eniac.dev.cray.com
 ```
 
-The test will cycle through all of the test networks specified in gateway-test-defn.yaml.
+The test will cycle through all of the test networks specified in `gateway-test-defn.yaml`.
 
-```bash
+```yaml
 test-networks:
 - name: nmnlb
   gateway: services-gateway
@@ -31,7 +31,7 @@ test-networks:
   gateway: customer-user-gateway
 ```
 
-For each network it will attempt to obtain a token from keycloak.  On an NCN, it should be able to get a token from each of those networks.  It will then use that token to attempt to access each of the services defined in gateway-test-defn.yaml on each of the test-networks.   The test will be able to determine whether it should or should not be able to access the service and it will output a PASS or FAIL for each test depending on the actual results.
+For each network it will attempt to obtain a token from Keycloak. On an NCN, it should be able to get a token from each of those networks. It will then use that token to attempt to access each of the services defined in `gateway-test-defn.yaml` on each of the `test-networks`. The test will be able to determine whether it should or should not be able to access the service and it will output a PASS or FAIL for each test, depending on the actual results.
 
 ## Running gateway tests from UAN, Compute Node, or a device outside of the cluster
 
@@ -47,7 +47,7 @@ You will then need to set the ADMIN_CLIENT_SECRET environment variable to the ad
 linux# export ADMIN_CLIENT_SECRET=26947343-d4ab-403b-14e937dbd700
 ```
 
-You can run the tests by executing the following the command. You will need to specify the system domain (e.g. eniac.dev.cray.com).
+Run the tests by executing the following the command. The system domain (e.g. eniac.dev.cray.com) must be specified.
 
 ```bash
 linux# /usr/share/doc/csm/scripts/operations/gateway-test/gateway-test.py eniac.dev.cray.com
@@ -55,41 +55,39 @@ linux# /usr/share/doc/csm/scripts/operations/gateway-test/gateway-test.py eniac.
 
 ## Running gateway tests on a UAI 
 
-To test the gateways from a UAI you will need to run `uai-gateway-test.sh`.  
+In order to test the gateways from a UAI, you will need to run `uai-gateway-test.sh`.
 
 This script will execute the following steps:
 
-* Create a UAI with a cray-uai-gateway-test image.
-* Pass the system domain, user network, and admin client secret to the test UAI.
-* Execute gateway-test.py on the node
-* Output the results
-* Delete the test UAI
+1. Create a UAI with a `cray-uai-gateway-test` image.
+1. Pass the system domain, user network, and admin client secret to the test UAI.
+1. Execute `gateway-test.py` on the node.
+1. Output the results.
+1. Delete the test UAI.
 
-You can run the test by executing the following command.
+Run the test by executing the following command.
 
 ```bash
 ncn# /usr/share/doc/csm/scripts/operations/gateway-test/uai-gateway-test.sh
 ```
 
-The test will find the first UAI gateway-test image to create the test UAI.  If you prefer to specify a different image, you can use the --imagename option.
+The test will find the first UAI `cray-uai-gateway-test` image to create the test UAI. A different image may optionally be specified by using the `--imagename` option.
 
 ## Example Results 
 
 The results of running the tests will show the following
 
 * Retrieval of a token on the CMN network in order to get SLS data to determine which networks are defined on the system
-* For each of the test networks...
-    * Retrieval of a token on the network under test
+* For each of the test networks:
+    * Retrieval of a token on the network under test.
     * Results from each of the networks defined in `gateway-test-defn.yaml`. It will attempt to access each of the services with the token and check the expected results.
     * It will show PASS or FAIL depending on the expected response for the service and the token being used.
     * It will show SKIP for services that are not expected to be installed on the system.
-* The return code at the end of gateway-test.py will be non-zero if any of the tests within it fail or we are unable to retrieve a token on any of the networks that are expected to be accessible.
+* The return code of `gateway-test.py` will be non-zero if any of the tests within it fail or we are unable to retrieve a token on any of the networks that are expected to be accessible.
 
-### Running from an NCN that is configured with CHN as the user network. 
+### Running from an NCN that is configured with CHN as the user network
 
 ```bash
-# ./gateway-test.py eniac.dev.cray.com
-
 ncn-m001# ./gateway-test.py eniac.dev.cray.com
 auth.cmn.eniac.dev.cray.com is reachable
 Token successfully retrieved at https://auth.cmn.eniac.dev.cray.com/keycloak/realms/shasta/protocol/openid-connect/token

--- a/scripts/operations/gateway-test/gateway-test-defn.yaml
+++ b/scripts/operations/gateway-test/gateway-test-defn.yaml
@@ -24,7 +24,7 @@
 
 
 use-api-gw-override: true
-networks:
+test-networks:
 - name: nmnlb
   gateway: services-gateway
 - name: cmn
@@ -33,6 +33,8 @@ networks:
   gateway: customer-user-gateway
 - name: chn
   gateway: customer-user-gateway
+
+reachable-networks: [ "can", "chn" ]
 
 ingress_api_services:
 - name: cray-bos
@@ -167,13 +169,6 @@ ingress_api_services:
   expected-result: 200
   namespace: services
   gateways: ["services-gateway","customer-admin-gateway"]
-  project: CSM
-- name: gitea-vcs-web 
-  path: vcs
-  port: 443
-  expected-result: 200
-  namespace: services
-  gateways: ["services-gateway"]
   project: CSM
 - name: nmdv2-service
   path: apis/v2/nmd/dumps

--- a/scripts/operations/gateway-test/uai-gateway-test.sh
+++ b/scripts/operations/gateway-test/uai-gateway-test.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+
+while [[ $# -gt 0 ]]; do
+  key="$1"
+
+   case $key in
+       --imagename)
+         GATEWAY_IMAGE_NAME="$2"
+         shift # past argument
+         shift # past value
+         ;;
+       --publickey)
+         PUBKEY="$2"
+         shift # past argument
+         shift # past value
+         ;;
+       *)    # unknown option
+         echo "[ERROR] - unknown options"
+         echo "usage: $0 [--imagename <image-name>] [--publickey <path-to-key>]"
+         exit 1
+         ;;
+  esac
+done
+
+# Make sure the cray, craysys, kubectl, and jq commands are available
+
+cray --version > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+  echo "cray command is not available"
+  exit 1
+fi
+
+craysys type get > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+  echo "craysys command is not available"
+  exit 1
+fi
+
+kubectl version > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+  echo "kubectl command is not available"
+  exit 1
+fi
+
+which jq > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+  echo "jq command is not available"
+  exit 1
+fi
+
+
+# Find gateway image if one was not specified
+if [[ -z ${GATEWAY_IMAGE_NAME} ]]; then
+  GATEWAY_IMAGE_NAME=$(cray uas images list --format json | jq '.image_list' | jq .[] | grep gateway |  sed -e 's/"//g' | head -1)
+  if [[ -z ${GATEWAY_IMAGE_NAME} ]]; then
+    echo "Could not find a cray-gateway-test image" >2
+    exit 1 
+  fi
+else
+  cray uas images list --format json | jq '.image_list' | jq .[] | grep -q -v ${GATEWAY_IMAGE_NAME}
+  if [ $? -eq 0 ]; then
+    echo "${GATEWAY_IMAGE_NAME} not found"
+    exit 1
+  fi
+fi
+
+# If public key file was not specified, use ~/.ssh/id_rsa.pub as default
+if [[ -z ${PUBKEY} ]]; then
+  PUBKEY=~/.ssh/id_rsa.pub
+else
+  if [ ! -r $PUBKEY ]; then
+    echo "${PUBKEY} not found"
+    exit 1
+  fi
+fi
+
+# Create the UAI pod
+echo "Creating Gateway Test UAI with image ${GATEWAY_IMAGE_NAME}"
+UAI_NAME=$(cray uas create --publickey ~/.ssh/id_rsa.pub --imagename ${GATEWAY_IMAGE_NAME} | grep uai_name | awk '{print $3}' | sed -e 's/"//g')
+
+if [[ -z ${UAI_NAME} ]]; then
+  echo "Failure creating UAI"
+  exit 1
+fi
+
+# Wait for it pod to become ready
+echo "Waiting for ${UAI_NAME} to be ready"
+UAI_READY=0
+for i in `seq 1 10`;do 
+  UAI_STATUS=$(cray uas list --format json | jq --arg n "${UAI_NAME}" '.[] | select(.uai_name == $n) | .uai_status' | sed -e 's/"//g')
+  echo "status = $UAI_STATUS"
+  if [ "$UAI_STATUS" == "Running: Ready" ]; then
+    UAI_READY=1
+    break
+  fi
+  sleep 5
+done 
+
+if [ ${UAI_READY} -eq 0 ]; then
+  echo "UAI ${UAI_NAME} is not ready"
+  exit 1
+fi
+
+# Find the UAI pod name
+UAI_POD=$(kubectl -n user get pods | grep ${UAI_NAME} | awk '{print $1}')
+if [[ -z ${UAI_POD} ]]; then
+  echo "Could not find pod for UAI ${UAI_NAME}"
+  exit 1
+fi
+
+# Get a token to talk to SLS
+export TOKEN=$(curl -s -k -S -d grant_type=client_credentials -d client_id=admin-client -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
+
+# Get the SYSTEM_DOMAIN from SLS
+SYSTEM_NAME=$(craysys metadata get system-name)
+SITE_DOMAIN=$(craysys metadata get site-domain)
+SYSTEM_DOMAIN=${SYSTEM_NAME}.${SITE_DOMAIN}
+echo "System domain is ${SYSTEM_DOMAIN}"
+
+# Get the USER_NETWORK from SLS
+USER_NETWORK=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" https://api-gw-service-nmn.local/apis/sls/v1/dumpstate | jq -r '.Networks.BICAN.ExtraProperties.SystemDefaultRoute' | tr '[:upper:]' '[:lower:]')
+echo "User Network on ${SYSTEM_NAME} is ${USER_NETWORK}"
+
+# Get the ADMIN_CLIENT_SECRET
+ADMIN_CLIENT_SECRET=$(kubectl get secrets admin-client-auth -ojsonpath='{.data.client-secret}' | base64 -d)
+if [[ -z ${ADMIN_CLIENT_SECRET} ]]; then
+    echo "Failed to retrieve admin client secret" >2
+    exit 1
+fi
+echo "Got admin client secret"
+
+# Set the variables in the UAI 
+kubectl -n user exec ${UAI_POD} -- sh -c "echo 'export ADMIN_CLIENT_SECRET=$ADMIN_CLIENT_SECRET' > /test/vars.sh"
+kubectl -n user exec ${UAI_POD} -- sh -c "echo 'export SYSTEM_DOMAIN=$SYSTEM_DOMAIN' >> /test/vars.sh"
+kubectl -n user exec ${UAI_POD} -- sh -c "echo 'export USER_NETWORK=$USER_NETWORK' >> /test/vars.sh"
+
+# Run the gateway tests in the UAI
+echo "Running gateway tests on the UAI...(this may take 1-2 minutes)"
+kubectl -n user exec ${UAI_POD} -- sh -c /test/run-test.sh
+
+# Remove the UAI pod
+printf "\nDeleting UAI ${UAI_NAME}\n"
+cray uas delete --uai-list ${UAI_NAME}
+


### PR DESCRIPTION
## Summary and Scope

This adds a new uai-gateway-test.sh script.  This script will spin up a UAI with the new cray-uai-gateway-test image and then run the gateway tests included in that image.

I modified gateway-test.py to not require specifying the network.  I had to make some modifications to gateway-test.py to be able to run in an environment (like UAIs and UANs) that will not have access to SLS to get some of the network confiiguraiton.   To make gateway-test.py to run, it will just cycle through all networks.  I modified the gateway-test.md description to no longer specify the network and updated the example give in that document.

## Issues and Related PRs

* Resolves CASMINST-4246
* Related uai-images PR: https://github.com/Cray-HPE/uai-images/pull/10


## Testing

### Tested on:

  * `hela`

### Test description:

Ran uai-gateway-test.sh on hela.   I tested both success and failure cases to ensure that clear output is given in both cases.   I also ran gateway-test.py on an NCN on both hela and wasp to make sure that still works as expected on NCNs.

Output of a successful test run of uai-gateway-test.sh:

```
ncn-m001:~/johren/uai # ./uai-gateway-test.sh 
Creating Gateway Test UAI with image artifactory.algol60.net/csm-docker/stable/cray-gateway_test:1.4.0-20220418215843_786bfac
Waiting for uai-vers-733eea45 to be ready
status = Running: Not Ready
status = Running: Ready
System domain is hela.dev.cray.com
User Network on hela is chn
Got admin client secret
Running gateway tests on the UAI...(this may take 1-2 minutes)

Getting token for nmnlb
api-gw-service-nmn.local is NOT reachable

Getting token for cmn
auth.cmn.hela.dev.cray.com is NOT reachable

Getting token for can
auth.can.hela.dev.cray.com is reachable
Token successfully retrieved at https://auth.can.hela.dev.cray.com/keycloak/realms/shasta/protocol/openid-connect/token


------------- api-gw-service-nmn.local -------------------
api-gw-service-nmn.local is NOT reachable
nmnlb is not reachable and is not expected to be

------------- api.cmn.hela.dev.cray.com -------------------
api.cmn.hela.dev.cray.com is NOT reachable
cmn is not reachable and is not expected to be

------------- api.can.hela.dev.cray.com -------------------
api.can.hela.dev.cray.com is reachable
PASS - [cray-bos]: https://api.can.hela.dev.cray.com/apis/bos/v1/session - 404
PASS - [cray-bss]: https://api.can.hela.dev.cray.com/apis/bss/boot/v1/bootparameters - 404
PASS - [cray-capmc]: https://api.can.hela.dev.cray.com/apis/capmc/capmc/get_node_rules - 404
PASS - [cray-cfs-api]: https://api.can.hela.dev.cray.com/apis/cfs/v2/sessions - 404
PASS - [cray-console-data]: https://api.can.hela.dev.cray.com/apis/consoledata/liveness - 404
PASS - [cray-console-node]: https://api.can.hela.dev.cray.com/apis/console-node/console-node/liveness - 404
PASS - [cray-console-operator]: https://api.can.hela.dev.cray.com/apis/console-operator/console-operator/liveness - 404
SKIP - [cray-cps]: https://api.can.hela.dev.cray.com/apis/v2/cps/contents
PASS - [cray-fas]: https://api.can.hela.dev.cray.com/apis/fas/v1/snapshots - 404
PASS - [cray-hbtd]: https://api.can.hela.dev.cray.com/apis/hbtd/hmi/v1/health - 404
PASS - [cray-hmnfd]: https://api.can.hela.dev.cray.com/apis/hmnfd/hmi/v2/health - 404
PASS - [cray-ims]: https://api.can.hela.dev.cray.com/apis/ims/images - 404
PASS - [cray-powerdns-manager]: https://api.can.hela.dev.cray.com/apis/powerdns-manager/v1/liveness - 404
PASS - [cray-reds]: https://api.can.hela.dev.cray.com/apis/reds/v1/liveness - 404
PASS - [cray-scsd]: https://api.can.hela.dev.cray.com/apis/scsd/v1/health - 404
PASS - [cray-sls]: https://api.can.hela.dev.cray.com/apis/sls/v1/health - 404
PASS - [cray-smd]: https://api.can.hela.dev.cray.com/apis/smd/hsm/v1/service/ready - 404
PASS - [cray-sts]: https://api.can.hela.dev.cray.com/apis/sts/healthz - 404
PASS - [cray-uas-mgr]: https://api.can.hela.dev.cray.com/apis/uas-mgr/v1/images - 404
SKIP - [nmdv2-service]: https://api.can.hela.dev.cray.com/apis/v2/nmd/dumps
SKIP - [slingshot-fabric-manager]: https://api.can.hela.dev.cray.com/apis/fabric-manager/fabric/port-policies
SKIP - [sma-telemetry]: https://api.can.hela.dev.cray.com/apis/sma-telemetry-api/v1/ping

------------- api.chn.hela.dev.cray.com -------------------
api.chn.hela.dev.cray.com is reachable
PASS - [cray-bos]: https://api.chn.hela.dev.cray.com/apis/bos/v1/session - 404
PASS - [cray-bss]: https://api.chn.hela.dev.cray.com/apis/bss/boot/v1/bootparameters - 404
PASS - [cray-capmc]: https://api.chn.hela.dev.cray.com/apis/capmc/capmc/get_node_rules - 404
PASS - [cray-cfs-api]: https://api.chn.hela.dev.cray.com/apis/cfs/v2/sessions - 404
PASS - [cray-console-data]: https://api.chn.hela.dev.cray.com/apis/consoledata/liveness - 404
PASS - [cray-console-node]: https://api.chn.hela.dev.cray.com/apis/console-node/console-node/liveness - 404
PASS - [cray-console-operator]: https://api.chn.hela.dev.cray.com/apis/console-operator/console-operator/liveness - 404
SKIP - [cray-cps]: https://api.chn.hela.dev.cray.com/apis/v2/cps/contents
PASS - [cray-fas]: https://api.chn.hela.dev.cray.com/apis/fas/v1/snapshots - 404
PASS - [cray-hbtd]: https://api.chn.hela.dev.cray.com/apis/hbtd/hmi/v1/health - 404
PASS - [cray-hmnfd]: https://api.chn.hela.dev.cray.com/apis/hmnfd/hmi/v2/health - 404
PASS - [cray-ims]: https://api.chn.hela.dev.cray.com/apis/ims/images - 404
PASS - [cray-powerdns-manager]: https://api.chn.hela.dev.cray.com/apis/powerdns-manager/v1/liveness - 404
PASS - [cray-reds]: https://api.chn.hela.dev.cray.com/apis/reds/v1/liveness - 404
PASS - [cray-scsd]: https://api.chn.hela.dev.cray.com/apis/scsd/v1/health - 404
PASS - [cray-sls]: https://api.chn.hela.dev.cray.com/apis/sls/v1/health - 404
PASS - [cray-smd]: https://api.chn.hela.dev.cray.com/apis/smd/hsm/v1/service/ready - 404
PASS - [cray-sts]: https://api.chn.hela.dev.cray.com/apis/sts/healthz - 404
PASS - [cray-uas-mgr]: https://api.chn.hela.dev.cray.com/apis/uas-mgr/v1/images - 404
SKIP - [nmdv2-service]: https://api.chn.hela.dev.cray.com/apis/v2/nmd/dumps
SKIP - [slingshot-fabric-manager]: https://api.chn.hela.dev.cray.com/apis/fabric-manager/fabric/port-policies
SKIP - [sma-telemetry]: https://api.chn.hela.dev.cray.com/apis/sma-telemetry-api/v1/ping

Getting token for chn
auth.chn.hela.dev.cray.com is reachable
Token successfully retrieved at https://auth.chn.hela.dev.cray.com/keycloak/realms/shasta/protocol/openid-connect/token


------------- api-gw-service-nmn.local -------------------
api-gw-service-nmn.local is NOT reachable
nmnlb is not reachable and is not expected to be

------------- api.cmn.hela.dev.cray.com -------------------
api.cmn.hela.dev.cray.com is NOT reachable
cmn is not reachable and is not expected to be

------------- api.can.hela.dev.cray.com -------------------
api.can.hela.dev.cray.com is reachable
PASS - [cray-bos]: https://api.can.hela.dev.cray.com/apis/bos/v1/session - 404
PASS - [cray-bss]: https://api.can.hela.dev.cray.com/apis/bss/boot/v1/bootparameters - 404
PASS - [cray-capmc]: https://api.can.hela.dev.cray.com/apis/capmc/capmc/get_node_rules - 404
PASS - [cray-cfs-api]: https://api.can.hela.dev.cray.com/apis/cfs/v2/sessions - 404
PASS - [cray-console-data]: https://api.can.hela.dev.cray.com/apis/consoledata/liveness - 404
PASS - [cray-console-node]: https://api.can.hela.dev.cray.com/apis/console-node/console-node/liveness - 404
PASS - [cray-console-operator]: https://api.can.hela.dev.cray.com/apis/console-operator/console-operator/liveness - 404
SKIP - [cray-cps]: https://api.can.hela.dev.cray.com/apis/v2/cps/contents
PASS - [cray-fas]: https://api.can.hela.dev.cray.com/apis/fas/v1/snapshots - 404
PASS - [cray-hbtd]: https://api.can.hela.dev.cray.com/apis/hbtd/hmi/v1/health - 404
PASS - [cray-hmnfd]: https://api.can.hela.dev.cray.com/apis/hmnfd/hmi/v2/health - 404
PASS - [cray-ims]: https://api.can.hela.dev.cray.com/apis/ims/images - 404
PASS - [cray-powerdns-manager]: https://api.can.hela.dev.cray.com/apis/powerdns-manager/v1/liveness - 404
PASS - [cray-reds]: https://api.can.hela.dev.cray.com/apis/reds/v1/liveness - 404
PASS - [cray-scsd]: https://api.can.hela.dev.cray.com/apis/scsd/v1/health - 404
PASS - [cray-sls]: https://api.can.hela.dev.cray.com/apis/sls/v1/health - 404
PASS - [cray-smd]: https://api.can.hela.dev.cray.com/apis/smd/hsm/v1/service/ready - 404
PASS - [cray-sts]: https://api.can.hela.dev.cray.com/apis/sts/healthz - 404
PASS - [cray-uas-mgr]: https://api.can.hela.dev.cray.com/apis/uas-mgr/v1/images - 404
SKIP - [nmdv2-service]: https://api.can.hela.dev.cray.com/apis/v2/nmd/dumps
SKIP - [slingshot-fabric-manager]: https://api.can.hela.dev.cray.com/apis/fabric-manager/fabric/port-policies
SKIP - [sma-telemetry]: https://api.can.hela.dev.cray.com/apis/sma-telemetry-api/v1/ping

------------- api.chn.hela.dev.cray.com -------------------
api.chn.hela.dev.cray.com is reachable
PASS - [cray-bos]: https://api.chn.hela.dev.cray.com/apis/bos/v1/session - 404
PASS - [cray-bss]: https://api.chn.hela.dev.cray.com/apis/bss/boot/v1/bootparameters - 404
PASS - [cray-capmc]: https://api.chn.hela.dev.cray.com/apis/capmc/capmc/get_node_rules - 404
PASS - [cray-cfs-api]: https://api.chn.hela.dev.cray.com/apis/cfs/v2/sessions - 404
PASS - [cray-console-data]: https://api.chn.hela.dev.cray.com/apis/consoledata/liveness - 404
PASS - [cray-console-node]: https://api.chn.hela.dev.cray.com/apis/console-node/console-node/liveness - 404
PASS - [cray-console-operator]: https://api.chn.hela.dev.cray.com/apis/console-operator/console-operator/liveness - 404
SKIP - [cray-cps]: https://api.chn.hela.dev.cray.com/apis/v2/cps/contents
PASS - [cray-fas]: https://api.chn.hela.dev.cray.com/apis/fas/v1/snapshots - 404
PASS - [cray-hbtd]: https://api.chn.hela.dev.cray.com/apis/hbtd/hmi/v1/health - 404
PASS - [cray-hmnfd]: https://api.chn.hela.dev.cray.com/apis/hmnfd/hmi/v2/health - 404
PASS - [cray-ims]: https://api.chn.hela.dev.cray.com/apis/ims/images - 404
PASS - [cray-powerdns-manager]: https://api.chn.hela.dev.cray.com/apis/powerdns-manager/v1/liveness - 404
PASS - [cray-reds]: https://api.chn.hela.dev.cray.com/apis/reds/v1/liveness - 404
PASS - [cray-scsd]: https://api.chn.hela.dev.cray.com/apis/scsd/v1/health - 404
PASS - [cray-sls]: https://api.chn.hela.dev.cray.com/apis/sls/v1/health - 404
PASS - [cray-smd]: https://api.chn.hela.dev.cray.com/apis/smd/hsm/v1/service/ready - 404
PASS - [cray-sts]: https://api.chn.hela.dev.cray.com/apis/sts/healthz - 404
PASS - [cray-uas-mgr]: https://api.chn.hela.dev.cray.com/apis/uas-mgr/v1/images - 404
SKIP - [nmdv2-service]: https://api.chn.hela.dev.cray.com/apis/v2/nmd/dumps
SKIP - [slingshot-fabric-manager]: https://api.chn.hela.dev.cray.com/apis/fabric-manager/fabric/port-policies
SKIP - [sma-telemetry]: https://api.chn.hela.dev.cray.com/apis/sma-telemetry-api/v1/ping

Overall Gateway Test Status:  PASS

Deleting UAI uai-vers-733eea45
results = [ "Successfully deleted uai-vers-733eea45",]
```

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

