### PR TITLE
CASMINST-4645 run csm_ntp.py from the tarball everytime during upgrad…

### DIFF
--- a/upgrade/1.2/scripts/common/ncn-rebuild-common.sh
+++ b/upgrade/1.2/scripts/common/ncn-rebuild-common.sh
@@ -48,6 +48,36 @@ else
     echo "====> ${state_name} has been completed"
 fi
 
+state_name="ELIMINATE_NTP_CLOCK_SKEW"
+state_recorded=$(is_state_recorded "${state_name}" "${target_ncn}")
+if [[ $state_recorded == "0" && $2 != "--rebuild" ]]; then
+    echo "====> ${state_name} ..."
+    {
+    # ensure the directory exists
+    ssh "${target_ncn}" 'mkdir -p /srv/cray/scripts/common/'
+    # copy the ntp script and template to the node
+    scp -r "${CSM_ARTI_DIR}"/chrony/ "${target_ncn}":/srv/cray/scripts/common/
+    # run the script
+    #shellcheck disable=SC2029
+    if ! ssh "${target_ncn}" "TOKEN=$TOKEN /srv/cray/scripts/common/chrony/csm_ntp.py"; then
+        echo "${target_ncn} csm_ntp failed"
+        exit 1
+    else
+        record_state "${state_name}" "${target_ncn}"
+    fi
+
+    # if the node is not in sync after two minutes, fail
+    if ! ssh "${target_ncn}" 'chronyc waitsync 6 0.5 0.5 20'; then
+        echo "${target_ncn} the clock is not in sync.  Wait a bit more or try again."
+        exit 1
+    else
+        record_state "${state_name}" "${target_ncn}"
+    fi
+    } >> ${LOG_FILE} 2>&1
+else
+    echo "====> ${state_name} has been completed"
+fi
+
 state_name="WIPE_NODE_DISK"
 state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
 if [[ $state_recorded == "0" ]]; then


### PR DESCRIPTION
…e and wait for clocks to be in sync before proceeding

Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>

## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs


* Resolves CASMINST-4645
* Merge with https://github.com/Cray-HPE/csm/pull/836

## Testing

### Tested on:

  * `#surtur`

### Test description:

Tested upgrading a node via the standard procedure.

Checked the logs and validated the output looked good.

```
ncn-m001:~ # /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/ncn-upgrade-ceph-nodes.sh ncn-s001


 ************
 *** NOTE ***
 ************
LOG_FILE is not specified; use default location: /root/output.log

====> CEPH_NODES_SET_NO_WIPE has been completed
====> BACKUP_CEPH_DATA has been completed
====> CSI_VALIDATE_BSS_NTP has been completed
====> ELIMINATE_NTP_CLOCK_SKEW ...
====> WIPE_NODE_DISK has been completed
====> SET_PXE_BOOT has been completed
====> POWER_CYCLE_NCN has been completed
====> WAIT_FOR_NCN_BOOT ...
TIPS:
    operations/conman/ConMan.md has instructions for watching boot/console output of a node
waiting for boot: ncn-s001 ................................^C
ncn-m001:~ # tail -n100 /root/output.log
...
...
...
Problematic config found: /etc/chrony.d/cray.conf.dist
Problematic config found: /etc/chrony.d/pool.conf
Restarted chronyd
====> ELIMINATE_NTP_CLOCK_SKEW has been completed
try: 1, refid: 7F7F0101, correction: 0.000000000, skew: 0.000
try: 2, refid: 0AFC010A, correction: 0.000000830, skew: 3.704
try: 3, refid: 0AFC010A, correction: 0.000027512, skew: 48.181
try: 4, refid: 0AFC010A, correction: 0.001032135, skew: 4.271
try: 5, refid: 0AFC010A, correction: 0.000433775, skew: 0.820
try: 6, refid: 0AFC010A, correction: 0.000354577, skew: 0.355
====> ELIMINATE_NTP_CLOCK_SKEW has been completed
mgmt IP/Host: ncn-s001-mgmt
ncn-m001:~ #
```

Also verified a helpful message appears when the clock did not quiesce quickly enough:

```
Restarted chronyd
====> ELIMINATE_NTP_CLOCK_SKEW has been completed
try: 1, refid: 7F7F0101, correction: 0.000000000, skew: 0.000
try: 2, refid: 0AFC010A, correction: 0.000002571, skew: 10.477
try: 3, refid: 0AFC010A, correction: 0.000000001, skew: 10.092
try: 4, refid: 0AFC010A, correction: 0.000000006, skew: 2.224
try: 5, refid: 0AFC010A, correction: 0.000000005, skew: 1.679
try: 6, refid: 0AFC010A, correction: 0.000000003, skew: 1.580
ncn-s001 the clock is not in sync.  Wait a bit more or try again.
```

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

