### PR TITLE
Add step in prereq's to reconfigure haproxy on masters

### DIFF
--- a/upgrade/1.2/scripts/k8s/reconfigure_haproxy.sh
+++ b/upgrade/1.2/scripts/k8s/reconfigure_haproxy.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+sed -i.bak '/    default-server/s/.*/    default-server verify none check-ssl inter 10s downinter 5s rise 2 fall 2 slowstart 60s maxconn 250 maxqueue 256 weight 100/' /etc/haproxy/haproxy.cfg
+sed -i.bak '0,/    option tcp-check/s//    option httpchk GET \/readyz HTTP\/1.0\n    option  log-health-checks\n    http-check expect status 200/' /etc/haproxy/haproxy.cfg
+
+systemctl restart haproxy


### PR DESCRIPTION
## Summary and Scope

Change kube-api haproxy health check from tcp to http, which makes failover more responsive and doesn't hork up postgres.

## Issues and Related PRs

* Resolves [CASMTRIAGE-3263](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3263)

## Testing

```
====> RECONFIGURE_HAPROXY_MASTERS ...
====> RECONFIGURE_HAPROXY_MASTERS has been completed

[OK] - Successfully completed
```

```
ncn-m003:~ # diff /etc/haproxy/haproxy.cfg /etc/haproxy/haproxy.cfg.orig
44,46c44
<     option httpchk GET /readyz HTTP/1.0
<     option  log-health-checks
<     http-check expect status 200
---
>     option tcp-check
48c46
<     default-server verify none check-ssl inter 10s downinter 5s rise 2 fall 2 slowstart 60s maxconn 250 maxqueue 256 weight 100
---
>     default-server inter 10s downinter 5s rise 2 fall 2 slowstart 60s maxconn 250 maxqueue 256 weight 100
```

```
● haproxy.service - HAProxy Load Balancer
     Loaded: loaded (/usr/lib/systemd/system/haproxy.service; disabled; vendor preset: disabled)
     Active: active (running) since Wed 2022-04-27 14:51:42 UTC; 51s ago
    Process: 47769 ExecStartPre=/usr/sbin/haproxy -f $CONFIG -c -q $EXTRAOPTS (code=exited, status=0/SUCCESS)
   Main PID: 47782 (haproxy)
      Tasks: 3
     CGroup: /system.slice/haproxy.service
             ├─47782 /usr/sbin/haproxy -Ws -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid -S /run/haproxy-master.s>
             └─47783 /usr/sbin/haproxy -Ws -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid -S /run/haproxy-master.s>

Apr 27 14:51:42 ncn-m003 haproxy[47782]: Proxy etcd started.
Apr 27 14:51:42 ncn-m003 haproxy[47782]: [NOTICE] 116/145142 (47782) : New worker #1 (47783) forked
```


### Tested on:

  * `craystack`

### Test description:

Ran the new code in craystack, watched haproxy come up with http check instead of tcp

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

