### PR TITLE
MTL-1698 pushd/popd for ntp script so it can find the template

### DIFF
--- a/operations/node_management/Configure_NTP_on_NCNs.md
+++ b/operations/node_management/Configure_NTP_on_NCNs.md
@@ -47,8 +47,9 @@ The following steps are structured to be executed on one node at a time. However
     > If more than nine NCNs are in use on the system, update the for loop in the following command accordingly.
 
     ```bash
-    ncn-m002# for i in ncn-{w,s}00{1..3} ncn-m00{2..3}; do echo \
-    "------$i--------"; ssh $i '/srv/cray/scripts/common/chrony/csm_ntp.py'; done
+    ncn-m001# export TOKEN=$(curl -k -s -S -d grant_type=client_credentials -d client_id=admin-client -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
+    ncn-m001# for i in ncn-{w,s}00{1..3} ncn-m00{2..3}; do echo \
+    "------$i--------"; ssh $i 'pushd /srv/cray/scripts/common/chrony/ && TOKEN=$TOKEN /srv/cray/scripts/common/chrony/csm_ntp.py && popd'; done
     ```
 
 <a name="fix-broken-configs"></a>
@@ -58,5 +59,8 @@ The following steps are structured to be executed on one node at a time. However
 On each NCN, run:
 
 ```
-ncn# csm_ntp.py
+ncn# pushd /srv/cray/scripts/common/chrony
+ncn# export TOKEN=$(curl -k -s -S -d grant_type=client_credentials -d client_id=admin-client -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token') 
+ncn# /srv/cray/scripts/common/chrony/csm_ntp.py
+ncn# popd
 ```

--- a/operations/resiliency/NTP_Resiliency.md
+++ b/operations/resiliency/NTP_Resiliency.md
@@ -27,6 +27,7 @@ This procedure requires administrative privileges.
     If more than nine NCNs are in use on the system, update the for loop in the following command accordingly.
 
     ```bash
+    ncn-m001# export TOKEN=$(curl -k -s -S -d grant_type=client_credentials -d client_id=admin-client -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
     ncn-m002# for i in ncn-{w,s}00{1..3} ncn-m00{2..3}; do echo \
-    "------$i--------"; ssh $i '/srv/cray/scripts/common/chrony/csm_ntp.py'; done
+    "------$i--------"; ssh $i 'pushd /srv/cray/scripts/common/chrony/ && TOKEN=$TOKEN /srv/cray/scripts/common/chrony/csm_ntp.py && popd'; done
     ```


### PR DESCRIPTION
Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>

## Summary and Scope

`pushd`/`popd`'s to allow the ntp script to find the template.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves MTL-1698
* instead of https://github.com/Cray-HPE/node-image-build/pull/249, docs will be used per this PR
* Fixed in 1.3 in https://github.com/Cray-HPE/node-image-build/pull/250

## Testing

### Tested on:

  * `#surtur`
  *  `#redbull`

### Test description:

Ran the code snippet from ncn-m001 and validated the script was successful.

## Risks and Mitigations

N/A

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

