### PR TITLE
CASMINST-4609 Move UAS from non-backed-up to backed up etcd

### DIFF
--- a/operations/kubernetes/Backups_for_etcd-operator_Clusters.md
+++ b/operations/kubernetes/Backups_for_etcd-operator_Clusters.md
@@ -11,6 +11,7 @@ The following services are backed up \(daily, one week's worth of backups retain
 - Compute Rolling Upgrade Service \(CRUS\)
 - External DNS
 - Firmware Action Service \(FAS\)
+- User Access Service \(UAS\)
 
 Run the following command on any master node \(`ncn-mXXX`\) or the first worker node \(`ncn-w001`\) to list the backups for a specific project. In the example below, the backups for BSS are listed.
 
@@ -66,7 +67,6 @@ The following projects are not backed up as part of the automated solution:
 - Heartbeat Tracking Daemon \(HBTD\)
 - HMS Notification Fanout Daemon \(HMNFD\)
 - River Endpoint Discovery Service \(REDS\)
-- User Access Service \(UAS\) Manager
 - Content Projection Service \(CPS\)
 
 If these clusters become unhealthy, the process for rediscovering their data should be followed. See [Repopulate Data in etcd Clusters When Rebuilding Them](Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md).


### PR DESCRIPTION
## Summary and Scope

Move the User Access Service (UAS) from the list of services that use etcd and are not automatically backed up to the list of services that use etcd and are automatically backed up, since that is now true as of CSM release 1.2.

Backward compatible change

## Issues and Related PRs

* Resolves [CASMINST-4609](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4609)

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Verified that cray-uas-mgr was in the list of services to be backed up daily with in etcd-backup configuration and verified that I could create a backup of the cray-uas-mgr etcd contents and then restore it using the standard procedures for backup and restore.  Verified that the backed up configuration was restored as expected and the UAS saw the newly restorred configuration correctly.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? If not, why? N/A
- Was upgrade tested? If not, why? N/A
- Was downgrade tested? If not, why? N/A
- Were new tests (or test issues/Jiras) created for this change? N/A

## Risks and Mitigations

There are no known issues or risks with this change.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
