### PR TITLE
CASMPET-5593 Update spire postgres without backup restore doc

### DIFF
--- a/operations/spire/Restore_Spire_Postgres_without_a_Backup.md
+++ b/operations/spire/Restore_Spire_Postgres_without_a_Backup.md
@@ -18,7 +18,7 @@ event that `spire-postgres` databases cannot be restored from a backup.
    ncn# kubectl get pvc -n spire | grep spire-data-spire-server | awk '{print $1}' | xargs kubectl delete -n spire pvc
    ```
 
-3. Disable spire-agent on all of the Kubernetes NCNs (all worker nodes and
+3. Disable `spire-agent` on all of the Kubernetes NCNs (all worker nodes and
    master nodes) and delete the join data.
 
    ```bash
@@ -37,7 +37,6 @@ event that `spire-postgres` databases cannot be restored from a backup.
 
    ```bash
    ncn# kubectl get cm -n loftsman loftsman-sysmgmt -o jsonpath='{.data.manifest\.yaml}' > spire.yaml
-
    ```
 
 1. Run the following command to remove non-Spire charts from the `spire.yaml`
@@ -84,7 +83,7 @@ event that `spire-postgres` databases cannot be restored from a backup.
 
 1. Validate that the `manifest.yaml` file only contains chart information for
    Spire, and that the sources chart location points to
-   `https://packages.local/repository/charts`
+   `https://packages.local/repository/charts`.
 
 1. Redeploy the Spire chart.
 

--- a/operations/spire/Restore_Spire_Postgres_without_a_Backup.md
+++ b/operations/spire/Restore_Spire_Postgres_without_a_Backup.md
@@ -3,7 +3,7 @@
 Reinstall the Spire helm chart in the
 event that spire-postgres databases cannot be restored from a backup.
 
-### Uninstall Spire
+## Uninstall Spire
 
 1. Uninstall the Spire helm chart.
 
@@ -24,7 +24,7 @@ event that spire-postgres databases cannot be restored from a backup.
    ncn# for ncn in $(kubectl get nodes -o name | cut -d'/' -f2); do ssh "${ncn}" systemctl stop spire-agent; ssh "${ncn}" rm /root/spire/data/svid.key /root/spire/agent_svid.der /root/spire/bundle.der; done
    ```
 
-### Re-install the Spire Helm Chart
+## Re-install the Spire Helm Chart
 
 The CSM release tarball is required as it contains the Spire helm chart.
 

--- a/operations/spire/Restore_Spire_Postgres_without_a_Backup.md
+++ b/operations/spire/Restore_Spire_Postgres_without_a_Backup.md
@@ -1,7 +1,7 @@
 # Restore Spire Postgres without an Existing Backup
 
 Reinstall the Spire helm chart in the
-event that spire-postgres databases cannot be restored from a backup.
+event that `spire-postgres` databases cannot be restored from a backup.
 
 ## Uninstall Spire
 
@@ -12,13 +12,14 @@ event that spire-postgres databases cannot be restored from a backup.
    ```
 
 2. Wait for the pods in the Spire namespace to terminate. Once that is done, remove
-   the spire-data-server pvcs.
+   the spire-data-server `PVCs`.
 
    ```bash
    ncn# kubectl get pvc -n spire | grep spire-data-spire-server | awk '{print $1}' | xargs kubectl delete -n spire pvc
    ```
 
-3. Disable spire-agent on all of the Kubernetes NCNs (all worker nodes and master nodes) and delete the join data.
+3. Disable spire-agent on all of the Kubernetes NCNs (all worker nodes and
+   master nodes) and delete the join data.
 
    ```bash
    ncn# for ncn in $(kubectl get nodes -o name | cut -d'/' -f2); do ssh "${ncn}" systemctl stop spire-agent; ssh "${ncn}" rm /root/spire/data/svid.key /root/spire/agent_svid.der /root/spire/bundle.der; done
@@ -26,40 +27,35 @@ event that spire-postgres databases cannot be restored from a backup.
 
 ## Re-install the Spire Helm Chart
 
-The CSM release tarball is required as it contains the Spire helm chart.
-
-1. Extract the current release tarball.
-
-   ```bash
-   ## This example assumes the csm-1.0.1 release is currently running and the csm-1.0.1.tar.gz has been pulled down under /root
-   ncn# cd /root
-   ncn# tar -xzf csm-1.0.1.tar.gz
-   ncn# rm csm-1.0.1.tar.gz
-   ncn# PATH_TO_RELEASE=/root/csm-1.0.1
-   ```
-
-2. Get the current cached customizations.
+1. Get the current cached customizations.
 
    ```bash
    ncn# kubectl get secrets -n loftsman site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d > customizations.yaml
    ```
 
-3. Get the current cached sysmgmt manifest.
+1. Get the current cached `sysmgmt` manifest.
 
    ```bash
-   ncn# kubectl get cm -n loftsman loftsman-sysmgmt  -o jsonpath='{.data.manifest\.yaml}' > spire.yaml
+   ncn# kubectl get cm -n loftsman loftsman-sysmgmt -o jsonpath='{.data.manifest\.yaml}' > spire.yaml
 
    ```
 
-4. Run the following command to remove non-spire charts from the spire.yaml file. This will also change the metadata.name so that it doesn't overwrite the sysmgmt.yaml file that is stored in the loftsman namespace.
+1. Run the following command to remove non-Spire charts from the `spire.yaml`
+   file. This will also change the `metadata.name` so that it does not overwrite the
+   `sysmgmt.yaml` file that is stored in the `loftsman` namespace.
 
    ```bash
-   for i in $(yq r spire.yaml 'spec.charts[*].name' | grep -Ev '^spire$'); do yq d -i spire.yaml  'spec.charts(name=='"$i"')'; done; yq w -i spire.yaml metadata.name spire
+   ncn# for i in $(yq r spire.yaml 'spec.charts[*].name' | grep -Ev '^spire$'); do yq d -i spire.yaml  'spec.charts(name=='"$i"')'; done
+   ncn# yq w -i spire.yaml metadata.name spire
+   ncn# yq d -i spire.yaml spec.sources
+   ncn# yq w -i spire.yaml spec.sources.charts[0].location 'https://packages.local/repository/charts'
+   ncn# yq w -i spire.yaml spec.sources.charts[0].name csm-algol60
+   ncn# yq w -i spire.yaml spec.sources.charts[0].type repo
    ```
 
-   Example spire.yaml after the command is run:
+   Example `spire.yaml` after the command is run:
 
-   ```text
+   ```yaml
    apiVersion: manifests/v1beta1
      metadata:
        name: spire
@@ -73,38 +69,40 @@ The CSM release tarball is required as it contains the Spire helm chart.
                fqdn: spire.local
              trustDomain: shasta
            version: 0.11.5
+       charts:
+         - location: https://packages.local/repository/charts
+           name: csm-algol60
+           type: repo
    ```
 
-5. Generate the manifest that will be used to redeploy the chart with the modified resources.
+1. Generate the manifest that will be used to redeploy the chart with the
+   modified resources.
 
    ```bash
    ncn# manifestgen -c customizations.yaml -i spire.yaml -o manifest.yaml
    ```
 
-6. Update the helm chart path in the manifest.yaml file.
+1. Validate that the `manifest.yaml` file only contains chart information for
+   Spire, and that the sources chart location points to
+   `https://packages.local/repository/charts`
 
-   ```bash
-   ncn# sed -i "s|./helm|${PATH_TO_RELEASE}/helm|" manifest.yaml
-   ```
-
-7. Validate that the manifest.yaml file only contains chart information for Spire,
-   and that the sources charts location points to the directory the helm chart was extracted from to prepend to /helm.
-
-8. Redeploy the Spire chart.
+1. Redeploy the Spire chart.
 
    ```bash
    ncn# loftsman ship --manifest-path ${PWD}/manifest.yaml
    ```
 
-9. Verify that all Spire pods have started.
+1. Verify that all Spire pods have started.
 
-   This step may take a few minutes due to a number of pods requiring other pods to be up.
+   This step may take a few minutes due to a number of pods requiring other pods
+   to be up.
 
    ```bash
    ncn# kubectl get pods -n spire
    ```
 
-10. Restart all compute nodes and User Access Nodes (UANs).
+1. Restart all compute nodes and User Access Nodes (UANs).
 
-Compute nodes and UANs get their join token on boot from the Boot Script Service (BSS).
-Their old SVID data is no longer valid and a reboot is required in order for them to re-join Spire.
+Compute nodes and UANs get their join token on boot from the Boot Script Service
+(BSS). Their old SVID data is no longer valid and a reboot is required in order
+for them to re-join Spire.


### PR DESCRIPTION
This fixes some issues where spacing would cause the command to try to run rm / if you copy/pasted it. It also replaces the sysmgmt hand-edits with a for loop that will reduce errors and prevent the sysmgmt.yaml that's saved in the loftsman namespace from being overwritten. Commands were tested on Loki.