### PR TITLE
CASMTRIAGE-3246: fixed generate_switch_config.md, generating switch config for single …

### DIFF
--- a/operations/network/management_network/generate_switch_configs.md
+++ b/operations/network/management_network/generate_switch_configs.md
@@ -27,16 +27,16 @@ The following are the different architectures that can be specified:
 * ***Full*** – Aruba-based Leaf-Spine systems, usually customer production systems.
 * ***V1*** – Dell and Mellanox based systems of either a TDS or Full layout.
 
-Generating a configuration file can be done for a single switch, or for the full system. In below, example commands for both scenarios: 
+Generating a configuration file can be done for a single switch, or for the full system. Below are example commands for both scenarios:
 
 ***Important***
 
-You will need to modify following items from your command: 
+Modify the following items in your command:
 
-* --csm : Which CSM version configuration do you want to use. I.e.  1.2 or 1.0
-* --a   : Which architecture is the system based of. (See above)
-* --ccj : Match the ccj.json file to the one you created for your system.
-* --sls : Match the sls_file.json to the one you created for your system.
+* `--csm` : Which CSM version configuration do you want to use? For example, 1.2 or 1.0
+* `--a`   : What is the system architecture? (See above)
+* `--ccj` : Match the `ccj.json` file to the one you created for your system.
+* `--sls` : Match the `sls_file.json` to the one you created for your system.
 
 * Generate a configuration file for single switch:
 

--- a/operations/network/management_network/generate_switch_configs.md
+++ b/operations/network/management_network/generate_switch_configs.md
@@ -41,11 +41,11 @@ You will need to modify following items from your command:
 * Generate a configuration file for single switch:
 
   ```bash
-  ncn# canu generate switch config --csm 1.2 -a full --ccj cabling.json  --sls-file sls_file.json --name sw-spine-001
+  ncn# canu generate switch config --csm 1.2 -a full --ccj system-ccj.json  --sls-file sls_file.json --name sw-spine-001
   ```
 
 * Generate a configuration files for full system:
 
   ```bash
-  ncn# canu generate switch config --csm 1.2 -a full --ccj cabling.json  --sls-file sls_file.json --folder generated
+  ncn# canu generate switch config --csm 1.2 -a full --ccj system-ccj.json  --sls-file sls_file.json --folder generated
   ```

--- a/operations/network/management_network/generate_switch_configs.md
+++ b/operations/network/management_network/generate_switch_configs.md
@@ -27,12 +27,21 @@ The following are the different architectures that can be specified:
 * ***Full*** – Aruba-based Leaf-Spine systems, usually customer production systems.
 * ***V1*** – Dell and Mellanox based systems of either a TDS or Full layout.
 
-Select one of the following commands to generate a configuration file for a single switch, or for the full system.
+Generating a configuration file can be done for a single switch, or for the full system. In below, example commands for both scenarios: 
+
+***Important***
+
+You will need to modify following items from your command: 
+
+* --csm : Which CSM version configuration do you want to use. I.e.  1.2 or 1.0
+* --a   : Which architecture is the system based of. (See above)
+* --ccj : Match the ccj.json file to the one you created for your system.
+* --sls : Match the sls_file.json to the one you created for your system.
 
 * Generate a configuration file for single switch:
 
   ```bash
-  ncn# canu generate switch config --csm 1.2 -a full --ccj cabling.json  --sls-file sls_file.json --name sw-spine-001.cfg
+  ncn# canu generate switch config --csm 1.2 -a full --ccj cabling.json  --sls-file sls_file.json --name sw-spine-001
   ```
 
 * Generate a configuration files for full system:

--- a/operations/network/management_network/generate_switch_configs.md
+++ b/operations/network/management_network/generate_switch_configs.md
@@ -47,5 +47,5 @@ You will need to modify following items from your command:
 * Generate a configuration files for full system:
 
   ```bash
-  ncn# canu generate switch config --csm 1.2 -a full --ccj system-ccj.json  --sls-file sls_file.json --folder generated
+  ncn# canu generate network config --csm 1.2 -a full --ccj system-ccj.json  --sls-file sls_file.json --folder generated
   ```

--- a/operations/network/management_network/generate_switch_configs.md
+++ b/operations/network/management_network/generate_switch_configs.md
@@ -32,7 +32,7 @@ Select one of the following commands to generate a configuration file for a sing
 * Generate a configuration file for single switch:
 
   ```bash
-  ncn# canu generate switch config --csm 1.2 -a full --ccj cabling.json  --sls-file sls_file.json --name sw-spine-001 --folder generated
+  ncn# canu generate switch config --csm 1.2 -a full --ccj cabling.json  --sls-file sls_file.json --name sw-spine-001.cfg
   ```
 
 * Generate a configuration files for full system:


### PR DESCRIPTION
## Summary and Scope

Fixed generate_switch_config.md, generating switch config for single device was incorrect. 

Essentially for single device, the config file will just be created in working directory vs in generate whole network will create a folder to output generated config files.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-3246](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3246)
* Change will also be needed in `1.2.5, done in branch CASMTRIAGE-3246-1`


## Testing

Re-run command

### Tested on:

  * `Gamora`
  * Local development environment=

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

