### PR TITLE
CASMINST-4625 use full path for csm_ntp.py

### DIFF
--- a/operations/node_management/Configure_NTP_on_NCNs.md
+++ b/operations/node_management/Configure_NTP_on_NCNs.md
@@ -4,59 +4,79 @@ The management nodes serve Network Time Protocol (NTP) at stratum 10, except for
 
 Until an upstream NTP server is configured, the time on the NCNs may not match the current time at the site, but they will stay in sync with each other.
 
-**Topics**
-   * [Fix BSS Metadata](#fix-bss-metadata)
-   * [Fix broken configs](#fix-broken-configs)
+## Topics
+
+* [Fix BSS Metadata](#fix-bss-metadata)
+* [Fix broken configurations](#fix-broken-configurations)
 
 <a name="fix-bss-metadata"></a>
 
-###### Fix BSS Metadata
+## Fix BSS Metadata
 
-If nodes are missing metadata for NTP, you will be required to generate the data using `csi` and your system's `system_config.yaml`. If you do not have your seed data in the `system_config.yaml` then you will need to open a ticket to help generate the NTP data.
+If nodes are missing metadata for NTP, you will be required to generate the data using `csi` and your system's `system_config.yaml`.
+
+If you do not have your seed data in the `system_config.yaml` then you will need to open a ticket to help generate the NTP data.
 
 The following steps are structured to be executed on one node at a time. However, step #3 will generate all relevant files for each node. If multiple nodes are missing NTP data in BSS, you can apply this fix to each node.
 
-1. Update system_config.yaml to have the correct NTP settings:
+1. Update `system_config.yaml` to have the correct NTP settings:
+
     ```yaml
     ntp-servers:
       - ncn-m001
       - time.nist.gov
     ntp-timezone: UTC
     ```
-2. Generate new configs:
+
+2. Generate new configurations:
+
     ```bash
     ncn# csi config init
     ```
+
 3. In the newly created `system/basecamp` directory, copy in and execute the metadata script that is included in the upgrade scripts of this documentation:
+
     ```bash
     ncn# ./upgrade_ntp_timezone_metadata.sh
+
     ```
+
 4. Find the relevant file(s) to the node(s) with missing metadata, such as `upgrade-metadata-000000000000.json` based on the mac address of the node.
+
 5. Find the xname for the node that needs to be fixed:
+
     ```bash
     ncn# cat /etc/cray/xname
+
     ```
+
 6. From `ncn-m001` execute the following command to update BSS:
+
     ```bash
     ncn# csi handoff bss-update-cloud-init --user-data="upgrade-metadata-000000000000.json" --limit=<xname>`
     ```
 
 7. Continue with the upgrade.
-8. When the upgrade is completed, run this script on each NCN to ensure the time is set correctly:
+
+8. Set a token as described in [Identify Nodes and Update Metadata](Rebuild_NCNs/Identify_Nodes_and_Update_Metadata.md)
+
+9. When the upgrade is completed, run this script on each NCN to ensure the time is set correctly:
 
     > If more than nine NCNs are in use on the system, update the for loop in the following command accordingly.
 
     ```bash
-    ncn-m002# for i in ncn-{w,s}00{1..3} ncn-m00{2..3}; do echo \
-    "------$i--------"; ssh $i '/srv/cray/scripts/common/chrony/csm_ntp.py'; done
+     ncn-m001# for i in ncn-{w,s}00{1..3} ncn-m00{2..3}; do echo \
+     "------$i--------"; ssh $i 'TOKEN=$TOKEN /srv/cray/scripts/common/chrony/csm_ntp.py'; done
     ```
 
 <a name="fix-broken-configs"></a>
 
-###### Fix Broken Configs
+### Fix Broken Configuration
 
-On each NCN, run:
+1. Set a token as described in [Identify Nodes and Update Metadata](Rebuild_NCNs/Identify_Nodes_and_Update_Metadata.md)
 
-```
-ncn# csm_ntp.py
+1. On each affected NCN, run:
+
+```bash
+ncn# /srv/cray/scripts/common/chrony/csm_ntp.py
 ```

--- a/operations/node_management/Configure_NTP_on_NCNs.md
+++ b/operations/node_management/Configure_NTP_on_NCNs.md
@@ -68,14 +68,14 @@ The following steps are structured to be executed on one node at a time. However
 
     ```bash
     ncn-m001# for i in $(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u); do 
-    ssh $i "TOKEN=$TOKEN /srv/cray/scripts/common/chrony/csm_ntp.py"; done
+                  ssh $i "TOKEN=$TOKEN /srv/cray/scripts/common/chrony/csm_ntp.py"; done
     ```
 
 <a name="fix-broken-configs"></a>
 
-## Fix Broken Configuration
+## Fix broken configuration
 
-1. Set a token as described in [Identify Nodes and Update Metadata](Rebuild_NCNs/Identify_Nodes_and_Update_Metadata.md)
+1. Set a token as described in [Identify Nodes and Update Metadata](Rebuild_NCNs/Identify_Nodes_and_Update_Metadata.md).
 
 1. On each affected NCN, run:
 


### PR DESCRIPTION
Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>

## Summary and Scope

Uses the full path for `csm_ntp.py`

## Issues and Related PRs


* Resolves  CASMINST-4625
* 
## Testing

_List the environments in which these changes were tested._

### Tested on:

N/A


## Risks and Mitigations

Low


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

