### PR TITLE
CAST-25340 - Added procedure to reconfigure Unbound forwarder

### DIFF
--- a/operations/network/dns/Manage_the_DNS_Unbound_Resolver.md
+++ b/operations/network/dns/Manage_the_DNS_Unbound_Resolver.md
@@ -185,7 +185,7 @@ Use the following procedure to change the site DNS server that Unbound forwards 
 
 1. Update `customizations.yaml`.
 
-   **`IMPORTANT:`** If this step is not performed, then the Unbound configuration will be overwritten with the previous value the next time CSM or Unbound is upgraded.
+   **IMPORTANT:** If this step is not performed, then the Unbound configuration will be overwritten with the previous value the next time CSM or Unbound is upgraded.
 
    1. Extract `customizations.yaml` from the `site-init` secret in the `loftsman` namespace.
 

--- a/operations/network/dns/Manage_the_DNS_Unbound_Resolver.md
+++ b/operations/network/dns/Manage_the_DNS_Unbound_Resolver.md
@@ -202,20 +202,20 @@ Use the following procedure to change the site DNS server that Unbound forwards 
             system_to_site_lookups: 172.30.84.40
       ```
 
-     If multiple DNS servers are required, add the additional servers into the `cray-dns-unbound` service configuration.
+      If multiple DNS servers are required, add the additional servers into the `cray-dns-unbound` service configuration.
 
-     ```yaml
-     spec:
-       kubernetes:
-         services:
-           cray-dns-unbound:
-             forwardZones:
-               - name: "."
-                 forwardIps:
-                   - "{{ network.netstaticips.system_to_site_lookups }}"
-                   - "192.168.0.1"
-             domain_name: '{{ network.dns.external }}'
-     ```
+      ```yaml
+      spec:
+        kubernetes:
+          services:
+            cray-dns-unbound:
+              forwardZones:
+                - name: "."
+                  forwardIps:
+                    - "{{ network.netstaticips.system_to_site_lookups }}"
+                    - "192.168.0.1"
+              domain_name: '{{ network.dns.external }}'
+      ```
 
    1. Update the site-init secret in the loftsman namespace.
 

--- a/operations/network/dns/Manage_the_DNS_Unbound_Resolver.md
+++ b/operations/network/dns/Manage_the_DNS_Unbound_Resolver.md
@@ -190,7 +190,7 @@ Use the following procedure to change the site DNS server that Unbound forwards 
    1. Extract `customizations.yaml` from the site-init secret in the loftsman namespace.
 
       ```bash
-      kubectl -n loftsman get secret site-init -o json | jq -r '.data."customizations.yaml"' | base64 -d > customizations.yaml
+      ncn-m001# kubectl -n loftsman get secret site-init -o json | jq -r '.data."customizations.yaml"' | base64 -d > customizations.yaml
       ```
 
    1. Update the `system_to_site_lookups` with the value of the new DNS server.

--- a/operations/network/dns/Manage_the_DNS_Unbound_Resolver.md
+++ b/operations/network/dns/Manage_the_DNS_Unbound_Resolver.md
@@ -150,16 +150,16 @@ ncn-w001# kubectl -n services patch configmaps cray-dns-unbound \
 --type merge -p '{"binaryData":{"records.json.gz":"H4sICLQ/Z2AAA3JlY29yZHMuanNvbgCLjuUCAETSaHADAAAA"}}'
 ```
 
-### Change the site DNS server
+### Change the Site DNS server
 
 Use the following procedure to change the site DNS server that Unbound forwards queries to.
 
 1. Edit the `cray-dns-unbound` ConfigMap.
 
-  ```bash
-  ncn-m001# kubectl -n services edit configmap cray-dns-unbound
-  ```
-  Update the forward-zone value in unbound.conf.
+   ```bash
+   ncn-m001# kubectl -n services edit configmap cray-dns-unbound
+   ```
+   Update the `forward-zone` value in `unbound.conf`.
 
    ```yaml
    forward-zone:
@@ -167,7 +167,7 @@ Use the following procedure to change the site DNS server that Unbound forwards 
        forward-addr: 172.30.84.40
    ```
 
-  Multiple DNS servers can be defined if required.
+   Multiple DNS servers can be defined if required.
 
    ```yaml
    forward-zone:
@@ -176,16 +176,16 @@ Use the following procedure to change the site DNS server that Unbound forwards 
        forward-addr: 192.168.0.1
    ```
 
-1. Restart cray-dns-unbound for this change to take effect.
+1. Restart `cray-dns-unbound` for this change to take effect.
 
-  ```bash
-  ncn-m001# kubectl -n services rollout restart deployment cray-dns-unbound
-  deployment.apps/cray-dns-unbound restarted
-  ```
+   ```bash
+   ncn-m001# kubectl -n services rollout restart deployment cray-dns-unbound
+   deployment.apps/cray-dns-unbound restarted
+   ```
 
 1. Update `customizations.yaml`.
 
-   **`IMPORTANT:`** If this step is not performed then the Unbound configuration will be overwritten with the previous value next time CSM or Unbound is upgraded.
+   **`IMPORTANT:`** If this step is not performed, then the Unbound configuration will be overwritten with the previous value the next time CSM or Unbound is upgraded.
 
    1. Extract `customizations.yaml` from the site-init secret in the loftsman namespace.
 
@@ -202,7 +202,7 @@ Use the following procedure to change the site DNS server that Unbound forwards 
            system_to_site_lookups: 172.30.84.40
      ```
 
-     If multiple DNS servers are required then add the additional servers into the cray-dns-unbound service configuration.
+     If multiple DNS servers are required, add the additional servers into the `cray-dns-unbound` service configuration.
 
      ```yaml
      spec:

--- a/operations/network/dns/Manage_the_DNS_Unbound_Resolver.md
+++ b/operations/network/dns/Manage_the_DNS_Unbound_Resolver.md
@@ -193,14 +193,14 @@ Use the following procedure to change the site DNS server that Unbound forwards 
    kubectl -n loftsman get secret site-init -o json | jq -r '.data."customizations.yaml"' | base64 -d > customizations.yaml
    ```
 
-  1. Update the `system_to_site_lookups` with the value of the new DNS server.
+   1. Update the `system_to_site_lookups` with the value of the new DNS server.
 
-     ```yaml
-     spec:
-       network:
-         netstaticips:
-           system_to_site_lookups: 172.30.84.40
-     ```
+      ```yaml
+      spec:
+        network:
+          netstaticips:
+            system_to_site_lookups: 172.30.84.40
+      ```
 
      If multiple DNS servers are required, add the additional servers into the `cray-dns-unbound` service configuration.
 
@@ -217,9 +217,9 @@ Use the following procedure to change the site DNS server that Unbound forwards 
              domain_name: '{{ network.dns.external }}'
      ```
 
-  1. Update the site-init secret in the loftsman namespace.
+   1. Update the site-init secret in the loftsman namespace.
 
-     ```bash
-     ncn-m001# kubectl delete secret -n loftsman site-init
-     ncn-m001# kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
-     ```
+      ```bash
+      ncn-m001# kubectl delete secret -n loftsman site-init
+      ncn-m001# kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
+      ```

--- a/operations/network/dns/Manage_the_DNS_Unbound_Resolver.md
+++ b/operations/network/dns/Manage_the_DNS_Unbound_Resolver.md
@@ -150,7 +150,7 @@ ncn-w001# kubectl -n services patch configmaps cray-dns-unbound \
 --type merge -p '{"binaryData":{"records.json.gz":"H4sICLQ/Z2AAA3JlY29yZHMuanNvbgCLjuUCAETSaHADAAAA"}}'
 ```
 
-### Change the Site DNS server
+### Change the Site DNS Server
 
 Use the following procedure to change the site DNS server that Unbound forwards queries to. This may be necessary if the site DNS server is moved to a different IP address.
 
@@ -193,7 +193,7 @@ Use the following procedure to change the site DNS server that Unbound forwards 
       ncn-m001# kubectl -n loftsman get secret site-init -o json | jq -r '.data."customizations.yaml"' | base64 -d > customizations.yaml
       ```
 
-   1. Update the `system_to_site_lookups` with the value of the new DNS server.
+   1. Update `system_to_site_lookups` with the value of the new DNS server.
 
       ```yaml
       spec:

--- a/operations/network/dns/Manage_the_DNS_Unbound_Resolver.md
+++ b/operations/network/dns/Manage_the_DNS_Unbound_Resolver.md
@@ -150,3 +150,76 @@ ncn-w001# kubectl -n services patch configmaps cray-dns-unbound \
 --type merge -p '{"binaryData":{"records.json.gz":"H4sICLQ/Z2AAA3JlY29yZHMuanNvbgCLjuUCAETSaHADAAAA"}}'
 ```
 
+### Change the site DNS server
+
+Use the following procedure to change the site DNS server that Unbound forwards queries to.
+
+1. Edit the `cray-dns-unbound` ConfigMap.
+
+  ```bash
+  ncn-m001# kubectl -n services edit configmap cray-dns-unbound
+  ```
+  Update the forward-zone value in unbound.conf.
+
+   ```yaml
+   forward-zone:
+       name: .
+       forward-addr: 172.30.84.40
+   ```
+
+  Multiple DNS servers can be defined if required.
+
+   ```yaml
+   forward-zone:
+       name: .
+       forward-addr: 172.30.84.40
+       forward-addr: 192.168.0.1
+   ```
+
+1. Restart cray-dns-unbound for this change to take effect.
+
+  ```bash
+  ncn-m001# kubectl -n services rollout restart deployment cray-dns-unbound
+  deployment.apps/cray-dns-unbound restarted
+  ```
+
+1. Update `customizations.yaml`.
+
+   **`IMPORTANT:`** If this step is not performed then the Unbound configuration will be overwritten with the previous value next time CSM or Unbound is upgraded.
+
+   1. Extract `customizations.yaml` from the site-init secret in the loftsman namespace.
+
+   ```bash
+   kubectl -n loftsman get secret site-init -o json | jq -r '.data."customizations.yaml"' | base64 -d > customizations.yaml
+   ```
+
+  1. Update the `system_to_site_lookups` with the value of the new DNS server.
+
+     ```yaml
+     spec:
+       network:
+         netstaticips:
+           system_to_site_lookups: 172.30.84.40
+     ```
+
+     If multiple DNS servers are required then add the additional servers into the cray-dns-unbound service configuration.
+
+     ```yaml
+     spec:
+       kubernetes:
+         services:
+           cray-dns-unbound:
+             forwardZones:
+               - name: "."
+                 forwardIps:
+                   - "{{ network.netstaticips.system_to_site_lookups }}"
+                   - "192.168.0.1"
+             domain_name: '{{ network.dns.external }}'
+     ```
+
+  1. Update the site-init secret in the loftsman namespace.
+
+     ```bash
+     ncn-m001# kubectl delete secret -n loftsman site-init
+     ncn-m001# kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
+     ```

--- a/operations/network/dns/Manage_the_DNS_Unbound_Resolver.md
+++ b/operations/network/dns/Manage_the_DNS_Unbound_Resolver.md
@@ -189,9 +189,9 @@ Use the following procedure to change the site DNS server that Unbound forwards 
 
    1. Extract `customizations.yaml` from the site-init secret in the loftsman namespace.
 
-   ```bash
-   kubectl -n loftsman get secret site-init -o json | jq -r '.data."customizations.yaml"' | base64 -d > customizations.yaml
-   ```
+      ```bash
+      kubectl -n loftsman get secret site-init -o json | jq -r '.data."customizations.yaml"' | base64 -d > customizations.yaml
+      ```
 
    1. Update the `system_to_site_lookups` with the value of the new DNS server.
 

--- a/operations/network/dns/Manage_the_DNS_Unbound_Resolver.md
+++ b/operations/network/dns/Manage_the_DNS_Unbound_Resolver.md
@@ -217,7 +217,7 @@ Use the following procedure to change the site DNS server that Unbound forwards 
               domain_name: '{{ network.dns.external }}'
       ```
 
-   1. Update the site-init secret in the loftsman namespace.
+   1. Update the `site-init` secret in the `loftsman` namespace.
 
       ```bash
       ncn-m001# kubectl delete secret -n loftsman site-init

--- a/operations/network/dns/Manage_the_DNS_Unbound_Resolver.md
+++ b/operations/network/dns/Manage_the_DNS_Unbound_Resolver.md
@@ -152,7 +152,7 @@ ncn-w001# kubectl -n services patch configmaps cray-dns-unbound \
 
 ### Change the Site DNS server
 
-Use the following procedure to change the site DNS server that Unbound forwards queries to.
+Use the following procedure to change the site DNS server that Unbound forwards queries to. This may be necessary if the site DNS server is moved to a different IP address.
 
 1. Edit the `cray-dns-unbound` ConfigMap.
 

--- a/operations/network/dns/Manage_the_DNS_Unbound_Resolver.md
+++ b/operations/network/dns/Manage_the_DNS_Unbound_Resolver.md
@@ -187,7 +187,7 @@ Use the following procedure to change the site DNS server that Unbound forwards 
 
    **`IMPORTANT:`** If this step is not performed, then the Unbound configuration will be overwritten with the previous value the next time CSM or Unbound is upgraded.
 
-   1. Extract `customizations.yaml` from the site-init secret in the loftsman namespace.
+   1. Extract `customizations.yaml` from the `site-init` secret in the `loftsman` namespace.
 
       ```bash
       ncn-m001# kubectl -n loftsman get secret site-init -o json | jq -r '.data."customizations.yaml"' | base64 -d > customizations.yaml


### PR DESCRIPTION
## Summary and Scope

Document procedure to change the site DNS server Unbound forwards queries to post-install.

## Issues and Related PRs

* Resolves [CAST-25340](https://jira-pro.its.hpecorp.net:8443/browse/CAST-25340)
* Change will also be needed in `main`

## Testing

### Tested on:

  * `hela`

### Test description:

Tested procedure on hela, also tested that the cray-dns-unbound chart deploys correctly with a second forwarder configured.

## Risks and Mitigations

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

