### PR TITLE
CASMINST-4649:  Fix sls updater ordering

### DIFF
--- a/upgrade/1.2/scripts/sls/sls_updater_csm_1.2.py
+++ b/upgrade/1.2/scripts/sls/sls_updater_csm_1.2.py
@@ -46,14 +46,14 @@ help = """Upgrade a system SLS file from CSM 1.0 to CSM 1.2.
     1. Migrate switch naming (in order):  leaf to leaf-bmc and agg to leaf.\n
     2. Remove api-gateway entries from HMLB subnets for CSM 1.2 security.\n
     3. Remove kubeapi-vip reservations for all networks except NMN.\n
-    4. Create the new BICAN "toggle" network.\n
-    5. Migrate the existing CAN to CMN.\n
-    7. Create the CHN network.\n
-    7. Convert IPs of the CAN network.\n
-    8. Create MetalLB Pools and ASN entries on CMN and NMN networks.\n
-    9. Update uai_macvlan in NMN dhcp ranges and uai_macvlan VLAN.\n
-   10. Rename uai_macvlan_bridge reservation to uai_nmn_blackhole
-   11. Remove unused user networks (CAN or CHN) if requested [--retain-unused-user-network to keep].\n
+    4. Migrate the existing CAN to CMN.\n
+    5. Create the CHN network.\n
+    6. Convert IPs of the CAN network.\n
+    7. Create MetalLB Pools and ASN entries on CMN and NMN networks.\n
+    8. Update uai_macvlan in NMN dhcp ranges and uai_macvlan VLAN.\n
+    9. Rename uai_macvlan_bridge reservation to uai_nmn_blackhole
+   10. Remove unused user networks (CAN or CHN) if requested [--retain-unused-user-network to keep].\n
+   11. Create the new BICAN "toggle" network.\n
 """
 
 
@@ -263,11 +263,6 @@ def main(
     remove_api_gw_from_hmnlb_reservations(networks)
 
     #
-    # Create BICAN network
-    #   (not order dependent)
-    create_bican_network(networks, default_route_network_name=bican_user_network_name)
-
-    #
     # Clone (existing) CAN network to CMN
     #   (ORDER DEPENDENT!!!)
     #   Use CAN as a template and create the CMN (leaves CAN in-place)
@@ -338,6 +333,11 @@ def main(
             click.secho("Removing unused CAN and CHN (if they exist) as requested", fg="bright_white")
             networks.pop("CAN", None)
             networks.pop("CHN", None)
+
+    #
+    # Create BICAN network
+    #   (not order dependent)
+    create_bican_network(networks, default_route_network_name=bican_user_network_name)
 
     click.secho(
         f"Writing CSM 1.2 upgraded and schema validated SLS file to {sls_output_file.name}",


### PR DESCRIPTION
## Summary and Scope

The fix for CASMINST-4560 to allow running the SLS updater on 1.2->1.2 upgrades had an ordering issue that caused it to skip converting the 1.0 CAN to the 1.2 CAN.   This resulted in incorrect CIDR and VLANID for the CAN network in SLS.

We are using the existence of the BICAN network as an indicator of whether the current configuration is 1.0 or 1.2.   The issue was that we are adding the BICAN network part-way through the process. That caused the rest of the script to think it was a 1.2 config when it was 1.0.   The fix was simply to move the creation of the BICAN network to the last step after it has done all other modifications.

## Issues and Related PRs

* Resolves CASMINST-4649


## Testing

### Tested on:

  * `surtur`

### Test description:

The following tests were performed:

* Ran the fixed sls_updater_csm_1.2.py on the 1.0 SLS data on surtur.   
** Verified that the resulting CAN configuration had the correct CIDR and VLANID (6)
** Uploaded the fixed SLS json file and s001 was then able to boot.
* Ran the pre-CASMINST-4560 sls_updater_csm_1.2.py on the 1.0 SLS data on surtur and compared the resulting migrated_sls_file.json with the one from the fixed sls_updater_csm_1.2.py
** Verified that the migrated_sls_file.json was identical in both cases.
* Ran the fixed sls_updater_csm_1.2.py on the 1.2 SLS data on surtur and compared the resulting migrated_sls_file.json with the one generated using the 1.0 SLS data.
** Verified that there were no errors in a 1.2 -> 1.2 upgrade
** Verified that it resulted in the same SLS output
** This shows that there are no regressions from the CASMINST-4560 fix


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

