### PR TITLE
CASMINST-4477: Streamline and lint bootstrap PIT node, prepare site-init procedures

### DIFF
--- a/install/bootstrap_livecd_remote_iso.md
+++ b/install/bootstrap_livecd_remote_iso.md
@@ -1,26 +1,28 @@
 # Bootstrap PIT Node from LiveCD Remote ISO
 
-The Pre-Install Toolkit (PIT) node needs to be bootstrapped from the LiveCD. There are two install medias available
-to bootstrap the PIT node: the RemoteISO or a bootable USB device. This procedure describes using the
-RemoteISO. If not using the RemoteISO, see [Bootstrap PIT Node from LiveCD USB](bootstrap_livecd_usb.md)
+The Pre-Install Toolkit (PIT) node needs to be bootstrapped from the LiveCD. There are two media available
+to bootstrap the PIT node: the RemoteISO or a bootable USB device. This procedure describes using the USB
+device. If not using the RemoteISO, see [Bootstrap PIT Node from LiveCD USB](bootstrap_livecd_usb.md)
 
-The installation process is similar to the USB based installation with adjustments to account for the
+The installation process is similar to the USB-based installation, with adjustments to account for the
 lack of removable storage.
 
 **Important:** Before starting this procedure be sure to complete the procedure to
 [Prepare Configuration Payload](prepare_configuration_payload.md) for the relevant installation scenario.
 
 ## Topics
-   1. [Known Compatibility Issues](#known-compatibility-issues)
-   1. [Attaching and Booting the LiveCD with the BMC](#attaching-and-booting-the-livecd-with-the-bmc)
-   1. [First Login](#first-login)
-   1. [Configure the Running LiveCD](#configure-the-running-livecd)
-      1. [Generate Installation Files](#generate-installation-files)
-         1. [Subsequent Fresh-Installs (Re-Installs)](#subsequent-fresh-installs-re-installs)
-         1. [First-Time/Initial Installs (bare-metal)](#first-timeinitial-installs-bare-metal)
-      1. [Prepare Site Init](#prepare-site-init)
-   1. [Bring-up the PIT Services and Validate PIT Health](#bring---up-the-pit-services-and-validate-pit-health)
-   1. [Next Topic](#next-topic)
+
+1. [Known Compatibility Issues](#known-compatibility-issues)
+1. [Attaching and Booting the LiveCD with the BMC](#attaching-and-booting-the-livecd-with-the-bmc)
+1. [First Login](#first-login)
+1. [Configure the Running LiveCD](#configure-the-running-livecd)
+   1. [Generate Installation Files](#generate-installation-files)
+      * [Subsequent Installs (Reinstalls)](#subsequent-fresh-installs-re-installs)
+      * [Initial Installs (bare-metal)](#first-timeinitial-installs-bare-metal)
+   1. [Verify and Backup `system_config.yaml`](#verify-csi-versions-match)
+   1. [Prepare Site Init](#prepare-site-init)
+1. [Bring-up the PIT Services and Validate PIT Health](#bring---up-the-pit-services-and-validate-pit-health)
+1. [Next Topic](#next-topic)
 
 <a name="known-compatibility-issues"></a>
 ## 1. Known Compatibility Issues
@@ -37,33 +39,35 @@ The LiveCD Remote ISO has known compatibility issues for nodes from certain vend
 > installation, then that USB device must be wiped before continuing. Failing to wipe the USB, if present, may result in confusion.
 > If the USB is still booted, then it can wipe itself using the [basic wipe from Wipe NCN Disks for Reinstallation](wipe_ncn_disks_for_reinstallation.md#basic-wipe). If it is not booted, please do so and wipe it _or_ disable the USB ports in the BIOS (not available for all vendors).
 
-Obtain and attach the LiveCD cray-pre-install-toolkit ISO file to the BMC. Depending on the vendor of the node,
+Obtain and attach the LiveCD `cray-pre-install-toolkit` ISO file to the BMC. Depending on the vendor of the node,
 the instructions for attaching to the BMC will differ.
 
-1. The CSM software release should be downloaded and expanded for use.
+1. Download the CSM software release and extract the LiveCD remote ISO image.
 
    **Important:** Ensure that you have the CSM release plus any patches or hotfixes by
    following the instructions in [Update CSM Product Stream](../update_product_stream/index.md)
 
-   The cray-pre-install-toolkit ISO and other files are now available in the directory from the extracted CSM tar.
+   The `cray-pre-install-toolkit` ISO and other files are now available in the directory from the extracted CSM tar file.
    The ISO will have a name similar to
    `cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20211203183315-geddda8a.iso`
+   
+   This ISO file can be extracted from the CSM release tar file using the following command:
+   ```bash
+   linux# tar --wildcards --no-anchored -xzvf <csm-release>.tar.gz 'cray-pre-install-toolkit-*.iso'
+   ```
 
-1. Prepare a server on the network to host the cray-pre-install-toolkit ISO.
+1. Prepare a server on the network to host the `cray-pre-install-toolkit` ISO file.
 
-   This release of CSM software, the cray-pre-install-toolkit ISO should be placed on a server which the PIT node
+   Place the `cray-pre-install-toolkit` ISO file on a server which the BMC of the PIT node
    will be able to contact using HTTP or HTTPS.
 
-   **Note:** A shorter path name is better than a long path name on the webserver.
-
-      - The Cray Pre-Install Toolkit ISO is included in the CSM release tarball. It will have a long filename similar to
-        `cray-pre-install-toolkit-sle15sp3.x86_64-1.5.8-20211203183315-geddda8a.iso`, so pick a shorter name on the webserver.
+   **Note:** A short URL is better than a long URL for the PIT file on the webserver.
 
 1. See the respective procedure below to attach an ISO.
 
    - [HPE iLO BMCs](boot_livecd_virtual_iso.md#hpe-ilo-bmcs)
-   - **Gigabyte BMCs** Should not use the RemoteISO method. See [Bootstrap PIT Node from LiveCD USB](bootstrap_livecd_usb.md)
-   - **Intel BMCs** Should not use the RemoteISO method. See [Bootstrap PIT Node from LiveCD USB](bootstrap_livecd_usb.md)
+   - **Gigabyte BMCs** Do not use the RemoteISO method. See [Bootstrap PIT Node from LiveCD USB](bootstrap_livecd_usb.md)
+   - **Intel BMCs** Do not use the RemoteISO method. See [Bootstrap PIT Node from LiveCD USB](bootstrap_livecd_usb.md)
 
 1. The chosen procedure should have rebooted the server. Observe the server boot into the LiveCD.
 
@@ -72,7 +76,7 @@ the instructions for attaching to the BMC will differ.
 
 On first login (over SSH or at local console) the LiveCD will prompt the administrator to change the password.
 
-1. **The initial password is empty**; set the username of `root` and press `return` twice.
+1. **The initial password is empty**; enter the username of `root` and press `return` twice.
 
    ```
    pit login: root
@@ -93,17 +97,25 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
 <a name="configure-the-running-livecd"></a>
 ## 4. Configure the Running LiveCD
 
-1. Set up the Typescript directory as well as the initial typescript. This directory will be returned to for every typescript in the entire CSM installation.
-
+1. Start a typescript to record this section of activities done on `ncn-m001` while booted from the LiveCD.
 
    ```bash
-   pit# cd ~
-   pit# script -af csm-install-remoteiso.$(date +%Y-%m-%d).txt
+   pit# script -af ~/csm-install-remoteiso.$(date +%Y-%m-%d).txt
    pit# export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
+   ```
+   
+1. Print information about the booted PIT image.
+
+   There is nothing in the output that needs to be verified. This is run in order to ensure the information is
+   recorded in the typescript file, in case it is needed later. For example, this information is useful to include in
+   any bug reports or service queries for issues encountered on the PIT node.
+
+   ```bash
    pit# /root/bin/metalid.sh
    ```
    
-   Expected output of the last command looks similar to the following:
+   Expected output looks similar to the following:
+
    ```
    = PIT Identification = COPY/CUT START =======================================
    VERSION=1.5.7
@@ -124,33 +136,81 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
    ```
 
 1. <a name="set-up-site-link"></a>Set up the site-link, enabling SSH to work. You can reconnect with SSH after this step.
-   > **`Note:`** If your site's network authority or network administrator has already provisioned a DHCP given IPv4 address for your master node(s) external NIC(s), **then skip this step**.
+   > **Note:** If your site's network authority or network administrator has already provisioned a DHCP IPv4 address for your master node's external NIC(s), **then skip this step**.
 
-   1. Setup variables.
+   1. Set networking variables.
+
+      > If you have previously created the `system_config.yaml` file for this system, the values for these variables are in it. The
+      > following table lists the variables being set, their corresponding `system_config.yaml` fields, and a description of what
+      > they are.
+
+      | Variable    | `system_config.yaml`   | Description                                                                        |
+      |-------------|------------------------|------------------------------------------------------------------------------------|
+      | `site_ip`   | `site-ip`              | The IPv4 address **and CIDR netmask** for the node's external interface(s)         |
+      | `site_gw`   | `site-gw`              | The IPv4 gateway address for the node's external interface(s)                      |
+      | `site_dns`  | `site-dns`             | The IPv4 domain name server address for the site                                   |
+      | `site_nics` | `site-nic`             | The actual NIC name(s) for the external site interface(s)                          |
+      
+      > If the `system_config.yaml` file has not yet been generated for this system, the values for `site_ip`, `site_gw`, and
+      > `site_dns` should be provided by the site's network administrator or network authority. The `site_nics` interface(s)
+      > are typically the first onboard adapter or the first copper 1 GbE PCIe adapter on the PIT node. If multiple interfaces are
+      > specified, they must be separated by spaces (for example, `site_nics='p2p1 p2p2 p2p3'`).
 
       ```bash
-      # The IPv4 Address for the nodes external interface(s); this will be provided if not already by the site's network administrator or network authority.
       pit# site_ip=172.30.XXX.YYY/20
       pit# site_gw=172.30.48.1
       pit# site_dns=172.30.84.40
-      # The actual NIC names for the external site interface; the first onboard or the first 1GBe PCIe (RJ-45).
-      pit# site_nics='p2p1 p2p2 p2p3'
-      # another example:
       pit# site_nics=em1
       ```
 
-   1. Run the site-link setup script.
-      > **`Note:`** All of the `/root/bin/csi-*` scripts are harmless to run without parameters, doing so will dump usage statements.
+   1. Run the `csi-setup-lan0.sh` script to set up the site link.
+
+      > **Note:** All of the `/root/bin/csi-*` scripts are harmless to run without parameters; doing so will print usage statements.
 
       ```bash
       pit# /root/bin/csi-setup-lan0.sh $site_ip $site_gw $site_dns $site_nics
       ```
 
-   1. Check if `lan0` has an IP address and attempt to auto-set the hostname based on DNS (this script appends `-pit` to the end of the hostname as a means to mitigate confusing the PIT node with an actual, deployed NCN). Then exit the typescript, exit the console session, and log in again using SSH.
-
+   1. Verify that `lan0` has an IP address and attempt to auto-set the hostname based on DNS.
+   
+      The script appends `-pit` to the end of the hostname as a means to reduce the chances of confusing the PIT node with an actual, deployed NCN. 
+      
       ```bash
       pit# ip a show lan0
       pit# /root/bin/csi-set-hostname.sh # this will attempt to set the hostname based on the site's own DNS records.
+      ```
+
+   1. Add helper variables to PIT node environment.
+
+      > **Important:** All CSM install procedures on the PIT node assume that these variables are set
+      > and exported.
+
+      1. Set helper variables.
+
+         ```bash
+         pit# CSM_RELEASE=csm-x.y.z
+         pit# SYSTEM_NAME=eniac
+         ```
+
+      1. Add variables to the PIT environment.
+
+         By adding these to the `/etc/environment` file of the PIT node, these variables will be
+         automatically set and exported in shell sessions on the PIT node. 
+
+         > The `echo` prepends a newline to ensure that the variable assignment occurs on a unique line,
+         > and not at the end of another line.
+
+         ```bash
+         pit# echo "
+         CSM_PATH=/var/www/ephemeral/${CSM_RELEASE}
+         CSM_RELEASE=${CSM_RELEASE}
+         PITDATA=/var/www/ephemeral
+         SYSTEM_NAME=${SYSTEM_NAME}" | tee -a /etc/environment
+         ```
+
+   1. Exit the typescript, exit the console session, and log in again using SSH.
+
+      ```bash
       pit# exit # exit the typescript started earlier
       pit# exit # log out of the pit node
       # Close the console session by entering &. or ~.
@@ -161,9 +221,14 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
    1. After reconnecting, resume the typescript (the `-a` appends to an existing script).
 
        ```bash
-      pit# cd ~
-      pit# script -af $(ls -tr csm-install-remoteiso* | head -n 1)
+      pit# script -af $(ls -tr ~/csm-install-remoteiso*.txt | head -n 1)
       pit# export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
+      ```
+
+   1. Verify that expected environment variables are set in the new login shell.
+
+      ```bash
+      pit# echo -e "CSM_PATH=${CSM_PATH}\nCSM_RELEASE=${CSM_RELEASE}\nPITDATA=${PITDATA}\nSYSTEM_NAME=${SYSTEM_NAME}"
       ```
 
    1. Check hostname.
@@ -171,118 +236,105 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
       ```bash
       pit# hostnamectl
       ```
-      > **`Note:`** If the hostname returned by the `hostnamectl` command is still `pit`, then re-run the above csi-set-hostname.sh script with the same parameters. Otherwise an administrator should feel free to set the hostname by hand with `hostnamectl`, please continue to use the `-pit` suffix to prevent masquerading a PIT node as a real NCN to administrators and automation.
+
+      > **Note:** The hostname should be similar to `eniac-ncn-m001-pit` when booted from the LiveCD, but it will be shown as `pit#` 
+      > in the documentation command prompts from this point onward.
+
+      > **Note:** If the hostname returned by the `hostnamectl` command is `pit`, then re-run the `csi-set-hostname.sh` script with the same parameters. Otherwise, an administrator should set the hostname manually with `hostnamectl`. In the latter case, be sure to append the `-pit` suffix to prevent masquerading a PIT node as a real NCN to administrators and automation.
 
 1. Find a local disk for storing product installers.
 
-    ```bash
-    pit# disk="$(lsblk -l -o SIZE,NAME,TYPE,TRAN | grep -E '(sata|nvme|sas)' | sort -h | awk '{print $2}' | head -n 1 | tr -d '\n')"
-    pit# echo $disk
-    pit# parted --wipesignatures -m --align=opt --ignore-busy -s /dev/$disk -- mklabel gpt mkpart primary ext4 2048s 100%
-    pit# mkfs.ext4 -L PITDATA "/dev/${disk}1"
-    ```
+   ```bash
+   pit# disk="$(lsblk -l -o SIZE,NAME,TYPE,TRAN | grep -E '(sata|nvme|sas)' | sort -h | awk '{print $2}' | head -n 1 | tr -d '\n')"
+   pit# echo $disk
+   pit# parted --wipesignatures -m --align=opt --ignore-busy -s /dev/$disk -- mklabel gpt mkpart primary ext4 2048s 100%
+   pit# mkfs.ext4 -L PITDATA "/dev/${disk}1"
+   ```
 
-    In some cases the `parted` command may give an error similar to the following:
-    ```text
-    Error: Partition(s) 4 on /dev/sda have been written, but we have been unable to inform the kernel of the change, probably
-    because it/they are in use. As a result, the old partition(s) will remain in use. You should reboot now before making
-    further changes.
-    ```
+   The `parted` command may give an error similar to the following:
+   ```text
+   Error: Partition(s) 4 on /dev/sda have been written, but we have been unable to inform the kernel of the change, probably
+   because it/they are in use. As a result, the old partition(s) will remain in use. You should reboot now before making
+   further changes.
+   ```
 
-    In that case, the following steps may resolve the problem without needing to reboot. These commands will remove
-    volume groups and raid arrays that may be using the disk. **These commands only need to be run if the earlier
-    `parted` command failed.**
+   In that case, the following steps may resolve the problem without needing to reboot. These commands remove
+   volume groups and raid arrays that may be using the disk. **These commands only need to be run if the earlier
+   `parted` command failed.**
 
-    ```bash
-    pit# RAIDS=$(grep "${disk}[0-9]" /proc/mdstat | awk '{ print "/dev/"$1 }')
-    pit# echo $RAIDS
-    pit# VGS=$(echo $RAIDS | xargs -r pvs --noheadings -o vg_name 2>/dev/null)
-    pit# echo $VGS
-    pit# echo $VGS | xargs -r -t -n 1 vgremove -f -v
-    pit# echo $RAIDS | xargs -r -t -n 1 mdadm -S -f -v
-    ```
+   ```bash
+   pit# RAIDS=$(grep "${disk}[0-9]" /proc/mdstat | awk '{ print "/dev/"$1 }') ; echo ${RAIDS}
+   pit# VGS=$(echo ${RAIDS} | xargs -r pvs --noheadings -o vg_name 2>/dev/null) ; echo ${VGS}
+   pit# echo ${VGS} | xargs -r -t -n 1 vgremove -f -v
+   pit# echo ${RAIDS} | xargs -r -t -n 1 mdadm -S -f -v
+   ```
 
-    After running the above procedure, retry the `parted` command which failed. If it succeeds, resume the install from that point.
+   After running the above procedure, retry the `parted` command which failed. If it succeeds, resume the install from that point.
 
-1. Mount local disk, check the output of each command as it goes.
+1. Mount local disk.
 
-    > **`Note:`** The FSLabel `PITDATA` is already in `/etc/fstab`, so the path is omitted in the following calls to `mount`.
+   > **Note:** The FSLabel `PITDATA` is already in `/etc/fstab`, so the path is omitted in the following call to `mount`.
 
-    ```bash
-    pit# mount -v -L PITDATA
-    pit# pushd /var/www/ephemeral
-    pit# mkdir -v admin prep prep/admin configs data
-    ```
+   ```bash
+   pit# mount -vL PITDATA &&
+        mkdir -pv ${PITDATA}/{admin,configs} ${PITDATA}/prep/{admin,logs} ${PITDATA}/data/{k8s,ceph}
+   ```
 
-1. Quit the typescript session with the `exit` command, copy the file (csm-install-remoteiso.<date>.txt) from its initial location to the newly created directory, and restart the typescript.
+1. Relocate the typescript to the newly mounted `PITDATA` directory.
 
-    ```bash
-    pit# exit # The typescript
-    pit# cp -v ~/csm-install-remoteiso.*.txt /var/www/ephemeral/prep/admin
-    pit# cd /var/www/ephemeral/prep/admin
-    pit# script -af $(ls -tr csm-install-remoteiso* | head -n 1)
-    pit# export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
-    ```
+   1. Quit the typescript session with the `exit` command.
+
+   1. Copy the typescript file to its new location.
+
+      ```bash
+      pit# cp -v ~/csm-install-remoteiso.*.txt ${PITDATA}/prep/admin
+      ```
+
+   1. Restart the typescript, appending to the previous file.
+
+      ```bash
+      pit# script -af $(ls -tr ${PITDATA}/prep/admin/csm-install-remoteiso*.txt | head -n 1)
+      pit# export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
+      ```
 
 1. Download the CSM software release to the PIT node.
 
-   **Important:** In an earlier step, the CSM release plus any patches or hotfixes
-   was downloaded to a system using the instructions in [Update CSM Product Stream](../update_product_stream/index.md).
-   Either copy from that system to the PIT node or set the ENDPOINT variable to URL and use `wget`.
-
-   1. Set helper variables
+   1. Set variable to URL of CSM tarball.
 
       ```bash
-      pit# ENDPOINT=https://arti.dev.cray.com/artifactory/shasta-distribution-stable-local/csm
-      pit# export CSM_RELEASE=csm-x.y.z
-      pit# export SYSTEM_NAME=eniac
-      ```
-
-   1. Save the `CSM_RELEASE` for usage later; all subsequent shell sessions will have this variable set.
-
-      > The `echo` prepends a newline to ensure that the variable assignment occurs on a unique line,
-      > and not at the end of another.
-
-      ```bash      
-      pit# echo -e "\nCSM_RELEASE=$CSM_RELEASE" >>/etc/environment
+      pit# URL=https://arti.dev.cray.com/artifactory/shasta-distribution-stable-local/csm/${CSM_RELEASE}.tar.gz
       ```
 
    1. Fetch the release tarball.
 
       ```bash
-      pit# wget ${ENDPOINT}/${CSM_RELEASE}.tar.gz -O /var/www/ephemeral/${CSM_RELEASE}.tar.gz
+      pit# wget ${URL} -O ${CSM_PATH}.tar.gz
       ```
 
    1. Expand the tarball on the PIT node.
 
-      > Note: Expansion of the tarball may take more than 45 minutes.
+      > **Note:** Expansion of the tarball may take more than 45 minutes.
 
       ```bash
-      pit# tar -C /var/www/ephemeral -zxvf /var/www/ephemeral/${CSM_RELEASE}.tar.gz
-      pit# CSM_PATH=/var/www/ephemeral/${CSM_RELEASE}
-      pit# echo $CSM_PATH
-      pit# echo -e "\nCSM_PATH=$CSM_PATH" >>/etc/environment
-      pit# ls -l ${CSM_PATH}
+      pit# tar -C ${PITDATA} -zxvf ${CSM_PATH}.tar.gz && ls -l ${CSM_PATH}
       ```
 
    1. Copy the artifacts into place.
 
       ```bash
-      pit# mkdir -pv /var/www/ephemeral/data/{k8s,ceph} &&
-            rsync -a -P --delete ${CSM_PATH}/images/kubernetes/ /var/www/ephemeral/data/k8s/ &&
-            rsync -a -P --delete ${CSM_PATH}/images/storage-ceph/ /var/www/ephemeral/data/ceph/
+      pit# rsync -a -P --delete ${CSM_PATH}/images/kubernetes/   ${PITDATA}/data/k8s/ &&
+           rsync -a -P --delete ${CSM_PATH}/images/storage-ceph/ ${PITDATA}/data/ceph/
       ```
 
-   > **`Note:`** The PIT ISO, Helm charts/images, and bootstrap RPMs are now available in the extracted CSM tar.
+   > **Note:** The PIT ISO, Helm charts/images, and bootstrap RPMs are now available in the extracted CSM tar file.
 
-1. Install/upgrade CSI; check if a newer version was included in the tar-ball.
+1. Install/upgrade CSI; check if a newer version was included in the tarball.
 
    ```bash
    pit# rpm -Uvh $(find ${CSM_PATH}/rpm/ -name "cray-site-init-*.x86_64.rpm" | sort -V | tail -1)
    ```
 
-1. Download and install/upgrade the documentation RPM. If this machine does not have direct internet
-   access this RPM will need to be externally downloaded and then copied to this machine.
+1. Install the latest documentation RPM.
 
    See [Check for Latest Documentation](../update_product_stream/index.md#documentation)
 
@@ -322,13 +374,7 @@ Some files are needed for generating the configuration payload. See the [Command
 
 1. Create the `hmn_connections.json` file by following the [Create HMN Connections JSON](create_hmn_connections_json.md)  procedure. Return to this section when completed.
 
-1. Change into the preparation directory plus necessary PIT directories (for later):
-
-   ```bash
-   pit# cd /var/www/ephemeral/prep
-   ```
-
-1. Pull these files into the current working directory, or create them if this is a first-time/initial install:
+1. Copy these files into the current working directory, or create them if this is an initial install of the system:
 
    - `application_node_config.yaml` (optional - see below)
    - `cabinets.yaml` (optional - see below)
@@ -337,25 +383,30 @@ Some files are needed for generating the configuration payload. See the [Command
    - `switch_metadata.csv`
    - `system_config.yaml` (only available after [first-install generation of system files](#first-timeinitial-installs-bare-metal)
 
-   > The optional `application_node_config.yaml` file may be provided for further defining of settings relating to how application nodes will appear in HSM for roles and subroles. See [Create Application Node YAML](create_application_node_config_yaml.md)
+   > The optional `application_node_config.yaml` file may be provided for further definition of settings relating to how application nodes will appear in HSM for roles and subroles. See [Create Application Node YAML](create_application_node_config_yaml.md).
 
    > The optional `cabinets.yaml` file allows cabinet naming and numbering as well as some VLAN overrides. See [Create Cabinets YAML](create_cabinets_yaml.md).
 
-   > The `system_config.yaml` is required for a re-install, because it was created during a previous session of configuration generation. For a first time install, the information in it must be provided as command line arguments to `csi config init`.
+   > The `system_config.yaml` file is generated by the `csi` tool during the first install of a system, and can later be used for reinstalls of the system. For the initial install, the information in it must be provided as command line arguments to `csi config init`.
 
    After gathering the files into this working directory, move on to [Subsequent Fresh-Installs (Re-Installs)](#subsequent-fresh-installs-re-installs).
 
+1. Proceed to the appropriate next step.
+
+   * If this is the initial install of the system, then proceed to [Initial Installs (bare-metal)](#first-timeinitial-installs-bare-metal).
+   * If this is a reinstall of the system, then proceed to [Subsequent Installs (Reinstalls)](#subsequent-fresh-installs-re-installs).
+
 <a name="subsequent-fresh-installs-re-installs"></a>
-#### 4.1.a Subsequent Fresh-Installs (Re-Installs)
+#### 4.1.a Subsequent Installs (Reinstalls)
 
 1. **For subsequent fresh-installs (re-installs) where the `system_config.yaml` parameter file is available**, generate the updated system configuration (see [Cray Site Init Files](../background/index.md#cray_site_init_files)).
 
-   > **`Warning:`** If the `system_config.yaml` file is unavailable, please skip this step and move onto the next one in step 4.1.b to generate the first configuration payload.
+   > **Warning:** If the `system_config.yaml` file is unavailable, please skip this step and move onto the next one in step 4.1.b to generate the first configuration payload.
 
-   1. Check for the configuration files. The needed files should be in the current directory.
+   1. Check for the configuration files. The needed files should be in the preparation directory.
 
       ```bash
-      pit:/var/www/ephemeral/prep/# ls -1
+      pit# ls -1 ${PITDATA}/prep
       ```
 
       Expected output looks similar to the following:
@@ -369,30 +420,19 @@ Some files are needed for generating the configuration payload. See the [Command
       system_config.yaml
       ```
 
-   1. Verify that the `SYSTEM_NAME` variable is set.
-
-      ```bash
-      pit:/var/www/ephemeral/prep/# echo $SYSTEM_NAME
-      ```
-
    1. Generate the system configuration
 
-      > **`Note:`** For those more familiar with a CSM install, this step may be skipped entirely by using `pit-init.sh`, as detailed in the [Bring-up the PIT Services and Validate PIT Health](#bring---up-the-pit-services-and-validate-pit-health) section.
+      > **Note:** For those more familiar with a CSM install, this step may be skipped entirely by using `pit-init.sh`, as detailed in the [Bring-up the PIT Services and Validate PIT Health](#bring---up-the-pit-services-and-validate-pit-health) section.
 
-      > **`Note:`** Make sure to select a reachable NTP pool/server (passed in via the `--ntp-pools`/`--ntp-servers` flags, respectively). Adding an unreachable server can cause clock skew as `chrony` tries to continually reach out to a server it can never reach.
+      > **Note:** Make sure to select a reachable NTP pool/server (passed in via the `--ntp-pools`/`--ntp-servers` flags, respectively). Adding an unreachable server can cause clock skew as `chrony` tries to continually reach out to a server it can never reach.
 
       ```bash
-      pit:/var/www/ephemeral/prep/# csi config init
-
-      # Verify the newly generated configuration payload's `system_config.yaml` matches the current version of CSI.
-      # Note: Keep this new system_config.yaml somewhere safe to facilitate re-installs.
-      pit:/var/www/ephemeral/prep/# cat ${SYSTEM_NAME}/system_config.yaml
-      pit:/var/www/ephemeral/prep/# csi version
+      pit# cd ${PITDATA}/prep && csi config init
       ```
 
-      A new directory matching your `--system-name` argument will now exist in your working directory.
+      A new directory matching the `system-name` field in `system_config.yaml` will now exist in the working directory.
 
-      > **`Note:`** These warnings from `csi config init` for issues in `hmn_connections.json` can be ignored.
+      > **Note:** These warnings from `csi config init` for issues in `hmn_connections.json` can be ignored.
       >
       > 1. The node with the external connection (`ncn-m001`) will have a warning similar to this because its BMC is connected to the site and not the HMN like the other management NCNs. It can be ignored.
       >   ```bash
@@ -413,19 +453,19 @@ Some files are needed for generating the configuration payload. See the [Command
       >   {"Source":"x3000door-Motiv","SourceRack":"x3000","SourceLocation":" ","DestinationRack":"x3000","DestinationLocation":"u36","DestinationPort":"j27"}}
       >   ```
 
-   1. Skip the next step and continue to [prepare site init](#prepare-site-init).
+   1. Skip the next step and continue to [verify and backup `system_config.yaml`](#verify-csi-versions-match).
 
 <a name="first-timeinitial-installs-bare-metal"></a>
-#### 4.1.b First-Time/Initial Installs (bare-metal)
+#### 4.1.b Initial Installs (bare-metal)
 
 1. **For first-time/initial installs (without a `system_config.yaml`file)**, generate the system configuration. See below for an explanation of the command line parameters and some common settings.
 
-   1. Check for the configuration files. The needed files should be in the current directory.
+   1. Check for the configuration files. The needed files should be in the preperation directory.
 
-      > **`Note:`** For those more familiar with a CSM install, this step may be skipped entirely by using `pit-init.sh`, as detailed in the [Bring-up the PIT Services and Validate PIT Health](#bring---up-the-pit-services-and-validate-pit-health) section.
+      > **Note:** For those more familiar with a CSM install, this step may be skipped entirely by using `pit-init.sh`, as detailed in the [Bring-up the PIT Services and Validate PIT Health](#bring---up-the-pit-services-and-validate-pit-health) section.
 
       ```bash
-      pit:/var/www/ephemeral/prep/# ls -1
+      pit# ls -1 ${PITDATA}/prep
       ```
 
        1. Expected output looks similar to the following:
@@ -438,17 +478,11 @@ Some files are needed for generating the configuration payload. See the [Command
           switch_metadata.csv
           ```
 
-   1. Verify that the `SYSTEM_NAME` variable is set.
-
-      ```bash
-      pit:/var/www/ephemeral/prep/# echo $SYSTEM_NAME
-      ```
-
    1. Generate the system config:
-      > **`Note:`** The following command is an **example only**, run `csi config init --help` to print a full list of parameters that must be set. These will vary significantly depending on the system and site configuration in use.
+      > **Note:** The following command is an **example only**, run `csi config init --help` to print a full list of parameters that must be set. These will vary significantly depending on the system and site configuration in use.
 
       ```bash
-      pit:/var/www/ephemeral/prep/# csi config init \
+      pit# cd ${PITDATA}/prep && csi config init \
           --bootstrap-ncn-bmc-user root \
           --bootstrap-ncn-bmc-pass ${IPMI_PASSWORD} \
           --system-name ${SYSTEM_NAME} \
@@ -472,18 +506,13 @@ Some files are needed for generating the configuration payload. See the [Command
           --cabinets-yaml cabinets.yaml \
           --hmn-mtn-cidr 10.104.0.0/17 \
           --nmn-mtn-cidr 10.100.0.0/17 \
-
-      # Verify the newly generated configuration payload's `system_config.yaml` matches the current version of CSI.
-      # NOTE: Keep this new system_config.yaml somewhere safe to facilitate re-installs.
-      pit:/var/www/ephemeral/prep/# cat ${SYSTEM_NAME}/system_config.yaml
-      pit:/var/www/ephemeral/prep/# csi version
       ```
 
-      A new directory matching your `--system-name` argument will now exist in your working directory.
+      A new directory matching the `--system-name` argument will now exist in the working directory.
 
-      > **`IMPORTANT`** After generating a configuration, a visual audit of the generated files for network data should be performed.
+      > **Important:** After generating a configuration, a visual audit of the generated files for network data should be performed.
 
-      > **`SPECIAL NOTES`** Certain parameters to `csi config init` may be hard to grasp on first-time configuration generations:
+      > **Special Notes:** Certain parameters to `csi config init` may be hard to grasp on first-time configuration generations:
       >
       > * The `application_node_config.yaml` file is optional, but if one has one describing the mapping between prefixes in `hmn_connections.csv` that should be mapped to HSM subroles, one needs to include a command line option to have it used. See [Create Application Node YAML](create_application_node_config_yaml.md).
       > * The `bootstrap-ncn-bmc-user` and `bootstrap-ncn-bmc-pass` must match what is used for the BMC account and its password for the management NCNs.
@@ -497,7 +526,7 @@ Some files are needed for generating the configuration payload. See the [Command
       > * For systems that use non-sequential cabinet ID numbers, use `cabinets-yaml` to include the `cabinets.yaml` file. This file can include information about the starting ID for each cabinet type and number of cabinets which have separate command line options, but is a way to specify explicitly the id of every cabinet in the system. If one are using a `cabinets-yaml` file, flags specified on the `csi` command-line related to cabinets will be ignored. See [Create Cabinets YAML](create_cabinets_yaml.md).
       > * An override to default cabinet IPv4 subnets can be made with the `hmn-mtn-cidr` and `nmn-mtn-cidr` parameters.
 
-      > **`SPECIAL/IGNORABLE WARNINGS`** These warnings from `csi config init` for issues in `hmn_connections.json` can be ignored:
+      > **Ignorable Warnings:** These warnings from `csi config init` for issues in `hmn_connections.json` can be ignored:
       >
       > * The node with the external connection (`ncn-m001`) will have a warning similar to this because its BMC is connected to the site and not the HMN like the other management NCNs. It can be ignored.
       >
@@ -519,39 +548,52 @@ Some files are needed for generating the configuration payload. See the [Command
       >    {"Source":"x3000door-Motiv","SourceRack":"x3000","SourceLocation":" ","DestinationRack":"x3000","DestinationLocation":"u36","DestinationPort":"j27"}}
       >    ```
 
-   1. Continue with the next step to [prepare site init](#prepare-site-init).
+   1. Continue to the next step to [verify and backup `system_config.yaml`](#verify-csi-versions-match).
+
+<a name="verify-csi-versions-match"></a>
+### 4.2 Verify and Backup `system_config.yaml`
+
+1. Verify that the newly generated `system_config.yaml` matches the current version of CSI.
+
+   1. View the new `system_config.yaml` file and note the CSI version reported near the end of the file.
+
+      ```bash
+      pit# cat ${PITDATA}/prep/${SYSTEM_NAME}/system_config.yaml
+      ```
+
+   1. Note the version reported by the `csi` tool.
+
+      ```bash
+      pit# csi version
+      ```
+
+   1. The two versions should match. If they do not, determine the cause and regenerate the file.
+
+1. Copy the new `system_config.yaml` file somewhere safe to facilitate re-installs.
+
+1. Continue to the next step to [prepare site init](#prepare-site-init).
 
 <a name="prepare-site-init"></a>
-### 4.2 Prepare Site Init
+### 4.3 Prepare Site Init
 
-1. First, prepare a shim to facilitate going through the site-init guide:
+> **Important:** Although the command prompts in this procedure are `linux#`, the procedure should be
+> performed on the PIT node.
 
-    ```bash
-    pit# mkdir -vp /mnt/pitdata &&
-         mount -v --bind /var/www/ephemeral/ /mnt/pitdata/
-    ```
-
-1. Follow the procedures to [Prepare Site Init](prepare_site_init.md) directory for your system.
-
-1. Remove the shim:
-
-    > This uses `rmdir` to safely remove the directory, preventing accidental removal if one does not notice a `umount` command failure.
-
-    ```bash
-    pit# cd ~ && umount -v /mnt/pitdata/ && rmdir -v /mnt/pitdata
-    ```
+Prepare the `site-init` directory by performing the [Prepare Site Init](prepare_site_init.md) procedures.
 
 <a name="bring---up-the-pit-services-and-validate-pit-health"></a>
 ## 5. Bring-up the PIT Services and Validate PIT Health
 
 1. Set the same variables from the `csi config init` step from earlier, and then invoke `pit-init.sh` to set up the PIT server for deploying NCNs.
-   > **`Note:`** `pit-init.sh` will re-run `csi config init`, copy all generated files into place, apply the CA patch, and finally restart daemons. This will also re-print the `metalid.sh` content in case it was skipped in the previous step. **Re-installs** can skip running `csi config init` entirely and simply run `pit-init.sh` after gathering CSI input files into `/var/www/ephemeral/prep`.
+   > **Note:** `pit-init.sh` will re-run `csi config init`, copy all generated files into place, apply the CA patch, and finally restart daemons. This will also re-print the `metalid.sh` content in case it was skipped in the earlier step. **Re-installs** can skip running `csi config init` entirely and simply run `pit-init.sh` after gathering CSI input files into the `prep` directory.
 
-    ```bash
-    pit# export USERNAME=root
-    pit# export IPMI_PASSWORD=changeme
-    pit# /root/bin/pit-init.sh
-    ```
+   > `read -s` is used in order to prevent the credentials from being displayed on the screen or recorded in the shell history.
+
+   ```bash
+   pit# USERNAME=root
+   pit# read -s IPMI_PASSWORD
+   pit# export USERNAME IPMI_PASSWORD ; /root/bin/pit-init.sh
+   ```
 
 1. Start and configure NTP on the LiveCD for a fallback/recovery server.
 
@@ -561,11 +603,9 @@ Some files are needed for generating the configuration payload. See the [Command
 
 1. Install Goss Tests and Server
 
-   The following assumes the `CSM_PATH` environment variable is set to the absolute path of the unpacked CSM release.
-
    ```bash
-   pit# rpm -Uvh --force $(find ${CSM_PATH}/rpm/ -name "goss-servers*.rpm" | sort -V | tail -1)
-   pit# rpm -Uvh --force $(find ${CSM_PATH}/rpm/ -name "csm-testing*.rpm" | sort -V | tail -1)
+   pit# rpm -Uvh --force $(find ${CSM_PATH}/rpm/ -name "goss-servers*.rpm" | sort -V | tail -1) \
+                         $(find ${CSM_PATH}/rpm/ -name "csm-testing*.rpm" | sort -V | tail -1)
    ```
 
 <a name="next-topic"></a>

--- a/install/bootstrap_livecd_remote_iso.md
+++ b/install/bootstrap_livecd_remote_iso.md
@@ -422,8 +422,6 @@ Some files are needed for generating the configuration payload. See the [Command
 
    1. Generate the system configuration
 
-      > **Note:** For those more familiar with a CSM install, this step may be skipped entirely by using `pit-init.sh`, as detailed in the [Bring-up the PIT Services and Validate PIT Health](#bring---up-the-pit-services-and-validate-pit-health) section.
-
       > **Note:** Make sure to select a reachable NTP pool/server (passed in via the `--ntp-pools`/`--ntp-servers` flags, respectively). Adding an unreachable server can cause clock skew as `chrony` tries to continually reach out to a server it can never reach.
 
       ```bash
@@ -461,8 +459,6 @@ Some files are needed for generating the configuration payload. See the [Command
 1. **For first-time/initial installs (without a `system_config.yaml`file)**, generate the system configuration. See below for an explanation of the command line parameters and some common settings.
 
    1. Check for the configuration files. The needed files should be in the preperation directory.
-
-      > **Note:** For those more familiar with a CSM install, this step may be skipped entirely by using `pit-init.sh`, as detailed in the [Bring-up the PIT Services and Validate PIT Health](#bring---up-the-pit-services-and-validate-pit-health) section.
 
       ```bash
       pit# ls -1 ${PITDATA}/prep
@@ -584,9 +580,12 @@ Prepare the `site-init` directory by performing the [Prepare Site Init](prepare_
 <a name="bring---up-the-pit-services-and-validate-pit-health"></a>
 ## 5. Bring-up the PIT Services and Validate PIT Health
 
-1. Set the same variables from the `csi config init` step from earlier, and then invoke `pit-init.sh` to set up the PIT server for deploying NCNs.
-   > **Note:** `pit-init.sh` will re-run `csi config init`, copy all generated files into place, apply the CA patch, and finally restart daemons. This will also re-print the `metalid.sh` content in case it was skipped in the earlier step. **Re-installs** can skip running `csi config init` entirely and simply run `pit-init.sh` after gathering CSI input files into the `prep` directory.
+1. Initialize the PIT.
 
+   The `pit-init.sh` script will prepare the PIT server for deploying NCNs.
+
+   > Set the `USERNAME` and `IPMI_PASSWORD` variables to the credentials for the BMC of the PIT node.
+   >
    > `read -s` is used in order to prevent the credentials from being displayed on the screen or recorded in the shell history.
 
    ```bash

--- a/install/bootstrap_livecd_usb.md
+++ b/install/bootstrap_livecd_usb.md
@@ -291,8 +291,6 @@ Some files are needed for generating the configuration payload. See these topics
 
    1. Generate the system configuration
 
-      > **Note:** If it is desirable to expedite booting into the USB, this step may be skipped. Instead, after logging into the PIT for [#first time](#51-first-login) and running `pit-init`, the USB will gain connectivity and SSH. As long as the required files are present, then one may continue to the first time boot.
-
       > **Note:** Ensure that you select a reachable NTP pool/server passed in using the `--ntp-pools`/`--ntp-servers` flags, respectively. Adding an unreachable server can cause clock skew as chrony tries to continually reach out to a server it can never reach.
 
       ```bash
@@ -330,8 +328,6 @@ Some files are needed for generating the configuration payload. See these topics
 1. **For first-time/initial installs (without a `system_config.yaml`file)**, generate the system configuration. See below for an explanation of the command line parameters and some common settings.
 
    1. Check for the configuration files. The needed files should be in the preparation directory.
-
-     > **Note:** if it is desirable to expedite booting into the USB, this step may be skipped. Instead, after logging into the PIT for [#first time](#51-first-login) and running `pit-init` the USB will gain connectivity and SSH. As long as the required files are present then one may continue to the first time boot.
 
       ```bash
       linux# ls -1 ${PITDATA}/prep
@@ -772,8 +768,6 @@ On first log in (over SSH or at local console), the LiveCD will prompt the admin
 1. Initialize the PIT.
 
    The `pit-init.sh` script will prepare the PIT server for deploying NCNs.
-
-   > **Note:** `pit-init` will re-run `csi config init`, copy all generated files into place, apply the CA patch, and finally restart daemons. This will also re-print the `metalid.sh` content in case it was skipped in the previous step. **Re-installs** can skip running `csi config init` entirely and simply run `pit-init.sh` after gathering CSI input files into `/var/www/ephemeral/prep`.
 
    ```bash
    pit# /root/bin/pit-init.sh

--- a/install/bootstrap_livecd_usb.md
+++ b/install/bootstrap_livecd_usb.md
@@ -4,20 +4,23 @@ The Pre-Install Toolkit (PIT) node needs to be bootstrapped from the LiveCD. The
 to bootstrap the PIT node: the RemoteISO or a bootable USB device. This procedure describes using the USB
 device. If not using the USB device, see [Bootstrap PIT Node from LiveCD Remote ISO](bootstrap_livecd_remote_iso.md).
 
-There are 5 overall steps that provide a bootable USB with SSH enabled, capable of installing Shasta v1.5 (or higher).
+These steps provide a bootable USB with SSH enabled, capable of installing this CSM release.
 
 ## Topics
-   1. [Download and Expand the CSM Release](#download-and-expand-the-csm-release)
-   1. [Create the Bootable Media](#create-the-bootable-media)
-   1. [Configuration Payload](#configuration-payload)
-      1. [Generate Installation Files](#generate-installation-files)
-         1. [Subsequent Fresh-Installs (Re-Installs)](#subsequent-fresh-installs-re-installs)
-         1. [First-Time/Initial Installs (bare-metal)](#first-timeinitial-installs-bare-metal)
-      1. [Prepare Site Init](#prepare-site-init)
-   1. [Prepopulate LiveCD Daemons Configuration and NCN Artifacts](#prepopulate-livecd-daemons-configuration-and-ncn-artifacts)
-   1. [Boot the LiveCD](#boot-the-livecd)
-      1. [First Login](#first-login)
-   1. [Next Topic](#next-topic)
+
+1. [Download and Expand the CSM Release](#download-and-expand-the-csm-release)
+1. [Create the Bootable Media](#create-the-bootable-media)
+1. [Configuration Payload](#configuration-payload)
+   1. [Generate Installation Files](#generate-installation-files)
+      * [Subsequent Installs (Reinstalls)](#subsequent-fresh-installs-re-installs)
+      * [Initial Installs (bare-metal)](#first-timeinitial-installs-bare-metal)
+   1. [Verify and Backup `system_config.yaml`](#verify-csi-versions-match)
+   1. [Prepare Site Init](#prepare-site-init)
+1. [Prepopulate LiveCD Daemons Configuration and NCN Artifacts](#prepopulate-livecd-daemons-configuration-and-ncn-artifacts)
+1. [Boot the LiveCD](#boot-the-livecd)
+   1. [First Login](#first-login)
+1. [Configure the Running LiveCD](#configure-the-running-livecd)
+1. [Next Topic](#next-topic)
 
 <a name="download-and-expand-the-csm-release"></a>
 ## 1. Download and Expand the CSM Release
@@ -34,39 +37,50 @@ Fetch the base installation CSM tarball, extract it, and install the contained C
 1. Set up the initial typescript.
 
    ```bash
-   linux# script -af csm-install-usb.$(date +%Y-%m-%d).txt
+   linux# SCRIPT_FILE=$(pwd)/csm-install-usb.$(date +%Y-%m-%d).txt
+   linux# script -af ${SCRIPT_FILE}
    linux# export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
+   ```
+
+1. Set and export helper variables.
+
+   > **Important:** All CSM install procedures for preparing the PIT node assume that these variables are set
+   > and exported.
+
+   ```bash
+   pit# export CSM_RELEASE=csm-x.y.z
+   pit# export SYSTEM_NAME=eniac
+   pit# export PITDATA=/mnt/pitdata
    ```
 
 1. Download and expand the CSM software release.
 
-   **Important:** In order to ensure that the CSM release plus any patches, documentation updates,
-   or hotfixes are included, follow the instructions in [Update CSM Product Stream](../update_product_stream/index.md)
+   **Important:** Ensure that you have the CSM release plus any patches or hotfixes by
+   following the instructions in [Update CSM Product Stream](../update_product_stream/index.md)
 
    **Important:** Download to a location that has sufficient space for both the tarball and the expanded tarball.
 
-   > Note: Expansion of the tarball may take more than 45 minutes.
-
-   The rest of this procedure will use the `CSM_RELEASE` and `CSM_PATH` variables.
+   > **Important:** All CSM install procedures for preparing the PIT node assume that the `CSM_PATH` variable
+   > has been set and exported.
+   >
+   > **Note:** Expansion of the tarball may take more than 45 minutes.
 
    ```bash
-   linux# CSM_RELEASE=csm-x.y.z
-   linux# echo $CSM_RELEASE
    linux# tar -zxvf ${CSM_RELEASE}.tar.gz
    linux# ls -l ${CSM_RELEASE}
-   linux# CSM_PATH=$(pwd)/${CSM_RELEASE}
+   linux# export CSM_PATH=$(pwd)/${CSM_RELEASE}
    ```
 
    The ISO and other files are now available in the directory from the extracted CSM tarball.
 
-1. Install/upgrade CSI; check if a newer version was included in the tarball.
+<a name="install-csi-rpm"></a>
+1. Install the latest version of CSI tool.
 
    ```bash
-   linux# rpm -Uvh $(find ./${CSM_RELEASE}/rpm/cray/csm/ -name "cray-site-init-*.x86_64.rpm" | sort -V | tail -1)
+   linux# rpm -Uvh $(find ${CSM_PATH}/rpm/cray/csm/ -name "cray-site-init-*.x86_64.rpm" | sort -V | tail -1)
    ```
 
-1. Download and install/upgrade the documentation RPM. If this machine does not have direct internet
-   access this RPM will need to be externally downloaded and then copied to this machine.
+1. Install the latest documentation RPM.
 
    See [Check for Latest Documentation](../update_product_stream/index.md#documentation)
 
@@ -110,8 +124,8 @@ Fetch the base installation CSM tarball, extract it, and install the contained C
      from the `${CSM_PATH}/rpm/embedded` directory.
 
       ```bash
-      linux# rpm -Uvh ${CSM_PATH}/rpm/embedded/suse/SLE-Module-Containers/15-SP2/x86_64/update/podman-*.x86_64.rpm
-      linux# rpm -Uvh ${CSM_PATH}/rpm/embedded/suse/SLE-Module-Containers/15-SP2/x86_64/update/podman-cni-config-*.noarch.rpm
+      linux# rpm -Uvh $(find ${CSM_PATH}/rpm/embedded -name "podman-*.x86_64.rpm" | sort -V | tail -1) \
+                      $(find ${CSM_PATH}/rpm/embedded -name "podman-cni-config-*.noarch.rpm" | sort -V | tail -1)
       ```
 
 1. Install `lsscsi` to view attached storage devices.
@@ -129,7 +143,7 @@ Fetch the base installation CSM tarball, extract it, and install the contained C
      from the `${CSM_PATH}/rpm/embedded` directory.
 
       ```bash
-      linux# rpm -Uvh ${CSM_PATH}/rpm/embedded/suse/SLE-Module-Basesystem/15-SP2/x86_64/product/lsscsi-*.x86_64.rpm
+      linux# rpm -Uvh $(find ${CSM_PATH}/rpm/embedded -name "lsscsi-*.x86_64.rpm" | sort -V | tail -1)
       ```
 
 <a name="create-the-bootable-media"></a>
@@ -168,10 +182,10 @@ which device will be used for it.
     * On Linux, use the CSI application to do this:
 
         ```bash
-        linux# csi pit format $USB ${CSM_PATH}/cray-pre-install-toolkit-*.iso 50000
+        linux# csi pit format ${USB} ${CSM_PATH}/cray-pre-install-toolkit-*.iso 50000
         ```
 
-        > Note: If the previous command fails with the following error message, it indicates that this Linux computer does not have the checkmedia RPM installed. In that case, the RPM can be installed and `csi pit format` can be run again
+        > **Note:** If the previous command fails with the following error message, it indicates that this Linux computer does not have the checkmedia RPM installed. In that case, the RPM can be installed and `csi pit format` can be run again
         > ```
         > ERROR: Unable to validate ISO. Please install checkmedia
         > ```
@@ -180,28 +194,32 @@ which device will be used for it.
         >
         >   ```bash
         >   linux# zypper in --repo ${CSM_RELEASE}-embedded -y libmediacheck5 checkmedia
-        >   linux# csi pit format $USB ${CSM_PATH}/cray-pre-install-toolkit-*.iso 50000
+        >   linux# csi pit format ${USB} ${CSM_PATH}/cray-pre-install-toolkit-*.iso 50000
         >   ```
 
-    * On MacOS, use the `write-livecd.sh` script to do this:
+    * On MacOS, use the `write-livecd.sh` script to do this.
+    
+        This script is contained in the CSI tool RPM. See [install latest version of the CSI tool](#install-csi-rpm) step.
 
         ```bash
-        macos# ./cray-site-init/write-livecd.sh $USB ${CSM_PATH}/cray-pre-install-toolkit-*.iso 50000
+        macos# write-livecd.sh ${USB} ${CSM_PATH}/cray-pre-install-toolkit-*.iso 50000
         ```
 
-    > NOTE: At this point the USB device is usable in any server with an x86_64 architecture based CPU. The remaining steps help add the installation data and enable SSH on boot.
+    > **Note:** At this point, the USB device is usable in any server with a CPU with x86_64 architecture. The remaining steps help add the installation data and enable SSH on boot.
 
-1. Mount the configuration and persistent data partition:
+1. Mount the configuration and persistent data partitions.
 
     ```bash
-    linux# mkdir -pv /mnt/{cow,pitdata}
-    linux# mount -vL cow /mnt/cow && mount -vL PITDATA /mnt/pitdata
+    linux# mkdir -pv /mnt/{cow,pitdata} && 
+           mount -vL cow /mnt/cow && 
+           mount -vL PITDATA ${PITDATA} && 
+           mkdir -pv ${PITDATA}/{admin,configs} ${PITDATA}/prep/{admin,logs} ${PITDATA}/data/{k8s,ceph}
     ```
 
 1.  Copy and extract the tarball into the USB:
     ```bash
-    linux# cp -v ${CSM_PATH}.tar.gz /mnt/pitdata/
-    linux# tar -zxvf ${CSM_PATH}.tar.gz -C /mnt/pitdata/
+    linux# cp -v ${CSM_PATH}.tar.gz ${PITDATA} &&
+           tar -zxvf ${CSM_PATH}.tar.gz -C ${PITDATA}/
     ```
 
 The USB device is now bootable and contains the CSM artifacts. This may be useful for internal or quick usage. Administrators seeking a Shasta installation must continue onto the [configuration payload](#configuration-payload).
@@ -209,10 +227,11 @@ The USB device is now bootable and contains the CSM artifacts. This may be usefu
 <a name="configuration-payload"></a>
 ## 3. Configuration Payload
 
-The SHASTA-CFG structure and other configuration files will be prepared, then `csi` will generate system-unique configuration payload used for the rest of the CSM installation on the USB device.
+The SHASTA-CFG structure and other configuration files will be prepared, then `csi` will generate a system-unique configuration payload. This payload will be used for the rest of the CSM installation on the USB device.
 
-* [Generate Installation Files](#generate-installation-files)
-* [Prepare Site Init](#prepare-site-init)
+1. [Generate Installation Files](#generate-installation-files)
+1. [Verify and Backup `system_config.yaml`](#verify-csi-versions-match)
+1. [Prepare Site Init](#prepare-site-init)
 
 <a name="generate-installation-files"></a>
 ### 3.1 Generate Installation Files
@@ -222,16 +241,9 @@ Some files are needed for generating the configuration payload. See these topics
    * [Command Line Configuration Payload](prepare_configuration_payload.md#command_line_configuration_payload)
    * [Configuration Payload Files](prepare_configuration_payload.md#configuration_payload_files)
 
-> **`NOTE`**: The USB device is usable at this time, but without SSH enabled as well as core services. This means the USB device could be used to boot the system now, and a user can return to this step at another time.
+> **Note:**: The USB device is usable at this time, but without SSH enabled as well as core services. This means the USB device could be used to boot the system now, and a user can return to this step at another time.
 
 1. At this time see [Create HMN Connections JSON](create_hmn_connections_json.md) for instructions about creating the `hmn_connections.json`.
-
-1. Change into the preparation directory plus necessary PIT directories (for later):
-
-   ```bash
-   linux# mkdir -pv /mnt/pitdata/admin /mnt/pitdata/prep /mnt/pitdata/configs /mnt/pitdata/data/{k8s,ceph}
-   linux# cd /mnt/pitdata/prep
-   ```
 
 1. Pull these files into the current working directory, or create them if this is a first-time/initial install:
 
@@ -242,25 +254,28 @@ Some files are needed for generating the configuration payload. See these topics
    - `switch_metadata.csv`
    - `system_config.yaml` (only available after [first-install generation of system files](#first-timeinitial-installs-bare-metal)
 
-   > The optional `application_node_config.yaml` file may be provided for further defining of settings relating to how application nodes will appear in HSM for roles and subroles. See [Create Application Node YAML](create_application_node_config_yaml.md)
+   > The optional `application_node_config.yaml` file may be provided for further definition of settings relating to how application nodes will appear in HSM for roles and subroles. See [Create Application Node YAML](create_application_node_config_yaml.md)
 
    > The optional `cabinets.yaml` file allows cabinet naming and numbering as well as some VLAN overrides. See [Create Cabinets YAML](create_cabinets_yaml.md).
 
-   > The `system_config.yaml` is required for a re-install, because it was created during a previous session of configuration generation. For a first time install, the information in it must be provided as command line arguments to `csi config init`.
+   > The `system_config.yaml` file is generated by the `csi` tool during the first install of a system, and can later be used for reinstalls of the system. For the initial install, the information in it must be provided as command line arguments to `csi config init`.
 
-   After gathering the files into this working directory, move on to [Subsequent Fresh-Installs (Re-Installs)](#subsequent-fresh-installs-re-installs).
+1. Proceed to the appropriate next step.
+
+   * If this is the initial install of the system, then proceed to [Initial Installs (bare-metal)](#first-timeinitial-installs-bare-metal).
+   * If this is a reinstall of the system, then proceed to [Subsequent Installs (Re-Installs)](#subsequent-fresh-installs-re-installs).
 
 <a name="subsequent-fresh-installs-re-installs"></a>
-#### 3.1.a Subsequent Fresh-Installs (Re-Installs)
+#### 3.1.a Subsequent Installs (Reinstalls)
 
 1. **For subsequent fresh-installs (re-installs) where the `system_config.yaml` parameter file is available**, generate the updated system configuration (see [Cray Site Init Files](../background/index.md#cray_site_init_files)).
 
-   > **`SKIP STEP IF`** if the `system_config.yaml` file is unavailable please skip this step and move onto the next one in order to generate the first configuration payload.
+   > **SKIP STEP IF** if the `system_config.yaml` file is unavailable please skip this step and move onto the next one in order to generate the first configuration payload.
 
-   1. Check for the configuration files. The needed files should be in the current directory.
+   1. Check for the configuration files. The needed files should be in the preperation directory.
 
       ```bash
-      linux:/mnt/pitdata/prep# ls -1
+      linux# ls -1 ${PITDATA}/prep
       ```
 
       Expected output looks similar to the following:
@@ -274,31 +289,19 @@ Some files are needed for generating the configuration payload. See these topics
       system_config.yaml
       ```
 
-   1. Set an environment variable so this system name can be used in later commands.
-
-      ```bash
-      linux:/mnt/pitdata/prep# export SYSTEM_NAME=eniac
-      ```
-
    1. Generate the system configuration
 
-   > **`NOTE`** if it is desirable to expedite booting into the USB, this step may be skipped. Instead, after logging into the PIT for [#first time](#51-first-login) and running `pit-init` the USB will gain connectivity and SSH. As long as the required files are present then one may continue to the first time boot.
+      > **Note:** If it is desirable to expedite booting into the USB, this step may be skipped. Instead, after logging into the PIT for [#first time](#51-first-login) and running `pit-init`, the USB will gain connectivity and SSH. As long as the required files are present, then one may continue to the first time boot.
 
-   > **`NOTE`** ensure you select a reachable NTP pool/server passed in via the `--ntp-pools`/`--ntp-servers` flags, respectively. Adding an unreachable server can cause clock skew as chrony tries to continually reach out to a server it can never reach.
-
+      > **Note:** Ensure that you select a reachable NTP pool/server passed in using the `--ntp-pools`/`--ntp-servers` flags, respectively. Adding an unreachable server can cause clock skew as chrony tries to continually reach out to a server it can never reach.
 
       ```bash
-      linux:/mnt/pitdata/prep# csi config init
-
-      # Verify the newly generated configuration payload's `system_config.yaml` matches the current version of CSI.
-      # NOTE: Keep this new system_config.yaml somewhere safe to facilitate re-installs.
-      linux:/mnt/pitdata/prep# cat ${SYSTEM_NAME}/system_config.yaml
-      linux:/mnt/pitdata/prep# csi version
+      linux# cd ${PITDATA}/prep && csi config init
       ```
 
-      A new directory matching your `--system-name` argument will now exist in your working directory.
+      A new directory matching the `system-name` field in `system_config.yaml` will now exist in the working directory.
 
-      > **`NOTE`** These warnings from `csi config init` for issues in `hmn_connections.json` can be ignored.
+      > **Note:** These warnings from `csi config init` for issues in `hmn_connections.json` can be ignored.
       >
       > * The node with the external connection (`ncn-m001`) will have a warning similar to this because its BMC is connected to the site and not the HMN like the other management NCNs. It can be ignored.
       >    ```
@@ -319,19 +322,19 @@ Some files are needed for generating the configuration payload. See these topics
       >    {"Source":"x3000door-Motiv","SourceRack":"x3000","SourceLocation":" ","DestinationRack":"x3000","DestinationLocation":"u36","DestinationPort":"j27"}}
       >    ```
 
-   1. Skip the next step and continue to [prepare site init](#prepare-site-init).
+   1. Skip the next step and continue to [verify and backup `system_config.yaml`](#verify-csi-versions-match).
 
 <a name="first-timeinitial-installs-bare-metal"></a>
-#### 3.1.b First-Time/Initial Installs (bare-metal)
+#### 3.1.b Initial Installs (bare-metal)
 
 1. **For first-time/initial installs (without a `system_config.yaml`file)**, generate the system configuration. See below for an explanation of the command line parameters and some common settings.
 
-   1. Check for the configuration files. The needed files should be in the current directory.
+   1. Check for the configuration files. The needed files should be in the preparation directory.
 
-     > **`NOTE`** if it is desirable to expedite booting into the USB, this step may be skipped. Instead, after logging into the PIT for [#first time](#51-first-login) and running `pit-init` the USB will gain connectivity and SSH. As long as the required files are present then one may continue to the first time boot.
+     > **Note:** if it is desirable to expedite booting into the USB, this step may be skipped. Instead, after logging into the PIT for [#first time](#51-first-login) and running `pit-init` the USB will gain connectivity and SSH. As long as the required files are present then one may continue to the first time boot.
 
       ```bash
-      linux:/mnt/pitdata/prep# ls -1
+      linux# ls -1 ${PITDATA}/prep
       ```
 
       Expected output looks similar to the following:
@@ -344,17 +347,11 @@ Some files are needed for generating the configuration payload. See these topics
       switch_metadata.csv
       ```
 
-   1. Set an environment variable so this system name can be used in later commands.
-
-      ```bash
-      linux:/mnt/pitdata/prep# export SYSTEM_NAME=eniac
-      ```
-
    1. Generate the system config:
-      > **`NOTE`** the provided command below is an **example only**, run `csi config init --help` to print a full list of parameters that must be set. These will vary significatnly depending on ones system and site configuration.
+      > **Note:** the provided command below is an **example only**, run `csi config init --help` to print a full list of parameters that must be set. These will vary significatnly depending on ones system and site configuration.
 
       ```bash
-      linux:/mnt/pitdata/prep# csi config init \
+      linux# cd ${PITDATA}/prep && csi config init \
           --bootstrap-ncn-bmc-user root \
           --bootstrap-ncn-bmc-pass ${IPMI_PASSWORD} \
           --system-name ${SYSTEM_NAME} \
@@ -378,18 +375,13 @@ Some files are needed for generating the configuration payload. See these topics
           --cabinets-yaml cabinets.yaml \
           --hmn-mtn-cidr 10.104.0.0/17 \
           --nmn-mtn-cidr 10.100.0.0/17 \
-
-      # Verify the newly generated configuration payload's `system_config.yaml` matches the current version of CSI.
-      # NOTE: Keep this new system_config.yaml somewhere safe to facilitate re-installs.
-      linux:/mnt/pitdata/prep# cat ${SYSTEM_NAME}/system_config.yaml
-      linux:/mnt/pitdata/prep# csi version
       ```
 
-      A new directory matching your `--system-name` argument will now exist in your working directory.
+      A new directory matching the `--system-name` argument will now exist in the working directory.
 
-      > **`IMPORTANT`** After generating a configuration, a visual audit of the generated files for network data should be performed.
+      > **Important:** After generating a configuration, a visual audit of the generated files for network data should be performed.
 
-      > **`SPECIAL NOTES`** Certain parameters to `csi config init` may be hard to grasp on first-time configuration generations:
+      > **Special Notes:** Certain parameters to `csi config init` may be hard to grasp on first-time configuration generations:
       >
       > * The `application_node_config.yaml` file is optional, but if one has one describing the mapping between prefixes in `hmn_connections.csv` that should be mapped to HSM subroles, one needs to include a command line option to have it used. See [Create Application Node YAML](create_application_node_config_yaml.md).
       > * The `bootstrap-ncn-bmc-user` and `bootstrap-ncn-bmc-pass` must match what is used for the BMC account and its password for the management NCNs.
@@ -403,7 +395,7 @@ Some files are needed for generating the configuration payload. See these topics
       > * For systems that use non-sequential cabinet ID numbers, use `cabinets-yaml` to include the `cabinets.yaml` file. This file can include information about the starting ID for each cabinet type and number of cabinets which have separate command line options, but is a way to specify explicitly the id of every cabinet in the system. If one are using a `cabinets-yaml` file, flags specified on the `csi` command-line related to cabinets will be ignored. See [Create Cabinets YAML](create_cabinets_yaml.md).
       > * An override to default cabinet IPv4 subnets can be made with the `hmn-mtn-cidr` and `nmn-mtn-cidr` parameters.
 
-      > **`SPECIAL/IGNORABLE WARNINGS`** These warnings from `csi config init` for issues in `hmn_connections.json` can be ignored:
+      > **Ignorable Warnings:** These warnings from `csi config init` for issues in `hmn_connections.json` can be ignored:
       >
       > * The node with the external connection (`ncn-m001`) will have a warning similar to this because its BMC is connected to the site and not the HMN like the other management NCNs. It can be ignored.
       >
@@ -425,85 +417,128 @@ Some files are needed for generating the configuration payload. See these topics
       >    {"Source":"x3000door-Motiv","SourceRack":"x3000","SourceLocation":" ","DestinationRack":"x3000","DestinationLocation":"u36","DestinationPort":"j27"}}
       >    ```
 
-   1. Continue to the next step to [prepare site init](#prepare-site-init).
+   1. Continue to the next step to [verify and backup `system_config.yaml`](#verify-csi-versions-match).
+
+<a name="verify-csi-versions-match"></a>
+### 3.2 Verify and Backup `system_config.yaml`
+
+1. Verify that the newly generated `system_config.yaml` matches the current version of CSI.
+
+   1. View the new `system_config.yaml` file and note the CSI version reported near the end of the file.
+
+      ```bash
+      linux# cat ${PITDATA}/prep/${SYSTEM_NAME}/system_config.yaml
+      ```
+
+   1. Note the version reported by the `csi` tool.
+
+      ```bash
+      linux# csi version
+      ```
+
+   1. The two versions should match. If they do not, determine the cause and regenerate the file.
+
+1. Copy the new `system_config.yaml` file somewhere safe to facilitate re-installs.
+
+1. Continue to the next step to [prepare site init](#prepare-site-init).
 
 <a name="prepare-site-init"></a>
-### 3.2 Prepare Site Init
+### 3.3 Prepare Site Init
 
-> **`NOTE`**: It is assumed at this point that `/mnt/pitdata` is still mounted on the linux system, this is important as the following procedure depends on that mount existing.
+> **Note:**: It is assumed at this point that `$PITDATA` (that is, `/mnt/pitdata`) is still mounted on the Linux system. This is important because the following procedure depends on that mount existing.
 
 1. Install Git if not already installed (recommended).
 
-    Although not strictly required, the procedures for setting up the
+   Although not strictly required, the procedures for setting up the
    `site-init` directory recommend persisting `site-init` files in a Git
    repository.
 
-1. Follow all of the [Prepare Site Init](prepare_site_init.md) procedures.
+1. Prepare the `site-init` directory.
+
+   Perform the [Prepare Site Init](prepare_site_init.md) procedures.
 
 <a name="prepopulate-livecd-daemons-configuration-and-ncn-artifacts"></a>
 ## 4. Prepopulate LiveCD Daemons Configuration and NCN Artifacts
 
-Now that the configuration is generated, we can populate the LiveCD with the generated files.
+Now that the configuration is generated, the LiveCD must be populated with the generated files.
 
-This will enable SSH, and other services when the LiveCD starts.
-
-1. Set system name and enter prep directory if one has not already (one should already be here from the previous section).
+1. Set system name and enter prep directory.
 
     ```bash
-    linux# export SYSTEM_NAME=eniac
-    linux# cd /mnt/pitdata/prep
+    linux# cd ${PITDATA}/prep
     ```
 
 1. Use CSI to populate the LiveCD with networking files so SSH will work on the first boot.
 
-   > **`NOTE`** ll other files will be copied in by "PIT init" in a later step, after booting into the USB stick).
+   ```bash
+   linux# csi pit populate cow /mnt/cow/ ${SYSTEM_NAME}/
+   ```
 
-    ```bash
-    linux:/mnt/pitdata/prep# csi pit populate cow /mnt/cow/ ${SYSTEM_NAME}/
-    ```
+   Expected output looks similar to the following:
 
-    Expected output looks similar to the following:
-
-    ```
-    config------------------------> /mnt/cow/rw/etc/sysconfig/network/config...OK
-    ifcfg-bond0-------------------> /mnt/cow/rw/etc/sysconfig/network/ifcfg-bond0...OK
-    ifcfg-lan0--------------------> /mnt/cow/rw/etc/sysconfig/network/ifcfg-lan0...OK
-    ifcfg-bond0.nmn0--------------> /mnt/cow/rw/etc/sysconfig/network/ifcfg-bond0.nmn0...OK
-    ifcfg-bond0.hmn0--------------> /mnt/cow/rw/etc/sysconfig/network/ifcfg-bond0.hmn0...OK
-    ifcfg-bond0.can0--------------> /mnt/cow/rw/etc/sysconfig/network/ifcfg-bond0.can0...OK
-    ifcfg-bond0.cmn0--------------> /mnt/cow/rw/etc/sysconfig/network/ifcfg-bond0.cmn0...OK
-    ifroute-lan0------------------> /mnt/cow/rw/etc/sysconfig/network/ifroute-lan0...OK
-    ifroute-bond0.nmn0------------> /mnt/cow/rw/etc/sysconfig/network/ifroute-bond0.nmn0...OK
-    CAN.conf----------------------> /mnt/cow/rw/etc/dnsmasq.d/CAN.conf...OK
-    CMN.conf----------------------> /mnt/cow/rw/etc/dnsmasq.d/CMN.conf...OK
-    HMN.conf----------------------> /mnt/cow/rw/etc/dnsmasq.d/HMN.conf...OK
-    NMN.conf----------------------> /mnt/cow/rw/etc/dnsmasq.d/NMN.conf...OK
-    MTL.conf----------------------> /mnt/cow/rw/etc/dnsmasq.d/MTL.conf...OK
-    statics.conf------------------> /mnt/cow/rw/etc/dnsmasq.d/statics.conf...OK
-    conman.conf-------------------> /mnt/cow/rw/etc/conman.conf...OK
-    ```
+   ```
+   config------------------------> /mnt/cow/rw/etc/sysconfig/network/config...OK
+   ifcfg-bond0-------------------> /mnt/cow/rw/etc/sysconfig/network/ifcfg-bond0...OK
+   ifcfg-lan0--------------------> /mnt/cow/rw/etc/sysconfig/network/ifcfg-lan0...OK
+   ifcfg-bond0.nmn0--------------> /mnt/cow/rw/etc/sysconfig/network/ifcfg-bond0.nmn0...OK
+   ifcfg-bond0.hmn0--------------> /mnt/cow/rw/etc/sysconfig/network/ifcfg-bond0.hmn0...OK
+   ifcfg-bond0.can0--------------> /mnt/cow/rw/etc/sysconfig/network/ifcfg-bond0.can0...OK
+   ifcfg-bond0.cmn0--------------> /mnt/cow/rw/etc/sysconfig/network/ifcfg-bond0.cmn0...OK
+   ifroute-lan0------------------> /mnt/cow/rw/etc/sysconfig/network/ifroute-lan0...OK
+   ifroute-bond0.nmn0------------> /mnt/cow/rw/etc/sysconfig/network/ifroute-bond0.nmn0...OK
+   CAN.conf----------------------> /mnt/cow/rw/etc/dnsmasq.d/CAN.conf...OK
+   CMN.conf----------------------> /mnt/cow/rw/etc/dnsmasq.d/CMN.conf...OK
+   HMN.conf----------------------> /mnt/cow/rw/etc/dnsmasq.d/HMN.conf...OK
+   NMN.conf----------------------> /mnt/cow/rw/etc/dnsmasq.d/NMN.conf...OK
+   MTL.conf----------------------> /mnt/cow/rw/etc/dnsmasq.d/MTL.conf...OK
+   statics.conf------------------> /mnt/cow/rw/etc/dnsmasq.d/statics.conf...OK
+   conman.conf-------------------> /mnt/cow/rw/etc/conman.conf...OK
+   ```
 
 1. Set the hostname and print it into the hostname file.
 
-   > **`NOTE`** Do not confuse other administrators by naming the LiveCD `ncn-m001`. Please append the `-pit` suffix,
-   > that will indicate that the node is booted from the LiveCD.
+   > **Note:** Do not confuse other administrators by naming the LiveCD `ncn-m001`. Append the `-pit` suffix,
+   > indicating that the node is booted from the LiveCD.
 
    ```bash
-   linux:/mnt/pitdata/prep# echo "${SYSTEM_NAME}-ncn-m001-pit" >/mnt/cow/rw/etc/hostname
+   linux# echo "${SYSTEM_NAME}-ncn-m001-pit" | tee /mnt/cow/rw/etc/hostname
    ```
 
-1. Unmount the Overlay, we are done with it
+1. Add some helpful variables to the PIT environment.
+
+   By adding these to the `/etc/environment` file of the PIT image, these variables will be
+   automatically set and exported in shell sessions on the booted PIT node.
+
+   > **Important:** All CSM install procedures on the booted PIT node assume that these variables
+   > are set and exported.
+   >
+   > **Note:** It is intentional that the `PITDATA` and `CSM_PATH` variables here have different
+   > values here than what was set earlier. This is because after booting from the PIT node, some
+   > paths will be different.
+   >
+   > The `echo` prepends a newline to ensure that the variable assignment occurs on a unique line,
+   > and not at the end of another line.
+
+   ```bash
+   linux# echo "
+   CSM_PATH=/var/www/ephemeral/${CSM_RELEASE}
+   CSM_RELEASE=${CSM_RELEASE}
+   PITDATA=/var/www/ephemeral
+   SYSTEM_NAME=${SYSTEM_NAME}" | tee -a /mnt/cow/rw/etc/environment
+   ```
+
+1. Unmount the overlay.
 
     ```bash
-    linux:/mnt/pitdata/prep# umount -v /mnt/cow
+    linux# umount -v /mnt/cow
     ```
 
-1. Copy the NCN artifacts:
+1. Copy the NCN artifacts.
 
-   1. Copy k8s artifacts:
+   1. Copy Kubernetes node artifacts:
 
        ```bash
-       linux:/mnt/pitdata/prep# csi pit populate pitdata "${CSM_PATH}/images/kubernetes/" /mnt/pitdata/data/k8s/ -kiK
+       linux# csi pit populate pitdata "${CSM_PATH}/images/kubernetes/" ${PITDATA}/data/k8s/ -kiK
        ```
 
        Expected output looks similar to the following:
@@ -514,10 +549,10 @@ This will enable SSH, and other services when the LiveCD starts.
        kubernetes-0.0.6.squashfs-------------------------> /mnt/pitdata/data/k8s/...OK
        ```
 
-   1. Copy Ceph/storage artifacts:
+   1. Copy Ceph/storage node artifacts:
 
        ```bash
-       linux:/mnt/pitdata/prep# csi pit populate pitdata "${CSM_PATH}/images/storage-ceph/" /mnt/pitdata/data/ceph/ -kiC
+       linux# csi pit populate pitdata "${CSM_PATH}/images/storage-ceph/" ${PITDATA}/data/ceph/ -kiC
        ```
 
        Expected output looks similar to the following:
@@ -528,21 +563,25 @@ This will enable SSH, and other services when the LiveCD starts.
        storage-ceph-0.0.5.squashfs-----------------------> /mnt/pitdata/data/ceph/...OK
        ```
 
-1. Quit the typescript session with the `exit` command and copy the file (csm-install-usb.<date>.txt) to the data partition on the USB drive.
+1. Quit the typescript session with the `exit` command and copy the typescript file to the data partition on the USB drive.
 
     ```bash
-    linux:/mnt/pitdata/prep# exit
-    linux:/mnt/pitdata/prep# cp ~/csm-install-usb.*.txt /mnt/pitdata/prep/admin
+    linux# exit
+    linux# cp -v ${SCRIPT_FILE} ${PITDATA}/prep/admin
     ```
 
 1. Unmount the data partition:
 
     ```bash
-    linux# cd; umount -v /mnt/pitdata
+    linux# cd; umount -v ${PITDATA}
     ```
 
-Now the USB device may be reattached to the management node, or if it was made on the management node then it can now
-reboot into the LiveCD.
+1. Move the USB device to the system to be installed, if needed.
+
+   If the USB device was created somewhere other than `ncn-m001` of the system to be installed, 
+   move it there from its current location.
+
+1. Proceed to the next step to boot into the LiveCD image.
 
 <a name="boot-the-livecd"></a>
 ## 5. Boot the LiveCD
@@ -550,50 +589,56 @@ reboot into the LiveCD.
 Some systems will boot the USB device automatically if no other OS exists (bare-metal). Otherwise the
 administrator may need to use the BIOS Boot Selection menu to choose the USB device.
 
-If an administrator has the node booted with an operating system which will next be rebooting into the LiveCD, then use `efibootmgr` to set the boot order to be the USB device. See the [set boot order](../background/ncn_boot_workflow.md#set-boot-order) page for more information about how to set the boot order to have the USB device first.
+If an administrator has the node booted with an operating system which will next be rebooting into the LiveCD,
+then use `efibootmgr` to set the boot order to be the USB device. See the 
+[set boot order](../background/ncn_boot_workflow.md#set-boot-order) page for more information about how to set the
+boot order to have the USB device first.
 
-> UEFI booting must be enabled to find the USB device's EFI bootloader.
+> **Note:** UEFI booting must be enabled in order for the system to find the USB device's EFI bootloader.
 
-1. Start a typescript on an external system, such as a laptop or Linux system, to record this section of activities done on the console of `ncn-m001` via IPMI.
+1. Start a typescript on an external system.
+
+   This will record this section of activities done on the console of `ncn-m001` using IPMI.
 
    ```bash
    external# script -a boot.livecd.$(date +%Y-%m-%d).txt
    external# export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
    ```
 
-   Confirm that the IPMI credentials work for the BMC by checking the power status.
+1. Confirm that the IPMI credentials work for the BMC by checking the power status.
+
+   Set the `BMC` variable to the hostname or IP address of the BMC of the PIT node.
+
+   > `read -s` is used in order to prevent the credentials from being displayed on the screen or recorded in the shell history.
 
    ```bash
-   external# export SYSTEM_NAME=eniac
-   external# export USERNAME=root
-   external# export IPMI_PASSWORD=changeme
-   external# ipmitool -I lanplus -U $USERNAME -E -H ${SYSTEM_NAME}-ncn-m001-mgmt chassis power status
+   external# BMC=eniac-ncn-m001-mgmt
+   external# read -s IPMI_PASSWORD
+   external# export IPMI_PASSWORD ; ipmitool -I lanplus -U root -E -H ${BMC} chassis power status
    ```
 
-   Connect to the IPMI console.
+1. Connect to the IPMI console.
 
    ```bash
-   external# ipmitool -I lanplus -U $USERNAME -E -H ${SYSTEM_NAME}-ncn-m001-mgmt sol activate
-   ncn-m001#
+   external# ipmitool -I lanplus -U root -E -H ${BMC} sol activate
    ```
 
-1. Reboot
+1. Reboot `ncn-m001`.
 
-    ```bash
-    ncn-m001# reboot
-    ```
+   ```bash
+   ncn-m001# reboot
+   ```
 
-Watch the shutdown and boot from the ipmitool session to the console terminal.
-The typescript can be discarded, otherwise if issues arise then it should be submitted with the bug report.
+1. Watch the shutdown and boot from the `ipmitool` console session.
 
-> **An integrity check** runs before Linux starts by default, it can be skipped by selecting "OK" in its prompt.
+   > **An integrity check** runs before Linux starts by default; it can be skipped by selecting `OK` in its prompt.
 
 <a name="first-login"></a>
 ### 5.1 First Login
 
-On first login (over SSH or at local console) the LiveCD will prompt the administrator to change the password.
+On first log in (over SSH or at local console), the LiveCD will prompt the administrator to change the password.
 
-1. **The initial password is empty**; set the username of `root` and press `return` twice:
+1. **The initial password is empty**; enter the username of `root` and press `return` twice.
 
    ```
    pit login: root
@@ -611,20 +656,88 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
    Welcome to the CRAY Pre-Install Toolkit (LiveOS)
    ```
 
-   > **`NOTE`** If this password ever becomes lost or forgotten, one may reset it by mounting the USB device on another computer. See [Reset root Password on LiveCD](reset_root_password_on_LiveCD.md) for information on clearing the password.
-
+   > **Note:** If this password ever becomes lost or forgotten, one may reset it by mounting the USB device on another computer. See [Reset root Password on LiveCD](reset_root_password_on_LiveCD.md) for information on clearing the password.
 
 1. Disconnect from IPMI console.
 
    Once the network is up so that SSH to the node works, disconnect from the IPMI console.
 
-   You can disconnect from the IPMI console by using the "~.", that is, the tilde character followed by a period character.
+   You can disconnect from the IPMI console by entering `~.`; That is, the tilde character followed by a period character.
 
-   Log in via `ssh` to the node as root and run `metalid.sh` to print the PIT's ID tag (this is used for referring to ones running PIT in any triage request).
+1. Exit the typescript started on the external system and use `scp` to transfer it to the PIT node.
+
+   > Set `PIT_NODE` variable to the site IP address or hostname of the PIT node.
 
    ```bash
-   external# ssh root@${SYSTEM_NAME}-ncn-m001
+   external# exit
+   external# PIT_NODE=eniac-ncn-m001
+   external# scp boot.livecd.*.txt root@${PIT_NODE}:/root
+   ```
+
+1. Log in to the PIT node as `root` using `ssh`.
+
+   ```bash
+   external# ssh root@${PIT_NODE}
+   ```
+
+1. Mount the data partition.
+
+   The data partition is set to `fsopt=noauto` to facilitate LiveCDs over virtual-ISO mount. Therefore, USB installations
+   need to mount this manually by running the following command.
+   
+   > **Note:** When creating the USB PIT image, this was mounted over `/mnt/pitdata`. Now that the USB PIT is booted,
+   > it will mount over `/var/www/ephemeral`. The FSLabel `PITDATA` is already in `/etc/fstab`, so the path is omitted
+   > in the following call to `mount`.
+
+   ```bash
+   pit# mount -vL PITDATA
+   ```
+
+1. Start a typescript to record this section of activities done on `ncn-m001` while booted from the LiveCD.
+
+   ```bash
+   pit# script -af /var/www/ephemeral/prep/admin/booted-csm-livecd.$(date +%Y-%m-%d).txt
+   pit# export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
+   ```
+
+1. Verify that expected environment variables are set in the new login shell.
+
+   These were written into `/etc/environment` on the USB PIT image earlier in this procedure, before it was booted.
+
+   ```bash
+   pit# echo -e "CSM_PATH=${CSM_PATH}\nCSM_RELEASE=${CSM_RELEASE}\nPITDATA=${PITDATA}\nSYSTEM_NAME=${SYSTEM_NAME}"
+   ```
+
+1. Copy the typescript made on the external system into the `PITDATA` mount.
+
+   ```bash
+   pit# cp -v /root/boot.livecd.*.txt ${PITDATA}/prep/admin
+   ```
+
+1. Check hostname.
+
+   ```bash
+   pit# hostnamectl
+   ```
+
+   > **Note:** The hostname should be similar to `eniac-ncn-m001-pit` when booted from the LiveCD, but it will be shown as `pit#` 
+   > in the documentation command prompts from this point onward.
+
+   > **Note:** If the hostname returned by the `hostnamectl` command is `pit`, then set the hostname manually with `hostnamectl`. In that case, be sure to append the `-pit` suffix to prevent masquerading a PIT node as a real NCN to administrators and automation.
+
+1. Print information about the booted PIT image.
+
+   There is nothing in the output that needs to be verified. This is run in order to ensure the information is
+   recorded in the typescript file, in case it is needed later. For example, this information is useful to include in
+   any bug reports or service queries for issues encountered on the PIT node.
+
+   ```bash
    pit# /root/bin/metalid.sh
+   ```
+   
+   Expected output looks similar to the following:
+
+   ```
    = PIT Identification = COPY/CUT START =======================================
    VERSION=1.5.7
    TIMESTAMP=20211028194247
@@ -643,29 +756,28 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
    = PIT Identification = COPY/CUT END =========================================
    ```
 
-   Note: The hostname should be similar to `eniac-ncn-m001-pit` when booted from the LiveCD, but it will be shown as `pit#` in the command prompts from this point onward.
-
 <a name="configure-the-running-livecd"></a>
 ## 6. Configure the Running LiveCD
 
-1. Start a typescript to record this section of activities done on `ncn-m001` while booted from the LiveCD.
+1. Set and export BMC credential variables.
+
+   > `read -s` is used in order to prevent the credentials from being displayed on the screen or recorded in the shell history.
 
    ```bash
-   pit# mkdir -pv /var/www/ephemeral/prep/admin
-   pit# script -af /var/www/ephemeral/prep/admin/booted-csm-livecd.$(date +%Y-%m-%d).txt
-   pit# export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
+   pit# read -s IPMI_PASSWORD
+   pit# USERNAME=root
+   pit# export IPMI_PASSWORD USERNAME
    ```
 
-1. Set the same variables from the `csi config init` step from earlier, and then invoke "PIT init" to setup the PIT server for deploying NCNs.
-    > The data partition is set to `fsopt=noauto` to facilitate LiveCDs over virtual-ISO mount. USB installations need to mount this manually.
-   > **`NOTE`** `pit-init` will re-run `csi config init`, copy all generated files into place, apply the CA patch, and finally restart daemons. This will also re-print the `metalid.sh` content in case it was skipped in the previous step. **Re-installs** can skip running `csi config init` entirely and simply run `pit-init.sh` after gathering CSI input files into `/var/www/ephemeral/prep`.
+1. Initialize the PIT.
 
-    ```bash
-    pit# export SYSTEM_NAME=eniac
-    pit# export USERNAME=root
-    pit# export IPMI_PASSWORD=changeme
-    pit# /root/bin/pit-init.sh
-    ```
+   The `pit-init.sh` script will prepare the PIT server for deploying NCNs.
+
+   > **Note:** `pit-init` will re-run `csi config init`, copy all generated files into place, apply the CA patch, and finally restart daemons. This will also re-print the `metalid.sh` content in case it was skipped in the previous step. **Re-installs** can skip running `csi config init` entirely and simply run `pit-init.sh` after gathering CSI input files into `/var/www/ephemeral/prep`.
+
+   ```bash
+   pit# /root/bin/pit-init.sh
+   ```
 
 1. Start and configure NTP on the LiveCD for a fallback/recovery server.
 
@@ -673,26 +785,13 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
    pit# /root/bin/configure-ntp.sh
    ```
 
-1. Set shell environment variables.
-
-   The `CSM_RELEASE` and `CSM_PATH` variables will be used later.
-
-   ```bash
-   pit# cd /var/www/ephemeral
-   pit:/var/www/ephemeral# export CSM_RELEASE=csm-x.y.z
-   pit:/var/www/ephemeral# echo $CSM_RELEASE
-   pit:/var/www/ephemeral# export CSM_PATH=$(pwd)/${CSM_RELEASE}
-   pit:/var/www/ephemeral# echo $CSM_PATH
-   ```
-
 1. Install Goss Tests and Server
 
    The following assumes the `CSM_PATH` environment variable is set to the absolute path of the unpacked CSM release.
 
    ```bash
-   pit:/var/www/ephemeral# rpm -Uvh --force $(find ${CSM_PATH}/rpm/ -name "goss-servers*.rpm" | sort -V | tail -1)
-   pit:/var/www/ephemeral# rpm -Uvh --force $(find ${CSM_PATH}/rpm/ -name "csm-testing*.rpm" | sort -V | tail -1)
-   pit:/var/www/ephemeral# cd
+   pit# rpm -Uvh --force $(find ${CSM_PATH}/rpm/ -name "goss-servers*.rpm" | sort -V | tail -1) \
+                         $(find ${CSM_PATH}/rpm/ -name "csm-testing*.rpm" | sort -V | tail -1)
    ```
 
 <a name="next-topic"></a>

--- a/install/prepare_site_init.md
+++ b/install/prepare_site_init.md
@@ -3,24 +3,33 @@
 These procedures guide administrators through setting up the `site-init`
 directory which contains important customizations for various products.
 
-   **Note:** There are two media available to bootstrap the PIT node--the RemoteISO or a bootable USB device. Both of those can use this procedure. The only difference in this procedure is that the RemoteISO method will execute these commands on the `PIT` node with command prompt `pit#` while the USB method could be done on any Linux system with the command prompt `linux#`. This procedure works for both methods, but has the command prompt of `linux#`, even though it would normally be `pit#` for the RemoteISO method.
+**Note:** There are two media available to bootstrap the PIT node: the RemoteISO or a bootable USB device. Both of those can use this procedure. 
+The only difference in this procedure is that the RemoteISO method will execute these commands on the PIT node, while the USB method could be done
+on any Linux system. This procedure works for both methods, so in order to be generic, this document uses the command prompt of `linux#` in its
+examples.
 
-### Topics:
-   1. [Background](#background)
-   1. [Create and Initialize Site-Init Directory](#create-and-initialize-site-init-directory)
-   1. [Create Baseline System Customizations](#create-baseline-system-customizations)
-   1. [Generate Sealed Secrets](#generate-sealed-secrets)
-   1. [Version Control Site-Init Files](#version-control-site-init-files)
-      1. [Push to a Remote Repository](#push-to-a-remote-repository)
-   1. [Customer-Specific Customizations](#customer-specific-customizations)
+1. [Background](#background)
+1. [Create and Initialize Site-Init Directory](#create-and-initialize-site-init-directory)
+1. [Create Baseline System Customizations](#create-baseline-system-customizations)
+1. [Generate Sealed Secrets](#generate-sealed-secrets)
+1. [Version Control Site-Init Files](#version-control-site-init-files)
+    1. [Push to a Remote Repository](#push-to-a-remote-repository)
+1. [Customer-Specific Customizations](#customer-specific-customizations)
 
-## Details
+## Prerequisites
+
+The procedures on this page assumes that the `SYSTEM_NAME`, `CSM_RELEASE`, `CSM_PATH`, and `PITDATA` variables are
+set and exported. This is normally done as part of the [Bootstrap PIT Node](index.md#bootstrap_pit_node) procedure.
+
+```bash
+linux# echo -e "CSM_PATH=${CSM_PATH}\nCSM_RELEASE=${CSM_RELEASE}\nPITDATA=${PITDATA}\nSYSTEM_NAME=${SYSTEM_NAME}"
+```
 
 <a name="background"></a>
-### 1. Background
+## 1. Background
 
-The `shasta-cfg` directory included in CSM includes relatively static,
-installation-centric artifacts such as:
+The `shasta-cfg` directory included in the CSM release tarball includes relatively static,
+installation-centric artifacts, such as:
 
 *   Cluster-wide network configuration settings required by Helm Charts
     deployed by product stream Loftsman Manifests
@@ -31,60 +40,74 @@ installation-centric artifacts such as:
     product stream installers
 
 <a name="create-and-initialize-site-init-directory"></a>
-### 2. Create and Initialize Site-Init Directory
+## 2. Create and Initialize Site-Init Directory
 
-1.  Create directory `/mnt/pitdata/prep/site-init`:
+1.  Set the `SITE_INIT` variable.
 
-    ```bash
-    linux# mkdir -pv /mnt/pitdata/prep/site-init
-    linux# cd /mnt/pitdata/prep/site-init
-    ```
-
-1.  Set `CSM_RELEASE` and `SYSTEM_NAME` variables, if not already set:
+    > **Important:** All procedures on this page assume that this variable has been set.
 
     ```bash
-    linux# CSM_RELEASE=csm-x.y.z
-    linux# SYSTEM_NAME=eniac
+    linux# SITE_INIT=${PITDATA}/prep/site-init
     ```
 
-1.  Initialize `/mnt/pitdata/prep/site-init` from CSM:
+1.  Create the `site-init` directory.
 
     ```bash
-    linux# /mnt/pitdata/${CSM_RELEASE}/shasta-cfg/meta/init.sh /mnt/pitdata/prep/site-init
+    linux# mkdir -pv ${SITE_INIT} && pushd ${SITE_INIT}
     ```
 
-1.  Set up an alias to the `yq` tool for use in later procedures.
+1.  Initialize `site-init` from CSM.
 
     ```bash
-    linux# alias yq="/mnt/pitdata/${CSM_RELEASE}/shasta-cfg/utils/bin/$(uname | awk '{print tolower($0)}')/yq"
+    linux# ${CSM_PATH}/shasta-cfg/meta/init.sh ${SITE_INIT}
     ```
+
+1.  Set an alias to the `yq` tool for use in these procedures.
+
+    1.  Set the alias.
+
+        ```bash
+        linux# alias yq="${CSM_PATH}/shasta-cfg/utils/bin/$(uname | awk '{print tolower($0)}')/yq"
+        ```
+
+    1.  Confirm that the alias points to the `yq` command.
+
+        ```bash
+        linux# yq -V
+        ```
+
+        Expected output looks similar to the following (although the version number may vary):
+
+        ```
+        yq version 3.3.0
+        ```
 
 <a name="create-baseline-system-customizations"></a>
 ### 3. Create Baseline System Customizations
 
-The following steps update `/mnt/pitdata/prep/site-init/customizations.yaml`
+The following steps update `${SITE_INIT}/customizations.yaml`
 with system-specific customizations.
 
 1.  Merge the system-specific settings generated by CSI into
-    `customizations.yaml`:
+    `customizations.yaml`.
 
     ```bash
-    linux# yq merge -xP -i /mnt/pitdata/prep/site-init/customizations.yaml <(yq prefix -P "/mnt/pitdata/prep/${SYSTEM_NAME}/customizations.yaml" spec)
+    linux# yq merge -xP -i ${SITE_INIT}/customizations.yaml <(yq prefix -P "${PITDATA}/prep/${SYSTEM_NAME}/customizations.yaml" spec)
     ```
 
-1. Set the cluster name:
+1. Set the cluster name.
 
     ```bash
-    linux# yq write -i /mnt/pitdata/prep/site-init/customizations.yaml spec.wlm.cluster_name "$SYSTEM_NAME"
+    linux# yq write -i ${SITE_INIT}/customizations.yaml spec.wlm.cluster_name "${SYSTEM_NAME}"
     ```
 
-1. Make a backup copy of `/mnt/pitdata/prep/site-init/customizations.yaml`:
+1. Make a backup copy of `${SITE_INIT}/customizations.yaml`.
 
     ```bash
-    linux# cp -v /mnt/pitdata/prep/site-init/customizations.yaml /mnt/pitdata/prep/site-init/customizations.yaml.prepassword
+    linux# cp -v ${SITE_INIT}/customizations.yaml ${SITE_INIT}/customizations.yaml.prepassword
     ```
 
-1.  Review the configuration to generate these sealed secrets in `customizations.yaml` in the `site-init` directory:
+1.  Review the configuration to generate these sealed secrets in `customizations.yaml` in the `site-init` directory.
 
     * `spec.kubernetes.sealed_secrets.cray_reds_credentials`
     * `spec.kubernetes.sealed_secrets.cray_meds_credentials`
@@ -94,81 +117,103 @@ with system-specific customizations.
     The 'cray_meds_credentials' are used by the Mountain Endpoint Discovery Service (MEDS) for the liquid-cooled components in an Olympus (Mountain) cabinet.
     The 'cray_hms_rts_credentials' are used by the Redfish Translation Service (RTS) for any hardware components which are not managed by Redfish, such as a ServerTech PDU in a River Cabinet.
 
-    Edit `customizations.yaml` to replace the 'Username' and `Password` references in the file so that the values match the existing settings of your system hardware components.
+    Edit `customizations.yaml` to replace the `Username` and `Password` references in the file so that the values match the existing settings of your system hardware components.
     See the `Decrypt Sealed Secrets for Review` section of [Manage Sealed Secrets](../operations/security_and_authentication/Manage_Sealed_Secrets.md#decrypt-sealed-secrets-for-review)
     if you need to examine credentials from prior installs.
 
-1. Review the changes that you made:
-
     ```bash
-    linux# diff /mnt/pitdata/prep/site-init/customizations.yaml /mnt/pitdata/prep/site-init/customizations.yaml.prepassword
+    linux# vi ${SITE_INIT}/customizations.yaml
     ```
 
-1. Validate that REDS/MEDS/RTS sealed secrets contain valid JSON using `jq`:
+1. Review the changes that you made.
 
-    Validate REDS credentials (used by the REDS and HMS discovery services, targeting River Redfish BMC endpoints and management switches).
     ```bash
-    linux# yq read /mnt/pitdata/prep/site-init/customizations.yaml 'spec.kubernetes.sealed_secrets.cray_reds_credentials.generate.data[0].args.value' | jq
-    linux# yq read /mnt/pitdata/prep/site-init/customizations.yaml 'spec.kubernetes.sealed_secrets.cray_reds_credentials.generate.data[1].args.value' | jq
-    ```
-    > NOTE: For vault_redfish_defaults, the only entry used is '{"Cray": {"Username": "root", "Password": "XXXX"}'
-    > Make sure it is specified as shown, with the 'Cray' key. This key is not
-    > used in any of the other credential specifications. Make sure Username and
-    > Password entries are correct.
-
-    Validate MEDS credentials (used by the MEDS service, targeting Redfish BMC endpoints). Make sure Username and Password entries are correct.
-    ```bash
-    linux# yq read /mnt/pitdata/prep/site-init/customizations.yaml 'spec.kubernetes.sealed_secrets.cray_meds_credentials.generate.data[0].args.value' | jq
+    linux# diff ${SITE_INIT}/customizations.yaml ${SITE_INIT}/customizations.yaml.prepassword
     ```
 
-    Validate RTS credentials (used by the Redfish Translation Service, targeting River Redfish BMC endpoints and PDU controllers). Make sure Username and Password entries are correct.
-    ```bash
-    linux# yq read /mnt/pitdata/prep/site-init/customizations.yaml 'spec.kubernetes.sealed_secrets.cray_hms_rts_credentials.generate.data[0].args.value' | jq
-    linux# yq read /mnt/pitdata/prep/site-init/customizations.yaml 'spec.kubernetes.sealed_secrets.cray_hms_rts_credentials.generate.data[1].args.value' | jq
-    ```
+1. Validate that REDS/MEDS/RTS credentials.
+
+    For all credentials, Make sure `Username` and `Password` values are correct.
+
+    1. Validate REDS credentials.
+    
+        These credentials are used by the REDS and HMS discovery services, targeting River Redfish
+        BMC endpoints and management switches
+
+        > NOTE: For vault_redfish_defaults, the only entry used is '{"Cray": {"Username": "root", "Password": "XXXX"}'
+        > Make sure it is specified as shown, with the `Cray` key. This key is not used in any of the other credential specifications. 
+
+        ```bash
+        linux# yq read ${SITE_INIT}/customizations.yaml 'spec.kubernetes.sealed_secrets.cray_reds_credentials.generate.data[*].args.value' | jq
+        ```
+
+    1. Validate MEDS credentials.
+
+        These credentials are used by the MEDS service, targeting Redfish BMC endpoints.
+
+        ```bash
+        linux# yq read ${SITE_INIT}/customizations.yaml 'spec.kubernetes.sealed_secrets.cray_meds_credentials.generate.data[0].args.value' | jq
+        ```
+
+    1. Validate RTS credentials.
+
+        These credentials are used by the Redfish Translation Service, targeting River Redfish BMC endpoints and PDU controllers.
+
+        ```bash
+        linux# yq read ${SITE_INIT}/customizations.yaml 'spec.kubernetes.sealed_secrets.cray_hms_rts_credentials.generate.data[*].args.value' | jq
+        ```
 
 1.  To customize the PKI Certificate Authority (CA) used by the platform, see
     [Certificate_authority](../background/certificate_authority.md).
 
     > **`IMPORTANT`** The CA may not be modified after install.
 
-1.  To federate Keycloak with an upstream LDAP:
+1.  Federate Keycloak with an upstream LDAP server.
 
-    1. Set environment variables for LDAP and PORT
+    1. Set environment variables for the LDAP server and its port.
 
        In the example below, the LDAP server has the hostname `dcldap2.us.cray.com` and is using the port 636.
 
        ```bash
-       linux# export LDAP=dcldap2.us.cray.com
-       linux# export PORT=636
+       linux# LDAP=dcldap2.us.cray.com
+       linux# PORT=636
        ```
 
-    1.  If LDAP requires TLS (recommended), update the `cray-keycloak` sealed
-        secret value by supplying a base64 encoded Java KeyStore (JKS) that
+    1.  Update the `cray-keycloak` sealed secret value if LDAP requires TLS.
+    
+        If LDAP requires TLS (recommended), then update the `cray-keycloak` sealed
+        secret value by supplying a base64-encoded Java KeyStore (JKS) that
         contains the CA certificate that signed the LDAP server's host key. The
         password for the JKS file must be `password`. Administrators may use the
         `keytool` command from the `openjdk:11-jre-slim` container image
         packaged with CSM to create a JKS file that includes a PEM-encoded
         CA certificate to verify the LDAP host(s) as follows:
 
-        This step builds an example that will create (or update) `cert.jks` with the PEM-encoded CA certificate for an LDAP host and then prepares `certs.jks.b64` which will be injected into customizations.yaml.
+        This step builds an example that will create (or update) `cert.jks` with the PEM-encoded CA certificate for an LDAP host, and then
+        prepares `certs.jks.b64`, which will be injected into `customizations.yaml`.
 
-        1. Load the `openjdk` container image:
+        1. Load the `openjdk` container image.
 
            > **`NOTE`** Requires a properly configured Docker or Podman
            > environment.
 
            ```bash
-           linux# /mnt/pitdata/${CSM_RELEASE}/hack/load-container-image.sh artifactory.algol60.net/csm-docker/stable/docker.io/library/openjdk:11-jre-slim
+           linux# ${CSM_PATH}/hack/load-container-image.sh artifactory.algol60.net/csm-docker/stable/docker.io/library/openjdk:11-jre-slim
            ```
-        1.  Get the issuer certificate for the LDAP server at port 636. Use `openssl s_client` to connect
+
+        1.  Get the issuer certificate.
+        
+            Retrieve the issuer certificate for the LDAP server at port 636. Use `openssl s_client` to connect
             and show the certificate chain returned by the LDAP host:
 
             ```bash
-            linux# openssl s_client -showcerts -connect $LDAP:${PORT} </dev/null
+            linux# openssl s_client -showcerts -connect ${LDAP}:${PORT} </dev/null
             ```
-        1.  Either manually extract (i.e., cut/paste) the issuer's
-            certificate into `cacert.pem` or try the following commands to
+
+        1.  Enter the issuer's certificate into `cacert.pem`.
+        
+            Either manually extract (i.e., cut/paste) the issuer's
+            certificate into `cacert.pem`, or try the following commands to
             create it automatically.
 
             > **`NOTE`** The following commands were verified using OpenSSL
@@ -181,32 +226,32 @@ with system-specific customizations.
             > from the output of the above `openssl s_client` example if the
             > following commands are unsuccessful.
 
-            1.  Observe the issuer's DN:
+            1.  Observe the issuer's DN.
 
                 ```bash
-                linux# openssl s_client -showcerts -nameopt RFC2253 -connect $LDAP:${PORT} </dev/null 2>/dev/null | grep issuer= | sed -e 's/^issuer=//'
+                linux# openssl s_client -showcerts -nameopt RFC2253 -connect ${LDAP}:${PORT} </dev/null 2>/dev/null | grep issuer= | sed -e 's/^issuer=//'
                 ```
 
-                Expected output would include a line similar to this:
+                Expected output includes a line similar to this:
 
                 ```
                 emailAddress=dcops@hpe.com,CN=Data Center,OU=HPC/MCS,O=HPE,ST=WI,C=US
                 ```
 
-            2.  Extract the issuer's certificate using `awk`:
+            2.  Extract the issuer's certificate using `awk`.
 
                 > **`NOTE`** The issuer DN is properly escaped as part of the
                 > `awk` pattern below. It must be changed to match the value
-                > for emailAddress, CN, OU, etc. for your LDAP. If the value
+                > for `emailAddress`, `CN`, `OU`, etc. for your LDAP. If the value
                 > you are using is different, be sure to escape it properly!
 
                 ```bash
-                linux# openssl s_client -showcerts -nameopt RFC2253 -connect $LDAP:${PORT} </dev/null 2>/dev/null | \
-                          awk '/s:emailAddress=dcops@hpe.com,CN=Data Center,OU=HPC\/MCS,O=HPE,ST=WI,C=US/,/END CERTIFICATE/' | \
+                linux# openssl s_client -showcerts -nameopt RFC2253 -connect ${LDAP}:${PORT} </dev/null 2>/dev/null |
+                          awk '/s:emailAddress=dcops@hpe.com,CN=Data Center,OU=HPC\/MCS,O=HPE,ST=WI,C=US/,/END CERTIFICATE/' |
                           awk '/BEGIN CERTIFICATE/,/END CERTIFICATE/' > cacert.pem
                 ```
 
-        1.  Verify issuer's certificate was properly extracted and saved in `cacert.pem`:
+        1.  Verify that the issuer's certificate was properly extracted and saved in `cacert.pem`.
 
             ```bash
             linux# cat cacert.pem
@@ -240,29 +285,29 @@ with system-specific customizations.
             -----END CERTIFICATE-----
             ```
 
-        1.  Create `certs.jks`:
+        1.  Create `certs.jks`.
 
             > **`NOTE`** The alias used in this command for `cray-data-center-ca` should be changed to match your LDAP.
 
             ```bash
             linux# podman run --rm -v "$(pwd):/data" \
-            artifactory.algol60.net/csm-docker/stable/docker.io/library/openjdk:11-jre-slim keytool \
-            -importcert -trustcacerts -file /data/cacert.pem -alias cray-data-center-ca \
-            -keystore /data/certs.jks -storepass password -noprompt
+                    artifactory.algol60.net/csm-docker/stable/docker.io/library/openjdk:11-jre-slim keytool \
+                    -importcert -trustcacerts -file /data/cacert.pem -alias cray-data-center-ca \
+                    -keystore /data/certs.jks -storepass password -noprompt
             ```
 
-        1.  Create `certs.jks.b64` by base-64 encoding `certs.jks`:
+        1.  Create `certs.jks.b64` by base64 encoding `certs.jks`.
 
             ```bash
             linux# base64 certs.jks > certs.jks.b64
             ```
 
-        1. Inject and encrypt `certs.jks.b64` into `customizations.yaml`:
+        1. Inject and encrypt `certs.jks.b64` into `customizations.yaml`.
 
             ```bash
-            linux# cat <<EOF | yq w - 'data."certs.jks"' "$(<certs.jks.b64)" | \
-            yq r -j - | /mnt/pitdata/prep/site-init/utils/secrets-encrypt.sh | \
-            yq w -f - -i /mnt/pitdata/prep/site-init/customizations.yaml 'spec.kubernetes.sealed_secrets.cray-keycloak'
+            linux# cat <<EOF | yq w - 'data."certs.jks"' "$(<certs.jks.b64)" |
+                yq r -j - | ${SITE_INIT}/utils/secrets-encrypt.sh |
+                yq w -f - -i ${SITE_INIT}/customizations.yaml 'spec.kubernetes.sealed_secrets.cray-keycloak'
             {
               "kind": "Secret",
               "apiVersion": "v1",
@@ -275,27 +320,29 @@ with system-specific customizations.
             }
             EOF
             ```
+
     1.  Update the `keycloak_users_localize` sealed secret with the
         appropriate value for `ldap_connection_url`.
 
-        1. Set `ldap_connection_url` in `customizations.yaml`:
+        1. Set `ldap_connection_url` in `customizations.yaml`.
 
            For example:
 
            ```bash
-           linux# yq write -i /mnt/pitdata/prep/site-init/customizations.yaml \
-           'spec.kubernetes.sealed_secrets.keycloak_users_localize.generate.data.(args.name==ldap_connection_url).args.value' "ldaps://$LDAP"
+           linux# yq write -i ${SITE_INIT}/customizations.yaml \
+                    'spec.kubernetes.sealed_secrets.keycloak_users_localize.generate.data.(args.name==ldap_connection_url).args.value' \
+                    "ldaps://${LDAP}"
            ```
 
         1. On success, review the `keycloak_users_localize` sealed secret.
 
            ```bash
-           linux# yq read /mnt/pitdata/prep/site-init/customizations.yaml spec.kubernetes.sealed_secrets.keycloak_users_localize
+           linux# yq read ${SITE_INIT}/customizations.yaml spec.kubernetes.sealed_secrets.keycloak_users_localize
            ```
 
            Expected output is similar to:
 
-           ```
+           ```yaml
            generate:
                name: keycloak-users-localize
                data:
@@ -304,6 +351,7 @@ with system-specific customizations.
                    name: ldap_connection_url
                    value: ldaps://dcldap2.us.cray.com
            ```
+
     1.  Configure the `ldapSearchBase` and `localRoleAssignments` settings for
         the `cray-keycloak-users-localize` chart in `customizations.yaml`.
 
@@ -311,21 +359,20 @@ with system-specific customizations.
         Each admin group needs to be assigned to role `admin` and set to both `shasta` and `cray` clients in Keycloak.
         Each user group needs to be assigned to role `user` and set to both `shasta` and `cray` clients in Keycloak.
 
-
-        1. Set `ldapSearchBase` in `customizations.yaml`:
+        1. Set `ldapSearchBase` in `customizations.yaml`.
 
            This example sets `ldapSearchBase` to `dc=dcldap,dc=dit`
 
            ```bash
-           linux# yq write -i /mnt/pitdata/prep/site-init/customizations.yaml spec.kubernetes.services.cray-keycloak-users-localize.ldapSearchBase 'dc=dcldap,dc=dit'
+           linux# yq write -i ${SITE_INIT}/customizations.yaml spec.kubernetes.services.cray-keycloak-users-localize.ldapSearchBase 'dc=dcldap,dc=dit'
            ```
 
-        1. Set `localRoleAssignments` in `customizations.yaml`:
+        1. Set `localRoleAssignments` in `customizations.yaml`.
 
            This example sets `localRoleAssignments` for the LDAP groups `employee`, `craydev`, and `shasta_admins` to be the admin role and the LDAP group `shasta_users` to be the user role.
 
            ```bash
-           linux# yq write -s - -i /mnt/pitdata/prep/site-init/customizations.yaml <<EOF
+           linux# yq write -s - -i ${SITE_INIT}/customizations.yaml <<EOF
            - command: update
              path: spec.kubernetes.services.cray-keycloak-users-localize.localRoleAssignments
              value:
@@ -343,12 +390,12 @@ with system-specific customizations.
         1. On success, review the `cray-keycloak-users-localize` values.
 
            ```bash
-           linux# yq read /mnt/pitdata/prep/site-init/customizations.yaml spec.kubernetes.services.cray-keycloak-users-localize
+           linux# yq read ${SITE_INIT}/customizations.yaml spec.kubernetes.services.cray-keycloak-users-localize
            ```
 
            Expected output looks similar to:
 
-           ```
+           ```yaml
            sealedSecrets:
                - '{{ kubernetes.sealed_secrets.keycloak_users_localize | toYaml }}'
            localRoleAssignments:
@@ -365,7 +412,7 @@ with system-specific customizations.
 
 1.  Configure the Unbound DNS resolver (if needed).
 
-    If access to a site DNS server is required **and** this DNS server was specified to `csi` using the `site-dns` option (either on the command line or in the `system_config.yaml` file), **then no further action is required** and this step should be skipped.
+    **Important:** If access to a site DNS server is required **and** this DNS server was specified to `csi` using the `site-dns` option (either on the command line or in the `system_config.yaml` file), **then no further action is required and this step should be skipped**.
 
     The default configuration is as follows:
     ```yaml
@@ -380,23 +427,23 @@ with system-specific customizations.
     The configured site DNS server can be verified by inspecting the value set for `system_to_site_lookups`.
 
     ```bash
-    linux# yq r /mnt/pitdata/prep/site-init/customizations.yaml spec.network.netstaticips.system_to_site_lookups
+    linux# yq r ${SITE_INIT}/customizations.yaml spec.network.netstaticips.system_to_site_lookups
     172.30.84.40
     ```
 
     If there is **no requirement to resolve external hostnames or no upstream DNS server**,
     then remove the DNS forwarding configuration from the `cray-dns-unbound` service.
 
-    1. Remove the `forwardZones` configuration for the `cray-dns-unbound` service:
+    1. Remove the `forwardZones` configuration for the `cray-dns-unbound` service.
 
         ```bash
-        linux# yq delete -i /mnt/pitdata/prep/site-init/customizations.yaml spec.kubernetes.services.cray-dns-unbound.forwardZones
+        linux# yq delete -i ${SITE_INIT}/customizations.yaml spec.kubernetes.services.cray-dns-unbound.forwardZones
         ```
 
     1. Review the `cray-dns-unbound` values.
 
         ```bash
-        linux# yq read /mnt/pitdata/prep/site-init/customizations.yaml spec.kubernetes.services.cray-dns-unbound
+        linux# yq read ${SITE_INIT}/customizations.yaml spec.kubernetes.services.cray-dns-unbound
         ```
 
         Expected output is:
@@ -413,43 +460,44 @@ with system-specific customizations.
 
    * If DNSSEC is to be used then add the desired keys into the `dnssec` SealedSecret.
 
-   Please see the [PowerDNS Configuration Guide](../operations/network/dns/PowerDNS_Configuration.md) for more information.
+   See the [PowerDNS Configuration Guide](../operations/network/dns/PowerDNS_Configuration.md) for more information.
 
-1. (Optional) Configure Prometheus snmp-exporter.
+   <a name="configure-prometheus-snmp-exporter"></a>
 
-   The Prometheus snmp-exporter needs to be configured with a list of management network switches to scrape metrics from in order to populate the System Health Service Grafana dashboards.
+1. (Optional) Configure Prometheus SNMP Exporter.
 
-   Please see the [prometheus-snmp-exporter](../operations/network/management_network/snmp_exporter_configs.md) for more information.
+   The Prometheus SNMP exporter needs to be configured with a list of management network switches to scrape metrics from in
+   order to populate the System Health Service Grafana dashboards.
 
+   See [Prometheus SNMP Exporter](../operations/network/management_network/snmp_exporter_configs.md) for more information.
 
 <a name="generate-sealed-secrets"></a>
-### 4. Generate Sealed Secrets
+## 4. Generate Sealed Secrets
 
-Secrets are stored in `customizations.yaml` as `SealedSecret` resources (i.e.,
+Secrets are stored in `customizations.yaml` as `SealedSecret` resources (that is,
 encrypted secrets) which are deployed by specific charts and decrypted by the
 Sealed Secrets operator. But first, those secrets must be seeded generated and
 encrypted.
 
-1.  Load the `zeromq` container image required by Sealed Secret Generators:
+1.  Load the `zeromq` container image required by Sealed Secret Generators.
 
     > **`NOTE`** Requires a properly configured Docker or Podman environment.
 
     ```bash
-    linux# /mnt/pitdata/${CSM_RELEASE}/hack/load-container-image.sh artifactory.algol60.net/csm-docker/stable/docker.io/zeromq/zeromq:v4.0.5
+    linux# ${CSM_PATH}/hack/load-container-image.sh artifactory.algol60.net/csm-docker/stable/docker.io/zeromq/zeromq:v4.0.5
     ```
 
-1.  Re-encrypt existing secrets:
+1.  Re-encrypt existing secrets.
 
     ```bash
-    linux# /mnt/pitdata/prep/site-init/utils/secrets-reencrypt.sh /mnt/pitdata/prep/site-init/customizations.yaml \
-    /mnt/pitdata/prep/site-init/certs/sealed_secrets.key /mnt/pitdata/prep/site-init/certs/sealed_secrets.crt
+    linux# ${SITE_INIT}/utils/secrets-reencrypt.sh ${SITE_INIT}/customizations.yaml \
+                ${SITE_INIT}/certs/sealed_secrets.key ${SITE_INIT}/certs/sealed_secrets.crt
     ```
 
-1.  Generate secrets:
+1.  Generate secrets.
 
     ```bash
-    linux# /mnt/pitdata/prep/site-init/utils/secrets-seed-customizations.sh \
-    /mnt/pitdata/prep/site-init/customizations.yaml
+    linux# ${SITE_INIT}/utils/secrets-seed-customizations.sh ${SITE_INIT}/customizations.yaml
     ```
 
     Expected output looks similar to:
@@ -489,57 +537,58 @@ encrypted.
     Generating type static...
     ```
 
-
 <a name="version-control-site-init-files"></a>
-### 5. Version Control Site-Init Files
+## 5. Version Control Site-Init Files
 
-Setup `/mnt/pitdata/prep/site-init` as a Git repository in order to manage the
+Setup `site-init` as a Git repository in order to manage the
 baseline configuration during initial system installation.
 
-1.  Initialize `/mnt/pitdata/prep/site-init` as a Git repository:
+1.  Initialize `site-init` as a Git repository.
 
     ```bash
-    linux# cd /mnt/pitdata/prep/site-init
+    linux# cd ${SITE_INIT}
     linux# git init .
     ```
 
-1.  (Optional) **`WARNING`** If production system or operational security is a
+1.  (Optional) Exclude sealed secret private keys from Git.
+
+    **`WARNING`** If production system or operational security is a
     concern, do NOT store the sealed secret private key in Git; instead,
     **store the sealed secret key outside of Git in a secure offline system**.
-    To ensure these sensitive keys are not accidentally committed, configure
-    `.gitignore` to ignore files under the `certs` directory:
+    In order to ensure that these sensitive keys are not accidentally committed,
+    configure `.gitignore` to ignore files under the `certs` directory:
 
     ```bash
     linux# echo "certs/" >> .gitignore
     ```
 
-1.  Stage site-init files to be committed:
+1.  Stage `site-init` files to be committed.
 
     ```bash
     linux# git add -A
     ```
 
-1.  Review what will be committed:
+1.  Review what will be committed.
 
     ```bash
     linux# git status
     ```
 
-1.  Commit all the above changes as the baseline configuration:
+1.  Commit the baseline configuration.
 
     ```bash
-    linux# git commit -m "Baseline configuration for $(/mnt/pitdata/${CSM_RELEASE}/lib/version.sh)"
+    linux# git commit -m "Baseline configuration for $(${CSM_PATH}/lib/version.sh)"
     ```
 
 <a name="push-to-a-remote-repository"></a>
-#### 5.1 Push to a Remote Repository
+### 5.1 Push to a Remote Repository
 
-It is **strongly recommended** that the site-init repository be maintained
+It is **strongly recommended** that the `site-init` repository be maintained
 off-cluster. Add a remote repository and push the baseline configuration on
 `master` branch to a corresponding remote branch.
 
 <a name="customer-specific-customizations"></a>
-### 6. Customer-Specific Customizations
+## 6. Customer-Specific Customizations
 
 Customer-specific customizations are any changes on top of the baseline
 configuration to satisfy customer-specific requirements. It is recommended that
@@ -547,7 +596,7 @@ customer-specific customizations be tracked on branches separate from the
 mainline in order to make them easier to manage.
 
 Apply any customer-specific customizations by merging the corresponding
-branches into `master` branch of `/mnt/pitdata/prep/site-init`.
+branches into `master` branch of `site-init`.
 
 When considering merges, and especially when resolving conflicts, carefully
 examine differences to ensure all changes are relevant. For example, when

--- a/operations/network/management_network/snmp_exporter_configs.md
+++ b/operations/network/management_network/snmp_exporter_configs.md
@@ -6,16 +6,19 @@ The Prometheus SNMP Exporter is deployed by the the `cray-sysmgmt-health` chart 
 
 In order to provide data to the Grafana SNMP dashboards, the SNMP Exporter must be configured with a list of management network switches to scrape metrics from.
 
-1. Set the `SYSTEM_NAME` variable if not already set.
-
-    ```bash
-    linux# SYSTEM_NAME=eniac
-    ```
+This procedure assumes that this is being done as part of a CSM install as part of the 
+[Prepare Site Init](../../../install/prepare_site_init.md#configure-prometheus-snmp-exporter) procedure.
+Specifically, it assumes that the `SYSTEM_NAME` and `PITDATA` variables are set, and that the `PITDATA` mount is
+in place.
 
 1. Obtain the list of switches to use as targets using CSM Automatic Network Utility (CANU).
 
     ```bash
-    linux# canu init --sls-file /var/www/ephemeral/prep/${SYSTEM_NAME}/sls_input_file.json --out -
+    linux# canu init --sls-file ${PITDATA}/prep/${SYSTEM_NAME}/sls_input_file.json --out -
+    ```
+    
+    Expected output looks similar to the following:
+    ```
     10.252.0.2
     10.252.0.3
     10.252.0.4
@@ -26,7 +29,7 @@ In order to provide data to the Grafana SNMP dashboards, the SNMP Exporter must 
 1. Update `customizations.yaml` with the list of switches.
 
     ```bash
-    linux# yq write -s - -i /mnt/pitdata/prep/site-init/customizations.yaml <<EOF
+    linux# yq write -s - -i ${PITDATA}/prep/site-init/customizations.yaml <<EOF
     - command: update
       path: spec.kubernetes.services.cray-sysmgmt-health.prometheus-snmp-exporter
       value:
@@ -49,10 +52,10 @@ In order to provide data to the Grafana SNMP dashboards, the SNMP Exporter must 
 1. Review the SNMP Exporter configuration.
 
     ```bash
-    linux# yq r /mnt/pitdata/prep/site-init/customizations.yaml spec.kubernetes.services.cray-sysmgmt-health.prometheus-snmp-exporter
+    linux# yq r ${PITDATA}/prep/site-init/customizations.yaml spec.kubernetes.services.cray-sysmgmt-health.prometheus-snmp-exporter
     ```
 
-    The expected output looks similar to
+    The expected output looks similar to:
 
     ```yaml
     serviceMonitor:
@@ -74,9 +77,9 @@ The most common configuration parameters are specified in the following table. T
 
 |Customization|Default|Description|
 |-------------|-------|-----------|
-|`serviceMonitor.enabled`|`true`|Enables `serviceMonitor` for snmp exporter \(default chart value is `true`\)|
+|`serviceMonitor.enabled`|`true`|Enables `serviceMonitor` for SNMP exporter \(default chart value is `true`\)|
 |`params.enabled`|`false`|Sets the snmp exporter params change to true \(default chart value is `false`\)|
-|`params.conf.module`|`if_mib`| snmp exporter to select which module \(default chart value is `if_mib`\)|
-|`params.conf.target`|`127.0.0.1`| add list of switch targets to snmp exporter to monitor \(default chart value is `127.0.0.1`\)|
+|`params.conf.module`|`if_mib`| SNMP exporter to select which module \(default chart value is `if_mib`\)|
+|`params.conf.target`|`127.0.0.1`| Add list of switch targets to SNMP exporter to monitor \(default chart value is `127.0.0.1`\)|
 
 For a complete set of available parameters, consult the `values.yaml` file for the `cray-sysmgmt-health` chart.


### PR DESCRIPTION
## Summary and Scope

This ticket consists of a few changes:
* Modify the two bootstrap PIT node procedures to try and remove needless inconsistencies.
* Define additional common environment variables and add them to the PIT environments for both paths.
* Make use of these variables aggressively to reduce and simplify commands, both in the bootstrap procedures and the prepare site-init procedure
* One notable effect of this is that we no longer need the temporary "shim" mount in the remote ISO path before following the prepare site init procedure (nor the cleanup step after)
* Linted and cleaned up both bootstrap procedures
* Made use of the new common variables to correct an error in the "SNMP Exporter" page
* Removed sections of the bootstrap documents that were added when the `site-init.sh` script was modified to invoke `csi config init`. That change to `site-init.sh` is being reverted, so this updates the docs to follow suit.

While the PR consists of a lot of changes, the core procedures being followed are mostly unchanged. The thrust of this PR is quality of life for installers, and making the docs easier to maintain (by allowing us to assume some common variables, and making the install paths as similar as possible).

There is no reason this could not be backported into csm-1.0, but I do not plan to do that until I have time and opportunity to test them, since cherry-picking this back into 1.0 will involve some manual merge conflict resolution.

## Issues and Related PRs

* [1.2 backport](https://github.com/Cray-HPE/docs-csm/pull/1397)
* Reverts a portion of the changes made in [CASMINST-3457](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3457) related to `pit-init.sh` re-invoking `csi config init`

## Testing

No testing of the complete procedures, but I did test individual commands for much of it. If this has not merged by the time I am able to embark on the mug install, I plan to use it for that. But as I noted earlier, the core procedures are not being changed. Mostly we are just using variables in place of hard-coding things in the docs.

## Risks and Mitigations

Minor risk (and in any case, if we do find problems, they are almost certainly going to be very simple to correct).

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
