### PR TITLE
(main) CASMINST-4630: Use CSM_PATH instead of CSM_RELEASE when generating hmn_connections.json

### DIFF
--- a/install/create_hmn_connections_json.md
+++ b/install/create_hmn_connections_json.md
@@ -1,6 +1,7 @@
 # Create HMN Connections JSON File
 
-Use this procedure to generate the `hmn_connections.json` from the system's SHCD Excel document. This process is typically needed when generating the `hmn_connections.json` file for a new system, or regenerating it when a system's SHCD file is changed (specifically the `HMN` tab). The `hms-shcd-parser` tool can be used to generate the `hmn_connections.json` file.
+Use this procedure to generate the `hmn_connections.json` from the system's SHCD Excel document. This process is typically needed when generating the `hmn_connections.json` file for a new system, or regenerating it when a system's SHCD file is changed
+(specifically the `HMN` tab). The `hms-shcd-parser` tool can be used to generate the `hmn_connections.json` file.
 
 The [SHCD/HMN Connections Rules](shcd_hmn_connections_rules.md) document explains the expected naming conventions and rules for the `HMN` tab of the SHCD file, and for the `hmn_connections.json` file.
 
@@ -9,13 +10,15 @@ The [SHCD/HMN Connections Rules](shcd_hmn_connections_rules.md) document explain
 * SHCD Excel file for the system
 * Podman is available
 
-    > Podman is available on the CSM LiveCD, and is installed onto an NCN when being used as an environment to create the CSM PIT in the [Bootstrap PIT Node from LiveCD USB](bootstrap_livecd_usb.md) or [Bootstrap Pit Node from LiveCD Remote ISO](bootstrap_livecd_remote_iso.md) procedures.
+    > Podman is available on the CSM LiveCD, and is installed onto an NCN when being used as an environment to create the CSM PIT in the [Bootstrap PIT Node from LiveCD USB](bootstrap_livecd_usb.md) or
+    > [Bootstrap Pit Node from LiveCD Remote ISO](bootstrap_livecd_remote_iso.md) procedures.
 
 ## Procedure
 
 1. Inspect the `HMN` tab of the SHCD file.
 
-    Verify that it does not have unexpected data in columns `J` through `U` in rows 20 or below. If any unexpected data is present in this region of the `HMN` tab, then it will end up in the generated `hmn_connections.json`. Therefore, it must be removed before generating the `hmn_connections.json` file. Unexpected data is anything other than HMN cabling information, such as another table placed below the HMN cabling information. Any data above row 20 will not interfere when generating `hmn_connections.json`.
+    Verify that it does not have unexpected data in columns `J` through `U` in rows 20 or below. If any unexpected data is present in this region of the `HMN` tab, then it will end up in the generated `hmn_connections.json`. Therefore, it must be
+    removed before generating the `hmn_connections.json` file. Unexpected data is anything other than HMN cabling information, such as another table placed below the HMN cabling information. Any data above row 20 will not interfere when generating `hmn_connections.json`.
 
     For example, the following image shows an unexpected table present underneath HMN cabling information in rows 26 to 29. The HMN cabling information in this example is truncated for brevity.
 
@@ -23,21 +26,19 @@ The [SHCD/HMN Connections Rules](shcd_hmn_connections_rules.md) document explain
 
 1. Load the `hms-shcd-parser` container image from the CSM release distribution into Podman.
 
-    > The `CSM_RELEASE` environment variable is expected to to be set from the [Bootstrap PIT Node from LiveCD USB](bootstrap_livecd_usb.md) or [Bootstrap PIT Node from LiveCD Remote ISO](bootstrap_livecd_remote_iso.md) procedures.
-    >
-    > It is expected that the current directory contains the directory of the extracted CSM release tarball.
+    > The `CSM_PATH` environment variable is expected to to be set from the [Bootstrap PIT Node from LiveCD USB](bootstrap_livecd_usb.md) or [Bootstrap PIT Node from LiveCD Remote ISO](bootstrap_livecd_remote_iso.md) procedures.
 
     Determine the version of the `hms-shcd-parser` container image:
 
     ```bash
-    linux# SHCD_PARSER_VERSION=$(realpath ./${CSM_RELEASE}/docker/artifactory.algol60.net/csm-docker/stable/hms-shcd-parser* | egrep  -o '[0-9]+\.[0-9]+\.[0-9]+$')
+    linux# SHCD_PARSER_VERSION=$(realpath ${CSM_PATH}/docker/artifactory.algol60.net/csm-docker/stable/hms-shcd-parser* | egrep  -o '[0-9]+\.[0-9]+\.[0-9]+$')
     linux# echo $SHCD_PARSER_VERSION
     ```
 
     Load the `hms-shcd-parser` container image into Podman:
 
     ```bash
-    linux# ./${CSM_RELEASE}/hack/load-container-image.sh artifactory.algol60.net/csm-docker/stable/hms-shcd-parser:$SHCD_PARSER_VERSION
+    linux# ${CSM_PATH}/hack/load-container-image.sh artifactory.algol60.net/csm-docker/stable/hms-shcd-parser:$SHCD_PARSER_VERSION
     ```
 
 1. Copy the system's SHCD file to the machine being used to prepare the `hmn_connections.json` file.


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

Use CSM_PATH instead of CSM_RELEASE when generating hmn_connections.json.


_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMINST-4630

## Testing

_List the environments in which these changes were tested._

### Tested on:
  * Hermod


### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_
Tested these changes on Hermod while fresh install CSM 1.2.

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
Low risk.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

