### PR TITLE
Add wget progress option for image download

### DIFF
--- a/upgrade/1.2/scripts/upgrade/prepare-assets.sh
+++ b/upgrade/1.2/scripts/upgrade/prepare-assets.sh
@@ -106,7 +106,7 @@ if [[ -z ${TARBALL_FILE} ]]; then
         touch /etc/cray/upgrade/csm/myenv
         echo "====> ${state_name} ..."
         {
-        wget ${ENDPOINT}/${CSM_RELEASE}.tar.gz
+        wget --progress=dot:giga ${ENDPOINT}/${CSM_RELEASE}.tar.gz
         # set TARBALL_FILE to newly downloaded file
         TARBALL_FILE=${CSM_RELEASE}.tar.gz
         } >> ${LOG_FILE} 2>&1


### PR DESCRIPTION
## Summary and Scope

Adds the --progress=dot:giga option to the wget download of the release image.
This changes the progress indicator output that gets written to the output.log file
from over 700000 lines to just a little over 1000 lines.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-4561](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4561)

## Testing

### Tested on:

  * surtur

### Test description:

Ran the prepare_assets.sh script through the download part of the script to verify it
downloaded correctly, and verified the progress output was a much smaller amount.

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

## Risks and Mitigations

Low risk. Only change is the amount of output from the wget command indicating download progress.
