### PR TITLE
CASMINST-4646 run csm_ntp.py during fresh installs

### DIFF
--- a/install/deploy_final_ncn.md
+++ b/install/deploy_final_ncn.md
@@ -12,7 +12,7 @@ procedure entails deactivating the LiveCD, meaning the LiveCD and all of its res
 3. [Hand-off](#hand-off)
 4. [Reboot](#reboot)
 5. [Enable NCN disk wiping safeguard](#enable-ncn-disk-wiping-safeguard)
-6. [Remove the default NTP pool](#remove-the-default-ntp-pool)
+6. [Clean up chrony configurations](#clean-up-chrony-configurations)
 7. [Configure DNS and NTP on each BMC](#configure-dns-and-ntp-on-each-bmc)
 8. [Next topic](#next-topic)
 
@@ -511,12 +511,35 @@ it is used for Cray installation and bootstrap.
 
 <a name="remove-the-default-ntp-pool"></a>
 
-## 6. Remove the default NTP pool
+## 6. Clean up chrony configurations
 
-Run the following command on `ncn-m001` to remove the default pool, which can cause contention issues with NTP.
+Set a token as described in [Identify Nodes and Update Metadata](../operations/node_management/Rebuild_NCNs/Identify_Nodes_and_Update_Metadata.md), then run the following command.
 
-```bash
-ncn-m001# sed -i "s/^! pool pool\.ntp\.org.*//" /etc/chrony.conf
+```ShellSession
+ncn-m001# /srv/cray/scripts/common/chrony/csm_ntp.py
+```
+
+Successful output can appear as:
+
+If BSS is unreachable, local cache is checked and the configuration is still deployed:
+
+```text
+...
+BSS query failed. Checking local cache...
+Chrony configuration created
+Problematic config found: /etc/chrony.d/cray.conf.dist
+Problematic config found: /etc/chrony.d/pool.conf
+Restarted chronyd
+...
+```
+
+or
+
+```text
+...
+Chrony configuration created
+Restarted chronyd
+...
 ```
 
 <a name="configure-dns-and-ntp-on-each-bmc"></a>

--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -851,7 +851,7 @@ pit# popd
 
 ### 4.3 Clean up chrony configurations
 
-Set a token to any string since BSS is not yet available, which will allow the script to fail over to the local cache.
+Run the following command without editing the value of the `TOKEN` variable.
 
 ```ShellSession
 pit# for i in $(grep -oP 'ncn-\w\d+' /etc/dnsmasq.d/statics.conf | sort -u | grep -v ncn-m001); do 


### PR DESCRIPTION
Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>

## Summary and Scope

Omits the need for getting a `TOKEN` to run `csm_ntp.py`.  Also adjust the successful output so the user can see that it is a success.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMINST-4646
* Introduced in CASMTRIAGE-3336

## Testing

### Tested on:

  * `#redbull`

### Test description:


## Risks and Mitigations

Low


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

