### PR TITLE
Fix syntax for let command

### DIFF
--- a/upgrade/1.2/scripts/rebuild/ncn-rebuild-worker-nodes.sh
+++ b/upgrade/1.2/scripts/rebuild/ncn-rebuild-worker-nodes.sh
@@ -125,7 +125,7 @@ if [[ $redeploy == "1" ]];then
             fi
             echo "Command failed: cray cps deployment list --nodes $target_ncn; retrying in 5 seconds"
             sleep 5
-            let count += 1
+            let "count += 1"
             continue
         fi
         cps_state=$(grep -E "state =" "$tmpfile"|grep -v "running" | wc -l)
@@ -138,7 +138,7 @@ if [[ $redeploy == "1" ]];then
             fi
             echo "CPS not running yet on $target_ncn; checking again in 5 seconds"
             sleep 5
-            let count += 1
+            let "count += 1"
             continue
         fi
         rm -f "$tmpfile" >/dev/null 2>&1 || true
@@ -151,7 +151,7 @@ if [[ $redeploy == "1" ]];then
             fi
             echo "CPS pod not assigned yet to $target_ncn; checking again in 5 seconds"
             sleep 5
-            let count += 1
+            let "count += 1"
             continue
         fi
         break

--- a/upgrade/1.2/scripts/upgrade/ncn-upgrade-worker-nodes.sh
+++ b/upgrade/1.2/scripts/upgrade/ncn-upgrade-worker-nodes.sh
@@ -128,7 +128,7 @@ if [[ $redeploy == "1" ]];then
             fi
             echo "Command failed: cray cps deployment list --nodes $target_ncn; retrying in 5 seconds"
             sleep 5
-            let count += 1
+            let "count += 1"
             continue
         fi
         cps_state=$(grep -E "state =" "$tmpfile"|grep -v "running" | wc -l)
@@ -141,7 +141,7 @@ if [[ $redeploy == "1" ]];then
             fi
             echo "CPS not running yet on $target_ncn; checking again in 5 seconds"
             sleep 5
-            let count += 1
+            let "count += 1"
             continue
         fi
         rm -f "$tmpfile" >/dev/null 2>&1 || true
@@ -154,7 +154,7 @@ if [[ $redeploy == "1" ]];then
             fi
             echo "CPS pod not assigned yet to $target_ncn; checking again in 5 seconds"
             sleep 5
-            let count += 1
+            let "count += 1"
             continue
         fi
         break


### PR DESCRIPTION
## Summary and Scope

There is a syntax error in two scripts where the "let" command was used without quotes:
```
arbus:$ count=1
arbus:$ let count += 1
-bash: let: +=: syntax error: operand expected (error token is "+=")
arbus:$ echo $count
1
arbus:$ let "count += 1"
arbus:$ echo $count
2
```
On the vale system, this was worked around by removing the spaces, it may also be resolved by quoting the arguments to let. This error may have not have occurred in the past as the "cray cps deployments list ..." command worked the first time.

## Issues and Related PRs

* Resolves CASMTRIAGE-3306

## Testing

Tested locally and on `vale`

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Impacted script was rerurn with the fix
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y, this occurred during an upgrade
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Typically, this error seems to not have occurred when the `cray cps deployment list...` command worked the first time.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

