### PR TITLE
CASMINST-4534: Enable passwordless SSH on PIT earlier in the install

### DIFF
--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -469,7 +469,7 @@ be performed are in the [Deploy](#deploy) section.
         ```
 
         Expected output looks similar to the following:
-        
+
         ```text
         Password:
         receiving incremental file list
@@ -484,26 +484,27 @@ be performed are in the [Deploy](#deploy) section.
         ```
 
     1. Make a list of all of the NCNs (including `ncn-m001`).
-    
+
         ```ShellSession
         pit# NCNS=$(grep -oP "ncn-[msw][0-9]{3}" /etc/dnsmasq.d/statics.conf | sort -u | tr '\n' ',') ; echo "${NCNS}"
         ```
-        
+
         Expected output looks similar to the following:
-        
+
         ```text
         ncn-m001,ncn-m002,ncn-m003,ncn-s001,ncn-s002,ncn-s003,ncn-w001,ncn-w002,ncn-w003
         ```
 
     1. Verify that passwordless SSH is now working from the PIT node to the other NCNs.
-    
+
         The following command should not prompt you to enter a password.
-        
+
         ```ShellSession
         pit# PDSH_SSH_ARGS_APPEND='-o StrictHostKeyChecking=no' pdsh -Sw "${NCNS}" date && echo SUCCESS || echo ERROR
         ```
-        
+
         Expected output looks similar to the following:
+
         ```text
         ncn-w001: Warning: Permanently added 'ncn-w001,10.252.1.7' (ECDSA) to the list of known hosts.
         ncn-w003: Warning: Permanently added 'ncn-w003,10.252.1.9' (ECDSA) to the list of known hosts.

--- a/install/install_csm_services.md
+++ b/install/install_csm_services.md
@@ -10,7 +10,7 @@ This procedure will install CSM applications and services into the CSM Kubernete
 1. [Known Issues](#known-issues)
     * [install.sh known issues](#known-issues-install-sh)
     * [Setup Nexus known issues](#known-issues-setup-nexus)
-1.  [Next Topic](#next-topic)
+1. [Next Topic](#next-topic)
 
 ## Details
 
@@ -41,8 +41,8 @@ and tuning based on specific systems, see
     pit# popd
     ```
 
-    > **NOTES:** 
-    > 
+    > **NOTES:**
+    >
     > * If any errors are encountered, then potential fixes should be displayed where the error occurred. You can rerun above command any time.
     > * Output is redirected to `/usr/share/doc/csm/install/scripts/csm_services/yapl.log` . To show stdout in the terminal, use
     >   `yapl -f install.yaml --console-output execute`
@@ -69,7 +69,7 @@ error. It may be possible to resume installation from the last successful
 command executed by `install.sh`, but administrators will need to appropriately
 modify `install.sh` to pick up where the previous run left off. (Note: The
 `install.sh` script runs with `set -x`, so each command will be printed to
-stderr prefixed with the expanded value of PS4, namely, `+ `.)
+stderr prefixed with the expanded value of PS4, namely, `+`.)
 
 The following error may occur when running `./install.sh`:
 
@@ -119,4 +119,4 @@ Known potential issues with suggested fixes are listed in [Troubleshoot Nexus](.
 
 After completing this procedure the next step is to validate CSM health before redeploying the final NCN.
 
-- See [Validate CSM Health Before Final NCN Deployment](index.md#validate_csm_health_before_final_ncn_deploy)
+See [Validate CSM Health Before Final NCN Deployment](index.md#validate_csm_health_before_final_ncn_deploy)

--- a/install/install_csm_services.md
+++ b/install/install_csm_services.md
@@ -28,12 +28,6 @@ pit# rpm -Uvh /var/www/ephemeral/${CSM_RELEASE}/rpm/cray/csm/sle-15sp2/x86_64/ya
 
 > **NOTE**: During this step, on (only) TDS systems with three worker nodes the `customizations.yaml` file will be edited (automatically) to lower pod CPU requests for some services in order to better facilitate scheduling on smaller systems. See the file: `/var/www/ephemeral/${CSM_RELEASE}/tds_cpu_requests.yaml` for these settings. If desired, this file can be modified with different values (prior to executing the `yapl` command below) if other settings are desired in the `customizations.yaml` file for this system. For more information about modifying `customizations.yaml` and tuning based on specific systems, see [Post Install Customizations](https://github.com/Cray-HPE/docs-csm/blob/release/1.2/operations/CSM_product_management/Post_Install_Customizations.md).
 
-1. Setup passwordless SSH for the pit node:
-
-    ```bash
-    pit# rsync -av ncn-m002:.ssh/ /root/.ssh/
-    ```
-
 1. Install csm services using `yapl`:
 
     ```bash

--- a/install/install_csm_services.md
+++ b/install/install_csm_services.md
@@ -4,19 +4,18 @@ This procedure will install CSM applications and services into the CSM Kubernete
 
 > **NOTE:** Check the information in [Known Issues](#known-issues) before starting this procedure to be warned about possible problems.
 
-### Topics:
-
-1.  [Install Yapl](#install-yapl)
-1.  [Install CSM Services](#install-csm-services)
-1.  [Wait For Everything To Settle](#wait-for-everything-to-settle)
-1.  [Known Issues](#known-issues)
-    - [install.sh known issues](#known-issues-install-sh)
-    - [Setup Nexus known issues](#known-issues-setup-nexus)
+1. [Install Yapl](#install-yapl)
+1. [Install CSM Services](#install-csm-services)
+1. [Wait For Everything To Settle](#wait-for-everything-to-settle)
+1. [Known Issues](#known-issues)
+    * [install.sh known issues](#known-issues-install-sh)
+    * [Setup Nexus known issues](#known-issues-setup-nexus)
 1.  [Next Topic](#next-topic)
 
 ## Details
 
 <a name="install-yapl"></a>
+
 ### 1. Install Yapl
 
 ```bash
@@ -24,34 +23,44 @@ pit# rpm -Uvh /var/www/ephemeral/${CSM_RELEASE}/rpm/cray/csm/sle-15sp2/x86_64/ya
 ```
 
 <a>install-csm-services</a>
+
 ### 2. Install CSM Services
 
-> **NOTE**: During this step, on (only) TDS systems with three worker nodes the `customizations.yaml` file will be edited (automatically) to lower pod CPU requests for some services in order to better facilitate scheduling on smaller systems. See the file: `/var/www/ephemeral/${CSM_RELEASE}/tds_cpu_requests.yaml` for these settings. If desired, this file can be modified with different values (prior to executing the `yapl` command below) if other settings are desired in the `customizations.yaml` file for this system. For more information about modifying `customizations.yaml` and tuning based on specific systems, see [Post Install Customizations](https://github.com/Cray-HPE/docs-csm/blob/release/1.2/operations/CSM_product_management/Post_Install_Customizations.md).
+> **NOTE**: During this step, on (only) TDS systems with three worker nodes the `customizations.yaml` file will be edited (automatically) to lower pod
+CPU requests for some services in order to better facilitate scheduling on smaller systems. See the file:
+`/var/www/ephemeral/${CSM_RELEASE}/tds_cpu_requests.yaml` for these settings. If desired, this file can be modified with different values (prior to executing the
+`yapl` command below) if other settings are desired in the `customizations.yaml` file for this system. For more information about modifying `customizations.yaml`
+and tuning based on specific systems, see
+[Post Install Customizations](https://github.com/Cray-HPE/docs-csm/blob/release/1.2/operations/CSM_product_management/Post_Install_Customizations.md).
 
-1. Install csm services using `yapl`:
+1. Install CSM services using `yapl`:
 
     ```bash
-    pit# pushd /usr/share/doc/csm/install/scripts/csm_services
-    pit# yapl -f install.yaml execute
+    pit# pushd /usr/share/doc/csm/install/scripts/csm_services && \
+         yapl -f install.yaml execute
     pit# popd
     ```
 
-    > **`IMPORTANT:`** If any errors are encountered, then potential fixes should be displayed where the error occurred. You can rerun above command any time.
-
-    > **NOTE**: stdout is redirected to `/usr/share/doc/csm/install/scripts/csm_services/yapl.log` . If you would like to show stdout in the terminal, you can use `yapl -f install.yaml --console-output execute`
-
-    > **NOTE**: If you want to force a rerun, you can use `--no-cache`: `yapl -f install.yaml execute --no-cache`
+    > **NOTES:** 
+    > 
+    > * If any errors are encountered, then potential fixes should be displayed where the error occurred. You can rerun above command any time.
+    > * Output is redirected to `/usr/share/doc/csm/install/scripts/csm_services/yapl.log` . To show stdout in the terminal, use
+    >   `yapl -f install.yaml --console-output execute`
+    > * To force a rerun, use `yapl -f install.yaml execute --no-cache`
 
 <a name="wait-for-everything-to-settle"></a>
+
 ### 3. Wait For Everything To Settle
 
 Wait **at least 15 minutes** to let the various Kubernetes resources get initialized and started before proceeding with the rest of the install.
 Because there are a number of dependencies between them, some services are not expected to work immediately after the install script completes.
 
 <a name="known-issues"></a>
+
 ### 4. Known Issues
 
 <a name="known-issues-install-sh"></a>
+
 #### 4.1 install.sh known issues
 
 The `install.sh` script changes cluster state and should not simply be rerun
@@ -70,7 +79,7 @@ The following error may occur when running `./install.sh`:
 2021/10/05 18:42:58 Unable to SLS S3 secret from k8s:secrets "sls-s3-credentials" not found
 ```
 
-1. Verify the `sls-s3-credentials` secret exists in the `default` namespace:
+1. Verify that the `sls-s3-credentials` secret exists in the `default` namespace:
 
    ```bash
    pit# kubectl get secret sls-s3-credentials
@@ -78,7 +87,8 @@ The following error may occur when running `./install.sh`:
    sls-s3-credentials   Opaque   7      28d
    ```
 
-1. Check for running sonar-sync jobs. If there are no sonar-sync jobs, then wait for one to complete. The sonar-sync cronjob is responsible for copying the `sls-s3-credentials` secret from the `default` to `services` namespaces.
+1. Check for running `sonar-sync` jobs. If there are no `sonar-sync` jobs, then wait for one to complete. The `sonar-sync` cronjob is responsible
+   for copying the `sls-s3-credentials` secret from the `default` to `services` namespaces.
 
    ```bash
    pit# kubectl -n services get pods -l cronjob-name=sonar-sync
@@ -87,7 +97,7 @@ The following error may occur when running `./install.sh`:
    sonar-sync-1634322900-pnvl6   1/1     Running     0          13s
    ```
 
-1. Verify the `sls-s3-credentials` secret now exists in the `services` namespaces.
+1. Verify that the `sls-s3-credentials` secret now exists in the `services` namespaces.
 
    ```bash
    pit# kubectl -n services get secret sls-s3-credentials
@@ -98,11 +108,13 @@ The following error may occur when running `./install.sh`:
 1. Running `install.sh` again is expected to succeed.
 
 <a name="known-issues-setup-nexus"></a>
+
 #### 4.2 Setup Nexus known issues
 
 Known potential issues with suggested fixes are listed in [Troubleshoot Nexus](../operations/package_repository_management/Troubleshoot_Nexus.md).
 
 <a name="next-topic"></a>
+
 ### 5. Next Topic
 
 After completing this procedure the next step is to validate CSM health before redeploying the final NCN.


### PR DESCRIPTION
## Summary and Scope

Currently during the install we enable passwordless SSH at the start of the "Install CSM Services" step. There is no reason it needs to happen that far into the install. This PR moves that step to the middle of the "Deploy Management Nodes" step, which is about the earliest we can do it.

The benefit is that this will remove the requirement that installers manually enter root passwords for various operations.

Relatedly, I modified some of the commands in the "Deploy Management Nodes" procedure to take advantage of this change.

## Issues and Related PRs

csm-1.2 backport: https://github.com/Cray-HPE/docs-csm/pull/1501

## Testing

I tested all of the updated commands on the PIT node on drax.

## Risks and Mitigations

Low.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
