### PR TITLE
Corrections to install bootstrap PIT procedures

### DIFF
--- a/install/bootstrap_livecd_remote_iso.md
+++ b/install/bootstrap_livecd_remote_iso.md
@@ -283,13 +283,10 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
       >   Otherwise, an administrator should set the hostname manually with `hostnamectl`. In the latter case, do not confuse other administrators
       >   by using the hostname `ncn-m001`. Append the `-pit` suffix, indicating that the node is booted from the LiveCD.
 
-1. Mount local disk.
-
-   > **Note:** The FSLabel `PITDATA` is already in `/etc/fstab`, so the path is omitted in the following call to `mount`.
+1. Create necessary directories.
 
    ```bash
-   pit# mount -vL PITDATA &&
-        mkdir -pv ${PITDATA}/{admin,configs} ${PITDATA}/prep/{admin,logs} ${PITDATA}/data/{k8s,ceph}
+   pit# mkdir -pv ${PITDATA}/{admin,configs} ${PITDATA}/prep/{admin,logs} ${PITDATA}/data/{k8s,ceph}
    ```
 
 1. Relocate the typescript to the newly mounted `PITDATA` directory.

--- a/install/bootstrap_livecd_remote_iso.md
+++ b/install/bootstrap_livecd_remote_iso.md
@@ -12,21 +12,21 @@ lack of removable storage.
 
 ## Topics
 
-1. [Known Compatibility Issues](#known-compatibility-issues)
-1. [Attaching and Booting the LiveCD with the BMC](#attaching-and-booting-the-livecd-with-the-bmc)
-1. [First Login](#first-login)
-1. [Configure the Running LiveCD](#configure-the-running-livecd)
-   1. [Generate Installation Files](#generate-installation-files)
-      * [Subsequent Installs (Reinstalls)](#subsequent-fresh-installs-re-installs)
-      * [Initial Installs (bare-metal)](#first-timeinitial-installs-bare-metal)
-   1. [Verify and Backup `system_config.yaml`](#verify-csi-versions-match)
-   1. [Prepare Site Init](#prepare-site-init)
-1. [Bring-up the PIT Services and Validate PIT Health](#bring---up-the-pit-services-and-validate-pit-health)
-1. [Next Topic](#next-topic)
+1. [Known compatibility issues](#known-compatibility-issues)
+1. [Attaching and booting the LiveCD with the BMC](#attaching-and-booting-the-livecd-with-the-bmc)
+1. [First login](#first-login)
+1. [Configure the running LiveCD](#configure-the-running-livecd)
+   1. [Generate installation files](#generate-installation-files)
+      * [Subsequent installs (reinstalls)](#subsequent-fresh-installs-re-installs)
+      * [Initial installs (bare-metal)](#first-timeinitial-installs-bare-metal)
+   1. [Verify and backup `system_config.yaml`](#verify-csi-versions-match)
+   1. [Prepare `Site Init`](#prepare-site-init)
+1. [Bring up the PIT services and validate PIT health](#bring---up-the-pit-services-and-validate-pit-health)
+1. [Next topic](#next-topic)
 
 <a name="known-compatibility-issues"></a>
 
-## 1. Known Compatibility Issues
+## 1. Known compatibility issues
 
 The LiveCD Remote ISO has known compatibility issues for nodes from certain vendors.
 
@@ -35,12 +35,12 @@ The LiveCD Remote ISO has known compatibility issues for nodes from certain vend
 
 <a name="attaching-and-booting-the-livecd-with-the-bmc"></a>
 
-## 2. Attaching and Booting the LiveCD with the BMC
+## 2. Attaching and booting the LiveCD with the BMC
 
 > **Warning:** If this is a re-installation on a system that still has a USB device from a prior
 > installation, then that USB device must be wiped before continuing. Failing to wipe the USB, if present, may result in confusion.
 > If the USB is still booted, then it can wipe itself using the [basic wipe from Wipe NCN Disks for Reinstallation](wipe_ncn_disks_for_reinstallation.md#basic-wipe).
-> If it is not booted, please do so and wipe it _or_ disable the USB ports in the BIOS (not available for all vendors).
+> If it is not booted, please do so and wipe it **or** disable the USB ports in the BIOS (not available for all vendors).
 
 Obtain and attach the LiveCD `cray-pre-install-toolkit` ISO file to the BMC. Depending on the vendor of the node,
 the instructions for attaching to the BMC will differ.
@@ -77,7 +77,7 @@ the instructions for attaching to the BMC will differ.
 
 <a name="first-login"></a>
 
-## 3. First Login
+## 3. First login
 
 On first login (over SSH or at local console) the LiveCD will prompt the administrator to change the password.
 
@@ -101,7 +101,7 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
 
 <a name="configure-the-running-livecd"></a>
 
-## 4. Configure the Running LiveCD
+## 4. Configure the running LiveCD
 
 1. Start a typescript to record this section of activities done on `ncn-m001` while booted from the LiveCD.
 
@@ -376,7 +376,7 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
 
 <a name="generate-installation-files"></a>
 
-### 4.1 Generate Installation Files
+### 4.1 Generate installation files
 
 Some files are needed for generating the configuration payload. See the [Command Line Configuration Payload](prepare_configuration_payload.md#command_line_configuration_payload)
 and [Configuration Payload Files](prepare_configuration_payload.md#configuration_payload_files) topics if one has not already prepared the information for this system.
@@ -416,10 +416,10 @@ and [Configuration Payload Files](prepare_configuration_payload.md#configuration
 
 <a name="subsequent-fresh-installs-re-installs"></a>
 
-#### 4.1.a Subsequent Installs (Reinstalls)
+#### 4.1.a Subsequent installs (reinstalls)
 
 1. **For subsequent fresh-installs (re-installs) where the `system_config.yaml` parameter file is available**, generate the updated system configuration
-   (see [Cray Site Init Files](../background/index.md#cray_site_init_files)).
+   (see [Cray `Site Init` Files](../background/index.md#cray_site_init_files)).
 
    > **Warning:** If the `system_config.yaml` file is unavailable, then skip this step and proceed to [Initial Installs (bare-metal)](#first-timeinitial-installs-bare-metal).
 
@@ -479,7 +479,7 @@ and [Configuration Payload Files](prepare_configuration_payload.md#configuration
 
 <a name="first-timeinitial-installs-bare-metal"></a>
 
-#### 4.1.b Initial Installs (bare-metal)
+#### 4.1.b Initial installs (bare-metal)
 
 1. **For first-time/initial installs (without a `system_config.yaml`file)**, generate the system configuration. See below for an explanation of the command line parameters and some common settings.
 
@@ -563,7 +563,7 @@ and [Configuration Payload Files](prepare_configuration_payload.md#configuration
 
 <a name="verify-csi-versions-match"></a>
 
-### 4.2 Verify and Backup `system_config.yaml`
+### 4.2 Verify and backup `system_config.yaml`
 
 1. Verify that the newly generated `system_config.yaml` matches the current version of CSI.
 
@@ -583,20 +583,20 @@ and [Configuration Payload Files](prepare_configuration_payload.md#configuration
 
 1. Copy the new `system_config.yaml` file somewhere safe to facilitate re-installs.
 
-1. Continue to the next step to [Prepare Site Init](#prepare-site-init).
+1. Continue to the next step to [Prepare `Site Init`](#prepare-site-init).
 
 <a name="prepare-site-init"></a>
 
-### 4.3 Prepare Site Init
+### 4.3 Prepare `Site Init`
 
 > **Important:** Although the command prompts in this procedure are `linux#`, the procedure should be
 > performed on the PIT node.
 
-Prepare the `site-init` directory by performing the [Prepare Site Init](prepare_site_init.md) procedures.
+Prepare the `site-init` directory by performing the [Prepare `Site Init`](prepare_site_init.md) procedures.
 
 <a name="bring---up-the-pit-services-and-validate-pit-health"></a>
 
-## 5. Bring-up the PIT Services and Validate PIT Health
+## 5. Bring up the PIT services and validate PIT health
 
 1. Initialize the PIT.
 
@@ -627,7 +627,7 @@ Prepare the `site-init` directory by performing the [Prepare Site Init](prepare_
 
 <a name="next-topic"></a>
 
-## Next Topic
+## Next topic
 
 After completing this procedure, proceed to configure the management network switches.
 

--- a/install/bootstrap_livecd_remote_iso.md
+++ b/install/bootstrap_livecd_remote_iso.md
@@ -386,14 +386,18 @@ and [Configuration Payload Files](prepare_configuration_payload.md#configuration
 
 1. Create the `hmn_connections.json` file by following the [Create HMN Connections JSON](create_hmn_connections_json.md)  procedure. Return to this section when completed.
 
-1. Copy these files into the current working directory, or create them if this is an initial install of the system:
+1. Create the configuration input files if needed and copy them into the preparation directory.
+
+   The preparation directory is `${PITDATA}/prep`.
+
+   Copy these files into the preparation directory, or create them if this is an initial install of the system:
 
    * `application_node_config.yaml` (optional - see below)
    * `cabinets.yaml` (optional - see below)
    * `hmn_connections.json`
    * `ncn_metadata.csv`
    * `switch_metadata.csv`
-   * `system_config.yaml` (only available after [first-install generation of system files](#first-timeinitial-installs-bare-metal)
+   * `system_config.yaml` (only available after [first-install generation of system files](#first-timeinitial-installs-bare-metal))
 
    > The optional `application_node_config.yaml` file may be provided for further definition of settings relating to how application nodes will appear in HSM for roles and
    > subroles. See [Create Application Node YAML](create_application_node_config_yaml.md).
@@ -485,15 +489,15 @@ and [Configuration Payload Files](prepare_configuration_payload.md#configuration
       pit# ls -1 ${PITDATA}/prep
       ```
 
-       1. Expected output looks similar to the following:
+      Expected output looks similar to the following:
 
-          ```text
-          application_node_config.yaml
-          cabinets.yaml
-          hmn_connections.json
-          ncn_metadata.csv
-          switch_metadata.csv
-          ```
+      ```text
+      application_node_config.yaml
+      cabinets.yaml
+      hmn_connections.json
+      ncn_metadata.csv
+      switch_metadata.csv
+      ```
 
    1. Generate the system configuration.
 

--- a/install/bootstrap_livecd_remote_iso.md
+++ b/install/bootstrap_livecd_remote_iso.md
@@ -337,10 +337,10 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
 
    > **Note:** The PIT ISO, Helm charts/images, and bootstrap RPMs are now available in the extracted CSM tar file.
 
-1. Install/upgrade CSI; check if a newer version was included in the tarball.
+1. <a name="install-csi-rpm"></a>Install the latest version of CSI tool.
 
    ```bash
-   pit# rpm -Uvh $(find ${CSM_PATH}/rpm/ -name "cray-site-init-*.x86_64.rpm" | sort -V | tail -1)
+   pit# rpm -Uvh --force $(find ${CSM_PATH}/rpm/ -name "cray-site-init-*.x86_64.rpm" | sort -V | tail -1)
    ```
 
 1. Install the latest documentation RPM.

--- a/install/bootstrap_livecd_usb.md
+++ b/install/bootstrap_livecd_usb.md
@@ -77,7 +77,7 @@ Fetch the base installation CSM tarball, extract it, and install the contained C
 1. <a name="install-csi-rpm"></a>Install the latest version of CSI tool.
 
    ```bash
-   linux# rpm -Uvh $(find ${CSM_PATH}/rpm/cray/csm/ -name "cray-site-init-*.x86_64.rpm" | sort -V | tail -1)
+   linux# rpm -Uvh --force $(find ${CSM_PATH}/rpm/cray/csm/ -name "cray-site-init-*.x86_64.rpm" | sort -V | tail -1)
    ```
 
 1. Install the latest documentation RPM.

--- a/install/bootstrap_livecd_usb.md
+++ b/install/bootstrap_livecd_usb.md
@@ -8,23 +8,23 @@ These steps provide a bootable USB with SSH enabled, capable of installing this 
 
 ## Topics
 
-1. [Download and Expand the CSM Release](#download-and-expand-the-csm-release)
-1. [Create the Bootable Media](#create-the-bootable-media)
-1. [Configuration Payload](#configuration-payload)
-   1. [Generate Installation Files](#generate-installation-files)
-      * [Subsequent Installs (Reinstalls)](#subsequent-fresh-installs-re-installs)
-      * [Initial Installs (bare-metal)](#first-timeinitial-installs-bare-metal)
-   1. [Verify and Backup `system_config.yaml`](#verify-csi-versions-match)
-   1. [Prepare Site Init](#prepare-site-init)
-1. [Prepopulate LiveCD Daemons Configuration and NCN Artifacts](#prepopulate-livecd-daemons-configuration-and-ncn-artifacts)
+1. [Download and expand the CSM release](#download-and-expand-the-csm-release)
+1. [Create the bootable media](#create-the-bootable-media)
+1. [Configuration payload](#configuration-payload)
+   1. [Generate installation files](#generate-installation-files)
+      * [Subsequent installs (reinstalls)](#subsequent-fresh-installs-re-installs)
+      * [Initial installs (bare-metal)](#first-timeinitial-installs-bare-metal)
+   1. [Verify and backup `system_config.yaml`](#verify-csi-versions-match)
+   1. [Prepare `Site Init`](#prepare-site-init)
+1. [Prepopulate LiveCD daemons configuration and NCN artifacts](#prepopulate-livecd-daemons-configuration-and-ncn-artifacts)
 1. [Boot the LiveCD](#boot-the-livecd)
-   1. [First Login](#first-login)
-1. [Configure the Running LiveCD](#configure-the-running-livecd)
-1. [Next Topic](#next-topic)
+   1. [First login](#first-login)
+1. [Configure the running LiveCD](#configure-the-running-livecd)
+1. [Next topic](#next-topic)
 
 <a name="download-and-expand-the-csm-release"></a>
 
-## 1. Download and Expand the CSM Release
+## 1. Download and expand the CSM release
 
 Fetch the base installation CSM tarball, extract it, and install the contained CSI tool.
 
@@ -148,13 +148,13 @@ Fetch the base installation CSM tarball, extract it, and install the contained C
 
 1. Remove CNI configuration from prior install
 
-    If you are reinstalling the system and you are **using ncn-m001 to prepare the USB image**, remove some of prior CNI configuration.
+    If reinstalling the system and **using `ncn-m001` to prepare the USB image**, then remove the prior CNI configuration.
 
     ```bash
     ncn-m001# rm -rf /etc/cni/net.d/00-multus.conf /etc/cni/net.d/10-*.conflist /etc/cni/net.d/multus.d
     ```
 
-    This should leave you with the following two files in `/etc/cni/net.d`.
+    This should leave the following two files in `/etc/cni/net.d`.
 
     ```bash
     ncn-m001# ls /etc/cni/net.d
@@ -163,10 +163,9 @@ Fetch the base installation CSM tarball, extract it, and install the contained C
 
 <a name="create-the-bootable-media"></a>
 
-## 2. Create the Bootable Media
+## 2. Create the bootable media
 
-Cray Site Init will create the bootable LiveCD. Before creating the media, identify
-which device will be used for it.
+Before creating the the bootable LiveCD, identify which device will be used for it.
 
 1. Identify the USB device.
 
@@ -247,24 +246,24 @@ on to the [configuration payload](#configuration-payload).
 
 <a name="configuration-payload"></a>
 
-## 3. Configuration Payload
+## 3. Configuration payload
 
-The SHASTA-CFG structure and other configuration files will be prepared, then `csi` will generate a system-unique configuration payload. This payload will be used
-for the rest of the CSM installation on the USB device.
+The `SHASTA-CFG` structure and other configuration files will be prepared, then `csi` will generate a system-unique configuration payload.
+This payload will be used for the rest of the CSM installation on the USB device.
 
 1. [Generate Installation Files](#generate-installation-files)
 1. [Verify and Backup `system_config.yaml`](#verify-csi-versions-match)
-1. [Prepare Site Init](#prepare-site-init)
+1. [Prepare `Site Init`](#prepare-site-init)
 
 <a name="generate-installation-files"></a>
 
-### 3.1 Generate Installation Files
+### 3.1 Generate installation files
 
 Some files are needed for generating the configuration payload. See these topics in [Prepare Configuration Payload](prepare_configuration_payload.md) if the
 information for this system has not yet been prepared.
 
-* [Command Line Configuration Payload](prepare_configuration_payload.md#command_line_configuration_payload)
-* [Configuration Payload Files](prepare_configuration_payload.md#configuration_payload_files)
+* [Command line configuration payload](prepare_configuration_payload.md#command_line_configuration_payload)
+* [Configuration payload files](prepare_configuration_payload.md#configuration_payload_files)
 
 > **Note:**: The USB device is usable at this time, but without SSH enabled as well as core services. This means the USB device could be used to boot the system now, and
 > this step can be returned to at another time.
@@ -299,10 +298,10 @@ information for this system has not yet been prepared.
 
 <a name="subsequent-fresh-installs-re-installs"></a>
 
-#### 3.1.a Subsequent Installs (Reinstalls)
+#### 3.1.a Subsequent installs (reinstalls)
 
 1. **For subsequent fresh-installs (re-installs) where the `system_config.yaml` parameter file is available**, generate the updated system configuration
-   (see [Cray Site Init Files](../background/index.md#cray_site_init_files)).
+   (see [Cray `Site Init` Files](../background/index.md#cray_site_init_files)).
 
    > **Warning:** If the `system_config.yaml` file is unavailable, then skip this step and proceed to [Initial Installs (bare-metal)](#first-timeinitial-installs-bare-metal).
 
@@ -362,7 +361,7 @@ information for this system has not yet been prepared.
 
 <a name="first-timeinitial-installs-bare-metal"></a>
 
-#### 3.1.b Initial Installs (bare-metal)
+#### 3.1.b Initial installs (bare-metal)
 
 1. **For first-time/initial installs (without a `system_config.yaml`file)**, generate the system configuration. See below for an explanation of the command line parameters and
    some common settings.
@@ -447,7 +446,7 @@ information for this system has not yet been prepared.
 
 <a name="verify-csi-versions-match"></a>
 
-### 3.2 Verify and Backup `system_config.yaml`
+### 3.2 Verify and backup `system_config.yaml`
 
 1. Verify that the newly generated `system_config.yaml` matches the current version of CSI.
 
@@ -467,11 +466,11 @@ information for this system has not yet been prepared.
 
 1. Copy the new `system_config.yaml` file somewhere safe to facilitate re-installs.
 
-1. Continue to the next step to [Prepare Site Init](#prepare-site-init).
+1. Continue to the next step to [Prepare `Site Init`](#prepare-site-init).
 
 <a name="prepare-site-init"></a>
 
-### 3.3 Prepare Site Init
+### 3.3 Prepare `Site Init`
 
 > **Note:**: It is assumed at this point that `$PITDATA` (that is, `/mnt/pitdata`) is still mounted on the Linux system. This is important because the following procedure
 > depends on that mount existing.
@@ -484,11 +483,11 @@ information for this system has not yet been prepared.
 
 1. Prepare the `site-init` directory.
 
-   Perform the [Prepare Site Init](prepare_site_init.md) procedures.
+   Perform the [Prepare `Site Init`](prepare_site_init.md) procedures.
 
 <a name="prepopulate-livecd-daemons-configuration-and-ncn-artifacts"></a>
 
-## 4. Prepopulate LiveCD Daemons Configuration and NCN Artifacts
+## 4. Prepopulate LiveCD daemons configuration and NCN artifacts
 
 Now that the configuration is generated, the LiveCD must be populated with the generated files.
 
@@ -654,7 +653,7 @@ boot order to have the USB device first.
 
 <a name="first-login"></a>
 
-### 5.1 First Login
+### 5.1 First login
 
 On first log in (over SSH or at local console), the LiveCD will prompt the administrator to change the password.
 
@@ -707,8 +706,8 @@ On first log in (over SSH or at local console), the LiveCD will prompt the admin
    need to mount this manually by running the following command.
 
    > **Note:** When creating the USB PIT image, this was mounted over `/mnt/pitdata`. Now that the USB PIT is booted,
-   > it will mount over `/var/www/ephemeral`. The FSLabel `PITDATA` is already in `/etc/fstab`, so the path is omitted
-   > in the following call to `mount`.
+   > it will mount over `/var/www/ephemeral`. The `FSLabel` `PITDATA` is already in `/etc/fstab`, so the path is omitted
+   > in the following `mount` command.
 
    ```bash
    pit# mount -vL PITDATA
@@ -795,7 +794,7 @@ On first log in (over SSH or at local console), the LiveCD will prompt the admin
 
 <a name="configure-the-running-livecd"></a>
 
-## 6. Configure the Running LiveCD
+## 6. Configure the running LiveCD
 
 1. Set and export BMC credential variables.
 
@@ -832,7 +831,7 @@ On first log in (over SSH or at local console), the LiveCD will prompt the admin
 
 <a name="next-topic"></a>
 
-## Next Topic
+## Next topic
 
 After completing this procedure, proceed to configure the management network switches.
 

--- a/install/bootstrap_livecd_usb.md
+++ b/install/bootstrap_livecd_usb.md
@@ -271,14 +271,18 @@ information for this system has not yet been prepared.
 
 1. At this time see [Create HMN Connections JSON](create_hmn_connections_json.md) for instructions about creating the `hmn_connections.json`.
 
-1. Pull these files into the current working directory, or create them if this is a first-time/initial install:
+1. Create the configuration input files if needed and copy them into the preparation directory.
+
+   The preparation directory is `${PITDATA}/prep`.
+
+   Copy these files into the preparation directory, or create them if this is an initial install of the system:
 
    * `application_node_config.yaml` (optional - see below)
    * `cabinets.yaml` (optional - see below)
    * `hmn_connections.json`
    * `ncn_metadata.csv`
    * `switch_metadata.csv`
-   * `system_config.yaml` (only available after [first-install generation of system files](#first-timeinitial-installs-bare-metal)
+   * `system_config.yaml` (only available after [first-install generation of system files](#first-timeinitial-installs-bare-metal))
 
    > The optional `application_node_config.yaml` file may be provided for further definition of settings relating to how application nodes will appear in HSM for roles and subroles.
    > See [Create Application Node YAML](create_application_node_config_yaml.md)


### PR DESCRIPTION
## Summary and Scope

These are small corrections (and associated linting) to errors found in the bootstrap procedures during the hermod csm-1.2.0-rc.2 install. There are content changes here, but they are minor.

The main corrections are:
* The bootstrap remoteISO procedure tries to mount PITDATA twice. The second mount command fails (because it is already mounted), and this causes some mkdir commands to not run. The fix is just to remove the superfluous second mount command. This issue does not exist in the USB bootstrap procedure.
* In both remoteISO and USB bootstrap procedures, the command to install the cray-site-init RPM does not include the --force flag. On the hermod install, this resulted in the rpm install command failing, because the RPM was already installed at the same level. In our case, we actually noticed that the force-installed CSI RPM actually had a later build date than the one it replaced, even though their versions were identical. I don't think that is likely to be seen on customer installs, but it shouldn't hurt for them to use the force flag -- using the version of CSI provided with the release tarball is probably the safest course, and the force flag accomplishes that. So this ticket adds the force flag to the CSI RPM install command in both bootstrap procedures.
* Both bootstrap procedures tell you to copy the config files into the current working directory even before you are in the prep directory. This ticket modifies the instructions to make it clear that the files are to be copied into the prep directory.

## Issues and Related PRs

Resolves:
* [CASMINST-4627](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4627) - Second mount command fails
* [CASMINST-4628](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4628) - CSI RPM install fails
* [CASMINST-4629](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4629) - Config files must be copied to prep directory

Backport PRs:
csm-1.2: https://github.com/Cray-HPE/docs-csm/pull/1623
csm-1.0: https://github.com/Cray-HPE/docs-csm/pull/1624 ([CASMINST-4629](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4629)  only)

## Testing

The changed procedures were followed during the hermod install.

## Risks and Mitigations

Low -- changes are minor.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
