### PR TITLE
CASMTRIAGE-3253:  Blocking access to NMNLB from UAIs

### DIFF
--- a/upgrade/1.2/scripts/sls/sls_updater_csm_1.2.py
+++ b/upgrade/1.2/scripts/sls/sls_updater_csm_1.2.py
@@ -33,6 +33,7 @@ from csm_1_2_upgrade.sls_updates import create_metallb_pools_and_asns
 from csm_1_2_upgrade.sls_updates import migrate_can_to_cmn
 from csm_1_2_upgrade.sls_updates import migrate_switch_names
 from csm_1_2_upgrade.sls_updates import remove_api_gw_from_hmnlb_reservations
+from csm_1_2_upgrade.sls_updates import rename_uai_bridge_reservation
 from csm_1_2_upgrade.sls_updates import remove_can_static_pool
 from csm_1_2_upgrade.sls_updates import remove_kube_api_reservations
 from csm_1_2_upgrade.sls_updates import sls_and_input_data_checks
@@ -51,7 +52,8 @@ help = """Upgrade a system SLS file from CSM 1.0 to CSM 1.2.
     7. Convert IPs of the CAN network.\n
     8. Create MetalLB Pools and ASN entries on CMN and NMN networks.\n
     9. Update uai_macvlan in NMN dhcp ranges and uai_macvlan VLAN.\n
-   10. Remove unused user networks (CAN or CHN) if requested [--retain-unused-user-network to keep].\n
+   10. Rename uai_macvlan_bridge reservation to uai_nmn_blackhole
+   11. Remove unused user networks (CAN or CHN) if requested [--retain-unused-user-network to keep].\n
 """
 
 
@@ -315,6 +317,11 @@ def main(
     # Update uai_macvlan dhcp ranges in the NMN network.
     #   (not order dependent)
     update_nmn_uai_macvlan_dhcp_ranges(networks)
+
+    #
+    # Rename uai_macvlan_bridge reservation to uai_nmn_blackhole
+    #   (not order dependent)
+    rename_uai_bridge_reservation(networks)
 
     #
     # Remove superfluous user network if requested


### PR DESCRIPTION
## Summary and Scope

Renames the uai_macvlan_bridge reservation in the uai_macvlan subnet to uai_nmn_blackhole.   uai_macvlan_bridge is no longer being used.  We are repurposing that reservation to be used as the gw for the NMNLB route in UAIs.  This will block access to the NMNLB from the UAI.


## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMTRIAGE-3253

## Testing

### Tested on:

  * `hela`

### Test description:

Ran update-customizations.sh with the site-init secret on hela.  Checked that the NMNLB route in spec.wlm.macvlansetup.routes was updated correctly.    Ran the update-customizations.sh multiple time to check the idempotency.

Ran sls_updater_csm_1.2.py using the 1.0 sls data from Loki.   Checked that the uai_macvlan_bridge reservation was renamed correctly. 


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

