### PR TITLE
CAST-29739 - Incorrectly tagged zeromq image causes secret generation to fail

### DIFF
--- a/install/prepare_site_init.md
+++ b/install/prepare_site_init.md
@@ -428,7 +428,7 @@ encrypted.
     linux# /mnt/pitdata/${CSM_RELEASE}/hack/load-container-image.sh dtr.dev.cray.com/zeromq/zeromq:v4.0.5
     ```
 
-    **`IMPORTANT`** CSM 1.0.11 shipped a version of `shasta-cfg` that requires a diffent image tag for the `zeromq` image. If installing this release please see [incorrectly_tagged_zeromq_image.md](../troubleshooting/known_issues/incorrectly_tagged_zeromq_image.md) for instructions on re-tagging the image before proceeding.
+    **IMPORTANT** CSM 1.0.11 shipped a version of `shasta-cfg` that requires a different image tag for the `zeromq` image. If installing this release, see [Incorrectly Tagged `zeromq` Image](../troubleshooting/known_issues/incorrectly_tagged_zeromq_image.md) for instructions on re-tagging the image before proceeding.
 
 1.  Re-encrypt existing secrets:
 

--- a/install/prepare_site_init.md
+++ b/install/prepare_site_init.md
@@ -428,6 +428,8 @@ encrypted.
     linux# /mnt/pitdata/${CSM_RELEASE}/hack/load-container-image.sh dtr.dev.cray.com/zeromq/zeromq:v4.0.5
     ```
 
+    **`IMPORTANT`** CSM 1.0.11 shipped a version of `shasta-cfg` that requires a diffent image tag for the `zeromq` image. If installing this release please see [incorrectly_tagged_zeromq_image.md](../troubleshooting/known_issues/incorrectly_tagged_zeromq_image.md) for instructions on re-tagging the image before proceeding.
+
 1.  Re-encrypt existing secrets:
 
     ```bash

--- a/install/prepare_site_init.md
+++ b/install/prepare_site_init.md
@@ -428,7 +428,7 @@ encrypted.
     linux# /mnt/pitdata/${CSM_RELEASE}/hack/load-container-image.sh dtr.dev.cray.com/zeromq/zeromq:v4.0.5
     ```
 
-    **IMPORTANT** CSM 1.0.11 shipped a version of `shasta-cfg` that requires a different image tag for the `zeromq` image. If installing this release, see [Incorrectly Tagged `zeromq` Image](../troubleshooting/known_issues/incorrectly_tagged_zeromq_image.md) for instructions on re-tagging the image before proceeding.
+    **IMPORTANT:** CSM 1.0.11 shipped a version of `shasta-cfg` that requires a different image tag for the `zeromq` image. If installing this release, see [Incorrectly Tagged `zeromq` Image](../troubleshooting/known_issues/incorrectly_tagged_zeromq_image.md) for instructions on re-tagging the image before proceeding.
 
 1.  Re-encrypt existing secrets:
 

--- a/troubleshooting/known_issues/incorrectly_tagged_zeromq_image.md
+++ b/troubleshooting/known_issues/incorrectly_tagged_zeromq_image.md
@@ -1,8 +1,8 @@
-# Incorrectly tagged zeromq image
+# Incorrectly Tagged `zeromq` Image
 
 CSM 1.0.11 shipped a version of `shasta-cfg` which expects the `zeromq` image to be tagged differently to the one shipped in the product tarball. This may result in the following error when performing the "Generate Sealed Secrets" step in [prepare_site_init.md](../../install/prepare_site_init.md#generate-sealed-secrets).
 
-```
+```ShellSession
 pit# /mnt/pitdata/prep/site-init/utils/secrets-seed-customizations.sh \
 > /mnt/pitdata/prep/site-init/customizations.yaml
 Creating Sealed Secret keycloak-certs
@@ -37,7 +37,12 @@ The `zeromq` image needs to be re-tagged to work around this issue.
 1. Determine the image id of the `zeromq` image.
    
    ```bash
-   pit:~ # podman images *zeromq*
+   pit# podman images *zeromq*
+   ```
+
+   Expected output looks similar to the following:
+
+   ```text
    REPOSITORY                      TAG     IMAGE ID      CREATED      SIZE
    dtr.dev.cray.com/zeromq/zeromq  v4.0.5  1648d2dfc45f  7 years ago  462 MB
    ```
@@ -45,13 +50,18 @@ The `zeromq` image needs to be re-tagged to work around this issue.
 1. Tag the image.
 
    ```bash
-   pit:~ # podman tag 1648d2dfc45f arti.dev.cray.com/third-party-docker-stable-local/zeromq/zeromq:v4.0.5
+   pit# podman tag 1648d2dfc45f arti.dev.cray.com/third-party-docker-stable-local/zeromq/zeromq:v4.0.5
    ```
 
-1. Validate the image was correctly re-tagged.
+1. Validate that the image was correctly re-tagged.
 
    ```bash
-   pit:~ # podman images *zeromq*
+   pit# podman images *zeromq*
+   ```
+
+   Expected output will look similar to the following:
+
+   ```text
    REPOSITORY                                                       TAG     IMAGE ID      CREATED      SIZE
    dtr.dev.cray.com/zeromq/zeromq                                   v4.0.5  1648d2dfc45f  7 years ago  462 MB
    arti.dev.cray.com/third-party-docker-stable-local/zeromq/zeromq  v4.0.5  1648d2dfc45f  7 years ago  462 MB

--- a/troubleshooting/known_issues/incorrectly_tagged_zeromq_image.md
+++ b/troubleshooting/known_issues/incorrectly_tagged_zeromq_image.md
@@ -1,0 +1,60 @@
+# Incorrectly tagged zeromq image
+
+CSM 1.0.11 shipped a version of `shasta-cfg` which expects the `zeromq` image to be tagged differently to the one shipped in the product tarball. This may result in the following error when performing the "Generate Sealed Secrets" step in [prepare_site_init.md](../../install/prepare_site_init.md#generate-sealed-secrets).
+
+```
+pit# /mnt/pitdata/prep/site-init/utils/secrets-seed-customizations.sh \
+> /mnt/pitdata/prep/site-init/customizations.yaml
+Creating Sealed Secret keycloak-certs
+  Generating type static_b64...
+Creating Sealed Secret keycloak-master-admin-auth
+  Generating type static...
+  Generating type static...
+  Generating type randstr...
+  Generating type static...
+Creating Sealed Secret cray-reds-credentials
+  Generating type static...
+  Generating type static...
+Creating Sealed Secret cray-meds-credentials
+  Generating type static...
+Creating Sealed Secret cray-hms-rts-credentials
+  Generating type static...
+  Generating type static...
+Creating Sealed Secret vcs-user-credentials
+  Generating type randstr...
+  Generating type static...
+Creating Sealed Secret generated-platform-ca-1
+  Generating type platform_ca...
+Creating Sealed Secret pals-config
+  Generating type zmq_curve...
+Trying to pull arti.dev.cray.com/third-party-docker-stable-local/zeromq/zeromq:v4.0.5...
+  Get https://arti.dev.cray.com/v2/: dial tcp: lookup arti.dev.cray.com on 16.110.135.52:53: dial udp 16.110.135.52:53: connect: network is unreachable
+Error: unable to pull arti.dev.cray.com/third-party-docker-stable-local/zeromq/zeromq:v4.0.5: Error initializing source docker://arti.dev.cray.com/third-party-docker-stable-local/zeromq/zeromq:v4.0.5: error pinging docker registry arti.dev.cray.com: Get https://arti.dev.cray.com/v2/: dial tcp: lookup arti.dev.cray.com on 16.110.135.52:53: dial udp 16.110.135.52:53: connect: network is unreachable
+```
+
+The `zeromq` image needs to be re-tagged to work around this issue.
+
+1. Determine the image id of the `zeromq` image.
+   
+   ```bash
+   pit:~ # podman images *zeromq*
+   REPOSITORY                      TAG     IMAGE ID      CREATED      SIZE
+   dtr.dev.cray.com/zeromq/zeromq  v4.0.5  1648d2dfc45f  7 years ago  462 MB
+   ```
+
+1. Tag the image.
+
+   ```bash
+   pit:~ # podman tag 1648d2dfc45f arti.dev.cray.com/third-party-docker-stable-local/zeromq/zeromq:v4.0.5
+   ```
+
+1. Validate the image was correctly re-tagged.
+
+   ```bash
+   pit:~ # podman images *zeromq*
+   REPOSITORY                                                       TAG     IMAGE ID      CREATED      SIZE
+   dtr.dev.cray.com/zeromq/zeromq                                   v4.0.5  1648d2dfc45f  7 years ago  462 MB
+   arti.dev.cray.com/third-party-docker-stable-local/zeromq/zeromq  v4.0.5  1648d2dfc45f  7 years ago  462 MB
+   ```
+
+The "Generate Sealed Secrets" procedure will now succeed.


### PR DESCRIPTION
## Summary and Scope

CSM 1.0.11 introduced an issue such that the shasta-cfg `zeromq` secret generator requires the image to be tagged differently to how it was shipped in the product tarball.

This PR documents how to re-tag the image in the event that a fresh install of CSM 1.0.11 is occurring on an air-gapped system with no access to arti.dev.cray.com.

## Issues and Related PRs

* Resolves [CAST-29739](https://jira-pro.its.hpecorp.net:8443/browse/CAST-29739)
* These changes are not required for any other release, CSM 1.2 and beyond have now switched to an artifactory.algol60.net tagged version of this image.

## Testing

### Tested on:

  * Local development environment

### Test description:

Ran through `prepare_site_init.md` steps using the CSM 1.0.11 PIT in a virtual machine with no network access.

Verified secrets were created correctly
```
pit:~ # /mnt/pitdata/prep/site-init/utils/secrets-seed-customizations.sh /mnt/pitdata/prep/site-init/customizations.yaml
Creating Sealed Secret keycloak-certs
  Generating type static_b64...
Creating Sealed Secret keycloak-master-admin-auth
  Generating type static...
  Generating type static...
  Generating type randstr...
  Generating type static...
Creating Sealed Secret cray-reds-credentials
  Generating type static...
  Generating type static...
Creating Sealed Secret cray-meds-credentials
  Generating type static...
Creating Sealed Secret cray-hms-rts-credentials
  Generating type static...
  Generating type static...
Creating Sealed Secret vcs-user-credentials
  Generating type randstr...
  Generating type static...
Creating Sealed Secret generated-platform-ca-1
  Generating type platform_ca...
Creating Sealed Secret pals-config
  Generating type zmq_curve...
  Generating type zmq_curve...
Creating Sealed Secret munge-secret
  Generating type randstr...
Creating Sealed Secret slurmdb-secret
  Generating type static...
  Generating type static...
  Generating type randstr...
  Generating type randstr...
Creating Sealed Secret keycloak-users-localize
  Generating type static...
```

## Risks and Mitigations

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

