### PR TITLE
Check mon status after we've waited for good health first

### DIFF
--- a/upgrade/1.2/scripts/ceph/lib/ceph-health.sh
+++ b/upgrade/1.2/scripts/ceph/lib/ceph-health.sh
@@ -25,15 +25,20 @@
 
 function wait_for_health_ok() {
   cnt=0
+  node=$1
   while true; do
-    if [[ "$cnt" -eq 360 ]]; then
-      echo "ERROR: Giving up on waiting for Ceph to become healthy..."
-      break
-    fi
-    ceph_status=$(ceph health -f json-pretty | jq -r .status)
-    if [[ $ceph_status == "HEALTH_OK" ]]; then
-      echo "Ceph is healthy -- continuing..."
-      break
+    if [[ ! -z "$node" ]] && [[ "$cnt" -eq 300 ]] ; then
+      check_mon_daemon ${node}
+    else
+      if [[ "$cnt" -eq 360 ]]; then
+        echo "ERROR: Giving up on waiting for Ceph to become healthy..."
+        break
+      fi
+      ceph_status=$(ceph health -f json-pretty | jq -r .status)
+      if [[ $ceph_status == "HEALTH_OK" ]]; then
+        echo "Ceph is healthy -- continuing..."
+        break
+      fi
     fi
     sleep 5
     echo "Sleeping for five seconds waiting for Ceph to be healthy..."

--- a/upgrade/1.2/scripts/upgrade/ncn-upgrade-ceph-nodes.sh
+++ b/upgrade/1.2/scripts/upgrade/ncn-upgrade-ceph-nodes.sh
@@ -157,8 +157,7 @@ fi
 
 {
 . /usr/share/doc/csm/upgrade/1.2/scripts/ceph/lib/ceph-health.sh
-check_mon_daemon ${target_ncn}
-wait_for_health_ok
+wait_for_health_ok ${target_ncn}
 
 # Wait for rgw to start before executing goss tests
 target_ncn=ncn-s001


### PR DESCRIPTION
## Summary and Scope

Move mon test to health check to give ceph a chance to come up before intervening.

## Issues and Related PRs

* Resolves [CASMINST-4594](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4594)

## Testing

drax

### Tested on:

  * `drax`

### Test description:

Jim is trying s003 with the fix

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

