### PR TITLE
CASMINST-4589: Install document linting, corrections, and improvements

### DIFF
--- a/install/deploy_final_ncn.md
+++ b/install/deploy_final_ncn.md
@@ -42,7 +42,7 @@ and ready for reboot of the LiveCD:
 >
 > * SSH will cease to work when the LiveCD reboots; the serial console will need to be used.
 >
-> * Rebooting a remote ISO will dump all running changes on the PIT node; USBs are accessible after the install.
+> * Rebooting a remote ISO will dump all running changes on the PIT node; USB devices are accessible after the install.
 >
 > * The NCN **will never wipe a USB device** during installation.
 >
@@ -149,7 +149,7 @@ the Kubernetes cluster as the final of three master nodes, forming a quorum.
 
     1. Run the `export` commands listed at the end of the output from the previous step.
 
-1. <a name="csi-handoff-bss-metadata"></a>Upload the `data.json` file to BSS, our Kubernetes `cloud-init` DataSource.
+1. <a name="csi-handoff-bss-metadata"></a>Upload the `data.json` file to BSS, our `cloud-init` data source.
 
     **If any changes have been made** to this file (for example, as a result of any customizations or workarounds), use the path to that file instead. This step will prompt for the root password of the NCNs.
 
@@ -200,7 +200,10 @@ the Kubernetes cluster as the final of three master nodes, forming a quorum.
 
     > **NOTE:** This denotes information that should always be kept together in order to fresh-install the system again.
 
-    1. Log in; setup passwordless SSH _to_ the PIT node by copying ONLY the public keys from `ncn-m002` and `ncn-m003` to the PIT (**do not setup passwordless SSH _from_ the PIT** or the key will have to be securely tracked or expunged if using a USB installation).
+    1. Log in and set up passwordless SSH **to** the PIT node.
+
+        Copying **only** the public keys from `ncn-m002` and `ncn-m003` to the PIT node. **Do not** set up
+        passwordless SSH **from** the PIT node or the key will have to be securely tracked or expunged if using a USB installation).
 
         > The `ssh` commands below may prompt for the NCN root password.
 
@@ -379,7 +382,7 @@ the Kubernetes cluster as the final of three master nodes, forming a quorum.
 
 1. Run `kubectl get nodes` to see the full Kubernetes cluster.
 
-    > **NOTE:** If the new node fails to join the cluster after running other cloud-init items, refer to the `handoff`.
+    > **NOTE:** If the new node fails to join the cluster after running other `cloud-init` items, then refer to the `handoff`.
 
     ```bash
     ncn-m001# kubectl get nodes

--- a/install/deploy_final_ncn.md
+++ b/install/deploy_final_ncn.md
@@ -7,19 +7,18 @@ join the Kubernetes cluster as the final of three master nodes, forming a quorum
 **IMPORTANT:** While the node is rebooting, it will only be available through Serial-Over-LAN (SOL) and local terminals. This
 procedure entails deactivating the LiveCD, meaning the LiveCD and all of its resources will be unavailable.
 
-* [Required Services](#required-services)
-* [Notice of Danger](#notice-of-danger)
-* [Hand-Off](#hand-off)
-  * [Start Hand-Off](#start-hand-off)
-* [Reboot](#reboot)
-* [Enable NCN Disk Wiping Safeguard](#enable-ncn-disk-wiping-safeguard)
-* [Remove the default NTP pool](#remove-the-default-ntp-pool)
-* [Configure DNS and NTP on each BMC](#configure-dns-and-ntp-on-each-bmc)
-* [Next Topic](#next-topic)
+1. [Required services](#required-services)
+2. [Notice of danger](#notice-of-danger)
+3. [Hand-off](#hand-off)
+4. [Reboot](#reboot)
+5. [Enable NCN disk wiping safeguard](#enable-ncn-disk-wiping-safeguard)
+6. [Remove the default NTP pool](#remove-the-default-ntp-pool)
+7. [Configure DNS and NTP on each BMC](#configure-dns-and-ntp-on-each-bmc)
+8. [Next topic](#next-topic)
 
 <a name="required-services"></a>
 
-## 1. Required Services
+## 1. Required services
 
 These services must be healthy before the reboot of the LiveCD can take place. If the health checks performed earlier in the install
 completed successfully \([Validate CSM Health](../operations/validate_csm_health.md)\), the following platform services will be healthy
@@ -35,7 +34,7 @@ and ready for reboot of the LiveCD:
 
 <a name="notice-of-danger"></a>
 
-## 2. Notice of Danger
+## 2. Notice of danger
 
 > An administrator is **strongly encouraged** to be mindful of pitfalls during this segment of the CSM install.
 > The steps below do contain warnings themselves, but overall there are risks:
@@ -54,16 +53,11 @@ and ready for reboot of the LiveCD:
 
 <a name="hand-off"></a>
 
-## 3. Hand-Off
+## 3. Hand-off
 
-The steps in this guide load hand-off data and reboot the LiveCD node.
-
-At the end of these steps, the LiveCD will be no longer active. The node it was using will join
-the Kubernetes cluster as the final of three master nodes, forming a quorum.
+The steps in this section load hand-off data before a later procedure reboots the LiveCD node.
 
 <a name="start-hand-off"></a>
-
-### 3.1 Start Hand-Off
 
 1. Start a new typescript.
 
@@ -115,22 +109,18 @@ the Kubernetes cluster as the final of three master nodes, forming a quorum.
     `CSM_PATH` should be the fully-qualified path to the expanded CSM release tarball on `ncn-m001`.
 
     ```bash
-    pit# echo $CSM_RELEASE
-    pit# echo $CSM_PATH
+    pit# echo "CSM_RELEASE=${CSM_RELEASE} CSM_PATH=${CSM_PATH}"
     ```
 
 1. <a name="ncn-boot-artifacts-hand-off"></a>Upload NCN boot artifacts into S3.
 
-    1. Set the variables.
-
-        ```bash
-        pit# artdir=/var/www/ephemeral/data ; k8sdir=$artdir/k8s ; cephdir=$artdir/ceph
-        ```
-
     1. Run the following command.
 
         ```bash
-        pit# csi handoff ncn-images \
+        pit# artdir=/var/www/ephemeral/data && 
+             k8sdir=$artdir/k8s &&
+             cephdir=$artdir/ceph &&
+             csi handoff ncn-images \
                 --k8s-kernel-path $k8sdir/*.kernel \
                 --k8s-initrd-path $k8sdir/initrd.img*.xz \
                 --k8s-squashfs-path $k8sdir/secure-*.squashfs \
@@ -139,7 +129,7 @@ the Kubernetes cluster as the final of three master nodes, forming a quorum.
                 --ceph-squashfs-path $cephdir/secure-*.squashfs
         ```
 
-        Running this command will output a block that looks like this at the end:
+        The end of the command output contains a block similar to this:
 
         ```text
         Run the following commands so that the versions of the images that were just uploaded can be used in other steps:
@@ -151,7 +141,10 @@ the Kubernetes cluster as the final of three master nodes, forming a quorum.
 
 1. <a name="csi-handoff-bss-metadata"></a>Upload the `data.json` file to BSS, our `cloud-init` data source.
 
-    **If any changes have been made** to this file (for example, as a result of any customizations or workarounds), use the path to that file instead. This step will prompt for the root password of the NCNs.
+    **If any changes have been made** to this file (for example, as a result of any customizations or workarounds), then use the path to the
+    modified file instead.
+
+    > This step will prompt for the root password of the NCNs.
 
     ```bash
     pit# csi handoff bss-metadata --data-file /var/www/ephemeral/configs/data.json || echo "ERROR: csi handoff bss-metadata failed"
@@ -163,7 +156,7 @@ the Kubernetes cluster as the final of three master nodes, forming a quorum.
     pit# python3 /usr/share/doc/csm/scripts/patch-ceph-runcmd.py
     ```
 
-1. Ensure the DNS server value is correctly set to point toward Unbound at `10.92.100.225` (NMN) and `10.94.100.225` (HMN).
+1. Ensure that the DNS server value is correctly set to point toward Unbound at `10.92.100.225` (NMN) and `10.94.100.225` (HMN).
 
     ```bash
     pit# csi handoff bss-update-cloud-init --set meta-data.dns-server="10.92.100.225 10.94.100.225" --limit Global
@@ -174,7 +167,7 @@ the Kubernetes cluster as the final of three master nodes, forming a quorum.
     After the PIT node is redeployed, **all files on its local drives will be lost**. It is recommended to retain some of the log files and
     configuration files, because they may be useful if issues are encountered during the remainder of the install.
 
-    The following commands create a tar archive of these files, storing it in a directory that will be backed up in the next step.
+    The following commands create a `tar` archive of these files, storing it in a directory that will be backed up in the next step.
 
     ```bash
     pit# mkdir -pv /var/www/ephemeral/prep/logs &&
@@ -198,7 +191,7 @@ the Kubernetes cluster as the final of three master nodes, forming a quorum.
 
 1. <a name="backup-bootstrap-information"></a>Backup the bootstrap information from `ncn-m001`.
 
-    > **NOTE:** This denotes information that should always be kept together in order to fresh-install the system again.
+    > **NOTE:** This preserves information that should always be kept together in order to fresh-install the system again.
 
     1. Log in and set up passwordless SSH **to** the PIT node.
 
@@ -239,7 +232,9 @@ the Kubernetes cluster as the final of three master nodes, forming a quorum.
 
 1. Set and trim the boot order on the PIT node.
 
-    This only needs to be done for the PIT node, not for any of the other NCNs. For the procedures to do this, see [Setting Boot Order](../background/ncn_boot_workflow.md#setting-order) and [Trimming Boot Order](../background/ncn_boot_workflow.md#trimming_boot_order).
+    This only needs to be done for the PIT node, not for any of the other NCNs. See
+    [Setting boot order](../background/ncn_boot_workflow.md#setting-order) and
+    [Trimming boot order](../background/ncn_boot_workflow.md#trimming_boot_order).
 
 1. Tell the PIT node to PXE boot on the next boot.
 
@@ -472,7 +467,7 @@ the Kubernetes cluster as the final of three master nodes, forming a quorum.
 
 <a name="enable-ncn-disk-wiping-safeguard"></a>
 
-## 5. Enable NCN Disk Wiping Safeguard
+## 5. Enable NCN disk wiping safeguard
 
 The next steps require `csi` from the installation media. `csi` will not be provided on an NCN otherwise because
 it is used for Cray installation and bootstrap.
@@ -516,7 +511,7 @@ it is used for Cray installation and bootstrap.
 
 <a name="remove-the-default-ntp-pool"></a>
 
-## 6. Remove the Default NTP Pool
+## 6. Remove the default NTP pool
 
 Run the following command on `ncn-m001` to remove the default pool, which can cause contention issues with NTP.
 
@@ -526,7 +521,7 @@ ncn-m001# sed -i "s/^! pool pool\.ntp\.org.*//" /etc/chrony.conf
 
 <a name="configure-dns-and-ntp-on-each-bmc"></a>
 
-## 7. Configure DNS and NTP on Each BMC
+## 7. Configure DNS and NTP on each BMC
 
  > **NOTE:** Only follow this section if the NCNs are HPE hardware. If the system uses
  > Gigabyte or Intel hardware, skip this section.
@@ -584,6 +579,6 @@ However, the commands in this section are all run **on** `ncn-m001`.
 
 <a name="next-topic"></a>
 
-## Next Topic
+## 8. Next topic
 
 After completing this procedure, the next step is to [Configure Administrative Access](index.md#configure_administrative_access).

--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -503,7 +503,7 @@ be performed are in the [Deploy](#deploy) section.
         Expected output looks similar to the following:
 
         ```text
-        ncn-m001,ncn-m002,ncn-m003,ncn-s001,ncn-s002,ncn-s003,ncn-w001,ncn-w002,ncn-w003
+        ncn-m001,ncn-m002,ncn-m003,ncn-s001,ncn-s002,ncn-s003,ncn-w001,ncn-w002,ncn-w003,
         ```
 
     1. Verify that passwordless SSH is now working from the PIT node to the other NCNs.

--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -212,15 +212,15 @@ firmware requirement before starting.
    both been installed and configured. However, at that point a rolling reboot procedure for the management nodes will be needed,
    after the firmware has been updated.
 
-   See the 1.5 _HPE Cray EX System Software Getting Started Guide S-8000_
-   on the [HPE Customer Support Center](https://www.hpe.com/support/ex-gsg) for information about the _HPE Cray EX HPC Firmware Pack_ (HFP) product.
+   See the Shasta 1.5 `HPE Cray EX System Software Getting Started Guide S-8000`
+   on the [`HPE Customer Support Center`](https://www.hpe.com/support/ex-gsg) for information about the _HPE Cray EX HPC Firmware Pack_ (HFP) product.
 
    In the HFP documentation there is information about the recommended firmware packages to be installed.
    See "Product Details" in the HPE Cray EX HPC Firmware Pack Installation Guide.
 
    Some of the component types have manual procedures to check firmware versions and update firmware.
-   See "Upgrading Firmware Without FAS" in the HPE Cray EX HPC Firmware Pack Installation Guide.
-   It will be possible to extract the files from the product tarball, but the install.sh script from that product
+   See `Upgrading Firmware Without FAS` in the `HPE Cray EX HPC Firmware Pack Installation Guide`.
+   It will be possible to extract the files from the product tarball, but the `install.sh` script from that product
    will be unable to load the firmware versions into the Firmware Action Services (FAS) because the management nodes
    are not booted and running Kubernetes and FAS cannot be used until Kubernetes is running.
 
@@ -323,9 +323,9 @@ be performed are in the [Deploy](#deploy) section.
     * **Worker nodes** with more than two small disks need to make adjustments to [prevent bare-metal `etcd` creation](../background/ncn_mounts_and_file_systems.md#worker-nodes-with-etcd).
     * For a brief overview of what is expected, see [disk plan of record / baseline](../background/ncn_mounts_and_file_systems.md#plan-of-record--baseline).
 
-1. Run the BIOS Baseline script to apply a configs to BMCs.
+1. Run the BIOS baseline script to apply configurations to BMCs.
 
-    The script will apply helper configs to facilitate more deterministic network booting on any NCN port.
+    The script will apply helper configurations to facilitate more deterministic network booting on any NCN port.
     **This runs against any server vendor**, but some settings are not applied for certain vendors.
 
     > **NOTE:** This script will enable DCMI/IPMI on Hewlett-Packard Enterprise servers equipped with ILO. If `ipmitool` is not working at this time, it will after running this script.
@@ -646,7 +646,7 @@ If there are LVM check failures, then the problem must be resolved before contin
 >
 > **IMPORTANT:** Estimate the expected number of OSDs using the following table and using this equation:
 >
-> total_osds = (number of utility storage/Ceph nodes) * (OSD count from table below for the appropriate hardware)
+> `total_osds` = `(number of utility storage/Ceph nodes)` `*` `(OSD count from table below for the appropriate hardware)`
 
 | Hardware Manufacturer | OSD Drive Count (not including OS drives)|
 | :-------------------: | :---------------------------------------: |
@@ -664,7 +664,7 @@ If there are LVM check failures, then the problem must be resolved before contin
     24
     ```
 
-   **IMPORTANT:** If the returned number of OSDs is equal to total_osds calculated, then skip the following steps. If not, then proceed with the below additional checks and remediation steps.
+   **IMPORTANT:** If the returned number of OSDs is equal to `total_osds` calculated, then skip the following steps. If not, then proceed with the below additional checks and remediation steps.
 
 1. Compare the number of OSDs to the output (which should resemble the example below). The number of drives will depend on the server hardware.
 
@@ -954,7 +954,7 @@ Observe the output of the checks and note any failures, then remediate them.
 
       If any pods are listed by this command, it means they are not in the `Running` or `Completed` state. That needs to be investigated before proceeding.
 
-   1. Verify that the ceph-csi requirements are in place.
+   1. Verify that the `ceph-csi` requirements are in place.
 
       See [Ceph CSI Troubleshooting](ceph_csi_troubleshooting.md) for details.
 

--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -497,13 +497,13 @@ be performed are in the [Deploy](#deploy) section.
     1. Make a list of all of the NCNs (including `ncn-m001`).
 
         ```ShellSession
-        pit# NCNS=$(grep -oP "ncn-[msw][0-9]{3}" /etc/dnsmasq.d/statics.conf | sort -u | tr '\n' ',') ; echo "${NCNS}"
+        pit# NCNS=$(grep -oP "ncn-[msw][0-9]{3}" /etc/dnsmasq.d/statics.conf | sort -u | tr '\n' ',' | sed 's/,$//') ; echo "${NCNS}"
         ```
 
         Expected output looks similar to the following:
 
         ```text
-        ncn-m001,ncn-m002,ncn-m003,ncn-s001,ncn-s002,ncn-s003,ncn-w001,ncn-w002,ncn-w003,
+        ncn-m001,ncn-m002,ncn-m003,ncn-s001,ncn-s002,ncn-s003,ncn-w001,ncn-w002,ncn-w003
         ```
 
     1. Verify that passwordless SSH is now working from the PIT node to the other NCNs.

--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -3,6 +3,7 @@
 The following procedure deploys Linux and Kubernetes software to the management NCNs.
 Deployment of the nodes starts with booting the storage nodes followed by the master nodes
 and worker nodes together.
+
 After the operating system boots on each node, there are some configuration actions which
 take place. Watching the console or the console log for certain nodes can help to understand
 what happens and when. When the process completes for all nodes, the Ceph storage is
@@ -12,7 +13,7 @@ will join Kubernetes after it is rebooted later in
 
 <a name="timing-of-deployments"></a>
 
-## Timing of Deployments
+## Timing of deployments
 
 The timing of each set of boots varies based on hardware. Nodes from some manufacturers will
 POST faster than others or vary based on BIOS setting. After powering on a set of nodes,
@@ -21,34 +22,34 @@ the number of storage and worker nodes.
 
 ## Topics
 
-   1. [Prepare for Management Node Deployment](#prepare_for_management_node_deployment)
-      1. [Tokens and IPMI Password](#tokens-and-ipmi-password)
-      1. [Ensure Time Is Accurate Before Deploying NCNs](#ensure-time-is-accurate-before-deploying-ncns)
-   1. [Update Management Node Firmware](#update_management_node_firmware)
-   1. [Deploy Management Nodes](#deploy_management_nodes)
-      1. [Deploy Workflow](#deploy-workflow)
+   1. [Prepare for management node deployment](#prepare_for_management_node_deployment)
+      1. [Tokens and IPMI password](#tokens-and-ipmi-password)
+      1. [Ensure time is accurate before Deploying NCNs](#ensure-time-is-accurate-before-deploying-ncns)
+   1. [Update management node firmware](#update_management_node_firmware)
+   1. [Deploy management nodes](#deploy_management_nodes)
+      1. [Deploy workflow](#deploy-workflow)
       1. [Deploy](#deploy)
-      1. [Check LVM on Masters and Workers](#check-lvm-on-masters-and-workers)
-      1. [Check for Unused Drives on Utility Storage Nodes](#check-for-unused-drives-on-utility-storage-nodes)
-   1. [Configure after Management Node Deployment](#configure_after_management_node_deployment)
-      1. [LiveCD Cluster Authentication](#livecd-cluster-authentication)
-      1. [Install Tests and Test Server on NCNs](#install-tests)
+      1. [Check LVM on Kubernetes NCNs](#check-lvm-on-masters-and-workers)
+      1. [Check for unused drives on utility storage nodes](#check-for-unused-drives-on-utility-storage-nodes)
+   1. [Configure after management node deployment](#configure_after_management_node_deployment)
+      1. [LiveCD cluster authentication](#livecd-cluster-authentication)
+      1. [Install tests and test server on NCNs](#install-tests)
       1. [Remove the default NTP pool](#remove-the-default-ntp-pool)
-   1. [Validate Management Node Deployment](#validate_management_node_deployment)
+   1. [Validate management node deployment](#validate_management_node_deployment)
       1. [Validation](#validation)
-      1. [Optional Validation](#optional-validation)
-   1. [Important Checkpoint](#important-checkpoint)
-   1. [Next Topic](#next-topic)
+      1. [Optional validation](#optional-validation)
+   1. [Important checkpoint](#important-checkpoint)
+   1. [Next topic](#next-topic)
 
 <a name="prepare_for_management_node_deployment"></a>
 
-## 1. Prepare for Management Node Deployment
+## 1. Prepare for management node deployment
 
 Preparation of the environment must be done before attempting to deploy the management nodes.
 
 <a name="tokens-and-ipmi-password"></a>
 
-### 1.1 Tokens and IPMI Password
+### 1.1 Tokens and IPMI password
 
 1. Define shell environment variables that will simplify later commands to deploy management nodes.
 
@@ -70,25 +71,28 @@ Preparation of the environment must be done before attempting to deploy the mana
       pit# export mtoken='ncn-m(?!001)\w+-mgmt' ; export stoken='ncn-s\w+-mgmt' ; export wtoken='ncn-w\w+-mgmt' ; export USERNAME=root
       ```
 
-   Throughout the guide, simple one-liners can be used to query status of expected nodes. If the shell or environment is terminated, these environment variables should be re-exported.
+   Throughout the guide, simple one-liners can be used to query status of expected nodes. If the shell or environment is terminated, these
+   environment variables should be re-exported.
 
    Examples:
 
-   Check power status of all NCNs.
+   * Check power status of all NCNs.
 
-   ```bash
-   pit# grep -oP "($mtoken|$stoken|$wtoken)" /etc/dnsmasq.d/statics.conf | sort -u | xargs -t -i ipmitool -I lanplus -U $USERNAME -E -H {} power status
-   ```
+      ```bash
+      pit# grep -oP "($mtoken|$stoken|$wtoken)" /etc/dnsmasq.d/statics.conf | sort -u |
+              xargs -t -i ipmitool -I lanplus -U $USERNAME -E -H {} power status
+      ```
 
-   Power off all NCNs.
+   * Power off all NCNs.
 
-   ```bash
-   pit# grep -oP "($mtoken|$stoken|$wtoken)" /etc/dnsmasq.d/statics.conf | sort -u | xargs -t -i ipmitool -I lanplus -U $USERNAME -E -H {} power off
-   ```
+      ```bash
+      pit# grep -oP "($mtoken|$stoken|$wtoken)" /etc/dnsmasq.d/statics.conf | sort -u |
+              xargs -t -i ipmitool -I lanplus -U $USERNAME -E -H {} power off
+      ```
 
 <a name="ensure-time-is-accurate-before-deploying-ncns"></a>
 
-### 1.2 Ensure Time Is Accurate Before Deploying NCNs
+### 1.2 Ensure time is accurate before deploying NCNs
 
 **NOTE:** Optionally, in order to use a timezone other than UTC, instead of step 1 below, follow
 [this procedure for setting a local timezone](../operations/node_management/Configure_NTP_on_NCNs.md#set-a-local-timezone). Then
@@ -154,8 +158,8 @@ proceed to step 2.
    1. Using another terminal to watch the console, boot the node to BIOS.
 
       ```console
-      pit# ipmitool -I lanplus -U $USERNAME -E -H $bmc chassis bootdev bios
-      pit# ipmitool -I lanplus -U $USERNAME -E -H $bmc chassis power off && sleep 10 && \
+      pit# ipmitool -I lanplus -U $USERNAME -E -H $bmc chassis bootdev bios &&
+           ipmitool -I lanplus -U $USERNAME -E -H $bmc chassis power off && sleep 10 &&
            ipmitool -I lanplus -U $USERNAME -E -H $bmc chassis power on
       ```
 
@@ -196,7 +200,7 @@ proceed to step 2.
 
 <a name="update_management_node_firmware"></a>
 
-## 2. Update Management Node Firmware
+## 2. Update management node firmware
 
 > All firmware can be found in the HFP package provided with the Shasta release.
 
@@ -212,7 +216,7 @@ firmware requirement before starting.
    both been installed and configured. However, at that point a rolling reboot procedure for the management nodes will be needed,
    after the firmware has been updated.
 
-   See the Shasta 1.5 `HPE Cray EX System Software Getting Started Guide S-8000`
+   See the `Shasta 1.5 HPE Cray EX System Software Getting Started Guide S-8000`
    on the [`HPE Customer Support Center`](https://www.hpe.com/support/ex-gsg) for information about the _HPE Cray EX HPC Firmware Pack_ (HFP) product.
 
    In the HFP documentation there is information about the recommended firmware packages to be installed.
@@ -248,7 +252,7 @@ firmware requirement before starting.
 
 <a name="deploy_management_nodes"></a>
 
-## 3. Deploy Management Nodes
+## 3. Deploy management nodes
 
 Deployment of the nodes starts with booting the storage nodes first. Then, the master nodes and worker nodes should be booted together.
 After the operating system boots on each node, there are some configuration actions which take place. Watching the
@@ -257,7 +261,7 @@ for all nodes, the Ceph storage will have been initialized and the Kubernetes cl
 
 <a name="deploy-workflow"></a>
 
-### 3.1 Deploy Workflow
+### 3.1 Deploy workflow
 
 The configuration workflow described here is intended to help understand the expected path for booting and configuring. The actual steps to
 be performed are in the [Deploy](#deploy) section.
@@ -549,9 +553,9 @@ be performed are in the [Deploy](#deploy) section.
 
 <a name="check-lvm-on-masters-and-workers"></a>
 
-### 3.3 Check LVM on Masters and Workers
+### 3.3 Check LVM on Kubernetes NCNs
 
-#### 3.3.1 Run The Check
+#### 3.3.1 Run the check
 
 Run the following command on the PIT node to validate that the expected LVM labels are present on disks on the master and worker nodes.
 
@@ -559,7 +563,7 @@ Run the following command on the PIT node to validate that the expected LVM labe
 pit# /usr/share/doc/csm/install/scripts/check_lvm.sh
 ```
 
-#### 3.3.2 Expected Check Output
+#### 3.3.2 Expected check output
 
 Expected output looks similar to the following:
 
@@ -594,7 +598,7 @@ If the check succeeds, skip the manual check procedure and recovery steps.
 
 <a name="manual-lvm-check-procedure"></a>
 
-#### 3.3.3 Manual LVM Check Procedure
+#### 3.3.3 Manual LVM check procedure
 
 If needed, the LVM checks can be performed manually on the master and worker nodes.
 
@@ -622,7 +626,7 @@ for details on how to do so.
 
 <a name="lvm-check-failure-recovery"></a>
 
-#### 3.3.4 LVM Check Failure Recovery
+#### 3.3.4 LVM check failure recovery
 
 If there are LVM check failures, then the problem must be resolved before continuing with the install.
 
@@ -640,7 +644,7 @@ If there are LVM check failures, then the problem must be resolved before contin
 
 <a name="check-for-unused-drives-on-utility-storage-nodes"></a>
 
-### 3.4 Check for Unused Drives on Utility Storage Nodes
+### 3.4 Check for unused drives on utility storage nodes
 
 > **IMPORTANT:** Do the following if NCNs are Gigabyte hardware. It is suggested (but optional) for HPE NCNs.
 >
@@ -765,7 +769,7 @@ If there are LVM check failures, then the problem must be resolved before contin
     ncn-s# cephadm shell -- ceph-volume inventory --format json-pretty | jq -r '.[]|select(.available==true)|.path'
     ```
 
-##### Wipe and Add Drives
+##### Wipe and add drives
 
 1. Wipe the drive **ONLY after confirming that the drive is not being used by the current Ceph cluster** using options 1, 2, or both.
 
@@ -785,13 +789,13 @@ More information can be found at [the `cephadm` reference page](../operations/ut
 
 <a name="configure_after_management_node_deployment"></a>
 
-## 4. Configure after Management Node Deployment
+## 4. Configure after management node deployment
 
 After the management nodes have been deployed, configuration can be applied to the booted nodes.
 
 <a name="livecd-cluster-authentication"></a>
 
-### 4.1 LiveCD Cluster Authentication
+### 4.1 LiveCD cluster authentication
 
 The LiveCD needs to authenticate with the cluster to facilitate the rest of the CSM installation.
 
@@ -834,7 +838,7 @@ The LiveCD needs to authenticate with the cluster to facilitate the rest of the 
 
 <a name="install-tests"></a>
 
-### 4.2 Install Tests and Test Server on NCNs
+### 4.2 Install tests and test server on NCNs
 
 Run the following commands on the PIT node.
 
@@ -864,7 +868,7 @@ SUCCESS
 
 <a name="validate_management_node_deployment"></a>
 
-## 5. Validate Management Node Deployment
+## 5. Validate management node deployment
 
 Do all of the validation steps. The optional validation steps are manual steps which could be skipped.
 
@@ -942,7 +946,7 @@ Observe the output of the checks and note any failures, then remediate them.
 
 <a name="optional-validation"></a>
 
-### 5.2 Optional Validation
+### 5.2 Optional validation
 
    1. Verify that all the pods in the `kube-system` namespace are `Running` or `Completed`.
 
@@ -960,13 +964,13 @@ Observe the output of the checks and note any failures, then remediate them.
 
 <a name="important-checkpoint"></a>
 
-## Important Checkpoint
+## Important checkpoint
 
 Before proceeding, be aware that this is the last point where the other NCN nodes can be rebuilt without also having to rebuild the PIT node. Therefore, take time to double check both the cluster and the validation test results
 
 <a name="next-topic"></a>
 
-## Next Topic
+## Next topic
 
 After completing the deployment of the management nodes, the next step is to install the CSM services.
 

--- a/operations/system_management_health/Configure_Prometheus_Email_Alert_Notifications.md
+++ b/operations/system_management_health/Configure_Prometheus_Email_Alert_Notifications.md
@@ -1,105 +1,108 @@
 # Configure Prometheus Email Alert Notifications
 
-Configure an email alert notification for all Prometheus Postgres replication alerts: PostgresReplicationLagSMA, PostgresReplicationServices, PostgresqlFollowerReplicationLagSMA and PostgresqlFollowerReplicationLagServices.
+Configure an email alert notification for all Prometheus Postgres replication alerts: `PostgresReplicationLagSMA`,
+`PostgresReplicationServices`, `PostgresqlFollowerReplicationLagSMA`, and `PostgresqlFollowerReplicationLagServices`.
 
-### Procedure
+## Procedure
 
-1.  Save the current alert notification configuration in case a rollback is needed.
-
-    ```bash
-    ncn-w001# kubectl get secret -n sysmgmt-health \
-    alertmanager-cray-sysmgmt-health-promet-alertmanager -ojsonpath='{.data.alertmanager.yaml}' \
-    | base64 --decode > /tmp/alertmanager-default.yaml
-    ```
-
-2.  Create a secret and an alert configuration that will be used to add email notifications for the alerts.
-
-    Create these files on `ncn-w001`.
+1. Save the current alert notification configuration in case a rollback is needed.
 
     ```bash
-    cat << 'EOF' > /tmp/alertmanager-secret.yaml
-    apiVersion: v1
-    data:
-      alertmanager.yaml: ALERTMANAGER_CONFIG
-    kind: Secret
-    metadata:
-      labels:
-        app: prometheus-operator-alertmanager
-        chart: prometheus-operator-8.15.4
-        heritage: Tiller
-        release: cray-sysmgmt-health
-      name: alertmanager-cray-sysmgmt-health-promet-alertmanager
-      namespace: sysmgmt-health
-    type: Opaque
-    EOF
+    ncn# kubectl get secret -n sysmgmt-health alertmanager-cray-sysmgmt-health-promet-alertmanager \
+            -ojsonpath='{.data.alertmanager.yaml}' | base64 --decode > /tmp/alertmanager-default.yaml
     ```
 
-    In the following example file, the Gmail SMTP server is used in this example to relay the notification to receiver-email@yourcompany.com. Update the fields under `email_configs:` accordingly before running the following command.
+1. Create a secret and an alert configuration that will be used to add email notifications for the alerts.
+
+    1. Create the secret file.
+
+        ```bash
+        ncn# cat << 'EOF' > /tmp/alertmanager-secret.yaml
+        apiVersion: v1
+        data:
+          alertmanager.yaml: ALERTMANAGER_CONFIG
+        kind: Secret
+        metadata:
+          labels:
+            app: prometheus-operator-alertmanager
+            chart: prometheus-operator-8.15.4
+            heritage: Tiller
+            release: cray-sysmgmt-health
+          name: alertmanager-cray-sysmgmt-health-promet-alertmanager
+          namespace: sysmgmt-health
+        type: Opaque
+        EOF
+        ```
+
+    1. Create the alert configuration file.
+
+        In the following example file, the Gmail SMTP server is used in this example to relay the notification to `receiver-email@yourcompany.com`.
+        Update the fields under `email_configs:` accordingly before running the following command.
+
+        ```bash
+        ncn# cat << 'EOF' > /tmp/alertmanager-new.yaml
+        global:
+          resolve_timeout: 5m
+        route:
+          group_by:
+          - job
+          group_interval: 5m
+          group_wait: 30s
+          receiver: "null"
+          repeat_interval: 12h
+          routes:
+          - match:
+              alertname: Watchdog
+            receiver: "null"
+          - match:
+              alertname: PostgresqlReplicationLagSMA
+            receiver:  email-alert
+          - match:
+              alertname: PostgresqlReplicationLagServices
+            receiver:  email-alert
+          - match:
+              alertname: PostgresqlFollowerReplicationLagSMA
+            receiver:  email-alert
+          - match:
+              alertname: PostgresqlFollowerReplicationLagServices
+            receiver:  email-alert
+        receivers:
+        - name: "null"
+        - name: email-alert
+          email_configs:
+          - to: receiver-email@yourcompany.com
+            from: sender-email@gmail.com
+            # Your smtp server address
+            smarthost: smtp.gmail.com:587
+            auth_username: sender-email@gmail.com
+            auth_identity: sender-email@gmail.com
+            auth_password: xxxxxxxxxxxxxxxx
+        EOF
+        ```
+
+1. Replace the alert notification configuration based on the files created in the previous step.
 
     ```bash
-    cat << 'EOF' > /tmp/alertmanager-new.yaml
-    global:
-      resolve_timeout: 5m
-    route:
-      group_by:
-      - job
-      group_interval: 5m
-      group_wait: 30s
-      receiver: "null"
-      repeat_interval: 12h
-      routes:
-      - match:
-          alertname: Watchdog
-        receiver: "null"
-      - match:
-          alertname: PostgresqlReplicationLagSMA
-        receiver:  email-alert
-      - match:
-          alertname: PostgresqlReplicationLagServices
-        receiver:  email-alert
-      - match:
-          alertname: PostgresqlFollowerReplicationLagSMA
-        receiver:  email-alert
-      - match:
-          alertname: PostgresqlFollowerReplicationLagServices
-        receiver:  email-alert
-    receivers:
-    - name: "null"
-    - name: email-alert
-      email_configs:
-      - to: receiver-email@yourcompany.com
-        from: sender-email@gmail.com
-        # Your smtp server address
-        smarthost: smtp.gmail.com:587
-        auth_username: sender-email@gmail.com
-        auth_identity: sender-email@gmail.com
-        auth_password: xxxxxxxxxxxxxxxx
-    EOF
+    ncn# sed "s/ALERTMANAGER_CONFIG/$(cat /tmp/alertmanager-new.yaml \
+                | base64 -w0)/g" /tmp/alertmanager-secret.yaml \
+                | kubectl replace --force -f -
     ```
 
-3.  Replace the alert notification configuration based on the files created in the previous step.
+1. Validate the configuration changes.
 
     ```bash
-    ncn-w001# sed "s/ALERTMANAGER_CONFIG/$(cat /tmp/alertmanager-new.yaml \
-    | base64 -w0)/g" /tmp/alertmanager-secret.yaml \
-    | kubectl replace --force -f -
+    ncn# kubectl exec alertmanager-cray-sysmgmt-health-promet-alertmanager-0 \
+                -n sysmgmt-health -c alertmanager -- cat /etc/alertmanager/config/alertmanager.yaml
     ```
 
-4.  Validate the configuration changes.
+    Check the logs for any errors if the configuration does not look accurate.
 
     ```bash
-    ncn-w001# kubectl exec alertmanager-cray-sysmgmt-health-promet-alertmanager-0 \
-    -n sysmgmt-health -c alertmanager -- cat /etc/alertmanager/config/alertmanager.yaml
+    ncn# kubectl logs -f -n sysmgmt-health pod/alertmanager-cray-sysmgmt-health-promet-alertmanager-0 alertmanager
     ```
 
-5.  Check the logs for any errors if the configuration does not look accurate.
+An email notification will be sent once either of the alerts set in this procedure is `FIRING` in Prometheus.
+See `https://prometheus.SYSTEM-NAME.SITE-DOMAIN/alerts` for more information.
 
-    ```bash
-    ncn-w001# kubectl logs -f -n sysmgmt-health \
-    pod/alertmanager-cray-sysmgmt-health-promet-alertmanager-0 alertmanager
-    ```
-
-An email notification will be sent once either of the alerts set in this procedure is `FIRING` in Prometheus. See https://prometheus.SYSTEM-NAME.SITE-DOMAIN/alerts for more information.
-
-If an alert is received, refer to [Troubleshoot Postgres Database](../kubernetes/Troubleshoot_Postgres_Database.md) section for more information about recovering replication.
-
+If an alert is received, then refer to [Troubleshoot Postgres Database](../kubernetes/Troubleshoot_Postgres_Database.md) for more information
+about recovering replication.

--- a/operations/system_management_health/Configure_Prometheus_Email_Alert_Notifications.md
+++ b/operations/system_management_health/Configure_Prometheus_Email_Alert_Notifications.md
@@ -16,7 +16,7 @@ Configure an email alert notification for all Prometheus Postgres replication al
 
     1. Create the secret file.
 
-        ```bash
+        ```console
         ncn# cat << 'EOF' > /tmp/alertmanager-secret.yaml
         apiVersion: v1
         data:
@@ -39,7 +39,7 @@ Configure an email alert notification for all Prometheus Postgres replication al
         In the following example file, the Gmail SMTP server is used in this example to relay the notification to `receiver-email@yourcompany.com`.
         Update the fields under `email_configs:` accordingly before running the following command.
 
-        ```bash
+        ```console
         ncn# cat << 'EOF' > /tmp/alertmanager-new.yaml
         global:
           resolve_timeout: 5m
@@ -90,16 +90,18 @@ Configure an email alert notification for all Prometheus Postgres replication al
 
 1. Validate the configuration changes.
 
-    ```bash
-    ncn# kubectl exec alertmanager-cray-sysmgmt-health-promet-alertmanager-0 \
+    1. View the current configuration.
+
+        ```bash
+        ncn# kubectl exec alertmanager-cray-sysmgmt-health-promet-alertmanager-0 \
                 -n sysmgmt-health -c alertmanager -- cat /etc/alertmanager/config/alertmanager.yaml
-    ```
+        ```
 
-    Check the logs for any errors if the configuration does not look accurate.
+    1. Check the logs for any errors if the configuration does not look accurate.
 
-    ```bash
-    ncn# kubectl logs -f -n sysmgmt-health pod/alertmanager-cray-sysmgmt-health-promet-alertmanager-0 alertmanager
-    ```
+        ```bash
+        ncn# kubectl logs -f -n sysmgmt-health pod/alertmanager-cray-sysmgmt-health-promet-alertmanager-0 alertmanager
+        ```
 
 An email notification will be sent once either of the alerts set in this procedure is `FIRING` in Prometheus.
 See `https://prometheus.SYSTEM-NAME.SITE-DOMAIN/alerts` for more information.


### PR DESCRIPTION
## Summary and Scope

During the mug install I noticed some small errors in the docs, and some areas for improvement. This PR contains those, plus the necessary linting to make the style and spell checkers happy.

One thing I removed was a step in Deploy Final NCNs which had the installer change the NCN root password if they didn't customize it in the NCN image. Now that we require it to be customized in the image, that step is no longer needed.

csm-1.2 backport: https://github.com/Cray-HPE/docs-csm/pull/1562
csm-1.0 backport: https://github.com/Cray-HPE/docs-csm/pull/1563