### PR TITLE
CASMINST-4490: Backport missing commit into main from csm-1.2

### DIFF
--- a/upgrade/1.2/scripts/ceph/ceph-services-stage2.sh
+++ b/upgrade/1.2/scripts/ceph/ceph-services-stage2.sh
@@ -44,7 +44,7 @@ if [[ $(hostname) =~ ncn-s00[1-3] ]]; then
   create_k8s_storage_class
 fi
 
-echo "Enabling ceph services to start on boot and starting if stopped"
+echo "Enabling Ceph services to start on boot and starting if stopped"
 for service in $(cephadm ls |jq -r .[].systemd_unit|grep $(ceph status -f json-pretty |jq -r .fsid));
 do
   systemctl enable $service


### PR DESCRIPTION
## Summary and Scope

This PR cherry-picks a minor typo commit from csm-1.2 into main branch. It accidentally was omitted from the corresponding main branch PR yesterday.

This is just changing a single character, to correct capitalization.

No backport of this PR is needed, since this commit already exists in the other relevant branches.

## Issues and Related PRs

This should have gone in with https://github.com/Cray-HPE/docs-csm/pull/1400, but that PR merged before it got pulled in. The other PRs for that ticket included this commit in their merge:
* https://github.com/Cray-HPE/docs-csm/pull/1401
* https://github.com/Cray-HPE/docs-csm/pull/1402

## Testing

N/A

## Risks and Mitigations

Incalculable.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

