### PR TITLE
CASMINST-4538: Only upload customized NCN images into S3

### DIFF
--- a/install/deploy_final_ncn.md
+++ b/install/deploy_final_ncn.md
@@ -157,7 +157,7 @@ the Kubernetes cluster as the final of three master nodes, forming a quorum.
     pit# csi handoff bss-metadata --data-file /var/www/ephemeral/configs/data.json || echo "ERROR: csi handoff bss-metadata failed"
     ```
 
-1. Patch the metadata for the Ceph nodes to have the correct run commands:
+1. Patch the metadata for the Ceph nodes to have the correct run commands.
 
     ```bash
     pit# python3 /usr/share/doc/csm/scripts/patch-ceph-runcmd.py
@@ -228,7 +228,7 @@ the Kubernetes cluster as the final of three master nodes, forming a quorum.
             rsync -e 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' -rltD -P --delete pit.nmn:${CSM_PATH}/cray-pre-install-toolkit*.iso /metal/bootstrap/"
         ```
 
-1. List IPv4 boot options using `efibootmgr`:
+1. List IPv4 boot options using `efibootmgr`.
 
     ```bash
     pit# efibootmgr | grep -Ei "ip(v4|4)"
@@ -444,7 +444,7 @@ the Kubernetes cluster as the final of three master nodes, forming a quorum.
     ncn-m001# ip r show default
     ```
 
-1. Verify that there **is not** a metal bootstrap IP.
+1. Verify that there **is not** a metal bootstrap IP address.
 
     ```bash
      ncn-m001# ip a show bond0

--- a/install/deploy_final_ncn.md
+++ b/install/deploy_final_ncn.md
@@ -128,10 +128,10 @@ the Kubernetes cluster as the final of three master nodes, forming a quorum.
         pit# csi handoff ncn-images \
                 --k8s-kernel-path $k8sdir/*.kernel \
                 --k8s-initrd-path $k8sdir/initrd.img*.xz \
-                --k8s-squashfs-path $k8sdir/*.squashfs \
+                --k8s-squashfs-path $k8sdir/secure-*.squashfs \
                 --ceph-kernel-path $cephdir/*.kernel \
                 --ceph-initrd-path $cephdir/initrd.img*.xz \
-                --ceph-squashfs-path $cephdir/*.squashfs
+                --ceph-squashfs-path $cephdir/secure-*.squashfs
         ```
 
         Running this command will output a block that looks like this at the end:

--- a/install/deploy_final_ncn.md
+++ b/install/deploy_final_ncn.md
@@ -7,12 +7,10 @@ join the Kubernetes cluster as the final of three master nodes, forming a quorum
 **IMPORTANT:** While the node is rebooting, it will only be available through Serial-Over-LAN (SOL) and local terminals. This
 procedure entails deactivating the LiveCD, meaning the LiveCD and all of its resources will be unavailable.
 
-**Topics**
-
 * [Required Services](#required-services)
 * [Notice of Danger](#notice-of-danger)
 * [Hand-Off](#hand-off)
-   * [Start Hand-Off](#start-hand-off)
+  * [Start Hand-Off](#start-hand-off)
 * [Reboot](#reboot)
 * [Enable NCN Disk Wiping Safeguard](#enable-ncn-disk-wiping-safeguard)
 * [Remove the default NTP pool](#remove-the-default-ntp-pool)
@@ -20,36 +18,42 @@ procedure entails deactivating the LiveCD, meaning the LiveCD and all of its res
 * [Next Topic](#next-topic)
 
 <a name="required-services"></a>
+
 ## 1. Required Services
 
-These services must be healthy before the reboot of the LiveCD can take place. If the health checks performed earlier in the install completed successfully \([Validate CSM Health](../operations/validate_csm_health.md)\), the following platform services will be healthy and ready for reboot of the LiveCD:
+These services must be healthy before the reboot of the LiveCD can take place. If the health checks performed earlier in the install
+completed successfully \([Validate CSM Health](../operations/validate_csm_health.md)\), the following platform services will be healthy
+and ready for reboot of the LiveCD:
 
-   * Utility Storage (Ceph)
-   * `cray-bss`
-   * `cray-dhcp-kea`
-   * `cray-dns-unbound`
-   * `cray-ipxe`
-   * `cray-sls`
-   * `cray-tftp`
+* Utility Storage (Ceph)
+* `cray-bss`
+* `cray-dhcp-kea`
+* `cray-dns-unbound`
+* `cray-ipxe`
+* `cray-sls`
+* `cray-tftp`
 
 <a name="notice-of-danger"></a>
+
 ## 2. Notice of Danger
 
 > An administrator is **strongly encouraged** to be mindful of pitfalls during this segment of the CSM install.
 > The steps below do contain warnings themselves, but overall there are risks:
 >
-> - SSH will cease to work when the LiveCD reboots; the serial console will need to be used.
+> * SSH will cease to work when the LiveCD reboots; the serial console will need to be used.
 >
-> - Rebooting a remoteISO will dump all running changes on the PIT node; USBs are accessible after the install.
+> * Rebooting a remote ISO will dump all running changes on the PIT node; USBs are accessible after the install.
 >
-> - The NCN **will never wipe a USB device** during installation.
+> * The NCN **will never wipe a USB device** during installation.
 >
-> - Prior to shutting down the PIT, learning the CAN IP addresses of the other NCNs will be helpful if troubleshooting is required.
+> * Prior to shutting down the PIT node, learning the CAN IP addresses of the other NCNs will be helpful if
+>   troubleshooting is required.
 >
 > This procedure entails deactivating the LiveCD, meaning the LiveCD and all of its resources will be
 > **unavailable**.
 
 <a name="hand-off"></a>
+
 ## 3. Hand-Off
 
 The steps in this guide load hand-off data and reboot the LiveCD node.
@@ -58,7 +62,8 @@ At the end of these steps, the LiveCD will be no longer active. The node it was 
 the Kubernetes cluster as the final of three master nodes, forming a quorum.
 
 <a name="start-hand-off"></a>
-#### 3.1 Start Hand-Off
+
+### 3.1 Start Hand-Off
 
 1. Start a new typescript.
 
@@ -137,7 +142,7 @@ the Kubernetes cluster as the final of three master nodes, forming a quorum.
         Running this command will output a block that looks like this at the end:
 
         ```text
-        You should run the following commands so the versions you just uploaded can be used in other steps:
+        Run the following commands so that the versions of the images that were just uploaded can be used in other steps:
         export KUBERNETES_VERSION=x.y.z
         export CEPH_VERSION=x.y.z
         ```
@@ -146,7 +151,7 @@ the Kubernetes cluster as the final of three master nodes, forming a quorum.
 
 1. <a name="csi-handoff-bss-metadata"></a>Upload the `data.json` file to BSS, our Kubernetes `cloud-init` DataSource.
 
-    __If you have made any changes__ to this file (for example, as a result of any customizations or workarounds), use the path to that file instead. This step will prompt for the root password of the NCNs.
+    **If any changes have been made** to this file (for example, as a result of any customizations or workarounds), use the path to that file instead. This step will prompt for the root password of the NCNs.
 
     ```bash
     pit# csi handoff bss-metadata --data-file /var/www/ephemeral/configs/data.json || echo "ERROR: csi handoff bss-metadata failed"
@@ -164,9 +169,9 @@ the Kubernetes cluster as the final of three master nodes, forming a quorum.
     pit# csi handoff bss-update-cloud-init --set meta-data.dns-server="10.92.100.225 10.94.100.225" --limit Global
     ```
 
-1.  Preserve logs and configuration files if desired (optional).
+1. Preserve logs and configuration files if desired (optional).
 
-    After the PIT node is redeployed, **all files on its local drives will be lost**. It is recommended that you retain some of the log files and
+    After the PIT node is redeployed, **all files on its local drives will be lost**. It is recommended to retain some of the log files and
     configuration files, because they may be useful if issues are encountered during the remainder of the install.
 
     The following commands create a tar archive of these files, storing it in a directory that will be backed up in the next step.
@@ -197,7 +202,7 @@ the Kubernetes cluster as the final of three master nodes, forming a quorum.
 
     1. Log in; setup passwordless SSH _to_ the PIT node by copying ONLY the public keys from `ncn-m002` and `ncn-m003` to the PIT (**do not setup passwordless SSH _from_ the PIT** or the key will have to be securely tracked or expunged if using a USB installation).
 
-        > The `ssh` commands below may prompt for your NCN root password.
+        > The `ssh` commands below may prompt for the NCN root password.
 
         ```bash
         pit# ssh ncn-m002 cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys &&
@@ -223,7 +228,7 @@ the Kubernetes cluster as the final of three master nodes, forming a quorum.
             rsync -e 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' -rltD -P --delete pit.nmn:${CSM_PATH}/cray-pre-install-toolkit*.iso /metal/bootstrap/"
         ```
 
-1. List ipv4 boot options using `efibootmgr`:
+1. List IPv4 boot options using `efibootmgr`:
 
     ```bash
     pit# efibootmgr | grep -Ei "ip(v4|4)"
@@ -264,16 +269,18 @@ the Kubernetes cluster as the final of three master nodes, forming a quorum.
         ncn-m002#
         ```
 
-    > Keep this terminal active as it will enable `kubectl` commands during the bring-up of the new NCN.
-    If the reboot successfully deploys the LiveCD, this terminal can be exited.
-
-    > **POINT OF NO RETURN:** The next step will wipe the underlying nodes disks clean, it will ignore USB devices. RemoteISOs are at risk here; even though a backup has been
-    > performed of the PIT node, we cannot simply boot back to the same state.
-    > This is the last step before rebooting the node.
+        > Keep this terminal active as it will enable `kubectl` commands during the bring-up of the new NCN.
+        > If the reboot successfully deploys the LiveCD, this terminal can be exited.
+        >
+        > **POINT OF NO RETURN:** The next step will wipe the underlying nodes disks clean, it will ignore USB devices.
+        > RemoteISOs are at risk here; even though a backup has been performed of the PIT node, it is not possible to
+        > boot back to the same state. This is the last step before rebooting the node.
 
 1. Wipe the disks on the PIT node.
 
-    > **`WARNING : USER ERROR`** Do not assume to wipe the first three disks (e.g. `sda`, `sdb`, and `sdc`); they are not pinned to any physical disk layout. **Choosing the wrong ones may result in wiping the USB device**. USB devices can only be wiped by operators at this point in the install. USB devices are never wiped by the CSM installer.
+    > **WARNING:** Risk of **USER ERROR**! Do not assume to wipe the first three disks (e.g. `sda`, `sdb`, and `sdc`); they are not
+    > pinned to any physical disk layout. **Choosing the wrong ones may result in wiping the USB device**. USB devices can
+    > only be wiped by operators at this point in the install. USB devices are never wiped by the CSM installer.
 
     1. Select disks to wipe (SATA/NVME/SAS).
 
@@ -314,16 +321,17 @@ the Kubernetes cluster as the final of three master nodes, forming a quorum.
 
         If there was any wiping done, output should appear similar to the output above. If this is re-run, there may be no output or an ignorable error.
 
-1.  Quit the typescript session and copy it off `ncn-m001`.
+1. Quit the typescript session and copy the typescript file off of `ncn-m001`.
 
     1. Stop the typescript session:
+
         ```bash
         pit# exit
         ```
 
     1. Back up the completed typescript file by re-running the `rsync` commands in the [Backup Bootstrap Information](#backup-bootstrap-information) section.
 
-1.  (Optional) Setup ConMan or serial console, if not already on, from any laptop or other system with network connectivity to the cluster.
+1. (Optional) Setup ConMan or serial console, if not already on, from any laptop or other system with network connectivity to the cluster.
 
     ```bash
     external# script -a boot.livecd.$(date +%Y-%m-%d).txt
@@ -336,6 +344,7 @@ the Kubernetes cluster as the final of three master nodes, forming a quorum.
     ```
 
 <a name="reboot"></a>
+
 ## 4. Reboot
 
 1. Reboot the LiveCD.
@@ -349,7 +358,7 @@ the Kubernetes cluster as the final of three master nodes, forming a quorum.
     If all of that happens successfully, **skip the rest of this step and proceed to the next step**. Otherwise, use the following information to remediate the problems.
 
     > **NOTE:** If the node has PXE boot issues, such as getting PXE errors or not pulling the `ipxe.efi` binary, see [PXE boot troubleshooting](pxe_boot_troubleshooting.md).
-
+    >
     > **NOTE:** If `ncn-m001` did not run all the `cloud-init` scripts, the following commands need to be run **(but only in that circumstance)**.
 
     ```bash
@@ -357,7 +366,7 @@ the Kubernetes cluster as the final of three master nodes, forming a quorum.
               cloud-init modules -m config ; cloud-init modules -m final
     ```
 
-1. Once `cloud-init` has completed successfully, log in and start a typescript (the IP address used here is the one we noted for `ncn-m002` in an earlier step).
+1. Once `cloud-init` has completed successfully, log in and start a typescript (the IP address used here is the one noted for `ncn-m002` in an earlier step).
 
     ```bash
     external# ssh root@10.102.11.13
@@ -396,7 +405,10 @@ the Kubernetes cluster as the final of three master nodes, forming a quorum.
     ncn-w003   Ready    <none>                 4h    v1.20.13
     ```
 
-1. Restore and verify the site link. It will be necessary to restore the `ifcfg-lan0` file from either manual backup taken during the prior "Hand-Off" step or re-mount the USB and copy it from the prep directory to `/etc/sysconfig/network/`.
+1. Restore and verify the site link.
+
+    It will be necessary to restore the `ifcfg-lan0` file from either manual backup taken during the prior "Hand-Off" step or
+    re-mount the USB and copy it from the prep directory to `/etc/sysconfig/network/`.
 
     ```bash
     ncn-m001# SYSTEM_NAME=eniac
@@ -411,13 +423,13 @@ the Kubernetes cluster as the final of three master nodes, forming a quorum.
        addr:     ipv4 172.30.53.88/20 [static]
     ```
 
-1. Run `ip a` to show our lan0 IP address, verify the site link.
+1. Run `ip a` to show the lan0 IP address; verify the site link.
 
     ```bash
     ncn-m001# ip a show lan0
     ```
 
-1. Run `ip a` to show our VLANs, verify they all have IP addresses.
+1. Run `ip a` to show the VLANs; verify that they all have IP addresses.
 
     ```bash
     ncn-m001# ip a show bond0.nmn0
@@ -426,30 +438,34 @@ the Kubernetes cluster as the final of three master nodes, forming a quorum.
     ncn-m001# ip a show bond0.cmn0
     ```
 
-1. Run `ip r` to show our default route is via the CMN.
+1. Run `ip r` to show that the default route is via the CMN.
 
     ```bash
     ncn-m001# ip r show default
     ```
 
-1. Verify we **do not** have a metal bootstrap IP.
+1. Verify that there **is not** a metal bootstrap IP.
 
     ```bash
      ncn-m001# ip a show bond0
      ```
 
- 1. Verify zypper repositories are empty and all remote SUSE repositories are disabled.
+1. Verify zypper repositories are empty and all remote SUSE repositories are disabled.
 
     ```bash
     ncn-m001# rm -v /etc/zypp/repos.d/* && zypper ms --remote --disable
     ```
 
-1. Download and install/upgrade the documentation RPM. If this machine does not have direct internet
-   access this RPM will need to be externally downloaded and then copied to this machine.
+1. Download and install/upgrade the documentation RPM.
+
+    If this machine does not have direct internet access, then this RPM will need to be
+    externally downloaded and then copied to this machine.
 
     See [Check for Latest Documentation](../update_product_stream/index.md#documentation)
 
-1. Exit the typescript and move the backup to `ncn-m001`, thus removing the need to track `ncn-m002` as yet-another bootstrapping agent. This is required to facilitate reinstallations, because it pulls the preparation data back over to the documented area (`ncn-m001`).
+1. Exit the typescript and move the backup to `ncn-m001`.
+
+    This is required to facilitate reinstallations, because it pulls the preparation data back over to the documented area (`ncn-m001`).
 
     ```bash
     ncn-m001# exit
@@ -461,9 +477,11 @@ the Kubernetes cluster as the final of three master nodes, forming a quorum.
     ```
 
 <a name="enable-ncn-disk-wiping-safeguard"></a>
+
 ## 5. Enable NCN Disk Wiping Safeguard
 
-> The next steps require `csi` from the installation media. `csi` will not be provided on an NCN otherwise because it is used for Cray installation and bootstrap. The CSI binary is compiled against the NCN base, simply fetching it from the bootable media will suffice.
+The next steps require `csi` from the installation media. `csi` will not be provided on an NCN otherwise because
+it is used for Cray installation and bootstrap.
 
 1. SSH back into `ncn-m001`, or restart a local console and resume the typescript.
 
@@ -493,13 +511,14 @@ the Kubernetes cluster as the final of three master nodes, forming a quorum.
     https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
     ```
 
-1.  Set the wipe safeguard to allow safe net-reboots on all NCNs.
+1. Set the wipe safeguard to allow safe net-reboots on all NCNs.
 
     ```bash
     ncn-m001# /tmp/csi handoff bss-update-param --set metal.no-wipe=1
     ```
 
-> **`CSI NOTE`** `/tmp/csi` will delete itself on the next reboot. The `/tmp` directory is `tmpfs` and runs in memory, it normally will not persist on restarts.
+**NOTE** `/tmp/csi` will delete itself on the next reboot. The `/tmp` directory is `tmpfs` and runs in memory;
+it will not persist on restarts.
 
 <a name="remove-the-default-ntp-pool"></a>
 
@@ -512,6 +531,7 @@ ncn-m001# sed -i "s/^! pool pool\.ntp\.org.*//" /etc/chrony.conf
 ```
 
 <a name="configure-dns-and-ntp-on-each-bmc"></a>
+
 ## 7. Configure DNS and NTP on each BMC
 
  > **NOTE:** If the system uses Gigabyte or Intel hardware, skip this section.
@@ -521,7 +541,7 @@ However, the commands in this section are all run **on** `ncn-m001`.
 
 1. Set environment variables.
 
-    Set the `IPMI_PASSWORD` and `USERNAME` variables to the BMC credentials for your NCNs.
+    Set the `IPMI_PASSWORD` and `USERNAME` variables to the BMC credentials for the NCNs.
 
     > Using `read -s` for this prevents the credentials from being echoed to the screen
 
@@ -562,6 +582,7 @@ However, the commands in this section are all run **on** `ncn-m001`.
     ```
 
 <a name="next-topic"></a>
+
 ## Next Topic
 
 After completing this procedure, the next step is to [Configure Administrative Access](index.md#configure_administrative_access).

--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -118,9 +118,9 @@ proceed to step 2.
    pit# /root/bin/configure-ntp.sh
    ```
 
-   This ensures that the PIT is configured with an accurate date/time, which will be properly propagated to the NCNs during boot.
+   This ensures that the PIT is configured with an accurate date/time, which will be propagated to the NCNs during boot.
 
-   If the error `Failed to set time: NTP unit is active` is received, then stop `chrony` first.
+   If the error `Failed to set time: NTP unit is active` is observed, then stop `chrony` first.
 
    ```bash
    pit# systemctl stop chronyd
@@ -128,38 +128,44 @@ proceed to step 2.
 
    Then run the commands above to complete the process.
 
-1. Ensure the current time is set in BIOS for all management NCNs.
+1. Ensure that the current time is set in BIOS for all management NCNs.
 
-   > If each NCN is booted to the BIOS menu, then check and set the current UTC time.
+   Each NCN is booted to the BIOS menu, the date and time are checked, and set to the current UTC time if needed.
 
-   ```bash
-   pit# export USERNAME=root
-   pit# export IPMI_PASSWORD=changeme
-   ```
+   > **NOTE:** Some steps in this procedure depend on `USERNAME` and `IPMI_PASSWORD` being set. This is done in
+[Tokens and IPMI Password](#tokens-and-ipmi-password).
 
    Repeat the following process for each NCN.
 
+   1. Set the `bmc` variable to the name of the BMC of the NCN being checked.
+
+      **Important:** Be sure to change the below example to the appropriate NCN.
+
+      ```console
+      pit# bmc=ncn-w001-mgmt
+      ```
+
    1. Start an IPMI console session to the NCN.
 
-      ```bash
-      pit# bmc=ncn-w001-mgmt  # Change this to be each node in turn.
+      ```console
       pit# conman -j $bmc
       ```
 
    1. Using another terminal to watch the console, boot the node to BIOS.
 
-      ```bash
-      pit# bmc=ncn-w001-mgmt  # Change this to be each node in turn.
+      ```console
       pit# ipmitool -I lanplus -U $USERNAME -E -H $bmc chassis bootdev bios
-      pit# ipmitool -I lanplus -U $USERNAME -E -H $bmc chassis power off
-      pit# sleep 10
-      pit# ipmitool -I lanplus -U $USERNAME -E -H $bmc chassis power on
+      pit# ipmitool -I lanplus -U $USERNAME -E -H $bmc chassis power off && sleep 10 && \
+           ipmitool -I lanplus -U $USERNAME -E -H $bmc chassis power on
       ```
 
-      > For HPE NCNs the above process will boot the nodes to their BIOS, but the menu is unavailable through conman as the node is booted into a graphical BIOS menu.
+      > For HPE NCNs, the above process will boot the nodes to their BIOS; however, the BIOS menu is unavailable through conman because
+      > the node is booted into a graphical BIOS menu.
       >
-      > To access the serial version of the BIOS setup. Perform the ipmitool steps above to boot the node. Then, in conman, press `ESC+9` key combination when
-      > the following messages are shown in the console. This will open a menu that can be used to enter the BIOS using conman.
+      > In order to access the serial version of the BIOS menu, perform the `ipmitool` steps above to boot the node.
+      > Then, in conman, press `ESC+9` key combination when
+      > the following messages are shown on the console. That key combination will open a menu that can be used to enter
+      > the BIOS using conman.
       >
       > ```text
       > For access via BIOS Serial Console:
@@ -169,13 +175,13 @@ proceed to step 2.
       > Press 'ESC+@' for Network Boot
       > ```
       >
-      > For HPE NCNs the date configuration menu can be found at the following path: `System Configuration -> BIOS/Platform Configuration (RBSU) -> Date and Time`
+      > For HPE NCNs, the date configuration menu is at the following path: `System Configuration -> BIOS/Platform Configuration (RBSU) -> Date and Time`.
       >
       > Alternatively, for HPE NCNs, log in to the BMC's web interface and access the HTML5 console for the node, in order to interact with the graphical BIOS.
       > From the administrator's own machine, create an SSH tunnel (`-L` creates the tunnel; `-N` prevents a shell and stubs the connection):
       >
       > ```bash
-      > linux# bmc=ncn-w001-mgmt # Change this to be each node in turn.
+      > linux# bmc=ncn-w001-mgmt # Change this to be the appropriate node
       > linux# ssh -L 9443:$bmc:443 -N root@eniac-ncn-m001
       > ```
       >
@@ -295,7 +301,7 @@ be performed are in the [Deploy](#deploy) section.
 ### 3.2 Deploy
 
 > **NOTE:** Some scripts in this section depend on `IPMI_PASSWORD` being set. This is done in
-[Tokens and IPMI Password](#tokens-and-ipmi-password)
+[Tokens and IPMI Password](#tokens-and-ipmi-password).
 
 1. Set the default root password and SSH keys and optionally change the timezone.
 

--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -90,11 +90,11 @@ Preparation of the environment must be done before attempting to deploy the mana
 
 ### 1.2 Ensure Time Is Accurate Before Deploying NCNs
 
-**NOTE:** If you wish to use a timezone other than UTC, instead of step 1 below, follow
-[this procedure for setting a local timezone](../operations/node_management/Configure_NTP_on_NCNs.md#set-a-local-timezone), then
+**NOTE:** Optionally, in order to use a timezone other than UTC, instead of step 1 below, follow
+[this procedure for setting a local timezone](../operations/node_management/Configure_NTP_on_NCNs.md#set-a-local-timezone). Then
 proceed to step 2.
 
-1. Ensure that the PIT node has the current and correct time.
+1. Ensure that the PIT node has the correct current time.
 
    The time can be inaccurate if the system has been powered off for a long time, or, for example, the CMOS was cleared on a Gigabyte node. See [Clear Gigabyte CMOS](clear_gigabyte_cmos.md).
 
@@ -120,7 +120,7 @@ proceed to step 2.
 
    This ensures that the PIT is configured with an accurate date/time, which will be properly propagated to the NCNs during boot.
 
-   If you receive the error `Failed to set time: NTP unit is active` you will need to stop `chrony` first.
+   If the error `Failed to set time: NTP unit is active` is received, then stop `chrony` first.
 
    ```bash
    pit# systemctl stop chronyd
@@ -130,7 +130,7 @@ proceed to step 2.
 
 1. Ensure the current time is set in BIOS for all management NCNs.
 
-   > If each NCN is booted to the BIOS menu, you can check and set the current UTC time.
+   > If each NCN is booted to the BIOS menu, then check and set the current UTC time.
 
    ```bash
    pit# export USERNAME=root
@@ -158,8 +158,8 @@ proceed to step 2.
 
       > For HPE NCNs the above process will boot the nodes to their BIOS, but the menu is unavailable through conman as the node is booted into a graphical BIOS menu.
       >
-      > To access the serial version of the BIOS setup. Perform the ipmitool steps above to boot the node. Then in conman press `ESC+9` key combination when you
-      > see the following messages in the console. This will open a menu you use to enter the BIOS via conman.
+      > To access the serial version of the BIOS setup. Perform the ipmitool steps above to boot the node. Then, in conman, press `ESC+9` key combination when
+      > the following messages are shown in the console. This will open a menu that can be used to enter the BIOS using conman.
       >
       > ```text
       > For access via BIOS Serial Console:
@@ -171,7 +171,7 @@ proceed to step 2.
       >
       > For HPE NCNs the date configuration menu can be found at the following path: `System Configuration -> BIOS/Platform Configuration (RBSU) -> Date and Time`
       >
-      > Alternatively, for HPE NCNs you can log in to the BMC's web interface and access the HTML5 console for the node, in order to interact with the graphical BIOS.
+      > Alternatively, for HPE NCNs, log in to the BMC's web interface and access the HTML5 console for the node, in order to interact with the graphical BIOS.
       > From the administrator's own machine, create an SSH tunnel (`-L` creates the tunnel; `-N` prevents a shell and stubs the connection):
       >
       > ```bash
@@ -181,10 +181,10 @@ proceed to step 2.
       >
       > Opening a web browser to `https://localhost:9443` will give access to the BMC's web interface.
 
-   1. When the node boots, you will be able to use the conman session to see the BIOS menu to check and set the time to current UTC time.
+   1. When the node boots, the conman session can be used to see the BIOS menu, in order to check and set the time to current UTC time.
       The process varies depending on the vendor of the NCN.
 
-   1. After you have verified the correct time, power off the NCN.
+   1. After the correct time has been verified, power off the NCN.
 
    Repeat the above process for each NCN.
 
@@ -294,16 +294,20 @@ be performed are in the [Deploy](#deploy) section.
 
 ### 3.2 Deploy
 
+> **NOTE:** Some scripts in this section depend on `IPMI_PASSWORD` being set. This is done in
+[Tokens and IPMI Password](#tokens-and-ipmi-password)
+
 1. Set the default root password and SSH keys and optionally change the timezone.
 
-   The management nodes images do not contain a default password or default ssh keys.
+   The management nodes images do not contain a default password or default SSH keys.
 
    It is **required** to set the default root password and SSH keys in the images used to boot the management nodes.
    Follow the NCN image customization steps in [Change NCN Image Root Password and SSH Keys on PIT Node](../operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md)
 
-1. Create boot directories for any NCN in DNS This will create folders for each host in `/var/www`, allowing each host to have their own unique set of artifacts; kernel, initrd, SquashFS, and `script.ipxe` bootscript.
+1. Create boot directories for any NCN in DNS.
 
-    > **`NOTE`** This script depends on `IPMI_PASSWORD` being set, this is done in [Tokens and IPMI Password](#tokens-and-ipmi-password)
+    This will create folders for each host in `/var/www`, allowing each host to have its own unique set of artifacts:
+    kernel, initrd, SquashFS, and `script.ipxe` bootscript.
 
     ```bash
     pit# /root/bin/set-sqfs-links.sh
@@ -313,11 +317,12 @@ be performed are in the [Deploy](#deploy) section.
     * **Worker nodes** with more than two small disks need to make adjustments to [prevent bare-metal `etcd` creation](../background/ncn_mounts_and_file_systems.md#worker-nodes-with-etcd).
     * For a brief overview of what is expected, see [disk plan of record / baseline](../background/ncn_mounts_and_file_systems.md#plan-of-record--baseline).
 
-1. Run the BIOS Baseline script to apply a configs to BMCs. The script will apply helper configs to facilitate more deterministic network booting on any NCN port. **This runs against any server vendor**, some settings are not applied for certain vendors.
+1. Run the BIOS Baseline script to apply a configs to BMCs.
 
-    > **`NOTE`** This script depends on `IPMI_PASSWORD` being set, this is done in [Tokens and IPMI Password](#tokens-and-ipmi-password)
-    >
-    > **`NOTE`** This script will enable DCMI/IPMI on Hewlett-Packard Enterprise servers equipped with ILO. If `ipmitool` is not working at this time, it will after running this script.
+    The script will apply helper configs to facilitate more deterministic network booting on any NCN port.
+    **This runs against any server vendor**, but some settings are not applied for certain vendors.
+
+    > **NOTE:** This script will enable DCMI/IPMI on Hewlett-Packard Enterprise servers equipped with ILO. If `ipmitool` is not working at this time, it will after running this script.
 
     ```bash
     pit# /root/bin/bios-baseline.sh
@@ -330,7 +335,7 @@ be performed are in the [Deploy](#deploy) section.
     pit# grep -oP "($mtoken|$stoken|$wtoken)" /etc/dnsmasq.d/statics.conf | sort -u | xargs -t -i ipmitool -I lanplus -U $USERNAME -E -H {} power off
     ```
 
-    > **`NOTE`**:The NCN boot order is further explained in [NCN Boot Workflow](../background/ncn_boot_workflow.md).
+    > **NOTE:** The NCN boot order is further explained in [NCN Boot Workflow](../background/ncn_boot_workflow.md).
 
 1. Validate that the LiveCD is ready for installing NCNs.
 
@@ -350,7 +355,7 @@ be performed are in the [Deploy](#deploy) section.
 
     > Note: Ignore any errors about not being able resolve `arti.dev.cray.com`.
 
-1. Print the consoles available to you:
+1. Print the available consoles.
 
     ```bash
     pit# conman -q
@@ -497,7 +502,7 @@ be performed are in the [Deploy](#deploy) section.
 
     1. Verify that passwordless SSH is now working from the PIT node to the other NCNs.
 
-        The following command should not prompt you to enter a password.
+        The following command should not prompt for a password.
 
         ```ShellSession
         pit# PDSH_SSH_ARGS_APPEND='-o StrictHostKeyChecking=no' pdsh -Sw "${NCNS}" date && echo SUCCESS || echo ERROR
@@ -615,13 +620,13 @@ for details on how to do so.
 
 If there are LVM check failures, then the problem must be resolved before continuing with the install.
 
-* If **any master node** has the problem, then you must wipe and redeploy **all** of the NCNs before continuing the installation:
+* If **any master node** has the problem, then wipe and redeploy **all** of the NCNs before continuing the installation:
     1. Wipe each worker node using the 'Basic Wipe' section of [Wipe NCN Disks for Reinstallation](wipe_ncn_disks_for_reinstallation.md#basic-wipe).
     1. Wipe each master node (**except** `ncn-m001` because it is the PIT node) using the 'Basic Wipe' section of [Wipe NCN Disks for Reinstallation](wipe_ncn_disks_for_reinstallation.md#basic-wipe).
     1. Wipe each storage node using the 'Full Wipe' section of [Wipe NCN Disks for Reinstallation](wipe_ncn_disks_for_reinstallation.md#full-wipe).
     1. Return to the [Set each node to always UEFI Network Boot, and ensure they are powered off](#set-uefi-and-power-off) step of the [Deploy Management Nodes](#deploy_management_nodes) section above.
 
-* If **only worker nodes** have the problem, then you must wipe and redeploy the affected worker nodes before continuing the installation:
+* If **only worker nodes** have the problem, then wipe and redeploy the affected worker nodes before continuing the installation:
     1. Wipe each affected worker node using the 'Basic Wipe' section of [Wipe NCN Disks for Reinstallation](wipe_ncn_disks_for_reinstallation.md#basic-wipe).
     1. Power off each affected worker node.
     1. Return to the [Boot the Master and Worker Nodes](#boot-master-and-worker-nodes) step of the [Deploy Management Nodes](#deploy_management_nodes) section above.
@@ -644,7 +649,7 @@ If there are LVM check failures, then the problem must be resolved before contin
 
 #### Option 1
 
-  If you have OSDs on each node (`ceph osd tree` can show this), then you have all your nodes in Ceph. That means you can utilize the orchestrator to look for the devices.
+  If there are OSDs on each node (`ceph osd tree` can show this), then all the nodes are in Ceph. That means the orchestrator can be used to look for the devices.
 
 1. Get the number of OSDs in the cluster.
 
@@ -653,11 +658,11 @@ If there are LVM check failures, then the problem must be resolved before contin
     24
     ```
 
-   **IMPORTANT:** If the returned number of OSDs is equal to total_osds calculated, then you can skip the following steps. If not, then please proceed with the below additional checks and remediation steps.
+   **IMPORTANT:** If the returned number of OSDs is equal to total_osds calculated, then skip the following steps. If not, then proceed with the below additional checks and remediation steps.
 
-1. Compare your number of OSDs to your output which should resemble the example below. The number of drives will depend on the server hardware.
+1. Compare the number of OSDs to the output (which should resemble the example below). The number of drives will depend on the server hardware.
 
-    > **NOTE:**  If your Ceph cluster is large and has a lot of nodes, you can specify a node after the below command to limit the results.
+    > **NOTE:** If the Ceph cluster is large and has a lot of nodes, a node may be specified after the below command to limit the results.
 
     ```bash
     ncn-s# ceph orch device ls
@@ -688,24 +693,24 @@ If there are LVM check failures, then the problem must be resolved before contin
     ncn-s003  /dev/sdj  ssd   PHYF016500TQ1P9DGN  1920G  Unknown  N/A    N/A    No
     ```
 
-    If you have devices that are "Available = Yes" and they are not being automatically added, you may have to zap that device.
+    If there are devices that show `Available` as `Yes` and they are not being automatically added, that device may need to be zapped.
 
-    **IMPORTANT:** Prior to zapping any device please ensure it is not being used.
+    **IMPORTANT:** Prior to zapping any device, ensure that it is not being used.
 
-1. Check to see if the number of devices is less than the number of listed drives or your output from step 1.
+1. Check to see if the number of devices is less than the number of listed drives in the output from step 1.
 
    ```bash
     ncn-s# ceph orch device ls|grep dev|wc -l
     24
     ```
 
-    If the numbers are equal, but less than the `total_osds` calculated, then you may need to fail your `ceph-mgr` daemon to get a fresh inventory.
+    If the numbers are equal, but less than the `total_osds` calculated, then the `ceph-mgr` daemon may need to be failed in order to get a fresh inventory.
 
     ```bash
     ncn-s# ceph mgr fail $(ceph mgr dump | jq -r .active_name)
     ```
 
-    Give it 5 minutes then re-check `ceph orch device ls` to see if the drives are still showing as available. If so, then proceed to the next step.
+    Wait 5 minutes and then re-check `ceph orch device ls`. See if the drives are still showing as `Available`. If so, then proceed to the next step.
 
 1. `ssh` to the host and look at `lsblk` output and check against the device from the above `ceph orch device ls`
 
@@ -721,17 +726,17 @@ If there are LVM check failures, then the problem must be resolved before contin
      └─ceph--0a476f53--8b38--450d--8779--4e587402f8a8-osd--data--b620b7ef--184a--46d7--9a99--771239e7a323 254:7    0   1.8T  0 lvm
     ```
 
-    * If it has an LVM volume like above, then it may be in use and you should do the option 2 check below to make sure we can wipe the drive.
+    * If it has an LVM volume like above, then it may be in use. In that case, do the option 2 check below to make sure that the drive can be wiped.
 
 #### Option 2
 
-1. Log into **each** ncn-s node and check for unused drives.
+1. Log into **each** `ncn-s` node and check for unused drives.
 
     ```bash
     ncn-s# cephadm shell -- ceph-volume inventory
     ```
 
-    **IMPORTANT:** The `cephadm` command may output this warning `WARNING: The same type, major and minor should not be used for multiple devices.`. You can ignore this warning.
+    **IMPORTANT:** The `cephadm` command may output this warning `WARNING: The same type, major and minor should not be used for multiple devices.`. Ignore this warning.
 
     The field `available` would be `True` if Ceph sees the drive as empty and can
     be used. For example:
@@ -756,7 +761,7 @@ If there are LVM check failures, then the problem must be resolved before contin
 
 ##### Wipe and Add Drives
 
-1. Wipe the drive **ONLY after you have confirmed the drive is not being used by the current Ceph cluster** using options 1, 2, or both.
+1. Wipe the drive **ONLY after confirming that the drive is not being used by the current Ceph cluster** using options 1, 2, or both.
 
     > The following example wipes drive `/dev/sdc` on `ncn-s002`. Replace these values with the appropriate ones for the situation.
 
@@ -786,9 +791,9 @@ The LiveCD needs to authenticate with the cluster to facilitate the rest of the 
 
 1. Determine which master node is the first master node.
 
-   If you are provisioning your HPE Cray EX system from `ncn-m001` (i.e. it is your PIT node), then most likely this will be `ncn-m002`.
+   Most often the first master node will be `ncn-m002`.
 
-   Run the following commands on the PIT node to extract the value of the `first-master-hostname` field from your `/var/www/ephemeral/configs/data.json` file:
+   Run the following commands on the PIT node to extract the value of the `first-master-hostname` field from the `/var/www/ephemeral/configs/data.json` file:
 
    ```bash
    pit# FM=$(cat /var/www/ephemeral/configs/data.json | jq -r '."Global"."meta-data"."first-master-hostname"')
@@ -804,7 +809,7 @@ The LiveCD needs to authenticate with the cluster to facilitate the rest of the 
    pit# scp ${FM}.nmn:/etc/kubernetes/admin.conf ~/.kube/config
    ```
 
-1. Validate that you are now able to run `kubectl` commands from the PIT node.
+1. Validate that `kubectl` commands run successfully from the PIT node.
 
     ```bash
     pit# kubectl get nodes -o wide
@@ -881,7 +886,7 @@ Observe the output of the checks and note any failures, then remediate them.
 
    If the test total line reports any failed tests, look through the full output of the test in `csi-pit-validate-ceph.log` to see which node had the failed test and what the details are for that test.
 
-   **Note:** Please see [Utility Storage](../operations/utility_storage/Utility_Storage.md) to help resolve any failed tests.
+   **Note:** See [Utility Storage](../operations/utility_storage/Utility_Storage.md) in order to help resolve any failed tests.
 
 1. Check the master and worker nodes.
 
@@ -910,7 +915,7 @@ Observe the output of the checks and note any failures, then remediate them.
 
    If these total lines report any failed tests, look through the full output of the test to see which node had the failed test and what the details are for that test.
 
-   > **WARNING** If there are failures for tests with names like `Worker Node CONLIB FS Label`, then manual tests should be run on the node which reported the failure.
+   > **WARNING:** If there are failures for tests with names like `Worker Node CONLIB FS Label`, then manual tests should be run on the node which reported the failure.
    See [Manual LVM Check Procedure](#manual-lvm-check-procedure). If the manual tests fail, then the problem must be resolved before continuing to the next step. See
    [LVM Check Failure Recovery](#lvm-check-failure-recovery).
 
@@ -923,7 +928,7 @@ Observe the output of the checks and note any failures, then remediate them.
            'weave --local status connections | grep -i failed || true'
    ```
 
-   If the check is successful, there will be no output. If you see messages like `IP allocation was seeded by different peers`, then `weave` appears to be split-brained.
+   If the check is successful, there will be no output. If messages like `IP allocation was seeded by different peers` are seen, then `weave` appears to be split-brained.
    At this point, it is necessary to wipe the NCNs and start the PXE boot again:
 
    1. Wipe the NCNs using the 'Basic Wipe' section of [Wipe NCN Disks for Reinstallation](wipe_ncn_disks_for_reinstallation.md).
@@ -970,7 +975,7 @@ Observe the output of the checks and note any failures, then remediate them.
 
 ## Important Checkpoint
 
-> Before you move on, this is the last point where you will be able to rebuild nodes without having to rebuild the PIT node. So take time to double check both the cluster and the validation test results
+Before proceeding, be aware that this is the last point where the other NCN nodes can be rebuilt without also having to rebuild the PIT node. Therefore, take time to double check both the cluster and the validation test results
 
 <a name="next-topic"></a>
 

--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md
@@ -4,23 +4,24 @@ Modify the NCN images by setting the root password and adding SSH keys for the r
 Optionally, changing the timezone for the NCNs can also be done at this time. This procedure shows this process being
 done on the PIT node during a first time installation of the CSM software.
 
-***Note:*** This procedure must be done before management nodes are deployed for the first time.
+***Note:*** This procedure **is required** to be done during an initial CSM software installation
+**before management nodes are first deployed**.
 
 ## Set the root password and add SSH keys to the NCN images
 
-This step is required. There is no default root password and no default SSH keys in the NCN images.
+This step is required. **There is no default root password and no default SSH keys in the NCN images.**
 
 1. Add SSH keys and set the password in the SquashFS. Optionally, set the timezone.
 
-   If desired, create new SSH keys on the PIT. These will be copied into the NCN SquashFS images in the next step. Alternately,
+   If desired, create new SSH keys on the PIT node. These will be copied into the NCN Squashfs images in the next step. Alternatively,
    copy an existing set of keys and `authorized_hosts` file into a directory for reference in the following step. It is assumed
    that public keys have a `.pub` extension.
 
-   Execute the `ncn-image-modification.sh` script located at the top level of the CSM release tarball to add SSH keys and set the
-   root password. Optionally, set a local timezone (UTC is the default). If you chose to create new SSH keys above, execute this
-   script with `-d ~/.ssh` in addition to the other required options.
+   Execute the `ncn-image-modification.sh` script located at the top level of the CSM release tarball in order to add SSH keys and
+   set the root password. Optionally, set a local timezone (UTC is the default). If you choose to create new SSH keys, then specify
+   the directory where these keys are located with the `-d` argument to the script, in addition to the other required options.
 
-   ```bash
+   ```console
    pit# ncn-image-modification.sh -h
    Usage: ncn-image-modification.sh [-p] [-d dir] [ -z timezone] [-k kubernetes-squashfs-file] [-s storage-squashfs-file] [ssh-keygen arguments]
 
@@ -71,11 +72,11 @@ This step is required. There is no default root password and no default SSH keys
                                    interpreted.
 
           DEBUG                    If set, the script will be run with 'set -x'
-   pit#
    ```
 
-   An example referencing a directory with existing keys and setting the timezone to America/Chicago.
-   This example will prompt the admin to enter a root password after each squash is unsquashed.
+   The following example references a directory with existing keys and setting the timezone to
+   `America/Chicago`. This example will prompt the administrator to enter a root password after
+   each squashed image is unsquashed.
 
    ```bash
    pit# cd /var/www/ephemeral/data/
@@ -85,9 +86,10 @@ This step is required. There is no default root password and no default SSH keys
                                               -s ./ceph/storage-ceph-<version>.squashfs
    ```
 
-   An example generating new keys with an empty passphrase and the `$SQUASHFS_ROOT_PW_HASH` variable set.
-   The variable will be set to reuse the same root password hash that exists on the PIT node.
-   This example will not prompt the admin for any input after it is invoked.
+   The following example generates new keys with an empty passphrase, and the 
+   `$SQUASHFS_ROOT_PW_HASH` variable set. This variable will be set to reuse the same root
+   password hash that exists on the PIT node. This example will not prompt the administrator for
+   any input after it is invoked.
 
    ```bash
    pit# cd /var/www/ephemeral/data/
@@ -99,8 +101,8 @@ This step is required. There is no default root password and no default SSH keys
                                               -s ./ceph/storage-ceph-<version>.squashfs
    ```
 
-   The script will save the original SquashFS images in `./{k8s,ceph}/old`.  The new images will have a `secure-` prefix.
-   The initrd and kernel will retain their original names.
+   The script will save the original SquashFS images in `./{k8s,ceph}/old`. The new image filenames will
+   have a `secure-` prefix. The initrd and kernel will retain their original filenames.
 
 1. Set the boot links.
 
@@ -113,9 +115,8 @@ This step is required. There is no default root password and no default SSH keys
 
 1. Clean up temporary storage used to prepare images.
 
-   These could be removed now or after verification that the nodes are able to boot successfully with the new images.
+   These may be removed now, or after verifying that the nodes are able to boot successfully with the new images.
 
    ```bash
-   pit# cd /var/www/ephemeral/data
-   pit# rm -rf ceph/old k8s/old
+   pit# cd /var/www/ephemeral/data && rm -rf ceph/old k8s/old
    ```

--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md
@@ -13,7 +13,7 @@ This step is required. **There is no default root password and no default SSH ke
 
 1. Add SSH keys and set the password in the SquashFS. Optionally, set the timezone.
 
-   If desired, create new SSH keys on the PIT node. These will be copied into the NCN Squashfs images in the next step. Alternatively,
+   If desired, create new SSH keys on the PIT node. These will be copied into the NCN SquashFS images in the next step. Alternatively,
    copy an existing set of keys and `authorized_hosts` file into a directory for reference in the following step. It is assumed
    that public keys have a `.pub` extension.
 
@@ -86,7 +86,7 @@ This step is required. **There is no default root password and no default SSH ke
                                               -s ./ceph/storage-ceph-<version>.squashfs
    ```
 
-   The following example generates new keys with an empty passphrase, and the 
+   The following example generates new keys with an empty passphrase, and the
    `$SQUASHFS_ROOT_PW_HASH` variable set. This variable will be set to reuse the same root
    password hash that exists on the PIT node. This example will not prompt the administrator for
    any input after it is invoked.


### PR DESCRIPTION
## Summary and Scope

The primary change in this PR is a very slight change to the `csi` command used in the "Deploy Final NCN" step, so that it will only upload SquashFS images with a `secure-` filename prefix. This prefix will be there if the `ncn-image-modification.sh` script was run on the images earlier, as required for csm-1.2 installs.

This PR also contains some minor linting of a couple of pages.

## Issues and Related PRs

* csm-1.2 backport PR: https://github.com/Cray-HPE/docs-csm/pull/1512
* csm-1.0 backport PR for just the linting parts of this PR: https://github.com/Cray-HPE/docs-csm/pull/1514
* The preflight checks performed before deploying NCNs are also being changed to help address this problem. [main PR for this test change](https://github.com/Cray-HPE/csm-testing/pull/297)

## Testing

None

## Risks and Mitigations

Very low risk.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
