### PR TITLE
CASMTRIAGE-3336 run csm_ntp.py everytime during upgrade and wait for …

### DIFF
--- a/install/deploy_final_ncn.md
+++ b/install/deploy_final_ncn.md
@@ -12,7 +12,7 @@ procedure entails deactivating the LiveCD, meaning the LiveCD and all of its res
 3. [Hand-off](#hand-off)
 4. [Reboot](#reboot)
 5. [Enable NCN disk wiping safeguard](#enable-ncn-disk-wiping-safeguard)
-6. [Remove the default NTP pool](#remove-the-default-ntp-pool)
+6. [Clean up chrony configurations](#clean-up-chrony-configurations)
 7. [Configure DNS and NTP on each BMC](#configure-dns-and-ntp-on-each-bmc)
 8. [Next topic](#next-topic)
 
@@ -511,12 +511,19 @@ it is used for Cray installation and bootstrap.
 
 <a name="remove-the-default-ntp-pool"></a>
 
-## 6. Remove the default NTP pool
+## 6. Clean up chrony configurations
 
-Run the following command on `ncn-m001` to remove the default pool, which can cause contention issues with NTP.
+Set a token as described in [Identify Nodes and Update Metadata](../operations/node_management/Rebuild_NCNs/Identify_Nodes_and_Update_Metadata.md), then run the following command.
 
-```bash
-ncn-m001# sed -i "s/^! pool pool\.ntp\.org.*//" /etc/chrony.conf
+```ShellSession
+ncn-m001# /srv/cray/scripts/common/chrony/csm_ntp.py
+```
+
+Successful output is:
+
+```text
+Chrony configuration created
+Restarted chronyd
 ```
 
 <a name="configure-dns-and-ntp-on-each-bmc"></a>

--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -34,7 +34,7 @@ the number of storage and worker nodes.
    1. [Configure after management node deployment](#configure_after_management_node_deployment)
       1. [LiveCD cluster authentication](#livecd-cluster-authentication)
       1. [Install tests and test server on NCNs](#install-tests)
-      1. [Remove the default NTP pool](#remove-the-default-ntp-pool)
+      1. [Clean up chrony configurations](#clean-up-chrony-configurations)
    1. [Validate management node deployment](#validate_management_node_deployment)
    1. [Important checkpoint](#important-checkpoint)
    1. [Next topic](#next-topic)
@@ -847,21 +847,24 @@ pit# ${CSM_RELEASE}/lib/install-goss-tests.sh
 pit# popd
 ```
 
-<a name="remove-default-ntp-pool"></a>
+<a name="clean-up-chrony-configurations"></a>
 
-### 4.3 Remove the default NTP pool
+### 4.3 Clean up chrony configurations
 
-Run the following command on the PIT node to remove the default pool, which can cause contention issues with NTP.
+Set a token as described in [Identify Nodes and Update Metadata](../operations/node_management/Rebuild_NCNs/Identify_Nodes_and_Update_Metadata.md) and then run the following command:
 
 ```ShellSession
-pit# pdsh -b -S -w "$(grep -oP 'ncn-\w\d+' /etc/dnsmasq.d/statics.conf | grep -v m001 | sort -u |  tr -t '\n' ',')" \
-        'sed -i "s/^! pool pool\.ntp\.org.*//" /etc/chrony.conf' && echo SUCCESS
+pit# for i in $(grep -oP 'ncn-\w\d+' /etc/dnsmasq.d/statics.conf | sort -u | grep -v ncn-m001); do 
+       ssh $i "TOKEN=$TOKEN /srv/cray/scripts/common/chrony/csm_ntp.py"; done
 ```
 
 Successful output is:
 
 ```text
-SUCCESS
+...
+Chrony configuration created
+Restarted chronyd
+...
 ```
 
 <a name="validate_management_node_deployment"></a>


### PR DESCRIPTION
…clocks to be in sync before proceeding

Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>

## Summary and Scope

Runs `csm_ntp.py` to remove any problematic files and deploy a known-good config.  It fails if either that script returns non-zero or the nodes are not in sync.

## Issues and Related PRs


* Resolves CASMTRIAGE-3336
* Merge with https://github.com/Cray-HPE/csm-testing/pull/312
* Merge with https://github.com/Cray-HPE/docs-csm/pull/1619

## Testing

### Tested on:

  * `<development system>`

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

