### PR TITLE
Change vcs backup path for gitea 1.2

### DIFF
--- a/operations/configuration_management/Version_Control_Service_VCS.md
+++ b/operations/configuration_management/Version_Control_Service_VCS.md
@@ -35,6 +35,7 @@ ncn# kubectl create secret generic vcs-user-credentials --save-config \
 --from-literal=vcs_password="NEW_PASSWORD" \
 --dry-run=client -o yaml | kubectl apply -f -
 ```
+
 The `NEW_PASSWORD` value must be replaced with the updated password.
 
 ## Access the `cray` Gitea Organization
@@ -75,7 +76,7 @@ Data for Gitea is stored in two places. Git content is stored directly in a PVC,
 
 1. Determine which Postgres member is the leader and exec into the leader pod to dump the data to a local file:
 
-    ```
+    ```bash
     ncn-w001# kubectl exec gitea-vcs-postgres-0 -n services -c postgres -it -- patronictl list
     ```
 
@@ -99,7 +100,7 @@ Data for Gitea is stored in two places. Git content is stored directly in a PVC,
 
 2. Determine what secrets are associated with the postgresql credentials:
 
-    ```
+    ```bash
     ncn-w001# kubectl get secrets -n services | grep gitea-vcs-postgres.credentials
     ```
 
@@ -113,7 +114,7 @@ Data for Gitea is stored in two places. Git content is stored directly in a PVC,
 
 3. Export each secret to a manifest file:
 
-    ```
+    ```bash
     ncn# SECRETS="postgres service-account standby"
     ncn# echo "---" > gitea-vcs-postgres.manifest
     ncn# for secret in $SECRETS; do
@@ -124,7 +125,6 @@ Data for Gitea is stored in two places. Git content is stored directly in a PVC,
 
 4. Edit the manifest file to remove creationTimestamp, resourceVersion, selfLink, uid for each entry. Then, copy all files to a safe location.
 
-
 ### Backup PVC Data
 
 The VCS postgres backups should be accompanied by backups of the VCS PVC. The export process can be run at any time while the service is running using the following commands:
@@ -133,7 +133,7 @@ Backup (save the resulting tar file to a safe location):
 
 ```bash
 ncn# POD=$(kubectl -n services get pod -l app.kubernetes.io/instance=gitea -o json | jq -r '.items[] | .metadata.name')
-ncn# kubectl -n services exec ${POD} -- tar -cvf vcs.tar /data/
+ncn# kubectl -n services exec ${POD} -- tar -cvf vcs.tar /var/lib/gitea/
 ncn# kubectl -n services cp ${POD}:vcs.tar ./vcs.tar
 ```
 

--- a/upgrade/1.2/scripts/upgrade/prerequisites.sh
+++ b/upgrade/1.2/scripts/upgrade/prerequisites.sh
@@ -595,7 +595,16 @@ if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     done
 
     POD=$(kubectl -n services get pod -l app.kubernetes.io/instance=gitea -o json | jq -r '.items[] | .metadata.name')
-    kubectl -n services exec ${POD} -- tar -cvf vcs.tar /data/
+    #
+    # Gitea change in 1.2 from /data to /var/lib/gitea, see which version we're
+    # backing up (in support of 1.2 -> 1.2 upgrades)
+    #
+    if kubectl -n services exec -it ${POD} -- /bin/sh -c 'ls /data' >/dev/null 2>&1; then
+      kubectl -n services exec ${POD} -- tar -cvf vcs.tar /data/
+    else
+      kubectl -n services exec ${POD} -- tar -cvf vcs.tar /var/lib/gitea/
+    fi
+
     kubectl -n services cp ${POD}:vcs.tar ./vcs.tar
 
     backupBucket="config-data"


### PR DESCRIPTION
## Summary and Scope

Support 1.x and 1.2 gitea data path versions on upgrade (changed from /data to /var/lib/gitea).

## Issues and Related PRs

* Resolves [CASMINST-4556](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4556)

## Testing

1.0.11:

```
ncn-m001:~/bklein # ./foo.sh
Defaulting container name to vcs.
Use 'kubectl describe pod/gitea-vcs-7c6f5b5c45-tzv4q -n services' to see all of the containers in this pod.
tar: removing leading '/' from member names
data/
data/ssh/
data/ssh/ssh_host_rsa_key.pub
data/ssh/ssh_host_rsa_key
data/ssh/ssh_host_dsa_key
data/ssh/ssh_host_ecdsa_key.pub
data/ssh/ssh_host_ecdsa_key
data/ssh/ssh_host_dsa_key.pub
data/ssh/ssh_host_ed25519_key
data/ssh/ssh_host_ed25519_key.pub
data/gitea/
data/gitea/curl
data/gitea/crayvcs_user_created
.
.
.
```

1.2:
```
ncn-m001:~/bklein # ./foo.sh
Defaulting container name to vcs.
Use 'kubectl describe pod/gitea-vcs-65c98746b-lqcmh -n services' to see all of the containers in this pod.
tar: removing leading '/' from member names
tar: /var/lib/gitea/vcs.tar: file is the archive; skipping
var/lib/gitea/
var/lib/gitea/ssh/
var/lib/gitea/ssh/ssh_host_rsa_key.pub
var/lib/gitea/ssh/ssh_host_rsa_key
var/lib/gitea/ssh/ssh_host_dsa_key
var/lib/gitea/ssh/ssh_host_ecdsa_key.pub
var/lib/gitea/ssh/ssh_host_ecdsa_key
.
.
.
```

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

