### PR TITLE
CASMINST-4599: Download docs-csm RPM so that it overwrites existing copies

### DIFF
--- a/update_product_stream/index.md
+++ b/update_product_stream/index.md
@@ -1,111 +1,113 @@
 # Update CSM Product Stream
 
-The software included in the CSM product stream is released in more than one way. The initial product release may be augmented with patches, documentation updates, or hotfixes after the release.
+The software included in the CSM product stream is released in more than one way. The initial product release may be augmented with patches, documentation updates, or
+hotfixes after the release.
 
 The CSM documentation is included within the CSM product release tarball inside the `docs-csm` RPM.
 After the RPM has been installed, the documentation will be available at `/usr/share/doc/csm`.
 
-## Topics:
-   * [Download and Extract CSM Product Release](#download-and-extract)
-   * [Apply Patch to CSM Release](#patch)
-   * [Check for Latest Documentation](#documentation)
-   * [Check for Field Notices about Hotfixes](#hotfixes)
+- [Download and Extract CSM Product Release](#download-and-extract)
+- [Apply Patch to CSM Release](#patch)
+- [Check for Latest Documentation](#documentation)
+- [Check for Field Notices about Hotfixes](#hotfixes)
 
 <a name="download-and-extract"></a>
+
 ## Download and Extract CSM Product Release
 
 Acquire a CSM software release tarball for installation on the HPE Cray EX supercomputer.
 
-### Details
+1. Download the CSM software release tarball for the HPE Cray EX system to a Linux system.
 
-   1. Download the CSM software release tarball for the HPE Cray EX system to a Linux system.
+   ```bash
+   linux# export ENDPOINT=URL_SERVER_Hosting_tarball
+   linux# export CSM_RELEASE=csm-x.y.z
+   linux# wget ${ENDPOINT}/${CSM_RELEASE}.tar.gz
+   ```
 
-      ```bash
-      linux# export ENDPOINT=URL_SERVER_Hosting_tarball
-      linux# export CSM_RELEASE=csm-x.y.z
-      linux# wget ${ENDPOINT}/${CSM_RELEASE}.tar.gz
-      ```
+1. Extract the source release distribution.
 
-   1. Extract the source release distribution.
+   If doing a first time install, this can be done on a Linux system, but for an upgrade, it may be done on one of the NCNs, such as `ncn-m001`.
 
-      If doing a first time install, this can be done on a Linux system, but for an upgrade, it could be done on one of the NCNs, such as ncn-m001.
+   ```bash
+   linux# tar -xzvf ${CSM_RELEASE}.tar.gz
+   ```
 
-      ```bash
-      linux# tar -xzvf ${CSM_RELEASE}.tar.gz
-      ```
-
-   1. Before using this software release, check for any patches available for it. If patches are available, see [Apply Patch to CSM Release](#patch).
+1. Before using this software release, check for any patches available for it. If patches are available, see [Apply Patch to CSM Release](#patch).
 
 <a name="patch"></a>
+
 ## Apply Patch to CSM Release
 
 Apply a CSM update patch to the release tarball. This ensures that the latest CSM product artifacts are installed on the HPE Cray EX supercomputer.
 
-### Details
+1. Verify that the Git version is at least `2.16.5` on the Linux system which will apply the patch.
 
-   1. Verify that the Git version is at least 2.16.5 on the Linux system which will apply the patch.
+   The patch process is known to work with Git version `2.16.5` or higher. Older versions of Git may not correctly apply the
+   binary patch.
 
-      The patch process is known to work with Git >= 2.16.5. Older versions of Git may not correctly apply the
-      binary patch.
+   ```bash
+   linux# git version
+   ```
 
-      ```bash
-      linux# git version
-      git version 2.26.2
-      ```
+   Example output:
 
-      If the Git version is less than 2.16.15, update Git to at least that version.
+   ```text
+   git version 2.26.2
+   ```
 
-   1. Download the compressed CSM software package patch csm-x.y.z-x.z.a.patch.gz for the HPE Cray EX system.
+   If the Git version is less than `2.16.15`, update Git to at least that version.
 
-      ```bash
-      linux# export ENDPOINT=URL_SERVER_Hosting_tarball
-      linux# export CSM_RELEASE=csm-x.y.z
-      linux# export PATCH_RELEASE=x.z.a
-      linux# wget ${ENDPOINT}/${CSM_RELEASE}-${PATCH_RELEASE}.patch.gz
-      ```
+1. Download the compressed CSM software package patch `csm-x.y.z-x.z.a.patch.gz` for the HPE Cray EX system.
 
-      The following steps should be run from the node to which the original $CSM_RELEASE release was downloaded and extracted.
+   ```bash
+   linux# export ENDPOINT=URL_SERVER_Hosting_tarball
+   linux# export CSM_RELEASE=csm-x.y.z
+   linux# export PATCH_RELEASE=x.z.a
+   linux# wget ${ENDPOINT}/${CSM_RELEASE}-${PATCH_RELEASE}.patch.gz
+   ```
 
-   1. Uncompress the patch.
+   Run the remaining steps from the node to which the original `$CSM_RELEASE` release was downloaded and extracted.
 
-      ```bash
-      linux# gunzip -v ${CSM_RELEASE}-${PATCH_RELEASE}.patch.gz
-      ```
+1. Uncompress the patch.
 
-   1. Apply the patch.
+   ```bash
+   linux# gunzip -v ${CSM_RELEASE}-${PATCH_RELEASE}.patch.gz
+   ```
 
-      ```bash
-      linux# git apply -p2 --whitespace=nowarn \
-                           --directory=${CSM_RELEASE} \
-                           ${CSM_RELEASE}-${PATCH_RELEASE}.patch
-      ```
+1. Apply the patch.
 
-   1. Set a variable to reflect the new version.
+   ```bash
+   linux# git apply -p2 --whitespace=nowarn \
+                        --directory=${CSM_RELEASE} \
+                        ${CSM_RELEASE}-${PATCH_RELEASE}.patch
+   ```
 
-      ```bash
-      linux# export NEW_CSM_RELEASE="$(./${CSM_RELEASE/lib/version.sh)"
-      ```
+1. Set a variable to reflect the new version.
 
-   1. Update the name of the CSM release distribution directory.
+   ```bash
+   linux# export NEW_CSM_RELEASE="$(./${CSM_RELEASE/lib/version.sh)"
+   ```
 
-      ```bash
-      linux# mv -v $CSM_RELEASE $NEW_CSM_RELEASE
-      ```
+1. Update the name of the CSM release distribution directory.
 
-   1. Create a tarball from the patched release distribution.
+   ```bash
+   linux# mv -v $CSM_RELEASE $NEW_CSM_RELEASE
+   ```
 
-      ```bash
-      linux# tar -cvzf ${NEW_CSM_RELEASE}.tar.gz "${NEW_CSM_RELEASE}/"
-      ```
+1. Create a tarball from the patched release distribution.
+
+   ```bash
+   linux# tar -cvzf ${NEW_CSM_RELEASE}.tar.gz "${NEW_CSM_RELEASE}/"
+   ```
 
 This tarball can now be used in place of the original CSM software release tarball.
 
 <a name="documentation"></a>
+
 ## Check for Latest Documentation
 
 Acquire the latest documentation RPM. This may include updates, corrections, and enhancements that were not available until after the software release.
-
-### Details
 
 1. Check the version of the currently installed CSM documentation.
 
@@ -119,7 +121,7 @@ Acquire the latest documentation RPM. This may include updates, corrections, and
    linux# rpm -Uvh --force https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/docs-csm/1.2/noarch/docs-csm-latest.noarch.rpm
    ```
 
-   If this machine does not have direct Internet access, then this RPM will need to be externally downloaded and copied to the system. This example copies it to `ncn-m001`.
+   If this machine does not have direct internet access, then this RPM will need to be externally downloaded and copied to the system. This example copies it to `ncn-m001`.
 
    ```bash
    linux# wget https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/docs-csm/1.2/noarch/docs-csm-latest.noarch.rpm -O docs-csm-latest.noarch.rpm
@@ -131,11 +133,7 @@ Acquire the latest documentation RPM. This may include updates, corrections, and
 1. Repeat the first step in this procedure to display the version of the CSM documentation after the update.
 
 <a name="hotfixes"></a>
+
 ## Check for Field Notices about Hotfixes
 
-Collect all available Field Notices about Hotfixes which should be applied to this CSM software release.
-
-### Details
-
-Check with HPE Cray service for any Field Notices about Hotfixes which should be applied to this CSM software release.
-
+Collect all available field notices about hotfixes which should be applied to this CSM software release. Check with HPE Cray service for more information.

--- a/update_product_stream/index.md
+++ b/update_product_stream/index.md
@@ -119,10 +119,10 @@ Acquire the latest documentation RPM. This may include updates, corrections, and
    linux# rpm -Uvh --force https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/docs-csm/1.2/noarch/docs-csm-latest.noarch.rpm
    ```
 
-   If this machine does not have direct Internet access, this RPM will need to be externally downloaded and then copied to the system. This example copies it to `ncn-m001`.
+   If this machine does not have direct Internet access, then this RPM will need to be externally downloaded and copied to the system. This example copies it to `ncn-m001`.
 
    ```bash
-   linux# wget https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/docs-csm/1.2/noarch/docs-csm-latest.noarch.rpm
+   linux# wget https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/docs-csm/1.2/noarch/docs-csm-latest.noarch.rpm -O docs-csm-latest.noarch.rpm
    linux# scp -p docs-csm-*rpm ncn-m001:/root
    linux# ssh ncn-m001
    ncn-m001# rpm -Uvh --force docs-csm-latest.noarch.rpm

--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -20,13 +20,21 @@ Stage 0 has several critical procedures which prepares and verify if the environ
 
 1. Install latest documentation RPM package and prepare assets:
 
-   > The install scripts will look for the RPM in `/root`, so it is important that you copy it there.
+   > **Important:** The install scripts will look for the `docs-csm` RPM in `/root`, so be sure copy it there.
 
    ```bash
     ncn-m001# CSM_RELEASE=csm-1.2.0
    ```
 
    - Internet Connected
+
+      1. Download and install the latest documentation RPM.
+
+         ```bash
+         ncn-m001# wget https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/docs-csm/1.2/noarch/docs-csm-latest.noarch.rpm \
+                        -O /root/docs-csm-latest.noarch.rpm &&
+                   rpm -Uvh --force /root/docs-csm-latest.noarch.rpm
+         ```
 
       1. Set the ENDPOINT variable to the URL of the directory containing the CSM release tarball.
 
@@ -38,20 +46,19 @@ Stage 0 has several critical procedures which prepares and verify if the environ
          ncn-m001# ENDPOINT=https://put.the/url/here/
          ```
 
-      1. Run the script
+      1. Run the script.
 
          ```bash
-         ncn-m001# wget https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/docs-csm/1.2/noarch/docs-csm-latest.noarch.rpm -P /root &&
-                   rpm -Uvh --force /root/docs-csm-latest.noarch.rpm
-
          ncn-m001# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version [CSM_RELEASE] --endpoint [ENDPOINT]
          ```
 
    - Air Gapped (replace the PATH_TO below with the location of the rpm)
 
-      1. Copy the docs-csm RPM package and CSM release tarball to `ncn-m001`.
+      1. Copy the `docs-csm` RPM package and CSM release tarball to `ncn-m001`.
 
-      1. Run the script
+         See [Update Product Stream](../update_product_stream/index.md).
+
+      1. Run the script.
 
          ```bash
          ncn-m001# cp [PATH_TO_docs-csm-*.noarch.rpm] /root

--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -1,12 +1,16 @@
 # Stage 0 - Prerequisites and Preflight Checks
 
-> **`Note`:** CSM-1.0.1 or higher is required in order to upgrade to CSM-1.2.0
+> **Note:** CSM 1.0.1 or higher is required in order to upgrade to CSM 1.2.0.
 
-## Abstract
+## Abstract (Stage 0)
 
-Stage 0 has several critical procedures which prepares and verify if the environment is ready for upgrade. First, the latest docs RPM is installed; it includes critical install scripts used in the upgrade procedure. Next, the current configuration of the System Layout Service (SLS) is updated to have necessary information for CSM 1.2. The management network configuration is also upgraded. Towards the end, prerequisite checks are performed to ensure that the upgrade is ready to proceed. Finally, a backup of Workload Manager configuration data and files is created. Once complete, the upgrade proceeds to Stage 1.
+Stage 0 has several critical procedures which prepares and verify if the environment is ready for upgrade. First, the latest documentation RPM is installed; it includes
+critical install scripts used in the upgrade procedure. Next, the current configuration of the System Layout Service (SLS) is updated to have necessary information for CSM 1.2.
+The management network configuration is also upgraded. Towards the end, prerequisite checks are performed to ensure that the upgrade is ready to proceed. Finally, a
+backup of Workload Manager configuration data and files is created. Once complete, the upgrade proceeds to Stage 1.
 
-**Stages**
+### Stages
+
 - [Stage 0.1 - Install latest docs RPM](#install-latest-docs)
 - [Stage 0.2 - Update SLS](#update-sls)
 - [Stage 0.3 - Upgrade Management Network](#update-management-network)
@@ -18,7 +22,7 @@ Stage 0 has several critical procedures which prepares and verify if the environ
 
 ## Stage 0.1 - Install latest documentation RPM
 
-1. Install latest documentation RPM package and prepare assets:
+1. Install latest documentation RPM package and prepare assets.
 
    > **Important:** The install scripts will look for the `docs-csm` RPM in `/root`, so be sure copy it there.
 
@@ -26,65 +30,75 @@ Stage 0 has several critical procedures which prepares and verify if the environ
     ncn-m001# CSM_RELEASE=csm-1.2.0
    ```
 
-   - Internet Connected
+### Internet Connected
 
-      1. Download and install the latest documentation RPM.
+1. Download and install the latest documentation RPM.
 
-         ```bash
-         ncn-m001# wget https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/docs-csm/1.2/noarch/docs-csm-latest.noarch.rpm \
-                        -O /root/docs-csm-latest.noarch.rpm &&
-                   rpm -Uvh --force /root/docs-csm-latest.noarch.rpm
-         ```
+   ```bash
+   ncn-m001# wget https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/docs-csm/1.2/noarch/docs-csm-latest.noarch.rpm \
+                -O /root/docs-csm-latest.noarch.rpm &&
+             rpm -Uvh --force /root/docs-csm-latest.noarch.rpm
+   ```
 
-      1. Set the ENDPOINT variable to the URL of the directory containing the CSM release tarball.
+1. Set the `ENDPOINT` variable to the URL of the directory containing the CSM release tarball.
 
-         In other words, the full URL to the CSM release tarball will be ${ENDPOINT}${CSM_RELEASE}.tar.gz
+   In other words, the full URL to the CSM release tarball will be `${ENDPOINT}${CSM_RELEASE}.tar.gz`.
 
-         **Note:** This step is optional for Cray/HPE internal installs.
+   > **Note:** This step is optional for Cray/HPE internal installs.
 
-         ```bash
-         ncn-m001# ENDPOINT=https://put.the/url/here/
-         ```
+   ```bash
+   ncn-m001# ENDPOINT=https://put.the/url/here/
+   ```
 
-      1. Run the script.
+1. Run the script.
 
-         ```bash
-         ncn-m001# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version [CSM_RELEASE] --endpoint [ENDPOINT]
-         ```
+```bash
+ncn-m001# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version $CSM_RELEASE --endpoint $ENDPOINT
+```
 
-   - Air Gapped (replace the PATH_TO below with the location of the rpm)
+### Air-Gapped
 
-      1. Copy the `docs-csm` RPM package and CSM release tarball to `ncn-m001`.
+1. Copy the `docs-csm` RPM package and CSM release tarball to `ncn-m001`.
 
-         See [Update Product Stream](../update_product_stream/index.md).
+   See [Update Product Stream](../../update_product_stream/index.md).
 
-      1. Run the script.
+1. Copy the documentation RPM to `/root` and install it.
 
-         ```bash
-         ncn-m001# cp [PATH_TO_docs-csm-*.noarch.rpm] /root
+   > Replace the `PATH_TO` below with the location of the RPM.
 
-         ncn-m001# rpm -Uvh --force /root/docs-csm-*.noarch.rpm
+   ```bash
+   ncn-m001# cp [PATH_TO_docs-csm-*.noarch.rpm] /root/docs-csm-latest.noarch.rpm &&
+             rpm -Uvh --force /root/docs-csm-latest.noarch.rpm
+   ```
 
-         ncn-m001# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version [CSM_RELEASE] --tarball-file [PATH_TO_CSM_TARBALL_FILE]
-         ```
+1. Run the script.
+
+   ```bash
+   ncn-m001# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version $CSM_RELEASE --tarball-file [PATH_TO_CSM_TARBALL_FILE]
+   ```
 
 <a name="update-sls"></a>
 
 ## Stage 0.2 - Update SLS
 
-### Abstract
+### Abstract (Stage 0.2)
 
-CSM 1.2 introduces the bifurcated CAN as well as network configuration controlled by data in SLS. An offline upgrade of SLS data is performed. More details on the upgrade and its sequence of events can be found in the [README.SLS_upgrade.md](./scripts/sls/README.SLS_Upgrade.md).
+CSM 1.2 introduces the bifurcated CAN (BICAN) as well as network configuration controlled by data in SLS. An offline upgrade of SLS data is performed. For more details on the
+upgrade and its sequence of events, see the [SLS upgrade `README`](scripts/sls/README.SLS_Upgrade.md).
 
-The SLS data upgrade is a critical step in moving to CSM 1.2. Upgraded SLS data is used in DNS and management network configuration. Details of Bifurcated CAN can be found in the [BICAN document](../../operations/network/management_network/index.md) to aid in understanding and decision-making.
+The SLS data upgrade is a critical step in moving to CSM 1.2. Upgraded SLS data is used in DNS and management network configuration. For details to aid in understanding and
+decision making, see the [Management Network User Guide](../../operations/network/management_network/index.md).
 
-One detail which must not be overlooked is that the existing Customer Access Network (CAN) will be migrated or retrofitted into the new Customer Management Network (CMN) while minimizing changes. A new CAN, (or CHN) network is then created. Pivoting the existing CAN to the new CMN allows administrative traffic (already on the CAN) to remain as-is while moving standard user traffic to a new site-routable network.
+One detail which must not be overlooked is that the existing Customer Access Network (CAN) will be migrated or retrofitted into the new Customer Management Network (CMN) while
+minimizing changes. A new CAN (or CHN) network is then created. Pivoting the existing CAN to the new CMN allows administrative traffic (already on the CAN) to remain as-is while
+moving standard user traffic to a new site-routable network.
 
-> **`Important:`** If this is the first time performing the SLS update to CSM 1.2, you should review the [README.SLS_upgrade.md](./scripts/sls/README.SLS_Upgrade.md) to ensure you use all the correct options for your environment. Two examples are given below. To see all options from the update script run `./sls_updater_csm_1.2.py --help`
+> **Important:** If this is the first time performing the SLS update to CSM 1.2, review the [SLS upgrade `README`](scripts/sls/README.SLS_Upgrade.md) in order to ensure
+the correct options for the specific environment are used. Two examples are given below. To see all options from the update script, run `./sls_updater_csm_1.2.py --help`.
 
 ### Retrieve SLS data as JSON
 
-1. Obtain a token:
+1. Obtain a token.
 
    ```bash
    ncn-m001# export TOKEN=$(curl -s -k -S -d grant_type=client_credentials -d client_id=admin-client \
@@ -92,20 +106,19 @@ One detail which must not be overlooked is that the existing Customer Access Net
                                 https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
    ```
 
-1. Create a working directory:
+1. Create a working directory.
 
    ```bash
-   ncn-m001# mkdir /root/sls_upgrade
-   ncn-m001# cd /root/sls_upgrade
+   ncn-m001# mkdir /root/sls_upgrade && cd /root/sls_upgrade
    ```
 
-1. Extract SLS data to a file:
+1. Extract SLS data to a file.
 
    ```bash
    ncn-m001# curl -k -H "Authorization: Bearer ${TOKEN}" https://api-gw-service-nmn.local/apis/sls/v1/dumpstate | jq -S . > sls_input_file.json
    ```
 
-### Migrate SLS data JSON to CSM 1.2
+### Migrate SLS Data JSON to CSM 1.2
 
 - Example 1: The CHN as the system default route (will by default output to `migrated_sls_file.json`).
 
@@ -126,7 +139,8 @@ One detail which must not be overlooked is that the existing Customer Access Net
                          --preserve-existing-subnet-for-cmn external-dns
    ```
 
-- **`Note:`**: A detailed review of the migrated/upgraded data (using `vimdiff` or otherwise) for production systems and for systems which have many add-on components (UAN, login nodes, storage integration points, etc.) is strongly recommended. Particularly, ensure that subnet reservations are correct in order to prevent any data mismatches.
+- **Note:**: A detailed review of the migrated/upgraded data (using `vimdiff` or otherwise) for production systems and for systems which have many add-on components (UANs, login
+  nodes, storage integration points, etc.) is strongly recommended. Particularly, ensure that subnet reservations are correct in order to prevent any data mismatches.
 
 ### Upload migrated SLS file to SLS service
 
@@ -138,25 +152,29 @@ One detail which must not be overlooked is that the existing Customer Access Net
 
 ## Stage 0.3 - Upgrade Management Network
 
-### Verify if switches have 1.2 configuration in place
+### Verify That Switches Have 1.2 Configuration In Place
 
-1. Log in to each management switch
+1. Log in to each management switch.
+
    ```bash
    linux# ssh admin@1.2.3.4
    ```
 
-1. Examine the text displayed when logging in to the switch. Specifically, look for output similar to the following:
+1. Examine the text displayed when logging in to the switch.
 
-   ```
+   Specifically, look for output similar to the following:
+
+   ```text
    ##################################################################################
    # CSM version:  1.2
    # CANU version: 1.3.2
    ##################################################################################
    ```
 
-   - If you see text like the above, then it means that the switches have a CANU-generated configuration for CSM 1.2 in place. In this case, follow the steps in the [Management Network 1.0 (1.2 Preconfig) to 1.2](https://github.com/Cray-HPE/docs-csm/blob/release/1.2/operations/network/management_network/1.0_to_1.2_upgrade.md).
+   - If you see text like the above, then it means that the switches have a CANU-generated configuration for CSM 1.2 in place. In this case, follow the steps in
+     [Management Network 1.0 (`1.2 Preconfig`) to 1.2](https://github.com/Cray-HPE/docs-csm/blob/release/1.2/operations/network/management_network/1.0_to_1.2_upgrade.md).
 
-   - If the banner does NOT contain text like the above, then contact support in order to get the 1.2 preconfigs applied to the system.
+   - If the banner does NOT contain text like the above, then contact support in order to get the `1.2 Preconfig` applied to the system.
 
    - See the [Management Network User Guide](../../operations/network/management_network/index.md) for more information on the management network.
 
@@ -174,10 +192,10 @@ One detail which must not be overlooked is that the existing Customer Access Net
 
 1. Set the `NEXUS_PASSWORD` variable **only if needed**.
 
-   > **`IMPORTANT:`** If the password for the local Nexus `admin` account has
+   > **IMPORTANT:** If the password for the local Nexus `admin` account has
    > been changed from the default `admin123` (not typical), then set the
    > `NEXUS_PASSWORD` environment variable to the correct `admin` password
-   > before running `prerequisites.sh`!
+   > and export it, before running `prerequisites.sh`.
    >
    > For example:
    >
@@ -194,7 +212,8 @@ One detail which must not be overlooked is that the existing Customer Access Net
    ncn-m001# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prerequisites.sh --csm-version [CSM_RELEASE]
    ```
 
-   **`IMPORTANT:`** If any errors are encountered, then potential fixes should be displayed where the error occurred. **IF** the upgrade `prerequisites.sh` script fails and does not provide guidance, then try rerunning it. If the failure persists, then open a support ticket for guidance before proceeding.
+   **IMPORTANT:** If any errors are encountered, then potential fixes should be displayed where the error occurred. **If** the upgrade `prerequisites.sh` script fails and does
+   not provide guidance, then try rerunning it. If the failure persists, then open a support ticket for guidance before proceeding.
 
 1. Unset the `NEXUS_PASSWORD` variable, if it was set in the earlier step.
 
@@ -204,8 +223,9 @@ One detail which must not be overlooked is that the existing Customer Access Net
 
 1. Commit changes to `customizations.yaml` (optional).
 
-   `customizations.yaml` has been updated in this procedure. If [using an external Git repository for managing customizations](../../install/prepare_site_init.md#version-control-site-init-files) as recommended,
-then clone a local working tree and commit appropriate changes to `customizations.yaml`.
+   `customizations.yaml` has been updated in this procedure. If
+   [using an external Git repository for managing customizations](../../install/prepare_site_init.md#version-control-site-init-files) as recommended,
+   then clone a local working tree and commit appropriate changes to `customizations.yaml`.
 
    For example:
 
@@ -222,7 +242,9 @@ then clone a local working tree and commit appropriate changes to `customization
 
 ## Stage 0.5 - Backup Workload Manager Data
 
-To prevent any possibility of losing Workload Manager configuration data or files, a back-up is required. Please execute all Backup procedures (for the Workload Manager in use) located in the `Troubleshooting and Administrative Tasks` sub-section of the `Install a Workload Manager` section of the `HPE Cray Programming Environment Installation Guide: CSM on HPE Cray EX`. The resulting backup data should be stored in a safe location off of the system.
+To prevent any possibility of losing workload manager configuration data or files, a backup is required. Execute all backup procedures (for the Workload manager in use) located in
+the `Troubleshooting and Administrative Tasks` sub-section of the `Install a Workload Manager` section of the
+`HPE Cray Programming Environment Installation Guide: CSM on HPE Cray EX`. The resulting backup data should be stored in a safe location off of the system.
 
 <a name="stage_completed"></a>
 


### PR DESCRIPTION
## Summary and Scope

In a couple of places in the docs we download the docs-csm RPM using a wget command which will not overwrite an existing docs-csm RPM file in the same location. Instead it will create a "docs-csm...-1" file. If the user does not notice this, they may then install the previous RPM rather than the new one.

This PR modifies those wget commands to use the -O option, which will overwrite the target if it exists.

## Issues and Related PRs

Backport PR forthcoming

## Testing

I manually tested the new commands to make sure that they correctly overwrote the existing files as desired.

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
