### PR TITLE
CASMINST-4560 - Do not allow upgrader to run on CSM 1.2 or later SLS files

### DIFF
--- a/upgrade/1.2/scripts/sls/csm_1_2_upgrade/sls_updates.py
+++ b/upgrade/1.2/scripts/sls/csm_1_2_upgrade/sls_updates.py
@@ -63,36 +63,6 @@ def sls_and_input_data_checks(
         fg="bright_white",
     )
 
-    bican = networks.get("BICAN")
-    if bican is not None:
-        click.secho(
-            "    ERROR: A BICAN network already exists in the SLS file being upgraded "
-            "and exists only in CSM 1.2 systems and later. This system has already been "
-            "upgraded to CSM 1.2 and the upgrader cannot be re-run.",
-            fg="red",
-        )
-        sys.exit(1)
-
-    cmn = networks.get("CMN")
-    if cmn is not None:
-        click.secho(
-            "    ERROR: A CMN network already exists in the SLS file being upgraded "
-            "and exists only in CSM 1.2 systems and later. This system has already been "
-            "upgraded to CSM 1.2 and the upgrader cannot be re-run.",
-            fg="red",
-        )
-        sys.exit(1)
-
-    chn = networks.get("CHN")
-    if chn is not None:
-        click.secho(
-            "    ERROR: A BICAN network already exists in the SLS file being upgraded "
-            "and exists only in CSM 1.2 systems and later. This system has already been "
-            "upgraded to CSM 1.2 and the upgrader cannot be re-run.",
-            fg="red",
-        )
-        sys.exit(1)
-
     can = networks.get("CAN")
     if can is not None:
         click.secho(
@@ -106,6 +76,21 @@ def sls_and_input_data_checks(
                 fg="bright_yellow",
             )
 
+    cmn = networks.get("CMN")
+    if cmn is not None:
+        click.secho(
+            "    INFO: A CMN network already exists in SLS.  This is unusual except where the "
+            "upgrade process has already run or on an existing CSM 1.2 system.",
+            fg="white",
+        )
+
+    chn = networks.get("CHN")
+    if chn is not None:
+        click.secho(
+            "    INFO: A CHN network already exists in SLS.  This is unusual except where the "
+            "upgrade process has already run or on an existing CSM 1.2 system.",
+            fg="white",
+        )
     if bican_name == "CHN":
         if chn_data[1] == ipaddress.IPv4Network("10.104.7.0/24"):
             click.secho(

--- a/upgrade/1.2/scripts/sls/csm_1_2_upgrade/sls_updates.py
+++ b/upgrade/1.2/scripts/sls/csm_1_2_upgrade/sls_updates.py
@@ -63,6 +63,36 @@ def sls_and_input_data_checks(
         fg="bright_white",
     )
 
+    bican = networks.get("BICAN")
+    if bican is not None:
+        click.secho(
+            "    ERROR: A BICAN network already exists in the SLS file being upgraded "
+            "and exists only in CSM 1.2 systems and later. This system has already been "
+            "upgraded to CSM 1.2 and the upgrader cannot be re-run.",
+            fg="red",
+        )
+        sys.exit(1)
+
+    cmn = networks.get("CMN")
+    if cmn is not None:
+        click.secho(
+            "    ERROR: A CMN network already exists in the SLS file being upgraded "
+            "and exists only in CSM 1.2 systems and later. This system has already been "
+            "upgraded to CSM 1.2 and the upgrader cannot be re-run.",
+            fg="red",
+        )
+        sys.exit(1)
+
+    chn = networks.get("CHN")
+    if chn is not None:
+        click.secho(
+            "    ERROR: A BICAN network already exists in the SLS file being upgraded "
+            "and exists only in CSM 1.2 systems and later. This system has already been "
+            "upgraded to CSM 1.2 and the upgrader cannot be re-run.",
+            fg="red",
+        )
+        sys.exit(1)
+
     can = networks.get("CAN")
     if can is not None:
         click.secho(
@@ -76,21 +106,6 @@ def sls_and_input_data_checks(
                 fg="bright_yellow",
             )
 
-    cmn = networks.get("CMN")
-    if cmn is not None:
-        click.secho(
-            "    INFO: A CMN network already exists in SLS.  This is unusual except where the "
-            "upgrade process has already run or on an existing CSM 1.2 system.",
-            fg="white",
-        )
-
-    chn = networks.get("CHN")
-    if chn is not None:
-        click.secho(
-            "    INFO: A CHN network already exists in SLS.  This is unusual except where the "
-            "upgrade process has already run or on an existing CSM 1.2 system.",
-            fg="white",
-        )
     if bican_name == "CHN":
         if chn_data[1] == ipaddress.IPv4Network("10.104.7.0/24"):
             click.secho(

--- a/upgrade/1.2/scripts/sls/sls_updater_csm_1.2.py
+++ b/upgrade/1.2/scripts/sls/sls_updater_csm_1.2.py
@@ -329,15 +329,15 @@ def main(
     #   NEVER REMOVE THE HSN!!!
     if retain_unused_user_network:
         if bican_user_network_name == "CAN":
-            click.secho("Removing unused CHN as requested", fg="bright_white")
-            networks.pop("CHN")
+            click.secho("Removing unused CHN (if it exists) as requested", fg="bright_white")
+            networks.pop("CHN", None)
         if bican_user_network_name == "CHN":
-            click.secho("Removing unused CAN as requested", fg="bright_white")
-            networks.pop("CAN")
+            click.secho("Removing unused CAN (if it exists) as requested", fg="bright_white")
+            networks.pop("CAN", None)
         if bican_user_network_name == "HSN":
-            click.secho("Removing unused CAN as requested", fg="bright_white")
-            networks.pop("CAN")
-            networks.pop("CHN")
+            click.secho("Removing unused CAN and CHN (if they exist) as requested", fg="bright_white")
+            networks.pop("CAN", None)
+            networks.pop("CHN", None)
 
     click.secho(
         f"Writing CSM 1.2 upgraded and schema validated SLS file to {sls_output_file.name}",


### PR DESCRIPTION
## Summary and Scope

Previously if a BICAN, CMN or CHN networks existed in the SLS file to be upgraded by `sls_updater_csm_1.2.py`, the upgrade process would provide an informational warning but continue onward, often failing in a later step.  These networks are new artifacts in CSM 1.2.  The upgrader exists explicitly in the 1.0 to 1.2 upgrade section of the docs and 1.2-to-1.2 upgrades were not expected given location.  

This change allows processing of a previously upgraded 1.2 SLS file in an idempotent manner.  The behavior is as follows if a 1.2 SLS file is discovered:

1. SKIP: Migrate switch naming (in order): leaf to leaf-bmc and agg to leaf.
2. Remove api-gateway entries from HMLB subnets for CSM 1.2 security.\n
3. Remove kubeapi-vip reservations for all networks except NMN.\n
4. SKIP: Create the new BICAN "toggle" network.\n
5. SKIP: Migrate the existing CAN to CMN.\n
7. SKIP: Create the CHN network.\n
8. SKIP: Convert IPs of the CAN network.\n
9. SKIP: Create MetalLB Pools and ASN entries on CMN and NMN networks.\n
10. Update uai_macvlan in NMN dhcp ranges and uai_macvlan VLAN.\n
11. Rename uai_macvlan_bridge reservation to uai_nmn_blackhole
12. SKIP: Remove unused user networks (CAN or CHN) if requested [--retain-unused-user-network to keep]

**NOTE** "SKIP" implies this step is bypassed because some 1.2-only attribute is found - e.g. the existence of the BICAN network, the existence of the CMN network, etc...  Items 2, 3, 10 and 11 will be processed whether a 1.0 or 1.2 SLS is discovered.

**1.0 Example**
```
./sls_updater_csm_1.2.py --sls-input-file sls_file_1.0.json --bican-user-network-name CHN
Loading SLS JSON file.
Extracting existing Networks from SLS file and schema validating.
WARNING: Gateway not in Subnet for uai_macvlan (possibly supernetting).
Checking input values and SLS data for proper logic.
    INFO: A CAN network already exists in SLS.
    WARNING: CAN network found, but command line --customer-access-network values not found. Using [default: 6, 10.103.6.0/24]
    WARNING: Command line --customer-highspeed-network values not found. Using [default: 5, 10.104.7.0/24]
Migrating switch naming in Networks.
    Renaming sw-leaf to sw-leaf-bmc in reservations for subnet network_hardware in network HMN.
    Renaming sw-agg  to sw-leaf     in reservations for subnet network_hardware in network HMN.
    Renaming sw-leaf to sw-leaf-bmc in reservations for subnet network_hardware in network MTL.
    Renaming sw-agg  to sw-leaf     in reservations for subnet network_hardware in network MTL.
    Renaming sw-leaf to sw-leaf-bmc in reservations for subnet network_hardware in network NMN.
    Renaming sw-agg  to sw-leaf     in reservations for subnet network_hardware in network NMN.
Migrating switch naming in Hardware.
    Renaming sw-leaf to sw-leaf-bmc in hardware for Xname x3002c0w48
    Renaming sw-leaf to sw-leaf-bmc in hardware for Xname x3010c0w48
    Renaming sw-agg  to sw-leaf     in hardware for Xname x3112c0h38s1
    Renaming sw-agg  to sw-leaf     in hardware for Xname x3112c0h39s1
    Renaming sw-agg  to sw-leaf     in hardware for Xname x3112c0h40s1
    Renaming sw-agg  to sw-leaf     in hardware for Xname x3112c0h41s1
    Renaming sw-agg  to sw-leaf     in hardware for Xname x3112c0h42s1
    Renaming sw-agg  to sw-leaf     in hardware for Xname x3112c0h43s1
    Renaming sw-leaf to sw-leaf-bmc in hardware for Xname x3112c0w47
    Renaming sw-leaf to sw-leaf-bmc in hardware for Xname x3113c0w47
    Renaming sw-leaf to sw-leaf-bmc in hardware for Xname x3114c0w47
    Renaming sw-leaf to sw-leaf-bmc in hardware for Xname x3115c0w47
    Renaming sw-leaf to sw-leaf-bmc in hardware for Xname x3116c0w47
Removing any api-gw aliases from HMNLB.
    Removing api-gw aliases istio-ingressgateway from HMNLB hmn_metallb_address_pool
    Removing api-gw aliases istio-ingressgateway-local from HMNLB hmn_metallb_address_pool
Creating new BICAN network and toggling to CHN.
Converting existing CAN network to CMN.
    Creating subnets in the following order ['network_hardware', 'bootstrap_dhcp', 'metallb_address_pool', 'metallb_static_pool']
    Subnet network_hardware not found, using HMN as template
    Calculating seed/start prefix based on devices in case no further guidance is given
        INFO:  Overrides may be provided on the command line with --<can|cmn>-subnet-override.
    Creating network_hardware with 21 devices:
        A /27 could work and would hold up to 30 devices (including gateway)
...snip...
    Applying supernet hack to network_hardware
    Applying supernet hack to bootstrap_dhcp
    Cleaning up remnant CAN switch reservations in boostrap_dhcp
Removing CAN MetalLB static pool
Removing kubeapi-vip reservations from all network except NMN
Creating CHN network with VLAN: 5 and IPv4 CIDR: 10.104.7.0/24
    Updating subnet naming for chn_metallb_address_pool
    Updating reservation names and aliases for chn_metallb_address_pool
    Updating subnet naming for bootstrap_dhcp
    Updating reservation names and aliases for bootstrap_dhcp
    Updating subnet IPv4 addresses for bootstrap_dhcp to 10.104.7.0/24
    Updating reservation IPv4 addresses for bootstrap_dhcp
    Updating DHCP start-end IPv4 addresses 10.104.7.50-10.104.7.126
Creating BGP peering ASNs and MetalLBPool names
    Updating the CHN network with BGP peering info MyASN: 65530 and PeerASN: 65533
    Updating the CMN network with BGP peering info MyASN: 65532 and PeerASN: 65533
    Updating the NMN network with BGP peering info MyASN: 65533 and PeerASN: 65533
    Updating can_metallb_address_pool subnet in the CAN network with MetalLBPoolName customer-access
    Updating hmn_metallb_address_pool subnet in the HMNLB network with MetalLBPoolName hardware-management
    Updating nmn_metallb_address_pool subnet in the NMNLB network with MetalLBPoolName node-management
    Updating cmn_metallb_address_pool subnet in the CMN network with MetalLBPoolName customer-management
    Updating cmn_metallb_static_pool subnet in the CMN network with MetalLBPoolName customer-management-static
    Updating chn_metallb_address_pool subnet in the CHN network with MetalLBPoolName customer-high-speed
Updating DHCP Start and End Ranges for uai_macvlan subnet in NMN network
Updating uai_macvlan subnet VLAN in NMN network
Renaming uai_macvlan_bridge reservation to uai_nmn_blackhole
    Found macvlan-bridge in alias uai-macvlan-bridge
    Found macvlan_bridge in alias uai_macvlan_bridge.local
Removing unused CAN (if it exists) as requested
Writing CSM 1.2 upgraded and schema validated SLS file to migrated_sls_file.json
```

**1.2 Example - previously migrated 1.0 "remigrated"**
```
./sls_updater_csm_1.2.py --sls-input-file sls_file_1.2.json --bican-user-network-name CHN
Loading SLS JSON file.
Extracting existing Networks from SLS file and schema validating.
WARNING: Gateway not in Subnet for uai_macvlan (possibly supernetting).
Checking input values and SLS data for proper logic.
    INFO: A CMN network already exists in SLS.  This is unusual except where the upgrade process has already run or on an existing CSM 1.2 system.
    INFO: A CHN network already exists in SLS.  This is unusual except where the upgrade process has already run or on an existing CSM 1.2 system.
    WARNING: Command line --customer-highspeed-network values not found. Using [default: 5, 10.104.7.0/24]
    WARNING: BGP Peering information exists in the NMN network and will be overwritten.
Removing any api-gw aliases from HMNLB.
Removing kubeapi-vip reservations from all network except NMN
Creating BGP peering ASNs and MetalLBPool names
    Updating chn_metallb_address_pool subnet in the CHN network with MetalLBPoolName customer-high-speed
    Updating cmn_metallb_address_pool subnet in the CMN network with MetalLBPoolName customer-management
    Updating cmn_metallb_static_pool subnet in the CMN network with MetalLBPoolName customer-management-static
    Updating hmn_metallb_address_pool subnet in the HMNLB network with MetalLBPoolName hardware-management
    Updating nmn_metallb_address_pool subnet in the NMNLB network with MetalLBPoolName node-management
Updating DHCP Start and End Ranges for uai_macvlan subnet in NMN network
Updating uai_macvlan subnet VLAN in NMN network
Renaming uai_macvlan_bridge reservation to uai_nmn_blackhole
Removing unused CAN (if it exists) as requested
Writing CSM 1.2 upgraded and schema validated SLS file to migrated_sls_file.json
```

Note that 1.0 -> 1.2 -> 1.2 -> 1.2 has also been tested.

## Issues and Related PRs

* Resolves CASMINST-4560

## Testing

1. Ran against 0.9 and 1.0 SLS files and proved that existing behavior (ie. SLS upgrade) continued as desired.
2. Ran against several 1.2 SLS files and proved that existence of BICAN, CMN or CHN networks exited the upgrader with an informative error.

### Tested on:

  * Local
  * Local development environment
  * Virtual Shasta

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

