### PR TITLE
CASMTRIAGE-3342 Ensure fresh installs copy system_config.yaml into place

### DIFF
--- a/install/bootstrap_livecd_remote_iso.md
+++ b/install/bootstrap_livecd_remote_iso.md
@@ -559,6 +559,14 @@ and [Configuration Payload Files](prepare_configuration_payload.md#configuration
       >   {"Source":"x3000door-Motiv","SourceRack":"x3000","SourceLocation":" ","DestinationRack":"x3000","DestinationLocation":"u36","DestinationPort":"j27"}}
       >   ```
 
+   1. Link the generated `system_config.yaml` file into the `prep/` directory. This is needed for `pit-init` to find and resolve the file.
+
+      > **`NOTE`** This step is removed in CSM 1.3, this step is needed only for Fresh Installs where `system_config.yaml` is missing.
+
+      ```bash
+      pit# cd ${PITDATA}/prep && ln ${SYSTEM_NAME}/system_config.yaml
+      ```
+
    1. Continue to the next step to [verify and backup `system_config.yaml`](#verify-csi-versions-match).
 
 <a name="verify-csi-versions-match"></a>

--- a/install/bootstrap_livecd_usb.md
+++ b/install/bootstrap_livecd_usb.md
@@ -442,6 +442,14 @@ information for this system has not yet been prepared.
       >    {"Source":"x3000door-Motiv","SourceRack":"x3000","SourceLocation":" ","DestinationRack":"x3000","DestinationLocation":"u36","DestinationPort":"j27"}}
       >    ```
 
+   1. Link the generated `system_config.yaml` file into the `prep/` directory. This is needed for `pit-init` to find and resolve the file.
+
+      > **`NOTE`** This step is removed in CSM 1.3, this step is needed only for Fresh Installs where `system_config.yaml` is missing.
+
+      ```bash
+      pit# cd ${PITDATA}/prep && ln ${SYSTEM_NAME}/system_config.yaml
+      ```
+
    1. Continue to the next step to [verify and backup `system_config.yaml`](#verify-csi-versions-match).
 
 <a name="verify-csi-versions-match"></a>


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

This adds a block to fresh installs for RemoteISOs and USB Sticks to ensure users make `system_config.yaml` to `pit-init`.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-3342](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3342)
* Change will also be needed in `release/1.2` and `release/1.0`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `redbull`
  * Local development environment

### Test description:

Doc step produced a useable `system_config.yaml` for `pit-init` to find.

```bash
redbull-ncn-m001-pit:/var/www/ephemeral/prep # ll
total 24
-rwxr-xr-x 1 root root 2623 May 11 15:40 hmn_connections.json
-rw-r--r-- 1 root root 1112 May 11 15:40 ncn_metadata.csv
drwxr-xr-x 6 root root 4096 May 11 15:59 redbull
drwx------ 7 root root 4096 May 11 15:40 site-init
-rw-r--r-- 1 root root  104 May 11 15:40 switch_metadata.csv
-rw-r--r-- 1 root root 2766 May 11 15:40 system_config.yaml
redbull-ncn-m001-pit:/var/www/ephemeral/prep # mv system_config.yaml test
redbull-ncn-m001-pit:/var/www/ephemeral/prep # export SYSTEM_NAME=redbull
redbull-ncn-m001-pit:/var/www/ephemeral/prep # ln ${SYSTEM_NAME}/system_config.yaml
redbull-ncn-m001-pit:/var/www/ephemeral/prep # ll
total 28
-rwxr-xr-x 1 root root 2623 May 11 15:40 hmn_connections.json
-rw-r--r-- 1 root root 1112 May 11 15:40 ncn_metadata.csv
drwxr-xr-x 6 root root 4096 May 11 15:59 redbull
drwx------ 7 root root 4096 May 11 15:40 site-init
-rw-r--r-- 1 root root  104 May 11 15:40 switch_metadata.csv
-rw-r--r-- 2 root root 2792 May 11 15:59 system_config.yaml
-rw-r--r-- 1 root root 2766 May 11 15:40 test
```

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

