### PR TITLE
CASMINST-4492: Linting: Import_External_Image_to_IMS, Customize_an_Image_Root_Using_IMS

### DIFF
--- a/operations/image_management/Customize_an_Image_Root_Using_IMS.md
+++ b/operations/image_management/Customize_an_Image_Root_Using_IMS.md
@@ -2,32 +2,31 @@
 
 The Image Management Service \(IMS\) customization workflow sets up a temporary image customization environment within a Kubernetes pod and mounts the image to be customized in that environment. A system administrator then makes the desired changes to the image root within the customization environment.
 
-Afterwards, the IMS customization workflow automatically copies the NCN CA public key to */etc/cray/ca/certificate\_authority.crt* within the image root being customized to enable secure communications between NCNs and client nodes. IMS then compresses the customized image root and uploads it and its associated initrd image and kernel image \(needed to boot a node\) to the artifact repository.
+Afterwards, the IMS customization workflow automatically copies the NCN CA public key to `/etc/cray/ca/certificate_authority.crt` within the image root being customized, in order to enable secure communications between NCNs and client nodes. IMS then compresses the customized image root and uploads it and its associated initrd image and kernel image \(needed to boot a node\) to the artifact repository.
 
 ## Prerequisites
 
 * System management services \(SMS\) are running in a Kubernetes cluster on non-compute nodes \(NCN\) and include the following deployments:
-  * `cray-ims`, the Image Management Service \(IMS\)
-  * `cray-nexus`, the Nexus repository manager service
+    * `cray-ims`, the Image Management Service \(IMS\)
+    * `cray-nexus`, the Nexus repository manager service
 * `kubectl` is installed locally and configured to point at the SMS Kubernetes cluster.
 * An IMS registered image root archive or a pre-built image root SquashFS archive is available to customize.
 * The NCN Certificate Authority \(CA\) public key has been properly installed into the CA cache for this system.
 * A token providing Simple Storage Service \(S3\) credentials has been generated.
-* When customizing an image using IMS Image Customization, once chrooted into the image root \(if using a \`jailed\` environment\), the image will only have access to whatever configuration the image already contains. In order to talk to services, including Nexus RPM repositories, the image root must first be configured with DNS and other settings. A base level of customization is provided by the default Ansible plays used by the Configuration Framework Service \(CFS\) to enable DNS resolution.
+* When customizing an image using IMS Image Customization, once inside the image root using `chroot` \(if using a \`jailed\` environment\), the image will only have access to whatever configuration the image already contains. In order to talk to services, including Nexus RPM repositories, the image root must first be configured with DNS and other settings. A base level of customization is provided by the default Ansible plays used by the Configuration Framework Service \(CFS\) to enable DNS resolution.
 
 ## Limitations
 
 * The commands in this procedure must be run as the `root` user.
 * Currently, the initrd image and kernel image are not regenerated automatically when the image root is changed. The admin must manually regenerate them while in the customization environment, if needed.
-* Images in the .txz compressed format need to be converted to SquashFS in order to use IMS image customization.
+* Images in the `.txz` compressed format need to be converted to SquashFS in order to use IMS image customization.
 
 ## Procedure
 
-**Enable Passwordless SSH**
+1.  Check for an existing IMS public key.
 
-1.  Check for an existing IMS public key `id`.
-
-    Skip this step if it is known that a public key associated with the user account being used was not previously uploaded to the IMS service.
+    > If it is known that a public key associated with the user account being used was not previously uploaded to the IMS service, then skip this
+    > step and proceed to [upload the SSH public key to the IMS service](#upload-ssh-public-key-to-ims).
 
     The following query may return multiple public key records. The correct one will have a name value including the current username in use.
 
@@ -49,15 +48,14 @@ Afterwards, the IMS customization workflow automatically copies the NCN CA publi
     [...]
     ```
 
-    If a public key associated with the username in use is not returned, proceed to the next step. If a public key associated with the username does exist, create a variable for the IMS public key `id` value in the returned data and then proceed to step 3.
+    * If a public key associated with the username in use is not returned, then proceed to [upload the SSH public key to the IMS service](#upload-ssh-public-key-to-ims).
+    * Otherwise, if a public key associated with the username does exist, then note the value of its `id` field and proceed to [record the IMS publlic key ID](#record-ims-public-key-id).
 
-    ```bash
-    ncn# export IMS_PUBLIC_KEY_ID=a252ff6f-c087-4093-a305-122b41824a3e
-    ```
+    <a name="upload-ssh-public-key-to-ims"></a>
+1.  Upload the SSH public key to the IMS service.
 
-2.  Upload the SSH public key to the IMS service.
-
-    Skip this step if an IMS public key record has already been created for the account being used.
+    > If an IMS public key record has already been created for the account being used, then note the value of its `id` field and proceed
+    > to [record the IMS publlic key ID](#record-ims-public-key-id).
 
     The IMS debug/configuration shell relies on passwordless SSH. This SSH public key needs to be uploaded to IMS to enable interaction with the image customization environment later in this procedure.
 
@@ -76,25 +74,25 @@ Afterwards, the IMS customization workflow automatically copies the NCN CA publi
     created = "2018-11-21T17:19:07.830000+00:00"
     ```
 
-    If successful, create a variable for the IMS public key `id` value in the returned data.
+    Note the value of the `id` field and proceed to [record the IMS publlic key ID](#record-ims-public-key-id).
+
+    <a name="record-ims-public-key-id"></a>
+1.  Record the IMS publlic key ID.
+
+    Create a variable for the IMS public key `id` value noted previously.
 
     ```bash
     ncn# export IMS_PUBLIC_KEY_ID=a252ff6f-c087-4093-a305-122b41824a3e
     ```
 
-**Locate or Register an Image Root Archive to Customize**
+1.  Determine if the image root being used is in IMS and ready to be customized.
 
-3.  Determine if the image root being used is in IMS and ready to be customized.
-
-    * If the image to be customized is already known to IMS, proceed to [Locate an IMS Image to Customize](#locate).
-    * If the image to be customized was created outside of IMS and is not yet known to IMS, proceed to [Import External Image to IMS](Import_External_Image_to_IMS.md).
+    * If the image to be customized is already known to IMS, then proceed to [Locate an IMS Image to Customize](#locate).
+    * If the image to be customized was created outside of IMS and is not yet known to IMS, then proceed to [Import External Image to IMS](Import_External_Image_to_IMS.md).
     * To build an image from an existing IMS recipe, proceed to [Build an Image Using IMS REST Service](Build_an_Image_Using_IMS_REST_Service.md).
 
-<a name="locate"></a>
-
-**Locate an IMS Image to Customize**
-
-11. Locate the IMS image record for the image that is being customized.
+    <a name="locate"></a>
+1. Locate the IMS image record for the image that is being customized.
 
     ```bash
     ncn# cray ims images list
@@ -118,109 +116,115 @@ Afterwards, the IMS customization workflow automatically copies the NCN CA publi
     [...]
     ```
 
-    If successful, create a variable for the `id` for the image that is being customized.
+1.  Record the IMS image ID.
+
+    Create a variable for the `id` field value for the image that is being customized.
 
     ```bash
     ncn# export IMS_IMAGE_ID=4e78488d-4d92-4675-9d83-97adfc17cb19
     ```
 
-**Submit the Kubernetes Image Customization Job**
+1.  Create an IMS job record in order to start the image customization job.
 
-12. Create an IMS job record and start the image customization job.
+    After customizing the image, IMS will automatically upload any build artifacts \(root file system, kernel, and initrd\) to S3, and associate the S3 artifacts with IMS. Unfortunately, IMS is not able to dynamically determine the names of the Linux kernel and initrd to look for, because the file name for these vary depending upon Linux distribution, Linux version, dracut configuration, and more. Therefore the user must pass into IMS the name of the kernel and initrd in the resultant image root's `/boot` directory.
 
-    After customizing the image, IMS will automatically upload any build artifacts \(root file system, kernel, and initrd\) to S3, and associate the S3 artifacts with IMS. Unfortunately, IMS is not able to dynamically determine the names of the Linux kernel and initrd to look for, because the file name for these vary depending upon Linux distribution, Linux version, dracut configuration, and more. Thus, the user must pass the name of the kernel and initrd that IMS is to look for in the resultant image root's /boot directory.
-
-    Use the following table to help determine the default kernel and initrd file names to specify when submitting the job to customize an image. These are just default names. Please consult with the site administrator to determine if these names have been changed for a given image or recipe.
+    Use the following table to help determine the default kernel and initrd file names to specify when submitting the job to customize an image. These are just default names. Consult with the site administrator to determine if these names have been changed for a given image or recipe.
 
     |Recipe|Recipe Name|Kernel File Name|Initrd File Name|
     |------|-----------|----------------|----------------|
-    |SLES 15 SP3 Barebones|cray-sles15sp3-barebones|vmlinuz|initrd|
-    |COS|cray-shasta-compute-sles15sp3.x86_64-1.4.66|vmlinuz|initrd|
+    |SLES 15 SP3 Barebones|`cray-sles15sp3-barebones`|`vmlinuz`|`initrd`|
+    |COS|`cray-shasta-compute-sles15sp3.x86_64-1.4.66`|`vmlinuz`|`initrd`|
 
-    1. Start the image customization job.
+    > Under normal circumstances, IMS customization jobs will download and mount the rootfs for the specified IMS image under the `/mnt/image/image-root` directory within the SSH shell. After SSHing into the job container, `cd` or `chroot` into the `/mnt/image/image-root` directory in order to interact with the image root being customized.
+    >
+    > Optionally, IMS can be told to create a jailed SSH environment by specifying the `--ssh-containers-jail True` parameter.
+    >
+    > A jailed environment lets users SSH into the SSH container and be immediately within the image root for the image being customized. Users do not need to `cd` or `chroot` into the image root. Using a jailed environment has some advantages, such as making the IMS SSH job shell look more like a compute node. This allows applications like the CFS to perform actions on both IMS job pods \(pre-boot\) and compute nodes \(post-boot\).
+    >
+    > Before running the following command, replace the `MY_CUSTOMIZED_IMAGE` value with the name of the image root being used.
 
-       Before running the following command, replace the MY\_CUSTOMIZED\_IMAGE value with the name of the image root being used.
+    ```bash
+    ncn# cray ims jobs create \
+            --job-type customize \
+            --kernel-file-name vmlinuz \
+            --initrd-file-name initrd \
+            --artifact-id $IMS_IMAGE_ID \
+            --public-key-id $IMS_PUBLIC_KEY_ID \
+            --enable-debug False \
+            --image-root-archive-name MY_CUSTOMIZED_IMAGE
+    ```
 
-       ```bash
-       ncn# cray ims jobs create \
-       --job-type customize \
-       --kernel-file-name vmlinuz \
-       --initrd-file-name initrd \
-       --artifact-id $IMS_IMAGE_ID \
-       --public-key-id $IMS_PUBLIC_KEY_ID \
-       --enable-debug False \
-       --image-root-archive-name MY_CUSTOMIZED_IMAGE
-       ```
+    Example output:
 
-       Example output:
+    ```
+    status = "creating"
+    enable_debug = false
+    kernel_file_name = "vmlinuz"
+    artifact_id = "4e78488d-4d92-4675-9d83-97adfc17cb19"
+    build_env_size = 10
+    job_type = "customize"
+    kubernetes_service = "cray-ims-ad5163d2-398d-4e93-94f0-2f439f114fe7-service"
+    kubernetes_job = "cray-ims-ad5163d2-398d-4e93-94f0-2f439f114fe7-customize"
+    id = "ad5163d2-398d-4e93-94f0-2f439f114fe7"
+    image_root_archive_name = "MY_CUSTOMIZED_IMAGE"
+    initrd_file_name = "initrd"
+    created = "2018-11-21T18:22:53.409405+00:00"
+    kubernetes_namespace = "ims"
+    public_key_id = "a252ff6f-c087-4093-a305-122b41824a3e"
+    kubernetes_configmap = "cray-ims-ad5163d2-398d-4e93-94f0-2f439f114fe7-configmap"
+    [[ssh_containers]]
+    status = "pending"
+    jail = false
+    name = "customize"
 
-       ```
-       status = "creating"
-       enable_debug = false
-       kernel_file_name = "vmlinuz"
-       artifact_id = "4e78488d-4d92-4675-9d83-97adfc17cb19"
-       build_env_size = 10
-       job_type = "customize"
-       kubernetes_service = "cray-ims-ad5163d2-398d-4e93-94f0-2f439f114fe7-service"
-       kubernetes_job = "cray-ims-ad5163d2-398d-4e93-94f0-2f439f114fe7-customize"
-       id = "ad5163d2-398d-4e93-94f0-2f439f114fe7"
-       image_root_archive_name = "MY_CUSTOMIZED_IMAGE"
-       initrd_file_name = "initrd"
-       created = "2018-11-21T18:22:53.409405+00:00"
-       kubernetes_namespace = "ims"
-       public_key_id = "a252ff6f-c087-4093-a305-122b41824a3e"
-       kubernetes_configmap = "cray-ims-ad5163d2-398d-4e93-94f0-2f439f114fe7-configmap"
-       [[ssh_containers]]
-       status = "pending"
-       jail = false
-       name = "customize"
+    [ssh_containers.connection_info."cluster.local"]
+    host = "cray-ims-ad5163d2-398d-4e93-94f0-2f439f114fe7-service.ims.svc.cluster.local"
+    port = 22
+    [ssh_containers.connection_info.customer_access]
+    host = "ad5163d2-398d-4e93-94f0-2f439f114fe7.ims.cmn.shasta.cray.com"
+    port = 22
+    ```
 
-       [ssh_containers.connection_info."cluster.local"]
-       host = "cray-ims-ad5163d2-398d-4e93-94f0-2f439f114fe7-service.ims.svc.cluster.local"
-       port = 22
-       [ssh_containers.connection_info.customer_access]
-       host = "ad5163d2-398d-4e93-94f0-2f439f114fe7.ims.cmn.shasta.cray.com"
-       port = 22
-       ```
+1.  Create variables for the IMS job ID and Kubernetes job ID.
 
-    2. Create variables for the IMS job ID, Kubernetes job ID, and the SSH connection values in the returned data.
+    The values for these variables are taken from the output of the command in the previous step.
+    Set `IMS_JOB_ID` to the value of the `id` field. Set the `IMS_KUBERNETES_JOB` to the value of
+    the `kubernetes_job` field.
 
-       Before setting the SSH values, determine the appropriate method to SSH into the customization pod:
+    ```bash
+    ncn# export IMS_JOB_ID=ad5163d2-398d-4e93-94f0-2f439f114fe7
+    ncn# export IMS_KUBERNETES_JOB=cray-ims-ad5163d2-398d-4e93-94f0-2f439f114fe7-customize
+    ```
 
-       - `[ssh_containers.connection_info.customer_access]` values \(**preferred**\): The `customer_access` address is a dynamic hostname that is made available for use by the customer to access the IMS Job from outside the Kubernetes cluster.
-       - `[ssh_containers.connection_info."cluster.local"]` values: The `cluster.local` address is used when trying to access an IMS Job from a pod that is running within the HPE Cray EX Kubernetes cluster. For example, this is the address that CFS uses to talk to the IMS Job during a pre-boot customization session.
+1.  Create variables for the SSH connection values in the returned data.
 
-       The external IP address should only be used if the dynamic `customer_access` hostname does not resolve properly. In the following example, the admin could then SSH to the 10.103.2.160 IP address.
+    The IMS customization job enables customization of the image root via an SSH shell accessible by one or more dynamic host names. The user needs to know if they will SSH from inside or outside the Kubernetes cluster to determine which host name to use. Typically, customers access the system from outside the Kubernetes cluster using the Customer Access Network \(CAN\).
 
-       ```bash
-       ncn# kubectl get services -n ims | grep IMS_JOB_ID
-       ```
+    Before setting the SSH values, determine the appropriate method to SSH into the customization pod:
 
-       Example output:
+    * `[ssh_containers.connection_info.customer_access]` values \(**preferred**\): The `customer_access` address is a dynamic hostname that is made available for use by the customer to access the IMS Job from outside the Kubernetes cluster.
+    * `[ssh_containers.connection_info."cluster.local"]` values: The `cluster.local` address is used when trying to access an IMS Job from a pod that is running within the HPE Cray EX Kubernetes cluster. For example, this is the address that CFS uses to talk to the IMS Job during a pre-boot customization session.
 
-       ```
-       NAME                                                    TYPE           CLUSTER-IP      EXTERNAL-IP    PORT(S)        AGE
-       cray-ims-06c3dd57-f347-4229-85b3-1d024a947b3f-service   LoadBalancer   10.29.129.204   10.103.2.160   22:31627/TCP   21h
-       ```
+    The external IP address should only be used if the dynamic `customer_access` hostname does not resolve properly. In the following example, the admin could then SSH to the `10.103.2.160` IP address.
 
-       To create the variables:
+    ```bash
+    ncn# kubectl get services -n ims | grep $IMS_JOB_ID
+    ```
 
-       ```bash
-       ncn# export IMS_JOB_ID=ad5163d2-398d-4e93-94f0-2f439f114fe7
-       ncn# export IMS_KUBERNETES_JOB=cray-ims-ad5163d2-398d-4e93-94f0-2f439f114fe7-customize
-       ncn# export IMS_SSH_HOST=ad5163d2-398d-4e93-94f0-2f439f114fe7.ims.cmn.shasta.cray.com
-       ncn# export IMS_SSH_PORT=22
-       ```
+    Example output:
 
-       The IMS customization job enables customization of the image root via an SSH shell accessible by one or more dynamic host names. The user needs to know if they will SSH from inside or outside the Kubernetes cluster to determine which host name to use. Typically, customers access the system from outside the Kubernetes cluster using the Customer Access Network \(CAN\).
+    ```
+    cray-ims-06c3dd57-f347-4229-85b3-1d024a947b3f-service   LoadBalancer   10.29.129.204   10.103.2.160   22:31627/TCP   21h
+    ```
 
-       Under normal circumstances, IMS customization jobs will download and mount the rootfs for the specified IMS image under the `/mnt/image/image-root` directory within the SSH shell. After SSHing into the job container, `cd` or `chroot` into the `/mnt/image/image-root` directory in order to interact with the image root being customized.
+    To create the variables:
 
-       Optionally, IMS can be told to create a jailed SSH environment by specifying the `--ssh-containers-jail True` parameter.
+    ```bash
+    ncn# export IMS_SSH_HOST=ad5163d2-398d-4e93-94f0-2f439f114fe7.ims.cmn.shasta.cray.com
+    ncn# export IMS_SSH_PORT=22
+    ```
 
-       A jailed environment lets users SSH into the SSH container and be immediately within the image root for the image being customized. Users do not need to `cd` or `chroot` into the image root. Using a jailed environment has some advantages, such as making the IMS SSH job shell look more like a compute node. This allows applications like the CFS to perform actions on both IMS job pods \(pre-boot\) and compute nodes \(post-boot\).
-
-13. Use `kubectl` and the returned `IMS_KUBERNETES_JOB` value to describe the image create job.
+1.  Describe the image create job.
 
     ```bash
     ncn# kubectl -n ims describe job $IMS_KUBERNETES_JOB
@@ -240,13 +244,13 @@ Afterwards, the IMS customization workflow automatically copies the NCN CA publi
     Normal SuccessfulCreate 4m job-controller Created pod: cray-ims-cfa864b3-4e08-49b1-9c57-04573228fd3f-customize-xh2jf
     ```
 
-    If successful, create a variable for the pod name using the value indicated in the output above, which will be used in future steps.
+1.  Record the name of the Kubernetes pod from the previous command.
 
     ```bash
     ncn# export POD=cray-ims-cfa864b3-4e08-49b1-9c57-04573228fd3f-customize-xh2jf
     ```
 
-14. Verify that the status of the IMS job is waiting_on_user.
+1. Verify that the status of the IMS job is `waiting_on_user`.
 
     ```bash
     ncn# cray ims jobs describe $IMS_JOB_ID
@@ -283,13 +287,13 @@ Afterwards, the IMS customization workflow automatically copies the NCN CA publi
     port = 22
     ```
 
-15. Customize the image in the image customization environment.
+1. Customize the image in the image customization environment.
 
-    Once chrooted into the image root \(or if using a \`jailed\` environment\) during image customization, the image will only have access to whatever configuration the image already contains. In order to talk to services, including Nexus RPM repositories, the image root must first be configured with DNS and other settings. A base level of customization is provided by the default Ansible plays used by the CFS to enable DNS resolution.
+    > Once chrooted into the image root \(or if using a \`jailed\` environment\) during image customization, the image will only have access to whatever configuration the image already contains. In order to talk to services, including Nexus RPM repositories, the image root must first be configured with DNS and other settings. A base level of customization is provided by the default Ansible plays used by the CFS to enable DNS resolution.
 
     *   **Option 1:** SSH to the image customization environment.
 
-        The image root is available under /mnt/image/image-root. For passwordless SSH to work, ensure that the correct public/private key pair is used. The private key will need to match the public key that was uploaded to the IMS service and specified in the IMS Job.
+        For passwordless SSH to work, ensure that the correct public/private key pair is used. The private key will need to match the public key that was uploaded to the IMS service and specified in the IMS Job.
 
         > **IMPORTANT:** The following command will work when run on any of the master nodes and worker nodes, except for `ncn-w001`.
 
@@ -299,14 +303,14 @@ Afterwards, the IMS customization workflow automatically copies the NCN CA publi
         [root@POD ~]#
         ```
 
-        Once connected to the IMS image customization shell, perform any customizations required. If the SSH shell was created without using the `--ssh-containers-jail True` parameter, cd or chroot into the image root.
+        Once connected to the IMS image customization shell, perform any customizations required. If the SSH shell was created without using the `--ssh-containers-jail True` parameter, `cd` or `chroot` into the image root. The image root is available under `/mnt/image/image-root`.
 
-        After changes have been made, run the touch command on the `complete` file. The location of the complete file depends on whether or not the SSH job shell was created using the `--ssh-containers-jail True` parameter. See the table below for more information.
+        After changes have been made, run the `touch` command on the `complete` file. The location of the `complete` file depends on whether or not the SSH job shell was created using the `--ssh-containers-jail True` parameter. See the table below for more information.
 
-        |--ssh-containers-jail|Command used to create the complete file|
+        |`--ssh-containers-jail`|Command used to create the complete file|
         |---------------------|----------------------------------------|
-        |False \(default\)|touch /mnt/image/complete|
-        |True|touch /tmp/complete|
+        |`False` \(default\)|`touch /mnt/image/complete`|
+        |`True`|`touch /tmp/complete`|
 
         ```bash
         [root@POD image]# cd /mnt/image/
@@ -318,15 +322,15 @@ Afterwards, the IMS customization workflow automatically copies the NCN CA publi
 
         When the complete file has been created, the following actions will occur:
 
-        * The job SSH container will close any active SSH connections
-        * The `buildenv-sidecar` container will compresses the image root
-        * The customized artifacts will be uploaded to S3 and associated with a new IMS image record
+        1. The job SSH container will close any active SSH connections.
+        1. The `buildenv-sidecar` container will compresses the image root.
+        1. The customized artifacts will be uploaded to S3 and associated with a new IMS image record.
 
     *   **Option 2:** Use Ansible to run playbooks against the image root.
 
         ```bash
-        ncn# ansible all -i $IMS_SSH_HOST, -m ping --ssh-extra-args " -p $IMS_SSH_PORT -i ./pod_rsa_key \
-        -o StrictHostKeyChecking=no" -u root
+        ncn# ansible all -i $IMS_SSH_HOST, -m ping --ssh-extra-args \
+                " -p $IMS_SSH_PORT -i ./pod_rsa_key -o StrictHostKeyChecking=no" -u root
         ad5163d2-398d-4e93-94f0-2f439f114fe7.ims.cmn.shasta.cray.com | SUCCESS => {
             "changed": false,
             "ping": "pong"
@@ -335,7 +339,7 @@ Afterwards, the IMS customization workflow automatically copies the NCN CA publi
 
         This Ansible inventory file below can also be used. The private key \(`./pod_rsa_key`\) corresponds to the public key file the container has in its authorized\_keys file.
 
-        ```bash
+        ```
         myimage-customize ansible_user=root ansible_host=ad5163d2-398d-4e93-94f0-2f439f114fe7.ims.cmn.shasta.cray.com ansible_port=22 \
                           ansible_ssh_private_key_file=./pod_rsa_key ansible_ssh_common_args='-o \
                           StrictHostKeyChecking=no'
@@ -343,7 +347,7 @@ Afterwards, the IMS customization workflow automatically copies the NCN CA publi
 
         A sample playbook can be run on the image root:
 
-        ```bash
+        ```yaml
         ---
         # The playbook creates a new database test and populates data in the database to test the sharding.
 
@@ -374,18 +378,21 @@ Afterwards, the IMS customization workflow automatically copies the NCN CA publi
         ncn# ansible-playbook -i ./inventory.ini sample_playbook.yml
         ```
 
-16. Tail the `buildenv-sidecar` to ensure that any artifacts are properly uploaded to S3 and associated with IMS.
+1.  Follow the `buildenv-sidecar` to ensure that any artifacts are properly uploaded to S3 and associated with IMS.
 
     ```bash
     ncn# kubectl -n ims logs -f $POD -c buildenv-sidecar
-    + python -m ims_python_helper image upload_artifacts sles15_barebones_image 7de80ccc-1e7d-43a9-a6e4-02cad10bb60b
-    -v -r /mnt/image/sles15_barebones_image.sqsh -k /mnt/image/image-root/boot/vmlinuz
-    -i /mnt/image/image-root/boot/initrd
     ```
 
     Example output:
 
     ```
+    + python -m ims_python_helper image upload_artifacts sles15_barebones_image 7de80ccc-1e7d-43a9-a6e4-02cad10bb60b
+    -v -r /mnt/image/sles15_barebones_image.sqsh -k /mnt/image/image-root/boot/vmlinuz
+    -i /mnt/image/image-root/boot/initrd
+
+    ...
+
     {
         "ims_image_artifacts": [
             {
@@ -459,7 +466,7 @@ Afterwards, the IMS customization workflow automatically copies the NCN CA publi
 
     The IMS customization workflow automatically copies the NCN Certificate Authority's public certificate to `/etc/cray/ca/certificate_authority.crt` within the image root being customized. This can be used to enable secure communications between the NCN and the client node.
 
-17. Look up the ID of the newly created image.
+1. Look up the ID of the newly created image.
 
     ```bash
     ncn# cray ims jobs describe $IMS_JOB_ID
@@ -486,13 +493,15 @@ Afterwards, the IMS customization workflow automatically copies the NCN CA publi
     kubernetes_configmap = "cray-ims-ad5163d2-398d-4e93-94f0-2f439f114fe7-configmap"
     ```
 
-    If successful, create a variable for the IMS `resultant_image_id` value in the returned data.
+1.  Record the IMS image ID of the created image.
+
+    Set `IMS_RESULTANT_IMAGE_ID` to the value of the `resultant_image_id` field in the output of the previous command.
 
     ```bash
     ncn# export IMS_RESULTANT_IMAGE_ID=d88521c3-b339-43bc-afda-afdfda126388
     ```
 
-18. Verify the new IMS image record exists.
+1. Verify that the new IMS image record exists.
 
     ```bash
     ncn# cray ims images describe $IMS_RESULTANT_IMAGE_ID
@@ -511,9 +520,9 @@ Afterwards, the IMS customization workflow automatically copies the NCN CA publi
     etag = "28f3d78c8cceca2083d7d3090d96bbb7"
     ```
 
-**Clean Up the Image Customization Environment**
+1. Clean up the image customization environment.
 
-19. Delete the IMS job record.
+    Delete the IMS job record.
 
     ```bash
     ncn# cray ims jobs delete $IMS_JOB_ID
@@ -521,6 +530,4 @@ Afterwards, the IMS customization workflow automatically copies the NCN CA publi
 
     Deleting the job record also deletes the underlying Kubernetes job, service, and ConfigMap that were created when the job record was submitted.
 
-
 The image root has been modified, compressed, and uploaded to S3, along with its associated initrd and kernel files. The image customization environment has also been cleaned up.
-

--- a/operations/image_management/Import_External_Image_to_IMS.md
+++ b/operations/image_management/Import_External_Image_to_IMS.md
@@ -1,16 +1,16 @@
 # Import an External Image to IMS
 
 The Image Management Service \(IMS\) is typically used to build images from IMS recipes and customize Images that are already known to IMS.
-However, it is sometimes the case that an image is built using a mechanism other than by IMS and needs to be added to IMS. In these cases, 
-the following procedure can be used to add this external image to IMS and upload the image's artifact(s) to the Simple Storage Service (S3). 
+However, it is sometimes the case that an image is built using a mechanism other than by IMS and needs to be added to IMS. In these cases,
+the following procedure can be used to add this external image to IMS and upload the image's artifact(s) to the Simple Storage Service (S3).
 
 ## Prerequisites
 
 * System management services \(SMS\) are running in a Kubernetes cluster on non-compute nodes \(NCN\) and include the following deployments:
-  * `cray-ims`, the Image Management Service \(IMS\)
+    * `cray-ims`, the Image Management Service \(IMS\)
 * `kubectl` is installed locally and configured to point at the SMS Kubernetes cluster.
-* An image root archive or a pre-built image root SquashFS archive is available. 
-* Optionally, additional image artifacts including a kernel, initrd and kernel parameters file are available. 
+* An image root archive or a pre-built image root SquashFS archive is available.
+* Optionally, additional image artifacts including a kernel, initrd, and kernel parameters file are available.
 * The NCN Certificate Authority \(CA\) public key has been properly installed into the CA cache for this system.
 * A token providing Simple Storage Service \(S3\) credentials has been generated.
 
@@ -22,24 +22,24 @@ the following procedure can be used to add this external image to IMS and upload
 ## Procedure
 
 <a name="ensure_supported_format"></a>
+1.  Ensure that the image root is in a supported format.
 
-**Ensure that the image root is in a supported format**
+    IMS requires that an image's root filesystem is in SquashFS format. Select one of the following options based on the current state of the image root being used:
 
-1. IMS requires that an image meet the following criteria:
-
-    * The image's root filesystem is in SquashFS format.
-    
-    Select one of the following options based on the current state of the image root being used:
-
-    * If the image being added is in tgz format, refer to [Convert TGZ Archives to SquashFS Images](Convert_TGZ_Archives_to_SquashFS_Images.md).
+    * If the image being added is in `tgz` format, refer to [Convert TGZ Archives to SquashFS Images](Convert_TGZ_Archives_to_SquashFS_Images.md).
     * If the image being added meets the above requirements, proceed to [Create an IMS Image Record](#create_image_record).
-    * If the image root is in a format other than tgz or squashfs, please convert the image root to tgz/squashfs before continuing.
-    
-<a name="create_image_record"></a>
+    * If the image root is in a format other than `tgz` or SquashFS, convert the image root to `tgz`/SquashFS before continuing.
 
-**Create an IMS Image Record**
+    <a name="create_image_record"></a>
+1.  Choose a descriptive name for the new IMS Image Record.
 
-2. Create a new IMS image record for the image. Give the image a descriptive name.
+    Set the `IMS_ROOTFS_FILENAME` variable to the chosen name.
+
+    ```bash
+    ncn# IMS_ROOTFS_FILENAME=sles_15_image.squashfs
+    ```
+
+1.  Create a new IMS image record for the image.
 
     ```bash
     ncn# cray ims images create --name $IMS_ROOTFS_FILENAME
@@ -53,33 +53,53 @@ the following procedure can be used to add this external image to IMS and upload
     name = "sles_15_image.squashfs"
     ```
 
-    If successful, create a variable for the id value in the returned data.
+1.  Create an environment variable for the ID of the new IMS Image Record.
+
+    Set and export the `IMS_IMAGE_ID` variable, using the `id` field value from the returned data in the previous step.
 
     ```bash
     ncn# export IMS_IMAGE_ID=4e78488d-4d92-4675-9d83-97adfc17cb19
     ```
 
-<a name="upload_to_s3"></a>
+    <a name="upload_to_s3"></a>
+1.  Upload the image root to S3.
 
-**Upload Image Artifacts to S3**
+    1.  Set an environment variable with the actual path and filename of the image root to be uploaded.
 
-3. Upload the image root to S3.
+        > This may be the same name as your `IMS_ROOTFS_FILENAME`, but it is not required to be.
 
-    ```bash
-    ncn# cray artifacts create boot-images $IMS_IMAGE_ID/$IMS_ROOTFS_FILENAME $IMS_ROOTFS_FILENAME
-    ncn# export IMS_ROOTFS_MD5SUM=`md5sum $IMS_ROOTFS_FILENAME | awk '{ print $1 }'`
-    ```
+        ```bash
+        ncn# ROOTFS_FILENAME=/home/rootfs.squashfs
+        ```
 
-4. Optionally, upload the kernel for the image to S3.
+    1. Record the `md5sum` of the image root to be uploaded.
+
+        ```bash
+        ncn# export IMS_ROOTFS_MD5SUM=`md5sum $ROOTFS_FILENAME | awk '{ print $1 }'`
+        ```
+
+    1. Upload the image root to S3.
+
+        ```bash
+        ncn# cray artifacts create boot-images $IMS_IMAGE_ID/$IMS_ROOTFS_FILENAME $ROOTFS_FILENAME
+        ```
+
+1.  Optionally, upload the kernel for the image to S3.
+
+    > In this example, the relative path to the kernel from the working directory is
+    > `image-root/boot/vmlinuz`.
 
     ```bash
     ncn# export IMS_KERNEL_FILENAME=vmlinuz
     ncn# cray artifacts create boot-images $IMS_IMAGE_ID/$IMS_KERNEL_FILENAME \
-    image-root/boot/$IMS_KERNEL_FILENAME
+            image-root/boot/$IMS_KERNEL_FILENAME
     ncn# export IMS_KERNEL_MD5SUM=`md5sum image-root/boot/$IMS_KERNEL_FILENAME | awk '{ print $1 }'`
     ```
 
-5. Optionally, upload the initrd for the image to S3.
+1. Optionally, upload the initrd for the image to S3.
+
+    > In this example, the relative path to the initrd file from working directory is
+    > `image-root/boot/initrd`.
 
     ```bash
     ncn# export IMS_INITRD_FILENAME=initrd
@@ -88,70 +108,70 @@ the following procedure can be used to add this external image to IMS and upload
     ncn# export IMS_INITRD_MD5SUM=`md5sum image-root/boot/$IMS_INITRD_FILENAME | awk '{ print $1 }'`
     ```
 
-<a name="image_manifest"></a>
+    <a name="image_manifest"></a>
+1.  Create an image manifest and upload it to S3.
 
-**Create an Image Manifest and Upload it to S3**
+    HPE Cray uses a manifest file that associates multiple related boot artifacts \(kernel, initrd, rootfs, etc.\) into
+    an image description that is used by IMS and other services to boot nodes. Artifacts listed within the manifest are
+    identified by a `type` value:
 
-HPE Cray uses a manifest file that associates multiple related boot artifacts \(kernel, initrd, rootfs, etc.\) into an image description that is used by IMS and other services to boot nodes. Artifacts listed within the manifest are identified by a `type` value:
+    - `application/vnd.cray.image.rootfs.squashfs`
+    - `application/vnd.cray.image.initrd`
+    - `application/vnd.cray.image.kernel`
+    - `application/vnd.cray.image.parameters.boot`
 
-- application/vnd.cray.image.rootfs.squashfs
-- application/vnd.cray.image.initrd
-- application/vnd.cray.image.kernel
-- application/vnd.cray.image.parameters.boot
+    1. Generate an image manifest file.
 
-6. Generate an image manifest file. 
-
-    ```bash
-    ncn# cat <<EOF> manifest.json
-    {
-      "created": "`date '+%Y-%m-%d %H:%M:%S'`",
-      "version": "1.0",
-      "artifacts": [
+        ```bash
+        ncn# cat <<EOF> manifest.json
         {
-          "link": {
-              "path": "s3://boot-images/$IMS_IMAGE_ID/$IMS_ROOTFS_FILENAME",
-              "type": "s3"
-          },
-          "md5": "$IMS_ROOTFS_MD5SUM",
-          "type": "application/vnd.cray.image.rootfs.squashfs"
-        },
-        {
-          "link": {
-              "path": "s3://boot-images/$IMS_IMAGE_ID/$IMS_KERNEL_FILENAME",
-              "type": "s3"
-          },
-          "md5": "$IMS_KERNEL_MD5SUM",
-          "type": "application/vnd.cray.image.kernel"
-        },
-        {
-          "link": {
-              "path": "s3://boot-images/$IMS_IMAGE_ID/$IMS_INITRD_FILENAME",
-              "type": "s3"
-          },
-          "md5": "$IMS_INITRD_MD5SUM",
-          "type": "application/vnd.cray.image.initrd"
+          "created": "`date '+%Y-%m-%d %H:%M:%S'`",
+          "version": "1.0",
+          "artifacts": [
+            {
+              "link": {
+                  "path": "s3://boot-images/$IMS_IMAGE_ID/$IMS_ROOTFS_FILENAME",
+                  "type": "s3"
+              },
+              "md5": "$IMS_ROOTFS_MD5SUM",
+              "type": "application/vnd.cray.image.rootfs.squashfs"
+            },
+            {
+              "link": {
+                  "path": "s3://boot-images/$IMS_IMAGE_ID/$IMS_KERNEL_FILENAME",
+                  "type": "s3"
+              },
+              "md5": "$IMS_KERNEL_MD5SUM",
+              "type": "application/vnd.cray.image.kernel"
+            },
+            {
+              "link": {
+                  "path": "s3://boot-images/$IMS_IMAGE_ID/$IMS_INITRD_FILENAME",
+                  "type": "s3"
+              },
+              "md5": "$IMS_INITRD_MD5SUM",
+              "type": "application/vnd.cray.image.initrd"
+            }
+          ]
         }
-      ]
-    }
-    EOF
-    ```
+        EOF
+        ```
 
-7. Upload the manifest to S3.
+    1. Upload the manifest to S3.
 
-    ```bash
-    ncn# cray artifacts create boot-images $IMS_IMAGE_ID/manifest.json manifest.json
-    ```
+        ```bash
+        ncn# cray artifacts create boot-images $IMS_IMAGE_ID/manifest.json manifest.json
+        ```
 
-<a name="register"></a>
+    <a name="register"></a>
+1.  Register the image manifest with the IMS service.
 
-**Register the Image Manifest with the IMS Service**
-
-8. Update the IMS image record.
+    Update the IMS image record.
 
     ```bash
     ncn# cray ims images update $IMS_IMAGE_ID \
-    --link-type s3 \
-    --link-path s3://boot-images/$IMS_IMAGE_ID/manifest.json
+            --link-type s3 \
+            --link-path s3://boot-images/$IMS_IMAGE_ID/manifest.json
     ```
 
     Example output:


### PR DESCRIPTION
## Summary and Scope

More than just minor linting of the pages, but no content changes -- some sections were slightly reorganized, but the procedure is unchanged.

## Issues and Related PRs

csm-1.2 backport https://github.com/Cray-HPE/docs-csm/pull/1413
csm-1.0 backport https://github.com/Cray-HPE/docs-csm/pull/1418

## Testing

None

## Risks and Mitigations

Never tell me the odds.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

