### PR TITLE
Check for running mon daemon on upgraded ceph node, restart if necessary

### DIFF
--- a/upgrade/1.2/scripts/ceph/lib/ceph-health.sh
+++ b/upgrade/1.2/scripts/ceph/lib/ceph-health.sh
@@ -120,3 +120,55 @@ function wait_for_osds() {
    done
  done
 }
+
+function get_ip_from_metadata() {
+  host=$1
+  ip=$(cloud-init query ds | jq -r ".meta_data[].host_records[] | select(.aliases[]? == \"$host\") | .ip" 2>/dev/null)
+  echo $ip
+}
+
+function wait_for_mon_stat() {
+  node=$1
+  cnt=0
+  while true; do
+    if [[ "$cnt" -eq 60 ]]; then
+      echo "ERROR: Giving up waiting for mon process to start on $node..."
+      break
+    fi
+    if [[ "$cnt" -eq 30 ]]; then
+      echo "Manually adding mon process for $node..."
+      ip=$(get_ip_from_metadata "${node}.nmn")
+      ceph mon add $node $ip
+    else
+      state_name=$(ceph mon stat -f json-pretty | jq --arg node $node -r '.quorum[] | select(.name==$node) | .name' )
+      if [ "$state_name" == "$node" ]; then
+        echo "Found mon process on $node..."
+        break
+      fi
+    fi
+    sleep 5
+    echo "Sleeping for five seconds waiting for mon process to start on $node..."
+    cnt=$((cnt+1))
+  done
+}
+
+function check_mon_daemon() {
+  node=$1
+  state_name=$(ceph mon stat -f json-pretty | jq --arg node $node -r '.quorum[] | select(.name==$node) | .name' )
+  if [ "$state_name" == "$node" ]; then
+    echo "Found ${node} in ceph mon stat command, continuing..."
+  else
+    echo "Didn't find ${node} in ceph mon stat command, ensuring we have quorum before restarting daemon..."
+    ceph mon ok-to-stop ${node}
+    if [ $? -ne 0 ]; then
+      echo "Unable to restart mon process for ${node}, would break quorum, halting..."
+      exit 1
+    fi
+    echo "Removing/restarting mon daemon for node ${node}..."
+    ceph orch daemon rm mon.${node} --force
+    wait_for_running_daemons "mon" 3
+    wait_for_mon_stat ${node}
+    echo "Archiving daemon crash info..."
+    ceph crash archive-all
+  fi
+}

--- a/upgrade/1.2/scripts/upgrade/ncn-upgrade-ceph-nodes.sh
+++ b/upgrade/1.2/scripts/upgrade/ncn-upgrade-ceph-nodes.sh
@@ -157,6 +157,7 @@ fi
 
 {
 . /usr/share/doc/csm/upgrade/1.2/scripts/ceph/lib/ceph-health.sh
+check_mon_daemon ${target_ncn}
 wait_for_health_ok
 
 # Wait for rgw to start before executing goss tests


### PR DESCRIPTION
## Summary and Scope

After a node has been upgraded, verify the mon daemon starts successfully after the tarfile is restored on the node.  If not, delete the daemon and let ceph create a new podman container.

## Issues and Related PRs

* Resolves [CASMINST-4557](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4557)

## Testing

```
ncn-s002:/usr/share/doc/csm/upgrade/1.2/scripts/ceph/lib # check_mon_daemon ncn-s002
Removing/restarting mon daemon for node ncn-s002...
Removed mon.ncn-s002 from host 'ncn-s002'
Sleeping for five seconds waiting for 3 running mon daemons...
Sleeping for five seconds waiting for 3 running mon daemons...
Sleeping for five seconds waiting for 3 running mon daemons...
Sleeping for five seconds waiting for 3 running mon daemons...
Sleeping for five seconds waiting for 3 running mon daemons...
Found 3 running mon daemons -- continuing...
Sleeping for five seconds waiting for mon process to start on ncn-s002...
Manually adding mon process for ncn-s002...
adding mon.ncn-s002 at [v2:10.248.4.215:3300/0,v1:10.248.4.215:6789/0]
Sleeping for five seconds waiting for mon process to start on ncn-s002...
Sleeping for five seconds waiting for mon process to start on ncn-s002...
Found mon process on ncn-s002...
Archiving daemon crash info...
```

### Tested on:

  * `craystack`

### Test description:

Stopped the daemon and ran the function -- it deployed the daemon and waited for all three to come up.

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable