### PR TITLE
CASMTRIAGE-3232: Uploading BMC Recovery Firmware into TFTP Servers

### DIFF
--- a/install/configure_administrative_access.md
+++ b/install/configure_administrative_access.md
@@ -87,6 +87,9 @@ BMC/controller passwords.
       down or power up as part of the compute node booting process, it may be necessary to look at the logs
       on the BMC for node power down or node power up.
 
+      This step requires the CSM software, Cray CLI, and HPC Firmware Pack (HFP) to be installed.
+      If these are not currently installed, then this step will need to be skipped and run later in the install process.
+
       See [Configure BMC and Controller Parameters with SCSD](../operations/system_configuration_service/Configure_BMC_and_Controller_Parameters_with_scsd.md)
    <a name="configure-ncns"></a>
    1. Configure Non-compute Nodes with CFS
@@ -109,4 +112,3 @@ BMC/controller passwords.
       After completing the operational procedures above which configure administrative access, the next step is to validate the health of management nodes and CSM services.
 
       See [Validate CSM Health](index.md#validate_csm_health)
-

--- a/install/configure_administrative_access.md
+++ b/install/configure_administrative_access.md
@@ -7,7 +7,7 @@ services via commands. The management nodes can be locked from accidental manipu
 management nodes. The `cray scsd` command can change the SSH keys, NTP server, syslog server, and
 BMC/controller passwords.
 
-### Topics
+## Topics
 
    1. [Configure Keycloak Account](#configure_keycloak_account)
    1. [Configure the Cray Command Line Interface (cray CLI)](#configure_cray_cli)
@@ -24,11 +24,12 @@ BMC/controller passwords.
 ## Details
 
    <a name="configure_keycloak_account"></a>
+
    1. Configure Keycloak Account
 
       Upcoming steps in the installation workflow require an account to be configured in Keycloak for
-      authentication. This can be either a local keycloak account or an external Identity Provider (IdP),
-      such as LDAP. Having an account in keycloak with administrative credentials enables the use of many
+      authentication. This can be either a local Keycloak account or an external Identity Provider (IdP),
+      such as LDAP. Having an account in Keycloak with administrative credentials enables the use of many
       management services via the `cray` command.
 
       See [Configure Keycloak Account](../operations/CSM_product_management/Configure_Keycloak_Account.md)
@@ -56,6 +57,7 @@ BMC/controller passwords.
       For more info on the importance of locking these components, see [Lock Management Nodes](#lock_management_nodes).
 
    <a name="lock_management_nodes"></a>
+
    1. Lock Management Nodes
 
       The management nodes are unlocked at this point in the installation. Locking the management nodes and their BMCs will
@@ -69,7 +71,8 @@ BMC/controller passwords.
       **Lock the management nodes now!**
 
       Run the `lock_management_nodes.py` script to lock all management nodes and their BMCs that are not already locked:
-      ```
+
+      ```bash
       ncn# /opt/cray/csm/scripts/admin_access/lock_management_nodes.py
       ```
 
@@ -103,7 +106,9 @@ BMC/controller passwords.
    <a name="cray_upload_recovery_images"></a>
    1. Upload Olympus BMC Recovery Firmware into TFTP server
 
-      The Olympus hardware (NodeBMCs, ChassisBMCs, RouterBMCs) needs to have recovery firmware loaded to the cray-tftp server in case the BMC loses its firmware. The BMCs are configured to load a recovery firmware from a TFTP server. This procedure does not modify any BMC firmware, but only stages the firmware on the TFTP server for download in the event it is needed.
+      The Olympus hardware (NodeBMCs, ChassisBMCs, RouterBMCs) needs to have recovery firmware loaded to the cray-tftp server in case the BMC loses its firmware.
+      The BMCs are configured to load a recovery firmware from a TFTP server.
+      This procedure does not modify any BMC firmware, but only stages the firmware on the TFTP server for download in the event it is needed.
 
       See [Load Olympus BMC Recovery Firmware into TFTP server](../operations/firmware/Upload_Olympus_BMC_Recovery_Firmware_into_TFTP_Server.md)
    <a name="next-topic"></a>

--- a/operations/firmware/Upload_Olympus_BMC_Recovery_Firmware_into_TFTP_Server.md
+++ b/operations/firmware/Upload_Olympus_BMC_Recovery_Firmware_into_TFTP_Server.md
@@ -3,6 +3,12 @@
 `cray-upload-recovery-images` is a utility for uploading the BMC recovery files for ChassisBMCs, NodeBMCs, and RouterBMCs to be served by the `cray-tftp` service. The tool uses the `cray` CLI (`fas`, `artifacts`) and `cray-tftp` to download the S3 recovery images (as remembered by FAS), then upload them into the PVC that is used by `cray-tftp`.
 `cray-upload-recovery-images` should be run on every system.
 
+## Prerequisites
+
+* Cray System Management (CSM) software is installed.
+* The Cray Command Line Interface (CLI) tool is initialized and configured on the system.
+* Firmware is loaded into FAS as part of the HPC Firmware Pack (HFP) install; refer to the *HPE Cray EX System HPC Firmware Pack Install Guide* on the HPE Customer Support Center for more information.
+
 ## Procedure
 
 1. Execute the `cray-upload-recovery-images` script.

--- a/operations/firmware/Upload_Olympus_BMC_Recovery_Firmware_into_TFTP_Server.md
+++ b/operations/firmware/Upload_Olympus_BMC_Recovery_Firmware_into_TFTP_Server.md
@@ -1,6 +1,7 @@
 # Upload BMC Recovery Firmware into TFTP Server
 
-`cray-upload-recovery-images` is a utility for uploading the BMC recovery files for ChassisBMCs, NodeBMCs, and RouterBMCs to be served by the `cray-tftp` service. The tool uses the `cray` CLI (`fas`, `artifacts`) and `cray-tftp` to download the S3 recovery images (as remembered by FAS), then upload them into the PVC that is used by `cray-tftp`.
+`cray-upload-recovery-images` is a utility for uploading the BMC recovery files for ChassisBMCs, NodeBMCs, and RouterBMCs to be served by the `cray-tftp` service.
+The tool uses the `cray` CLI (`fas`, `artifacts`) and `cray-tftp` to download the S3 recovery images (as remembered by FAS), then upload them into the PVC that is used by `cray-tftp`.
 `cray-upload-recovery-images` should be run on every system.
 
 ## Prerequisites
@@ -13,35 +14,35 @@
 
 1. Execute the `cray-upload-recovery-images` script.
 
-	```bash
-	ncn# cray-upload-recovery-images
-	Attempting to retrieve ChassisBMC .itb file
-	s3:/fw-update/d7bb5be9eecc11eab18c26c5771395a4/cc-1.3.10.itb
-	d7bb5be9eecc11eab18c26c5771395a4/cc-1.3.10.itb
+  ```bash
+  ncn# cray-upload-recovery-images
+  Attempting to retrieve ChassisBMC .itb file
+  s3:/fw-update/d7bb5be9eecc11eab18c26c5771395a4/cc-1.3.10.itb
+  d7bb5be9eecc11eab18c26c5771395a4/cc-1.3.10.itb
 
-	Uploading file: /tmp/cc.itb
-	Defaulting container name to cray-ipxe.
-	Successfully uploaded /tmp/cc.itb!
-	removed /tmp/cc.itb
-	ChassisBMC recovery image upload complete
-	========================================
-	Attempting to retrieve NodeBMC .itb file
-	s3:/fw-update/d81157f7eecc11ea943d26c5771395a4/nc-1.3.10.itb
-	d81157f7eecc11ea943d26c5771395a4/nc-1.3.10.itb
+  Uploading file: /tmp/cc.itb
+  Defaulting container name to cray-ipxe.
+  Successfully uploaded /tmp/cc.itb!
+  removed /tmp/cc.itb
+  ChassisBMC recovery image upload complete
+  ========================================
+  Attempting to retrieve NodeBMC .itb file
+  s3:/fw-update/d81157f7eecc11ea943d26c5771395a4/nc-1.3.10.itb
+  d81157f7eecc11ea943d26c5771395a4/nc-1.3.10.itb
 
-	Uploading file: /tmp/nc.itb
-	Defaulting container name to cray-ipxe.
-	Successfully uploaded /tmp/nc.itb!
-	removed /tmp/nc.itb
-	NodeBMC recovery image upload complete
-	========================================
-	Attempting to retrieve RouterBMC .itb file
-	s3:/fw-update/d85398f2eecc11ea94ff26c5771395a4/rec-1.3.10.itb
-	d85398f2eecc11ea94ff26c5771395a4/rec-1.3.10.itb
+  Uploading file: /tmp/nc.itb
+  Defaulting container name to cray-ipxe.
+  Successfully uploaded /tmp/nc.itb!
+  removed /tmp/nc.itb
+  NodeBMC recovery image upload complete
+  ========================================
+  Attempting to retrieve RouterBMC .itb file
+  s3:/fw-update/d85398f2eecc11ea94ff26c5771395a4/rec-1.3.10.itb
+  d85398f2eecc11ea94ff26c5771395a4/rec-1.3.10.itb
 
-	Uploading file: /tmp/rec.itb
-	Defaulting container name to cray-ipxe.
-	Successfully uploaded /tmp/rec.itb!
-	removed /tmp/rec.itb
-	RouterBMC recovery image upload complete
-	```
+  Uploading file: /tmp/rec.itb
+  Defaulting container name to cray-ipxe.
+  Successfully uploaded /tmp/rec.itb!
+  removed /tmp/rec.itb
+  RouterBMC recovery image upload complete
+  ```


### PR DESCRIPTION
Added prerequisites for uploading BMC recovery firmware into tftp servers. Added a note in the install procedures to skip uploading to tftp if FAS not installed and ready, and to run the step after that has been completed.