### PR TITLE
CASMINST-4525: Minor linting and enhancements to Deploy Management Nodes

### DIFF
--- a/.github/config/markdown_style.yaml
+++ b/.github/config/markdown_style.yaml
@@ -224,7 +224,7 @@ MD042: true
 # MD043/required-headings/required-headers - Required heading structure
 MD043:
   # List of headings
-  headings: []
+  headings: [ "+" ]
   # List of headings
   headers: []
 

--- a/.github/config/markdown_style.yaml
+++ b/.github/config/markdown_style.yaml
@@ -184,7 +184,7 @@ MD032: true
 # MD033/no-inline-html - Inline HTML
 MD033:
   # Allowed elements
-  allowed_elements: []
+  allowed_elements: [ "a" ]
 
 # MD034/no-bare-urls - Bare URL used
 MD034: true

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -38,7 +38,7 @@ jobs:
         files: "**/*.md"
         files_ignore: ".github/**/*"
 
-    - uses: docker://ghcr.io/tcort/markdown-link-check:stable
+    - uses: docker://ghcr.io/tcort/markdown-link-check:3.9.3
       with:
         args: "--config .github/config/markdown_link.json ${{ steps.changed-files.outputs.all_changed_files }}"
 

--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -36,6 +36,7 @@ the number of storage and worker nodes.
    1. [Validate Management Node Deployment](#validate_management_node_deployment)
       1. [Validation](#validation)
       1. [Optional Validation](#optional-validation)
+   1. [Important Checkpoint](#important-checkpoint)
    1. [Next Topic](#next-topic)
 
 <a name="prepare_for_management_node_deployment"></a>
@@ -48,15 +49,23 @@ Preparation of the environment must be done before attempting to deploy the mana
 
 1. Define shell environment variables that will simplify later commands to deploy management nodes.
 
-    **Notice** that one of them is the `IPMI_PASSWORD`. Replace `changeme` with the real root password for BMCs.
+   1. Set `IPMI_PASSWORD` to the root password for the NCN BMCs.
 
-   ```bash
-   pit# export mtoken='ncn-m(?!001)\w+-mgmt'
-   pit# export stoken='ncn-s\w+-mgmt'
-   pit# export wtoken='ncn-w\w+-mgmt'
-   pit# export USERNAME=root
-   pit# export IPMI_PASSWORD=changeme
-   ```
+      >  `read -s` is used to prevent the password
+      > from being written to the screen or the shell history.
+
+      ```bash
+      pit# read -s IPMI_PASSWORD
+      pit# export IPMI_PASSWORD
+      ```
+
+   1. Set the remaining helper variables.
+
+      > These values do not need to be altered from what is shown.
+
+      ```bash
+      pit# export mtoken='ncn-m(?!001)\w+-mgmt' ; export stoken='ncn-s\w+-mgmt' ; export wtoken='ncn-w\w+-mgmt' ; export USERNAME=root
+      ```
 
    Throughout the guide, simple one-liners can be used to query status of expected nodes. If the shell or environment is terminated, these environment variables should be re-exported.
 
@@ -85,7 +94,7 @@ proceed to step 2.
 
    The time can be inaccurate if the system has been powered off for a long time, or, for example, the CMOS was cleared on a Gigabyte node. See [Clear Gigabyte CMOS](clear_gigabyte_cmos.md).
 
-   > This step should not be skipped
+   > **This step should not be skipped.**
 
    Check the time on the PIT node to see whether it matches the current time:
 
@@ -339,8 +348,7 @@ The configuration workflow described here is intended to help understand the exp
 
     > **`NOTE`**: All console logs are located at `/var/log/conman/console*`
 
-<a name="boot-the-storage-nodes"></a>
-1. Boot the **Storage Nodes**
+1. <a name="boot-the-storage-nodes"></a>Boot the **Storage Nodes**
 
     Boot all the storage nodes. `ncn-s001` will start 1 minute after the other storage nodes.
 
@@ -840,12 +848,13 @@ Observe the output of the checks and note any failures, then remediate them.
 
       See [Ceph CSI Troubleshooting](ceph_csi_troubleshooting.md) for details.
 
-# Important Checkpoint
+<a name="important-checkpoint"></a>
+## Important Checkpoint
 
 > Before you move on, this is the last point where you will be able to rebuild nodes without having to rebuild the PIT node. So take time to double check both the cluster and the validation test results
 
 <a name="next-topic"></a>
-# Next Topic
+## Next Topic
 
 After completing the deployment of the management nodes, the next step is to install the CSM services.
 

--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -225,7 +225,7 @@ firmware requirement before starting.
     > This is **optional**, the BIOS settings (or lack thereof) do not prevent deployment. The NCN installation will work with the CMOS' default
     > BIOS. There may be settings that facilitate the speed of deployment, but they may be tuned at a later time.
     >
-    > **NOTE** The BIOS tuning will be automated, further reducing this step.
+    > **NOTE:** The BIOS tuning will be automated, further reducing this step.
 
 1. The firmware on the management nodes should be checked for compliance with the minimum required version
    and updated, if necessary, at this point.
@@ -333,6 +333,7 @@ be performed are in the [Deploy](#deploy) section.
     > **`NOTE`**:The NCN boot order is further explained in [NCN Boot Workflow](../background/ncn_boot_workflow.md).
 
 1. Validate that the LiveCD is ready for installing NCNs.
+
    > Observe the output of the checks and note any failures, then remediate them.
 
     Specify the admin user password for the management switches in the system.
@@ -347,7 +348,7 @@ be performed are in the [Deploy](#deploy) section.
     pit# csi pit validate --livecd-preflight
     ```
 
-    > Note: You can ignore any errors about not being able resolve arti.dev.cray.com.
+    > Note: Ignore any errors about not being able resolve `arti.dev.cray.com`.
 
 1. Print the consoles available to you:
 

--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -222,8 +222,9 @@ firmware requirement before starting.
 
 1. (optional) Check these BIOS settings on management nodes [NCN BIOS](../background/ncn_bios.md).
 
-    > This is **optional**, the BIOS settings (or lack thereof) do not prevent deployment. The NCN installation will work with the CMOS' default BIOS. There may be settings that facilitate the speed of deployment, but they may be tuned at a later time.
-
+    > This is **optional**, the BIOS settings (or lack thereof) do not prevent deployment. The NCN installation will work with the CMOS' default
+    > BIOS. There may be settings that facilitate the speed of deployment, but they may be tuned at a later time.
+    >
     > **NOTE** The BIOS tuning will be automated, further reducing this step.
 
 1. The firmware on the management nodes should be checked for compliance with the minimum required version
@@ -315,7 +316,7 @@ be performed are in the [Deploy](#deploy) section.
 1. Run the BIOS Baseline script to apply a configs to BMCs. The script will apply helper configs to facilitate more deterministic network booting on any NCN port. **This runs against any server vendor**, some settings are not applied for certain vendors.
 
     > **`NOTE`** This script depends on `IPMI_PASSWORD` being set, this is done in [Tokens and IPMI Password](#tokens-and-ipmi-password)
-
+    >
     > **`NOTE`** This script will enable DCMI/IPMI on Hewlett-Packard Enterprise servers equipped with ILO. If `ipmitool` is not working at this time, it will after running this script.
 
     ```bash

--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -748,7 +748,7 @@ The LiveCD needs to authenticate with the cluster to facilitate the rest of the 
 
 <a name="install-tests"></a>
 
-### 4.4 Install Tests and Test Server on NCNs
+### 4.2 Install Tests and Test Server on NCNs
 
 Run the following commands on the PIT node.
 
@@ -761,7 +761,7 @@ pit# popd
 
 <a name="remove-default-ntp-pool"></a>
 
-### 4.5 Remove the default NTP pool
+### 4.3 Remove the default NTP pool
 
 Run the following command on the PIT node to remove the default pool, which can cause contention issues with NTP. When it prompts you for a password, enter the root password for `ncn-m002`.
 

--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -125,6 +125,7 @@ proceed to step 2.
    ```bash
    pit# systemctl stop chronyd
    ```
+
    Then run the commands above to complete the process.
 
 1. Ensure the current time is set in BIOS for all management NCNs.
@@ -334,11 +335,13 @@ be performed are in the [Deploy](#deploy) section.
    > Observe the output of the checks and note any failures, then remediate them.
 
     Specify the admin user password for the management switches in the system.
+
     ```bash
     pit# export SW_ADMIN_PASSWORD='changeme'
     ```
 
     Run the LiveCD preflight checks.
+
     ```bash
     pit# csi pit validate --livecd-preflight
     ```


### PR DESCRIPTION
## Summary and Scope

There is a formatting error in the page which causes the step numbering to be mess up in section 3.2. This PR corrects that, makes a few other small linting changes, and makes a small improvement to how the initial environment variables are set.

## Issues and Related PRs

csm-1.2 backport: https://github.com/Cray-HPE/docs-csm/pull/1466
csm-1.0 backport: https://github.com/Cray-HPE/docs-csm/pull/1467

## Testing

N/A.

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
