### PR TITLE
STP-3186 (1.0): correcting broken fenced code blocks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "workbench.settings.settingsSearchTocBehavior": "filter",
+    "markdown.extension.toc.levels": "1..3"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-    "workbench.settings.settingsSearchTocBehavior": "filter",
-    "markdown.extension.toc.levels": "1..3"
-}

--- a/install/bootstrap_livecd_remote_iso.md
+++ b/install/bootstrap_livecd_remote_iso.md
@@ -41,7 +41,7 @@ the instructions for attaching to the BMC will differ.
 
 1. The CSM software release should be downloaded and expanded for use.
 
-   **Important:** To ensure that the CSM release plus any patches, workarounds, or hotfixes are included
+   **Important:** To ensure that the CSM release plus any patches, workarounds, or hot fixes are included
    follow the instructions in [Update CSM Product Stream](../update_product_stream/index.md)
 
    The `cray-pre-install-toolkit` ISO and other files are now available in the directory from the extracted CSM `tar`.
@@ -137,7 +137,7 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
       external# ssh root@${SYSTEM_NAME}-ncn-m001
       ```
 
-   1. (recommended) After reconnecting, resume the typescript (the `-a` appends to an existing script).
+   1. (Recommended) After reconnecting, resume the typescript (the `-a` appends to an existing script).
 
       ```bash
       pit# cd ~
@@ -212,11 +212,11 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
 
 1. Download the CSM software release to the PIT node.
 
-   **Important:** In an earlier step, the CSM release plus any patches, workarounds, or hotfixes
+   **Important:** In an earlier step, the CSM release plus any patches, workarounds, or hot fixes
    were downloaded to a system using the instructions in [Update CSM Product Stream](../update_product_stream/index.md)
    Either copy from that system to the PIT node or set the ENDPOINT variable to URL and use `wget`.
 
-   1. Set helper variables
+   1. Set helper variables.
 
       ```bash
       pit# ENDPOINT=https://arti.dev.cray.com/artifactory/shasta-distribution-stable-local/csm
@@ -288,7 +288,7 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
 
    If this machine does not have direct Internet access these RPMs will need to be externally downloaded and then copied to the system.
 
-   **Important:** In an earlier step, the CSM release plus any patches, workarounds, or hotfixes
+   **Important:** In an earlier step, the CSM release plus any patches, workarounds, or hot fixes
    were downloaded to a system using the instructions in [Check for Latest Workarounds and Documentation Updates](../update_product_stream/index.md#workarounds). Use that set of RPMs rather than downloading again.
 
    ```bash
@@ -557,7 +557,7 @@ and [Configuration Payload Files](prepare_configuration_payload.md#configuration
        addr:     ipv4 10.254.1.4/17 [static]
        ```
 
-    1. Run tests, inspect failures.
+    2. Run tests, inspect failures.
 
        ```bash
        pit# csi pit validate --network
@@ -574,7 +574,7 @@ and [Configuration Payload Files](prepare_configuration_payload.md#configuration
         pit# cp -pv /var/www/ephemeral/prep/${SYSTEM_NAME}/basecamp/* /var/www/ephemeral/configs/
         ```
 
-    1. Enable, and fully restart all PIT services.
+    2. Enable, and fully restart all PIT services.
 
         ```bash
         pit# systemctl enable basecamp nexus dnsmasq conman

--- a/install/bootstrap_livecd_remote_iso.md
+++ b/install/bootstrap_livecd_remote_iso.md
@@ -139,7 +139,7 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
 
    1. (recommended) After reconnecting, resume the typescript (the `-a` appends to an existing script).
 
-       ```bash
+      ```bash
       pit# cd ~
       pit# script -af $(ls -tr csm-install-remoteiso* | head -n 1)
       pit# export PS1='\u@\H \D{%Y-%m-%d} \t \w # '

--- a/install/bootstrap_livecd_usb.md
+++ b/install/bootstrap_livecd_usb.md
@@ -36,7 +36,7 @@ Fetch the base installation CSM tarball, extract it, and install the contained C
 
 1. Download and expand the CSM software release.
 
-   **Important:** In order to ensure that the CSM release plus any patches, workarounds, or hotfixes are included,
+   **Important:** In order to ensure that the CSM release plus any patches, workarounds, or hot fixes are included,
    follow the instructions in [Update CSM Product Stream](../update_product_stream/index.md)
 
    **Important:** Download to a location that has sufficient space for both the tarball and the expanded tarball.
@@ -44,7 +44,7 @@ Fetch the base installation CSM tarball, extract it, and install the contained C
    > Note: Expansion of the tarball may take more than 45 minutes.
 
    The rest of this procedure will use the `CSM_RELEASE` variable and expects to have the
-   contents of the CSM software release tarball plus any patches, workarounds, or hotfixes.
+   contents of the CSM software release tarball plus any patches, workarounds, or hot fixes.
 
    ```bash
    linux# CSM_RELEASE=csm-x.y.z
@@ -515,7 +515,7 @@ This will enable SSH, and other services when the LiveCD starts.
    linux# echo "${SYSTEM_NAME}-ncn-m001-pit" >/mnt/cow/rw/etc/hostname
    ```
 
-1. Unmount the Overlay, we are done with it
+1. Unmount the Overlay, we are done with it.
 
     ```bash
     linux# umount -v /mnt/cow
@@ -705,7 +705,7 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
 
    If this machine does not have direct Internet access these RPMs will need to be externally downloaded and then copied to the system.
 
-   **Important:** In an earlier step, the CSM release plus any patches, workarounds, or hotfixes
+   **Important:** In an earlier step, the CSM release plus any patches, workarounds, or hot fixes
    were downloaded to a system using the instructions in [Check for Latest Workarounds and Documentation Updates](../update_product_stream/index.md#workarounds). Use that set of RPMs rather than downloading again.
 
    ```bash
@@ -789,4 +789,4 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
 
 After completing this procedure, the next step is to configure the management network switches.
 
-See [Configure Management Network Switches](index.md#configure_management_network)
+See [Configure Management Network Switches](index.md#configure_management_network).

--- a/install/bootstrap_livecd_usb.md
+++ b/install/bootstrap_livecd_usb.md
@@ -84,7 +84,7 @@ Fetch the base installation CSM tarball, extract it, and install the contained C
    Git Version    : b3ed3046a460d804eb545d21a362b3a5c7d517a3
    Platform       : linux/amd64
    App. Version   : 1.5.18
-    ```
+   ```
 
 1. Configure `zypper` with the `embedded` repository from the CSM release.
 

--- a/install/bootstrap_livecd_usb.md
+++ b/install/bootstrap_livecd_usb.md
@@ -781,7 +781,7 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
    c7638b573b93  dtr.dev.cray.com/cray/metal-basecamp:1.1.0-1de4aa6                        5 minutes ago  Up 5 minutes ago          basecamp
    ```
 
-1. Follow directions in the output from the 'csi pit validate' commands for failed validations before continuing.
+1. Follow directions in the output from the `csi pit validate` commands for failed validations before continuing.
 
 <a name="next-topic"></a>
 

--- a/install/bootstrap_livecd_usb.md
+++ b/install/bootstrap_livecd_usb.md
@@ -14,7 +14,7 @@ There are 5 overall steps that provide a bootable USB with SSH enabled, capable 
       1. [Before Configuration Payload Workarounds](#before-configuration-payload-workarounds)
       1. [Generate Installation Files](#generate-installation-files)
       1. [CSI Workarounds](#csi-workarounds)
-      1. [Prepare Site Init](#prepare_site_init)
+      1. [Prepare `site-init`](#prepare_site_init)
    1. [Prepopulate LiveCD Daemons Configuration and NCN Artifacts](#prepopulate-livecd-daemons-configuration-and-ncn-artifacts)
    1. [Boot the LiveCD](#boot-the-livecd)
       1. [First Login](#first-login)
@@ -155,7 +155,7 @@ Fetch the base installation CSM tarball, extract it, and install the contained C
 
 ## 2. Create the Bootable Media
 
-Cray Site Init will create the bootable LiveCD. Before creating the media, identify
+Cray `site-init` will create the bootable LiveCD. Before creating the media, identify
 which device will be used for it.
 
 1. Identify the USB device.
@@ -235,13 +235,13 @@ on to the [configuration payload](#configuration-payload).
 
 ## 3. Configuration Payload
 
-The SHASTA-CFG structure and other configuration files will be prepared, then `csi` will generate a system-unique configuration payload. This payload will be used
+The `SHASTA-CFG` structure and other configuration files will be prepared, then `csi` will generate a system-unique configuration payload. This payload will be used
 for the rest of the CSM installation on the USB device.
 
 * [Before Configuration Payload Workarounds](#before-configuration-payload-workarounds)
 * [Generate Installation Files](#generate-installation-files)
 * [CSI Workarounds](#csi-workarounds)
-* [Prepare Site Init](#prepare_site_init)
+* [Prepare `site-init`](#prepare_site_init)
 
 <a name="before-configuration-payload-workarounds"></a>
 
@@ -289,7 +289,7 @@ information for this system has not yet been prepared.
    > the information in it must be provided as command line arguments to `csi config init`.
 
 1. **For subsequent fresh-installs (re-installs) where the `system_config.yaml` parameter file is available**, generate the updated system configuration
-   (see [Cray Site Init Files](../background/index.md#cray_site_init_files)).
+   (see [Cray `site-init` Files](../background/index.md#cray_site_init_files)).
 
    > **Warning:** If the `system_config.yaml` file is unavailable, then skip this step and proceed to [Initial Installs (bare-metal)](#first-timeinitial-installs-bare-metal).
 
@@ -463,9 +463,9 @@ Follow the [workaround instructions](../update_product_stream/index.md#apply-wor
 
 <a name="prepare_site_init"></a>
 
-#### 3.4 Prepare Site Init
+#### 3.4 Prepare `site-init`
 
-Follow the procedures to [Prepare Site Init](prepare_site_init.md) directory for your system.
+Follow the procedures to [Prepare `site-init`](prepare_site_init.md) directory for your system.
 
 <a name="prepopulate-livecd-daemons-configuration-and-ncn-artifacts"></a>
 
@@ -549,7 +549,7 @@ This will enable SSH, and other services when the LiveCD starts.
     --sealed-secret-key-file /mnt/pitdata/prep/site-init/certs/sealed_secrets.key
    ```
 
-1. Copy k8s artifacts:
+1. Copy Kubernetes artifacts:
 
     ```bash
     linux# csi pit populate pitdata "${CSM_PATH}/images/kubernetes/" /mnt/pitdata/data/k8s/ -kiK
@@ -635,7 +635,7 @@ See the [set boot order](../background/ncn_boot_workflow.md#set-boot-order) page
     ncn-m001# reboot
     ```
 
-Watch the shutdown and boot from the ipmitool session to the console terminal.
+Watch the shutdown and boot from the `ipmitool` session to the console terminal.
 The typescript can be discarded, otherwise if issues arise then it should be submitted with the bug report.
 
 > **An integrity check** runs before Linux starts by default, it can be skipped by selecting "OK" in its prompt.

--- a/install/bootstrap_livecd_usb.md
+++ b/install/bootstrap_livecd_usb.md
@@ -453,7 +453,7 @@ information for this system has not yet been prepared.
       pit# cd ${PITDATA}/prep && ln ${SYSTEM_NAME}/system_config.yaml
       ```
 
-   1. Continue to the next step to apply the csi-config workarounds.
+   1. Continue to the next step to apply the `csi-config` workarounds.
 
 <a name="csi-workarounds"></a>
 

--- a/install/collect_mac_addresses_for_ncns.md
+++ b/install/collect_mac_addresses_for_ncns.md
@@ -15,11 +15,13 @@ topic could be skipped and instead move to [Deploy Management Nodes](index.md#de
 
 ## Topics
 
-1. [Collect the BMC MAC addresses](#collect_the_bmc_mac_addresses)
-1. [Restart Services after BMC MAC Addresses Collected](#restart_services_after_bmc_mac_addresses_collected)
-1. [Collect the NCN MAC addresses](#collect_the_ncn_mac_addresses)
-1. [Restart Services after NCN MAC Addresses Collected](#restart_services_after_ncn_mac_addresses_collected)
-1. [Next Topic](#next-topic)
+* [Collect MAC Addresses for NCNs](#collect-mac-addresses-for-ncns)
+  * [Topics](#topics)
+  * [1. Collect the BMC MAC addresses](#1-collect-the-bmc-mac-addresses)
+  * [2. Restart Services after BMC MAC Addresses Collected](#2-restart-services-after-bmc-mac-addresses-collected)
+  * [3. Collect the NCN MAC addresses](#3-collect-the-ncn-mac-addresses)
+    * [4. Restart Services after NCN MAC Addresses Collected](#4-restart-services-after-ncn-mac-addresses-collected)
+  * [Next Topic](#next-topic)
 
 <a name="collect_the_bmc_mac_addresses"></a>
 ## 1. Collect the BMC MAC addresses
@@ -116,6 +118,7 @@ making a backup of them, in case they need to be examined at a later time.
          ```json
          {"level":"warn","ts":1612552159.2962296,"msg":"Cooling door found, but xname does not yet exist for cooling doors!","row":
          {"Source":"x3000door-Motiv","SourceRack":"x3000","SourceLocation":" ","DestinationRack":"x3000","DestinationLocation":"u36","DestinationPort":"j27"}}
+         ```
 
 
 1. Follow the [workaround instructions](../update_product_stream/index.md#apply-workarounds) for the `csi-config` breakpoint.

--- a/install/collect_mac_addresses_for_ncns.md
+++ b/install/collect_mac_addresses_for_ncns.md
@@ -24,6 +24,7 @@ topic could be skipped and instead move to [Deploy Management Nodes](index.md#de
   * [Next Topic](#next-topic)
 
 <a name="collect_the_bmc_mac_addresses"></a>
+
 ## 1. Collect the BMC MAC addresses
 
 The BMC MAC address can be collected from the switches using knowledge about the cabling of the NMN from the SHCD.
@@ -31,6 +32,7 @@ The BMC MAC address can be collected from the switches using knowledge about the
 See [Collecting BMC MAC Addresses](collecting_bmc_mac_addresses.md).
 
 <a name="restart_services_after_bmc_mac_addresses_collected"></a>
+
 ## 2. Restart Services after BMC MAC Addresses Collected
 
 The previous step updated `ncn_metadata.csv` with the BMC MAC addresses, so several earlier steps need to be repeated.
@@ -81,7 +83,7 @@ making a backup of them, in case they need to be examined at a later time.
 
    Expected output looks similar to the following:
 
-   ```
+   ```text
    application_node_config.yaml
    cabinets.yaml
    hmn_connections.json
@@ -102,7 +104,7 @@ making a backup of them, in case they need to be examined at a later time.
    These warnings from `csi config init` for issues in `hmn_connections.json` can be ignored.
       * The node with the external connection (`ncn-m001`) will have a warning similar to this because its BMC is connected to the site and not the HMN like the other management NCNs. It can be ignored.
 
-         ```
+         ```text
          "Couldn't find switch port for NCN: x3000c0s1b0"
          ```
 
@@ -120,10 +122,9 @@ making a backup of them, in case they need to be examined at a later time.
          {"Source":"x3000door-Motiv","SourceRack":"x3000","SourceLocation":" ","DestinationRack":"x3000","DestinationLocation":"u36","DestinationPort":"j27"}}
          ```
 
-
 1. Follow the [workaround instructions](../update_product_stream/index.md#apply-workarounds) for the `csi-config` breakpoint.
 
-1. Copy the interface config files generated earlier by `csi config init` into `/etc/sysconfig/network/`.
+1. Copy the interface configuration files generated earlier by `csi config init` into `/etc/sysconfig/network/`.
 
    ```bash
    pit# cp -pv /var/www/ephemeral/prep/${SYSTEM_NAME}/pit-files/* /etc/sysconfig/network/
@@ -173,8 +174,8 @@ making a backup of them, in case they need to be examined at a later time.
     pit# csi pit validate --network
     ```
 
-1. Copy the service configuration files generated earlier by `csi config init` for DNSMasq, Metal
-   Basecamp (cloud-init), and ConMan.
+1. Copy the service configuration files generated earlier by `csi config init` for `DNSMasq`, Metal
+   Basecamp (`cloud-init`), and ConMan.
 
     1. Copy files (files only, `-r` is expressly not used).
 
@@ -194,7 +195,7 @@ making a backup of them, in case they need to be examined at a later time.
 
 1. Verify that all BMCs can be pinged.
 
-   **Note:** It may take about 10 minutes from when dnsmasq is restarted to when the BMCs pick up new DHCP leases.
+   **Note:** It may take about 10 minutes from when `dnsmasq` is restarted to when the BMCs pick up new DHCP leases.
 
    This step will check all management nodes except `ncn-m001-mgmt` because that has an external connection and could
    not be booted by itself as the PIT node.
@@ -207,6 +208,7 @@ making a backup of them, in case they need to be examined at a later time.
    ```
 
 <a name="collect_the_ncn_mac_addresses"></a>
+
 ## 3. Collect the NCN MAC addresses
 
 Now that the BMC MAC addresses are correct in `ncn_metadata.csv` and the PIT node services have been restarted,
@@ -216,9 +218,10 @@ logs on the PIT node using the [Procedure: iPXE Consoles](collecting_ncn_mac_add
 See [Procedure: iPXE Consoles](collecting_ncn_mac_addresses.md#procedure-ipxe-consoles).
 
 <a name="restart_services_after_ncn_mac_addresses_collected"></a>
+
 ### 4. Restart Services after NCN MAC Addresses Collected
 
-The previous step updated `ncn_metadata.csv` with the NCN MAC Addresses for Bootstrap MAC, Bond0 MAC0, and Bond0 MAC1
+The previous step updated `ncn_metadata.csv` with the NCN MAC Addresses for Bootstrap MAC, `Bond0 MAC0`, and `Bond0 MAC1`
 so several earlier steps need to be repeated.
 
 1. Change into the preparation directory.
@@ -228,25 +231,26 @@ so several earlier steps need to be repeated.
    ```
 
 1. Confirm that the `ncn_metadata.csv` file in this directory has the new information.
-   There should be no remaining dummy data (de:ad:be:ef:00:00) for columns or rows in the file.
+   There should be no remaining dummy data (`de:ad:be:ef:00:00`) for columns or rows in the file.
    Every row should have uniquely different MAC addresses from the other rows.
 
    ```bash
    pit# grep "de:ad:be:ef:00:00" ncn_metadata.csv
    ```
 
-   Expected output looks similar to the following, that is, no lines that still have "de:ad:be:ef:00:00":
+   Expected output looks similar to the following, that is, no lines that still have `"de:ad:be:ef:00:00"`:
 
    ```bash
 
    ```
 
    Display the file and confirm the contents are unique between the different rows.
+
    ```bash
    pit# cat ncn_metadata.csv
    ```
 
-1. Remove the incorrectly generated configs. Before deleting the incorrectly generated configs consider
+1. Remove the incorrectly generated configurations. Before deleting the incorrectly generated configurations consider
 making a backup of them, in case they need to be examined at a later time.
 
    > **`WARNING`** Ensure that the `SYSTEM_NAME` environment variable is correctly set.
@@ -278,7 +282,7 @@ making a backup of them, in case they need to be examined at a later time.
 
    Expected output looks similar to the following:
 
-   ```
+   ```text
    application_node_config.yaml
    cabinets.yaml
    hmn_connections.json
@@ -288,6 +292,7 @@ making a backup of them, in case they need to be examined at a later time.
    ```
 
    Regenerate the system configuration. The `system_config.yaml` file contains all of the options that where used to generate the initial system configuration, and can be used in place of specifying CLI flags to CSI.
+
    ```bash
    pit# csi config init
    ```
@@ -297,7 +302,7 @@ making a backup of them, in case they need to be examined at a later time.
    These warnings from `csi config init` for issues in `hmn_connections.json` can be ignored.
       * The node with the external connection (`ncn-m001`) will have a warning similar to this because its BMC is connected to the site and not the HMN like the other management NCNs. It can be ignored.
 
-         ```
+         ```text
          "Couldn't find switch port for NCN: x3000c0s1b0"
          ```
 
@@ -394,7 +399,7 @@ making a backup of them, in case they need to be examined at a later time.
         ```
 
 1. Ensure system-specific settings generated by CSI are merged into `customizations.yaml`.
-    > The `yq` tool used in the following procedures is available under `/var/www/ephemeral/prep/site-init/utils/bin` once the SHASTA-CFG repo has been cloned.
+    > The `yq` tool used in the following procedures is available under `/var/www/ephemeral/prep/site-init/utils/bin` once the `SHASTA-CFG` repo has been cloned.
 
     ```bash
     pit# alias yq="/var/www/ephemeral/prep/site-init/utils/bin/$(uname | awk '{print tolower($0)}')/yq"
@@ -404,6 +409,7 @@ making a backup of them, in case they need to be examined at a later time.
 1. Follow the [workaround instructions](../update_product_stream/index.md#apply-workarounds) for the `before-ncn-boot` breakpoint.
 
 <a name="next-topic"></a>
+
 ## Next Topic
 
 After completing the collection of BMC MAC addresses and NCN MAC addresses in order to update `ncn_metadata.csv`, and after restarting

--- a/install/collect_mac_addresses_for_ncns.md
+++ b/install/collect_mac_addresses_for_ncns.md
@@ -108,7 +108,9 @@ making a backup of them, in case they need to be examined at a later time.
          "Couldn't find switch port for NCN: x3000c0s1b0"
          ```
 
-      * An unexpected component may have this message. If this component is an application node with an unusual prefix, it should be added to the `application_node_config.yaml` file. Then rerun `csi config init`. See the procedure to [Create Application Node Config YAML](create_application_node_config_yaml.md)
+      * An unexpected component may have this message.
+        If this component is an application node with an unusual prefix, it should be added to the `application_node_config.yaml` file.
+        Then rerun `csi config init`. See the procedure to [Create Application Node Config YAML](create_application_node_config_yaml.md).
 
          ```json
          {"level":"warn","ts":1610405168.8705149,"msg":"Found unknown source prefix! If this is expected to be an Application node, please update application_node_config.yaml","row":
@@ -185,7 +187,7 @@ making a backup of them, in case they need to be examined at a later time.
         pit# cp -pv /var/www/ephemeral/prep/${SYSTEM_NAME}/basecamp/* /var/www/ephemeral/configs/
         ```
 
-    1. Restart all PIT services.
+    2. Restart all PIT services.
 
         ```bash
         pit# systemctl restart basecamp nexus dnsmasq conman
@@ -306,7 +308,9 @@ making a backup of them, in case they need to be examined at a later time.
          "Couldn't find switch port for NCN: x3000c0s1b0"
          ```
 
-      * An unexpected component may have this message. If this component is an application node with an unusual prefix, it should be added to the `application_node_config.yaml` file. Then rerun `csi config init`. See the procedure to [Create Application Node Config YAML](create_application_node_config_yaml.md)
+      * An unexpected component may have this message.
+        If this component is an application node with an unusual prefix, it should be added to the `application_node_config.yaml` file.
+        Then rerun `csi config init`. See the procedure to [Create Application Node Config YAML](create_application_node_config_yaml.md).
 
          ```json
          {"level":"warn","ts":1610405168.8705149,"msg":"Found unknown source prefix! If this is expected to be an Application node, please update application_node_config.yaml","row":
@@ -372,8 +376,8 @@ making a backup of them, in case they need to be examined at a later time.
     pit# csi pit validate --network
     ```
 
-1. Copy the service configuration files generated earlier by `csi config init` for DNSMasq, Metal
-   Basecamp (cloud-init), and ConMan.
+1. Copy the service configuration files generated earlier by `csi config init` for `dnsmasq`, Metal
+   Basecamp (`cloud-init`), and ConMan.
 
     1. Copy files (files only, `-r` is expressly not used).
 
@@ -383,7 +387,7 @@ making a backup of them, in case they need to be examined at a later time.
         pit# cp -pv /var/www/ephemeral/prep/${SYSTEM_NAME}/basecamp/* /var/www/ephemeral/configs/
         ```
 
-    1. Update CA Cert on the copied `data.json` file for Basecamp with the generated certificate in site-init:
+    2. Update CA Cert on the copied `data.json` file for Basecamp with the generated certificate in site-init:
 
         ```bash
         pit# csi patch ca \
@@ -392,7 +396,7 @@ making a backup of them, in case they need to be examined at a later time.
         --sealed-secret-key-file /var/www/ephemeral/prep/site-init/certs/sealed_secrets.key
         ```
 
-    1. Restart all PIT services.
+    3. Restart all PIT services.
 
         ```bash
         pit# systemctl restart basecamp nexus dnsmasq conman

--- a/install/collecting_bmc_mac_addresses.md
+++ b/install/collecting_bmc_mac_addresses.md
@@ -141,7 +141,7 @@ Results may vary if an unconfigured switch is being used.
    x3000c0s8b0n0,Management,Storage,a4:bf:01:48:1f:e0,de:ad:be:ef:00:00,de:ad:be:ef:00:00,de:ad:be:ef:00:00
    x3000c0s7b0n0,Management,Storage,a4:bf:01:38:f0:b1,de:ad:be:ef:00:00,de:ad:be:ef:00:00,de:ad:be:ef:00:00
                                      ^^^^^^^^^^^^^^^^^
-    ```
+   ```
 
    The column heading must match that shown above for `csi` to parse it correctly.
 

--- a/install/collecting_bmc_mac_addresses.md
+++ b/install/collecting_bmc_mac_addresses.md
@@ -142,7 +142,9 @@ Results may vary if an unconfigured switch is being used.
    Fill in the `Bootstrap MAC`, `Bond0 MAC0`, and `Bond0 MAC1` columns with a placeholder value, such as `de:ad:be:ef:00:00`,
    as a marker that the correct value is not in this file yet.
 
-   **IMPORTANT:** Mind the index for each group of nodes (3, 2, 1.... ; not 1, 2, 3). If storage nodes are `ncn-s001 x3000c0s7b0n0`, `ncn-s002 x3000c0s8b0n0`, `ncn-s003 x3000c0s9b0n0`, then their portion of the file would be ordered `x3000c0s9b0n0`, `x3000c0s8b0n0`, `x3000c0s7b0n0`.
+   **IMPORTANT:** Mind the index for each group of nodes (3, 2, 1.... ; not 1, 2, 3).
+   If storage nodes are `ncn-s001 x3000c0s7b0n0`, `ncn-s002 x3000c0s8b0n0`, `ncn-s003 x3000c0s9b0n0`,
+   then their portion of the file would be ordered `x3000c0s9b0n0`, `x3000c0s8b0n0`, `x3000c0s7b0n0`.
 
    ```text
    Xname,Role,Subrole,BMC MAC,Bootstrap MAC,Bond0 MAC0,Bond0 MAC1

--- a/install/collecting_bmc_mac_addresses.md
+++ b/install/collecting_bmc_mac_addresses.md
@@ -7,7 +7,7 @@ Results may vary if an unconfigured switch is being used.
 
 ## Prerequisites
 
-* There is a configured switch with SSH access _or_ unconfigured with COM access (serial-over-lan/DB-9).
+* There is a configured switch with SSH access or unconfigured with COM access (serial-over-lan/DB-9).
 * A file is available to record the collected BMC information.
 
 ## Procedure

--- a/install/collecting_bmc_mac_addresses.md
+++ b/install/collecting_bmc_mac_addresses.md
@@ -14,7 +14,7 @@ Results may vary if an unconfigured switch is being used.
 
 1. Start a session on the leaf switch, either using SSH or a USB serial cable (see [Connect to Switch over USB-Serial Cable](connect_to_switch_over_usb_serial_cable.md) for details on how to do that).
 
-    > **NOTE:** These IP addresses are examples; 10.X.0.4 may or may not match the setup.
+    > **NOTE:** These IP addresses are examples; `10.X.0.4` may or may not match the setup.
 
     ```bash
     # SSH over METAL MANAGEMENT
@@ -39,21 +39,24 @@ Results may vary if an unconfigured switch is being used.
     Print using the VLAN ID:
 
     DellOS 10
+
     ```bash
     # DellOS 10
     sw-leaf-001# show mac address-table vlan 4
-    VlanId	Mac Address		Type		Interface
-    4	00:1e:67:98:fe:2c	dynamic		ethernet1/1/11
-    4	a4:bf:01:38:f0:b1	dynamic		ethernet1/1/27
-    4	a4:bf:01:38:f1:44	dynamic		ethernet1/1/25
-    4	a4:bf:01:48:1e:ac	dynamic		ethernet1/1/28
-    4	a4:bf:01:48:1f:70	dynamic		ethernet1/1/31
-    4	a4:bf:01:48:1f:e0	dynamic		ethernet1/1/26
-    4	a4:bf:01:48:20:03	dynamic		ethernet1/1/30
-    4	a4:bf:01:48:20:57	dynamic		ethernet1/1/29
-    4	a4:bf:01:4d:d9:9a	dynamic		ethernet1/1/32
+    VlanId  Mac Address  Type      Interface
+    4 00:1e:67:98:fe:2c  dynamic   ethernet1/1/11
+    4 a4:bf:01:38:f0:b1  dynamic   ethernet1/1/27
+    4 a4:bf:01:38:f1:44  dynamic   ethernet1/1/25
+    4 a4:bf:01:48:1e:ac  dynamic   ethernet1/1/28
+    4 a4:bf:01:48:1f:70  dynamic   ethernet1/1/31
+    4 a4:bf:01:48:1f:e0  dynamic   ethernet1/1/26
+    4 a4:bf:01:48:20:03  dynamic   ethernet1/1/30
+    4 a4:bf:01:48:20:57  dynamic   ethernet1/1/29
+    4 a4:bf:01:4d:d9:9a  dynamic   ethernet1/1/32
     ```
+
     Aruba AOS-CX
+
     ```bash
     # Aruba AOS-CX
     sw-leaf-bmc-001# show mac-address-table vlan 4
@@ -80,13 +83,16 @@ Results may vary if an unconfigured switch is being used.
     Print using the interface and trunk:
 
     DellOS 10
+
     ```bash
     # DellOS 10
     sw-leaf-001# show mac address-table interface ethernet 1/1/32
-    VlanId	Mac Address		Type		Interface
-    4	a4:bf:01:4d:d9:9a	dynamic		ethernet1/1/32
+    VlanId Mac Address    Type      Interface
+    4 a4:bf:01:4d:d9:9a   dynamic   ethernet1/1/32
     ```
+
     Aruba AOS-CX
+
     ```bash
     # Aruba AOS-CX
     sw-leaf-bmc-001# show mac-address-table port
@@ -103,16 +109,19 @@ Results may vary if an unconfigured switch is being used.
     Print everything:
 
     DellOS 10
+
     ```bash
     # DellOS 10
     sw-leaf-001# show mac address-table
-    VlanId	Mac Address		Type		Interface
-    4	a4:bf:01:4d:d9:9a	dynamic		ethernet1/1/32
+    VlanId  Mac Address  Type     Interface
+    4 a4:bf:01:4d:d9:9a  dynamic  ethernet1/1/32
     ....
     # Onyx and Aruba
     sw-leaf-001# show mac-address-table
     ```
+
     Aruba AOS-CX
+
     ```bash
     # Aruba AOS-CX
     sw-leaf-bmc-001# show mac-address-table
@@ -135,7 +144,7 @@ Results may vary if an unconfigured switch is being used.
 
    **IMPORTANT:** Mind the index for each group of nodes (3, 2, 1.... ; not 1, 2, 3). If storage nodes are `ncn-s001 x3000c0s7b0n0`, `ncn-s002 x3000c0s8b0n0`, `ncn-s003 x3000c0s9b0n0`, then their portion of the file would be ordered `x3000c0s9b0n0`, `x3000c0s8b0n0`, `x3000c0s7b0n0`.
 
-   ```
+   ```text
    Xname,Role,Subrole,BMC MAC,Bootstrap MAC,Bond0 MAC0,Bond0 MAC1
    x3000c0s9b0n0,Management,Storage,a4:bf:01:38:f1:44,de:ad:be:ef:00:00,de:ad:be:ef:00:00,de:ad:be:ef:00:00
    x3000c0s8b0n0,Management,Storage,a4:bf:01:48:1f:e0,de:ad:be:ef:00:00,de:ad:be:ef:00:00,de:ad:be:ef:00:00
@@ -161,7 +170,7 @@ Results may vary if an unconfigured switch is being used.
 
    Add this information for `ncn-m001` to the `ncn_metadata.csv` file. There should be `ncn-m003`, then `ncn-m002`, and this new entry for `ncn-m001` as the last line in the file.
 
-   ```
+   ```text
    x3000c0s1b0n0,Management,Master,a4:bf:01:37:87:32,de:ad:be:ef:00:00,de:ad:be:ef:00:00,de:ad:be:ef:00:00
    ```
 
@@ -172,7 +181,7 @@ Results may vary if an unconfigured switch is being used.
    Sample file showing storage nodes 3, 2, and 1, then worker nodes 3, 2, and 1, and finally master nodes 3, 2, and 1 with valid `BMC MAC`
   addresses, but placeholder value `de:ad:be:ef:00:00` for the `Bootstrap MAC`, `Bond0 MAC0`, and `Bond0 MAC1`.
 
-   ```
+   ```text
    Xname,Role,Subrole,BMC MAC,Bootstrap MAC,Bond0 MAC0,Bond0 MAC1
    x3000c0s9b0n0,Management,Storage,a4:bf:01:38:f1:44,de:ad:be:ef:00:00,de:ad:be:ef:00:00,de:ad:be:ef:00:00
    x3000c0s8b0n0,Management,Storage,a4:bf:01:48:1f:e0,de:ad:be:ef:00:00,de:ad:be:ef:00:00,de:ad:be:ef:00:00
@@ -184,4 +193,3 @@ Results may vary if an unconfigured switch is being used.
    x3000c0s2b0n0,Management,Master,a4:bf:01:4d:d9:9a,de:ad:be:ef:00:00,de:ad:be:ef:00:00,de:ad:be:ef:00:00
    x3000c0s1b0n0,Management,Master,a4:bf:01:37:87:32,de:ad:be:ef:00:00,de:ad:be:ef:00:00,de:ad:be:ef:00:00
    ```
-

--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -636,7 +636,7 @@ If there are LVM check failures, then the problem must be resolved before contin
 
 1. Check to see if the number of devices is less than the number of listed drives in the output from step 1.
 
-   ```bash
+    ```bash
     ncn-s# ceph orch device ls|grep dev|wc -l
     24
     ```

--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -808,25 +808,25 @@ below and see [Update BGP Neighbors](../operations/network/metallb_bgp/Update_BG
         ###############################################################################
         ```
 
-1. Make sure the `SYSTEM_NAME` variable is set to name of your system.
+2. Make sure the `SYSTEM_NAME` variable is set to name of your system.
 
     ```bash
     pit# export SYSTEM_NAME=eniac
     ```
 
-1. Determine the IP addresses of the worker NCNs.
+3. Determine the IP addresses of the worker NCNs.
 
     ```bash
     pit# grep -B1 "name: ncn-w" /var/www/ephemeral/prep/${SYSTEM_NAME}/networks/NMN.yaml
     ```
 
-1. Determine the IP addresses of the switches that are peering.
+4. Determine the IP addresses of the switches that are peering.
 
     ```bash
     pit# grep peer-address /var/www/ephemeral/prep/${SYSTEM_NAME}/metallb.yaml
     ```
 
-1. Run the script appropriate for your switch hardware vendor.
+5. Run the script appropriate for your switch hardware vendor.
 
     * If you have Mellanox switches, run the BGP helper script.
 
@@ -858,7 +858,7 @@ below and see [Update BGP Neighbors](../operations/network/metallb_bgp/Update_BG
         pit# canu -s 1.5 config bgp --ips 10.252.0.2,10.252.0.3 --csi-folder /var/www/ephemeral/prep/${SYSTEM_NAME}/
         ```
 
-1. Do the following steps **for each of the switch IP addresses that you found previously**.
+6. Do the following steps **for each of the switch IP addresses that you found previously**.
 
     1. Log in to the switch as the `admin` user:
 
@@ -866,7 +866,7 @@ below and see [Update BGP Neighbors](../operations/network/metallb_bgp/Update_BG
         pit# ssh admin@<switch_ip_address>
         ```
 
-    1. Check the status of the BGP peering sessions
+    2. Check the status of the BGP peering sessions
         * Aruba: `show bgp ipv4 unicast summary`
         * Mellanox: `show ip bgp summary`
 
@@ -876,7 +876,7 @@ below and see [Update BGP Neighbors](../operations/network/metallb_bgp/Update_BG
 
         You should see that the `MsgRcvd` and `MsgSent` columns for the worker IP addresses are 0.
 
-    1. Check the BGP configuration to verify that the NCN neighbors are configured as passive.
+    3. Check the BGP configuration to verify that the NCN neighbors are configured as passive.
         * Aruba: `show run bgp` The passive neighbor configuration is required. `neighbor 10.252.1.7 passive`
 
             EXAMPLE ONLY
@@ -916,7 +916,7 @@ below and see [Update BGP Neighbors](../operations/network/metallb_bgp/Update_BG
             router bgp 65533 vrf default neighbor 10.252.1.9 transport connection-mode passive
             ```
 
-    1. Repeat the previous steps for the remaining switch IP addresses.
+    4. Repeat the previous steps for the remaining switch IP addresses.
 
 <a name="install-tests"></a>
 

--- a/install/restart_network_services_and_interfaces_on_ncns.md
+++ b/install/restart_network_services_and_interfaces_on_ncns.md
@@ -135,6 +135,7 @@ sorted by safest to touch relative to keeping an SSH connection up.
          route:    ipv6 fe80::/64 type unicast table main scope universe protocol kernel priority 256
 
    eth0            no-device
+   ```
 
 
 * Print real devices (ignore no-device)

--- a/install/restart_network_services_and_interfaces_on_ncns.md
+++ b/install/restart_network_services_and_interfaces_on_ncns.md
@@ -7,21 +7,22 @@ Any process covered on this page will be covered by the installer.
 
 The use cases for resetting services:
 
-   * Interfaces not showing up
-   * IP Addresses not applying
-   * Member/children interfaces not being included
+* Interfaces not showing up
+* IP Addresses not applying
+* Member/children interfaces not being included
 
-### Topics:
+## Topics
 
-   * [Restart Network Services and Interfaces](#restart_network_services_and_interfaces))))
-   * [Command Reference](#command_reference)
-      * Check interface status (up/down/broken)
-      * Show routing and status for all devices
-      * Print real devices ( ignore no-device )
-      * Show the currently enabled network service (Wicked or Network Manager)
+* [Restart Network Services and Interfaces](#restart_network_services_and_interfaces))))
+* [Command Reference](#command_reference)
+  * Check interface status (up/down/broken)
+  * Show routing and status for all devices
+  * Print real devices (ignore no-device)
+  * Show the currently enabled network service (Wicked or Network Manager)
 
 <a name="restart_network_services_and_interfaces"></a>
-### Restart Network Services
+
+## Restart Network Services
 
 There are a few daemons that make up the SUSE network stack. The following are
 sorted by safest to touch relative to keeping an SSH connection up.
@@ -53,7 +54,8 @@ sorted by safest to touch relative to keeping an SSH connection up.
     ```
 
 <a name="command_reference"></a>
-### Command Reference
+
+## Command Reference
 
 * Check interface status (up/down/broken)
 
@@ -137,7 +139,6 @@ sorted by safest to touch relative to keeping an SSH connection up.
    eth0            no-device
    ```
 
-
 * Print real devices (ignore no-device)
 
    ```bash
@@ -150,4 +151,3 @@ sorted by safest to touch relative to keeping an SSH connection up.
    ncn# systemctl show -p Id network.service
    Id=wicked.service
    ```
-

--- a/operations/firmware/FAS_Admin_Procedures.md
+++ b/operations/firmware/FAS_Admin_Procedures.md
@@ -142,6 +142,7 @@ If an update fails because of `"No Image available"`, it may be caused by FAS be
            "overwriteSameImage":false
          }
        }
+   ```
 
 3. Verify the correct image ID was found.
 

--- a/operations/firmware/FAS_Admin_Procedures.md
+++ b/operations/firmware/FAS_Admin_Procedures.md
@@ -111,7 +111,7 @@ If an update fails because of `"No Image available"`, it may be caused by FAS be
 
    If the `firmwareVersion` from the FAS image matches the `fromFirmwareVersion` from the FAS action, the firmware is at the latest version and no update is needed.
 
-2. Use the imageID from the `cray images list` in the previous step and add the following line to the action JSON file, replacing *IMAGEID* with the imageID.
+2. Use the `imageID` from the `cray images list` in the previous step and add the following line to the action JSON file, replacing *IMAGEID* with the `imageID`.
 
      In this example, the value would be: `ff268e8a-8f73-414f-a9c7-737a34bb02fc`.
 
@@ -122,7 +122,7 @@ If an update fails because of `"No Image available"`, it may be caused by FAS be
        }
    ```
 
-   Example actions JSON file with imageFilter added:
+   Example actions JSON file with `imageFilter` added:
 
    ```json
        {
@@ -155,8 +155,8 @@ If an update fails because of `"No Image available"`, it may be caused by FAS be
 
    > **WARNING:** FAS will force a flash of the device -- using incorrect firmware may make it inoperable.
 
-Re-run the FAS actions command using the updated json file.
-**It is strongly recommended to run a dry-run (overrideDryrun=false) first and check the actions output.**
+Re-run the FAS actions command using the updated JSON file.
+**It is strongly recommended to run a dry-run (`overrideDryrun=false`) first and check the actions output.**
 
 ---
 
@@ -165,7 +165,7 @@ Re-run the FAS actions command using the updated json file.
 ## Check for New Firmware Versions with a Dry-Run
 
 Use the Firmware Action Service \(FAS\) dry-run feature to determine what firmware can be updated on the system.
-Dry-runs are enabled by default, and can be configured with the overrideDryrun parameter.
+Dry-runs are enabled by default, and can be configured with the `overrideDryrun` parameter.
 A dry-run will create a query according to the filters requested by the admin.
 It will initiate an update sequence to determine what firmware is available, but will not actually change the state of the firmware.
 
@@ -523,7 +523,7 @@ This procedure will read all RPMs in the Nexus repository and upload firmware im
 
 This procedure will read a single local RPM (or ZIP) file, upload firmware images to S3, and create image records for any firmware that is not already in FAS.
 
-1. Copy the file to ncn-m001 or one of the other NCNs.
+1. Copy the file to `ncn-m001` or one of the other NCNs.
 
 2. Check the loader status:
 

--- a/operations/firmware/FAS_Admin_Procedures.md
+++ b/operations/firmware/FAS_Admin_Procedures.md
@@ -8,12 +8,12 @@ Procedures for leveraging the Firmware Action Service (FAS) CLI to manage firmwa
 
 ## Topics
 
-  * [Warning for Non-Compute Nodes (NCNs)](#warning-for-non-compute-nodes-ncns)
-  * [Ignore Nodes within FAS](#ignore-nodes-within-fas)
-  * [Override an Image for an Update](#override-an-image-for-an-update)
-  * [Check for New Firmware Versions with a Dry-Run](#check-for-new-firmware-versions-with-a-dry-run)
-  * [Load Firmware from Nexus](#load-firmware-from-nexus)
-  * [Load Firmware from RPM or ZIP file](#load-firmware-from-rpm-or-zip-file)
+* [Warning for Non-Compute Nodes (NCNs)](#warning-for-non-compute-nodes-ncns)
+* [Ignore Nodes within FAS](#ignore-nodes-within-fas)
+* [Override an Image for an Update](#override-an-image-for-an-update)
+* [Check for New Firmware Versions with a Dry-Run](#check-for-new-firmware-versions-with-a-dry-run)
+* [Load Firmware from Nexus](#load-firmware-from-nexus)
+* [Load Firmware from RPM or ZIP file](#load-firmware-from-rpm-or-zip-file)
 
 ---
 
@@ -21,7 +21,9 @@ Procedures for leveraging the Firmware Action Service (FAS) CLI to manage firmwa
 
 ## Warning for Non-Compute Nodes (NCNs)
 
-NCNs and their BMCs should be locked with the HSM locking API to ensure they are not unintentionally updated by FAS. Research [Lock and Unlock Management Nodes](../hardware_state_manager/Lock_and_Unlock_Management_Nodes.md) for more information. Failure to lock the NCNs could result in unintentional update of the NCNs if FAS is not used correctly; this will lead to system instability problems.
+NCNs and their BMCs should be locked with the HSM locking API to ensure they are not unintentionally updated by FAS.
+Research [Lock and Unlock Management Nodes](../hardware_state_manager/Lock_and_Unlock_Management_Nodes.md) for more information.
+Failure to lock the NCNs could result in unintentional update of the NCNs if FAS is not used correctly; this will lead to system instability problems.
 
 ---
 
@@ -29,23 +31,25 @@ NCNs and their BMCs should be locked with the HSM locking API to ensure they are
 
 ## Ignore Nodes within FAS
 
-The default configuration of FAS no longer ignores `management` nodes, which prevents FAS from firmware updating the NCNs. To reconfigure the FAS deployment to exclude non-compute nodes (NCNs) and ensure they cannot have their firmware upgraded, the `NODE_BLACKLIST` value must be manually enabled
+The default configuration of FAS no longer ignores `management` nodes, which prevents FAS from firmware updating the NCNs.
+To reconfigure the FAS deployment to exclude non-compute nodes (NCNs) and ensure they cannot have their firmware upgraded, the `NODE_BLACKLIST` value must be manually enabled.
 
-**Preferred Method:** Nodes can also be locked with the Hardware State Manager (HSM) API. Refer to [Lock and Unlock Management Nodes](../hardware_state_manager/Lock_and_Unlock_Management_Nodes.md) for more information.
+**Preferred Method:** Nodes can also be locked with the Hardware State Manager (HSM) API.
+Refer to [Lock and Unlock Management Nodes](../hardware_state_manager/Lock_and_Unlock_Management_Nodes.md) for more information.
 
 <a name="procedure"></a>
 
-### Procedure
+### Procedure to Ignore Nodes
 
 1. Check that there are no FAS actions running.
 
-    ```
+    ```bash
     ncn# cray fas actions list
     ```
 
-2. Edit the cray-fas deployment.
+2. Edit the `cray-fas` deployment.
 
-    ```
+    ```bash
     ncn# kubectl -n services edit deployment cray-fas
     ```
 
@@ -63,7 +67,7 @@ If an update fails because of `"No Image available"`, it may be caused by FAS be
 
 <a name="procedure-1"></A>
 
-### Procedure
+### Procedure to Override an Image
 
 1. Find the available image in FAS.
 
@@ -72,17 +76,16 @@ If an update fails because of `"No Image available"`, it may be caused by FAS be
    ```bash
    ncn# cray fas images list --format json | jq '.[] | .[] | select(.target=="TARGETNAME")'
    ```
-   
+
    To narrow down the selection, update the select field to match multiple items. For example:
-   
+
    ```bash
    ncn# cray fas images list --format json | jq '.[] | .[] | select(.target=="BMC" and .manufacturer=="cray" and .deviceType=="NodeBMC")'
    ```
 
-
    The example command displays one or more images available for updates.
 
-   ```
+   ```text
    {
          "imageID": "ff268e8a-8f73-414f-a9c7-737a34bb02fc",
          "createTime": "2021-02-24T02:25:03Z",
@@ -152,7 +155,8 @@ If an update fails because of `"No Image available"`, it may be caused by FAS be
 
    > **WARNING:** FAS will force a flash of the device -- using incorrect firmware may make it inoperable.
 
-Re-run the FAS actions command using the updated json file. **It is strongly recommended to run a dry-run (overrideDryrun=false) first and check the actions output.**
+Re-run the FAS actions command using the updated json file.
+**It is strongly recommended to run a dry-run (overrideDryrun=false) first and check the actions output.**
 
 ---
 
@@ -160,89 +164,96 @@ Re-run the FAS actions command using the updated json file. **It is strongly rec
 
 ## Check for New Firmware Versions with a Dry-Run
 
-Use the Firmware Action Service \(FAS\) dry-run feature to determine what firmware can be updated on the system. Dry-runs are enabled by default, and can be configured with the overrideDryrun parameter. A dry-run will create a query according to the filters requested by the admin. It will initiate an update sequence to determine what firmware is available, but will not actually change the state of the firmware.
+Use the Firmware Action Service \(FAS\) dry-run feature to determine what firmware can be updated on the system.
+Dry-runs are enabled by default, and can be configured with the overrideDryrun parameter.
+A dry-run will create a query according to the filters requested by the admin.
+It will initiate an update sequence to determine what firmware is available, but will not actually change the state of the firmware.
 
-> **WARNING:** It is crucial that an administrator is familiar with the release notes of any firmware. The release notes will indicate what new features the firmware provides and if there are any incompatibilities. FAS does not know about incompatibilities or dependencies between versions. The administrator assumes full responsibility for this knowledge.
+> **WARNING:** It is crucial that an administrator is familiar with the release notes of any firmware.
+> The release notes will indicate what new features the firmware provides and if there are any incompatibilities.
+> FAS does not know about incompatibilities or dependencies between versions. The administrator assumes full responsibility for this knowledge.
 
-It is likely that when performing a firmware update, that the current version of firmware will not be available. This means that after successfully upgrading, the firmware cannot be downgraded.
+It is likely that when performing a firmware update, that the current version of firmware will not be available.
+This means that after successfully upgrading, the firmware cannot be downgraded.
 
 This procedure includes information on how check the firmware versions for the entire system, as well as how to target specific manufacturers, component names (xnames), and targets.
 
 <a name="procedure-2"></a>
 
-### Procedure
+### Procedure to Check for New Firmware
 
 1. Run a dry-run firmware update.
 
-	The following command parameters should be included in dry-run JSON files:
+    The following command parameters should be included in dry-run JSON files:
 
-	* `overrideDryrun`: The `overrideDryrun` parameter is set to `false` by default. FAS will only update the system if this is parameter is set to `true`.
-	* `restoreNotPossibleOverride`: FAS will not perform an update if the currently running firmware is not available in the images repository. Set this parameter to `true` in order to allow FAS to update firmware even if the current firmware is unavailable on the system.
-	* `description`: A brief description that helps administrators distinguish between actions.
-	* `version`: Determines if the firmware should be set to the `latest`, the `earliest` semantic version, or set to a specific firmware version.
+    * `overrideDryrun`: The `overrideDryrun` parameter is set to `false` by default. FAS will only update the system if this is parameter is set to `true`.
+    * `restoreNotPossibleOverride`: FAS will not perform an update if the currently running firmware is not available in the images repository.
+    Set this parameter to `true` in order to allow FAS to update firmware even if the current firmware is unavailable on the system.
+    * `description`: A brief description that helps administrators distinguish between actions.
+    * `version`: Determines if the firmware should be set to the `latest`, the `earliest` semantic version, or set to a specific firmware version.
 
-	Use one of the options below to run on a dry-run on every system device or on targeted devices:
+    Use one of the options below to run on a dry-run on every system device or on targeted devices:
 
-	**Option 1:** Determine the available firmware for every device on the system:
+    **Option 1:** Determine the available firmware for every device on the system:
 
-    1. Create a JSON file for the command parameters.
+      1. Create a JSON file for the command parameters.
 
-        ```json
+          ```json
+          {
+            "command": {
+              "restoreNotPossibleOverride": true,
+              "timeLimit": 1000,
+              "description": "full system dryrun 2020623_0"
+            }
+          }
+          ```
+
+      2. Run the dry-run for the full system.
+
+          ```bash
+          ncn# cray fas actions create COMMAND.json
+          ```
+
+          Proceed to the next step to determine if any firmware needs to be updated.
+
+    **Option 2:** Determine the available firmware for specific devices:
+
+      1. Create a JSON file with the specific device information to target when doing a dry-run.
+
+      ```json
         {
-          "command": {
+        "stateComponentFilter": {
+            "xnames": [
+              "x9000c1s3b1"
+            ]
+          },
+        "inventoryHardwareFilter": {
+            "manufacturer": "cray"
+            },
+        "targetFilter": {
+            "targets": [
+                "Node1.BIOS",
+                "Node0.BIOS"
+            ]
+          },
+        "command": {
+            "version": "latest",
+            "tag": "default",
+            "overrideDryrun": false,
             "restoreNotPossibleOverride": true,
             "timeLimit": 1000,
-            "description": "full system dryrun 2020623_0"
+            "description": "dryrun upgrade of x9000c1s3b1 Nodex.BIOS to WNC 1.1.2"
           }
         }
-        ```
+      ```
 
-    1. Run the dry-run for the full system.
+      1. Run a dry-run on the targeted devices.
 
-        ```bash
-        ncn# cray fas actions create COMMAND.json
-        ```
+         ```bash
+         ncn# cray fas actions create CUSTOM_DEVICE_PARAMETERS.json
+         ```
 
-        Proceed to the next step to determine if any firmware needs to be updated.
-
-	**Option 2:** Determine the available firmware for specific devices:
-
-    1. Create a JSON file with the specific device information to target when doing a dry-run.
-
-       ```json
-       {
-       "stateComponentFilter": {
-           "xnames": [
-             "x9000c1s3b1"
-           ]
-         },
-       "inventoryHardwareFilter": {
-           "manufacturer": "cray"
-           },
-       "targetFilter": {
-           "targets": [
-              "Node1.BIOS",
-              "Node0.BIOS"
-           ]
-         },
-       "command": {
-           "version": "latest",
-           "tag": "default",
-           "overrideDryrun": false,
-           "restoreNotPossibleOverride": true,
-           "timeLimit": 1000,
-           "description": "dryrun upgrade of x9000c1s3b1 Nodex.BIOS to WNC 1.1.2"
-         }
-       }
-       ```
-
-    2. Run a dry-run on the targeted devices.
-
-       ```bash
-       ncn# cray fas actions create CUSTOM_DEVICE_PARAMETERS.json
-       ```
-
-       Proceed to the next step to determine if any firmware needs to be updated.
+         Proceed to the next step to determine if any firmware needs to be updated.
 
 2. View the status of the dry-run to determine if any firmware updates can be made.
 
@@ -295,9 +306,9 @@ This procedure includes information on how check the firmware versions for the e
 
       The action is still in progress if the `state` field is not `completed` or `aborted`.
 
-    2. View the details of an action to get more information on each operation in the FAS action.
+   2. View the details of an action to get more information on each operation in the FAS action.
 
-		In the example below, there is an operation for a component name (xname) in the failed state, indicating there is something that FAS could do, but it likely would fail. A common cause for an operation failing is due to a missing firmware image file.
+      In the example below, there is an operation for a component name (xname) in the failed state, indicating there is something that FAS could do, but it likely would fail. A common cause for an operation failing is due to a missing firmware image file.
 
        ```bash
        ncn# cray fas actions describe {actionID} --format json
@@ -431,6 +442,7 @@ Update the firmware on any devices indicating a new version is needed.
 This procedure will read all RPMs in the Nexus repository and upload firmware images to S3 and create image records for firmware not already in FAS.
 
 1. Check the loader status.
+
     ```bash
     ncn# cray fas loader list | grep loaderStatus
     ```
@@ -500,7 +512,8 @@ This procedure will read all RPMs in the Nexus repository and upload firmware im
 
     A successful run will end with `*** Number of Updates: x ***`.
 
-    > **NOTE:** The FAS loader will not overwrite image records already in FAS. `Number of Updates` will be the number of new images found in Nexus. If the number is 0, all images were already in FAS.
+    > **NOTE:** The FAS loader will not overwrite image records already in FAS.
+    >`Number of Updates` will be the number of new images found in Nexus. If the number is 0, all images were already in FAS.
 
 ---
 
@@ -528,7 +541,7 @@ This procedure will read a single local RPM (or ZIP) file, upload firmware image
 
 3. Run the `loader` command.
 
-    firmware.rpm is the name of the RPM. If the file is not in the current directory, add the path to the filename.
+    `firmware.rpm` is the name of the RPM. If the file is not in the current directory, add the path to the filename.
 
     ```bash
     ncn# cray fas loader create --file firmware.RPM
@@ -563,8 +576,15 @@ This procedure will read a single local RPM (or ZIP) file, upload firmware image
         "2021-04-28T14:40:45Z-FWLoader-INFO-get_file_list(file://download/)",
         "2021-04-28T14:40:45Z-FWLoader-INFO-Processing File: file://download/ ilo5_241.json",
         "2021-04-28T14:40:45Z-FWLoader-INFO-Uploading b73a48cea82f11eb8c8a0242c0a81003/ilo5_241.bin",
-        "2021-04-28T14:40:45Z-FWLoader-INFO-Metadata {'imageData': \"{'deviceType': 'nodeBMC', 'manufacturer': 'hpe', 'models': ['ProLiant XL270d Gen10', 'ProLiant DL325 Gen10', 'ProLiant DL325 Gen10 Plus', 'ProLiant DL385 Gen10', 'ProLiant DL385 Gen10 Plus', 'ProLiant XL645d Gen10 Plus', 'ProLiant XL675d Gen10 Plus'], 'targets': ['iLO 5'], 'tags': ['default'], 'firmwareVersion': '2.41 Mar 08 2021', 'semanticFirmwareVersion': '2.41.0', 'pollingSpeedSeconds': 30, 'fileName': 'ilo5_241.bin'}\"}",
-        "2021-04-28T14:40:46Z-FWLoader-INFO-IMAGE: {\"s3URL\": \"s3:/fw-update/b73a48cea82f11eb8c8a0242c0a81003/ilo5_241.bin\", \"target\": \"iLO 5\", \"deviceType\": \"nodeBMC\", \"manufacturer\": \"hpe\", \"models\": [\"ProLiant XL270d Gen10\", \"ProLiant DL325 Gen10\", \"ProLiant DL325 Gen10 Plus\", \"ProLiant DL385 Gen10\", \"ProLiant DL385 Gen10 Plus\", \"ProLiant XL645d Gen10 Plus\", \"ProLiant XL675d Gen10 Plus\"], \"softwareIds\": [], \"tags\": [\"default\"], \"firmwareVersion\": \"2.41 Mar 08 2021\", \"semanticFirmwareVersion\": \"2.41.0\", \"allowableDeviceStates\": [], \"needManualReboot\": false, \"pollingSpeedSeconds\": 30}",
+        "2021-04-28T14:40:45Z-FWLoader-INFO-Metadata {'imageData': \"{'deviceType': 'nodeBMC', 'manufacturer': 'hpe', 'models': ['ProLiant XL270d Gen10', 'ProLiant DL325 Gen10', 'ProLiant DL325 Gen10 Plus', 'ProLiant DL385 Gen10', 'ProLiant DL385 
+        Gen10 Plus', 'ProLiant XL645d Gen10 Plus', 'ProLiant XL675d Gen10 Plus'], 'targets': ['iLO 5'], 'tags': ['default'], 
+        'firmwareVersion': '2.41 Mar 08 2021', 'semanticFirmwareVersion': '2.41.0', 'pollingSpeedSeconds': 30, 'fileName': 
+        'ilo5_241.bin'}\"}",
+        "2021-04-28T14:40:46Z-FWLoader-INFO-IMAGE: {\"s3URL\": \"s3:/fw-update/b73a48cea82f11eb8c8a0242c0a81003/ilo5_241.bin\", 
+        \"target\": \"iLO 5\", \"deviceType\": \"nodeBMC\", \"manufacturer\": \"hpe\", \"models\": [\"ProLiant XL270d Gen10\", 
+        \"ProLiant DL325 Gen10\", \"ProLiant DL325 Gen10 Plus\", \"ProLiant DL385 Gen10\", \"ProLiant DL385 Gen10 Plus\", 
+        \"ProLiant XL645d Gen10 Plus\", \"ProLiant XL675d Gen10 Plus\"], \"softwareIds\": [], \"tags\": [\"default\"], 
+        \"firmwareVersion\": \"2.41 Mar 08 2021\", \"semanticFirmwareVersion\": \"2.41.0\", \"allowableDeviceStates\": [], \"needManualReboot\": false, \"pollingSpeedSeconds\": 30}",
         "2021-04-28T14:40:46Z-FWLoader-INFO-Number of Updates: 1",
         "2021-04-28T14:40:46Z-FWLoader-INFO-Iterate images",
         "2021-04-28T14:40:46Z-FWLoader-INFO-update ACL to public-read for 5ab9f804a82b11eb8a700242c0a81003/wnc.bios-1.1.2.tar.gz",
@@ -577,7 +597,7 @@ This procedure will read a single local RPM (or ZIP) file, upload firmware image
       ]
     }
     ```
-    
+
     A successful run will end with `*** Number of Updates: x ***`.
 
     > **NOTE:** The FAS loader will not overwrite image records already in FAS. `Number of Updates` will be the number of new images found in the RPM. If the number is 0, all images were already in FAS.

--- a/operations/kubernetes/Restore_Postgres.md
+++ b/operations/kubernetes/Restore_Postgres.md
@@ -3,12 +3,13 @@
 Below are the service specific steps required to restore data to a Postgres cluster.
 
 Restore Postgres Procedures by Service:
-- [Restore Postgres for Spire](#spire)
-- [Restore Postgres for Keycloak](#keycloak)
-- [Restore Postgres for HSM (Hardware State Manager)](../hardware_state_manager/Restore_HSM_Postgres_from_Backup.md)
-- [Restore Postgres for SLS (System Layout Service)](../system_layout_service/Restore_SLS_Postgres_Database_from_Backup.md)
-- [Restore Postgres for VCS](#vcs)
-- [Restore Postgres for Capsules Services](#capsules)
+* [Restore Postgres](#restore-postgres)
+    * [Restore Postgres for Spire](#restore-postgres-for-spire)
+    * [Restore Postgres for Keycloak](#restore-postgres-for-keycloak)
+    * [Restore Postgres for VCS](#restore-postgres-for-vcs)
+    * [Restore Postgres for Capsules](#restore-postgres-for-capsules)
+      * [Capsules Warehouse Server](#capsules-warehouse-server)
+      * [Capsules Dispatch Server](#capsules-dispatch-server)
 
 
 <a name="spire"> </a>
@@ -511,7 +512,7 @@ In the event that the VCS Postgres cluster is in a state that the cluster must b
 	backup_bucket = s3.Bucket('postgres-backup')
 	for file in backup_bucket.objects.filter(Prefix='vcs-postgres'):
    	    print(file.key)
-    ````
+    ```
 
     download.py:
 
@@ -703,7 +704,7 @@ In the event that the Capsules Warehouse Postgres cluster is in a state that the
 	backup_bucket = s3.Bucket('postgres-backup')
 	for file in backup_bucket.objects.filter(Prefix='capsules-warehouse-server-postgres'):
    	    print(file.key)
-    ````
+    ```
 
     download.py:
 

--- a/operations/kubernetes/Restore_Postgres.md
+++ b/operations/kubernetes/Restore_Postgres.md
@@ -3,25 +3,30 @@
 Below are the service specific steps required to restore data to a Postgres cluster.
 
 Restore Postgres Procedures by Service:
-* [Restore Postgres](#restore-postgres)
-    * [Restore Postgres for Spire](#restore-postgres-for-spire)
-    * [Restore Postgres for Keycloak](#restore-postgres-for-keycloak)
-    * [Restore Postgres for VCS](#restore-postgres-for-vcs)
-    * [Restore Postgres for Capsules](#restore-postgres-for-capsules)
-      * [Capsules Warehouse Server](#capsules-warehouse-server)
-      * [Capsules Dispatch Server](#capsules-dispatch-server)
 
+* [Restore Postgres for Spire](#restore-postgres-for-spire)
+* [Restore Postgres for Keycloak](#restore-postgres-for-keycloak)
+* [Restore Postgres for VCS](#restore-postgres-for-vcs)
+* [Restore Postgres for Capsules](#restore-postgres-for-capsules)
+  * [Capsules Warehouse Server](#capsules-warehouse-server)
+  * [Capsules Dispatch Server](#capsules-dispatch-server)
 
 <a name="spire"> </a>
-### Restore Postgres for Spire
 
-In the event that the spire Postgres cluster is in a state that the cluster must be rebuilt and the data restored, the following procedures are recommended. This assumes that a dump of the database exists.
+## Restore Postgres for Spire
+
+In the event that the spire Postgres cluster is in a state that the cluster must be rebuilt and the data restored,
+the following procedures are recommended. This assumes that a dump of the database exists.
 
 1. Copy the database dump to an accessible location.
 
-    - If a manual dump of the database was taken, check that the dump file exists in a location off the Postgres cluster. It will be needed in the steps below.
-
-    - If the database is being automatically backed up, then the most recent version of the dump and the secrets should exist in the `postgres-backup` S3 bucket. These will be needed in the steps below. List the files in the `postgres-backup` S3 bucket and if the files exist, download the dump and secrets out of the S3 bucket. The python3 scripts below can be used to help list and download the files. Note that the .psql file contains the database dump and the .manifest file contains the secrets. The `aws_access_key_id` and `aws_secret_access_key` will need to be set based on the `postgres-backup-s3-credentials` secret.
+    * If a manual dump of the database was taken, check that the dump file exists in a location off the Postgres cluster.
+      It will be needed in the steps below.
+    * If the database is being automatically backed up, then the most recent version of the dump and the secrets should exist in the `postgres-backup` S3 bucket.
+      These will be needed in the steps below. List the files in the `postgres-backup` S3 bucket and if the files exist, download the dump and secrets out of the S3 bucket.
+      The python3 scripts below can be used to help list and download the files.
+      Note that the `.psql` file contains the database dump and the `.manifest` file contains the secrets.
+      The `aws_access_key_id` and `aws_secret_access_key` will need to be set based on the `postgres-backup-s3-credentials` secret.
 
     ```bash
     ncn-w001# export S3_ACCESS_KEY=`kubectl get secrets postgres-backup-s3-credentials -ojsonpath='{.data.access_key}' | base64 --decode`
@@ -131,48 +136,48 @@ In the event that the spire Postgres cluster is in a state that the cluster must
 
 7. Either update or re-create the `spire-postgres` secrets.
 
-  - Update the secrets in Postgres.
+   * Update the secrets in Postgres.
 
-    If a manual dump was done, and the secrets were not saved, then the secrets in the newly created Postgres cluster will need to be updated.
+        If a manual dump was done, and the secrets were not saved, then the secrets in the newly created Postgres cluster will need to be updated.
 
-    Based off the four `spire-postgres` secrets, collect the password for each Postgres username: `postgres`, `service_account`, `spire`, and `standby`. Then `kubectl exec` into the Postgres pod and update the password for each user. For example:
+        Based off the four `spire-postgres` secrets, collect the password for each Postgres username: `postgres`, `service_account`, `spire`, and `standby`. Then `kubectl exec` into the Postgres pod and update the password for each user. For example:
 
-    ```bash
-    ncn-w001# for secret in postgres.spire-postgres.credentials service-account.spire-postgres.credentials spire.spire-postgres.credentials standby.spire-postgres.credentials; do echo -n "secret ${secret} username & password: "; echo -n "`kubectl get secret ${secret} -n ${NAMESPACE} -ojsonpath='{.data.username}' | base64 -d` "; echo `kubectl get secret ${secret} -n ${NAMESPACE} -ojsonpath='{.data.password}'| base64 -d`; done
+        ```bash
+        ncn-w001# for secret in postgres.spire-postgres.credentials service-account.spire-postgres.credentials spire.spire-postgres.credentials standby.spire-postgres.credentials; do echo -n "secret ${secret} username & password: "; echo -n "`kubectl get secret ${secret} -n ${NAMESPACE} -ojsonpath='{.data.username}' | base64 -d` "; echo `kubectl get secret ${secret} -n ${NAMESPACE} -ojsonpath='{.data.password}'| base64 -d`; done
 
-    secret postgres.spire-postgres.credentials username & password: postgres ABCXYZ
-    secret service-account.spire-postgres.credentials username & password: service_account ABC123
-    secret spire.spire-postgres.credentials username & password: spire XYZ123
-    secret standby.spire-postgres.credentials username & password: standby 123456
-    ```
+        secret postgres.spire-postgres.credentials username & password: postgres ABCXYZ
+        secret service-account.spire-postgres.credentials username & password: service_account ABC123
+        secret spire.spire-postgres.credentials username & password: spire XYZ123
+        secret standby.spire-postgres.credentials username & password: standby 123456
+        ```
 
-    ```bash
-    ncn-w001# kubectl exec "${POSTGRESQL}-0" -n ${NAMESPACE} -c postgres -it -- bash
-    root@spire-postgres-0:/home/postgres# /usr/bin/psql postgres postgres
-    postgres=# ALTER USER postgres WITH PASSWORD 'ABCXYZ';
-    ALTER ROLE
-    postgres=# ALTER USER service_account WITH PASSWORD 'ABC123';
-    ALTER ROLE
-    postgres=#ALTER USER spire WITH PASSWORD 'XYZ123';
-    ALTER ROLE
-    postgres=#ALTER USER standby WITH PASSWORD '123456';
-    ALTER ROLE
-    postgres=#
-    ```
+        ```bash
+        ncn-w001# kubectl exec "${POSTGRESQL}-0" -n ${NAMESPACE} -c postgres -it -- bash
+        root@spire-postgres-0:/home/postgres# /usr/bin/psql postgres postgres
+        postgres=# ALTER USER postgres WITH PASSWORD 'ABCXYZ';
+        ALTER ROLE
+        postgres=# ALTER USER service_account WITH PASSWORD 'ABC123';
+        ALTER ROLE
+        postgres=#ALTER USER spire WITH PASSWORD 'XYZ123';
+        ALTER ROLE
+        postgres=#ALTER USER standby WITH PASSWORD '123456';
+        ALTER ROLE
+        postgres=#
+        ```
 
-  - Re-create secrets in Kubernetes.
+   * Re-create secrets in Kubernetes.
 
-    If the Postgres secrets were auto-backed up, then re-create the secrets in Kubernetes.
+        If the Postgres secrets were auto-backed up, then re-create the secrets in Kubernetes.
 
-    Delete and re-create the four `spire-postgres` secrets using the manifest that was copied from S3 in step 1 above.
+        Delete and re-create the four `spire-postgres` secrets using the manifest that was copied from S3 in step 1 above.
 
-    ```bash
-    ncn-w001# MANIFEST=spire-postgres-2021-07-21T19:03:18.manifest
+        ```bash
+        ncn-w001# MANIFEST=spire-postgres-2021-07-21T19:03:18.manifest
 
-    ncn-w001# kubectl delete secret postgres.spire-postgres.credentials service-account.spire-postgres.credentials spire.spire-postgres.credentials standby.spire-postgres.credentials -n ${NAMESPACE}
+        ncn-w001# kubectl delete secret postgres.spire-postgres.credentials service-account.spire-postgres.credentials spire.spire-postgres.credentials standby.spire-postgres.credentials -n ${NAMESPACE}
 
-    ncn-w001# kubectl apply -f ${MANIFEST}
-    ```
+        ncn-w001# kubectl apply -f ${MANIFEST}
+        ```
 
 8. Restart the Postgres cluster.
 
@@ -228,72 +233,77 @@ In the event that the spire Postgres cluster is in a state that the cluster must
     ```
 
 <a name="keycloak"> </a>
-### Restore Postgres for Keycloak
 
-In the event that the keycloak Postgres cluster is in a state that the cluster must be rebuilt and the data restored, the following procedures are recommended. This assumes that a dump of the database exists.
+## Restore Postgres for Keycloak
+
+In the event that the Keycloak Postgres cluster is in a state that the cluster must be rebuilt and the data restored, the following procedures are recommended. This assumes that a dump of the database exists.
 
 1. Copy the database dump to an accessible location.
 
-    - If a manual dump of the database was taken, check that the dump file exists in a location off the Postgres cluster. It will be needed in the steps below.
+    * If a manual dump of the database was taken, check that the dump file exists in a location off the Postgres cluster.
+      It will be needed in the steps below.
+    * If the database is being automatically backed up, then the most recent version of the dump and the secrets should exist in the `postgres-backup` S3 bucket.
+      These will be needed in the steps below. List the files in the `postgres-backup` S3 bucket and if the files exist, download the dump and secrets out of the S3 bucket.
+      The python3 scripts below can be used to help list and download the files.
+      Note that the `.psql` file contains the database dump and the `.manifest` file contains the secrets.
+      The `aws_access_key_id` and `aws_secret_access_key` will need to be set based on the `postgres-backup-s3-credentials` secret.
 
-    - If the database is being automatically backed up, then the most recent version of the dump and the secrets should exist in the `postgres-backup` S3 bucket. These will be needed in the steps below. List the files in the `postgres-backup` S3 bucket and if the files exist, download the dump and secrets out of the S3 bucket. The python3 scripts below can be used to help list and download the files. Note that the .psql file contains the database dump and the .manifest file contains the secrets. The `aws_access_key_id` and `aws_secret_access_key` will need to be set based on the `postgres-backup-s3-credentials` secret.
+        ```bash
+        ncn-w001# export S3_ACCESS_KEY=`kubectl get secrets postgres-backup-s3-credentials -ojsonpath='{.data.access_key}' | base64 --decode`
 
-    ```bash
-    ncn-w001# export S3_ACCESS_KEY=`kubectl get secrets postgres-backup-s3-credentials -ojsonpath='{.data.access_key}' | base64 --decode`
+        ncn-w001# export S3_SECRET_KEY=`kubectl get secrets postgres-backup-s3-credentials -ojsonpath='{.data.secret_key}' | base64 --decode`
+        ```
 
-    ncn-w001# export S3_SECRET_KEY=`kubectl get secrets postgres-backup-s3-credentials -ojsonpath='{.data.secret_key}' | base64 --decode`
-    ```
+        list.py:
 
-    list.py:
+        ```python
+        import io
+        import boto3
+        import os
 
-    ```python
-    import io
-    import boto3
-    import os
+        # postgres-backup-s3-credentials are needed to list keys in the postgres-backup bucket
 
-    # postgres-backup-s3-credentials are needed to list keys in the postgres-backup bucket
+        s3_access_key = os.environ['S3_ACCESS_KEY']
+        s3_secret_key = os.environ['S3_SECRET_KEY']
 
-    s3_access_key = os.environ['S3_ACCESS_KEY']
-    s3_secret_key = os.environ['S3_SECRET_KEY']
+        s3 = boto3.resource(
+            's3',
+            endpoint_url='http://rgw-vip.nmn',
+            aws_access_key_id=s3_access_key,
+            aws_secret_access_key=s3_secret_key,
+            verify=False)
 
-    s3 = boto3.resource(
-        's3',
-        endpoint_url='http://rgw-vip.nmn',
-        aws_access_key_id=s3_access_key,
-        aws_secret_access_key=s3_secret_key,
-        verify=False)
+        backup_bucket = s3.Bucket('postgres-backup')
+        for file in backup_bucket.objects.filter(Prefix='keycloak-postgres'):
+            print(file.key)
+        ```
 
-	backup_bucket = s3.Bucket('postgres-backup')
-	for file in backup_bucket.objects.filter(Prefix='keycloak-postgres'):
-   	    print(file.key)
-    ```
+        download.py:
 
-    download.py:
+        Update the script for the specific .manifest and .psql files you wish to download from S3.
 
-    Update the script for the specific .manifest and .psql files you wish to download from S3.
+        ```python
+        import io
+        import boto3
+        import os
 
-    ```python
-    import io
-    import boto3
-    import os
+        # postgres-backup-s3-credentials are needed to download from postgres-backup bucket
 
-    # postgres-backup-s3-credentials are needed to download from postgres-backup bucket
+        s3_access_key = os.environ['S3_ACCESS_KEY']
+        s3_secret_key = os.environ['S3_SECRET_KEY']
 
-    s3_access_key = os.environ['S3_ACCESS_KEY']
-    s3_secret_key = os.environ['S3_SECRET_KEY']
+        s3_client = boto3.client(
+            's3',
+            endpoint_url='http://rgw-vip.nmn',
+            aws_access_key_id=s3_access_key,
+            aws_secret_access_key=s3_secret_key,
+            verify=False)
 
-    s3_client = boto3.client(
-        's3',
-        endpoint_url='http://rgw-vip.nmn',
-        aws_access_key_id=s3_access_key,
-        aws_secret_access_key=s3_secret_key,
-        verify=False)
+        response = s3_client.download_file('postgres-backup', 'keycloak-postgres-2021-07-29T17:56:07.manifest', 'keycloak-postgres-2021-07-29T17:56:07.manifest')
+        response = s3_client.download_file('postgres-backup', 'keycloak-postgres-2021-07-29T17:56:07.psql', 'keycloak-postgres-2021-07-29T17:56:07.psql')
+        ```
 
-    response = s3_client.download_file('postgres-backup', 'keycloak-postgres-2021-07-29T17:56:07.manifest', 'keycloak-postgres-2021-07-29T17:56:07.manifest')
-    response = s3_client.download_file('postgres-backup', 'keycloak-postgres-2021-07-29T17:56:07.psql', 'keycloak-postgres-2021-07-29T17:56:07.psql')
-    ```
-
-2. Scale the keycloak service to 0.
+2. Scale the Keycloak service to 0.
 
     ```bash
     ncn-w001# CLIENT=cray-keycloak
@@ -306,7 +316,7 @@ In the event that the keycloak Postgres cluster is in a state that the cluster m
     ncn-w001# while [ $(kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/instance="${CLIENT}" | grep -v NAME | wc -l) != 0 ] ; do echo "  waiting for pods to terminate"; sleep 2; done
     ```
 
-3. Delete the keycloak Postgres cluster.
+3. Delete the Keycloak Postgres cluster.
 
     ```bash
     ncn-w001# kubectl get postgresql ${POSTGRESQL} -n ${NAMESPACE} -o json | jq 'del(.spec.selector)' | jq 'del(.spec.template.metadata.labels."controller-uid")' | jq 'del(.status)' > postgres-cr.json
@@ -317,7 +327,7 @@ In the event that the keycloak Postgres cluster is in a state that the cluster m
     ncn-w001# while [ $(kubectl get pods -l "application=spilo,cluster-name=${POSTGRESQL}" -n ${NAMESPACE} | grep -v NAME | wc -l) != 0 ] ; do echo "  waiting for pods to terminate"; sleep 2; done
     ```
 
-4. Create a new single instance keycloak Postgres cluster.
+4. Create a new single instance Keycloak Postgres cluster.
 
     ```bash
     ncn-w001# cp postgres-cr.json postgres-orig-cr.json
@@ -346,45 +356,45 @@ In the event that the keycloak Postgres cluster is in a state that the cluster m
 
 7. Either update or re-create the `keycloak-postgres` secrets.
 
-  - Update the secrets in Postgres.
+   * Update the secrets in Postgres.
 
-    If a manual dump was done, and the secrets were not saved, then the secrets in the newly created Postgres cluster will need to be updated.
+        If a manual dump was done, and the secrets were not saved, then the secrets in the newly created Postgres cluster will need to be updated.
 
-    Based off the three `keycloak-postgres` secrets, collect the password for each Postgres username: `postgres`, `service_account`, and `standby`. Then `kubectl exec` into the Postgres pod and update the password for each user. For example:
+        Based off the three `keycloak-postgres` secrets, collect the password for each Postgres username: `postgres`, `service_account`, and `standby`. Then `kubectl exec` into the Postgres pod and update the password for each user. For example:
 
-    ```bash
-    ncn-w001# for secret in postgres.keycloak-postgres.credentials service-account.keycloak-postgres.credentials standby.keycloak-postgres.credentials; do echo -n "secret ${secret} username & password: "; echo -n "`kubectl get secret ${secret} -n ${NAMESPACE} -ojsonpath='{.data.username}' | base64 -d` "; echo `kubectl get secret ${secret} -n ${NAMESPACE} -ojsonpath='{.data.password}'| base64 -d`; done
+        ```bash
+        ncn-w001# for secret in postgres.keycloak-postgres.credentials service-account.keycloak-postgres.credentials standby.keycloak-postgres.credentials; do echo -n "secret ${secret} username & password: "; echo -n "`kubectl get secret ${secret} -n ${NAMESPACE} -ojsonpath='{.data.username}' | base64 -d` "; echo `kubectl get secret ${secret} -n ${NAMESPACE} -ojsonpath='{.data.password}'| base64 -d`; done
 
-    secret postgres.keycloak-postgres.credentials username & password: postgres ABCXYZ
-    secret service-account.keycloak-postgres.credentials username & password: service_account ABC123
-    secret standby.keycloak-postgres.credentials username & password: standby 123456
-    ```
+        secret postgres.keycloak-postgres.credentials username & password: postgres ABCXYZ
+        secret service-account.keycloak-postgres.credentials username & password: service_account ABC123
+        secret standby.keycloak-postgres.credentials username & password: standby 123456
+        ```
 
-    ```bash
-    ncn-w001# kubectl exec "${POSTGRESQL}-0" -n ${NAMESPACE} -c postgres -it -- bash
-    root@keycloak-postgres-0:/home/postgres# /usr/bin/psql postgres postgres
-    postgres=# ALTER USER postgres WITH PASSWORD 'ABCXYZ';
-    ALTER ROLE
-    postgres=# ALTER USER service_account WITH PASSWORD 'ABC123';
-    ALTER ROLE
-    postgres=#ALTER USER standby WITH PASSWORD '123456';
-    ALTER ROLE
-    postgres=#
-    ```
+        ```bash
+        ncn-w001# kubectl exec "${POSTGRESQL}-0" -n ${NAMESPACE} -c postgres -it -- bash
+        root@keycloak-postgres-0:/home/postgres# /usr/bin/psql postgres postgres
+        postgres=# ALTER USER postgres WITH PASSWORD 'ABCXYZ';
+        ALTER ROLE
+        postgres=# ALTER USER service_account WITH PASSWORD 'ABC123';
+        ALTER ROLE
+        postgres=#ALTER USER standby WITH PASSWORD '123456';
+        ALTER ROLE
+        postgres=#
+        ```
 
-  - Re-create secrets in Kubernetes.
+   * Re-create secrets in Kubernetes.
 
-    If the Postgres secrets were automatically backed up, then re-create the secrets in Kubernetes.
+        If the Postgres secrets were automatically backed up, then re-create the secrets in Kubernetes.
 
-    Delete and re-create the three `keycloak-postgres` secrets using the manifest that was copied from S3 in step 1 above.
+        Delete and re-create the three `keycloak-postgres` secrets using the manifest that was copied from S3 in step 1 above.
 
-    ```bash
-    ncn-w001# MANIFEST=keycloak-postgres-2021-07-29T17:56:07.manifest
+        ```bash
+        ncn-w001# MANIFEST=keycloak-postgres-2021-07-29T17:56:07.manifest
 
-    ncn-w001# kubectl delete secret postgres.keycloak-postgres.credentials service-account.keycloak-postgres.credentials standby.keycloak-postgres.credentials -n ${NAMESPACE}
+        ncn-w001# kubectl delete secret postgres.keycloak-postgres.credentials service-account.keycloak-postgres.credentials standby.keycloak-postgres.credentials -n ${NAMESPACE}
 
-    ncn-w001# kubectl apply -f ${MANIFEST}
-    ```
+        ncn-w001# kubectl apply -f ${MANIFEST}
+        ```
 
 8. Restart the Postgres cluster.
 
@@ -404,7 +414,7 @@ In the event that the keycloak Postgres cluster is in a state that the cluster m
     ncn-w001# while [ $(kubectl get postgresql "${POSTGRESQL}" -n "${NAMESPACE}" -o json | jq -r '.status.PostgresClusterStatus') != "Running" ] ; do echo "  waiting for postgresql to start running"; sleep 2; done
     ```
 
-10. Scale the keycloak service back to 3 replicas.
+10. Scale the Keycloak service back to 3 replicas.
 
     ```bash
     ncn-w001# kubectl scale statefulset ${CLIENT} -n ${NAMESPACE} --replicas=3
@@ -413,7 +423,8 @@ In the event that the keycloak Postgres cluster is in a state that the cluster m
     ncn-w001# while [ $(kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/instance="${CLIENT}" | grep -v NAME | wc -l) != 3 ] ; do echo "  waiting for pods to start"; sleep 2; done
     ```
 
-    Also check the status of the keycloak pods. If there are pods that do not show that both containers are ready (READY is `2/2`), wait a few seconds and re-run the command until all containers are ready.
+    Also check the status of the Keycloak pods.
+    If there are pods that do not show that both containers are ready (READY is `2/2`), wait a few seconds and re-run the command until all containers are ready.
 
     ```bash
     ncn-w001# kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/instance="${CLIENT}"
@@ -426,45 +437,47 @@ In the event that the keycloak Postgres cluster is in a state that the cluster m
 
 11. Re-run the `keycloak-setup` and `keycloak-users-localize` jobs, and restart Keycloak gatekeeper.
 
-  - Run the `keycloak-setup` job to restore the Kubernetes client secrets:
+    * Run the `keycloak-setup` job to restore the Kubernetes client secrets:
 
-    ```bash
-    ncn-w001# kubectl get job -n ${NAMESPACE} -l app.kubernetes.io/instance=cray-keycloak -o json > keycloak-setup.json
-    ncn-w001# cat keycloak-setup.json | jq '.items[0]' | jq 'del(.metadata.creationTimestamp)' | jq 'del(.metadata.managedFields)' | jq 'del(.metadata.resourceVersion)' | jq 'del(.metadata.selfLink)' | jq 'del(.metadata.uid)' | jq 'del(.spec.selector)' | jq 'del(.spec.template.metadata.labels)' | jq 'del(.status)' | kubectl replace --force -f -
-    ```
+        ```bash
+        ncn-w001# kubectl get job -n ${NAMESPACE} -l app.kubernetes.io/instance=cray-keycloak -o json > keycloak-setup.json
+        ncn-w001# cat keycloak-setup.json | jq '.items[0]' | jq 'del(.metadata.creationTimestamp)' | jq 'del(.metadata.managedFields)' | jq 'del(.metadata.resourceVersion)' | jq 'del(.metadata.selfLink)' | jq 'del(.metadata.uid)' | jq 'del(.spec.selector)' | jq 'del(.spec.template.metadata.labels)' | jq 'del(.status)' | kubectl replace --force -f -
+        ```
 
-    Check the status of the `keycloak-setup` job. If the `COMPLETIONS` value is not `1/1`, wait a few seconds and run the command again until the `COMPLETIONS` value is `1/1`.
+        Check the status of the `keycloak-setup` job. If the `COMPLETIONS` value is not `1/1`,
+        wait a few seconds and run the command again until the `COMPLETIONS` value is `1/1`.
 
-    ```bash
-    ncn-w001# kubectl get jobs -n ${NAMESPACE} -l app.kubernetes.io/instance=cray-keycloak
+        ```bash
+        ncn-w001# kubectl get jobs -n ${NAMESPACE} -l app.kubernetes.io/instance=cray-keycloak
 
-    NAME               COMPLETIONS   DURATION   AGE
-    keycloak-setup-2   1/1           59s        91s
-    ```
+        NAME               COMPLETIONS   DURATION   AGE
+        keycloak-setup-2   1/1           59s        91s
+        ```
 
-  - Run the `keycloak-users-localize` job to restore the users and groups in S3 and the Kubernetes configmap:
+    * Run the `keycloak-users-localize` job to restore the users and groups in S3 and the Kubernetes ConfigMap:
 
-    ```bash
-    ncn-w001# kubectl get job -n ${NAMESPACE} -l app.kubernetes.io/instance=cray-keycloak-users-localize -o json > cray-keycloak-users-localize.json
-    ncn-w001# cat cray-keycloak-users-localize.json | jq '.items[0]' | jq 'del(.metadata.creationTimestamp)' | jq 'del(.metadata.managedFields)' | jq 'del(.metadata.resourceVersion)' | jq 'del(.metadata.selfLink)' | jq 'del(.metadata.uid)' | jq 'del(.spec.selector)' | jq 'del(.spec.template.metadata.labels)' | jq 'del(.status)' | kubectl replace --force -f -`
-    ```
+        ```bash
+        ncn-w001# kubectl get job -n ${NAMESPACE} -l app.kubernetes.io/instance=cray-keycloak-users-localize -o json > cray-keycloak-users-localize.json
+        ncn-w001# cat cray-keycloak-users-localize.json | jq '.items[0]' | jq 'del(.metadata.creationTimestamp)' | jq 'del(.metadata.managedFields)' | jq 'del(.metadata.resourceVersion)' | jq 'del(.metadata.selfLink)' | jq 'del(.metadata.uid)' | jq 'del(.spec.selector)' | jq 'del(.spec.template.metadata.labels)' | jq 'del(.status)' | kubectl replace --force -f -`
+        ```
 
-    Check the status of the `cray-keycloak-users-localize` job. If the `COMPLETIONS` value is not `1/1`, wait a few seconds and run the command again until the `COMPLETIONS` value is `1/1`.
+        Check the status of the `cray-keycloak-users-localize` job.
+        If the `COMPLETIONS` value is not `1/1`, wait a few seconds and run the command again until the `COMPLETIONS` value is `1/1`.
 
-    ```bash
-    ncn-w001# kubectl get jobs -n ${NAMESPACE} -l app.kubernetes.io/instance=cray-keycloak-users-localize
+        ```bash
+        ncn-w001# kubectl get jobs -n ${NAMESPACE} -l app.kubernetes.io/instance=cray-keycloak-users-localize
 
-    NAME                        COMPLETIONS   DURATION   AGE
-    keycloak-users-localize-2   1/1           45s        49s
-    ```
+        NAME                        COMPLETIONS   DURATION   AGE
+        keycloak-users-localize-2   1/1           45s        49s
+        ```
 
-  - Restart Keycloak gatekeeper:
+    * Restart Keycloak gatekeeper:
 
-    ```bash
-    ncn-w001# kubectl rollout restart -n ${NAMESPACE} deployment/cray-keycloak-gatekeeper-ingress
-    ```
+        ```bash
+        ncn-w001# kubectl rollout restart -n ${NAMESPACE} deployment/cray-keycloak-gatekeeper-ingress
+        ```
 
-12. Verify the service is working. The following should return an access_token for an existing user. Replace the <username> and <password> as appropriate.
+12. Verify the service is working. The following should return an `access_token` for an existing user. Replace the `<username>` and `<password>` as appropriate.
 
     ```bash
     ncn-w001:# curl -s -k -d grant_type=password -d client_id=shasta -d username=<username> -d password=<password> https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token
@@ -474,69 +487,73 @@ In the event that the keycloak Postgres cluster is in a state that the cluster m
 
 <a name="vcs"> </a>
 
-### Restore Postgres for VCS
+## Restore Postgres for VCS
 
 In the event that the VCS Postgres cluster is in a state that the cluster must be rebuilt and the data restored, the following procedures are recommended. This assumes that a dump of the database exists, as well as a backup of the VCS PVC.
 
 1. Copy the database dump to an accessible location.
 
-    - If a manual dump of the database was taken, check that the dump file exists in a location off the Postgres cluster. It will be needed in the steps below.
+    * If a manual dump of the database was taken, check that the dump file exists in a location off the Postgres cluster.
+      It will be needed in the steps below.
+    * If the database is being automatically backed up, then the most recent version of the dump and the secrets should exist in the `postgres-backup` S3 bucket.
+      These will be needed in the steps below. List the files in the `postgres-backup` S3 bucket and if the files exist, download the dump and secrets out of the S3 bucket.
+      The python3 scripts below can be used to help list and download the files.
+      Note that the `.psql` file contains the database dump and the `.manifest` file contains the secrets.
+      The `aws_access_key_id` and `aws_secret_access_key` will need to be set based on the `postgres-backup-s3-credentials` secret.
 
-    - If the database is being automatically backed up, then the most recent version of the dump and the secrets should exist in the `postgres-backup` S3 bucket. These will be needed in the steps below. List the files in the `postgres-backup` S3 bucket and if the files exist, download the dump and secrets out of the S3 bucket. The python3 scripts below can be used to help list and download the files. Note that the .psql file contains the database dump and the .manifest file contains the secrets. The `aws_access_key_id` and `aws_secret_access_key` will need to be set based on the `postgres-backup-s3-credentials` secret.
+        ```bash
+        ncn-w001# export S3_ACCESS_KEY=`kubectl get secrets postgres-backup-s3-credentials -ojsonpath='{.data.access_key}' | base64 --decode`
 
-    ```bash
-    ncn-w001# export S3_ACCESS_KEY=`kubectl get secrets postgres-backup-s3-credentials -ojsonpath='{.data.access_key}' | base64 --decode`
+        ncn-w001# export S3_SECRET_KEY=`kubectl get secrets postgres-backup-s3-credentials -ojsonpath='{.data.secret_key}' | base64 --decode`
+        ```
 
-    ncn-w001# export S3_SECRET_KEY=`kubectl get secrets postgres-backup-s3-credentials -ojsonpath='{.data.secret_key}' | base64 --decode`
-    ```
+        list.py:
 
-    list.py:
+        ```python
+        import io
+        import boto3
+        import os
 
-    ```python
-    import io
-    import boto3
-    import os
+        # postgres-backup-s3-credentials are needed to list keys in the postgres-backup bucket
 
-    # postgres-backup-s3-credentials are needed to list keys in the postgres-backup bucket
+        s3_access_key = os.environ['S3_ACCESS_KEY']
+        s3_secret_key = os.environ['S3_SECRET_KEY']
 
-    s3_access_key = os.environ['S3_ACCESS_KEY']
-    s3_secret_key = os.environ['S3_SECRET_KEY']
+        s3 = boto3.resource(
+            's3',
+            endpoint_url='http://rgw-vip.nmn',
+            aws_access_key_id=s3_access_key,
+            aws_secret_access_key=s3_secret_key,
+            verify=False)
 
-    s3 = boto3.resource(
-        's3',
-        endpoint_url='http://rgw-vip.nmn',
-        aws_access_key_id=s3_access_key,
-        aws_secret_access_key=s3_secret_key,
-        verify=False)
+        backup_bucket = s3.Bucket('postgres-backup')
+        for file in backup_bucket.objects.filter(Prefix='vcs-postgres'):
+            print(file.key)
+        ```
 
-	backup_bucket = s3.Bucket('postgres-backup')
-	for file in backup_bucket.objects.filter(Prefix='vcs-postgres'):
-   	    print(file.key)
-    ```
+        download.py:
 
-    download.py:
+        Update the script for the specific .manifest and .psql files you wish to download from S3.
 
-    Update the script for the specific .manifest and .psql files you wish to download from S3.
+        ```python
+        import boto3
+        import os
 
-    ```python
-    import boto3
-    import os
+        # postgres-backup-s3-credentials are needed to download from postgres-backup bucket
 
-    # postgres-backup-s3-credentials are needed to download from postgres-backup bucket
+        s3_access_key = os.environ['S3_ACCESS_KEY']
+        s3_secret_key = os.environ['S3_SECRET_KEY']
 
-    s3_access_key = os.environ['S3_ACCESS_KEY']
-    s3_secret_key = os.environ['S3_SECRET_KEY']
+        s3_client = boto3.client(
+            's3',
+            endpoint_url='http://rgw-vip.nmn',
+            aws_access_key_id=s3_access_key,
+            aws_secret_access_key=s3_secret_key,
+            verify=False)
 
-    s3_client = boto3.client(
-        's3',
-        endpoint_url='http://rgw-vip.nmn',
-        aws_access_key_id=s3_access_key,
-        aws_secret_access_key=s3_secret_key,
-        verify=False)
-
-    response = s3_client.download_file('postgres-backup', 'vcs-postgres-2021-07-21T19:03:18.manifest', 'vcs-postgres-2021-07-21T19:03:18.manifest')
-    response = s3_client.download_file('postgres-backup', 'vcs-postgres-2021-07-21T19:03:18.psql', 'vcs-postgres-2021-07-21T19:03:18.psql')
-    ```
+        response = s3_client.download_file('postgres-backup', 'vcs-postgres-2021-07-21T19:03:18.manifest', 'vcs-postgres-2021-07-21T19:03:18.manifest')
+        response = s3_client.download_file('postgres-backup', 'vcs-postgres-2021-07-21T19:03:18.psql', 'vcs-postgres-2021-07-21T19:03:18.psql')
+        ```
 
 2. Scale the VCS service to 0.
 
@@ -592,48 +609,48 @@ In the event that the VCS Postgres cluster is in a state that the cluster must b
 
 7. Either update or re-create the `gitea-vcs-postgres` secrets.
 
-  - Update the secrets in Postgres.
+   * Update the secrets in Postgres.
 
-    If a manual dump was done, and the secrets were not saved, then the secrets in the newly created Postgres cluster will need to be updated.
+        If a manual dump was done, and the secrets were not saved, then the secrets in the newly created Postgres cluster will need to be updated.
 
-    Based off the three `gitea-vcs-postgres` secrets, collect the password for each Postgres username: `postgres`, `service_account`, and `standby`. Then `kubectl exec` into the Postgres pod and update the password for each user. For example:
+        Based off the three `gitea-vcs-postgres` secrets, collect the password for each Postgres username: `postgres`, `service_account`, and `standby`. Then `kubectl exec` into the Postgres pod and update the password for each user. For example:
 
-    ```bash
-    ncn-w001# for secret in postgres.gitea-vcs-postgres.credentials service-account.gitea-vcs-postgres.credentials gitea.gitea-vcs-postgres.credentials standby.gitea-vcs-postgres.credentials; do echo -n "secret ${secret} username & password: "; echo -n "`kubectl get secret ${secret} -n ${NAMESPACE} -ojsonpath='{.data.username}' | base64 -d` "; echo `kubectl get secret ${secret} -n ${NAMESPACE} -ojsonpath='{.data.password}'| base64 -d`; done
+        ```bash
+        ncn-w001# for secret in postgres.gitea-vcs-postgres.credentials service-account.gitea-vcs-postgres.credentials gitea.gitea-vcs-postgres.credentials standby.gitea-vcs-postgres.credentials; do echo -n "secret ${secret} username & password: "; echo -n "`kubectl get secret ${secret} -n ${NAMESPACE} -ojsonpath='{.data.username}' | base64 -d` "; echo `kubectl get secret ${secret} -n ${NAMESPACE} -ojsonpath='{.data.password}'| base64 -d`; done
 
-    secret postgres.gitea-vcs-postgres.credentials username & password: postgres ABCXYZ
-    secret service-account.gitea-vcs-postgres.credentials username & password: service_account ABC123
-    secret gitea.gitea-vcs-postgres.credentials username & password: gitea XYZ123
-    secret standby.gitea-vcs-postgres.credentials username & password: standby 123456
-    ```
+        secret postgres.gitea-vcs-postgres.credentials username & password: postgres ABCXYZ
+        secret service-account.gitea-vcs-postgres.credentials username & password: service_account ABC123
+        secret gitea.gitea-vcs-postgres.credentials username & password: gitea XYZ123
+        secret standby.gitea-vcs-postgres.credentials username & password: standby 123456
+        ```
 
-    ```bash
-    ncn-w001# kubectl exec "${POSTGRESQL}-0" -n ${NAMESPACE} -c postgres -it -- bash
-    root@gitea-vcs-postgres-0:/home/postgres# /usr/bin/psql postgres postgres
-    postgres=# ALTER USER postgres WITH PASSWORD 'ABCXYZ';
-    ALTER ROLE
-    postgres=# ALTER USER service_account WITH PASSWORD 'ABC123';
-    ALTER ROLE
-    postgres=#ALTER USER gitea WITH PASSWORD 'XYZ123';
-    ALTER ROLE
-    postgres=#ALTER USER standby WITH PASSWORD '123456';
-    ALTER ROLE
-    postgres=#
-    ```
+        ```bash
+        ncn-w001# kubectl exec "${POSTGRESQL}-0" -n ${NAMESPACE} -c postgres -it -- bash
+        root@gitea-vcs-postgres-0:/home/postgres# /usr/bin/psql postgres postgres
+        postgres=# ALTER USER postgres WITH PASSWORD 'ABCXYZ';
+        ALTER ROLE
+        postgres=# ALTER USER service_account WITH PASSWORD 'ABC123';
+        ALTER ROLE
+        postgres=#ALTER USER gitea WITH PASSWORD 'XYZ123';
+        ALTER ROLE
+        postgres=#ALTER USER standby WITH PASSWORD '123456';
+        ALTER ROLE
+        postgres=#
+        ```
 
-  - Re-create secrets in Kubernetes.
+   * Re-create secrets in Kubernetes.
 
-    If the Postgres secrets were auto-backed up, then re-create the secrets in Kubernetes.
+        If the Postgres secrets were auto-backed up, then re-create the secrets in Kubernetes.
 
-    Delete and re-create the four `gitea-vcs-postgres` secrets using the manifest that was copied from S3 in step 1 above.
+        Delete and re-create the four `gitea-vcs-postgres` secrets using the manifest that was copied from S3 in step 1 above.
 
-    ```bash
-    ncn-w001# MANIFEST=gitea-vcs-postgres-2021-07-21T19:03:18.manifest
+        ```bash
+        ncn-w001# MANIFEST=gitea-vcs-postgres-2021-07-21T19:03:18.manifest
 
-    ncn-w001# kubectl delete secret postgres.gitea-vcs-postgres.credentials service-account.gitea-vcs-postgres.credentials standby.gitea-vcs-postgres.credentials -n services
+        ncn-w001# kubectl delete secret postgres.gitea-vcs-postgres.credentials service-account.gitea-vcs-postgres.credentials standby.gitea-vcs-postgres.credentials -n services
 
-    ncn-w001# kubectl apply -f ${MANIFEST}
-    ```
+        ncn-w001# kubectl apply -f ${MANIFEST}
+        ```
 
 8. Restart the Postgres cluster.
 
@@ -653,7 +670,7 @@ In the event that the VCS Postgres cluster is in a state that the cluster must b
     ncn-w001# while [ $(kubectl get postgresql "${POSTGRESQL}" -n "${NAMESPACE}" -o json | jq -r '.status.PostgresClusterStatus') != "Running" ] ; do echo "  waiting for postgresql to start running"; sleep 2; done
     ```
 
-10. Scale the gitea service back up.
+10. Scale the Gitea service back up.
 
     ```bash
     ncn-w001# kubectl scale deployment ${SERVICE} -n ${NAMESPACE} --replicas=3
@@ -664,72 +681,76 @@ In the event that the VCS Postgres cluster is in a state that the cluster must b
 
 <a name="capsules"> </a>
 
-### Restore Postgres for Capsules
+## Restore Postgres for Capsules
 
-#### Capsules Warehouse Server
+### Capsules Warehouse Server
 
 In the event that the Capsules Warehouse Postgres cluster is in a state that the cluster must be rebuilt and the data restored, the following procedures are recommended. This assumes that a dump of the database exists.
 
 1. Copy the database dump to an accessible location.
 
-    - If a manual dump of the database was taken, check that the dump file exists in a location off the Postgres cluster. It will be needed in the steps below.
+    * If a manual dump of the database was taken, check that the dump file exists in a location off the Postgres cluster.
+      It will be needed in the steps below.
+    * If the database is being automatically backed up, then the most recent version of the dump and the secrets should exist in the `postgres-backup` S3 bucket.
+      These will be needed in the steps below. List the files in the `postgres-backup` S3 bucket and if the files exist, download the dump and secrets out of the S3 bucket.
+      The python3 scripts below can be used to help list and download the files.
+      Note that the `.psql` file contains the database dump and the `.manifest` file contains the secrets.
+      The `aws_access_key_id` and `aws_secret_access_key` will need to be set based on the `postgres-backup-s3-credentials` secret.
 
-    - If the database is being automatically backed up, then the most recent version of the dump and the secrets should exist in the `postgres-backup` S3 bucket. These will be needed in the steps below. List the files in the `postgres-backup` S3 bucket and if the files exist, download the dump and secrets out of the S3 bucket. The python3 scripts below can be used to help list and download the files. Note that the .psql file contains the database dump and the .manifest file contains the secrets. The `aws_access_key_id` and `aws_secret_access_key` will need to be set based on the `postgres-backup-s3-credentials` secret.
+        ```bash
+        ncn-w001# export S3_ACCESS_KEY=`kubectl get secrets postgres-backup-s3-credentials -ojsonpath='{.data.access_key}' | base64 --decode`
 
-    ```bash
-    ncn-w001# export S3_ACCESS_KEY=`kubectl get secrets postgres-backup-s3-credentials -ojsonpath='{.data.access_key}' | base64 --decode`
+        ncn-w001# export S3_SECRET_KEY=`kubectl get secrets postgres-backup-s3-credentials -ojsonpath='{.data.secret_key}' | base64 --decode`
+        ```
 
-    ncn-w001# export S3_SECRET_KEY=`kubectl get secrets postgres-backup-s3-credentials -ojsonpath='{.data.secret_key}' | base64 --decode`
-    ```
+        list.py:
 
-    list.py:
+        ```python
+        import io
+        import boto3
+        import os
 
-    ```python
-    import io
-    import boto3
-    import os
+        # postgres-backup-s3-credentials are needed to list keys in the postgres-backup bucket
 
-    # postgres-backup-s3-credentials are needed to list keys in the postgres-backup bucket
+        s3_access_key = os.environ['S3_ACCESS_KEY']
+        s3_secret_key = os.environ['S3_SECRET_KEY']
 
-    s3_access_key = os.environ['S3_ACCESS_KEY']
-    s3_secret_key = os.environ['S3_SECRET_KEY']
+        s3 = boto3.resource(
+            's3',
+            endpoint_url='http://rgw-vip.nmn',
+            aws_access_key_id=s3_access_key,
+            aws_secret_access_key=s3_secret_key,
+            verify=False)
 
-    s3 = boto3.resource(
-        's3',
-        endpoint_url='http://rgw-vip.nmn',
-        aws_access_key_id=s3_access_key,
-        aws_secret_access_key=s3_secret_key,
-        verify=False)
+        backup_bucket = s3.Bucket('postgres-backup')
+        for file in backup_bucket.objects.filter(Prefix='capsules-warehouse-server-postgres'):
+            print(file.key)
+        ```
 
-	backup_bucket = s3.Bucket('postgres-backup')
-	for file in backup_bucket.objects.filter(Prefix='capsules-warehouse-server-postgres'):
-   	    print(file.key)
-    ```
+        download.py:
 
-    download.py:
+        Update the script for the specific .manifest and .psql files you wish to download from S3.
 
-    Update the script for the specific .manifest and .psql files you wish to download from S3.
+        ```python
+        import io
+        import boto3
+        import os
 
-    ```python
-    import io
-    import boto3
-    import os
+        # postgres-backup-s3-credentials are needed to download from postgres-backup bucket
 
-    # postgres-backup-s3-credentials are needed to download from postgres-backup bucket
+        s3_access_key = os.environ['S3_ACCESS_KEY']
+        s3_secret_key = os.environ['S3_SECRET_KEY']
 
-    s3_access_key = os.environ['S3_ACCESS_KEY']
-    s3_secret_key = os.environ['S3_SECRET_KEY']
+        s3_client = boto3.client(
+            's3',
+            endpoint_url='http://rgw-vip.nmn',
+            aws_access_key_id=s3_access_key,
+            aws_secret_access_key=s3_secret_key,
+            verify=False)
 
-    s3_client = boto3.client(
-        's3',
-        endpoint_url='http://rgw-vip.nmn',
-        aws_access_key_id=s3_access_key,
-        aws_secret_access_key=s3_secret_key,
-        verify=False)
-
-    response = s3_client.download_file('postgres-backup', 'capsules-warehouse-server-postgres-2021-07-21T19:03:18.manifest', 'capsules-warehouse-server-postgres-2021-07-21T19:03:18.manifest')
-    response = s3_client.download_file('postgres-backup', 'capsules-warehouse-server-postgres-2021-07-21T19:03:18.psql', 'capsules-warehouse-server-postgres-2021-07-21T19:03:18.psql')
-    ```
+        response = s3_client.download_file('postgres-backup', 'capsules-warehouse-server-postgres-2021-07-21T19:03:18.manifest', 'capsules-warehouse-server-postgres-2021-07-21T19:03:18.manifest')
+        response = s3_client.download_file('postgres-backup', 'capsules-warehouse-server-postgres-2021-07-21T19:03:18.psql', 'capsules-warehouse-server-postgres-2021-07-21T19:03:18.psql')
+        ```
 
 2. Scale the capsules-warehouse-server service to 0.
 
@@ -784,45 +805,45 @@ In the event that the Capsules Warehouse Postgres cluster is in a state that the
 
 7. Either update or re-create the `capsules-warehouse-server-postgres` secrets.
 
-  - Update the secrets in Postgres.
+   * Update the secrets in Postgres.
 
-    If a manual dump was done, and the secrets were not saved, then the secrets in the newly created Postgres cluster will need to be updated.
+        If a manual dump was done, and the secrets were not saved, then the secrets in the newly created Postgres cluster will need to be updated.
 
-    Based off the four `capsules-warehouse-server-postgres` secrets, collect the password for each Postgres username: `postgres`, `service_account`, and `standby`. Then `kubectl exec` into the Postgres pod and update the password for each user. For example:
+        Based off the four `capsules-warehouse-server-postgres` secrets, collect the password for each Postgres username: `postgres`, `service_account`, and `standby`. Then `kubectl exec` into the Postgres pod and update the password for each user. For example:
 
-    ```bash
-    ncn-w001# for secret in postgres.capsules-warehouse-server-postgres.credentials service-account.capsules-warehouse-server-postgres.credentials standby.capsules-warehouse-server-postgres.credentials; do echo -n "secret ${secret} username & password: "; echo -n "`kubectl get secret ${secret} -n ${NAMESPACE} -ojsonpath='{.data.username}' | base64 -d` "; echo `kubectl get secret ${secret} -n ${NAMESPACE} -ojsonpath='{.data.password}'| base64 -d`; done
+        ```bash
+        ncn-w001# for secret in postgres.capsules-warehouse-server-postgres.credentials service-account.capsules-warehouse-server-postgres.credentials standby.capsules-warehouse-server-postgres.credentials; do echo -n "secret ${secret} username & password: "; echo -n "`kubectl get secret ${secret} -n ${NAMESPACE} -ojsonpath='{.data.username}' | base64 -d` "; echo `kubectl get secret ${secret} -n ${NAMESPACE} -ojsonpath='{.data.password}'| base64 -d`; done
 
-    secret postgres.capsules-warehouse-server-postgres.credentials username & password: postgres ABCXYZ
-    secret service-account.capsules-warehouse-server-postgres.credentials username & password: service_account ABC123
-    secret standby.capsules-warehouse-server-postgres.credentials username & password: standby 123456
-    ```
+        secret postgres.capsules-warehouse-server-postgres.credentials username & password: postgres ABCXYZ
+        secret service-account.capsules-warehouse-server-postgres.credentials username & password: service_account ABC123
+        secret standby.capsules-warehouse-server-postgres.credentials username & password: standby 123456
+        ```
 
-    ```bash
-    ncn-w001# kubectl exec "${POSTGRESQL}-0" -n ${NAMESPACE} -c postgres -it -- bash
-    root@capsules-warehouse-server-postgres-0:/home/postgres# /usr/bin/psql postgres postgres
-    postgres=# ALTER USER postgres WITH PASSWORD 'ABCXYZ';
-    ALTER ROLE
-    postgres=# ALTER USER service_account WITH PASSWORD 'ABC123';
-    ALTER ROLE
-    postgres=#ALTER USER standby WITH PASSWORD '123456';
-    ALTER ROLE
-    postgres=#
-    ```
+        ```bash
+        ncn-w001# kubectl exec "${POSTGRESQL}-0" -n ${NAMESPACE} -c postgres -it -- bash
+        root@capsules-warehouse-server-postgres-0:/home/postgres# /usr/bin/psql postgres postgres
+        postgres=# ALTER USER postgres WITH PASSWORD 'ABCXYZ';
+        ALTER ROLE
+        postgres=# ALTER USER service_account WITH PASSWORD 'ABC123';
+        ALTER ROLE
+        postgres=#ALTER USER standby WITH PASSWORD '123456';
+        ALTER ROLE
+        postgres=#
+        ```
 
-  - Re-create secrets in Kubernetes.
+   * Re-create secrets in Kubernetes.
 
-    If the Postgres secrets were auto-backed up, then re-create the secrets in Kubernetes.
+        If the Postgres secrets were auto-backed up, then re-create the secrets in Kubernetes.
 
-    Delete and re-create the three `capsules-warehouse-server-postgres` secrets using the manifest that was copied from S3 in step 1 above.
+        Delete and re-create the three `capsules-warehouse-server-postgres` secrets using the manifest that was copied from S3 in step 1 above.
 
-    ```bash
-    ncn-w001# MANIFEST=capsules-warehouse-server-postgres-2021-07-21T19:03:18.manifest
+        ```bash
+        ncn-w001# MANIFEST=capsules-warehouse-server-postgres-2021-07-21T19:03:18.manifest
 
-    ncn-w001# kubectl delete secret postgres.capsules-warehouse-server-postgres.credentials service-account.capsules-warehouse-server-postgres.credentials standby.capsules-warehouse-server-postgres.credentials -n ${NAMESPACE}
+        ncn-w001# kubectl delete secret postgres.capsules-warehouse-server-postgres.credentials service-account.capsules-warehouse-server-postgres.credentials standby.capsules-warehouse-server-postgres.credentials -n ${NAMESPACE}
 
-    ncn-w001# kubectl apply -f ${MANIFEST}
-    ```
+        ncn-w001# kubectl apply -f ${MANIFEST}
+        ```
 
 8. Restart the Postgres cluster.
 
@@ -851,7 +872,8 @@ In the event that the Capsules Warehouse Postgres cluster is in a state that the
     ncn-w001# while [ $(kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/name="${CLIENT}" | grep -v NAME | wc -l) != 3 ] ; do echo "  waiting for pods to start"; sleep 2; done
     ```
 
-    Also check the status of the capsules-warehouse-server pods. If there are pods that do not show that both containers are ready (READY is `2/2`), wait a few seconds and re-run the command until all containers are ready.
+    Also check the status of the capsules-warehouse-server pods.
+    If there are pods that do not show that both containers are ready (READY is `2/2`), wait a few seconds and re-run the command until all containers are ready.
 
     ```bash
     ncn-w001# kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/instance="${CLIENT}"
@@ -862,7 +884,8 @@ In the event that the Capsules Warehouse Postgres cluster is in a state that the
     capsules-warehouse-server-2   2/2     Running   0          35s
     ```
 
-11. Verify Capsules services are accessible and contain the expected data. You may need to configure your default warehouse and default warehouse user as well as login though the keycloak service depending on where you login from. It is recommended to use a UAN.
+11. Verify Capsules services are accessible and contain the expected data.
+    You may need to configure your default warehouse and default warehouse user as well as login though the Keycloak service depending on where you login from. It is recommended to use a UAN.
 
     ```bash
     ncn-w001# capsule list
@@ -874,4 +897,6 @@ In the event that the Capsules Warehouse Postgres cluster is in a state that the
 
 #### Capsules Dispatch Server
 
-The Capsules Dispatch Server can be restored in the same manner as the warehouse server by substituting the keyword `warehouse` with `dispatch`; however, the dispatch server maintains temporary information for running Capsules Environments. Therefore, restoring data to this service is not necessary. Using the analytics docs, you can instead cleanup existing jobs and skip this step.
+The Capsules Dispatch Server can be restored in the same manner as the warehouse server by substituting
+the keyword `warehouse` with `dispatch`; however, the dispatch server maintains temporary information for running Capsules Environments.
+Therefore, restoring data to this service is not necessary. Using the analytics docs, you can instead cleanup existing jobs and skip this step.

--- a/operations/kubernetes/Restore_Postgres.md
+++ b/operations/kubernetes/Restore_Postgres.md
@@ -28,60 +28,60 @@ the following procedures are recommended. This assumes that a dump of the databa
       Note that the `.psql` file contains the database dump and the `.manifest` file contains the secrets.
       The `aws_access_key_id` and `aws_secret_access_key` will need to be set based on the `postgres-backup-s3-credentials` secret.
 
-    ```bash
-    ncn-w001# export S3_ACCESS_KEY=`kubectl get secrets postgres-backup-s3-credentials -ojsonpath='{.data.access_key}' | base64 --decode`
+        ```bash
+        ncn-w001# export S3_ACCESS_KEY=`kubectl get secrets postgres-backup-s3-credentials -ojsonpath='{.data.access_key}' | base64 --decode`
 
-    ncn-w001# export S3_SECRET_KEY=`kubectl get secrets postgres-backup-s3-credentials -ojsonpath='{.data.secret_key}' | base64 --decode`
-    ```
+        ncn-w001# export S3_SECRET_KEY=`kubectl get secrets postgres-backup-s3-credentials -ojsonpath='{.data.secret_key}' | base64 --decode`
+        ```
 
-    list.py:
+        list.py:
 
-    ```python
-    import io
-    import boto3
-    import os
+        ```python
+        import io
+        import boto3
+        import os
 
-    # postgres-backup-s3-credentials are needed to list keys in the postgres-backup bucket
+        # postgres-backup-s3-credentials are needed to list keys in the postgres-backup bucket
 
-    s3_access_key = os.environ['S3_ACCESS_KEY']
-    s3_secret_key = os.environ['S3_SECRET_KEY']
+        s3_access_key = os.environ['S3_ACCESS_KEY']
+        s3_secret_key = os.environ['S3_SECRET_KEY']
 
-    s3 = boto3.resource(
-        's3',
-        endpoint_url='http://rgw-vip.nmn',
-        aws_access_key_id=s3_access_key,
-        aws_secret_access_key=s3_secret_key,
-        verify=False)
+        s3 = boto3.resource(
+            's3',
+            endpoint_url='http://rgw-vip.nmn',
+            aws_access_key_id=s3_access_key,
+            aws_secret_access_key=s3_secret_key,
+            verify=False)
 
-	backup_bucket = s3.Bucket('postgres-backup')
-	for file in backup_bucket.objects.filter(Prefix='spire-postgres'):
-   	    print(file.key)
-    ```
+        backup_bucket = s3.Bucket('postgres-backup')
+        for file in backup_bucket.objects.filter(Prefix='spire-postgres'):
+            print(file.key)
+        ```
 
-    download.py:
+        download.py:
 
-    Update the script for the specific .manifest and .psql files you wish to download from S3.
+        Update the script for the specific .manifest and .psql files you wish to download from S3.
 
-    ```python
-    import io
-    import boto3
-    import os
+        ```python
+        import io
+        import boto3
+        import os
 
-    # postgres-backup-s3-credentials are needed to download from postgres-backup bucket
+        # postgres-backup-s3-credentials are needed to download from postgres-backup bucket
 
-    s3_access_key = os.environ['S3_ACCESS_KEY']
-    s3_secret_key = os.environ['S3_SECRET_KEY']
+        s3_access_key = os.environ['S3_ACCESS_KEY']
+        s3_secret_key = os.environ['S3_SECRET_KEY']
 
-    s3_client = boto3.client(
-        's3',
-        endpoint_url='http://rgw-vip.nmn',
-        aws_access_key_id=s3_access_key,
-        aws_secret_access_key=s3_secret_key,
-        verify=False)
+        s3_client = boto3.client(
+            's3',
+            endpoint_url='http://rgw-vip.nmn',
+            aws_access_key_id=s3_access_key,
+            aws_secret_access_key=s3_secret_key,
+            verify=False)
 
-    response = s3_client.download_file('postgres-backup', 'spire-postgres-2021-07-21T19:03:18.manifest', 'spire-postgres-2021-07-21T19:03:18.manifest')
-    response = s3_client.download_file('postgres-backup', 'spire-postgres-2021-07-21T19:03:18.psql', 'spire-postgres-2021-07-21T19:03:18.psql')
-    ```
+        response = s3_client.download_file('postgres-backup', 'spire-postgres-2021-07-21T19:03:18.manifest', 'spire-postgres-2021-07-21T19:03:18.manifest')
+        response = s3_client.download_file('postgres-backup', 'spire-postgres-2021-07-21T19:03:18.psql', 'spire-postgres-2021-07-21T19:03:18.psql')
+        ```
 
 2. Scale the spire service to 0.
 
@@ -143,7 +143,10 @@ the following procedures are recommended. This assumes that a dump of the databa
         Based off the four `spire-postgres` secrets, collect the password for each Postgres username: `postgres`, `service_account`, `spire`, and `standby`. Then `kubectl exec` into the Postgres pod and update the password for each user. For example:
 
         ```bash
-        ncn-w001# for secret in postgres.spire-postgres.credentials service-account.spire-postgres.credentials spire.spire-postgres.credentials standby.spire-postgres.credentials; do echo -n "secret ${secret} username & password: "; echo -n "`kubectl get secret ${secret} -n ${NAMESPACE} -ojsonpath='{.data.username}' | base64 -d` "; echo `kubectl get secret ${secret} -n ${NAMESPACE} -ojsonpath='{.data.password}'| base64 -d`; done
+        ncn-w001# for secret in postgres.spire-postgres.credentials service-account.spire-postgres.credentials spire.
+        spire-postgres.credentials standby.spire-postgres.credentials; do echo -n "secret ${secret} username & password: "; echo 
+        -n "`kubectl get secret ${secret} -n ${NAMESPACE} -ojsonpath='{.data.username}' | base64 -d` "; echo `kubectl get secret $
+        {secret} -n ${NAMESPACE} -ojsonpath='{.data.password}'| base64 -d`; done
 
         secret postgres.spire-postgres.credentials username & password: postgres ABCXYZ
         secret service-account.spire-postgres.credentials username & password: service_account ABC123
@@ -363,7 +366,10 @@ In the event that the Keycloak Postgres cluster is in a state that the cluster m
         Based off the three `keycloak-postgres` secrets, collect the password for each Postgres username: `postgres`, `service_account`, and `standby`. Then `kubectl exec` into the Postgres pod and update the password for each user. For example:
 
         ```bash
-        ncn-w001# for secret in postgres.keycloak-postgres.credentials service-account.keycloak-postgres.credentials standby.keycloak-postgres.credentials; do echo -n "secret ${secret} username & password: "; echo -n "`kubectl get secret ${secret} -n ${NAMESPACE} -ojsonpath='{.data.username}' | base64 -d` "; echo `kubectl get secret ${secret} -n ${NAMESPACE} -ojsonpath='{.data.password}'| base64 -d`; done
+        ncn-w001# for secret in postgres.keycloak-postgres.credentials service-account.keycloak-postgres.credentials standby.
+        keycloak-postgres.credentials; do echo -n "secret ${secret} username & password: "; echo -n "`kubectl get secret $
+        {secret} -n ${NAMESPACE} -ojsonpath='{.data.username}' | base64 -d` "; echo `kubectl get secret ${secret} -n ${NAMESPACE} 
+        -ojsonpath='{.data.password}'| base64 -d`; done
 
         secret postgres.keycloak-postgres.credentials username & password: postgres ABCXYZ
         secret service-account.keycloak-postgres.credentials username & password: service_account ABC123
@@ -441,7 +447,9 @@ In the event that the Keycloak Postgres cluster is in a state that the cluster m
 
         ```bash
         ncn-w001# kubectl get job -n ${NAMESPACE} -l app.kubernetes.io/instance=cray-keycloak -o json > keycloak-setup.json
-        ncn-w001# cat keycloak-setup.json | jq '.items[0]' | jq 'del(.metadata.creationTimestamp)' | jq 'del(.metadata.managedFields)' | jq 'del(.metadata.resourceVersion)' | jq 'del(.metadata.selfLink)' | jq 'del(.metadata.uid)' | jq 'del(.spec.selector)' | jq 'del(.spec.template.metadata.labels)' | jq 'del(.status)' | kubectl replace --force -f -
+        ncn-w001# cat keycloak-setup.json | jq '.items[0]' | jq 'del(.metadata.creationTimestamp)' | jq 'del(.metadata.
+        managedFields)' | jq 'del(.metadata.resourceVersion)' | jq 'del(.metadata.selfLink)' | jq 'del(.metadata.uid)' | jq 'del(.
+        spec.selector)' | jq 'del(.spec.template.metadata.labels)' | jq 'del(.status)' | kubectl replace --force -f -
         ```
 
         Check the status of the `keycloak-setup` job. If the `COMPLETIONS` value is not `1/1`,
@@ -458,7 +466,9 @@ In the event that the Keycloak Postgres cluster is in a state that the cluster m
 
         ```bash
         ncn-w001# kubectl get job -n ${NAMESPACE} -l app.kubernetes.io/instance=cray-keycloak-users-localize -o json > cray-keycloak-users-localize.json
-        ncn-w001# cat cray-keycloak-users-localize.json | jq '.items[0]' | jq 'del(.metadata.creationTimestamp)' | jq 'del(.metadata.managedFields)' | jq 'del(.metadata.resourceVersion)' | jq 'del(.metadata.selfLink)' | jq 'del(.metadata.uid)' | jq 'del(.spec.selector)' | jq 'del(.spec.template.metadata.labels)' | jq 'del(.status)' | kubectl replace --force -f -`
+        ncn-w001# cat cray-keycloak-users-localize.json | jq '.items[0]' | jq 'del(.metadata.creationTimestamp)' | jq 'del(.
+        metadata.managedFields)' | jq 'del(.metadata.resourceVersion)' | jq 'del(.metadata.selfLink)' | jq 'del(.metadata.uid)' | 
+        jq 'del(.spec.selector)' | jq 'del(.spec.template.metadata.labels)' | jq 'del(.status)' | kubectl replace --force -f -`
         ```
 
         Check the status of the `cray-keycloak-users-localize` job.
@@ -616,7 +626,10 @@ In the event that the VCS Postgres cluster is in a state that the cluster must b
         Based off the three `gitea-vcs-postgres` secrets, collect the password for each Postgres username: `postgres`, `service_account`, and `standby`. Then `kubectl exec` into the Postgres pod and update the password for each user. For example:
 
         ```bash
-        ncn-w001# for secret in postgres.gitea-vcs-postgres.credentials service-account.gitea-vcs-postgres.credentials gitea.gitea-vcs-postgres.credentials standby.gitea-vcs-postgres.credentials; do echo -n "secret ${secret} username & password: "; echo -n "`kubectl get secret ${secret} -n ${NAMESPACE} -ojsonpath='{.data.username}' | base64 -d` "; echo `kubectl get secret ${secret} -n ${NAMESPACE} -ojsonpath='{.data.password}'| base64 -d`; done
+        ncn-w001# for secret in postgres.gitea-vcs-postgres.credentials service-account.gitea-vcs-postgres.credentials gitea.
+        gitea-vcs-postgres.credentials standby.gitea-vcs-postgres.credentials; do echo -n "secret ${secret} username & password: 
+        "; echo -n "`kubectl get secret ${secret} -n ${NAMESPACE} -ojsonpath='{.data.username}' | base64 -d` "; echo `kubectl get 
+        secret ${secret} -n ${NAMESPACE} -ojsonpath='{.data.password}'| base64 -d`; done
 
         secret postgres.gitea-vcs-postgres.credentials username & password: postgres ABCXYZ
         secret service-account.gitea-vcs-postgres.credentials username & password: service_account ABC123
@@ -812,7 +825,10 @@ In the event that the Capsules Warehouse Postgres cluster is in a state that the
         Based off the four `capsules-warehouse-server-postgres` secrets, collect the password for each Postgres username: `postgres`, `service_account`, and `standby`. Then `kubectl exec` into the Postgres pod and update the password for each user. For example:
 
         ```bash
-        ncn-w001# for secret in postgres.capsules-warehouse-server-postgres.credentials service-account.capsules-warehouse-server-postgres.credentials standby.capsules-warehouse-server-postgres.credentials; do echo -n "secret ${secret} username & password: "; echo -n "`kubectl get secret ${secret} -n ${NAMESPACE} -ojsonpath='{.data.username}' | base64 -d` "; echo `kubectl get secret ${secret} -n ${NAMESPACE} -ojsonpath='{.data.password}'| base64 -d`; done
+        ncn-w001# for secret in postgres.capsules-warehouse-server-postgres.credentials service-account.
+        capsules-warehouse-server-postgres.credentials standby.capsules-warehouse-server-postgres.credentials; do echo -n "secret 
+        ${secret} username & password: "; echo -n "`kubectl get secret ${secret} -n ${NAMESPACE} -ojsonpath='{.data.username}' | 
+        base64 -d` "; echo `kubectl get secret ${secret} -n ${NAMESPACE} -ojsonpath='{.data.password}'| base64 -d`; done
 
         secret postgres.capsules-warehouse-server-postgres.credentials username & password: postgres ABCXYZ
         secret service-account.capsules-warehouse-server-postgres.credentials username & password: service_account ABC123

--- a/operations/kubernetes/Restore_Postgres.md
+++ b/operations/kubernetes/Restore_Postgres.md
@@ -24,7 +24,7 @@ the following procedures are recommended. This assumes that a dump of the databa
       It will be needed in the steps below.
     * If the database is being automatically backed up, then the most recent version of the dump and the secrets should exist in the `postgres-backup` S3 bucket.
       These will be needed in the steps below. List the files in the `postgres-backup` S3 bucket and if the files exist, download the dump and secrets out of the S3 bucket.
-      The python3 scripts below can be used to help list and download the files.
+      The `python3` scripts below can be used to help list and download the files.
       Note that the `.psql` file contains the database dump and the `.manifest` file contains the secrets.
       The `aws_access_key_id` and `aws_secret_access_key` will need to be set based on the `postgres-backup-s3-credentials` secret.
 
@@ -244,7 +244,7 @@ In the event that the Keycloak Postgres cluster is in a state that the cluster m
       It will be needed in the steps below.
     * If the database is being automatically backed up, then the most recent version of the dump and the secrets should exist in the `postgres-backup` S3 bucket.
       These will be needed in the steps below. List the files in the `postgres-backup` S3 bucket and if the files exist, download the dump and secrets out of the S3 bucket.
-      The python3 scripts below can be used to help list and download the files.
+      The `python3` scripts below can be used to help list and download the files.
       Note that the `.psql` file contains the database dump and the `.manifest` file contains the secrets.
       The `aws_access_key_id` and `aws_secret_access_key` will need to be set based on the `postgres-backup-s3-credentials` secret.
 
@@ -497,7 +497,7 @@ In the event that the VCS Postgres cluster is in a state that the cluster must b
       It will be needed in the steps below.
     * If the database is being automatically backed up, then the most recent version of the dump and the secrets should exist in the `postgres-backup` S3 bucket.
       These will be needed in the steps below. List the files in the `postgres-backup` S3 bucket and if the files exist, download the dump and secrets out of the S3 bucket.
-      The python3 scripts below can be used to help list and download the files.
+      The `python3` scripts below can be used to help list and download the files.
       Note that the `.psql` file contains the database dump and the `.manifest` file contains the secrets.
       The `aws_access_key_id` and `aws_secret_access_key` will need to be set based on the `postgres-backup-s3-credentials` secret.
 
@@ -580,7 +580,7 @@ In the event that the VCS Postgres cluster is in a state that the cluster must b
     ncn-w001# while [ $(kubectl get pods -l "application=spilo,cluster-name=${POSTGRESQL}" -n ${NAMESPACE} | grep -v NAME | wc -l) != 0 ] ; do echo "  waiting for pods to terminate"; sleep 2; done
     ```
 
-4. Create a new single instance vcs Postgres cluster.
+4. Create a new single instance VCS Postgres cluster.
 
     ```bash
     ncn-w001# cp postgres-cr.json postgres-orig-cr.json
@@ -693,7 +693,7 @@ In the event that the Capsules Warehouse Postgres cluster is in a state that the
       It will be needed in the steps below.
     * If the database is being automatically backed up, then the most recent version of the dump and the secrets should exist in the `postgres-backup` S3 bucket.
       These will be needed in the steps below. List the files in the `postgres-backup` S3 bucket and if the files exist, download the dump and secrets out of the S3 bucket.
-      The python3 scripts below can be used to help list and download the files.
+      The `python3` scripts below can be used to help list and download the files.
       Note that the `.psql` file contains the database dump and the `.manifest` file contains the secrets.
       The `aws_access_key_id` and `aws_secret_access_key` will need to be set based on the `postgres-backup-s3-credentials` secret.
 

--- a/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System.md
+++ b/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System.md
@@ -349,7 +349,7 @@ Use boot orchestration to power on and boot the nodes. Specify the appropriate B
 
 16. Determine how the BOS Session template references compute hosts.
     
-    Typically, they are referenced by their "Compute" role. However, if they are referenced by xname, then these new nodes should added to the BOS Session template.
+    Typically, they are referenced by their `Compute` role. However, if they are referenced by component name (xname), then these new nodes should added to the BOS Session template.
     
     ```bash
     ncn-m001# BOS_TEMPLATE=cos-2.0.30-slurm-healthy-compute
@@ -367,7 +367,7 @@ Use boot orchestration to power on and boot the nodes. Specify the appropriate B
           ncn-m001# cray bos sessiontemplate describe $BOS_TEMPLATE --format json > tmp.txt
           ```
        
-       2. Edit the tmp.txt file adding the new nodes to the node_list.
+       2. Edit the `tmp.txt` file, adding the new nodes to the node_list.
           
           ```bash
           ncn-m001# vi tmp.txt
@@ -375,9 +375,9 @@ Use boot orchestration to power on and boot the nodes. Specify the appropriate B
 
     2. Create the Session template.
        
-       1. The name of the Session template is determined by the name provided to the '--name' option on the command line. Use the current value of $BOS_TEMPLATE if you want to overwrite the existing Session template. If you want to use the current value, skip this sub-step and go on to sub-step 2. Otherwise, provide a different name for BOS_TEMPLATE which will be used the '--name' option. The name specified in tmp.txt is overridden by the value provided by the '--name' option.
+       1. The name of the Session template is determined by the name provided to the `--name` option on the command line. Use the current value of `$BOS_TEMPLATE` if you want to overwrite the existing Session template. If you want to use the current value, skip this sub-step and go on to sub-step 2. Otherwise, provide a different name for `BOS_TEMPLATE` which will be used with the `--name` option. The name specified in `tmp.txt` is overridden by the value provided by the `--name` option.
   	    
-       ```bash
+           ```bash
 	   ncn-m001# $BOS_TEMPLATE=<New Session Template name>
 	   ```
 	   

--- a/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System.md
+++ b/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System.md
@@ -348,38 +348,53 @@ This procedure will add a liquid-cooled blades from an HPE Cray EX system.
 Use boot orchestration to power on and boot the nodes. Specify the appropriate BOS template for the node type.
 
 16. Determine how the BOS Session template references compute hosts.
+    
     Typically, they are referenced by their "Compute" role. However, if they are referenced by xname, then these new nodes should added to the BOS Session template.
-      ```bash
-      ncn-m001# BOS_TEMPLATE=cos-2.0.30-slurm-healthy-compute
-      ncn-m001# cray bos sessiontemplate describe $BOS_TEMPLATE --format json|jq '.boot_sets[] | select(.node_list)'
-      ```
+    
+    ```bash
+    ncn-m001# BOS_TEMPLATE=cos-2.0.30-slurm-healthy-compute
+    ncn-m001# cray bos sessiontemplate describe $BOS_TEMPLATE --format json|jq '.boot_sets[] | select(.node_list)'
+    ```
+    
     If this query returns empty, then skip to sub-step 3.
     If this query returns with data, then one or more boot sets within the BOS Session template reference nodes explicitly by xname. Consider adding your new nodes to this list (sub-step 1) or adding them on the command line (sub-step 2).
 
     1. Adding new nodes to your list.
-          1. Dump the current Session template.
-             ```bash
-             ncn-m001# cray bos sessiontemplate describe $BOS_TEMPLATE --format json > tmp.txt
-             ```
-          2. Edit the tmp.txt file adding the new nodes to the node_list.
-             ```bash
-             ncn-m001# vi tmp.txt
-             ```
+       
+       1. Dump the current Session template.
+          
+          ```bash
+          ncn-m001# cray bos sessiontemplate describe $BOS_TEMPLATE --format json > tmp.txt
+          ```
+       
+       2. Edit the tmp.txt file adding the new nodes to the node_list.
+          
+          ```bash
+          ncn-m001# vi tmp.txt
+          ```
+
     2. Create the Session template.
-         1. The name of the Session template is determined by the name provided to the '--name' option on the command line. Use the current value of $BOS_TEMPLATE if you want to overwrite the existing Session template. If you want to use the current value, skip this sub-step and go on to sub-step 2. Otherwise, provide a different name for BOS_TEMPLATE which will be used the '--name' option. The name specified in tmp.txt is overridden by the value provided by the '--name' option.
-  	    ```bash
-	    ncn-m001# $BOS_TEMPLATE=<New Session Template name>
-	    ```
-	 2. Create the Session template.
-            ```bash
-            ncn-m001# cray bos sessiontemplate create --file tmp.txt --name $BOS_TEMPLATE
-            ```
-         3. Verify that the Session template contains the additional nodes and the proper name.
-            ```bash
-            ncn-m001# cray bos sessiontemplate describe $BOS_TEMPLATE --format json
-            ```
+       
+       1. The name of the Session template is determined by the name provided to the '--name' option on the command line. Use the current value of $BOS_TEMPLATE if you want to overwrite the existing Session template. If you want to use the current value, skip this sub-step and go on to sub-step 2. Otherwise, provide a different name for BOS_TEMPLATE which will be used the '--name' option. The name specified in tmp.txt is overridden by the value provided by the '--name' option.
+  	    
+       ```bash
+	   ncn-m001# $BOS_TEMPLATE=<New Session Template name>
+	   ```
+	   
+       2. Create the Session template.
+          
+          ```bash
+          ncn-m001# cray bos sessiontemplate create --file tmp.txt --name $BOS_TEMPLATE
+          ```
+         
+       3. Verify that the Session template contains the additional nodes and the proper name.
+          
+          ```bash
+          ncn-m001# cray bos sessiontemplate describe $BOS_TEMPLATE --format json
+          ```
 
     3. Boot the nodes.
+       
        ```bash
        ncn-m001# cray bos session create --template-uuid $BOS_TEMPLATE \
          --operation reboot --limit x1005c3s0b0n0,x1005c3s0b0n1,x1005c3s0b1n0,x1005c3s0b1n1

--- a/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System.md
+++ b/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System.md
@@ -202,7 +202,7 @@ This procedure will add a liquid-cooled blades from an HPE Cray EX system.
 
     1. Repeat the preceding command for each node in the blade.
 
-#### Re-enable hms-discovery cron job
+#### Re-enable `hms-discovery` cronjob
 
 1. Rediscover the `ChassisBMC` (the example shows cabinet 1005, chassis 3).
    Rediscovering the `ChassisBMC` will update HSM to become aware of the newly populated slot and allow CAPMC to perform power actions on the slot.

--- a/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System.md
+++ b/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System.md
@@ -1,21 +1,18 @@
-# Adding a Liquid-cooled blade to a System
+# Adding a Liquid-cooled Blade to a System
 
 This procedure will add a liquid-cooled blades from an HPE Cray EX system.
 
-## Perquisites
--   The Cray command line interface \(CLI\) tool is initialized and configured on the system.
+## Prerequisites
 
--   Knowledge of whether DVS is operating over the Node Management Network (NMN) or the High Speed Network (HSN).
-
--   Blade is being added to an existing liquid-cooled cabinet in the system.
-
--   The Slingshot fabric must be configured with the desired topology for desired state of the blades in the system.
-
--   The System Layout Service (SLS) must have the desired HSN configuration.
-
--   Check the status of the high-speed network (HSN) and record link status before the procedure.
-
--   Review the following command examples. The commands can be used to capture the required values from the HSM `ethernetInterfaces` table and write the values to a file. The file then can be used to automate subsequent commands in this procedure, for example:
+* The Cray command line interface \(CLI\) tool is initialized and configured on the system.
+* Knowledge of whether DVS is operating over the Node Management Network (NMN) or the High Speed Network (HSN).
+* Blade is being added to an existing liquid-cooled cabinet in the system.
+* The Slingshot fabric must be configured with the desired topology for desired state of the blades in the system.
+* The System Layout Service (SLS) must have the desired HSN configuration.
+* Check the status of the high-speed network (HSN) and record link status before the procedure.
+* Review the following command examples.
+  The commands can be used to capture the required values from the HSM `ethernetInterfaces` table and write the values to a file.
+  The file then can be used to automate subsequent commands in this procedure, for example:
 
     ```bash
     ncn-m001# mkdir blade_swap_scripts; cd blade_swap_scripts
@@ -27,7 +24,8 @@ This procedure will add a liquid-cooled blades from an HPE Cray EX system.
 
     BLADE_DOT=$BLADE.
 
-    cray hsm inventory ethernetInterfaces list --format json | jq -c --arg BLADE "$BLADE_DOT" 'map(select(.ComponentID|test($BLADE))) | map(select(.Description == "Node Maintenance Network")) | .[] | {xname: .ComponentID, ID: .ID,MAC: .MACAddress, IP: .IPAddresses[0].IPAddress,Desc: .Description}' > $OUTFILE
+    cray hsm inventory ethernetInterfaces list --format json | jq -c --arg BLADE "$BLADE_DOT" 'map(select(.ComponentID|test
+    ($BLADE))) | map(select(.Description == "Node Maintenance Network")) | .[] | {xname: .ComponentID, ID: .ID,MAC: .MACAddress, IP: .IPAddresses[0].IPAddress,Desc: .Description}' > $OUTFILE
     ```
 
     ```bash
@@ -48,40 +46,44 @@ This procedure will add a liquid-cooled blades from an HPE Cray EX system.
     To insert an `ethernetInterfaces` entry using curl:
 
     ```bash
-    ncn-m001# while read  PAYLOAD ; do curl -H "Authorization: Bearer $TOKEN" -L -X POST 'https://api-gw-service-nmn.local/apis/smd/hsm/v1/Inventory/EthernetInterfaces' -H 'Content-Type: application/json' --data-raw "$(echo $PAYLOAD | jq -c '{ComponentID: .xname,Description: .Desc,MACAddress: .MAC,IPAddress: .IP}')";sleep 5;  done < x1000c0s1.json
+    ncn-m001# while read  PAYLOAD ; do curl -H "Authorization: Bearer $TOKEN" -L -X POST 'https://api-gw-service-nmn.local/apis/
+    smd/hsm/v1/Inventory/EthernetInterfaces' -H 'Content-Type: application/json' --data-raw "$(echo $PAYLOAD | jq -c '{ComponentID: .xname,Description: .Desc,MACAddress: .MAC,IPAddress: .IP}')";sleep 5;  done < x1000c0s1.json
     ```
 
-- The blades must have the coolant drained and filled during the swap to minimize cross-contamination of cooling systems.
-  - Review procedures in *HPE Cray EX Coolant Service Procedures H-6199*
-  - Review the *HPE Cray EX Hand Pump User Guide H-6200*
-
+* The blades must have the coolant drained and filled during the swap to minimize cross-contamination of cooling systems.
+  * Review procedures in *HPE Cray EX Coolant Service Procedures H-6199*
+  * Review the *HPE Cray EX Hand Pump User Guide H-6200*
 
 ## Procedure
-1.  Suspend the hms-discovery cron job to disable it.
+
+1. Suspend the `hms-discovery` cronjob to disable it.
 
     ```bash
     ncn-m001# kubectl -n services patch cronjobs hms-discovery -p '{"spec" : {"suspend" : true }}'
     ```
 
-    Verify that the hms-discovery cron job has stopped.
+    Verify that the `hms-discovery` cronjob has stopped.
 
     ```bash
     ncn-m001# kubectl get cronjobs -n services hms-discovery
     ```
 
     Example output. Note the `ACTIVE` = `0` and is `SUSPEND` = `True` in the output indicating the job has been suspended:
-    ```
+
+    ```text
     NAME             SCHEDULE        SUSPEND     ACTIVE   LAST   SCHEDULE  AGE
     hms-discovery    */3 * * * *     True         0       117s             15d
     ```
 
-2.  Determine if the destination chassis slot is populated. This example is checking slot 0 in chassis 3 of cabinet x1005.
+1. Determine if the destination chassis slot is populated. This example is checking slot 0 in chassis 3 of cabinet `x1005`.
+
     ```bash
     ncn-m001# cray hsm state components describe x1005c3s0
     ```
 
     Example output:
-    ```
+
+    ```text
     ID = "x1005c3s0"
     Type = "ComputeModule"
     State = "Empty"
@@ -95,26 +97,31 @@ This procedure will add a liquid-cooled blades from an HPE Cray EX system.
     If the state of the slot is `On` or `Off`, then the chassis slot is populated.
     If the state of the slot is `Empty`, then the chassis slot is not populated.
 
-3.  **Skip this step if the chassis slot is unpopulated**. Verify the chassis slot is powered off.
+1. **Skip this step if the chassis slot is unpopulated**.
+   Verify the chassis slot is powered off.
+
     ```bash
     ncn-m001# cray capmc get_xname_status create --xnames x1005c3s0
     ```
 
     Example output:
-    ```
+
+    ```text
     e = 0
     err_msg = ""
     off = [ "x1005c3s0",]
     ```
 
     If the slot is powered on, then power the chassis slot off.
-    ```
+
+    ```bash
     ncn-m001# cray capmc component name (xname)_off create --xnames x1005c3s0 --recursive true
     ```
 
-4.  Install the the blade into the system into the desired location.
+1. Install the the blade into the system into the desired location.
 
-5.  Obtain an authentication token to access the API gateway.
+1. Obtain an authentication token to access the API gateway.
+
     ```bash
     ncn-m001# export TOKEN=$(curl -s -S -d grant_type=client_credentials \
                           -d client_id=admin-client \
@@ -123,11 +130,18 @@ This procedure will add a liquid-cooled blades from an HPE Cray EX system.
     ```
 
 ### Preserve node component name (xname) to IP address mapping
-6.  **Skip this step if DVS is operating over the HSN, otherwise proceed with this step.** When DVS is operating over the NMN and a blade is being replaced, the mapping of node component name (xname) to node IP address must be preserved. Kea automatically adds entries to the HSM `ethernetInterfaces` table when DHCP lease is provided (about every 5 minutes). To prevent from Kea from automatically adding MAC entries to the HSM `ethernetInterfaces` table, use the following commands:
 
-    1.  Create an `eth_interfaces` file that contains the interface IDs for the `Node Maintenance Network` entries for the destination blade location. If there has not been a blade previously in the destination location there may not be any Ethernet Interfaces to delete from HSM.
+1. **Skip this step if DVS is operating over the HSN, otherwise proceed with this step.**
+   When DVS is operating over the NMN and a blade is being replaced, the mapping of node component name (xname) to node IP address must be preserved.
+   Kea automatically adds entries to the HSM `ethernetInterfaces` table when DHCP lease is provided (about every 5 minutes).
+   To prevent from Kea from automatically adding MAC entries to the HSM `ethernetInterfaces` table, use the following commands:
 
-        The `blade_query.sh` script from the perquisites section can help determine the IDs for the HSM Ethernet Interfaces associated with the blade if any. It is expected that if a blade has not been populated in the slot before that no HSM Ethernet Interfaces IDs would be found.
+    1. Create an `eth_interfaces` file that contains the interface IDs for the `Node Maintenance Network` entries for the destination blade location.
+
+        If there has not been a blade previously in the destination location there may not be any Ethernet Interfaces to delete from HSM.
+
+        The `blade_query.sh` script from the perquisites section can help determine the IDs for the HSM Ethernet Interfaces associated with the blade if any.
+        It is expected that if a blade has not been populated in the slot before that no HSM Ethernet Interfaces IDs would be found.
 
         ```bash
         ncn-m001# cat eth_interfaces
@@ -137,7 +151,8 @@ This procedure will add a liquid-cooled blades from an HPE Cray EX system.
         0040a68362e3
         ```
 
-    2.  Run the following commands in succession to remove the interfaces if any. Delete the cray-dhcp-kea pod to prevent the interfaces from being re-created.
+    1. Run the following commands in succession to remove the interfaces if any.
+       Delete the `cray-dhcp-kea` pod to prevent the interfaces from being re-created.
 
         ```bash
         ncn-m001# kubectl get pods -Ao wide | grep kea
@@ -146,9 +161,13 @@ This procedure will add a liquid-cooled blades from an HPE Cray EX system.
         ncn-m001# for ETH in $(cat eth_interfaces); do cray hsm inventory ethernetInterfaces delete $ETH --format json ; done
         ```
 
-    3.  **Skip this step if the destination blade location has not been previously populated with a blade** Add the MAC and IP addresses and also the `Node Maintenance Network` description to the interfaces. The ComponentID and IPAddress must be the values recorded from the blade previously in the destination location and the MACAddress must be the value recorded from the blade. These values were recorded if the blade was removed via the [Removing a Liquid-cooled blade from a System](Removing_a_Liquid-cooled_blade_from_a_System.md) procedure.
+    1. **Skip this step if the destination blade location has not been previously populated with a blade**.
+       Add the MAC and IP addresses and also the `Node Maintenance Network` description to the interfaces.
+       The `ComponentID` and `IPAddress` must be the values recorded from the blade previously in the destination
+       location and the MACAddress must be the value recorded from the blade.
 
         Values recorded from the blade that was was previously in the slot.
+
         ```bash
         ComponentID: "x1005c3s0b0n0"
         MACAddress: "00:40:a6:83:63:99"
@@ -169,6 +188,7 @@ This procedure will add a liquid-cooled blades from an HPE Cray EX system.
         ```
 
         **Note:** Kea may must be restarted when the curl command is issued.
+
         ```bash
         ncn-m001# kubectl delete pods -n services -l app.kubernetes.io/name=cray-dhcp-kea
         ```
@@ -180,23 +200,26 @@ This procedure will add a liquid-cooled blades from an HPE Cray EX system.
             'https://api-gw-service-nmn.local/apis/smd/hsm/v1/Inventory/EthernetInterfaces/0040a68350a4' -H 'Content-Type: application/json' --data-raw '{"MACAddress":"xx:xx:xx:xx:xx:xx","IPAddress":"10.xxx.xxx.xxx","ComponentID":"XNAME"}'
         ```
 
-    4.  Repeat the preceding command for each node in the blade.
+    1. Repeat the preceding command for each node in the blade.
 
 #### Re-enable hms-discovery cron job
-7. Rediscover the ChassisBMC (the example shows cabinet 1005, chassis 3). Rediscovering the ChassisBMC will update HSM to become aware of the newly populated slot and allow CAPMC to perform power actions on the slot.
+
+1. Rediscover the `ChassisBMC` (the example shows cabinet 1005, chassis 3).
+   Rediscovering the `ChassisBMC` will update HSM to become aware of the newly populated slot and allow CAPMC to perform power actions on the slot.
 
     ```bash
     ncn-m001# cray hsm inventory discover create --xnames x1005c3b0
     ```
 
-8.  Verify that discovery of the ChassisBMC has completed (`LastDiscoveryStatus` = "`DiscoverOK`").
+1. Verify that discovery of the `ChassisBMC` has completed (`LastDiscoveryStatus` = "`DiscoverOK`").
 
     ```bash
     ncn-m001# cray hsm inventory redfishEndpoints describe x1005c3b0 --format json
     ```
 
     Example output:
-    ```
+
+    ```text
     {
         "ID": "x1005c3b0",
         "Type": "ChassisBMC",
@@ -216,39 +239,41 @@ This procedure will add a liquid-cooled blades from an HPE Cray EX system.
     }
     ```
 
-9. Unsuspend the hms-discovery cronjob to re-enable the hms-discovery job.
+1. Unsuspend the `hms-discovery` cronjob to re-enable the `hms-discovery` job.
 
     ```bash
     ncn-m001# kubectl -n services patch cronjobs hms-discovery \
       -p '{"spec" : {"suspend" : false }}'
     ```
 
-    Verify the hms-discovery job has been unsuspended:
+    Verify the `hms-discovery` job has been unsuspended:
+
     ```bash
     ncn-m001# kubectl get cronjobs.batch -n services hms-discovery
     ```
 
     Example output. Note the `ACTIVE` = `1` and is `SUSPEND` = `False` in the output indicating the job has been unsuspended:
-    ```
+
+    ```text
     NAME             SCHEDULE      SUSPEND   ACTIVE   LAST   SCHEDULE  AGE
     hms-discovery    */3 * * * *   False       1      41s              33d
     ```
 
 #### Enable and power on the chassis slot
 
-10. Enable the chassis slot. The example enables slot 0, chassis 3, in cabinet 1005.
+1. Enable the chassis slot. The example enables slot 0, chassis 3, in cabinet 1005.
 
     ```bash
     ncn-m001# cray hsm state components enabled update --enabled true x1005c3s0
     ```
 
-11. Power on the chassis slot. The example powers on slot 0, chassis 3, in cabinet 1005.
+1. Power on the chassis slot. The example powers on slot 0, chassis 3, in cabinet 1005.
 
     ```bash
     ncn-m001# cray capmc component name (xname)_on create --xnames x1005c3s0 --recursive true
     ```
 
-12. Wait at least 3 minutes for the blade to power on and the node controllers (BMCs) to be discovered.
+1. Wait at least 3 minutes for the blade to power on and the node controllers (BMCs) to be discovered.
 
     ```bash
     ncn-m001# sleep 180
@@ -256,79 +281,87 @@ This procedure will add a liquid-cooled blades from an HPE Cray EX system.
 
 #### Verify discovery has completed
 
-13. To verify the two Node BMCs in the blade have been discovered by the HSM, run this command for each BMC in the blade (x1005c3s0b0 and x1005c3s0b1).
+1. To verify the two Node BMCs in the blade have been discovered by the HSM, run this command for each BMC in the blade (`x1005c3s0b0` and `x1005c3s0b1`).
 
     ```bash
     ncn-m001# cray hsm inventory redfishEndpoints describe x1005c3s0b0 --format json
     {
-    	"ID": "x1005c3s0b0",
-    	"Type": "NodeBMC",
-    	"Hostname": "x1005c3s0b0",
-    	"Domain": "",
-    	"FQDN": "x1005c3s0b0",
-    	"Enabled": true,
-    	"User": "root",
-    	"Password": "",
-    	"MACAddr": "02:03:E8:00:31:00",
-    	"RediscoverOnUpdate": true,
-    	"DiscoveryInfo": {
-    		"LastDiscoveryAttempt": "2021-06-10T18:01:59.920850Z",
-    		"LastDiscoveryStatus": "DiscoverOK",
-    		"RedfishVersion": "1.2.0"
-    	}
+        "ID": "x1005c3s0b0",
+        "Type": "NodeBMC",
+        "Hostname": "x1005c3s0b0",
+        "Domain": "",
+        "FQDN": "x1005c3s0b0",
+        "Enabled": true,
+        "User": "root",
+        "Password": "",
+        "MACAddr": "02:03:E8:00:31:00",
+        "RediscoverOnUpdate": true,
+        "DiscoveryInfo": {
+            "LastDiscoveryAttempt": "2021-06-10T18:01:59.920850Z",
+            "LastDiscoveryStatus": "DiscoverOK",
+            "RedfishVersion": "1.2.0"
+        }
     }
     ```
 
-    - When `LastDiscoveryStatus` displays as `DiscoverOK`, the node BMC has been successfully discovered.
-    - If the last discovery state is `DiscoveryStarted` then the BMC is currently being inventoried by HSM.
-    - If the last discovery state is `HTTPsGetFailed` or `ChildVerificationFailed`, then an error has
+    * When `LastDiscoveryStatus` displays as `DiscoverOK`, the node BMC has been successfully discovered.
+    * If the last discovery state is `DiscoveryStarted` then the BMC is currently being inventoried by HSM.
+    * If the last discovery state is `HTTPsGetFailed` or `ChildVerificationFailed`, then an error has
       occurred during the discovery process.
 
     **Troubleshooting**:
-    - If the redfish endpoint does not exist for a BMC verify the following:
+
+    * If the Redfish endpoint does not exist for a BMC verify the following:
 
         Verify the Node BMC is pingable:
+
         ```bash
         ncn-m001# ping x1005c3s0b0
         ```
 
         If the BMC is not pingable, verify the chassis slot has power.
+
         ```bash
         ncn-m001# cray capmc get_xname_status create --xnames x1005c3s0
         ```
 
-    - If the redfish endpoint is in `HTTPsGetFailed`:
+    * If the Redfish endpoint is in `HTTPsGetFailed`:
 
         Verify the Node BMC is pingable:
+
         ```bash
         ncn-m001# ping x1005c3s0b0
         ```
 
         If the BMC is pingable, verify the node BMC is configured with expected credentials.
+
         ```bash
         ncn-m001# curl -k -u root:password https://x1005c3s0b0/redfish/v1/Managers
         ```
 
-14. Enable the nodes in the HSM database.
+1. Enable the nodes in the HSM database.
 
     For a blade with four nodes per blade:
+
     ```bash
     ncn-m001# cray hsm state components bulkEnabled update --enabled true --component-ids x1005c3s0b0n0,x1005c3s0b0n1,x1005c3s0b1n0,x1005c3s0b1n1
     ```
 
     For a blade with two nodes per blade:
+
     ```bash
     ncn-m001# cray hsm state components bulkEnabled update --enabled true --component-ids x1005c3s0b0n0,x1005c3s0b1n0
     ```
 
-15. Verify that the nodes are enabled in the HSM.
+1. Verify that the nodes are enabled in the HSM.
 
     ```bash
     ncn-m001# cray hsm state components query create --component-ids x1005c3s0b0n0,x1005c3s0b0n1,x1005c3s0b1n0,x1005c3s0b1n1
     ```
 
     Example output:
-    ```
+
+    ```text
     [[Components]]
     ID = x1005c3s0b0n0
     Type = "Node"
@@ -347,76 +380,81 @@ This procedure will add a liquid-cooled blades from an HPE Cray EX system.
 
 Use boot orchestration to power on and boot the nodes. Specify the appropriate BOS template for the node type.
 
-16. Determine how the BOS Session template references compute hosts.
-    
+1. Determine how the BOS Session template references compute hosts.
+
     Typically, they are referenced by their `Compute` role. However, if they are referenced by component name (xname), then these new nodes should added to the BOS Session template.
-    
+
     ```bash
     ncn-m001# BOS_TEMPLATE=cos-2.0.30-slurm-healthy-compute
     ncn-m001# cray bos sessiontemplate describe $BOS_TEMPLATE --format json|jq '.boot_sets[] | select(.node_list)'
     ```
-    
+
     If this query returns empty, then skip to sub-step 3.
-    If this query returns with data, then one or more boot sets within the BOS Session template reference nodes explicitly by xname. Consider adding your new nodes to this list (sub-step 1) or adding them on the command line (sub-step 2).
+    If this query returns with data, then one or more boot sets within the BOS Session template reference nodes explicitly by xname.
+    Consider adding your new nodes to this list (sub-step 1) or adding them on the command line (sub-step 2).
 
     1. Adding new nodes to your list.
-       
+
        1. Dump the current Session template.
-          
+
           ```bash
           ncn-m001# cray bos sessiontemplate describe $BOS_TEMPLATE --format json > tmp.txt
           ```
-       
-       2. Edit the `tmp.txt` file, adding the new nodes to the node_list.
-          
+
+       2. Edit the `tmp.txt` file, adding the new nodes to the `node_list`.
+
           ```bash
           ncn-m001# vi tmp.txt
           ```
 
     2. Create the Session template.
-       
+
        1. The name of the Session template is determined by the name provided to the `--name` option on the command line. Use the current value of `$BOS_TEMPLATE` if you want to overwrite the existing Session template. If you want to use the current value, skip this sub-step and go on to sub-step 2. Otherwise, provide a different name for `BOS_TEMPLATE` which will be used with the `--name` option. The name specified in `tmp.txt` is overridden by the value provided by the `--name` option.
-  	    
-           ```bash
-	   ncn-m001# $BOS_TEMPLATE=<New Session Template name>
-	   ```
-	   
+
+            ```bash
+            ncn-m001# $BOS_TEMPLATE=<New Session Template name>
+            ```
+
        2. Create the Session template.
-          
+
           ```bash
           ncn-m001# cray bos sessiontemplate create --file tmp.txt --name $BOS_TEMPLATE
           ```
-         
+
        3. Verify that the Session template contains the additional nodes and the proper name.
-          
+
           ```bash
           ncn-m001# cray bos sessiontemplate describe $BOS_TEMPLATE --format json
           ```
 
     3. Boot the nodes.
-       
+
        ```bash
        ncn-m001# cray bos session create --template-uuid $BOS_TEMPLATE \
          --operation reboot --limit x1005c3s0b0n0,x1005c3s0b0n1,x1005c3s0b1n0,x1005c3s0b1n1
        ```
 
 #### Check firmware
-17. Verify that the correct firmware versions for node BIOS, node controller (nC), NIC mezzanine card (NMC), GPUs, and so on.
+
+1. Verify that the correct firmware versions for node BIOS, node controller (nC), NIC mezzanine card (NMC), GPUs, and so on.
+
     1. Review [FAS Admin Procedures](../firmware/FAS_Admin_Procedures.md) to perform a dry run using FAS to verify firmware versions.
 
     2. If necessary update firmware with FAS. See [Update Firmware with FAS](../firmware/Update_Firmware_with_FAS.md) for more information.
+
 #### Check DVS
 
-There should be a cray-cps pod (the broker), three cray-cps-etcd pods and their waiter, and at least one cray-cps-cm-pm pod. Usually there are two cray-cps-cm-pm pods, one on ncn-w002 and one on ncn-w003 and other worker nodes
+There should be a `cray-cps` pod (the broker), three `cray-cps-etcd` pods and their waiter, and at least one `cray-cps-cm-pm` pod. Usually there are two `cray-cps-cm-pm` pods, one on `ncn-w002` and one on `ncn-w003` and other worker nodes.
 
-18. Check the cray-cps pods on worker nodes and verify they are `Running`.
+1. Check the `cray-cps` pods on worker nodes and verify they are `Running`.
 
     ```bash
     ncn-m001# kubectl get pods -Ao wide | grep cps
     ```
 
     Example output:
-    ```
+
+    ```text
     services   cray-cps-75cffc4b94-j9qzf    2/2  Running   0   42h 10.40.0.57  ncn-w001
     services   cray-cps-cm-pm-g6tjx         5/5  Running   21  41h 10.42.0.77  ncn-w003
     services   cray-cps-cm-pm-kss5k         5/5  Running   21  41h 10.39.0.80  ncn-w002
@@ -426,14 +464,15 @@ There should be a cray-cps pod (the broker), three cray-cps-etcd pods and their 
     services   cray-cps-wait-for-etcd-jb95m 0/1  Completed
     ```
 
-19. SSH to each worker node running CPS/DVS, and run `dmesg -T` to ensure that there are no recurring `"DVS: merge_one" ` error messages as shown. The error messages indicate that DVS is detecting an IP address change for one of the client nodes.
+1. SSH to each worker node running CPS/DVS, and run `dmesg -T` to ensure that there are no recurring `"DVS: merge_one"` error messages as shown. The error messages indicate that DVS is detecting an IP address change for one of the client nodes.
 
     ```bash
     ncn-m001# dmesg -T | grep "DVS: merge_one"
     ```
 
     Example output:
-    ```
+
+    ```text
     [Tue Jul 21 13:09:54 2020] DVS: merge_one#351: New node map entry does not match the existing entry
     [Tue Jul 21 13:09:54 2020] DVS: merge_one#353:   nid: 8 -> 8
     [Tue Jul 21 13:09:54 2020] DVS: merge_one#355:   name: 'x3000c0s19b1n0' -> 'x3000c0s19b1n0'
@@ -441,21 +480,27 @@ There should be a cray-cps pod (the broker), three cray-cps-etcd pods and their 
     [Tue Jul 21 13:09:54 2020] DVS: merge_one#358:   Ignoring.
     ```
 
-20. Make sure the Configuration Framework Service (CFS) finished successfully. Review *HPE Cray EX DVS Administration Guide 1.4.1 S-8004*.
+1. Make sure the Configuration Framework Service (CFS) finished successfully. Review *HPE Cray EX DVS Administration Guide 1.4.1 `S-8004`*.
 
-21. SSH to the node and check each DVS mount.
+1. SSH to the node and check each DVS mount.
 
     ```bash
     nid# mount | grep dvs | head -1
     ```
 
     Example output:
+
+    ```text
+    /var/lib/cps-local/0dbb42538e05485de6f433a28c19e200 on /var/opt/cray/gpu/nvidia-squashfs-21.3 type dvs (ro,relatime,
+    blksize=524288,statsfile=/sys/kernel/debug/dvs/mounts/1/stats,attrcache_timeout=14400,cache,nodatasync,noclosesync,retry,
+    failover,userenv,noclusterfs,killprocess,noatomic,nodeferopens,no_distribute_create_ops,no_ro_cache,loadbalance,maxnodes=1,
+    nnodes=6,nomagic,hash_on_nid,hash=modulo,nodefile=/sys/kernel/debug/dvs/mounts/1/nodenames,
+    nodename=x3000c0s6b0n0:x3000c0s5b0n0:x3000c0s4b0n0:x3000c0s9b0n0:x3000c0s8b0n0:x3000c0s7b0n0)
     ```
-    /var/lib/cps-local/0dbb42538e05485de6f433a28c19e200 on /var/opt/cray/gpu/nvidia-squashfs-21.3 type dvs (ro,relatime,blksize=524288,statsfile=/sys/kernel/debug/dvs/mounts/1/stats,attrcache_timeout=14400,cache,nodatasync,noclosesync,retry,failover,userenv,noclusterfs,killprocess,noatomic,nodeferopens,no_distribute_create_ops,no_ro_cache,loadbalance,maxnodes=1,nnodes=6,nomagic,hash_on_nid,hash=modulo,nodefile=/sys/kernel/debug/dvs/mounts/1/nodenames,nodename=x3000c0s6b0n0:x3000c0s5b0n0:x3000c0s4b0n0:x3000c0s9b0n0:x3000c0s8b0n0:x3000c0s7b0n0)
-    ```
+
 #### Check the HSN for the affected nodes
 
-22. Determine the pod name for the Slingshot fabric manager pod and check the status of the fabric.
+1. Determine the pod name for the Slingshot fabric manager pod and check the status of the fabric.
 
     ```bash
     ncn-m001# kubectl exec -it -n services \
@@ -464,15 +509,18 @@ There should be a cray-cps pod (the broker), three cray-cps-etcd pods and their 
     ```
 
 #### Check for duplicate IP address entries
-23. Check for duplicate IP address entries in the Hardware State Management Database (HSM). Duplicate entries will cause DNS operations to fail.
 
-  1.  Verify each node hostname resolves to one IP address.
+1. Check for duplicate IP address entries in the Hardware State Management Database (HSM). Duplicate entries will cause DNS operations to fail.
+
+   1. Verify each node hostname resolves to one IP address.
+
       ```bash
       ncn-m001# nslookup x1005c3s0b0n0
       ```
 
       Example output with one IP address resolving:
-      ```
+
+      ```text
       Server:         10.92.100.225
       Address:        10.92.100.225#53
 
@@ -480,12 +528,14 @@ There should be a cray-cps pod (the broker), three cray-cps-etcd pods and their 
       Address: 10.100.0.26
       ```
 
-  2.  Reload the KEA configuration.
+   1. Reload the KEA configuration.
+
       ```bash
       ncn-m001# curl -s -k -H "Authorization: Bearer ${TOKEN}" -X POST -H "Content-Type: application/json" -d '{ "command": "config-reload",  "service": [ "dhcp4" ] }' https://api-gw-service-nmn.local/apis/dhcp-kea |jq
       ```
 
       If there are no duplicate IP addresses within HSM the following response is expected:
+
       ```json
       [
         {
@@ -496,17 +546,21 @@ There should be a cray-cps pod (the broker), three cray-cps-etcd pods and their 
       ```
 
       If there is a duplicate IP address an error message similar to the message below. This message indicates a duplicate IP address (10.100.0.105) in the HSM:
-      ```
-      [{'result': 1, 'text': "Config reload failed: configuration error using file '/usr/local/kea/cray-dhcp-kea-dhcp4.conf': failed to add new host using the HW address '00:40:a6:83:50:a4 and DUID '(null)' to the IPv4 subnet id '0' for the address 10.100.0.105: There's already a reservation for this address"}]
+
+      ```text
+      [{'result': 1, 'text': "Config reload failed: configuration error using file '/usr/local/kea/cray-dhcp-kea-dhcp4.conf': 
+      failed to add new host using the HW address '00:40:a6:83:50:a4 and DUID '(null)' to the IPv4 subnet id '0' for the address 
+      10.100.0.105: There's already a reservation for this address"}]
       ```
 
-24. Use the following example curl command to check for active DHCP leases. If there are 0 DHCP leases, there is a configuration error.
+1. Use the following example `curl` command to check for active DHCP leases. If there are 0 DHCP leases, there is a configuration error.
 
     ```bash
     ncn-m001# curl -H "Authorization: Bearer ${TOKEN}" -X POST -H "Content-Type: application/json" -d '{ "command": "lease4-get-all", "service": [ "dhcp4" ] }' https://api-gw-service-nmn.local/apis/dhcp-kea | jq
     ```
 
     Example output with no active DHCP leases:
+
     ```json
     [
       {
@@ -519,7 +573,7 @@ There should be a cray-cps pod (the broker), three cray-cps-etcd pods and their 
     ]
     ```
 
-25. If there are duplicate entries in the HSM as a result of this procedure, (10.100.0.105 in this example), delete the duplicate entry.
+1. If there are duplicate entries in the HSM as a result of this procedure, (10.100.0.105 in this example), delete the duplicate entry.
 
     1. Show the `EthernetInterfaces` for the duplicate IP address:
 
@@ -528,6 +582,7 @@ There should be a cray-cps pod (the broker), three cray-cps-etcd pods and their 
        ```
 
        Example output for an IP address that is associated with two MAC addresses:
+
        ```json
        [
          {
@@ -557,7 +612,7 @@ There should be a cray-cps pod (the broker), three cray-cps-etcd pods and their 
        ncn-m001# cray hsm inventory ethernetInterfaces delete 0040a68350a4
        ```
 
-26. Check DNS using `nslookup`.
+1. Check DNS using `nslookup`.
 
     ```bash
     ncn-m001# nslookup 10.100.0.105
@@ -567,14 +622,15 @@ There should be a cray-cps pod (the broker), three cray-cps-etcd pods and their 
     105.0.100.10.in-addr.arpa        name = x1005c3s0b0n0.local.
     ```
 
-27. Check SSH.
+1. Check SSH.
 
     ```bash
     ncn-m001# ssh x1005c3s0b0n0
     ```
 
     Example output:
-    ```
+
+    ```text
     The authenticity of host 'x1005c3s0b0n0 (10.100.0.105)' can't be established.
     ECDSA key fingerprint is SHA256:wttHXF5CaJcQGPTIq4zWp0whx3JTwT/tpx1dJNyyXkA.
     Are you sure you want to continue connecting (yes/no/[fingerprint])? yes

--- a/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System.md
+++ b/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System.md
@@ -409,11 +409,15 @@ Use boot orchestration to power on and boot the nodes. Specify the appropriate B
 
     2. Create the Session template.
 
-       1. The name of the Session template is determined by the name provided to the `--name` option on the command line. Use the current value of `$BOS_TEMPLATE` if you want to overwrite the existing Session template. If you want to use the current value, skip this sub-step and go on to sub-step 2. Otherwise, provide a different name for `BOS_TEMPLATE` which will be used with the `--name` option. The name specified in `tmp.txt` is overridden by the value provided by the `--name` option.
+       1. The name of the Session template is determined by the name provided to the `--name` option on the command line.
+          Use the current value of `$BOS_TEMPLATE` if you want to overwrite the existing Session template.
+          If you want to use the current value, skip this sub-step and go on to sub-step 2.
+          Otherwise, provide a different name for `BOS_TEMPLATE` which will be used with the `--name` option.
+          The name specified in `tmp.txt` is overridden by the value provided by the `--name` option.
 
-            ```bash
-            ncn-m001# $BOS_TEMPLATE=<New Session Template name>
-            ```
+          ```bash
+          ncn-m001# $BOS_TEMPLATE=<New Session Template name>
+          ```
 
        2. Create the Session template.
 

--- a/operations/node_management/Build_NCN_Images_Locally.md
+++ b/operations/node_management/Build_NCN_Images_Locally.md
@@ -139,7 +139,7 @@ Each layer creates a certain set of artifacts that can be used in different ways
 
 ```bash
 packer build -only=qemu.sles15-base -var "artifact_version=`git rev-parse --short HEAD`" -var 'ssh_password=$SLES15_INITIAL_ROOT_PASSWORD' -var 'headless=false' boxes/sles15-base/
-````
+```
 
 * If no version is passed to the builder then the version `none` is used when generating the archive.
 

--- a/operations/node_management/Build_NCN_Images_Locally.md
+++ b/operations/node_management/Build_NCN_Images_Locally.md
@@ -7,9 +7,9 @@ Build and test NCN images locally by using the following procedure. This procedu
 The listed software below will equip a local machine or build server to build for any medium (`.squashfs`, `.vbox`, `.qcow2`, `.iso`).
 
 * media (`.iso`, `.ovf`, or `.qcow2`) (depending on the layer)
-* packer
-* qemu
-* envsubst
+* `packer`
+* `qemu`
+* `envsubst`
 
 ## Media
 
@@ -40,7 +40,7 @@ And example entry for a custom repo:
 
 * There are two Providers that can be built; VirtualBox and QEMU
 * VirtualBox is best for local development.
-* QEMU is best for pipeline and portability on linux machines.
+* QEMU is best for pipeline and portability on Linux machines.
 * Both outputs are capable of creating the Kernel, Initrd, and SquashFS required to boot nodes.
 
 ### Setup
@@ -60,7 +60,7 @@ If you are building QEMU images in MacOS, you will need to adjust specific QEMU 
 * Check out `csm-rpms` repository and create a symlink to it in the root directory of the project.
 * Execute `source scripts/environment`
 * Execute `./scripts/setup.sh`
-* Render the autoinst template
+* Render the `autoinst` template
 
 ### Quick Start
 
@@ -113,7 +113,7 @@ Once the image is built, the output will be placed in the `output-ncn-common` di
 
 ### Non-Compute Node Image Layer
 
-The ncn-node-images stage builds on top of the common layer to create functional images for Kubernetes and Ceph.
+The `ncn-node-images` stage builds on top of the common layer to create functional images for Kubernetes and Ceph.
 
 To build with QEMU, run the following command.
 

--- a/operations/node_management/Build_NCN_Images_Locally.md
+++ b/operations/node_management/Build_NCN_Images_Locally.md
@@ -2,7 +2,7 @@
 
 Build and test NCN images locally by using the following procedure. This procedure can be done on any x86 machine with the following prerequisites.
 
-### Necessary Software
+## Necessary Software
 
 The listed software below will equip a local machine or build server to build for any medium (`.squashfs`, `.vbox`, `.qcow2`, `.iso`).
 
@@ -11,38 +11,39 @@ The listed software below will equip a local machine or build server to build fo
 * qemu
 * envsubst
 
-### Media
+## Media
 
 Packer can intake any ISO, the sections below detail utilized base ISOs in CRAY HPCaaS.
 
 For any ISO, copy it into the `iso` directory.
 
-#### SuSE Linux Enterprise
+### SuSE Linux Enterprise
 
 The file name is either:
-- `SLE-15-SP2-Full-x86_64-GM-Media1.iso`
-- `SLE-15-SP3-Full-x86_64-GM-Media1.iso`
 
-### Repositories
+* `SLE-15-SP2-Full-x86_64-GM-Media1.iso`
+* `SLE-15-SP3-Full-x86_64-GM-Media1.iso`
+
+## Repositories
 
 You will need access to the appropriate SLES repositories in the form of official access, self-hosted access, or the provided Nexus access.
 
 To build locally you will need to provide your own repositories file and the `custom_repos_file` variable must be passed with the packer command. The `custom_repos_file` variable is a filename that is placed into the `custom` folder of the project. The file must be formatted with the following fields: `url name flags`
 
-- `-var 'custom_repos_file=custom.repos'`
+* `-var 'custom_repos_file=custom.repos'`
 
 And example entry for a custom repo:
 
 `https://myserver.net/sles-mirror/Products/SLE-Module-Basesystem/15-SP3/x86_64/product     SUSE-SLE-Module-Basesystem-15-SP3-x86_64-Pool     -g -p 99  suse/SLE-Module-Basesystem/15-SP3/x86_64/product`
 
-### Build Steps
+## Build Steps
 
 * There are two Providers that can be built; VirtualBox and QEMU
 * VirtualBox is best for local development.
 * QEMU is best for pipeline and portability on linux machines.
-* Both outputs are capable of creating the kernel, initrd, and squashfs required to boot nodes.
+* Both outputs are capable of creating the Kernel, Initrd, and SquashFS required to boot nodes.
 
-#### Setup
+### Setup
 
 * Install packer from a reputable endpoint, like [this one](https://www.packer.io/downloads.html).
 
@@ -52,7 +53,7 @@ If you are building QEMU images in MacOS, you will need to adjust specific QEMU 
 * MacOS uses Cocoa for output
 * `-var 'qemu_display=cocoa' -var 'qemu_accelerator=hvf'`
 
-##### Notes
+#### Notes
 
 * Setup environment variables by copying `scripts/environment.template` to `scripts/environment` and modifying the values for your environment.
 * Ensure that `SLE-15-SP3-Full-x86_64-GM-Media1.iso` is in the `iso/` folder
@@ -61,7 +62,7 @@ If you are building QEMU images in MacOS, you will need to adjust specific QEMU 
 * Execute `./scripts/setup.sh`
 * Render the autoinst template
 
-#### Quick Start
+### Quick Start
 
 ```bash
 git clone <csm-rpms-repo>
@@ -76,7 +77,7 @@ wget https://<somepath>/SLE-15-SP3-Full-x86_64-GM-Media1.iso -O iso/SLE-15-SP3-F
 ./scripts/setup.sh
 ```
 
-#### Base Layer
+### Base Layer
 
 The base layer will install SLES 15 and prepare the image for the installation of Kubernetes and Ceph.
 
@@ -96,7 +97,7 @@ If you want to view the output of the build, disable `headless` mode:
 
 Once the images are built, the output will be placed in the `output-sles15-base` directory in the root of the project.
 
-#### Common Layer
+### Common Layer
 
 The common layer starts from the output of the base layer. As such the base layer must be created before building common.
 
@@ -110,7 +111,7 @@ To build with VirtualBox, run the following command.
 
 Once the image is built, the output will be placed in the `output-ncn-common` directory in the root of the project.
 
-#### Non-Compute Node Image Layer
+### Non-Compute Node Image Layer
 
 The ncn-node-images stage builds on top of the common layer to create functional images for Kubernetes and Ceph.
 
@@ -124,16 +125,16 @@ To build with VirtualBox, run the following command.
 
 Once the images are built, the output will be placed in the `output-sles15-images` directory in the root of the project.
 
-### Artifacts
+## Artifacts
 
 Each layer creates a certain set of artifacts that can be used in different ways.
 
 * Each layer creates a VM disk image that can be directly booted and/or used to create the next layer's image.
 * Each layer after `sles15-base` creates a list of packages and repos.
 * `ncn-common` creates kernel and initrd artifacts.
-* `ncn-node-images` creates kernel, initrd, and squashfs artifacts.
+* `ncn-node-images` creates Kernel, Initrd, and SquashFS artifacts.
 
-### Versioning
+## Versioning
 
 * The version of the build is passed with the `packer build` command as the `artifact_version` var:
 
@@ -142,4 +143,3 @@ packer build -only=qemu.sles15-base -var "artifact_version=`git rev-parse --shor
 ```
 
 * If no version is passed to the builder then the version `none` is used when generating the archive.
-

--- a/operations/node_management/Build_NCN_Images_Locally.md
+++ b/operations/node_management/Build_NCN_Images_Locally.md
@@ -28,7 +28,9 @@ The file name is either:
 
 You will need access to the appropriate SLES repositories in the form of official access, self-hosted access, or the provided Nexus access.
 
-To build locally you will need to provide your own repositories file and the `custom_repos_file` variable must be passed with the packer command. The `custom_repos_file` variable is a filename that is placed into the `custom` folder of the project. The file must be formatted with the following fields: `url name flags`
+To build locally you will need to provide your own repositories file and the `custom_repos_file` variable must be passed with the packer command.
+The `custom_repos_file` variable is a filename that is placed into the `custom` folder of the project.
+The file must be formatted with the following fields: `url name flags`
 
 * `-var 'custom_repos_file=custom.repos'`
 

--- a/operations/node_management/Reboot_NCNs.md
+++ b/operations/node_management/Reboot_NCNs.md
@@ -146,16 +146,22 @@ The `kubectl` command is installed.
         If there are BGP Peering sessions that are not ESTABLISHED on either switch, refer to [Check BGP Status and Reset Sessions](../network/metallb_bgp/Check_BGP_Status_and_Reset_Sessions.md).
 
 1. Ensure that no nodes are in a `failed` state in CFS.
-    Nodes that are in a failed state prior to the reboot will not be automatically
-    configured once they have been rebooted. To get a list of nodes in the failed state:
+   
+   Nodes that are in a failed state prior to the reboot will not be automatically
+   configured once they have been rebooted. To get a list of nodes in the failed state:
+   
    ```
    ncn-m001# cray cfs components list --status failed | jq .[].id
    ```
+   
    If there are any nodes in this list, they can be reset with:
+   
    ```
    ncn-m001# cray cfs components update <xname> --enabled False --error-count 0
    ```
+   
    Or, to reset the error count for all nodes:
+   
    ```
    ncn-m001# cray cfs components list --status failed | jq .[].id -r | while read -r xname ; do
        echo "$xname"
@@ -166,18 +172,21 @@ The `kubectl` command is installed.
    re-enable them when they reboot, this is just so that CFS does not immediately
    start retrying configuration against the failed node.
 
-    1. Check for components that have `failed` status in CFS.
+   1. Check for components that have `failed` status in CFS.
 
-        If there are any components with that status, this command will list them:
-        ```bash
-        ncn-m001# cray cfs components list --status failed
-        ```
+      If there are any components with that status, this command will list them:
+      
+      ```bash
+      ncn-m001# cray cfs components list --status failed
+      ```
 
-        For any NCN components found, reset the error count to 0. Each component will also have to be disabled in CFS in order to not immediately trigger configuration. The components will be re-enabled when they reboot.
-        **NOTE:** Be sure to replace the `<xname>` in the following command with the xname of the NCN component to be reset and disabled.
-        ```bash
-        ncn-m001# cray cfs components update <xname> --error-count 0 --enabled false
-        ```
+      For any NCN components found, reset the error count to 0. Each component will also have to be disabled in CFS in order to not immediately trigger configuration. The components will be re-enabled when they reboot.
+      
+      **NOTE:** Be sure to replace the `<xname>` in the following command with the xname of the NCN component to be reset and disabled.
+      
+      ```bash
+      ncn-m001# cray cfs components update <xname> --error-count 0 --enabled false
+      ```
 
 ### NCN Rolling Reboot
 
@@ -399,7 +408,7 @@ Before rebooting NCNs:
 
        If configurationStatus is `failed`, See [Troubleshoot Ansible Play Failures in CFS Sessions](../configuration_management/Troubleshoot_Ansible_Play_Failures_in_CFS_Sessions.md) for how to analyze the pod logs from cray-cfs to determine why the configuration may not have completed.
 
-    10. Uncordon the node
+    10. Uncordon the node.
 
         ```bash
         ncn-m# kubectl uncordon <node you just rebooted>
@@ -429,7 +438,7 @@ Before rebooting NCNs:
 
     15. Repeat all of the sub-steps above for the remaining worker nodes, going from the highest to lowest number until all worker nodes have successfully rebooted.
 
-1. Ensure that BGP sessions are reset so that all BGP peering sessions with the spine switches are in an ESTABLISHED state.
+1. Ensure that BGP sessions are reset so that all BGP peering sessions with the spine switches are in an `ESTABLISHED` state.
 
    See [Check BGP Status and Reset Sessions](../network/metallb_bgp/Check_BGP_Status_and_Reset_Sessions.md).
 

--- a/operations/node_management/Reboot_NCNs.md
+++ b/operations/node_management/Reboot_NCNs.md
@@ -143,26 +143,26 @@ The `kubectl` command is installed.
 
         This check will need to be run after all worker node have been rebooted. Ensure that the checks have been run to check BGP peering sessions on the spine switches \(instructions will vary for Aruba and Mellanox switches\)
 
-        If there are BGP Peering sessions that are not ESTABLISHED on either switch, refer to [Check BGP Status and Reset Sessions](../network/metallb_bgp/Check_BGP_Status_and_Reset_Sessions.md).
+        If there are BGP Peering sessions that are not `ESTABLISHED` on either switch, refer to [Check BGP Status and Reset Sessions](../network/metallb_bgp/Check_BGP_Status_and_Reset_Sessions.md).
 
 1. Ensure that no nodes are in a `failed` state in CFS.
    
    Nodes that are in a failed state prior to the reboot will not be automatically
    configured once they have been rebooted. To get a list of nodes in the failed state:
    
-   ```
+   ```bash
    ncn-m001# cray cfs components list --status failed | jq .[].id
    ```
    
    If there are any nodes in this list, they can be reset with:
    
-   ```
+   ```bash
    ncn-m001# cray cfs components update <xname> --enabled False --error-count 0
    ```
    
    Or, to reset the error count for all nodes:
    
-   ```
+   ```bash
    ncn-m001# cray cfs components list --status failed | jq .[].id -r | while read -r xname ; do
        echo "$xname"
        cray cfs components update $xname --enabled False --error-count 0
@@ -182,7 +182,7 @@ The `kubectl` command is installed.
 
       For any NCN components found, reset the error count to 0. Each component will also have to be disabled in CFS in order to not immediately trigger configuration. The components will be re-enabled when they reboot.
       
-      **NOTE:** Be sure to replace the `<xname>` in the following command with the xname of the NCN component to be reset and disabled.
+      **NOTE:** Be sure to replace the `<xname>` in the following command with the component name (xname) of the NCN component to be reset and disabled.
       
       ```bash
       ncn-m001# cray cfs components update <xname> --error-count 0 --enabled false
@@ -406,7 +406,7 @@ Before rebooting NCNs:
 
        If the configurationStatus is `pending`, wait for the job to finish before continuing. If the configurationStatus is `failed`, this means the failed CFS job configurationStatus should be addressed now for this node. If the configurationStatus is `unconfigured` and the NCN personalization procedure has not been done as part of an install yet, this can be ignored.
 
-       If configurationStatus is `failed`, See [Troubleshoot Ansible Play Failures in CFS Sessions](../configuration_management/Troubleshoot_Ansible_Play_Failures_in_CFS_Sessions.md) for how to analyze the pod logs from cray-cfs to determine why the configuration may not have completed.
+       If configurationStatus is `failed`, See [Troubleshoot Ansible Play Failures in CFS Sessions](../configuration_management/Troubleshoot_Ansible_Play_Failures_in_CFS_Sessions.md) for how to analyze the pod logs from `cray-cfs` to determine why the configuration may not have completed.
 
     10. Uncordon the node.
 

--- a/operations/node_management/Reboot_NCNs.md
+++ b/operations/node_management/Reboot_NCNs.md
@@ -637,7 +637,7 @@ Before rebooting NCNs:
 
     9. Disconnect from the console.
 
-3. Remove any dynamically assigned interface IP addresses that did not get released automatically by running the CASMINST-2015 script:
+3. Remove any dynamically assigned interface IP addresses that did not get released automatically by running the `CASMINST-2015.sh` script:
 
    ```bash
    ncn-m001# /usr/share/doc/csm/scripts/CASMINST-2015.sh

--- a/operations/node_management/Reboot_NCNs.md
+++ b/operations/node_management/Reboot_NCNs.md
@@ -299,12 +299,18 @@ Before rebooting NCNs:
 
          ```bash
          ncn-m001# kubectl describe pod -n user -lapp=slurmctld
-         Warning  FailedCreatePodSandBox  27m              kubelet, ncn-w001  Failed to create pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox "82c575cc978db00643b1bf84a4773c064c08dcb93dbd9741ba2e581bc7c5d545": Multus: Err in tearing down failed plugins: Multus: error in invoke Delegate add - "macvlan": failed to allocate for range 0: no IP addresses available in range set: 10.252.2.4-10.252.2.4
+         Warning  FailedCreatePodSandBox  27m              kubelet, ncn-w001  Failed to create pod sandbox: rpc error: code = 
+         Unknown desc = failed to setup network for sandbox "82c575cc978db00643b1bf84a4773c064c08dcb93dbd9741ba2e581bc7c5d545": 
+         Multus: Err in tearing down failed plugins: Multus: error in invoke Delegate add - "macvlan": failed to allocate for 
+         range 0: no IP addresses available in range set: 10.252.2.4-10.252.2.4
          ```
 
          ```bash
          ncn-m001# kubectl describe pod -n user -lapp=slurmdbd
-         Warning  FailedCreatePodSandBox  29m                    kubelet, ncn-w001  Failed to create pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox "314ca4285d0706ec3d76a9e953e412d4b0712da4d0cb8138162b53d807d07491": Multus: Err in tearing down failed plugins: Multus: error in invoke Delegate add - "macvlan": failed to allocate for range 0: no IP addresses available in range set: 10.252.2.4-10.252.2.4
+         Warning  FailedCreatePodSandBox  29m                    kubelet, ncn-w001  Failed to create pod sandbox: rpc error: code 
+         = Unknown desc = failed to setup network for sandbox "314ca4285d0706ec3d76a9e953e412d4b0712da4d0cb8138162b53d807d07491": 
+         Multus: Err in tearing down failed plugins: Multus: error in invoke Delegate add - "macvlan": failed to allocate for 
+         range 0: no IP addresses available in range set: 10.252.2.4-10.252.2.4
          ```
 
          Remove the following files on every worker node to resolve the failure:

--- a/operations/node_management/Reboot_NCNs.md
+++ b/operations/node_management/Reboot_NCNs.md
@@ -2,24 +2,26 @@
 
 The following is a high-level overview of the non-compute node \(NCN\) reboot workflow:
 
-- Run the NCN pre-reboot checks and procedures:
-   - Ensure `ncn-m001` is not running in "LiveCD" or install mode
-   - Check the `metal.no-wipe` settings for all NCNs
-   - Run all platform health checks, including checks on the Border Gateway Protocol \(BGP\) peering sessions
-   - [Validate the current boot order](../../background/ncn_boot_workflow.md#determine-the-current-boot-order) (or [specify the boot order](../../background/ncn_boot_workflow.md#set-boot-order))
-- Run the rolling NCN reboot procedure:
-   - Loop through reboots on storage nodes, worker nodes, and master nodes, where each boot consists of the following workflow:
-      - Establish console session with node to reboot
-      - Execute a Linux graceful shutdown or power off/on sequence to the node to allow it to boot up to completion
-      - Execute NCN/platform health checks and do not go on to reboot the next NCN until health has been ensured on the most recently rebooted NCN
-      - Disconnect console session with the node that was rebooted
-- Re-run all platform health checks, including checks on BGP peering sessions
+* Run the NCN pre-reboot checks and procedures:
+  * Ensure `ncn-m001` is not running in "LiveCD" or install mode
+  * Check the `metal.no-wipe` settings for all NCNs
+  * Run all platform health checks, including checks on the Border Gateway Protocol \(BGP\) peering sessions
+  * [Validate the current boot order](../../background/ncn_boot_workflow.md#determine-the-current-boot-order) (or [specify the boot order](../../background/ncn_boot_workflow.md#set-boot-order))
+* Run the rolling NCN reboot procedure:
+  * Loop through reboots on storage nodes, worker nodes, and master nodes, where each boot consists of the following workflow:
+    * Establish console session with node to reboot
+    * Execute a Linux graceful shutdown or power off/on sequence to the node to allow it to boot up to completion
+    * Execute NCN/platform health checks and do not go on to reboot the next NCN until health has been ensured on the most recently rebooted NCN
+      * Disconnect console session with the node that was rebooted
+* Re-run all platform health checks, including checks on BGP peering sessions
 
 The time duration for this procedure \(if health checks are being executed in between each boot, as recommended\) could take between two to four hours for a system with nine management nodes.
 
-This same procedure can be used to reboot a single management node as outlined above. Be sure to carry out the NCN pre-reboot checks and procedures before and after rebooting the node. Execute the rolling NCN reboot procedure steps for the particular node type being rebooted.
+This same procedure can be used to reboot a single management node as outlined above.
+Be sure to carry out the NCN pre-reboot checks and procedures before and after rebooting the node.
+Execute the rolling NCN reboot procedure steps for the particular node type being rebooted.
 
-**`IMPORTANT`** whenever an NCN is rebooted the CASMINST-2015 script should be run to remove any dynamically assigned IP addresses that were not released automatically.
+**`IMPORTANT`** whenever an NCN is rebooted the `CASMINST-2015.sh` script should be run to remove any dynamically assigned IP addresses that were not released automatically.
 
 ```bash
 ncn-m001# /usr/share/doc/csm/scripts/CASMINST-2015.sh
@@ -35,9 +37,11 @@ The `kubectl` command is installed.
 
 1. Ensure that `ncn-m001` is not running in "LiveCD" mode.
 
-    This mode should only be in effect during the initial product install. If the word "pit" is NOT in the hostname of `ncn-m001`, then it is not in the "LiveCD" mode.
+    This mode should only be in effect during the initial product install.
+    If the word "pit" is NOT in the hostname of `ncn-m001`, then it is not in the "LiveCD" mode.
 
-    If "pit" is in the hostname of `ncn-m001`, the system is not in normal operational mode and rebooting `ncn-m001` may have unexpected results. This procedure assumes that the node is not running in the "LiveCD" mode that occurs during product install.
+    If "pit" is in the hostname of `ncn-m001`, the system is not in normal operational mode and rebooting `ncn-m001` may have unexpected results.
+    This procedure assumes that the node is not running in the "LiveCD" mode that occurs during product install.
 
 1. Check and set the `metal.no-wipe` setting on NCNs to ensure data on the node is preserved when rebooting.
 
@@ -56,7 +60,10 @@ The `kubectl` command is installed.
         ncn-m001# /opt/cray/platform-utils/ncnPostgresHealthChecks.sh
         ```
 
-        **`NOTE`**: If the ncnHealthChecks script output indicates any `kube-multus-ds-` pods are in a `Terminating` state, that can indicate a previous restart of these pods did not complete. In this case, it is safe to force delete these pods in order to let them properly restart by executing the `kubectl delete po -n kube-system kube-multus-ds.. --force` command. After executing this command, re-running the ncnHealthChecks script should indicate a new pod is in a `Running` state.
+        **`NOTE`**: If the ncnHealthChecks script output indicates any `kube-multus-ds-` pods are in
+        a `Terminating` state, that can indicate a previous restart of these pods did not complete.
+        In this case, it is safe to force delete these pods in order to let them properly restart by executing the `kubectl delete po -n kube-system kube-multus-ds.. --force` command.
+        After executing this command, re-running the ncnHealthChecks script should indicate a new pod is in a `Running` state.
 
     1. Check the status of the Kubernetes nodes.
 
@@ -88,7 +95,8 @@ The `kubectl` command is installed.
 
     1. Check the status of the Kubernetes pods.
 
-        The bottom of the output returned after running the /opt/cray/platform-utils/ncnHealthChecks.sh script will show a list of pods that may be in a bad state. The following command can also be used to look for any pods that are not in a Running or Completed state:
+        The bottom of the output returned after running the `/opt/cray/platform-utils/ncnHealthChecks.sh` script will show a list of pods that may be in a bad state.
+        The following command can also be used to look for any pods that are not in a Running or Completed state:
 
         ```bash
         ncn-m001# kubectl get pods -o wide -A | grep -Ev 'Running|Completed'
@@ -96,11 +104,15 @@ The `kubectl` command is installed.
 
         It is important to pay attention to that list, but it is equally important to note what pods are in that list before and after node reboots to determine if the reboot caused any new issues.
 
-        There are pods that may normally be in an Error, Not Ready, or Init state, and this may not indicate any problems caused by the NCN reboots. Error states can indicate that a job pod ran and ended in an Error. That means that there may be a problem with that job, but does not necessarily indicate that there is an overall health issue with the system. The key takeaway \(for health purposes\) is understanding the statuses of pods prior to doing an action like rebooting all of the NCNs. Comparing the pod statuses in between each NCN reboot will give a sense of what is new or different with respect to health.
+        There are pods that may normally be in an `Error`, `Not Ready`, or `Init` state, and this may not indicate any problems caused by the NCN reboots.
+        `Error` states can indicate that a job pod ran and ended in an Error.
+        That means that there may be a problem with that job, but does not necessarily indicate that there is an overall health issue with the system.
+        The key takeaway \(for health purposes\) is understanding the statuses of pods prior to doing an action like rebooting all of the NCNs.
+        Comparing the pod statuses in between each NCN reboot will give a sense of what is new or different with respect to health.
 
     1. Verify Ceph health (the command mentioned below can be run on any master or storage node).
 
-        This output is included in the /opt/cray/platform-utils/ncnHealthChecks.sh script
+        This output is included in the `/opt/cray/platform-utils/ncnHealthChecks.sh` script
 
         Run the following command during NCN reboots:
 
@@ -108,7 +120,8 @@ The `kubectl` command is installed.
         ncn-m001# watch -n 10 'ceph -s'
         ```
 
-        This window can be kept up throughout the reboot process to ensure Ceph remains healthy and to watch if Ceph goes into a WARN state when rebooting storage node.
+        This window can be kept up throughout the reboot process to ensure Ceph remains healthy
+        and to watch if Ceph goes into a WARN state when rebooting storage node.
 
     1. Check the status of the `slurmctld` and `slurmdbd` pods to determine if they are starting:
 
@@ -136,38 +149,40 @@ The `kubectl` command is installed.
 
         If the preceding error is displayed, then remove all files in the following directories on all worker nodes:
 
-        - /var/lib/cni/networks/macvlan-slurmctld-nmn-conf
-        - /var/lib/cni/networks/macvlan-slurmdbd-nmn-conf
+        * /var/lib/cni/networks/macvlan-slurmctld-nmn-conf
+        * /var/lib/cni/networks/macvlan-slurmdbd-nmn-conf
 
     1. Check that the BGP peering sessions are established.
 
-        This check will need to be run after all worker node have been rebooted. Ensure that the checks have been run to check BGP peering sessions on the spine switches \(instructions will vary for Aruba and Mellanox switches\)
+        This check will need to be run after all worker node have been rebooted.
+        Ensure that the checks have been run to check BGP peering sessions on the spine switches \(instructions will vary for Aruba and Mellanox switches\)
 
         If there are BGP Peering sessions that are not `ESTABLISHED` on either switch, refer to [Check BGP Status and Reset Sessions](../network/metallb_bgp/Check_BGP_Status_and_Reset_Sessions.md).
 
 1. Ensure that no nodes are in a `failed` state in CFS.
-   
+
    Nodes that are in a failed state prior to the reboot will not be automatically
    configured once they have been rebooted. To get a list of nodes in the failed state:
-   
+
    ```bash
    ncn-m001# cray cfs components list --status failed | jq .[].id
    ```
-   
+
    If there are any nodes in this list, they can be reset with:
-   
+
    ```bash
    ncn-m001# cray cfs components update <xname> --enabled False --error-count 0
    ```
-   
+
    Or, to reset the error count for all nodes:
-   
+
    ```bash
    ncn-m001# cray cfs components list --status failed | jq .[].id -r | while read -r xname ; do
        echo "$xname"
        cray cfs components update $xname --enabled False --error-count 0
    done
    ```
+
    This will leave the nodes in a disabled state in CFS. CFS will automatically
    re-enable them when they reboot, this is just so that CFS does not immediately
    start retrying configuration against the failed node.
@@ -175,15 +190,15 @@ The `kubectl` command is installed.
    1. Check for components that have `failed` status in CFS.
 
       If there are any components with that status, this command will list them:
-      
+
       ```bash
       ncn-m001# cray cfs components list --status failed
       ```
 
       For any NCN components found, reset the error count to 0. Each component will also have to be disabled in CFS in order to not immediately trigger configuration. The components will be re-enabled when they reboot.
-      
+
       **NOTE:** Be sure to replace the `<xname>` in the following command with the component name (xname) of the NCN component to be reset and disabled.
-      
+
       ```bash
       ncn-m001# cray cfs components update <xname> --error-count 0 --enabled false
       ```
@@ -192,7 +207,8 @@ The `kubectl` command is installed.
 
 Before rebooting NCNs:
 
-* Ensure pre-reboot checks have been completed, including checking the `metal.no-wipe` setting for each NCN. Do not proceed if any of the NCN `metal.no-wipe` settings are zero.
+* Ensure pre-reboot checks have been completed, including checking the `metal.no-wipe` setting for each NCN.
+  Do not proceed if any of the NCN `metal.no-wipe` settings are zero.
 
 #### Utility Storage Nodes (Ceph)
 
@@ -231,14 +247,15 @@ Before rebooting NCNs:
             ```
 
         Ensure the power is reporting as on. This may take 5-10 seconds for this to update.
+
     4. Watch on the console until the node has successfully booted and the login prompt is reached.
 
     5. If desired verify method of boot is expected. If the `/proc/cmdline` begins with `BOOT_IMAGE` then this NCN booted from disk:
 
-   ```bash
-   ncn# egrep -o '^(BOOT_IMAGE.+/kernel)' /proc/cmdline
-   BOOT_IMAGE=(mduuid/a3899572a56f5fd88a0dec0e89fc12b4)/boot/grub2/../kernel
-   ```
+        ```bash
+        ncn# egrep -o '^(BOOT_IMAGE.+/kernel)' /proc/cmdline
+        BOOT_IMAGE=(mduuid/a3899572a56f5fd88a0dec0e89fc12b4)/boot/grub2/../kernel
+        ```
 
     6. Retrieve the component name (xname) for the node being rebooted.
 
@@ -263,11 +280,14 @@ Before rebooting NCNs:
          "retryPolicy": 3,
        ```
 
-       If the configurationStatus is `pending`, wait for the job to finish before continuing. If the configurationStatus is `failed`, this means the failed CFS job configurationStatus should be addressed now for this node. If the configurationStatus is `unconfigured` and the NCN personalization procedure has not been done as part of an install yet, this can be ignored.
+       If the configurationStatus is `pending`, wait for the job to finish before continuing.
+       If the configurationStatus is `failed`, this means the failed CFS job configurationStatus should be addressed now for this node.
+       If the configurationStatus is `unconfigured` and the NCN personalization procedure has not been done as part of an install yet, this can be ignored.
 
-       If configurationStatus is `failed`, See [Troubleshoot Ansible Play Failures in CFS Sessions](../configuration_management/Troubleshoot_Ansible_Play_Failures_in_CFS_Sessions.md) for how to analyze the pod logs from cray-cfs to determine why the configuration may not have completed.
+       If configurationStatus is `failed`, See [Troubleshoot Ansible Play Failures in CFS Sessions](../configuration_management/Troubleshoot_Ansible_Play_Failures_in_CFS_Sessions.md)
+       for how to analyze the pod logs from cray-cfs to determine why the configuration may not have completed.
 
-    8. Remove any dynamically assigned interface IP addresses that did not get released automatically by running the CASMINST-2015 script:
+    8. Remove any dynamically assigned interface IP addresses that did not get released automatically by running the `CASMINST-2015.sh` script:
 
        ```bash
        ncn-m001# /usr/share/doc/csm/scripts/CASMINST-2015.sh
@@ -289,11 +309,10 @@ Before rebooting NCNs:
 
          Remove the following files on every worker node to resolve the failure:
 
-         - /var/lib/cni/networks/macvlan-slurmctld-nmn-conf
-         - /var/lib/cni/networks/macvlan-slurmdbd-nmn-conf
+         * /var/lib/cni/networks/macvlan-slurmctld-nmn-conf
+         * /var/lib/cni/networks/macvlan-slurmdbd-nmn-conf
 
     10. Disconnect from the console.
-
 
     11. Repeat all of the sub-steps above for the remaining storage nodes, going from the highest to lowest number until all storage nodes have successfully rebooted.
 
@@ -312,7 +331,7 @@ Before rebooting NCNs:
 
         See [Establish a Serial Connection to NCNs](../conman/Establish_a_Serial_Connection_to_NCNs.md) for more information.
 
-    2. Failover any postgres leader that is running on the worker node you are rebooting.
+    2. Failover any Postgres leader that is running on the worker node you are rebooting.
 
        ```bash
        ncn-m# /usr/share/doc/csm/upgrade/1.0.1/scripts/k8s/failover-leader.sh <node to be rebooted>
@@ -330,13 +349,16 @@ Before rebooting NCNs:
        ncn-m# error when evicting pod "<pod>" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
        ```
 
-       In this case, there are some options. First, if the service is scalable, you can increase the scale to start up another pod on another node, and then the drain will be able to delete it. However, it will probably be necessary to force the deletion of the pod:
+       In this case, there are some options.
+       First, if the service is scalable, you can increase the scale to start up another pod on another node, and then the drain will be able to delete it.
+       However, it will probably be necessary to force the deletion of the pod:
 
        ```bash
        ncn-m# kubectl delete pod [-n <namespace>] --force --grace-period=0 <pod>
        ```
 
-       This will delete the offending pod, and Kubernetes should schedule a replacement on another node. You can then rerun the kubectl drain command, and it should report that the node is drained
+       This will delete the offending pod, and Kubernetes should schedule a replacement on another node.
+       You can then rerun the `kubectl drain` command, and it should report that the node is drained.
 
        ```bash
        ncn-m# kubectl drain --ignore-daemonsets=true --delete-local-data=true <node to be rebooted>
@@ -376,10 +398,10 @@ Before rebooting NCNs:
 
     7. If desired verify method of boot is expected. If the `/proc/cmdline` begins with `BOOT_IMAGE` then this NCN booted from disk:
 
-   ```bash
-   ncn# egrep -o '^(BOOT_IMAGE.+/kernel)' /proc/cmdline
-   BOOT_IMAGE=(mduuid/a3899572a56f5fd88a0dec0e89fc12b4)/boot/grub2/../kernel
-   ```
+        ```bash
+        ncn# egrep -o '^(BOOT_IMAGE.+/kernel)' /proc/cmdline
+        BOOT_IMAGE=(mduuid/a3899572a56f5fd88a0dec0e89fc12b4)/boot/grub2/../kernel
+        ```
 
     8. Retrieve the component name (xname) for the node being rebooted.
 
@@ -391,7 +413,8 @@ Before rebooting NCNs:
 
     9. Confirm what the Configuration Framework Service (CFS) configurationStatus is for the desiredConfig after rebooting the node.
 
-       The following command will indicate if a CFS job is currently in progress for this node. Replace the `XNAME` value in the following command with the component name (xname) of the node being rebooted.
+       The following command will indicate if a CFS job is currently in progress for this node.
+       Replace the `XNAME` value in the following command with the component name (xname) of the node being rebooted.
 
        ```bash
        ncn# cray cfs components describe XNAME --format json
@@ -404,9 +427,12 @@ Before rebooting NCNs:
          "retryPolicy": 3,
        ```
 
-       If the configurationStatus is `pending`, wait for the job to finish before continuing. If the configurationStatus is `failed`, this means the failed CFS job configurationStatus should be addressed now for this node. If the configurationStatus is `unconfigured` and the NCN personalization procedure has not been done as part of an install yet, this can be ignored.
+       If the configurationStatus is `pending`, wait for the job to finish before continuing.
+       If the configurationStatus is `failed`, this means the failed CFS job configurationStatus should be addressed now for this node.
+       If the configurationStatus is `unconfigured` and the NCN personalization procedure has not been done as part of an install yet, this can be ignored.
 
-       If configurationStatus is `failed`, See [Troubleshoot Ansible Play Failures in CFS Sessions](../configuration_management/Troubleshoot_Ansible_Play_Failures_in_CFS_Sessions.md) for how to analyze the pod logs from `cray-cfs` to determine why the configuration may not have completed.
+       If configurationStatus is `failed`, See [Troubleshoot Ansible Play Failures in CFS Sessions](../configuration_management/Troubleshoot_Ansible_Play_Failures_in_CFS_Sessions.md)
+       for how to analyze the pod logs from `cray-cfs` to determine why the configuration may not have completed.
 
     10. Uncordon the node.
 
@@ -484,10 +510,10 @@ Before rebooting NCNs:
 
     5. If desired verify method of boot is expected. If the `/proc/cmdline` begins with `BOOT_IMAGE` then this NCN booted from disk:
 
-   ```bash
-   ncn# egrep -o '^(BOOT_IMAGE.+/kernel)' /proc/cmdline
-   BOOT_IMAGE=(mduuid/a3899572a56f5fd88a0dec0e89fc12b4)/boot/grub2/../kernel
-   ```
+        ```bash
+        ncn# egrep -o '^(BOOT_IMAGE.+/kernel)' /proc/cmdline
+        BOOT_IMAGE=(mduuid/a3899572a56f5fd88a0dec0e89fc12b4)/boot/grub2/../kernel
+        ```
 
     6. Retrieve the component name (xname) for the node being rebooted.
 
@@ -499,7 +525,8 @@ Before rebooting NCNs:
 
     7. Confirm what the Configuration Framework Service (CFS) configurationStatus is for the desiredConfig after rebooting the node.
 
-       The following command will indicate if a CFS job is currently in progress for this node. Replace the `XNAME` value in the following command with the component name (xname) of the node being rebooted.
+       The following command will indicate if a CFS job is currently in progress for this node.
+       Replace the `XNAME` value in the following command with the component name (xname) of the node being rebooted.
 
        ```bash
        ncn# cray cfs components describe XNAME --format json
@@ -512,11 +539,14 @@ Before rebooting NCNs:
          "retryPolicy": 3,
        ```
 
-       If the configurationStatus is `pending`, wait for the job to finish before continuing. If the configurationStatus is `failed`, this means the failed CFS job configurationStatus should be addressed now for this node. If the configurationStatus is `unconfigured` and the NCN personalization procedure has not been done as part of an install yet, this can be ignored.
+       If the configurationStatus is `pending`, wait for the job to finish before continuing.
+       If the configurationStatus is `failed`, this means the failed CFS job configurationStatus should be addressed now for this node.
+       If the configurationStatus is `unconfigured` and the NCN personalization procedure has not been done as part of an install yet, this can be ignored.
 
-       If configurationStatus is `failed`, See [Troubleshoot Ansible Play Failures in CFS Sessions](../configuration_management/Troubleshoot_Ansible_Play_Failures_in_CFS_Sessions.md) for how to analyze the pod logs from cray-cfs to determine why the configuration may not have completed.
+       If configurationStatus is `failed`, See [Troubleshoot Ansible Play Failures in CFS Sessions](../configuration_management/Troubleshoot_Ansible_Play_Failures_in_CFS_Sessions.md)
+       for how to analyze the pod logs from cray-cfs to determine why the configuration may not have completed.
 
-    8. Remove any dynamically assigned interface IP addresses that did not get released automatically by running the CASMINST-2015 script:
+    8. Remove any dynamically assigned interface IP addresses that did not get released automatically by running the `CASMINST-2015.sh` script:
 
        ```bash
        ncn-m001# /usr/share/doc/csm/scripts/CASMINST-2015.sh
@@ -574,9 +604,10 @@ Before rebooting NCNs:
         ncn# ssh NODE cat /etc/cray/xname
         ```
 
-    7. Confirm what the Configuration Framework Service (CFS) configurationStatus is for the desiredConfig after rebooting the node.
+    7. Confirm what the Configuration Framework Service (CFS) configurationStatus is for the `desiredConfig` after rebooting the node.
 
-       The following command will indicate if a CFS job is currently in progress for this node. Replace the `XNAME` value in the following command with the component name (xname) of the node being rebooted.
+       The following command will indicate if a CFS job is currently in progress for this node.
+       Replace the `XNAME` value in the following command with the component name (xname) of the node being rebooted.
 
        ```bash
        ncn# cray cfs components describe XNAME --format json
@@ -589,9 +620,12 @@ Before rebooting NCNs:
          "retryPolicy": 3,
        ```
 
-       If the configurationStatus is `pending`, wait for the job to finish before continuing. If the configurationStatus is `failed`, this means the failed CFS job configurationStatus should be addressed now for this node. If the configurationStatus is `unconfigured` and the NCN personalization procedure has not been done as part of an install yet, this can be ignored.
+       If the configurationStatus is `pending`, wait for the job to finish before continuing.
+       If the configurationStatus is `failed`, this means the failed CFS job configurationStatus should be addressed now for this node.
+       If the configurationStatus is `unconfigured` and the NCN personalization procedure has not been done as part of an install yet, this can be ignored.
 
-       If configurationStatus is `failed`, See [Troubleshoot Ansible Play Failures in CFS Sessions](../configuration_management/Troubleshoot_Ansible_Play_Failures_in_CFS_Sessions.md) for how to analyze the pod logs from cray-cfs to determine why the configuration may not have completed.
+       If configurationStatus is `failed`, See [Troubleshoot Ansible Play Failures in CFS Sessions](../configuration_management/Troubleshoot_Ansible_Play_Failures_in_CFS_Sessions.md)
+       for how to analyze the pod logs from cray-cfs to determine why the configuration may not have completed.
 
     8. Run the platform health checks in [Validate CSM Health](../validate_csm_health.md).
 

--- a/operations/node_management/Reboot_NCNs.md
+++ b/operations/node_management/Reboot_NCNs.md
@@ -45,7 +45,7 @@ The `kubectl` command is installed.
 
 1. Check and set the `metal.no-wipe` setting on NCNs to ensure data on the node is preserved when rebooting.
 
-    Refer to [Check and Set the metal.no-wipe Setting on NCNs](Check_and_Set_the_metalno-wipe_Setting_on_NCNs.md).
+    Refer to [Check and Set the `metal.no-wipe` Setting on NCNs](Check_and_Set_the_metalno-wipe_Setting_on_NCNs.md).
 
 1. Run the platform health checks and analyze the results.
 
@@ -323,7 +323,7 @@ Before rebooting NCNs:
 
 1. Reboot each of the worker nodes (one at a time).
 
-    **NOTE:** You are doing a single worker at a time, so please keep track of what ncn-w0xx you are on for these steps.
+    **NOTE:** You are doing a single worker at a time, so please keep track of what `ncn-w` you are on for these steps.
 
     1. Establish a console session to the worker node you are rebooting.
 
@@ -448,7 +448,7 @@ Before rebooting NCNs:
          ncn-m# kubectl get pods -o wide -A | grep <node to be rebooted>
          ```
 
-    12. Remove any dynamically assigned interface IP addresses that did not get released automatically by running the CASMINST-2015 script:
+    12. Remove any dynamically assigned interface IP addresses that did not get released automatically by running the `CASMINST-2015.sh` script:
 
         ```bash
         ncn-m001# /usr/share/doc/csm/scripts/CASMINST-2015.sh

--- a/operations/node_management/Rebuild_NCNs/Prepare_Storage_Nodes.md
+++ b/operations/node_management/Rebuild_NCNs/Prepare_Storage_Nodes.md
@@ -138,16 +138,16 @@ If rebuilding `ncn-s001`, it is critical that the `storage-ceph-cloudinit.sh` ha
     The `ceph osd tree` capture indicated that there are down OSDs on `ncn-s003`.
 
     ```screen
-     ncn-s# ceph osd tree down
-     ID  CLASS  WEIGHT    TYPE NAME          STATUS  REWEIGHT  PRI-AFF
-     -1         62.87750  root default
-     -9         10.47958      host ncn-s003
-     36    ssd   1.74660          osd.36       down   1.00000  1.00000
-     37    ssd   1.74660          osd.37       down   1.00000  1.00000
-     38    ssd   1.74660          osd.38       down   1.00000  1.00000
-     39    ssd   1.74660          osd.39       down   1.00000  1.00000
-     40    ssd   1.74660          osd.40       down   1.00000  1.00000
-     41    ssd   1.74660          osd.41       down   1.00000  1.00000
+    ncn-s# ceph osd tree down
+    ID  CLASS  WEIGHT    TYPE NAME          STATUS  REWEIGHT  PRI-AFF
+    -1         62.87750  root default
+    -9         10.47958      host ncn-s003
+    36    ssd   1.74660          osd.36       down   1.00000  1.00000
+    37    ssd   1.74660          osd.37       down   1.00000  1.00000
+    38    ssd   1.74660          osd.38       down   1.00000  1.00000
+    39    ssd   1.74660          osd.39       down   1.00000  1.00000
+    40    ssd   1.74660          osd.40       down   1.00000  1.00000
+    41    ssd   1.74660          osd.41       down   1.00000  1.00000
     ```
 
     1. Remove the OSD references to allow the rebuild to re-use the original OSD references on the drives. By default, if the OSD reference is not removed, then there will still a reference to them in the CRUSH map. This will result in OSDs that no longer exist appearing to be down.

--- a/operations/node_management/Rebuild_NCNs/Prepare_Storage_Nodes.md
+++ b/operations/node_management/Rebuild_NCNs/Prepare_Storage_Nodes.md
@@ -109,7 +109,7 @@ If rebuilding `ncn-s001`, it is critical that the `storage-ceph-cloudinit.sh` ha
         client:   6.2 KiB/s rd, 280 KiB/s wr, 2 op/s rd, 49 op/s wr
     ```
 
-2. If the node is up, then stop and disable all the Ceph services on the node being rebuilt.
+1. If the node is up, then stop and disable all the Ceph services on the node being rebuilt.
 
     On the node being rebuilt run:
 
@@ -133,7 +133,7 @@ If rebuilding `ncn-s001`, it is critical that the `storage-ceph-cloudinit.sh` ha
     Removed /etc/systemd/system/ceph-184b8c56-172d-11ec-aa96-a4bf0138ee14.target.    wants/ceph-184b8c56-172d-11ec-aa96-a4bf0138ee14@osd.38.service.
     ```
 
-3. Remove Ceph OSDs.
+1. Remove Ceph OSDs.
 
     The `ceph osd tree` capture indicated that there are down OSDs on `ncn-s003`.
 
@@ -150,7 +150,9 @@ If rebuilding `ncn-s001`, it is critical that the `storage-ceph-cloudinit.sh` ha
     41    ssd   1.74660          osd.41       down   1.00000  1.00000
     ```
 
-    1. Remove the OSD references to allow the rebuild to re-use the original OSD references on the drives. By default, if the OSD reference is not removed, then there will still a reference to them in the CRUSH map. This will result in OSDs that no longer exist appearing to be down.
+    1. Remove the OSD references to allow the rebuild to re-use the original OSD references on the drives.
+       By default, if the OSD reference is not removed, then there will still a reference to them in the CRUSH map.
+       This will result in OSDs that no longer exist appearing to be down.
 
     This command assumes you have set the variables from [the prerequisites section](../Rebuild_NCNs.md#Prerequisites).
 

--- a/operations/node_management/Rebuild_NCNs/Prepare_Storage_Nodes.md
+++ b/operations/node_management/Rebuild_NCNs/Prepare_Storage_Nodes.md
@@ -16,7 +16,7 @@ If rebuilding `ncn-s001`, it is critical that the `storage-ceph-cloudinit.sh` ha
    linux# ssh ncn-s001 cat /etc/cray/xname
    ```
 
-2. Check the bss boot parameters for `ncn-s001`.
+2. Check the `bss bootparameters` for `ncn-s001`.
 
    ```bash
    ncn# cray bss bootparameters list --name x3000c0s7b0n0 --format=json|jq -r '.[]|.["cloud-init"]|.["user-data"].runcmd'

--- a/operations/power_management/Standard_Rack_Node_Power_Management.md
+++ b/operations/power_management/Standard_Rack_Node_Power_Management.md
@@ -48,9 +48,9 @@ power management strategies using JSON data structures.
 
 The rack-mounted compute nodes support these power limiting and monitoring API
 calls:
--   get_power_cap_capabilities
--   get_power_cap
--   set_power_cap
+* `get_power_cap_capabilities`
+* `get_power_cap`
+* `set_power_cap`
 
 In general, rack-mounted compute nodes do not allow for power limiting of any
 installed accelerators separately from the node limit.
@@ -86,16 +86,18 @@ Hardware State Manager (HSM).
             }
         ]
     }
-    ````
+    ```
 
 -   **Get Power Limiting Capabilities**
 
-    ```
+    ```bash
     ncn-m001# cray capmc get_power_cap_capabilities create –-nids NID_LIST --format json
     ```
+
     Return the min and max power limit settings for the node list and any
     accelerators that are installed.
-    ```
+    
+    ```json
     ncn-m001# cray capmc get_power_cap_capabilities create --nids 4 --format json
     {
         "e": 0,
@@ -127,13 +129,15 @@ Hardware State Manager (HSM).
 
 -   **Set Node Power Limit**
 
-    ```
+    ```bash
     ncn-m001#  cray capmc set_power_cap create --nids NID_LIST --control CONTROL_NAME VALUE --format json
     ```
+
     Set the total power limit of the node by using the name of the node control.
     The power provided to the host CPU and memory is the total node power limit
     minus the power limits of each of the accelerators installed on the node.
-    ```
+    
+    ```json
     ncn-m001# cray capmc set_power_cap create --nids 4 --control "Chassis Power Control" 600
     {
         "e": 0,
@@ -147,10 +151,12 @@ Hardware State Manager (HSM).
         ]
     }
     ```
+
     Multiple controls can be set at the same time on multiple nodes, but all
     target nodes must have the same set of controls available, otherwise the
     call will fail.
-    ```
+    
+    ```json
     ncn-m001# cray capmc set_power_cap create \
     --nids [1-4] --control "Chassis Power Control" 600
     {
@@ -183,14 +189,16 @@ Hardware State Manager (HSM).
 
 -   **Remove Node Power Limit (Set to Default)**
 
-    ```
+    ```bash
     ncn-m001#  cray capmc set_power_cap create --nids NID_LIST --control CONTROL_NAME 0 --format json
     ```
+
     Reset the power limit to the default maximum. Alternatively, using the max
-    value returned from get_power_cap_capabilities may also be used. Multiple
+    value returned from `get_power_cap_capabilities` may also be used. Multiple
     controls can be set at the same time on multiple nodes, but all target nodes
     must have the same set of controls available, otherwise the call will fail.
-    ```
+    
+    ```json
     ncn-m001# cray capmc set_power_cap create --nids 4 --control "Node Power Limit" 0
     {
         "e": 0,
@@ -211,14 +219,15 @@ Hardware State Manager (HSM).
 
 -   **Enable Power Limiting**
 
-    ```
+    ```bash
     ncn-m001# curl -k -u $login:$pass -H "Content-Type: application/json" \
     -X POST https://${BMC}/redfish/v1/Chassis/Self/Power/Actions/LimitTrigger \
     --data '{"PowerLimitTrigger": "Activate"}'
     ```
 
 -   **Deactivate Node Power Limit**
-    ```
+    
+    ```bash
     ncn-m001# curl -k -u $login:$pass -H "Content-Type: application/json" \
     -X POST https://${BMC}/redfish/v1/Chassis/Self/Power/Actions/LimitTrigger \
     --data '{"PowerLimitTrigger": "Deactivate"}'

--- a/operations/power_management/Standard_Rack_Node_Power_Management.md
+++ b/operations/power_management/Standard_Rack_Node_Power_Management.md
@@ -97,8 +97,13 @@ Hardware State Manager (HSM).
     Return the min and max power limit settings for the node list and any
     accelerators that are installed.
     
-    ```json
+    ```bash
     ncn-m001# cray capmc get_power_cap_capabilities create --nids 4 --format json
+    ```
+
+    Expected output looks similar to the following:
+
+    ```json
     {
         "e": 0,
         "err_msg": "",
@@ -137,8 +142,13 @@ Hardware State Manager (HSM).
     The power provided to the host CPU and memory is the total node power limit
     minus the power limits of each of the accelerators installed on the node.
     
-    ```json
+    ```bash
     ncn-m001# cray capmc set_power_cap create --nids 4 --control "Chassis Power Control" 600
+    ```
+
+    Expected output looks similar to the following:
+
+    ```json
     {
         "e": 0,
         "err_msg": "",
@@ -156,9 +166,14 @@ Hardware State Manager (HSM).
     target nodes must have the same set of controls available, otherwise the
     call will fail.
     
-    ```json
+    ```bash
     ncn-m001# cray capmc set_power_cap create \
-    --nids [1-4] --control "Chassis Power Control" 600
+            --nids [1-4] --control "Chassis Power Control" 600
+    ```
+
+    Expected output looks similar to the following:
+
+    ```json
     {
         "e": 0,
         "err_msg": "",
@@ -198,8 +213,13 @@ Hardware State Manager (HSM).
     controls can be set at the same time on multiple nodes, but all target nodes
     must have the same set of controls available, otherwise the call will fail.
     
-    ```json
+    ```bash
     ncn-m001# cray capmc set_power_cap create --nids 4 --control "Node Power Limit" 0
+    ```
+
+    Expected output looks similar to the following:
+
+    ```json
     {
         "e": 0,
         "err_msg": "",
@@ -221,14 +241,14 @@ Hardware State Manager (HSM).
 
     ```bash
     ncn-m001# curl -k -u $login:$pass -H "Content-Type: application/json" \
-    -X POST https://${BMC}/redfish/v1/Chassis/Self/Power/Actions/LimitTrigger \
-    --data '{"PowerLimitTrigger": "Activate"}'
+            -X POST https://${BMC}/redfish/v1/Chassis/Self/Power/Actions/LimitTrigger \
+            --data '{"PowerLimitTrigger": "Activate"}'
     ```
 
 -   **Deactivate Node Power Limit**
     
     ```bash
     ncn-m001# curl -k -u $login:$pass -H "Content-Type: application/json" \
-    -X POST https://${BMC}/redfish/v1/Chassis/Self/Power/Actions/LimitTrigger \
-    --data '{"PowerLimitTrigger": "Deactivate"}'
+            -X POST https://${BMC}/redfish/v1/Chassis/Self/Power/Actions/LimitTrigger \
+            --data '{"PowerLimitTrigger": "Deactivate"}'
     ```

--- a/operations/power_management/Standard_Rack_Node_Power_Management.md
+++ b/operations/power_management/Standard_Rack_Node_Power_Management.md
@@ -19,16 +19,19 @@ power limit request will be needed for each vendor and model that needs to have
 its power limited.
 
 ## Requirements
-* Hardware State Manager (cray-hms-smd) >= v1.30.16
-* CAPMC (cray-hms-capmc) >= 1.31.0
-* CrayCLI >= 0.44.0
+
+* Hardware State Manager (`cray-hms-smd`) >= v1.30.16
+* CAPMC (`cray-hms-capmc`) >= 1.31.0
+* `cray` CLI >= 0.44.0
 
 ## Deprecated Interfaces
+
 See the [CAPMC Deprecation Notice](../../introduction/CAPMC_deprecation.md) for
 more information.
--   get_node_energy (Deprecated)
--   get_node_energy_stats (Deprecated)
--   get_system_power (Deprecated)
+
+* `get_node_energy` (Deprecated)
+* `get_node_energy_stats` (Deprecated)
+* `get_system_power` (Deprecated)
 
 ## Redfish API
 
@@ -48,6 +51,7 @@ power management strategies using JSON data structures.
 
 The rack-mounted compute nodes support these power limiting and monitoring API
 calls:
+
 * `get_power_cap_capabilities`
 * `get_power_cap`
 * `set_power_cap`
@@ -61,15 +65,17 @@ Hardware State Manager (HSM).
 
 ## Cray CLI Examples for Standard Rack Compute Node Power Management
 
--   **Get Node Power Control and Limit Settings**
+* **Get Node Power Control and Limit Settings**
 
-    ```
+    ```bash
     ncn-m001# cray capmc get_power_cap create –-nids NID_LIST --format json
     ```
+
     Return the current power limit settings for a node and any accelerators that
     are installed. Valid settings are only returned if power limiting is enabled
     on the target nodes.
-    ```
+
+    ```bash
     ncn-m001# cray capmc get_power_cap create --nids 4
     {
         "e": 0,
@@ -88,7 +94,7 @@ Hardware State Manager (HSM).
     }
     ```
 
--   **Get Power Limiting Capabilities**
+* **Get Power Limiting Capabilities**
 
     ```bash
     ncn-m001# cray capmc get_power_cap_capabilities create –-nids NID_LIST --format json
@@ -96,7 +102,7 @@ Hardware State Manager (HSM).
 
     Return the min and max power limit settings for the node list and any
     accelerators that are installed.
-    
+
     ```bash
     ncn-m001# cray capmc get_power_cap_capabilities create --nids 4 --format json
     ```
@@ -132,7 +138,7 @@ Hardware State Manager (HSM).
     }
     ```
 
--   **Set Node Power Limit**
+* **Set Node Power Limit**
 
     ```bash
     ncn-m001#  cray capmc set_power_cap create --nids NID_LIST --control CONTROL_NAME VALUE --format json
@@ -141,7 +147,7 @@ Hardware State Manager (HSM).
     Set the total power limit of the node by using the name of the node control.
     The power provided to the host CPU and memory is the total node power limit
     minus the power limits of each of the accelerators installed on the node.
-    
+
     ```bash
     ncn-m001# cray capmc set_power_cap create --nids 4 --control "Chassis Power Control" 600
     ```
@@ -165,7 +171,7 @@ Hardware State Manager (HSM).
     Multiple controls can be set at the same time on multiple nodes, but all
     target nodes must have the same set of controls available, otherwise the
     call will fail.
-    
+
     ```bash
     ncn-m001# cray capmc set_power_cap create \
             --nids [1-4] --control "Chassis Power Control" 600
@@ -202,7 +208,7 @@ Hardware State Manager (HSM).
     }
     ```
 
--   **Remove Node Power Limit (Set to Default)**
+* **Remove Node Power Limit (Set to Default)**
 
     ```bash
     ncn-m001#  cray capmc set_power_cap create --nids NID_LIST --control CONTROL_NAME 0 --format json
@@ -212,7 +218,7 @@ Hardware State Manager (HSM).
     value returned from `get_power_cap_capabilities` may also be used. Multiple
     controls can be set at the same time on multiple nodes, but all target nodes
     must have the same set of controls available, otherwise the call will fail.
-    
+
     ```bash
     ncn-m001# cray capmc set_power_cap create --nids 4 --control "Node Power Limit" 0
     ```
@@ -237,7 +243,7 @@ Hardware State Manager (HSM).
 
 ### Gigabyte
 
--   **Enable Power Limiting**
+* **Enable Power Limiting**
 
     ```bash
     ncn-m001# curl -k -u $login:$pass -H "Content-Type: application/json" \
@@ -245,8 +251,8 @@ Hardware State Manager (HSM).
             --data '{"PowerLimitTrigger": "Activate"}'
     ```
 
--   **Deactivate Node Power Limit**
-    
+* **Deactivate Node Power Limit**
+
     ```bash
     ncn-m001# curl -k -u $login:$pass -H "Content-Type: application/json" \
             -X POST https://${BMC}/redfish/v1/Chassis/Self/Power/Actions/LimitTrigger \

--- a/troubleshooting/pxe_runbook.md
+++ b/troubleshooting/pxe_runbook.md
@@ -56,6 +56,7 @@ interface vlan 1 magp 1 ip virtual-router address 10.1.0.
 interface vlan 1 magp 1 ip virtual-router mac-address
 00:00:5E:00:01:
 ```
+
 ```
 sw-spine-002 [standalone: master] # show run int vlan 1
 interface vlan 1
@@ -81,6 +82,7 @@ ip bootp-gateway 10.1.0.
 ip helper-address 10.92.100.
 exit
 ```
+
 ```
 sw-spine-002# show run int vlan 1
 interface vlan

--- a/troubleshooting/pxe_runbook.md
+++ b/troubleshooting/pxe_runbook.md
@@ -25,7 +25,7 @@ This guide runs through the most common issues and shows what is needed in order
     This has to match what the IP address is on the switches doing the routing for the MTL network.
     This is most commonly on the spines. This configuration is commonly missed on the CSI input file.
 
->MTL dnsmasq file
+>MTL `dnsmasq` file
 
 ```text
 # MTL:
@@ -204,7 +204,7 @@ Displaying ipv4 routes selected for forwarding
 
 ## 2.4. Test TFTP traffic (Aruba Only)
 
-* You can test the TFTP traffic by trying to download the ipxe.efi binary.
+* You can test the TFTP traffic by trying to download the `ipxe.efi` binary.
 * Log into the leaf switch and try to download the iPXE binary.
 * This requires that the leaf switch can talk to the TFTP server "10.92.100.60"
 
@@ -220,7 +220,7 @@ tftp> get ipxe.efi
 Received 1007200 bytes in 2.2 seconds
 ```
 
-* You can see here that the ipxe.efi binary is downloaded three times in a row. When we have seen issues with ECMP hashing this
+* You can see here that the `ipxe.efi` binary is downloaded three times in a row. When we have seen issues with ECMP hashing this
 would fail intermittently.
 
 <a name="check-dhcp-lease"></a>
@@ -306,7 +306,7 @@ worker. We believe this has something to do with conntrack.
   * [Check DHCP lease is getting allocated](#check-dhcp-lease)
   * [Verify the DHCP traffic on the Workers](#verify-the-dhcp-traffic)
   * [Verify the switches are forwarding DHCP traffic](#verify-the-switches)
-* Verify the IP-Helpers on the VLAN the computes nodes are booting over. This is typically VLAN 2 or VLAN 2xxx (MTN Computes)
+* Verify the IP-Helpers on the VLAN the computes nodes are booting over. This is typically `VLAN 2` or `VLAN 2xxx` (MTN Computes)
 * If the compute nodes make it past PXE and go into the PXE shell you can verify DNS and connectivity.
 
 ```text

--- a/troubleshooting/pxe_runbook.md
+++ b/troubleshooting/pxe_runbook.md
@@ -18,7 +18,6 @@ This guide runs through the most common issues and shows what is needed in order
 
 ## 1. NCNs on install
 
-
 * Verify the DNSMASQ configuration file matches what is configured on the switches.
   * Here is a DNSMASQ configuration file for the Metal network (VLAN1).
     As you can see, the router IP address is `10.1.0.1`.
@@ -106,7 +105,7 @@ exit
   * `2021-04-19 23:27:09 PXE-E18: Server response timeout.`
   * `2021-02-02 17:06:13 PXE-E99: Unexpected network error.`
 
-* Verify the ip helper-address on VLAN 1 on the switches. This is the same configuration as above ^ "Mellanox Config" and "Aruba Config"
+* Verify the `ip helper-address` on VLAN 1 on the switches. This is the same configuration as above ^ "Mellanox Config" and "Aruba Config"
 
 <a name="Verify-DHCP-packets"></a>
 

--- a/troubleshooting/pxe_runbook.md
+++ b/troubleshooting/pxe_runbook.md
@@ -3,16 +3,16 @@
 PXE booting is a key component of a working Shasta system. There are a lot of different components involved, which increases the complexity.
 This guide runs through the most common issues and shows what is needed in order to have a successful PXE boot.
 
-1. [NCNs on install](#ncns-on-install)<br>
-2. [`ncn-m001` on reboot or NCN boot](#ncn-m001-on-reboot)<br>
-    2.1. [Verify DHCP packets can be forwarded from the workers to the MTL network (VLAN1)](#Verify-DHCP-packets)<br>
-    2.2. [Verify BGP](#verify-bgp)<br>
-    2.3. [Verify route to TFTP](#verify-route-to-tftp)<br>
-    2.4. [Test TFTP traffic (Aruba Only)](#test-tftp-traffic)<br>
-    2.5. [Check DHCP lease is getting allocated](#check-dhcp-lease)<br>
-    2.6. [Verify the DHCP traffic on the Workers](#verify-the-dhcp-traffic)<br>
-    2.7. [Verify the switches are forwarding DHCP traffic.](#verify-the-switches)<br>
-3. [Computes/UANs/Application Nodes](#computes-uans-applications-nodes)<br>
+1. [NCNs on install](#ncns-on-install)
+2. [`ncn-m001` on reboot or NCN boot](#ncn-m001-on-reboot)
+    2.1. [Verify DHCP packets can be forwarded from the workers to the MTL network (VLAN1)](#Verify-DHCP-packets)
+    2.2. [Verify BGP](#verify-bgp)
+    2.3. [Verify route to TFTP](#verify-route-to-tftp)
+    2.4. [Test TFTP traffic (Aruba Only)](#test-tftp-traffic)
+    2.5. [Check DHCP lease is getting allocated](#check-dhcp-lease)
+    2.6. [Verify the DHCP traffic on the Workers](#verify-the-dhcp-traffic)
+    2.7. [Verify the switches are forwarding DHCP traffic.](#verify-the-switches)
+3. [Computes/UANs/Application Nodes](#computes-uans-applications-nodes)
 
 <a name="ncns-on-install"></a>
 
@@ -20,7 +20,10 @@ This guide runs through the most common issues and shows what is needed in order
 
 
 * Verify the DNSMASQ configuration file matches what is configured on the switches.
-    * Here is a DNSMASQ configuration file for the Metal network (VLAN1). As you can see, the router IP address is `10.1.0.1`. This has to match what the IP address is on the switches doing the routing for the MTL network. This is most commonly on the spines. This configuration is commonly missed on the CSI input file.
+  * Here is a DNSMASQ configuration file for the Metal network (VLAN1).
+    As you can see, the router IP address is `10.1.0.1`.
+    This has to match what the IP address is on the switches doing the routing for the MTL network.
+    This is most commonly on the spines. This configuration is commonly missed on the CSI input file.
 
 >MTL dnsmasq file
 
@@ -42,11 +45,9 @@ dhcp-range=interface:bond0,10.1.1.33,10.1.1.233,10m
 
 * Here is an example of what the spine switch configuration should be.
 
-
-
 >Mellanox Configuration
 
-```
+```text
 sw-spine-001 [standalone: master] # show run int vlan 1
 interface vlan 1
 interface vlan 1 ip address 10.1.0.2/16 primary
@@ -57,7 +58,7 @@ interface vlan 1 magp 1 ip virtual-router mac-address
 00:00:5E:00:01:
 ```
 
-```
+```text
 sw-spine-002 [standalone: master] # show run int vlan 1
 interface vlan 1
 interface vlan 1 ip address 10.1.0.3/16 primary
@@ -70,7 +71,7 @@ interface vlan 1 magp 1 ip virtual-router mac-address
 
 >Aruba Configuration
 
-```
+```text
 sw-spine-001# show run int vlan 1
 interface vlan
 vsx-sync active-gateways
@@ -83,7 +84,7 @@ ip helper-address 10.92.100.
 exit
 ```
 
-```
+```text
 sw-spine-002# show run int vlan 1
 interface vlan
 vsx-sync active-gateways
@@ -94,23 +95,22 @@ ip mtu 9198
 ip helper-address 10.92.100.
 exit
 ```
+
 * You should be able to ping the MTL router from `ncn-m001`.
 
 <a name="ncn-m001-on-reboot"></a>
 
 ## 2. `ncn-m001` on reboot or NCN boot
 
-
 * Common Error messages.
-
-    * `2021-04-19 23:27:09 PXE-E18: Server response timeout.`
-    * `2021-02-02 17:06:13 PXE-E99: Unexpected network error.`
+  * `2021-04-19 23:27:09 PXE-E18: Server response timeout.`
+  * `2021-02-02 17:06:13 PXE-E99: Unexpected network error.`
 
 * Verify the ip helper-address on VLAN 1 on the switches. This is the same configuration as above ^ "Mellanox Config" and "Aruba Config"
 
 <a name="Verify-DHCP-packets"></a>
-## 2.1. Verify DHCP packets can be forwarded from the workers to the MTL network (VLAN1)
 
+## 2.1. Verify DHCP packets can be forwarded from the workers to the MTL network (VLAN1)
 
 * If the Worker nodes cannot reach the metal network DHCP will fail.
 * ALL WORKERS need to be able to reach the MTL network!
@@ -131,14 +131,14 @@ ncn-w# ip route add 10.1.0.0/16 via 10.252.0.1 dev vlan
 ```
 
 <a name="verify-bgp"></a>
-## 2.2. Verify BGP
 
+## 2.2. Verify BGP
 
 * Verify the BGP neighbors are in the established state on BOTH the switches.
 
 >Aruba BGP
 
-```
+```text
 sw-spine-002# show bgp ipv4 u s
 VRF : default
 BGP Summary
@@ -158,7 +158,7 @@ BGP Summary
 
 >Mellanox BGP
 
-```
+```text
 sw-spine-001 [standalone: master] # show ip bgp summary
 
 VRF name                  : default
@@ -185,7 +185,7 @@ Neighbor          V    AS           MsgRcvd   MsgSent   TblVer    InQ    OutQ   
 * On BOTH Aruba switches we need a single route to the TFTP server 10.92.100.60. This is needed because there are issues with Aruba
 ECMP hashing and TFTP traffic.
 
-```
+```text
 sw-spine-002# show ip route 10.92.100.60
 
 Displaying ipv4 routes selected for forwarding
@@ -201,14 +201,14 @@ Displaying ipv4 routes selected for forwarding
 * For the example above we would ping 10.252.1.9. If this is not reachable this is your problem.
 
 <a name="test-tftp-traffic"></a>
-## 2.4. Test TFTP traffic (Aruba Only)
 
+## 2.4. Test TFTP traffic (Aruba Only)
 
 * You can test the TFTP traffic by trying to download the ipxe.efi binary.
 * Log into the leaf switch and try to download the iPXE binary.
 * This requires that the leaf switch can talk to the TFTP server "10.92.100.60"
 
-```
+```text
 sw-leaf-001# start-shell
 sw-leaf-001:~$ sudo su
 sw-leaf-001:/home/admin# tftp 10.92.100.
@@ -224,30 +224,32 @@ Received 1007200 bytes in 2.2 seconds
 would fail intermittently.
 
 <a name="check-dhcp-lease"></a>
+
 ## 2.5. Check DHCP lease is getting allocated
 
 * Check the KEA logs and verify that the lease is getting allocated.
+  
 ```bash
 ncn# kubectl logs -n services pod/$(kubectl get -n services pods |
          grep kea | head -n1 | cut -f 1 -d ' ') -c cray-dhcp-kea
 ```
 
-```
+```text
 2021-04-21 00:13:05.416 INFO  [kea-dhcp4.leases/24.139710796402304] DHCP4_LEASE_ALLOC [hwtype=1 02:23:28:01:30:10], cid=[00:78:39:30:30:30:63:31:73:30:62:31], tid=0x21f2433a: lease 10.104.0.23 has been allocated for 300 seconds
 ```
 
 * Here we can see that KEA is allocating a lease to `10.104.0.23`.
 * The lease MUST say `DHCP4_LEASE_ALLOC`. If it says `DHCP4_LEASE_ADVERT`, there is likely a problem. Restarting KEA will fix this issue most of the time.
 
-```
+```text
 2021-06-21 16:44:31.124 INFO  [kea-dhcp4.leases/18.139837089017472] DHCP4_LEASE_ADVERT [hwtype=1 14:02:ec:d9:79:88], cid=[no info], tid=0xe87fad10: lease 10.252.1.16 will be advertised
 ```
 
 <a name="verify-the-dhcp-traffic"></a>
+
 ## 2.6. Verify the DHCP traffic on the Workers
 
-
-* We have ran into issues on HPE servers and Aruba switches where the source address of the DHCP Offer is the Metallb address
+* We have ran into issues on HPE servers and Aruba switches where the source address of the DHCP Offer is the MetalLB address
 of KEA `10.92.100.222`. The source address of the DHCP Reply/Offer **needs** to be the address of the VLAN interface on the
 Worker.
 * Here is how to look at DHCP traffic on the workers.
@@ -258,7 +260,7 @@ ncn-w# tcpdump -envli bond0 port 67 or 68
 
 * You are looking for the source IP address of the DHCP Reply/Offer.
 
-```
+```text
 10.252.1.9.67 > 255.255.255.255.68: BOOTP/DHCP, Reply, length 309, hops 1, xid 0x98b0982e, Flags [Broadcast]
       Your-IP 10.252.1.17
       Server-IP 10.92.100.60
@@ -270,7 +272,7 @@ ncn-w# tcpdump -envli bond0 port 67 or 68
 * If the Source IP address of the DHCP Reply/Offer is the MetalLB IP address, the DHCP packet will never make it out of the NCN. An example of
 this is below.
 
-```
+```text
 10.92.100.222.116 > 255.255.255.255.68: BOOTP/DHCP, Reply, length 309, hops 1, xid 0x260ea655, Flags [Broadcast]
   Your-IP 10.252.1.14
   Server-IP 10.92.100.60
@@ -283,29 +285,31 @@ this is below.
 worker. We believe this has something to do with conntrack.
 
 <a name="verify-the-switches"></a>
-## 2.7. Verify the switches are forwarding DHCP traffic.
+
+## 2.7. Verify the switches are forwarding DHCP traffic
 
 * If you still cannot PXE boot, the IP-Helper may be breaking on the switch.
 * On Aruba, Dell, and Mellanox switches we have seen the IP-Helpers get stuck and stop forwarding DHCP traffic to the client.
-    * The solutions vary from vendor to vendor.
-    * On an Aruba or Mellanox switch, delete the entire VLAN configuration and re-apply it, in order for the DHCP traffic to come back.
-    * On a Dell switch, do a reboot in order to restore DHCP traffic.
+  * The solutions vary from vendor to vendor.
+  * On an Aruba or Mellanox switch, delete the entire VLAN configuration and re-apply it, in order for the DHCP traffic to come back.
+  * On a Dell switch, do a reboot in order to restore DHCP traffic.
 * The underlying cause of IP-Helper breaking is not yet known.
 
 <a name="computes-uans-applications-nodes"></a>
+
 ## 3. Compute Nodes/UANs/Application Nodes
 
 * The following are required for compute node PXE booting.
-    * [Verify BGP](#ncns-on-install)<br>
-    * [Verify route to TFTP](#verify-route-to-tftp)
-    * [Test TFTP traffic](#test-tftp-traffic)
-    * [Check DHCP lease is getting allocated](#check-dhcp-lease)
-    * [Verify the DHCP traffic on the Workers](#verify-the-dhcp-traffic)
-    * [Verify the switches are forwarding DHCP traffic](#verify-the-switches)
+  * [Verify BGP](#ncns-on-install)
+  * [Verify route to TFTP](#verify-route-to-tftp)
+  * [Test TFTP traffic](#test-tftp-traffic)
+  * [Check DHCP lease is getting allocated](#check-dhcp-lease)
+  * [Verify the DHCP traffic on the Workers](#verify-the-dhcp-traffic)
+  * [Verify the switches are forwarding DHCP traffic](#verify-the-switches)
 * Verify the IP-Helpers on the VLAN the computes nodes are booting over. This is typically VLAN 2 or VLAN 2xxx (MTN Computes)
 * If the compute nodes make it past PXE and go into the PXE shell you can verify DNS and connectivity.
 
-```
+```text
 iPXE> dhcp
 Configuring (net0 98:03:9b:a8:60:88).................. No configuration methods succeeded (http://ipxe.org/040ee186)
 Configuring (net1 b4:2e:99:be:1a:37)...... ok
@@ -317,4 +321,3 @@ iPXE> nslookup address api-gw-service-nmn.local
 iPXE> echo ${address}
 10.92.100.71
 ```
-

--- a/troubleshooting/pxe_runbook.md
+++ b/troubleshooting/pxe_runbook.md
@@ -105,7 +105,7 @@ exit
   * `2021-04-19 23:27:09 PXE-E18: Server response timeout.`
   * `2021-02-02 17:06:13 PXE-E99: Unexpected network error.`
 
-* Verify the `ip helper-address` on VLAN 1 on the switches. This is the same configuration as above ^ "Mellanox Config" and "Aruba Config"
+* Verify the `ip helper-address` on VLAN 1 on the switches. This is the same configuration as above in "Mellanox Configuration" and "Aruba Configuration"
 
 <a name="Verify-DHCP-packets"></a>
 


### PR DESCRIPTION
## Summary and Scope

Correcting several instances throughout the docs where fenced code blocks start with a triple-backtick marker
but are never closed with a corresponding one.

## Issues and Related PRs

* Resolves [STP-3186](https://jira-pro.its.hpecorp.net:8443/browse/STP-3186) and https://github.com/Cray-HPE/docs-csm/issues/952
* Change will also be needed in `release/1.2` and `main`
* Merge with https://github.com/Cray-HPE/docs-csm/pull/1310 and https://github.com/Cray-HPE/docs-csm/pull/1476

## Testing

N/A

### Tested on:

N/A

### Test description:

N/A

## Risks and Mitigations

None.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
