### PR TITLE
CASMINST-4603: Filter out 1.6.0 gateway-test images and grab the latest

### DIFF
--- a/scripts/operations/gateway-test/uai-gateway-test.sh
+++ b/scripts/operations/gateway-test/uai-gateway-test.sh
@@ -75,9 +75,10 @@ fi
 
 # Find gateway image if one was not specified
 if [[ -z ${GATEWAY_IMAGE_NAME} ]]; then
-  GATEWAY_IMAGE_NAME=$(cray uas images list --format json | jq '.image_list' | jq .[] | grep gateway |  sed -e 's/"//g' | head -1)
+  # We will filter out the 1.6.0 image because we know that will not work with this version of the script
+  GATEWAY_IMAGE_NAME=$(cray uas images list --format json | jq '.image_list' | jq .[] | grep gateway |  sed -e 's/"//g' | grep -v "1.6.0" | sort | tail -1)
   if [[ -z ${GATEWAY_IMAGE_NAME} ]]; then
-    error "Could not find a cray-gateway-test image"
+    error "Could not find a valid cray-gateway-test image"
   fi
 else
   cray uas images list --format json | jq '.image_list' | jq .[] | grep -q -v ${GATEWAY_IMAGE_NAME}


### PR DESCRIPTION
## Summary and Scope

The new version of the uai-gateway-test.sh does not work with the 1.6.0 version of the gateway-test image.    When we do a 1.2 -> 1.2 upgrade, we discovered that we can end up with both the old (1.6.0) and new (1.6.1) image registered in uas.   The uai-gateway-test.sh currently grabs the first one it finds which is 1.6.0.   

To deal with this, I'm sorting the gateway-test images and grabbing the last one.   This is a best-effort sort since any number of additional images could be added.   To be safe, I am also filtering out 1.6.0 from the list since we know that one does not work with the latest uai-gateway-test.sh.

## Issues and Related PRs

* Resolves CASMINST-4603

## Testing

### Tested on:

  * `surtur` and `wasp`

### Test description:

I am no longer able to test the condition that initiated this ticket.   This happened on the 1.2 -> 1.2 upgrade on drax.  However, since it was opened there was a power outage in bay 1 taking down drax.   When it came up, the uas state was wiped.

I tested on wasp as a system that only has 1.6.0 to verify that it handles the filtering of that image.

I tested on surtur as a system that has 1.6.1 to verify that the test still runs there successfully.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

