### PR TITLE
CASMNET-1538 - Add switch name change info to CSM 1.2 release notes.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -41,6 +41,16 @@ CSM 1.2 contains approximately 2000 changes spanning bug fixes, new feature deve
   * Supports zone transfer to external DNS servers via AXFR query and DNSSEC
   * Please refer to the [PowerDNS Migration Guide](./operations/network/dns/PowerDNS_migration.md) and [PowerDNS Configuration Guide](./operations/network/dns/PowerDNS_Configuration.md) for further information.
 
+* Management network switch hostname changes
+
+  The management network switch hostnames have changed in CSM 1.2 to more accurately reflect the usage of each switch type.
+
+  | Old Name | New Name    | Usage                                                     |
+  |----------|-------------|-----------------------------------------------------------|
+  | sw-spine | Unchanged   | Network spine that links to other switches.               |
+  | sw-agg   | sw-leaf     | NMN connections for NCNs and Application nodes.           |
+  | sw-leaf  | sw-leaf-bmc | BMC connections, PDUs, Slingshot switches, Cooling doors. |
+
 ### Miscellaneous Functionality
 * SLES15 SP3 Support for NCNs, UANs, Compute Nodes, and Barebones validation image
 * S3FS added to master and worker nodes for storing SDU dumps and CPS content


### PR DESCRIPTION
## Summary and Scope

CSM 1.2 changed the management network switch hostnames slightly to more accurately reflect the use of each switch type.

Added documentation to the CSM release notes to highlight this fact.

## Issues and Related PRs

* Resolves [CASMNET-1538](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1538)

## Testing

N/A

## Risks and Mitigations

N/A

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

