### PR TITLE
CASMINST-4454:  Remove prior weave and multus CNI configuration on USB fresh install

### DIFF
--- a/install/bootstrap_livecd_usb.md
+++ b/install/bootstrap_livecd_usb.md
@@ -146,6 +146,21 @@ Fetch the base installation CSM tarball, extract it, and install the contained C
       linux# rpm -Uvh $(find ${CSM_PATH}/rpm/embedded -name "lsscsi-*.x86_64.rpm" | sort -V | tail -1)
       ```
 
+1. Remove CNI configuration from prior install
+
+    If you are reinstalling the system and you are **using ncn-m001 to prepare the USB image**, remove some of prior CNI configuration.
+
+    ```bash
+    ncn-m001# rm -rf /etc/cni/net.d/00-multus.conf /etc/cni/net.d/10-*.conflist /etc/cni/net.d/multus.d
+    ```
+
+    This should leave you with the following two files in `/etc/cni/net.d`.
+
+    ```bash
+    ncn-m001# ls /etc/cni/net.d
+    87-podman-bridge.conflist  99-loopback.conf.sample
+    ```
+
 <a name="create-the-bootable-media"></a>
 ## 2. Create the Bootable Media
 


### PR DESCRIPTION
## Summary and Scope

When we are going a USB fresh install on a system that had a prior install, m001 will have old multus and weave CNI configuration.  However, while we are setting up the USB image from m001, those two CNIs are no longer available because the cluster has been shut down.   This causes warnings when using podman because the old configuration is causing it to look for the CNIs.    This adds a step to only the USB path to remove that old configuration.

This is not an issue with Remote ISO installs because we boot into the Remote ISO right away.

## Issues and Related PRs

* Resolves CASMINST-4454

## Testing

### Tested on:

  * `drax`

### Test description:

Reproduced the issue at this specific point of the install on drax using the documented podman commands.   I then removed the files as documented in this new step and ran the podman commands again.  This time I did not see the "Error validating CNI config file" warnings.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

