### PR TITLE
Make haproxy reconfigure script idempotent

### DIFF
--- a/upgrade/1.2/scripts/k8s/reconfigure_haproxy.sh
+++ b/upgrade/1.2/scripts/k8s/reconfigure_haproxy.sh
@@ -23,7 +23,9 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-sed -i.bak '/    default-server/s/.*/    default-server verify none check-ssl inter 10s downinter 5s rise 2 fall 2 slowstart 60s maxconn 250 maxqueue 256 weight 100/' /etc/haproxy/haproxy.cfg
-sed -i.bak '0,/    option tcp-check/s//    option httpchk GET \/readyz HTTP\/1.0\n    option  log-health-checks\n    http-check expect status 200/' /etc/haproxy/haproxy.cfg
+if ! grep -q httpchk /etc/haproxy/haproxy.cfg; then
+  sed -i.bak '/    default-server/s/.*/    default-server verify none check-ssl inter 10s downinter 5s rise 2 fall 2 slowstart 60s maxconn 250 maxqueue 256 weight 100/' /etc/haproxy/haproxy.cfg
+  sed -i.bak '0,/    option tcp-check/s//    option httpchk GET \/readyz HTTP\/1.0\n    option  log-health-checks\n    http-check expect status 200/' /etc/haproxy/haproxy.cfg
+fi
 
 systemctl restart haproxy


### PR DESCRIPTION
## Summary and Scope

When running prerequisites for the second time (1.2 to 1.2 upgrade), the haproxy reconfigure script reconfigures etcd incorrectly instead of realizing kube-api has already been configured to use http.

## Issues and Related PRs

* Resolves [CASMINST-4558](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4558)

## Testing

Tested code snippet on surtur

### Tested on:

  * `surtur`

### Test description:

Tested code snippet on surtur

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

