### PR TITLE
Remove script references to private repo -- add script here

### DIFF
--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
@@ -39,9 +39,10 @@ The Kubernetes image `k8s-image` is used by the master and worker nodes.
    ```
 
    This example uses k8s/0.1.109 for the current version and adds a suffix for the new version.
-
+   ```bash
    ncn-m# export K8SVERSION=0.1.109
    ncn-m# export K8SNEW=0.1.109-2
+   ```
 
 1. Make a temporary directory for the k8s-image using the current version string.
 
@@ -69,8 +70,10 @@ The Ceph image `ceph-image` is used by the utility storage nodes.
 
    This example uses ceph/0.1.113 for the current version and adds a suffix for the new version.
 
+   ```bash
    ncn-m# export CEPHVERSION=0.1.113
    ncn-m# export CEPHNEW=0.1.113-2
+   ```
 
 1. Make a temporary directory for the ceph-image using the current version string.
 
@@ -174,54 +177,22 @@ The Ceph image `ceph-image` is used by the utility storage nodes.
 
 1. Put the new squashfs, kernel, and initrd into S3
 
-   1. If not already available, get this script which will put a file into S3 with public read setting.
+   ***Note:*** The version string for the kernel file may be different.
 
    ```bash
-   ncn-m# wget https://github.com/Cray-HPE/s3_examples/blob/main/no_STS/ceph-upload-file-public-read.py
-   ncn-m# chmod +x ceph-upload-file-public-read.py
+   ncn-m# cd k8s/${K8SNEW}
+   /usr/share/doc/csm/scripts/ceph-upload-file-public-read.py --bucket-name ncn-images --key-name 'k8s/${K8SNEW}/filesystem.squashfs' --file-name filesystem.squashfs
+   /usr/share/doc/csm/scripts/ceph-upload-file-public-read.py --bucket-name ncn-images --key-name 'k8s/${K8SNEW}/initrd' --file-name initrd.img.xz
+   /usr/share/doc/csm/scripts/ceph-upload-file-public-read.py --bucket-name ncn-images --key-name 'k8s/${K8SNEW}/kernel' --file-name 5.3.18-24.75-default.kernel
    ```
 
-   1. Get info to add to `credentials.json` for the SDS user
-
-      ```bash
-      ncn-m# ssh ncn-s001 radosgw-admin user info --uid SDS | grep key
-      "keys": [
-              "access_key": "FKZWSIY92VBC4LPGXW9I",
-              "secret_key": "mYcViYWwXDT7PAR5JOwzsT5vjkKhWHUb8MGJpjsm"
-      "swift_keys": [],
-      "temp_url_keys": [],
-      ```
-
-   1. Using the `access_key` and `secret_key`, construct a `credentials.json` file with contents similar to this.
-
-      ```json
-      {
-          "access_key": "KJ1B22VP2MBKYPALP8VW",
-          "secret_key": "EJbDkvoaHEcMfhkMeDSA3tEM6DwBSmuGzVYkuUOv",
-          "endpoint_url": "http://10.252.1.11:8080"
-      }
-      ```
-
-   1. Upload the boot artifacts to S3.
-
-      ***Note:*** The version string for the kernel file may be different.
-
-      ```bash
-      ncn-m# cp -p credentials.json ceph-upload-file-public-read.py k8s/${K8SNEW}
-      ncn-m# cd k8s/${K8SNEW}
-      ncn-m# ./ceph-upload-file-public-read.py --bucket-name ncn-images --key-name 'k8s/${K8SNEW}/filesystem.squashfs' --file-name secure-filesystem.squashfs
-      ncn-m# ./ceph-upload-file-public-read.py --bucket-name ncn-images --key-name 'k8s/${K8SNEW}/initrd' --file-name initrd.img.xz
-      ncn-m# ./ceph-upload-file-public-read.py --bucket-name ncn-images --key-name 'k8s/${K8SNEW}/kernel' --file-name 5.3.18-24.75-default.kernel
-      ```
-
-      ```bash
-      ncn-m# cp -p credentials.json ceph-upload-file-public-read.py ceph/${CEPHNEW}
-      ncn-m# cd ceph/${CEPHNEW}
-      ncn-m# ./ceph-upload-file-public-read.py --bucket-name ncn-images --key-name 'ceph/${CEPHNEW}/filesystem.squashfs' --file-name secure-filesystem.squashfs
-      ncn-m# ./ceph-upload-file-public-read.py --bucket-name ncn-images --key-name 'ceph/${CEPHNEW}/initrd' --file-name initrd.img.xz
-      ncn-m# ./ceph-upload-file-public-read.py --bucket-name ncn-images --key-name 'ceph/${CEPHNEW}/kernel' --file-name 5.3.18-24.75-default.kernel
-      ncn-m# cd ../..
-      ```
+   ```bash
+   ncn-m# cd ceph/${CEPHNEW}
+   /usr/share/doc/csm/scripts/ceph-upload-file-public-read.py --bucket-name ncn-images --key-name 'ceph/${CEPHNEW}/filesystem.squashfs' --file-name filesystem.squashfs
+   /usr/share/doc/csm/scripts/ceph-upload-file-public-read.py --bucket-name ncn-images --key-name 'ceph/${CEPHNEW}/initrd' --file-name initrd.img.xz
+   /usr/share/doc/csm/scripts/ceph-upload-file-public-read.py --bucket-name ncn-images --key-name 'ceph/${CEPHNEW}/kernel' --file-name 5.3.18-24.75-default.kernel
+   cd ../..
+   ```
 
 1. The Kubernetes and Storage images now have the image changes.
 

--- a/scripts/ceph-upload-file-public-read.py
+++ b/scripts/ceph-upload-file-public-read.py
@@ -1,0 +1,97 @@
+#! /usr/bin/env python3
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+
+import os
+import sys
+from argparse import ArgumentParser
+import json
+import subprocess
+from base64 import b64decode
+import boto3
+import botocore
+from botocore.config import Config
+S3_CONNECT_TIMEOUT=60
+S3_READ_TIMEOUT=1
+
+
+
+def main():
+
+    parser = ArgumentParser(description='Creates a bucket')
+    parser.add_argument('--bucket-name',
+                        dest='bucket_name',
+                        action='store',
+                        required=True,
+                        help='the name of the bucket to create')
+    parser.add_argument('--key-name',
+                        dest='key_name',
+                        action='store',
+                        required=True,
+                        help='the objects key name')
+    parser.add_argument('--file-name',
+                        dest='file_name',
+                        action='store',
+                        required=True,
+                        help='the file to upload')
+    args = parser.parse_args()
+
+    s3_config = Config(connect_timeout=S3_CONNECT_TIMEOUT,
+                           read_timeout=S3_READ_TIMEOUT)
+
+    #
+    # These bucket names have K8S secrets with non-standard names
+    #
+    non_std_bucket_map = {'ssm': 'ssm-swm-s3-credentials',
+                          'boot-images': 'ims-s3-credentials',
+                          'install-artifacts': 'artifacts-s3-credentials',
+                          'ncn-images': 'sds-s3-credentials'}
+    if args.bucket_name in non_std_bucket_map:
+        secret_name = non_std_bucket_map[args.bucket_name]
+    else:
+        secret_name = "%s-%s" % (args.bucket_name, "s3-credentials")
+
+    # get credentials
+    a_key = b64decode(subprocess.check_output(
+        ['kubectl', 'get', 'secret', secret_name, '-o', "jsonpath='{.data.access_key}'"])).decode()
+    s_key = b64decode(subprocess.check_output(
+        ['kubectl', 'get', 'secret', secret_name, '-o', "jsonpath='{.data.secret_key}'"])).decode()
+    credentials = {'endpoint_url': 'http://rgw-vip',
+                   'access_key': a_key, 'secret_key': s_key}
+    s3 = boto3.resource('s3',
+                        endpoint_url=credentials['endpoint_url'],
+                        aws_access_key_id=credentials['access_key'],
+                        aws_secret_access_key=credentials['secret_key'],
+                        config=s3_config)
+
+    bucket = s3.Bucket(args.bucket_name)
+
+    bucket.upload_file(Filename=args.file_name,
+                       Key=args.key_name,
+                       ExtraArgs={'ACL': 'public-read'})
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary and Scope

Import script referenced in docs from private repo to scripts dir.   Cleanup instructions to no longer create creds file.  Also fix line break issue (CASMTRIAGE-3229).

## Issues and Related PRs

* Resolves [CASMTRIAGE-3231](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3231)
* Resolves [CASMTRIAGE-3229](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3229)

## Testing

Tested on vshasta, credentials autogather worked great, object has public read:

```
.
.
    },
    "attrs": {
        "user.rgw.pg_ver": "\u0004",
        "user.rgw.source_zone": "��Y�",
        "user.rgw.tail_tag": "654c2e63-742a-44e8-8c54-ae3d955c49ba.34103.1191",
        "user.rgw.x-amz-acl": "public-read",
        "user.rgw.x-amz-content-sha256": "b31c970820a843c5f5254397e52aac3b60b724fd2835d73b75497e9bfce60207",
        "user.rgw.x-amz-date": "20220427T182542Z"
    }
}
```

### Tested on:

  * Virtual Shasta

### Test description:

Ran script on vshasta

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

