### PR TITLE
csm-1.2 backport: CASMINST-4475: Create script to write root password and SSH keys to Vault; document same

### DIFF
--- a/operations/CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md
+++ b/operations/CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md
@@ -3,17 +3,35 @@
 Non-compute node (NCN) personalization applies post-boot configuration to the
 HPE Cray EX management nodes. Several HPE Cray EX product environments outside
 of CSM require NCN personalization to function. Consult the manual for each
-product to configure them on NCNs by referring to the [1.5 HPE Cray EX System
-Software Getting Started Guide S-8000](https://www.hpe.com/support/ex-gsg) on
-the HPE Customer Support Center.
+product to configure them on NCNs by referring to the
+[`1.5 HPE Cray EX System Software Getting Started Guide S-8000`](https://www.hpe.com/support/ex-gsg)
+on the `HPE Customer Support Center`.
 
 This procedure defines the NCN personalization process for the CSM product using
 the [Configuration Framework Service (CFS)](../configuration_management/Configuration_Management.md).
 
-<a name="set_up_passwordless_ssh"></a>
-## Set Up Passwordless SSH
+During a fresh install, carry out these procedures in order. Later, individual
+procedures may be re-run as needed.
 
-This procedure should be run during CSM installation and afterwards whenever
+1. [Set Up Passwordless SSH](#set_up_passwordless_ssh)
+   - [Option 1: Use the CSM-provided SSH Keys](#set_up_passwordless_ssh_option_1)
+   - [Option 2: Option 2: Provide Custom SSH Keys](#set_up_passwordless_ssh_option_2)
+   - [Option 3: Disable CSM-provided Passwordless SSH](#set_up_passwordless_ssh_option_3)
+   - [Restore CSM-provided SSH Keys](#set_up_passwordless_ssh_restore)
+2. [Configure the Root Password and Root SSH Keys in Vault](#set_root_password)
+   - [Option 1: Automated Default](#set_root_password_option_1)
+   - [Option 2: Manual](#set_root_password_option_2)
+3. [Perform NCN Personalization](#perform_ncn_personalization)
+   - [Option 1: Automatically Apply CSM Configuration](#auto_apply_csm_config)
+     - [Automatic CSM Configuration Steps](#auto_apply_csm_config_steps)
+     - [Automatic CSM Configuration Overrides](#auto_apply_csm_config_overrides)
+   - [Option 2: Manually Apply CSM Configuration](#manual_apply_csm_config)
+
+<a name="set_up_passwordless_ssh"></a>
+
+## 1. Set Up Passwordless SSH
+
+This procedure should be run during CSM installation and any later time when
 the SSH keys need to be changed per site requirements.
 
 The goal of passwordless SSH is to enable an easy way for interactive
@@ -32,8 +50,9 @@ own keys, or use their own solution for authentication.
 
 The management of keys on NCNs is achieved by the `trust-csm-ssh-keys` and
 `passwordless-ssh` Ansible roles in the CSM configuration management repository.
-The SSH keypair is applied to management nodes via NCN personalization.
+The SSH keypair is applied to management nodes using NCN personalization.
 
+<a name="set_up_passwordless_ssh_option_1"></a>
 
 ### Option 1: Use the CSM-provided SSH Keys
 
@@ -41,164 +60,335 @@ The default CSM Ansible plays are already configured to enable Passwordless SSH
 by default. No further action is necessary before running NCN personalization
 with CFS.
 
+<a name="set_up_passwordless_ssh_option_2"></a>
+
 ### Option 2: Provide Custom SSH Keys
 
 Administrators may elect to replace the CSM-provided keys with their own custom
-keys. The `replace_ssh_keys.sh` script can be used to replace the keys from
-files.
+keys.
 
-```bash
-ncn-m001# /usr/share/doc/csm/scripts/operations/configuration/replace_ssh_keys.sh \
---public-key-file ./id_rsa-csm.pub --private-key-file ./id_rsa-csm
-```
+1. Set variables to the locations of the public and private SSH key files.
 
-Alternatively, the keys stored in Kubernetes can be updated directly.
+    > Replace the values in the examples below with the paths to the desired
+    > key files on the system.
 
-1. Replace the private key half:
-   ```bash
-   ncn# kubectl get secret -n services csm-private-key -o json | jq --arg value "$(cat ~/.ssh/id_rsa-csm | base64)" '.data["value"]=$value' | kubectl apply -f -
-   ```
-   where `~/.ssh/id_rsa-csm` is a local file containing a valid SSH private key.
+    ```bash
+    ncn# PUBLIC_KEY_FILE=/root/.ssh/id_rsa-csm.pub
+    ncn# PRIVATE_KEY_FILE=/root/.ssh/id_rsa-csm
+    ```
 
-1. Replace the public key half:
-   ```bash
-   ncn# kubectl delete configmap -n services csm-public-key && \
-      cat ~/.ssh/id_rsa-csm.pub | \
-      base64 > ./value && kubectl create configmap --from-file \
-      value csm-public-key --namespace services && rm ./value
-   ```
-   where `~/.ssh/id_rsa-csm.pub` is a local file containing a valid public key
-   intended for CSM and downstream products.
+1. Provide the custom keys by script or manually.
+
+    There are two options for providing the keys.
+
+    - Provide custom SSH keys by script.
+
+        The `replace_ssh_keys.sh` script can be used to replace the keys from files.
+
+        > The `docs-csm` RPM must be installed in order to use this script. See
+        > [Check for Latest Documentation](../../update_product_stream/index.md#documentation)
+
+        ```bash
+        ncn# /usr/share/doc/csm/scripts/operations/configuration/replace_ssh_keys.sh \
+                --public-key-file "${PUBLIC_KEY_FILE}" --private-key-file "${PRIVATE_KEY_FILE}"
+        ```
+
+    - Manually provide custom SSH keys
+
+        The keys stored in Kubernetes can be updated directly.
+
+        1. Replace the private key half:
+
+            ```bash
+            ncn# KEY64=$(cat "${PRIVATE_KEY_FILE}" | base64) &&
+                 kubectl get secret -n services csm-private-key -o json | \
+                    jq --arg value "$KEY64" '.data["value"]=$value' | kubectl apply -f - &&
+                 unset KEY64
+            ```
+
+        1. Replace the public key half:
+
+            ```bash
+            ncn# kubectl delete configmap -n services csm-public-key &&
+                    cat "${PUBLIC_KEY_FILE}" | base64 > ./value &&
+                    kubectl create configmap --from-file value csm-public-key --namespace services &&
+                    rm ./value
+            ```
 
 Passwordless SSH with the provided keys will be set up once NCN personalization
 runs on the NCNs.
 
-**NOTE**: This key pair may or may not be the same key pair used for the NCN
-`root` user. See the _Configure the Root Password and Root SSH Keys in Vault_
+**NOTE**: This keypair may or may not be the same keypair used for the NCN
+`root` user. See the [Configure the Root Password and Root SSH Keys in Vault](#set_root_password)
 procedure below for setting the root user SSH keys on NCNs.
 
-###  Option 3: Disable CSM-provided Passwordless SSH
+<a name="set_up_passwordless_ssh_option_3"></a>
+
+### Option 3: Disable CSM-provided Passwordless SSH
 
 Local site security requirements may preclude use of passwordless SSH access between
-management nodes. A variable has been added to the associated ansible roles that will
-allow you to disable passwordless SSH setup to any or all nodes. From the cloned
-csm-config-management repository directory:
+management nodes. A variable has been added to the associated Ansible roles that
+allows disabling of passwordless SSH setup to any or all nodes. From the cloned
+`csm-config-management` repository directory:
 
-    ```
-    ncn# grep csm_passwordless_ssh_enabled roles/trust-csm-ssh-keys/defaults/main.yaml
-    ```
+```bash
+ncn# grep csm_passwordless_ssh_enabled roles/trust-csm-ssh-keys/defaults/main.yaml
+```
 
-    Example output:
+Example output:
 
-    ```
-    csm_passwordless_ssh_enabled: 'false'
-    ```
+```yaml
+csm_passwordless_ssh_enabled: 'false'
+```
 
-This variable can be overwritten using either a host-specific setting or 'global' to affect
-all nodes where the playbook is run. Please reference [Customize Configuration Values](../configuration_management/Customize_Configuration_Values.md)
+This variable can be overwritten using either a host-specific setting or `global` to affect
+all nodes where the playbook is run. See
+[Customize Configuration Values](../configuration_management/Customize_Configuration_Values.md)
 for more detailed information. Do not modify the value in the `roles/trust-csm-ssh-keys/defaults/main.yaml`
 file.
 
 Published roles within product configuration repositories can contain more comprehensive
-information regarding these role-specific flags. Please reference any role specific associated Readme.md
-documents for additional information, as role documentation is updated more frequently as
+information regarding these role-specific flags. Reference any role-specific associated `Readme.md`
+documents for additional information, because role documentation is updated more frequently as
 changes are introduced.
 
-Consult the manual for each product to change the default configuration by
-referring to the [1.5 HPE Cray EX System Software Getting Started Guide S-8000](https://www.hpe.com/support/ex-gsg)
-on the HPE Customer Support Center. Similar configuration values for disabling the
-role will be required in these product specific configuration repositories.
+Consult the manual for each product in order to change the default configuration by
+referring to the [`1.5 HPE Cray EX System Software Getting Started Guide S-8000`](https://www.hpe.com/support/ex-gsg)
+on the `HPE Customer Support Center`. Similar configuration values for disabling the
+role will be required in these product-specific configuration repositories.
 
 Modifying Ansible plays in a configuration repository will require a new commit
 and subsequent update of the [configuration layer](../configuration_management/Configuration_Layers.md)
 associated with the product.
 
-> __NOTE__: CFS itself does not use the CSM-provided (or user-supplied) SSH keys
+> **NOTE:** CFS itself does not use the CSM-provided (or user-supplied) SSH keys
 > to make connections between nodes. CFS will continue to function if
 > passwordless SSH is disabled between CSM and other product environments.
+
+<a name="set_up_passwordless_ssh_restore"></a>
 
 ### Restore CSM-provided SSH Keys
 
 > Use this procedure if switching from custom keys to the default CSM SSH keys
-> only, otherwise it can be skipped.
+> only; otherwise it can be skipped.
 
-To restore the default CSM keys, administrators can run the
-`restore_ssh_keys.sh` script.
+In order to restore the default CSM keys, there are two options:
 
-```bash
-ncn-m001# /usr/share/doc/csm/scripts/operations/configuration/restore_ssh_keys.sh
-```
+- Restore by script.
 
-Alternatively, the keys can be deleted from Kubernetes directly.
-The `csm-ssh-keys` Kubernetes deployment provided by CSM periodically checks the
-ConfigMap and secret containing the key information. If these entries do not
-exist, it will recreate them from the default CSM keys. To manually restore
-keys, delete the associated ConfigMap and secret, and the default CSM-provided
-keys will be republished.
+    > The `docs-csm` RPM must be installed in order to use this script. See
+    > [Check for Latest Documentation](../../update_product_stream/index.md#documentation)
 
-1. Delete the `csm-private-key` Kubernetes secret.
-   ```bash
-   ncn# kubectl delete secret -n services csm-private-key
-   ```
-1. Delete the `csm-public-key` Kubernetes configmap.
-   ```bash
-   ncn# kubectl delete configmap -n services csm-public-key
-   ```
+    ```bash
+    ncn# /usr/share/doc/csm/scripts/operations/configuration/restore_ssh_keys.sh
+    ```
+
+- Restore manually.
+
+    The keys can be deleted from Kubernetes directly. The `csm-ssh-keys` Kubernetes deployment
+    provided by CSM periodically checks the ConfigMap and secret containing the key information.
+    If these entries do not exist, it will recreate them from the default CSM keys. Therefore, in
+    order to manually restore the keys, delete the associated ConfigMap and secret. The default CSM-provided
+    keys will be republished.
+
+    1. Delete the `csm-private-key` Kubernetes secret.
+
+        ```bash
+        ncn# kubectl delete secret -n services csm-private-key
+        ```
+
+    1. Delete the `csm-public-key` Kubernetes ConfigMap.
+
+        ```bash
+        ncn# kubectl delete configmap -n services csm-public-key
+        ```
 
 <a name="set_root_password"></a>
-## Configure the Root Password and Root SSH Keys in Vault
+
+## 2. Configure the Root Password and Root SSH Keys in Vault
 
 The root user password and SSH keys are managed on NCNs by using the
 `csm.password` and `csm.ssh_keys` Ansible roles, respectively, located in the
 CSM configuration management repository. Root user passwords and SSH keys are
 set and managed in Vault.
 
-1. Set the root user password in Vault by following the _Configure Root Password in Vault_
-   procedure in [Update NCN User Passwords](../security_and_authentication/Update_NCN_Passwords.md#configure_root_password_in_vault).
-1. Set the root user SSH keys in Vault by following the _Configure Root SSH Keys in Vault_
-   procedure in [Update NCN User SSH Keys](../security_and_authentication/SSH_Keys.md#configure_root_keys_in_vault).
-1. Apply the Vault password to the NCNs in the
-   [Perform NCN personalization](#perform_ncn_personalization) procedure.
+There are two options for setting the root password and SSH keys in Vault: automated default or manual.
+
+After these have been set in Vault, they will automatically be applied to NCNs during NCN personalization.
+For more information on how to configure and run NCN personalization, see the
+[Perform NCN Personalization](#perform_ncn_personalization) procedure later in this page.
+
+<a name="set_root_password_option_1"></a>
+
+### Option 1: Automated Default
+
+The automated default method uses the `write_root_secrets_to_vault.py` script to read in the current
+root password and SSH keys from the NCN where it is run, and write those to Vault. All of the NCNs are
+booted from images which already had their root passwords and SSH keys customized during the
+[Deploy Management Nodes](../../install/deploy_management_nodes.md#deploy)
+procedure of the CSM install. In most cases, these are the same password and keys that should be
+written to Vault, and this script provides an easy way to do that.
+
+Specifically, the `write_root_secrets_to_vault.py` script reads the following from the NCN where it is run:
+
+- The `root` user password hash from the `/etc/shadows` file.
+- The private SSH key from `/root/.ssh/id_rsa`.
+- The public SSH key from `/root/.ssh/id_rsa.pub`.
+
+This script can be run on any NCN which is configured to access the Kubernetes cluster.
+
+> The `docs-csm` RPM must be installed in order to use this script. See
+> [Check for Latest Documentation](../../update_product_stream/index.md#documentation)
+
+Run the script with the following command:
+
+```bash
+ncn# /usr/share/doc/csm/scripts/operations/configuration/write_root_secrets_to_vault.py
+```
+
+A successful execution will exit with return code 0 and will have output similar to the following:
+
+```text
+Reading in file '/root/.ssh/id_rsa'
+Reading in file '/root/.ssh/id_rsa.pub'
+Reading in file '/etc/shadow'
+Found root user line in /etc/shadow
+
+Initializing Kubernetes client
+
+Getting Vault token from vault/cray-vault-unseal-keys Kubernetes secret
+
+Examining Kubernetes cray-vault service to determine URL for Vault API endpoint of secret/csm/users/root
+
+Writing SSH keys and root password hash to secret/csm/users/root in Vault
+Making POST request to http://10.18.232.40:8200/v1/secret/csm/users/root
+Response status code = 204
+
+Read back secrets from Vault to verify that the values were correctly saved
+Making GET request to http://10.18.232.40:8200/v1/secret/csm/users/root
+Response status code = 200
+
+Validating that Vault contents match what was written to it
+All secrets successfully written to Vault
+
+SUCCESS
+```
+
+<a name="set_root_password_option_2"></a>
+
+### Option 2: Manual
+
+> **NOTE**: Information on writing the `root` user password and the SSH keys to Vault is documented
+> in two separate procedures. However, if both the password and the SSH keys are to be stored
+> in Vault (the standard case), then the two procedures must be combined. Specifically, only
+> a single `write` command must be made to Vault, containing both the password and the
+> SSH keys. If multiple `write` commands are performed, only the information from the
+> final command will persist.
+
+Set the `root` user password and SSH keys in Vault by combining the following two procedures:
+
+- The `Configure Root Password in Vault` procedure in [Update NCN User Passwords](../security_and_authentication/Update_NCN_Passwords.md#configure_root_password_in_vault).
+- The `Configure Root SSH Keys in Vault` procedure in [Update NCN User SSH Keys](../security_and_authentication/SSH_Keys.md#configure_root_keys_in_vault).
 
 <a name="perform_ncn_personalization"></a>
-## Perform NCN Personalization
+
+## 3. Perform NCN Personalization
 
 After completing the previous procedures, apply the configuration to the NCNs
 by running NCN personalization with [CFS](../configuration_management/Configuration_Management.md).
-This can be accomplished by running the `apply_csm_configuration.sh` script, or
-running the steps manually. By default the script will select the latest available
-csm release. However for clarity it is recommended that the user provide the csm release using the
-`--csm-release` parameter. For more detailed information on the script, see
-[Automatically Apply CSM Configuration to NCNs](#auto_apply_csm_config).
+This can be accomplished by running the `apply_csm_configuration.sh` script, or by
+running the steps manually.
+
+<a name="auto_apply_csm_config"></a>
+
+### Option 1: Automatically Apply CSM Configuration
+
+> The `docs-csm` RPM must be installed in order to use this script. See
+> [Check for Latest Documentation](../../update_product_stream/index.md#documentation)
+
+By default the script will select the latest available CSM release. However, for clarity
+providing the CSM release version using the `--csm-release` parameter is recommended.
 
 ```bash
-ncn-m001# /usr/share/doc/csm/scripts/operations/configuration/apply_csm_configuration.sh --csm-release <version e.g. 1.0.11>
+ncn# /usr/share/doc/csm/scripts/operations/configuration/apply_csm_configuration.sh --csm-release <version e.g. 1.0.11>
 ```
 
-To manually run NCN personalization, first gather the following information:
+<a name="auto_apply_csm_config_steps"></a>
 
-* HTTP clone URL for the configuration repository in [VCS](../configuration_management/Version_Control_Service_VCS.md)
-* Path to the Ansible play to run in the repository
-* Commit ID in the repository for CFS to pull and run on the nodes.
+#### Automatic CSM Configuration Steps
 
+By default, the script will perform the following steps:
+
+1. Finds the latest installed release version of the CSM product stream.
+1. Finds the CSM configuration version associated with the given release.
+1. Finds the latest commit on the release branch of the `csm-config-management` repository.
+1. Creates or updates the `ncn-personalization.json` configuration file.
+1. Finds all nodes in HSM with the `Management` role.
+1. Disables configuration for all NCNs.
+1. Updates the `ncn-personalization` configuration in CFS from the `ncn-personalization.json` file.
+1. Enables configuration for all NCN nodes, and sets their desired configuration to `ncn-personalization`.
+1. Monitors CFS until all NCN nodes have successfully completed or failed configuration.
+
+<a name="auto_apply_csm_config_overrides"></a>
+
+#### Automatic CSM Configuration Overrides
+
+The script also supports several flags to override these behaviors:
+
+- `--csm-release`: Overrides the version of the CSM release that is used. Defaults
+  to the latest version. Available versions can be found in the `cray-product-catalog`.
+
+  ```bash
+  ncn-m001# kubectl -n services get cm cray-product-catalog
+  ```
+
+- `--csm-config-version`: Overrides the version of the CSM configuration. This corresponds
+  to the version of a branch starting with `cray/csm/` in the `csm` repository in VCS.
+- `--git-commit`: Overrides the Git commit cloned for the configuration content.
+  Defaults to the latest commit on the `csm-release` branch.
+- `--git-clone-url`: Overrides the source of the configuration content. Defaults
+  to `https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git`.
+- `--ncn-config-file`: Sets a file other than `ncn-personalization.json` to be
+  used for the configuration.
+- `--xnames`: A comma-separated list of component names (xnames) to deploy to. Defaults to all
+  `Management` nodes in HSM.
+- `--clear-state`: Clears existing state from components to ensure that CFS runs. This
+   can be used if configuration needs to be re-run on successful nodes with no
+   change to the Git content since the previous run; for example, if the SSH
+   keys have changed.
+
+<a name="manual_apply_csm_config"></a>
+
+### Option 2: Manually Apply CSM Configuration
+
+In order to manually run NCN personalization, first gather the following information:
+
+- HTTP clone URL for the configuration repository in [VCS](../configuration_management/Version_Control_Service_VCS.md).
+- Path to the Ansible play to run in the repository.
+- Git commit ID in the repository for CFS to pull and run on the nodes.
 
 | Field | Value  | Description  |
 |:----------|:----------|:----------|
-| cloneUrl | https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git | CSM configuration repo |
-| commit  | **Example:** `5081c1ecea56002df41218ee39f6030c3eebdf27` | CSM configuration commit hash |
-| name | **Example:** `csm-ncn-<version>` | CSM Configuration layer name |
-| playbook | `site.yml` | Default site-wide Ansible playbook for CSM |
+| `cloneUrl` | `https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git` | CSM configuration repository |
+| `commit`  | **Example:** `5081c1ecea56002df41218ee39f6030c3eebdf27` | CSM configuration commit hash |
+| `name` | **Example:** `csm-1.9.21` | CSM configuration layer name |
+| `playbook` | `site.yml` | Default site-wide Ansible playbook for CSM |
 
 1. Retrieve the commit in the repository to use for configuration. If changes
    have been made to the default branch that was imported during a CSM
    installation or upgrade, use the commit containing the changes.
 
-1. If no changes have been made, the latest commit on the default branch for
+1. If no changes have been made, then the latest commit on the default branch for
    this version of CSM should be used. Find the commit in the
    `cray-product-catalog` for the current version of CSM. For example:
+
    ```bash
    ncn# kubectl -n services get cm cray-product-catalog -o jsonpath='{.data.csm}'
+   ```
 
+   Look for something similar to the following in the output:
+
+   ```yaml
    1.2.0:
       configuration:
          clone_url: https://vcs.cmn.SYSTEM_DOMAIN_NAME/vcs/cray/csm-config-management.git
@@ -206,21 +396,21 @@ To manually run NCN personalization, first gather the following information:
          import_branch: cray/csm/1.9.24
          import_date: 2021-07-28 03:26:01.869501
          ssh_url: git@vcs.cmn.SYSTEM_DOMAIN_NAME:cray/csm-config-management.git
-      ...
    ```
-   The commit will be different for each system and version of CSM. For
-   this example, it is:
 
-         43ecfa8236bed625b54325ebb70916f55884b3a4
+   The commit will be different for each system and version of CSM. For
+   this example, it is `43ecfa8236bed625b54325ebb70916f55884b3a4`.
 
 1. Craft a new configuration layer entry for the new CSM:
 
+   ```json
          {
-            "name": "csm-ncn-<version>",
+            "name": "csm-<version>",
             "cloneUrl": "https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git",
             "playbook": "site.yml",
-            "commit": "<retrieved git commit>"
+            "commit": "<retrieved git commit ID>"
          }
+   ```
 
 1. (Install Only) Follow the procedure in [Perform NCN Personalization](Perform_NCN_Personalization.md),
    adding a CSM configuration layer to the NCN personalization using the JSON
@@ -228,53 +418,7 @@ To manually run NCN personalization, first gather the following information:
 
 1. (Upgrade Only) Follow the procedure in [Perform NCN Personalization](Perform_NCN_Personalization.md),
    replacing the existing CSM configuration layer to the NCN personalization
-   using the JSON from the step 3.
+   using the JSON from step 3.
 
-> **NOTE:** The CSM configuration layer _MUST_ be the first layer in the
+> **NOTE:** The CSM configuration layer **MUST** be the first layer in the
 > NCN personalization CFS configuration.
-
-<a name="auto_apply_csm_config"></a>
-## Automatically Apply CSM Configuration to NCNs
-
-CSM configuration can automatically be applied to NCNs by running the
-`apply_csm_configuration.sh` script.
-
-```bash
-ncn-m001# /usr/share/doc/csm/scripts/operations/configuration/apply_csm_configuration.sh
-```
-
-### Automatic CSM Configuration Steps
-
-By default the script will perform the following steps:
-1. Finds the latest installed release version of the CSM product stream.
-1. Finds the CSM configuration version associated with the given release.
-1. Finds the latest commit on the release branch of the `csm-config-management` repo.
-1. Creates or updates the `ncn-personalization.json` configuration file.
-1. Finds all nodes in HSM with the `Management` role.
-1. Disables configuration for all NCNs.
-1. Updates the `ncn-personalization` configuration in CFS from the `ncn-personalization.json` file.
-1. Enables configuration for all NCN nodes, and sets their desired configuration to `ncn-personalization`.
-1. Monitors CFS until all NCN nodes have successfully completed, or failed, configuration.
-
-### Automatic CSM Configuration Overrides
-
-The script also supports several flags to override these behaviors:
-- `csm-release`: Overrides the version of the CSM release that is used. Defaults
-  to the latest version. Available versions can be found in the `cray-product-catalog`.
-  ```bash
-  ncn-m001# kubectl -n services get cm cray-product-catalog
-  ```
-- `csm-config-version`: Overrides the version of the CSM configuration. This corresponds
-  to the version of a branch starting with `cray/csm/` in the csm repo in VCS.
-- `git-commit`: Overrides the git commit cloned for the configuration content.
-  Defaults to the latest commit on the csm-release branch.
-- `git-clone-url`: Overrides the source of the configuration content. Defaults
-  to `https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git`.
-- `ncn-config-file`: Sets a file other than `ncn-personalization.json` to be
-  used for the configuration.
-- `xnames`: A comma-separated list of component names (xnames) to deploy to. Defaults to all
-  `Management` nodes in HSM.
-- `clear-state`: Clears existing state from components to ensure CFS runs. This
-   can be used if configuration needs to be re-run on successful nodes with no
-   change to the git content since the previous run. For examples, if the SSH
-   keys have changed.

--- a/scripts/operations/configuration/write_root_secrets_to_vault.py
+++ b/scripts/operations/configuration/write_root_secrets_to_vault.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# Reads in:
+# - the hashed root user password from /etc/shadow
+# - the root user SSH private key from /root/.ssh/id_rsa
+# - the root user SSH public key from /root/.ssh/id_rsa.pub
+#
+# Writes these to the secret/csm/users/root in Vault, and then
+# reads them back to verify that they match what was written.
+#
+# Beyond validating the inputs, currently this script does minimal error-checking.
+# This is because it is desirable for any errors to be fatal, so catching the
+# Python exceptions is only useful inasmuch as it gives the opportunity to translate
+# the error into a more user-friendly format. This is certainly something that should
+# eventually be implemented, but for the initial version of this tool, it is not
+# necessary.
+
+import base64
+import kubernetes
+import kubernetes.client
+import kubernetes.client.api
+import kubernetes.config
+import requests
+import sys
+import time
+
+VAULT_SECRET_FIELD_NAMES = [ "password", "ssh_private_key", "ssh_public_key" ]
+
+def stdout_write_flush(msg):
+    sys.stdout.write(msg)
+    sys.stdout.flush()
+
+def err(msg):
+    sys.stderr.write("ERROR: {}\n".format(msg))
+    sys.stderr.flush()
+
+def err_exit(msg):
+    err(msg)
+    sys.exit(1)
+
+def read_file(filename):
+    """
+    Reads contents of text file, verifies it is more than a few characters long,
+    and returns it as a string. The length check could be refined to be
+    more precise, but this will suffice.
+    """
+
+    print("Reading in file '%s'" % filename, flush=True)
+    try:
+        with open(filename, "rt") as textfile:
+            contents = textfile.read()
+    except FileNotFoundError:
+        err_exit("File '%s' does not exist" % filename)
+    if len(contents) < 4:
+        err_exit("File '%s' only contains %d characters" % (filename, len(contents)))
+    return contents
+
+def get_root_hash_from_etc_shadow():
+    """
+    Find the line in /etc/shadow for the root user and return the
+    hashed password field from that line.
+    """
+
+    for etc_shadow_line in read_file("/etc/shadow").splitlines():
+        line_fields = etc_shadow_line.split(":")
+        if line_fields[0] != "root":
+            continue
+        print("Found root user line in /etc/shadow", flush=True)
+        # Hash is in the second field of this line
+        root_password_hash = line_fields[1]
+        if not root_password_hash:
+            err_exit("No password hash found on root user line")
+        return root_password_hash
+    err_exit("No root user line found in /etc/shadow file")
+
+def get_vault_api_endpoint_url(k8s_core_v1_api):
+    """
+    1. Looks up the vault/cray-vault service in Kubernetes
+    2. Retrieves the cluster IP address of the service
+    3. Retrieves the port list of the service
+    4. Finds the API port.
+    5. Assembles the URL for the Vault API endpoint URL for the secret/csm/users/root Vault entry
+       and returns it as a string.
+    """
+    vault_service = k8s_core_v1_api.read_namespaced_service(name="cray-vault", namespace="vault")
+    vault_ip = vault_service.spec.cluster_ip
+    for vault_port in vault_service.spec.ports:
+        if vault_port.name == 'http-api-port':
+            return "http://{ip}:{port}/v1/secret/csm/users/root".format(ip=vault_ip, port=vault_port.port)
+    err_exit("No 'http-api-port' port found for vault/cray-vault Kubernetes service")
+
+def make_api_request_with_retries(request_method, url, expected_status_code, **request_kwargs):
+    """
+    Makes request with specified method to specified URL with specified keyword arguments (if any).
+    If the expected status code is returned, then the response body is returned (or None, if empty).
+    If a 5xx status code is returned, the request will be retried after a brief wait, a limited number
+    of times.
+    If the expected status code is never returned (or an unexpected and non-5xx status code is
+    ever returned), then exit in error.
+    """
+    count=0
+    max_attempts=6
+    while count < max_attempts:
+        count+=1
+        print("Making {method} request to {url}".format(method=request_method.__name__.upper(), url=url), flush=True)
+        resp = request_method(url, **request_kwargs)
+        print("Response status code = {}".format(resp.status_code), flush=True)
+        if resp.status_code == expected_status_code:
+            if resp.text:
+                return resp.json()
+            else:
+                return None
+        print("Response reason = {}".format(resp.reason), flush=True)
+        print("Response text = {}".format(resp.text), flush=True)
+        if not 500 <= resp.status_code <= 599:
+            err_exit("Unexpect status code received in response to API request")
+        elif count >= max_attempts:
+            err_exit("API request unsuccessful even after {} attempts".format(max_attempts))
+        stdout_write_flush("Sleeping 3 seconds before retrying..")
+        for x in range(3):
+            stdout_write_flush(".")
+            time.sleep(1)
+        stdout_write_flush("\n\n")
+    err_exit("PROGRAMMING LOGIC ERROR: Should never reach this point in the make_api_request_with_retries function")
+
+def main():
+    """
+    1. Read in the SSH keys and hashed root password from the system.
+    2. Initialize the Kubernetes API client.
+    3. Get the Vault token from the cray-vault-unseal-keys secret in Kubernetes.
+    4. Write the SSH keys and hashed password into Vault.
+    5. Read the SSH keys and hashed password from Vault.
+    6. Verify that what was read matches what was written.
+    """
+
+    # Read in secrets from the system
+    system_secrets = {
+        "ssh_private_key": read_file("/root/.ssh/id_rsa"),
+        "ssh_public_key": read_file("/root/.ssh/id_rsa.pub"),
+        "password": get_root_hash_from_etc_shadow() }
+
+    # Initialize our Kubernetes API client
+    print("\nInitializing Kubernetes client", flush=True)
+    kubernetes.config.load_kube_config()
+    k8s_configuration = kubernetes.client.Configuration().get_default_copy()
+    kubernetes.client.Configuration.set_default(k8s_configuration)
+    k8s_core_v1_api = kubernetes.client.api.core_v1_api.CoreV1Api()
+
+    # Obtain Vault token string from Kubernetes secret
+    print("\nGetting Vault token from vault/cray-vault-unseal-keys Kubernetes secret", flush=True)
+    vault_secret = k8s_core_v1_api.read_namespaced_secret(name="cray-vault-unseal-keys", namespace="vault")
+    encoded_vault_token = vault_secret.data["vault-root"]
+    decoded_token_bytes = base64.standard_b64decode(encoded_vault_token)
+    # Convert from bytes to string for API request header
+    vault_api_request_headers = { 
+        "X-Vault-Request": "true", 
+        "X-Vault-Token": decoded_token_bytes.decode() }
+
+    # Obtain Vault API IP address and port from Kubernetes cray-vault service
+    print("\nExamining Kubernetes cray-vault service to determine URL for Vault API endpoint of secret/csm/users/root", flush=True)
+    vault_api_url = get_vault_api_endpoint_url(k8s_core_v1_api)
+
+    # Create API request session
+    with requests.Session() as session:
+        # The same headers are used for all requests we'll be making
+        session.headers.update(vault_api_request_headers)
+
+        # Write secrets to Vault
+        print("\nWriting SSH keys and root password hash to secret/csm/users/root in Vault", flush=True)
+        # We do not expect or care about any output of the write request, so no need to save the function return
+        make_api_request_with_retries(request_method=session.post, url=vault_api_url, expected_status_code=204, json=system_secrets)
+
+        # Read secrets back from Vault
+        print("\nRead back secrets from Vault to verify that the values were correctly saved", flush=True)
+        resp_body = make_api_request_with_retries(request_method=session.get, url=vault_api_url, expected_status_code=200)
+        if resp_body == None:
+            err_exit("Empty body in response to Vault API request")
+        vault_secrets = { field: resp_body["data"][field] for field in VAULT_SECRET_FIELD_NAMES }
+
+    # Validate that Vault values match what we wrote
+    print("\nValidating that Vault contents match what was written to it", flush=True)
+    if vault_secrets == system_secrets:
+        print("All secrets successfully written to Vault\n", flush=True)
+        print("SUCCESS", flush=True)
+        sys.exit(0)
+
+    # Print summary of differences
+    for field in VAULT_SECRET_FIELD_NAMES:
+        if system_secrets[field] == vault_secrets[field]:
+            print("Vault value for {} matches what was written".format(field), flush=True)
+        else:
+            err("Vault value for {} DOES NOT MATCH what was written".format(field))
+    err_exit("Not all secrets successfully written to Vault")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/docs-csm/pull/1611