### PR TITLE
Export system domain name to Fabric Manager container for 1.2

### DIFF
--- a/upgrade/1.2/scripts/upgrade/util/update-customizations.sh
+++ b/upgrade/1.2/scripts/upgrade/util/update-customizations.sh
@@ -366,7 +366,6 @@ yq w -i "$c" 'spec.kubernetes.services.sma-grafana.externalAuthority' 'sma-grafa
 yq w -i "$c" 'spec.kubernetes.services.gatekeeper-policy-manager.gatekeeper-policy-manager.externalAuthority' 'opa-gpm.cmn.{{ network.dns.external }}'
 yq w -i "$c" 'spec.kubernetes.services.slingshot-fabric-manager.base_domain' "{{ network.dns.external }}"
 
-
 # cray-opa changes
 yq d -i "$c" 'spec.kubernetes.services.cray-opa.jwtValidation'
 yq w -i "$c" 'spec.kubernetes.services.cray-opa.ingresses.ingressgateway.issuers.shasta-cmn' 'https://api.cmn.{{ network.dns.external }}/keycloak/realms/shasta'

--- a/upgrade/1.2/scripts/upgrade/util/update-customizations.sh
+++ b/upgrade/1.2/scripts/upgrade/util/update-customizations.sh
@@ -364,6 +364,8 @@ yq w -i "$c" 'spec.kubernetes.services.sma-rsyslog-aggregator-udp.rsyslogAggrega
 yq w -i "$c" 'spec.kubernetes.services.sma-kibana.externalAuthority' 'sma-kibana.cmn.{{ network.dns.external }}'
 yq w -i "$c" 'spec.kubernetes.services.sma-grafana.externalAuthority' 'sma-grafana.cmn.{{ network.dns.external }}'
 yq w -i "$c" 'spec.kubernetes.services.gatekeeper-policy-manager.gatekeeper-policy-manager.externalAuthority' 'opa-gpm.cmn.{{ network.dns.external }}'
+yq w -i "$c" 'spec.kubernetes.services.slingshot-fabric-manager.base_domain' "{{ network.dns.external }}"
+
 
 # cray-opa changes
 yq d -i "$c" 'spec.kubernetes.services.cray-opa.jwtValidation'


### PR DESCRIPTION
SSHOTMGP-5040 Export system domain name to Fabric Manager container

## Summary and Scope

Slingshot need to get Base-domain to config slingshot switches with telemetry url . i am adding base-domain. Earlier versions we used to use static basename "api-gw-service-nmn.local" 

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_ 
its not backward compatible but not a breaking change for us . 

## Issues and Related PRs

-  SSHOTMGP-5040 Export system domain name to Fabric Manager container
* Change will also be needed in shasta CSM 1.2 


## Testing 
will test asap 

## Risks and Mitigations

No real risk as its a env variable. 


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable 
Not sure its applicable for my change
- [ ] Copyrights updated 
NA
- [ ] License file intact
Yes
- [ ] Target branch correct
Yes
- [ ] CHANGELOG.md updated 
Not sure its applicable for my change
- [ ] Testing is appropriate and complete, if applicable
Not sure its applicable for my change
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
Not sure its applicable for my change

