### PR TITLE
CASMTRIAGE-3258 - add known issue with console log files filling storage space.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -177,3 +177,4 @@ and many more...
 * Kube-multus pods may fail to restart due to ImagePullBackOff. For more information see [Kube-multus pod is in ImagePullBackOff](troubleshooting/known_issues/kube_multus_pod_in_ImagePullBackOff.md).
 * Power capping Olympus and River compute hardware via CAPMC is not supported.
 * On fresh install, API calls to Gitea/VCS may give 401 Errors. See [Gitea/VCS 401 Errors](troubleshooting/known_issues/gitea_vcs_401_errors.md) for more information.
+* Console logging may fill all available space for console log files. See [Console logs filling up availble storage](troubleshooting/known_issues/console_log_storage_filling.md) for more information.

--- a/troubleshooting/index.md
+++ b/troubleshooting/index.md
@@ -8,6 +8,7 @@ This document provides links to troubleshooting information for services and fun
     * [SAT/HSM/CAPMC Component Power State Mismatch](known_issues/component_power_state_mismatch.md)
     * [HMS Discovery job not creating `RedfishEndpoint`s in Hardware State Manager](known_issues/discovery_job_not_creating_redfish_endpoints.md)
     * [`initrd.img.xz` not found](known_issues/initrd.img.zx_not_found.md)
+    * [Console logs filling up available storage](known_issues/console_log_storage_filling.md)
 
 ## Troubleshooting Topics
 

--- a/troubleshooting/known_issues/console_log_storage_filling.md
+++ b/troubleshooting/known_issues/console_log_storage_filling.md
@@ -1,0 +1,68 @@
+# Console Logs Fill All Available Storage Space
+
+The log rotation functionality of the console logging services has a bug where
+the files are not rotated correctly. This will lead to the logs continuing to
+expand until eventually all space is consumed on the storage. This can lead to
+issues where the log files cease to capture log output, and can sometimes lead
+to the `cray-console-node` pods failing to connect to nodes.
+
+## Procedure
+
+1. Verify if the issue exists by checking the used space on the `/var/log/` mount in the `cray-console-node` pods:
+   ```text
+   ncn# kubectl -n services exec -it cray-console-node-0 -- sh
+   sh-4.4$ df -h | grep var
+   Filesystem                     Size  Used Avail Use% Mounted on
+   /volumes/csi/csi-vol-ab81e37b  100G   99G  100G  99% /var/log
+   ```
+
+2. If the issue is identified, manually delete log files to clear up space:
+   ```text
+   ncn# kubectl -n services exec -it cray-console-node-0 -- sh
+   sh-4.4$ rm -f /var/log/conman.old/*
+   sh-4.4$ rm -f /var/log/conman/*
+   sh-4.4$ exit
+   ncn#
+   ```
+
+3. Scale the services down to zero replicas:
+   ```text
+   ncn# kubectl -n services scale --replicas=0 deployment/cray-console-operator
+   deployment.apps/cray-console-operator scaled
+   ncn# kubectl -n services scale --replicas=0 statefulset/cray-console-node
+   statefulset.apps/cray-console-node scaled
+   ```
+
+4. Wait for the `cray-console-operator` and `cray-console-node` pods to terminate:
+   ```text
+   ncn# kubectl -n services get pods | grep console
+   console-node-post-upgrade-gtzj4       0/2     Completed   0    12d
+   cray-console-data-58764f845-frksj     2/2     Running     0    12d
+   cray-console-data-postgres-0          3/3     Running     0    12d
+   cray-console-data-postgres-1          3/3     Running     0    12d
+   cray-console-data-postgres-2          3/3     Running     0    12d
+   ncn#
+   ```
+
+5. Scale the `cray-console-operator` deployment back to 1 replica:
+   ```text
+   ncn# kubectl -n services scale --replicas=1 deployment/cray-console-operator
+   deployment.apps/cray-console-operator scaled
+   ```
+
+6. When the `cray-console-operator` pod is running again it will scale the `cray-console-node`
+stateful set to the correct number of replicas. Watch for the pods to come back up again:
+   ```text
+   ncn# kubectl -n services get pods | grep console
+   console-node-post-upgrade-gtzj4         0/2     Completed   0    12d
+   cray-console-data-58764f845-frksj       2/2     Running     0    12d
+   cray-console-data-postgres-0            3/3     Running     0    12d
+   cray-console-data-postgres-1            3/3     Running     0    12d
+   cray-console-data-postgres-2            3/3     Running     0    12d
+   cray-console-node-0                     3/3     Running     0    10m
+   cray-console-node-1                     3/3     Running     1    12m
+   cray-console-operator-69f6588596-6txtp  2/2     Running     0    10m
+   ncn#
+   ```
+
+It make take a few minutes for the system to start monitoring all consoles again.


### PR DESCRIPTION
## Summary and Scope

Add documentation for a defect discovered where log rotation is not working correctly and console logs may expand to fill all available space on the volume.

## Issues and Related PRs

* Resolves [CASMTRIAGE-3258](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3258)
* Change will also be needed in `release/1.2`

## Testing
### Tested on:
  * `Wasp`, and `Shandy`

### Test description:

I used shandy and wasp to verify the workaround steps and insure accurate documentation.

## Risks and Mitigations

This is just a documentation change - no code risk.

## Pull Request Checklist

- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
