### PR TITLE
Fix wait function to wait on 3 members AND running state for pod priority script

### DIFF
--- a/upgrade/1.0.1/scripts/upgrade/add_pod_priority.sh
+++ b/upgrade/1.0.1/scripts/upgrade/add_pod_priority.sh
@@ -83,11 +83,11 @@ function wait_for_running_pods() {
         operator_num_ready=$(kubectl get etcd $etcd_cluster -n $ns -o jsonpath='{.status.members.ready}' | jq .[] | wc -l)
         if [[ "$desired_size" -eq "$operator_num_ready" ]]; then
           echo "Found $desired_size ready members in $etcd_cluster etcd cluster"
-        fi
-        op_state=$(kubectl get etcd $etcd_cluster -n $ns -o jsonpath='{.status.phase}')
-        if [ $op_state == "Running" ]; then
-          echo "Found status of $op_state for $etcd_cluster etcd cluster"
-          break
+          op_state=$(kubectl get etcd $etcd_cluster -n $ns -o jsonpath='{.status.phase}')
+          if [ $op_state == "Running" ]; then
+            echo "Found status of $op_state for $etcd_cluster etcd cluster"
+            break
+          fi
         fi
         echo "Sleeping for ten seconds waiting for $desired_size ready members and 'Running' state for $etcd_cluster etcd cluster"
         sleep 10

--- a/upgrade/1.0.11/scripts/upgrade/add_pod_priority.sh
+++ b/upgrade/1.0.11/scripts/upgrade/add_pod_priority.sh
@@ -83,11 +83,11 @@ function wait_for_running_pods() {
         operator_num_ready=$(kubectl get etcd $etcd_cluster -n $ns -o jsonpath='{.status.members.ready}' | jq .[] | wc -l)
         if [[ "$desired_size" -eq "$operator_num_ready" ]]; then
           echo "Found $desired_size ready members in $etcd_cluster etcd cluster"
-        fi
-        op_state=$(kubectl get etcd $etcd_cluster -n $ns -o jsonpath='{.status.phase}')
-        if [ $op_state == "Running" ]; then
-          echo "Found status of $op_state for $etcd_cluster etcd cluster"
-          break
+          op_state=$(kubectl get etcd $etcd_cluster -n $ns -o jsonpath='{.status.phase}')
+          if [ $op_state == "Running" ]; then
+            echo "Found status of $op_state for $etcd_cluster etcd cluster"
+            break
+          fi
         fi
         echo "Sleeping for ten seconds waiting for $desired_size ready members and 'Running' state for $etcd_cluster etcd cluster"
         sleep 10


### PR DESCRIPTION
## Summary and Scope

Fix minor logic bug in pod priority wait script

## Issues and Related PRs

* Resolves [CASMINST-4523](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4523)

## Testing

```
ncn-m001-fec36008:/home/bklein # ./add_pod_priority.sh
Found 3 running pods in cray-bss-etcd etcd cluster
Found 3 ready members in cray-bss-etcd etcd cluster
Found status of Running for cray-bss-etcd etcd cluster
Creating csm-high-priority-service pod priority class
priorityclass.scheduling.k8s.io/csm-high-priority-service configured

Patching cray-bss-etcd etcdcluster in services namespace
etcdcluster.etcd.database.coreos.com/cray-bss-etcd patched (no change)

pod "cray-bss-etcd-dtnlvjtbj9" deleted
Sleeping for ten seconds waiting for 3 pods in cray-bss-etcd etcd cluster
Sleeping for ten seconds waiting for 3 pods in cray-bss-etcd etcd cluster
Sleeping for ten seconds waiting for 3 pods in cray-bss-etcd etcd cluster
Sleeping for ten seconds waiting for 3 pods in cray-bss-etcd etcd cluster
Found 3 running pods in cray-bss-etcd etcd cluster
Sleeping for ten seconds waiting for 3 ready members and 'Running' state for cray-bss-etcd etcd cluster
Found 3 ready members in cray-bss-etcd etcd cluster
Found status of Running for cray-bss-etcd etcd cluster
pod "cray-bss-etcd-lnmzfzdwj4" deleted
Sleeping for ten seconds waiting for 3 pods in cray-bss-etcd etcd cluster
Sleeping for ten seconds waiting for 3 pods in cray-bss-etcd etcd cluster
Sleeping for ten seconds waiting for 3 pods in cray-bss-etcd etcd cluster
Sleeping for ten seconds waiting for 3 pods in cray-bss-etcd etcd cluster
Sleeping for ten seconds waiting for 3 pods in cray-bss-etcd etcd cluster
Found 3 running pods in cray-bss-etcd etcd cluster
Sleeping for ten seconds waiting for 3 ready members and 'Running' state for cray-bss-etcd etcd cluster
Found 3 ready members in cray-bss-etcd etcd cluster
Found status of Running for cray-bss-etcd etcd cluster
pod "cray-bss-etcd-mfkp6twz8c" deleted
Sleeping for ten seconds waiting for 3 pods in cray-bss-etcd etcd cluster
Sleeping for ten seconds waiting for 3 pods in cray-bss-etcd etcd cluster
Sleeping for ten seconds waiting for 3 pods in cray-bss-etcd etcd cluster
Sleeping for ten seconds waiting for 3 pods in cray-bss-etcd etcd cluster
Found 3 running pods in cray-bss-etcd etcd cluster
Sleeping for ten seconds waiting for 3 ready members and 'Running' state for cray-bss-etcd etcd cluster
Found 3 ready members in cray-bss-etcd etcd cluster
Found status of Running for cray-bss-etcd etcd cluster
```

### Tested on:

  * Virtual Shasta

### Test description:

Deployed script and tested with fix

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable