### PR TITLE
CASMINST-4486 - Add conditionals to upgrade for storage nodes

### DIFF
--- a/upgrade/1.2/scripts/ceph/ceph-services-stage2.sh
+++ b/upgrade/1.2/scripts/ceph/ceph-services-stage2.sh
@@ -43,3 +43,13 @@ if [[ $(hostname) =~ ncn-s00[1-3] ]]; then
   . /srv/cray/scripts/common/csi-configuration.sh
   create_k8s_storage_class
 fi
+
+echo "Enabling ceph services to start on boot and starting if stopped"
+for service in $(cephadm ls |jq -r .[].systemd_unit|grep $(ceph status -f json-pretty |jq -r .fsid));
+do
+  systemctl enable $service
+  if [[ $(systemctl is-active $service) != "active" ]]
+  then
+    systemctl restart $service
+  fi
+done

--- a/upgrade/1.2/scripts/ceph/create_rgw_buckets.sh
+++ b/upgrade/1.2/scripts/ceph/create_rgw_buckets.sh
@@ -53,6 +53,18 @@ done
 
 sed -i "s/LASTNODE/$num_storage_nodes/g" /etc/ansible/hosts
 
+# Adding conditional wait for k8s credentials.
+# Will exit with error if they do not show up within 2 mins.
+
+COUNTER=0
+while [[ ! -f /etc/kubernetes/admin.conf ]]; do
+  sleep 5
+  let COUNTER=COUNTER+1
+  if [[ $COUNTER -gt 24 ]]; then
+    exit 1
+  fi
+done
+
 source /etc/ansible/boto3_ansible/bin/activate
 
 playbook=/etc/ansible/ceph-rgw-users/ceph-rgw-users.yaml


### PR DESCRIPTION
## Summary and Scope
- Check to see if admin.conf is present
- add enable ceph services to a post rebuild task

Addresses issues found in CAST-29770

## Issues and Related PRs

* Resolves CASMINST-4486

## Testing

### Tested on:

  * WASP

### Test description:

Tested the components of the script that were added in the exact way that they would be called. 

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

