### PR TITLE
CASMINST-4509: Lint/clarify disk wipe procedure

### DIFF
--- a/install/wipe_ncn_disks_for_reinstallation.md
+++ b/install/wipe_ncn_disks_for_reinstallation.md
@@ -1,30 +1,30 @@
 # Wipe NCN Disks for Reinstallation
 
-This page will detail how disks to wipe NCN disks.
+This page details how to wipe NCN disks.
 
 > **Everything in this section should be considered DESTRUCTIVE**.
 
-After following these procedures an NCN can be rebooted and redeployed.
+After following these procedures, an NCN can be rebooted and redeployed.
 
-All types of disk wipe can be run from Linux or an initramFS/initrd emergency shell.
-
-The following are potential use cases for wiping disks:
+All types of disk wipe can be run from Linux or from an initramFS/initrd emergency shell.
 
 <a name="use-cases"></a>
+The following are potential use cases for wiping disks:
+
    * Adding a node that is not bare.
    * Adopting new disks that are not bare.
    * Doing a fresh install.
 
-## Topics:
-   1. [Basic Wipe](#basic-wipe)
-   1. [Advanced Wipe](#advanced-wipe)
-   1. [Full Wipe](#full-wipe)
+## Topics
+   * [Basic Wipe](#basic-wipe)
+   * [Advanced Wipe](#advanced-wipe)
+   * [Full Wipe](#full-wipe)
 
 <a name="basic-wipe"></a>
-## 1. Basic Wipe
+## Basic Wipe
 
 A basic wipe includes wiping the disks and all of the RAIDs. These basic wipe instructions can be
-executed on **any management nodes** (master, worker, and storage).
+executed on **any type of management node** (master, storage, or worker).
 
 1. List the disks for verification.
 
@@ -38,7 +38,7 @@ executed on **any management nodes** (master, worker, and storage).
     ncn# wipefs --all --force /dev/sd* /dev/disk/by-label/*
     ```
 
-    If any disks had labels present, output looks similar to the following:
+    If any disks had labels present, then the output looks similar to the following:
 
     ```
     /dev/sda: 8 bytes were erased at offset 0x00000200 (gpt): 45 46 49 20 50 41 52 54
@@ -51,51 +51,62 @@ executed on **any management nodes** (master, worker, and storage).
     /dev/sdc: 2 bytes were erased at offset 0x000001fe (PMBR): 55 aa
     ```
 
-    Verify there are no error messages in the output.
+    Verify that there are no error messages in the output.
 
     The `wipefs` command may fail if no labeled disks are found, which is an indication of a larger problem.
 
 <a name="advanced-wipe"></a>
-## 2. Advanced Wipe
+## Advanced Wipe
 
-This section is specific to utility storage nodes. An advanced wipe includes deleting the Ceph volumes and then
-wiping the disks and RAIDs.
+**This section is specific to utility storage nodes**. An advanced wipe includes stopping Ceph, 
+deleting the Ceph volumes, and then wiping the disks and RAIDs.
 
-1. Delete Ceph volumes.
+1. Stop Ceph.
+
+    * ***CSM 0.9 or earlier***
+
+        ```bash
+        ncn-s# systemctl stop ceph-osd.target
+        ```
+
+    * ***CSM 1.0 or later***
+
+        ```bash
+        ncn-s# cephadm rm-cluster --fsid $(cephadm ls|jq -r '.[0].fsid') --force
+        ```
+
+1. Make sure the OSDs (if any) are not running.
+
+    * ***CSM 0.9 or earlier***
+
+        ```bash
+        ncn-s# ps -ef|grep ceph-osd
+        ```
+
+    * ***CSM 1.0 or later***
+
+        ```bash
+        ncn-s# podman ps
+        ```
+
+    Examine the output. There should be no running `ceph-osd` processes or containers.
+
+1. Remove the Ceph volume groups.
 
     ```bash
-    ncn-s# systemctl stop ceph-osd.target
-    ```
-
-    Make sure the OSDs (if any) are not running after running the first command.
-
-    ```bash
-    ncn-s# ls -1 /dev/sd* /dev/disk/by-label/*
     ncn-s# vgremove -f -v --select 'vg_name=~ceph*'
     ```
 
-1. List the disks for verification.
-
-    ```bash
-    ncn# ls -1 /dev/sd* /dev/disk/by-label/*
-    ```
-
-1. Wipe the disks and RAIDs.
-
-    ```bash
-    ncn-s# wipefs --all --force /dev/sd* /dev/disk/by-label/*
-    ```
-
-    See [Basic Wipe](#basic-wipe) section for expected output from the `wipefs` command.
+1. Perform the [Basic Wipe](#basic-wipe) procedure.
 
 <a name="full-wipe"></a>
-### 3. Full-Wipe
+## Full-Wipe
 
 This section is the preferred method for all nodes. A full wipe includes deleting the Ceph volumes (where applicable), stopping the
 RAIDs, zeroing the disks, and then wiping the disks and RAIDs.
 
-**IMPORTANT:** Pay attention to whether the command is to be run on a worker node, master node, or storage node.
-If a node type is not specified, the step should be run regardless of node type.
+**IMPORTANT:** For each step, pay attention to whether the command is to be run on a master node, storage node, or worker node. If
+wiping a different type of node than what a step specifies, then skip that step.
 
 1. Reset Kubernetes **on worker nodes ONLY**.
 
@@ -128,7 +139,7 @@ If a node type is not specified, the step should be run regardless of node type.
 
     This will stop kubelet, underlying containers, and remove the contents of `/var/lib/kubelet`.
 
-    1.  Reset Kubernetes.
+    1. Reset Kubernetes.
 
         ```bash
         ncn-m# kubeadm reset --force
@@ -136,15 +147,15 @@ If a node type is not specified, the step should be run regardless of node type.
 
    1. List any containers running in `containerd`.
 
-       ```bash
-       ncn-m# crictl ps
-       CONTAINER           IMAGE               CREATED              STATE               NAME                                                ATTEMPT             POD ID
-       66a78adf6b4c2       18b6035f5a9ce       About a minute ago   Running             spire-bundle                                        1212                6d89f7dee8ab6
-       7680e4050386d       c8344c866fa55       24 hours ago         Running             speaker                                             0                   5460d2bffb4d7
-       b6467c907f063       8e6730a2b718c       3 days ago           Running             request-ncn-join-token                              0                   a3a9ca9e1ca78
-       e8ce2d1a8379f       64d4c06dc3fb4       3 days ago           Running             istio-proxy                                         0                   6d89f7dee8ab6
-       c3d4811fc3cd0       0215a709bdd9b       3 days ago           Running             weave-npc                                    0                   f5e25c12e617e
-       ```
+        ```bash
+        ncn-m# crictl ps
+        CONTAINER           IMAGE               CREATED              STATE               NAME                                                ATTEMPT             POD ID
+        66a78adf6b4c2       18b6035f5a9ce       About a minute ago   Running             spire-bundle                                        1212                6d89f7dee8ab6
+        7680e4050386d       c8344c866fa55       24 hours ago         Running             speaker                                             0                   5460d2bffb4d7
+        b6467c907f063       8e6730a2b718c       3 days ago           Running             request-ncn-join-token                              0                   a3a9ca9e1ca78
+        e8ce2d1a8379f       64d4c06dc3fb4       3 days ago           Running             istio-proxy                                         0                   6d89f7dee8ab6
+        c3d4811fc3cd0       0215a709bdd9b       3 days ago           Running             weave-npc                                    0                   f5e25c12e617e
+        ```
 
    1. If there are any running containers from the output of the `crictl ps` command, stop them.
 
@@ -154,67 +165,63 @@ If a node type is not specified, the step should be run regardless of node type.
 
 1. Delete Ceph Volumes **on utility storage nodes ONLY**.
 
-    1. For each storage node:
+    For each storage node, perform the following steps:
 
-       1. Stop Ceph.
+    1. Stop Ceph.
 
-           * ***1.4 or earlier***
+        * ***CSM 0.9 or earlier***
 
-               ```bash
-               ncn-s# systemctl stop ceph-osd.target
-               ```
+            ```bash
+            ncn-s# systemctl stop ceph-osd.target
+            ```
 
-           * ***1.5 or later***
+        * ***CSM 1.0 or later***
 
-               ```bash
-               ncn-s# cephadm rm-cluster --fsid $(cephadm ls|jq -r '.[0].fsid') --force
-               ```
+            ```bash
+            ncn-s# cephadm rm-cluster --fsid $(cephadm ls|jq -r '.[0].fsid') --force
+            ```
 
-       1. Make sure the OSDs (if any) are not running.
+    1. Make sure the OSDs (if any) are not running.
 
-           * ***1.4 or earlier***
+        * ***CSM 0.9 or earlier***
 
-               ```bash
-               ncn-s# ps -ef|grep ceph-osd
-               ```
+            ```bash
+            ncn-s# ps -ef|grep ceph-osd
+            ```
 
-           * ***1.5 or later***
+        * ***CSM 1.0 or later***
 
-               ```bash
-               ncn-s# podman ps
-               ```
+            ```bash
+            ncn-s# podman ps
+            ```
 
-           Examine the output. There should be no running `ceph-osd` processes or containers.
+        Examine the output. There should be no running `ceph-osd` processes or containers.
 
-       1. Remove the VGs.
+    1. Remove the Ceph volume groups.
 
-           ```bash
-           ncn-s# ls -1 /dev/sd* /dev/disk/by-label/*
-           ncn-s# vgremove -f -v --select 'vg_name=~ceph*'
-           ```
+        ```bash
+        ncn-s# vgremove -f -v --select 'vg_name=~ceph*'
+        ```
 
 1. Unmount volumes.
 
-    > **NOTE:** Some of the following `umount` commands may fail or have warnings depending on the state of the NCN. Failures in this section can be ignored and will not inhibit the wipe process.
-
+    > **NOTE:** Some of the following `umount` commands may fail or have warnings depending on the state of the NCN. Failures in this
+    > section can be ignored and will not inhibit the wipe process.
+    >
     > **NOTE:** There is an edge case where the overlay may keep the drive from being unmounted. If this is a rebuild, ignore this.
 
-    * Master nodes
+    The exact commands used depends on the node type:
 
-        Stop the etcd service on the master node before unmounting /var/lib/etcd
+    * **Master nodes**
+
+        Stop the `etcd` service on the master node before unmounting `/var/lib/etcd` and other mounts.
 
         ```bash
         ncn-m# systemctl stop etcd.service
         ncn-m# umount -v /run/lib-etcd /var/lib/etcd /var/lib/sdu /var/opt/cray/sdu/collection-mount /var/lib/admin-tools /var/lib/s3fs_cache /var/lib/containerd
         ```
 
-    * Worker nodes
-
-        ```bash
-        ncn-w# umount -v /var/lib/kubelet /var/lib/sdu /run/containerd /var/lib/containerd /run/lib-containerd /var/opt/cray/sdu/collection-mount /var/lib/admin-tools /var/lib/s3fs_cache /var/lib/containerd
-        ```
-
-    * Storage nodes
+    * **Storage nodes**
 
         ```bash
         ncn-s# umount -vf /var/lib/ceph /var/lib/containers /etc/ceph /var/opt/cray/sdu/collection-mount /var/lib/admin-tools /var/lib/s3fs_cache /var/lib/containerd
@@ -222,21 +229,37 @@ If a node type is not specified, the step should be run regardless of node type.
 
         If the `umount` command is responding with `target is busy` on the storage node, then try the following:
 
+        1. Look for `containers` mounts:
+
+            ```bash
+            ncn-s# mount | grep "containers"
+            /dev/mapper/metalvg0-CONTAIN on /var/lib/containers type xfs (rw,noatime,swalloc,attr2,largeio,inode64,allocsize=131072k,logbufs=8,logbsize=32k,noquota)
+            /dev/mapper/metalvg0-CONTAIN on /var/lib/containers/storage/overlay type xfs (rw,noatime,swalloc,attr2,largeio,inode64,allocsize=131072k,logbufs=8,logbsize=32k,noquota)
+            ```
+
+        1. Unmount `/var/lib/containers/storage/overlay`.
+
+            ```bash
+            ncn-s# umount -v /var/lib/containers/storage/overlay
+            umount: /var/lib/containers/storage/overlay unmounted
+            ```
+
+        1. Unmount `/var/lib/containers`.
+
+            ```bash
+            ncn-s# umount -v /var/lib/containers
+            umount: /var/lib/containers unmounted
+            ```
+
+    * **Worker nodes**
+
         ```bash
-        ncn-s# mount | grep "containers"
-        /dev/mapper/metalvg0-CONTAIN on /var/lib/containers type xfs (rw,noatime,swalloc,attr2,largeio,inode64,allocsize=131072k,logbufs=8,logbsize=32k,noquota)
-        /dev/mapper/metalvg0-CONTAIN on /var/lib/containers/storage/overlay type xfs (rw,noatime,swalloc,attr2,largeio,inode64,allocsize=131072k,logbufs=8,logbsize=32k,noquota)
-
-        ncn-s# umount -v /var/lib/containers/storage/overlay
-        umount: /var/lib/containers/storage/overlay unmounted
-
-        ncn-s# umount -v /var/lib/containers
-        umount: /var/lib/containers unmounted
+        ncn-w# umount -v /var/lib/kubelet /var/lib/sdu /run/containerd /var/lib/containerd /run/lib-containerd /var/opt/cray/sdu/collection-mount /var/lib/admin-tools /var/lib/s3fs_cache /var/lib/containerd
         ```
 
-1. Stop `cray-sdu-rda`.
+1. Stop `cray-sdu-rda` on **all node types** (master, storage, or worker).
 
-    1. Stop `cray-sdu-rda` container if necessary.
+    1. See if any `cray-sdu-rda` containers are running.
 
         ```bash
         ncn# podman ps
@@ -244,58 +267,60 @@ If a node type is not specified, the step should be run regardless of node type.
         7741d5096625  registry.local/sdu-docker-stable-local/cray-sdu-rda:1.1.1  /bin/sh -c /usr/s...  6 weeks ago  Up 6 weeks ago          cray-sdu-rda
         ```
 
-    1. If there is a running `cray-sdu-rda` container in the above output, stop it using the container ID:
+    1. If there is a running `cray-sdu-rda` container in the above output, then stop it using the container ID:
 
         ```bash
         ncn# podman stop 7741d5096625
         7741d50966259410298bb4c3210e6665cdbd57a82e34e467d239f519ae3f17d4
         ```
 
-1. Remove etcd device **on master nodes ONLY**.
+1. Remove `etcd` device **on master nodes ONLY**.
 
-    1. This `dmsetup` command will determine whether an etcd volume is present.
+    1. Determine whether or not an `etcd` volume is present.
 
         ```bash
         ncn-m# dmsetup ls
         ```
 
-        Expected output when the etcd volume is present will show `ETCDLVM`, but the numbers might be different.
+        Expected output when the `etcd` volume is present will show `ETCDLVM`, but the numbers might be different.
 
-        ```bash
+        ```
         ETCDLVM (254:1)
         ```
 
-    1. This `dmsetup` command will remove the etcd device mapper.
+    1. Remove the `etcd` device mapper.
 
         ```bash
         ncn-m# dmsetup remove $(dmsetup ls | grep -i etcd | awk '{print $1}')
         ```
 
-        > **NOTE:** The following output means the etcd volume mapper is not present.
-        ```bash
+        > **NOTE:** The following output means the `etcd` volume mapper is not present. This is okay.
+        ```
         No device specified.
         Command failed.
         ```
 
-1. Remove etcd volumes **on master nodes ONLY**.
+1. Remove `etcd` volumes **on master nodes ONLY**.
 
     ```bash
     ncn-m# vgremove etcdvg0
     ```
 
-1. Remove metal LVM.
+1. Remove metal LVM on **all node types** (master, storage, or worker).
 
     ```bash
     ncn# vgremove -f -v --select 'vg_name=~metal*'
     ```
 
-    > **NOTE:** Optionally, run the `pvs` command. If any drives are still listed, remove them with `pvremove`, but this is rarely needed. Also, if the above command fails or returns a warning about the filesystem being in use, ignore the error and proceed to the next step, as this will not inhibit the wipe process.
+    > **NOTE:** Optionally, run the `pvs` command. If any drives are still listed, then remove them with `pvremove`, but this is rarely needed. Also, if the above command fails or returns a warning about the filesystem being in use, ignore the error and proceed to the next step. This will not inhibit the wipe process.
 
-1. Group these commands together for each node.
+1. Wipe the disks and RAIDs on **all node types** (master, storage, or worker).
 
-    This group of commands should be done in succession on one node before moving to do the same set of commands on the next node. The nodes would be addressed in descending order for each type of node. Start with the utility storage nodes, then the worker nodes, then `ncn-m003`, then `ncn-m002`.
+    If wiping multiple nodes, this group of commands should be done in succession on one node before moving to do the same set of commands on the next node. 
+    The nodes should be addressed in descending order for each type of node. Start with the utility storage nodes, then the worker nodes, then `ncn-m003`, and finally `ncn-m002`.
 
     > **WARNING:** Do not run these commands on `ncn-m001`
+
     1. List the disks for verification.
 
         ```bash
@@ -308,7 +333,7 @@ If a node type is not specified, the step should be run regardless of node type.
         ncn# wipefs --all --force /dev/sd* /dev/disk/by-label/*
         ```
 
-        If any disks had labels present, output from `wipefs` looks similar to the following:
+        If any disks had labels present, then output from `wipefs` looks similar to the following:
 
         ```
         /dev/sda: 8 bytes were erased at offset 0x00000200 (gpt): 45 46 49 20 50 41 52 54
@@ -321,9 +346,6 @@ If a node type is not specified, the step should be run regardless of node type.
         /dev/sdc: 2 bytes were erased at offset 0x000001fe (PMBR): 55 aa
         ```
 
-        Verify there are no error messages in the output.
+        Verify that there are no error messages in the output.
 
         The `wipefs` command may fail if no labeled disks are found, which is an indication of a larger problem.
-
-        See [Basic Wipe](#basic-wipe) section for expected output from the `wipefs` command.
-


### PR DESCRIPTION
## Summary and Scope

The disk wipe procedure referred to versions 1.4 and 1.5 without saying whether that was CSM or Shasta (or something else). Since we no longer use the Shasta versions normally, I updated the document so it clearly stated the appropriate CSM versions.

I also did an overall linting of the page, correcting a number of small errors, and making some things clearer.

## Issues and Related PRs

csm-1.2 backport: https://github.com/Cray-HPE/docs-csm/pull/1450
csm-1.0 backport: https://github.com/Cray-HPE/docs-csm/pull/1451

## Testing

None. No processes were changed.

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
