### PR TITLE
[release/1.2] CASMINST-4539 Fix list of changed files for spell, style, link and license checks

### DIFF
--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -23,7 +23,8 @@
 #
 name: Check Licenses
 
-on: push
+on:
+  pull_request:
 
 jobs:
   license-check:

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -23,7 +23,8 @@
 #
 name: Check Links
 
-on: push
+on:
+  pull_request:
 
 jobs:
   markdown-link-check:

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -39,7 +39,7 @@ jobs:
         files: "**/*.md"
         files_ignore: ".github/**/*"
 
-    - uses: docker://ghcr.io/tcort/markdown-link-check:stable
+    - uses: docker://ghcr.io/tcort/markdown-link-check:3.9.3
       with:
         args: "--config .github/config/markdown_link.json ${{ steps.changed-files.outputs.all_changed_files }}"
 

--- a/.github/workflows/markdown-lint.yaml
+++ b/.github/workflows/markdown-lint.yaml
@@ -23,7 +23,8 @@
 #
 name: Check Style
 
-on: push
+on:
+  pull_request:
 
 jobs:
   markdown-style-check:

--- a/.github/workflows/spell-check.yaml
+++ b/.github/workflows/spell-check.yaml
@@ -24,7 +24,7 @@
 name: Check Spelling
 
 on:
-  push:
+  pull_request:
 
 jobs:
   markdown-spell-check:


### PR DESCRIPTION
## Summary and Scope

Determine list of changed files only from `pull_request` event. Unfortunately, there's no way to determine list of changed files reliably for `push` event, so we'll have to skip these checks on regular push and only perform them when action is taken on existing PR. 

## Issues and Related PRs

* Resolves [CASMINST-4539](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4539)

## Testing

### Tested on:

  * Github actions on sandbox repository `test-actions`
 
### Test description:

Tested various combinations in dedicated sandbox repository. It appears that in case of triggering with `push` event, the following issues observed:
* List of files may appear empty on push
* If PR already exists, check triggered on `push` will be added as additional PR status check, which will cause confusion.
Therefore, the simple and most reliable solution is just to trigger on `pull_request` event only.

## Risks and Mitigations

Low - non-mandatory PR time status checks

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

