### PR TITLE
CASMINST-4631: Remove now-automated manual steps from Deploy Management Nodes

### DIFF
--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -920,10 +920,10 @@ Observe the output of the checks. If there are any failures, remediate them.
 
    > **WARNING:** Notes on specific failures:
    >
-   > - If any of the `FS Label` tests fail (they have names like `Master Node ETCDLVM FS Label` or `Worker Node CONLIB FS Label`),
+   > * If any of the `FS Label` tests fail (they have names like `Master Node ETCDLVM FS Label` or `Worker Node CONLIB FS Label`),
    > then run manual tests on the node which reported the failure. See [Manual LVM Check Procedure](#manual-lvm-check-procedure). If the manual tests fail,
    > then the problem must be resolved before continuing to the next step. See [LVM Check Failure Recovery](#lvm-check-failure-recovery).
-   > - If the `Weave Health` test fails, run `weave --local status connections` on the node where the test failed. If messages similar to
+   > * If the `Weave Health` test fails, run `weave --local status connections` on the node where the test failed. If messages similar to
    > `IP allocation was seeded by different peers` are seen, then `weave` appears to be split-brained. At this point, it is necessary to wipe
    > the NCNs and start the PXE boot again:
    >    1. Wipe the NCNs using the 'Basic Wipe' section of [Wipe NCN Disks for Reinstallation](wipe_ncn_disks_for_reinstallation.md).

--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -36,8 +36,6 @@ the number of storage and worker nodes.
       1. [Install tests and test server on NCNs](#install-tests)
       1. [Remove the default NTP pool](#remove-the-default-ntp-pool)
    1. [Validate management node deployment](#validate_management_node_deployment)
-      1. [Validation](#validation)
-      1. [Optional validation](#optional-validation)
    1. [Important checkpoint](#important-checkpoint)
    1. [Next topic](#next-topic)
 
@@ -870,15 +868,9 @@ SUCCESS
 
 ## 5. Validate management node deployment
 
-Do all of the validation steps. The optional validation steps are manual steps which could be skipped.
-
-<a name="validation"></a>
-
-### 5.1 Validation
-
 The following `csi pit validate` commands will run a series of remote tests on the other nodes to validate they are healthy and configured correctly.
 
-Observe the output of the checks and note any failures, then remediate them.
+Observe the output of the checks. If there are any failures, remediate them.
 
 1. Check the storage nodes.
 
@@ -896,7 +888,8 @@ Observe the output of the checks and note any failures, then remediate them.
 
    If the test total line reports any failed tests, look through the full output of the test in `csi-pit-validate-ceph.log` to see which node had the failed test and what the details are for that test.
 
-   **Note:** See [Utility Storage](../operations/utility_storage/Utility_Storage.md) in order to help resolve any failed tests.
+   **Note:** See [Utility Storage](../operations/utility_storage/Utility_Storage.md) and [Ceph CSI Troubleshooting](ceph_csi_troubleshooting.md) in order to help resolve any
+   failed tests.
 
 1. Check the master and worker nodes.
 
@@ -925,42 +918,16 @@ Observe the output of the checks and note any failures, then remediate them.
 
    If these total lines report any failed tests, look through the full output of the test to see which node had the failed test and what the details are for that test.
 
-   > **WARNING:** If there are failures for tests with names like `Worker Node CONLIB FS Label`, then manual tests should be run on the node which reported the failure.
-   See [Manual LVM Check Procedure](#manual-lvm-check-procedure). If the manual tests fail, then the problem must be resolved before continuing to the next step. See
-   [LVM Check Failure Recovery](#lvm-check-failure-recovery).
-
-1. Ensure that `weave` has not become split-brained.
-
-   To ensure that `weave` is operating as a single cluster, run the following command on the PIT node to check each member of the Kubernetes cluster:
-
-   ```ShellSession
-   ncn# pdsh -b -S -w "$(grep -oP 'ncn-[mw][0-9]{3}' /etc/dnsmasq.d/statics.conf | grep -v '^ncn-m001$' | sort -u |  tr -t '\n' ',')" \
-           'weave --local status connections | grep -i failed || true'
-   ```
-
-   If the check is successful, there will be no output. If messages like `IP allocation was seeded by different peers` are seen, then `weave` appears to be split-brained.
-   At this point, it is necessary to wipe the NCNs and start the PXE boot again:
-
-   1. Wipe the NCNs using the 'Basic Wipe' section of [Wipe NCN Disks for Reinstallation](wipe_ncn_disks_for_reinstallation.md).
-   1. Return to the 'Boot the **Storage Nodes**' step of [Deploy Management Nodes](#deploy_management_nodes) section above.
-
-<a name="optional-validation"></a>
-
-### 5.2 Optional validation
-
-   1. Verify that all the pods in the `kube-system` namespace are `Running` or `Completed`.
-
-      Run the following command on any Kubernetes master or worker node, or the PIT node:
-
-      ```bash
-      ncn-mw/pit# kubectl get pods -o wide -n kube-system | grep -Ev '(Running|Completed)'
-      ```
-
-      If any pods are listed by this command, it means they are not in the `Running` or `Completed` state. That needs to be investigated before proceeding.
-
-   1. Verify that the `ceph-csi` requirements are in place.
-
-      See [Ceph CSI Troubleshooting](ceph_csi_troubleshooting.md) for details.
+   > **WARNING:** Notes on specific failures:
+   >
+   > - If any of the `FS Label` tests fail (they have names like `Master Node ETCDLVM FS Label` or `Worker Node CONLIB FS Label`),
+   > then run manual tests on the node which reported the failure. See [Manual LVM Check Procedure](#manual-lvm-check-procedure). If the manual tests fail,
+   > then the problem must be resolved before continuing to the next step. See [LVM Check Failure Recovery](#lvm-check-failure-recovery).
+   > - If the `Weave Health` test fails, run `weave --local status connections` on the node where the test failed. If messages similar to
+   > `IP allocation was seeded by different peers` are seen, then `weave` appears to be split-brained. At this point, it is necessary to wipe
+   > the NCNs and start the PXE boot again:
+   >    1. Wipe the NCNs using the 'Basic Wipe' section of [Wipe NCN Disks for Reinstallation](wipe_ncn_disks_for_reinstallation.md).
+   >    1. Return to the 'Boot the **Storage Nodes**' step of [Deploy Management Nodes](#deploy_management_nodes) section above.
 
 <a name="important-checkpoint"></a>
 


### PR DESCRIPTION
## Summary and Scope

Some of the manual checks from the Deploy Management Nodes procedure have been replaced by automated tests. This ticket updates the procedure to omit the manual checks that are no longer needed.

There is a csm-1.2 backport for this, but it does not remove everything that this one does, because some of the test changes were held back from csm-1.2.

## Issues and Related PRs

Backport PR forthcoming.

## Testing

We have been testing the new automated tests for weeks now. In that time we haven't seen anything get caught by the redundant manual checks that was missed by the automated tests.

## Risks and Mitigations

Very low risk -- just removing steps.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
