### PR TITLE
CASMINST-4648 Ensure no directional quotes exist

### DIFF
--- a/.github/workflows/markdown-lint.yaml
+++ b/.github/workflows/markdown-lint.yaml
@@ -42,3 +42,9 @@ jobs:
     - uses: docker://ghcr.io/igorshubovych/markdownlint-cli:v0.31.1
       with:
         args: "--config .github/config/markdown_style.yaml ${{ steps.changed-files.outputs.all_changed_files }}"
+
+    - name: Check for illegal ASCII
+      id: illegal-ascii
+      run: |
+        ./runLint.sh
+

--- a/runLint.sh
+++ b/runLint.sh
@@ -22,10 +22,17 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-error=0
-printf "=============== Linting \” (https://www.compart.com/en/unicode/U+201D) ... \n"
-grep -n -R \” *.md && echo >&2 'Malformed quotes detected (bad: ” vs. good: ").' && error=1
-[ $error = 1 ] && echo '^FAILED'
+function check_quotes {
+    local error=0
+    printf "=============== Linting \” (https://www.compart.com/en/unicode/U+201C and U+201D) ... \n"
+    grep -n -R \” *.md && echo >&2 'Malformed quotes detected (bad: ” vs. good: ").' && error=1
+    if [ $error = 1 ]; then
+        echo >&2 "Failed: ${FUNCNAME[0]}"
+        return 1
+    else
+        echo "OK: ${FUNCNAME[0]}"
+        return 0
+    fi
+}
+check_quotes
 
-
-printf "+++++++++++++++ ... OK\n" && exit 0


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

Example of a successful run:
```bash
=============== Linting \” (https://www.compart.com/en/unicode/U+201C and U+201D) ...
OK: check_quotes
```

Example of a discovered, directional quote:
```bash
=============== Linting \” (https://www.compart.com/en/unicode/U+201C and U+201D) ...
index.md:2:”
Malformed quotes detected (bad: ” vs. good: ").
Failed: check_quotes
```

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

N/A

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-4648](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4648)
* Change will also be needed in `release/1.2` `release/1.0`

