### PR TITLE
CASMTRIAGE-3353 Detail larger "small" disks.

### DIFF
--- a/background/ncn_mounts_and_file_systems.md
+++ b/background/ncn_mounts_and_file_systems.md
@@ -6,11 +6,10 @@ reference information for these disks, their partition tables, and their managem
 ### Topics:
 
    * [What Controls Partitioning?](#what-controls-partitioning)
-   * [Plan of Record / Baseline](#plan-of-record--baseline)
-       * [Problems When Above/Below Baseline](#problems-when-abovebelow-baseline)
-       * [Worker Nodes with ETCD](#worker-nodes-with-etcd)
-           * [Disable Luks](#disable-luks)
-           * [Expand the RAID](#expand-the-raid)
+   * [Problems When Above/Below Baseline](#problems-when-abovebelow-baseline)
+   * [Worker Nodes with ETCD](#worker-nodes-with-etcd)
+       * [Disable Luks](#disable-luks)
+       * [Expand the RAID](#expand-the-raid)
    * [Disk Layout Quick-Reference Tables](#disk-layout-quick-reference-tables)
    * [OverlayFS and Persistence](#overlayfs-and-persistence)
        * [OverlayFS Example](#overlayfs-example)
@@ -36,21 +35,10 @@ Partitioning is controlled by two aspects:
 - dracut; this selects disks and builds their partition tables and/or LVM storage.
 - cloud-init; this manages standalone partitions or volumes, as well as high-level object storage.
 
-<a name="plan-of-record--baseline"></a>
-### Plan of Record / Baseline
-
-| Node Type | No. of "small" disks (0.5 TiB) | No. of "large" disks (1.9 TiB) |
-| --- |:---:|:---:|
-| k8s-master nodes | 3 | 0
-| k8s-worker nodes | 2 | 1
-| ceph-storage nodes | 2 | 3+
-
-Disks are chosen by dracut. Kubernetes and storage nodes use different dracut modules.
-- First, `two disks` for the OS are chosen from the pool of "small" disks
-- Second, `one disk` is selected for the ephemeral data
-
 <a name="problems-when-abovebelow-baseline"></a>
-#### Problems When Above/Below Baseline
+### Problems When Above/Below Baseline
+
+Plane of Record Baseline is defined in [NCN Plan of Record](./ncn_plan_of_record.md). See that document for help customizing PCIe and Disk differences.
 
 The master nodes and worker nodes use the same artifacts, and thus have the same dracut modules assimilating disks. Therefore, it is important
 to beware of:
@@ -58,13 +46,13 @@ to beware of:
 - ceph-storage nodes do not run the same dracut modules because they have different disk demands
 
 <a name="worker-nodes-with-etcd"></a>
-#### Worker Nodes with ETCD
+### Worker Nodes with ETCD
 
 k8s-worker nodes with 1 or more extra "small" disk(s); these disks are confusing and unnecessary and can be disabled
 easily.
 
 <a name="disable-luks"></a>
-##### Disable Luks
+#### Disable Luks
 
 > **`NOTE`** This is broken, use the [expand RAID](#expand-the-raid) option instead. (MTL-1309)
 

--- a/background/ncn_plan_of_record.md
+++ b/background/ncn_plan_of_record.md
@@ -30,8 +30,8 @@ This document outlines the hardware necessary to meet CSM's Plan of Record (PoR)
 <a name="master-disks"></a>
 #### Master Disks
 
-- _Operating System:_ 2x SSDs of equal size, and less than 500GiB (524288000000 bytes)
-- _ETCD:_ 1x SSD smaller than 500GiB (524288000000 bytes) (This disk will be fully encrypted with LUKS2)
+- _Operating System:_ 2x SSDs of equal size, and less than 1TiB (1048576000000 bytes)
+- _ETCD:_ 1x SSD smaller than 1GiB (1048576000000 bytes) (This disk will be fully encrypted with LUKS2)
 
 <a name="master-nics"></a>
 #### Master NICs
@@ -46,7 +46,7 @@ This document outlines the hardware necessary to meet CSM's Plan of Record (PoR)
 <a name="worker-disks"></a>
 #### Worker Disks
 
-- _Operating System:_ 2x SSDs of equal size, and less than 500GiB (524288000000 bytes)
+- _Operating System:_ 2x SSDs of equal size, and less than 1TiB (1048576000000 bytes)
 - _Ephemeral:_ 1x SSD larger than 1TiB (1048576000000 bytes)
 
 <a name="worker-nics"></a>
@@ -63,7 +63,7 @@ This document outlines the hardware necessary to meet CSM's Plan of Record (PoR)
 <a name="storage-disks"></a>
 #### Storage Disks
 
-- _Operating System:_ 2x SSDs of equal size, and less than 500GiB (524288000000 bytes)
+- _Operating System:_ 2x SSDs of equal size, and less than 1TiB (1048576000000 bytes)
 - _CEPH:_ 8x SSDs of any size
 
 > **`NOTE:`** Any available disk that is not consumed by the operating system will be used for CEPH, but a node needs a minimum of 8 disks for making an ideal CEPH pool for CSM.


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

This allows new plan of record systems with 960GiB drives for OS and LUKs.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

No.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-3353](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3353)
* Merge with/before/after https://github.com/Cray-HPE/dracut-metal-mdsquash/pull/30

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

