### PR TITLE
[release/1.0] CASMINST-4539 Fix list of changed files for spell, style, link and license checks

### DIFF
--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -23,7 +23,8 @@
 #
 name: Check Licenses
 
-on: push
+on:
+  pull_request:
 
 jobs:
   license-check:

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -1,0 +1,45 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+name: Check Links
+
+on:
+  pull_request:
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Get changed files
+      id: changed-files
+      uses: tj-actions/changed-files@v18.7
+      with:
+        files: "**/*.md"
+        files_ignore: ".github/**/*"
+
+    - uses: docker://ghcr.io/tcort/markdown-link-check:3.9.3
+      with:
+        args: "--config .github/config/markdown_link.json ${{ steps.changed-files.outputs.all_changed_files }}"
+

--- a/.github/workflows/markdown-lint.yaml
+++ b/.github/workflows/markdown-lint.yaml
@@ -23,7 +23,8 @@
 #
 name: Check Style
 
-on: push
+on:
+  pull_request:
 
 jobs:
   markdown-style-check:

--- a/.github/workflows/spell-check.yaml
+++ b/.github/workflows/spell-check.yaml
@@ -24,7 +24,7 @@
 name: Check Spelling
 
 on:
-  push:
+  pull_request:
 
 jobs:
   markdown-spell-check:


### PR DESCRIPTION
## Summary and Scope

Determine list of changed files only from `pull_request` event. Unfortunately, there's no way to determine list of changed files reliably for `push` event, so we'll have to skip these checks on regular push and only perform them when action is taken on existing PR. 

## Issues and Related PRs

* Resolves [CASMINST-4539](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4539)

## Testing

### Tested on:

  * Github actions on sandbox repository `test-actions`
 
### Test description:

Tested various combinations in dedicated sandbox repository. It appears that in case of triggering with `push` event, the following issues observed:
* List of files may appear empty on push
* If PR already exists, check triggered on `push` will be added as additional PR status check, which will cause confusion.
Therefore, the simple and most reliable solution is just to trigger on `pull_request` event only.

## Risks and Mitigations

Low - non-mandatory PR time status checks

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

