### PR TITLE
Ensure command to upload migrated SLS file does not fail silently due to errors

### DIFF
--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -144,7 +144,7 @@ the correct options for the specific environment are used. Two examples are give
 
 ### Upload migrated SLS file to SLS service
 
-If the following command does not complete successfully check the `TOKEN` environment variable is set correctly.
+If the following command does not complete successfully, check if the `TOKEN` environment variable is set correctly.
 
    ```bash
    ncn-m001# curl --fail -H "Authorization: Bearer ${TOKEN}" -k -L -X POST 'https://api-gw-service-nmn.local/apis/sls/v1/loadstate' -F 'sls_dump=@migrated_sls_file.json'

--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -144,8 +144,10 @@ the correct options for the specific environment are used. Two examples are give
 
 ### Upload migrated SLS file to SLS service
 
+If the following command does not complete successfully check the TOKEN variable is set correctly.
+
    ```bash
-   ncn-m001# curl -H "Authorization: Bearer ${TOKEN}" -k -L -X POST 'https://api-gw-service-nmn.local/apis/sls/v1/loadstate' -F 'sls_dump=@migrated_sls_file.json'
+   ncn-m001# curl --fail -H "Authorization: Bearer ${TOKEN}" -k -L -X POST 'https://api-gw-service-nmn.local/apis/sls/v1/loadstate' -F 'sls_dump=@migrated_sls_file.json'
    ```
 
 <a name="update-management-network"></a>

--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -144,7 +144,7 @@ the correct options for the specific environment are used. Two examples are give
 
 ### Upload migrated SLS file to SLS service
 
-If the following command does not complete successfully check the TOKEN variable is set correctly.
+If the following command does not complete successfully check the `TOKEN` environment variable is set correctly.
 
    ```bash
    ncn-m001# curl --fail -H "Authorization: Bearer ${TOKEN}" -k -L -X POST 'https://api-gw-service-nmn.local/apis/sls/v1/loadstate' -F 'sls_dump=@migrated_sls_file.json'


### PR DESCRIPTION
## Summary and Scope

The `curl` command used to upload the migrated data to SLS can fail silently if the `TOKEN` environment variable is not set leading an admin to believe that the upload has been successful when it has not.

This PR introduces the `--fail` option to the `curl` command so that the HTTP return code is printed if the command fails.

## Issues and Related PRs

* Resolves [CASMNET-1546](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1546)

## Testing

### Tested on:

  * `hela`

### Test description:

Verified the desired change in behaviour introduced by the `--fail` option.

```
# curl --fail -H "Authorization: Bearer ${TOKEN}" -k -L -X POST 'https://api-gw-service-nmn.local/apis/sls/v1/loadstate' -F 'sls_dump=@sls_input_file.json'
curl: (22) The requested URL returned error: 503
```

Without this option the same command fails silently
```
ncn-m001:~/cspiller/sls_updater # curl -H "Authorization: Bearer ${TOKEN}" -k -L -X POST 'https://api-gw-service-nmn.local/apis/sls/v1/loadstate' -F 'sls_dump=@sls_input_file.json'
ncn-m001:~/cspiller/sls_updater #
```

## Risks and Mitigations

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

