### PR TITLE
CASMINST-4602 Fix coloring in spell checker workflow [release/1.2]

### DIFF
--- a/.github/workflows/spell-check.yaml
+++ b/.github/workflows/spell-check.yaml
@@ -41,6 +41,8 @@ jobs:
 
     - uses: docker://tmaier/markdown-spellcheck:latest
       id: markdown-spellcheck
+      env:
+          FORCE_COLOR: "1"
       with:
         entrypoint: mdspell
         args: ${{ steps.changed-files.outputs.all_changed_files }} -r -a -n


### PR DESCRIPTION
## Summary and Scope

Coloring is off in spell checker log, which makes it hard to identify which word is misspelled. Spell checker prints entire sentence, and it's not clear which word is misspelled. This change enforces color indication of misspelled word.

## Issues and Related PRs

* Resolves [CASMINST-4602](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4602)

## Testing

Will add and revert a dummy commit to this PR to introduce a change in markdown file.

### Tested on:

  * Workflow run: https://github.com/Cray-HPE/docs-csm/runs/6373973422?check_suite_focus=true

### Test description:
![image](https://user-images.githubusercontent.com/320082/167677540-f8d21c53-aac8-4134-9334-2fc70bf9931e.png)

## Risks and Mitigations

Low  - non-mandatory check on docs build.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

