### PR TITLE
CASMINST-4644: Upgrade procedure linting, fixes, and improvements

### DIFF
--- a/.github/config/markdown_style.yaml
+++ b/.github/config/markdown_style.yaml
@@ -149,7 +149,7 @@ MD025:
 # MD026/no-trailing-punctuation - Trailing punctuation in heading
 MD026:
   # Punctuation characters
-  punctuation: ".,;:!。，；：！"
+  punctuation: ".,;:!。，；：！([{}<>^&~=_-$@#/*"
 
 # MD027/no-multiple-space-blockquote - Multiple spaces after blockquote symbol
 MD027: true

--- a/.github/config/markdown_style.yaml
+++ b/.github/config/markdown_style.yaml
@@ -93,7 +93,7 @@ MD013:
   # Number of characters for headings
   heading_line_length: 255
   # Number of characters for code blocks
-  code_block_line_length: 300
+  code_block_line_length: 375
   # Include code blocks
   code_blocks: true
   # Include tables

--- a/.spelling
+++ b/.spelling
@@ -105,6 +105,7 @@ CANU-generated
 CAPMC
 CAs
 Cassini
+catalog
 cataloged
 CDUs
 CECs

--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -632,7 +632,7 @@ This section can be run on any NCN or the PIT node.
    > waiting state trying to set up volume mounts. See the
    > [UAI Troubleshooting](#uas-uai-validate-debug) section for more information.
 
-This procedure must run on a master or worker node (**not the PIT node and not `ncn-w001`**) on the system.
+This procedure must run on a master or worker node (**not the PIT node**).
 
 1. Verify that a UAI can be created:
 

--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -14,38 +14,38 @@ The areas should be tested in the order they are listed on this page. Errors in 
 
 ## Topics
 
-- [0. Cray Command Line Interface](#0-cray-command-line-interface)
-- [1. Platform Health Checks](#1-platform-health-checks)
-  - [1.1 NCN Health Checks](#11-ncn-health-checks)
-    - [1.1.1 Known Test Issues](#111-known-test-issues)
-  - [1.2 NCN Resource Checks (optional)](#12-ncn-resource-checks-optional)
-    - [1.2.1 Known Issues](#121-known-issues)
-  - [1.3 Check of System Management Monitoring Tools](#13-check-of-system-management-monitoring-tools)
-- [2. Hardware Management Services Health Checks](#2-hardware-management-services-health-checks)
-  - [2.1 HMS CT Test Execution](#21-hms-ct-test-execution)
-  - [2.2 Hardware State Manager Discovery Validation](#22-hardware-state-manager-discovery-validation)
+- [0. Cray command line interface](#0-cray-command-line-interface)
+- [1. Platform health checks](#1-platform-health-checks)
+  - [1.1 NCN health checks](#11-ncn-health-checks)
+    - [1.1.1 known test issues](#111-known-test-issues)
+  - [1.2 NCN resource checks (optional)](#12-ncn-resource-checks-optional)
+    - [1.2.1 Known issues](#121-known-issues)
+  - [1.3 Check of system management monitoring tools](#13-check-of-system-management-monitoring-tools)
+- [2. Hardware Management Services health checks](#2-hardware-management-services-health-checks)
+  - [2.1 HMS CT test execution](#21-hms-ct-test-execution)
+  - [2.2 Hardware State Manager discovery validation](#22-hardware-state-manager-discovery-validation)
     - [2.2.1 Interpreting results](#221-interpreting-results)
-    - [2.2.2 Known Issues](#222-known-issues)
-- [3. Software Management Services Health Checks](#3-software-management-services-health-checks)
-  - [3.1 SMS Test Execution](#31-sms-test-execution)
-  - [3.2 Interpreting `cmsdev` Results](#32-interpreting-cmsdev-results)
-- [4. NCN Gateway Health Checks](#4-ncn-gateway-health-checks)
-  - [4.1 Gateway Test Execution](#41-gateway-test-execution)
-- [5. Booting CSM Barebones Image](#5-booting-csm-barebones-image)
-  - [5.1 Run the Test Script](#51-run-the-test-script)
-- [6. UAS / UAI Tests](#6-uas--uai-tests)
-  - [6.1 Validate the Basic UAS Installation](#61-validate-the-basic-uas-installation)
-  - [6.2 Validate UAI Creation](#62-validate-uai-creation)
-  - [6.3 Test UAI Gateway Health](#63-test-uai-gateway-health)
-  - [6.4 UAS/UAI Troubleshooting](#64-uasuai-troubleshooting)
-    - [6.4.1 Authorization Issues](#641-authorization-issues)
-    - [6.4.2 UAS Cannot Access Keycloak](#642-uas-cannot-access-keycloak)
-    - [6.4.3 UAI Images not in Registry](#643-uai-images-not-in-registry)
-    - [6.4.4 Missing Volumes and other Container Startup Issues](#644-missing-volumes-and-other-container-startup-issues)
+    - [2.2.2 Known issues](#222-known-issues)
+- [3. Software Management Services health checks](#3-software-management-services-health-checks)
+  - [3.1 SMS test execution](#31-sms-test-execution)
+  - [3.2 Interpreting `cmsdev` results](#32-interpreting-cmsdev-results)
+- [4. NCN gateway health checks](#4-ncn-gateway-health-checks)
+  - [4.1 Gateway test execution](#41-gateway-test-execution)
+- [5. Booting CSM `barebones` image](#5-booting-csm-barebones-image)
+  - [5.1 Run the test script](#51-run-the-test-script)
+- [6. UAS / UAI tests](#6-uas--uai-tests)
+  - [6.1 Validate the basic UAS installation](#61-validate-the-basic-uas-installation)
+  - [6.2 Validate UAI creation](#62-validate-uai-creation)
+  - [6.3 Test UAI gateway health](#63-test-uai-gateway-health)
+  - [6.4 UAS/UAI troubleshooting](#64-uasuai-troubleshooting)
+    - [6.4.1 Authorization issues](#641-authorization-issues)
+    - [6.4.2 UAS cannot access Keycloak](#642-uas-cannot-access-keycloak)
+    - [6.4.3 UAI images not in registry](#643-uai-images-not-in-registry)
+    - [6.4.4 Missing volumes and other container startup issues](#644-missing-volumes-and-other-container-startup-issues)
 
 <a name="cray-command-line-interface"></a>
 
-## 0. Cray Command Line Interface
+## 0. Cray command line interface
 
 The first time these checks are performed during a CSM install, the Cray Command Line Interface (CLI) has not yet been configured.
 Some of the health check tests cannot be run without the Cray CLI being configured. Tests with this dependency are noted in their
@@ -58,7 +58,7 @@ The Cray CLI must be configured on all NCNs and the PIT node. The following proc
 
 <a name="platform-health-checks"></a>
 
-## 1. Platform Health Checks
+## 1. Platform health checks
 
 All platform health checks are expected to pass. Each check has been implemented as a [Goss](https://github.com/aelsabbahy/goss) test which reports a PASS or FAIL.
 
@@ -70,7 +70,7 @@ Available Platform Health Checks:
 
 <a name="pet-ncnhealthchecks"></a>
 
-### 1.1 NCN Health Checks
+### 1.1 NCN health checks
 
 These checks require that the [Cray CLI is configured](#cray-command-line-interface) on all worker NCNs.
 
@@ -78,7 +78,9 @@ If `ncn-m001` is the PIT node, run these checks on `ncn-m001`, otherwise run the
 
 There are multiple Goss test suites available that cover a variety of subsystems. The platform health checks are defined in the test suites `ncn-healthcheck` and `ncn-kubernetes-checks`.
 
-1. Specify the admin user password for the management switches in the system, which is required for the `ncn-healthcheck` test.
+1. Specify the `admin` user password for the management switches in the system.
+
+    This is required for the `ncn-healthcheck` test.
 
     ```bash
     ncn/pit# export SW_ADMIN_PASSWORD='changeme'
@@ -102,7 +104,7 @@ There are multiple Goss test suites available that cover a variety of subsystems
 
 <a name="autogoss-issues"></a>
 
-#### 1.1.1 Known Test Issues
+#### 1.1.1 Known test issues
 
 - It is possible that the first pass of running these tests may fail due to `cloud-init` not being completed on the storage nodes.
   In this case, please wait five minutes and re-run the tests.
@@ -178,7 +180,7 @@ There are multiple Goss test suites available that cover a variety of subsystems
 
 <a name="pet-optional-ncnhealthchecks-resources"></a>
 
-### 1.2 NCN Resource Checks (optional)
+### 1.2 NCN resource checks (optional)
 
 To dump the NCN uptimes, the node resource consumptions, and/or the list of pods not in a running state, run the following:
 
@@ -190,7 +192,7 @@ ncn/pit# /opt/cray/platform-utils/ncnHealthChecks.sh -s pods_not_running
 
 <a name="known-issues"></a>
 
-#### 1.2.1 Known Issues
+#### 1.2.1 Known issues
 
 - `pods_not_running`
   - If the output of `pods_not_running` indicates that there are pods in the `Evicted` state, it may be due to the root file system
@@ -221,12 +223,14 @@ If in doubt, validate the CRUS service using the [CMS Validation Tool](#sms-heal
 
 <a name="check-of-system-management-monitoring-tools"></a>
 
-### 1.3 Check of System Management Monitoring Tools
+### 1.3 Check of system management monitoring tools
 
-If all designated prerequisites are met, the availability of system management health services may optionally be validated by accessing the URLs listed in [Access System Management Health Services](system_management_health/Access_System_Management_Health_Services.md).
+If all designated prerequisites are met, the availability of system management health services may optionally be validated by accessing the URLs listed in
+[Access System Management Health Services](system_management_health/Access_System_Management_Health_Services.md).
 It is very important to check the `Prerequisites` section of this document.
 
-If one or more of the the URLs listed in the procedure are inaccessible, it does not necessarily mean that system is not healthy. It may simply mean that not all of the prerequisites have been met to allow access to the system management health tools via URL.
+If one or more of the the URLs listed in the procedure are inaccessible, it does not necessarily mean that system is not healthy. It may simply mean that not all of the
+prerequisites have been met to allow access to the system management health tools via URL.
 
 Information to assist with troubleshooting some of the components mentioned in the prerequisites can be accessed here:
 
@@ -239,7 +243,7 @@ Information to assist with troubleshooting some of the components mentioned in t
 
 <a name="hms-health-checks"></a>
 
-## 2. Hardware Management Services Health Checks
+## 2. Hardware Management Services health checks
 
 The checks in this section require that the [Cray CLI is configured](#cray-command-line-interface) on nodes where the checks are executed.
 
@@ -249,7 +253,7 @@ Note: Do not run HMS tests concurrently on multiple nodes. They may interfere wi
 
 <a name="hms-test-execution"></a>
 
-### 2.1 HMS CT Test Execution
+### 2.1 HMS CT test execution
 
 These tests may be executed on any one worker or master NCN (but **not** `ncn-m001` if it is still the PIT node).
 
@@ -266,7 +270,7 @@ each failure. See the [Interpreting HMS Health Check Results](../troubleshooting
 
 <a name="hms-smd-discovery-validation"></a>
 
-### 2.2 Hardware State Manager Discovery Validation
+### 2.2 Hardware State Manager discovery validation
 
 By this point in the installation process, the Hardware State Manager (HSM) should
 have done its discovery of the system.
@@ -282,7 +286,7 @@ ncn# /opt/cray/csm/scripts/hms_verification/verify_hsm_discovery.py
 ```
 
 The output will ideally appear as follows, if there are mismatches these will be displayed in the appropriate section of
-the output. Refer to [2.3.1 Interpreting results](#hms-smd-discovery-validation-interpreting-results) and
+the output. Refer to [2.2.1 Interpreting results](#hms-smd-discovery-validation-interpreting-results) and
 [2.2.2 Known Issues](#hms-smd-discovery-validation-known-issues) below to troubleshoot any mismatched BMCs.
 
 ```text
@@ -315,7 +319,6 @@ x1000 (Mountain)
   Nodes: PASS
   NodeBMCs: PASS
   RouterBMCs: PASS
-
 ```
 
 The script will have an exit code of 0 if there are no failures. If there is
@@ -352,36 +355,31 @@ Redfish Endpoints use the following notes to determine whether the issue with th
 BMC can be safely ignored or needs to be addressed before proceeding.
 
 - The node BMC of `ncn-m001` will not typically be present in HSM component data, as it is typically connected to the site network instead of the HMN network.
-
-- The node BMCs for HPE Apollo XL645D nodes may report as a mismatch depending on the state of the system when the `hsm_discovery_verify.sh` script is run. If the system is currently going through the
+- The node BMCs for HPE Apollo XL645D nodes may report as a mismatch depending on the state of the system when the `verify_hsm_discovery.py` script is run. If the system is currently going through the
   process of installation, then this is an expected mismatch as the [Prepare Compute Nodes](../install/prepare_compute_nodes.md) procedure required to configure the BMC of the HPE Apollo 6500 XL645D node
   may not have been completed yet.
    > For more information refer to [Configure HPE Apollo 6500 XL645D Gen10 Plus Compute Nodes](../install/prepare_compute_nodes.md#configure-hpe-apollo-6500-x645d-gen10-plus-compute-nodes) for additional required configuration for this type of BMC.
 
    Example mismatch for the BMC of an HPE Apollo XL654D:
 
-   ```bash
-   ...
+   ```text
      Nodes: FAIL
        - x3000c0s30b1n0 (Compute, NID 5) - Not found in HSM Components.
      NodeBMCs: FAIL
        - x3000c0s19b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
-   ...
    ```
 
 - Chassis Management Controllers (CMC) may show up as not being present in HSM. CMCs for Intel node blades can be ignored. Gigabyte node blade CMCs not found in HSM is not normal and should be investigated.
   If a Gigabyte CMC is expected to not be connected to the HMN network, then it can be ignored. Otherwise, verify that the root service account is configured for the CMC and add it if needed by following
-  the steps outlined in [Add Root Service Account for Gigabyte Controllers](./security_and_authentication/Add_Root_Service_Account_for_Gigabyte_Controllers.md).
+  the steps outlined in [Add Root Service Account for Gigabyte Controllers](security_and_authentication/Add_Root_Service_Account_for_Gigabyte_Controllers.md).
    > CMCs have component names (xnames) in the form of `xXc0sSb999`, where `X` is the cabinet and `S` is the rack U of the compute node chassis.
 
    Example mismatch for a CMC an Intel node blade:
 
-```bash
-...
-  ChassisBMCs/CMCs: FAIL
-    - x3000c0s10b999 - Not found in HSM Components; Not found in HSM Redfish Endpoints; No mgmt port connection.
-...
-```
+   ```text
+     ChassisBMCs/CMCs: FAIL
+       - x3000c0s10b999 - Not found in HSM Components; Not found in HSM Redfish Endpoints; No mgmt port connection.
+   ```
 
 - HPE PDUs are supported and should show up as being found in HSM. If they are not, they should be investigated since that may indicate that configuration steps have not yet been executed which are
   required for the PDUs to be discovered. Refer to [HPE PDU Admin Procedures](hpe_pdu/hpe_pdu_admin_procedures.md) for additional configuration for this type of PDU. The steps to run will depend on
@@ -390,23 +388,20 @@ BMC can be safely ignored or needs to be addressed before proceeding.
 
    Example mismatch for HPE PDU:
 
-```bash
-...
-  CabinetPDUControllers: WARNING
-    - x3000m0 - Not found in HSM Components ; Not found in HSM Redfish Endpoints
-...
-```
+   ```text
+     CabinetPDUControllers: WARNING
+       - x3000m0 - Not found in HSM Components ; Not found in HSM Redfish Endpoints
+   ```
 
 - BMCs having no association with a management switch port will be annotated as such, and should be investigated. Exceptions to this are in Mountain or Hill configurations where Mountain BMCs will show this condition on SLS/HSM mismatches, which is normal.
-
 - In Hill configurations SLS assumes BMCs in chassis 1 and 3 are fully populated (32 Node BMCs), and in Mountain configurations SLS assumes all BMCs are fully populated (128 Node BMCs). Any non-populated
   BMCs will have no HSM data and will show up in the mismatch list.
 
-If it was determined that the mismatch can not be ignored, then proceed onto the the [2.3.2 Known Issues](#hms-smd-discovery-validation-known-issues) below to troubleshoot any mismatched BMCs.
+If it was determined that the mismatch can not be ignored, then proceed onto the the [2.2.2 Known Issues](#hms-smd-discovery-validation-known-issues) below to troubleshoot any mismatched BMCs.
 
 <a name="hms-smd-discovery-validation-known-issues"></a>
 
-#### 2.2.2 Known Issues
+#### 2.2.2 Known issues
 
 Known issues that may prevent hardware from getting discovered by Hardware State Manager:
 
@@ -414,7 +409,7 @@ Known issues that may prevent hardware from getting discovered by Hardware State
 
 <a name="sms-health-checks"></a>
 
-## 3 Software Management Services Health Checks
+## 3 Software Management Services health checks
 
 The Software Management Services health checks are run using `/usr/local/bin/cmsdev`.
 
@@ -427,7 +422,7 @@ The Software Management Services health checks are run using `/usr/local/bin/cms
 
 <a name="sms-checks"></a>
 
-### 3.1 SMS Test Execution
+### 3.1 SMS Test execution
 
 The test in this section requires that the [Cray CLI is configured](#cray-command-line-interface) on nodes where the test is executed.
 
@@ -439,39 +434,20 @@ ncn# /usr/local/bin/cmsdev test -q all
 
 <a name="cmsdev-results"></a>
 
-### 3.2 Interpreting `cmsdev` Results
+### 3.2 Interpreting `cmsdev` results
 
-If all checks passed:
-
-- The return code will be 0
-- The final line of output will begin with `SUCCESS`
-- For example:
-
-  ```bash
-  ncn# /usr/local/bin/cmsdev test -q all
-  ...
-  SUCCESS: All 7 service tests passed: bos, cfs, conman, crus, ims, tftp, vcs
-  ncn# echo $?
-  0
-  ```
-
-If one or more checks failed:
-
-- The return code will be non-zero
-- The final line of output will begin with `FAILURE` and will list which checks failed
-- For example:
-
-  ```bash
-  ncn# /usr/local/bin/cmsdev test -q all
-  ...
-  FAILURE: 2 service tests FAILED (conman, ims), 5 passed (bos, cfs, crus, tftp, vcs)
-  ncn# echo $?
-  1
-  ```
+- If all checks passed, then the following will be true:
+  - The return code will be zero.
+  - The final line of output will begin with `SUCCESS`.
+    - For example: `SUCCESS: All 7 service tests passed: bos, cfs, conman, crus, ims, tftp, vcs`
+- If one or more checks failed, then the following will be true:
+  - The return code will be non-zero.
+  - The final line of output will begin with `FAILURE` and will list which checks failed.
+    - For example: `FAILURE: 2 service tests FAILED (conman, ims), 5 passed (bos, cfs, crus, tftp, vcs)`
 
 Additional test execution details can be found in `/opt/cray/tests/cmsdev.log`.
 
-### 3.3 Known Issues
+### 3.3 Known issues
 
 If an Etcd restore has been performed on one of the `SMS` services (such as `BOS` or `CRUS`), the first Etcd pod that
 comes up after the restore will not have a `PVC` (Persistent Volume Claim) attached to it (until the pod is restarted).
@@ -484,17 +460,19 @@ ERROR (run tag 1khv7-crus): persistentvolumeclaims "cray-crus-etcd-ffmszl7bvh" n
 
 In this case, these errors can be ignored, or the pod with the same name as the `PVC` mentioned in the output can be restarted (as long as the other two Etcd pods are healthy).
 
-## 4. NCN Gateway Health Checks
+## 4. NCN gateway health checks
 
-The gateway tests check the health of the API Gateway on all of the relevant networks.   On NCNs, the API gateway is accessible
+The gateway tests check the health of the API Gateway on all of the relevant networks. On NCNs, the API gateway is accessible
 on the NMNLB network, the CMN network, and either the CAN or CHN user network depending on the configuration of the system.
-The gateway tests will check that the gateway is accessible on all networks it should be accessible and NOT accessible on all
-networks it should NOT be accessible.  It will also check several service endpoints to verify that they return the proper response
+The gateway tests will check that the gateway is accessible on all networks where it should be accessible, and NOT accessible on all
+networks where it should NOT be accessible. It will also check several service endpoints to verify that they return the proper response
 on each accessible network.
 
-### 4.1 Gateway Test Execution
+### 4.1 Gateway test execution
 
-The gateway tests are executed on `ncn-m001` (or any NCN with the `docs-csm` RPM installed) by running the following command.
+The gateway tests may be run on any NCN with the `docs-csm` RPM installed. For details on installing the `docs-csm` RPM, see [Check for Latest Documentation](../update_product_stream/index.md#documentation).
+
+Execute the tests by by running the following command.
 
 ```bash
 ncn# /usr/share/doc/csm/scripts/operations/gateway-test/ncn-gateway-test.sh
@@ -510,17 +488,13 @@ For more detailed information on the tests results and examples, see [Gateway Te
 
 <a name="booting-csm-barebones-image"></a>
 
-## 5. Booting CSM Barebones Image
+## 5. Booting CSM `barebones` image
 
 Included with the Cray System Management (CSM) release is a pre-built node image that can be used
 to validate that core CSM services are available and responding as expected. The CSM Barebones
 image contains only the minimal set of RPMs and configuration required to boot an image and is not
 suitable for production usage. To run production work loads, it is suggested that an image from
 the Cray OS (COS) product, or similar, be used.
-
----
-
-### NOTES
 
 - This test is **very important to run** during the CSM install prior to redeploying the PIT node
 because it validates all of the services required for that operation.
@@ -542,15 +516,11 @@ configured to allow an access token to be generated by the script.
 - For additional information on the script and for troubleshooting help look at the document
   [Barebones Image Boot](../troubleshooting/cms_barebones_image_boot.md).
 
----
-
-1. [Running the script](#csm-run-script)
-
 <a name="csm-run-script"></a>
 
-### 5.1 Run the Test Script
+### 5.1 Run the test script
 
-The script is executable and can be run without any arguments. It returns 0 on success and
+The script is executable and can be run without any arguments. It returns zero on success and
 non-zero on failure.
 
 ```bash
@@ -578,12 +548,13 @@ ncn# /opt/cray/tests/integration/csm/barebonesImageTest --xname x3000c0s10b4n0
 
 <a name="uas-uai-tests"></a>
 
-## 6. UAS / UAI Tests
+## 6. UAS / UAI tests
 
 The commands in this section require that the [Cray CLI is configured](#cray-command-line-interface) on nodes where the commands are being executed.
 
-The procedures below use the CLI as an authorized user and run on two separate node types. The first part runs on the LiveCD node, while the second part runs on a non-LiveCD Kubernetes master or worker node.
-When using the CLI on either node, the CLI configuration needs to be initialized and the user running the procedure needs to be authorized.
+The procedures below use the CLI as an authorized user and run on two separate node types. The first part runs on the LiveCD node, while the second part runs on a non-LiveCD
+Kubernetes master or worker node.
+In either case, the CLI configuration needs to be initialized on the node and the user running the procedure needs to be authorized.
 
 The following procedures run on separate nodes of the system.
 
@@ -598,38 +569,40 @@ The following procedures run on separate nodes of the system.
 
 <a name="uas-uai-validate-install"></a>
 
-### 6.1 Validate the Basic UAS Installation
+### 6.1 Validate the basic UAS installation
 
 This section can be run on any NCN or the PIT node.
 
-1. Basic UAS installation is validated using the following:
-   1.
+1. Show information about `cray-uas-mgr`.
 
-      ```bash
-      ncn# cray uas mgr-info list
-      ```
+    ```bash
+    ncn# cray uas mgr-info list
+    ```
 
-      Expected output looks similar to the following:
+    Expected output looks similar to the following:
 
-      ```text
-      service_name = "cray-uas-mgr"
-      version = "1.11.5"
-      ```
+    ```toml
+    service_name = "cray-uas-mgr"
+    version = "1.11.5"
+    ```
 
-      In this example output, it shows that UAS is installed and running the `1.11.5` version.
-   1.
+    In this example output, it shows that UAS is installed and running the `1.11.5` version.
 
-      ```bash
-      ncn# cray uas list
-      ```
+1. List UAIs on the system.
 
-      Expected output looks similar to the following:
+    ```bash
+    ncn# cray uas list
+    ```
 
-      ```text
-      results = []
-      ```
+    Expected output looks similar to the following:
 
-     This example output shows that there are no currently running UAIs. It is possible, if someone else has been using the UAS, that there could be UAIs in the list. That is acceptable too from a validation standpoint.
+    ```toml
+    results = []
+    ```
+
+    This example output shows that there are no currently running UAIs. It is possible, if someone else has been using the UAS, that there could be UAIs
+    in the list. That is acceptable too from a validation standpoint.
+
 1. Verify that the pre-made UAI images are registered with UAS
 
    ```bash
@@ -638,7 +611,7 @@ This section can be run on any NCN or the PIT node.
 
    Expected output looks similar to the following:
 
-   ```text
+   ```toml
    default_image = "artifactory.algol60.net/csm-docker/stable/cray-uai-sles15sp3:1.6.0"
    image_list = [ "artifactory.algol60.net/csm-docker/stable/cray-uai-sles15sp3:1.6.0", "artifactory.algol60.net/csm-docker/stable/cray-uai-gateway-test:1.6.0", "artifactory.algol60.net/csm-docker/stable/cray-uai-broker:1.6.0",]
    ```
@@ -649,14 +622,14 @@ This section can be run on any NCN or the PIT node.
 
 <a name="uas-uai-validate-create"></a>
 
-### 6.2 Validate UAI Creation
+### 6.2 Validate UAI creation
 
-   > **`IMPORTANT:`** If you are upgrading CSM and your site does not use UAIs, skip UAS and UAI validation.
-   > If you do use UAIs, there are products that configure UAS like Cray Analytics and Cray Programming
-   > Environment. These must be working correctly with UAIs and should be validated and corrected (the
-   > procedures for this are beyond the scope of this document) prior to validating UAS and UAI. Failures
-   > in UAI creation that result from incorrect or incomplete installation of these products will generally
-   > take the form of UAIs stuck in 'waiting' state trying to set up volume mounts. See the
+   > **IMPORTANT:** If the site does not use UAIs, skip UAS and UAI validation. If UAIs are used, there are
+   > products that configure UAS like Cray Analytics and Cray Programming Environment that
+   > must be working correctly with UAIs, and should be validated (the procedures for this are
+   > beyond the scope of this document) prior to validating UAS and UAI. Failures in UAI creation that result
+   > from incorrect or incomplete installation of these products will generally take the form of UAIs stuck in
+   > waiting state trying to set up volume mounts. See the
    > [UAI Troubleshooting](#uas-uai-validate-debug) section for more information.
 
 This procedure must run on a master or worker node (**not the PIT node and not `ncn-w001`**) on the system.
@@ -669,7 +642,7 @@ This procedure must run on a master or worker node (**not the PIT node and not `
 
    Expected output looks similar to the following:
 
-   ```text
+   ```toml
    uai_connect_string = "ssh vers@10.16.234.10"
    uai_host = "ncn-w001"
    uai_img = "registry.local/cray/cray-uai-sles15sp3:1.0.11"
@@ -682,7 +655,8 @@ This procedure must run on a master or worker node (**not the PIT node and not `
    [uai_portmap]
    ```
 
-   This has created the UAI and the UAI is currently in the process of initializing and running.
+   This has created the UAI and the UAI is currently in the process of initializing and running. The `uai_status` in
+   the output from this command may instead be `Waiting`, which is also acceptable.
 
 1. Set `UAINAME` to the value of the `uai_name` field in the previous command output (`uai-vers-a00fb46b` in our example):
 
@@ -698,7 +672,7 @@ This procedure must run on a master or worker node (**not the PIT node and not `
 
    Expected output looks similar to the following:
 
-   ```text
+   ```toml
    [[results]]
    uai_age = "0m"
    uai_connect_string = "ssh vers@10.16.234.10"
@@ -712,6 +686,7 @@ This procedure must run on a master or worker node (**not the PIT node and not `
    ```
 
    If the `uai_status` field is `Running: Ready`, proceed to the next step. Otherwise, wait and repeat this command until that is the case. It normally should not take more than a minute or two.
+
 1. The UAI is ready for use. Log into it with the command in the `uai_connect_string` field in the previous command output:
 
    ```bash
@@ -754,21 +729,23 @@ This procedure must run on a master or worker node (**not the PIT node and not `
 
    Expected output looks similar to the following:
 
-   ```text
+   ```toml
    results = [ "Successfully deleted uai-vers-a00fb46b",]
    ```
 
 If the commands ran with similar results, then the basic functionality of the UAS and UAI is working.
 
-### 6.3 Test UAI Gateway Health
+### 6.3 Test UAI gateway health
 
 Like the NCN gateway health check, the gateway tests check the health of the API Gateway on all of the relevant networks.
 On UAIs, the API gateway should only be accessible on the user network (either CAN or CHN depending on the configuration of the system).
-The gateway tests will check that the gateway is accessible on all networks it should be accessible and NOT accessible on all
-networks it should NOT be accessible.  It will also check several service endpoints to verify that they return the proper response
+The gateway tests will check that the gateway is accessible on all networks where it should be accessible, and NOT accessible on all
+networks where it should NOT be accessible. It will also check several service endpoints to verify that they return the proper response
 on each accessible network.
 
-#### 6.3.1 Gateway Test Execution
+#### 6.3.1 Gateway test execution
+
+The UAI gateway tests may be run on any NCN with the `docs-csm` RPM installed. For details on installing the `docs-csm` RPM, see [Check for Latest Documentation](../update_product_stream/index.md#documentation).
 
 The UAI gateway tests are executed by running the following command.
 
@@ -787,13 +764,13 @@ For more detailed information on the tests results and examples, see [Gateway Te
 
 <a name="uas-uai-validate-debug"></a>
 
-### 6.4 UAS/UAI Troubleshooting
+### 6.4 UAS/UAI troubleshooting
 
 The following subsections include common failure modes seen with UAS / UAI operations and how to resolve them.
 
 <a name="uas-uai-validate-debug-auth"></a>
 
-#### 6.4.1 Authorization Issues
+#### 6.4.1 Authorization issues
 
 An error will be returned when running CLI commands if the user is not logged in as a valid Keycloak user or is accidentally using the `CRAY_CREDENTIALS` environment variable. This variable is set regardless of the user credentials being used.
 
@@ -816,7 +793,7 @@ Fix this by logging in as a real user (someone with actual Linux credentials) an
 
 <a name="uas-uai-validate-debug-keycloak"></a>
 
-#### 6.4.2 UAS Cannot Access Keycloak
+#### 6.4.2 UAS cannot access Keycloak
 
 When running CLI commands, a Keycloak error may be returned.
 
@@ -853,13 +830,13 @@ The following shows an example of looking at UAS logs effectively (this example 
    cray-uas-mgr-6bbd584ccb-zg8vx                                    2/2     Running            0          12d
    ```
 
-2. Set `PODNAME` to the name of the manager pod whose logs are going to be viewed.
+1. Set `PODNAME` to the name of the manager pod whose logs are going to be viewed.
 
    ```bash
    ncn# export PODNAME=cray-uas-mgr-6bbd584ccb-zg8vx
    ```
 
-3. View the last 25 log entries of the `cray-uas-mgr` container in that pod, excluding `GET` events:
+1. View the last 25 log entries of the `cray-uas-mgr` container in that pod, excluding `GET` events:
 
    ```bash
    ncn# kubectl logs -n services $PODNAME cray-uas-mgr | grep -v 'GET ' | tail -25
@@ -897,7 +874,7 @@ The following shows an example of looking at UAS logs effectively (this example 
 
 <a name="uas-uai-validate-debug-registry"></a>
 
-#### 6.4.3 UAI Images not in Registry
+#### 6.4.3 UAI images not in registry
 
 When listing or describing a UAI, an error in the `uai_msg` field may be returned. For example:
 
@@ -907,7 +884,7 @@ ncn# cray uas list
 
 There may be something similar to the following output:
 
-```text
+```toml
 [[results]]
 uai_age = "0m"
 uai_connect_string = "ssh vers@10.103.13.172"
@@ -920,11 +897,12 @@ uai_status = "Waiting"
 username = "vers"
 ```
 
-This means the pre-made end-user UAI image is not in the local registry (or whatever registry it is being pulled from; see the `uai_img` value for details). To correct this, locate and push/import the image to the registry.
+This means the pre-made end-user UAI image is not in the local registry (or whatever registry it is being pulled from; see the `uai_img` value for details). To correct
+this, locate and push/import the image to the registry.
 
 <a name="uas-uai-validate-debug-container"></a>
 
-#### 6.4.4 Missing Volumes and other Container Startup Issues
+#### 6.4.4 Missing volumes and other container startup issues
 
 Various packages install volumes in the UAS configuration. All of those volumes must also have the underlying resources available, sometimes on the host node where the UAI is running sometimes from with
 Kubernetes. If a UAI gets stuck with a `ContainerCreating` `uai_msg` field for an extended time, this is a likely cause. UAIs run in the `user` Kubernetes namespace, and are pods that can be examined
@@ -936,10 +914,11 @@ using `kubectl describe`.
    ncn# kubectl get po -n user | grep <uai-name>
    ```
 
-2. Investigate the problem using the pod name from the previous step.
+1. Investigate the problem using the pod name from the previous step.
 
    ```bash
    ncn# kubectl describe pod -n user <pod-name>
    ```
 
-   If volumes are missing they will show up in the `Events:` section of the output. Other problems may show up there as well. The names of the missing volumes or other issues should indicate what needs to be fixed to make the UAI run.
+   If volumes are missing they will show up in the `Events:` section of the output. Other problems may show up there as well. The names of the missing volumes or other issues
+   should indicate what needs to be fixed to make the UAI run.

--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -11,28 +11,35 @@ backup of Workload Manager configuration data and files is created. Once complet
 
 ### Stages
 
-- [Stage 0.1 - Install latest docs RPM](#install-latest-docs)
+- [Stage 0.1 - Prepare assets](#prepare-assets)
 - [Stage 0.2 - Update SLS](#update-sls)
 - [Stage 0.3 - Upgrade Management Network](#update-management-network)
 - [Stage 0.4 - Prerequisites Check](#prerequisites-check)
 - [Stage 0.5 - Backup Workload Manager Data](#backup_workload_manager)
-- [Stage Completed](#stage_completed)
+- [Stage completed](#stage_completed)
 
-<a name="install-latest-docs"></a>
+<a name="prepare-assets"></a>
 
-## Stage 0.1 - Install latest documentation RPM
+## Stage 0.1 - Prepare assets
 
-1. Install latest documentation RPM package and prepare assets.
-
-   > **Important:** The install scripts will look for the `docs-csm` RPM in `/root`, so be sure copy it there.
+1. Set the `CSM_RELEASE` variable to the **target** CSM version of this upgrade.
 
    ```bash
     ncn-m001# CSM_RELEASE=csm-1.2.0
    ```
 
-### Internet Connected
+1. Follow either the [Direct download](#direct-download) or [Manual copy](#manual-copy) procedure.
+
+   - If there is a URL for the CSM `tar` file that is accessible from `ncn-m001`, then the [Direct download](#direct-download) procedure may be used.
+   - Alternatively, the [Manual copy](#manual-copy) procedure may be used, which includes manually copying the CSM `tar` file to `ncn-m001`.
+
+<a name="direct-download">
+
+### Direct download
 
 1. Download and install the latest documentation RPM.
+
+   > **Important:** The upgrade scripts expect the `docs-csm` RPM to be located at `/root/docs-csm-latest.noarch.rpm`; that is why this command copies it there.
 
    ```bash
    ncn-m001# wget https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/docs-csm/1.2/noarch/docs-csm-latest.noarch.rpm \
@@ -40,11 +47,11 @@ backup of Workload Manager configuration data and files is created. Once complet
              rpm -Uvh --force /root/docs-csm-latest.noarch.rpm
    ```
 
-1. Set the `ENDPOINT` variable to the URL of the directory containing the CSM release tarball.
+1. Set the `ENDPOINT` variable to the URL of the directory containing the CSM release `tar` file.
 
-   In other words, the full URL to the CSM release tarball will be `${ENDPOINT}${CSM_RELEASE}.tar.gz`.
+   In other words, the full URL to the CSM release `tar` file must be `${ENDPOINT}${CSM_RELEASE}.tar.gz`
 
-   > **Note:** This step is optional for Cray/HPE internal installs.
+   **NOTE** This step is optional for Cray/HPE internal installs, if `ncn-m001` can reach the internet.
 
    ```bash
    ncn-m001# ENDPOINT=https://put.the/url/here/
@@ -52,29 +59,44 @@ backup of Workload Manager configuration data and files is created. Once complet
 
 1. Run the script.
 
-```bash
-ncn-m001# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version $CSM_RELEASE --endpoint $ENDPOINT
-```
+   **NOTE** For Cray/HPE internal installs, if `ncn-m001` can reach the internet, then the `--endpoint` argument may be omitted.
 
-### Air-Gapped
+   ```bash
+   ncn-m001# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version ${CSM_RELEASE} --endpoint "${ENDPOINT}"
+   ```
 
-1. Copy the `docs-csm` RPM package and CSM release tarball to `ncn-m001`.
+1. Skip the `Manual copy` subsection.
+
+<a name="manual-copy">
+
+### Manual copy
+
+1. Copy the `docs-csm` RPM package and CSM release `tar` file to `ncn-m001`.
 
    See [Update Product Stream](../../update_product_stream/index.md).
 
 1. Copy the documentation RPM to `/root` and install it.
 
-   > Replace the `PATH_TO` below with the location of the RPM.
+   > **Important:**
+   >
+   > - Replace the `PATH_TO_DOCS_RPM` below with the location of the RPM on `ncn-m001`.
+   > - The upgrade scripts expect the `docs-csm` RPM to be located at `/root/docs-csm-latest.noarch.rpm`; that is why this command copies it there.
 
    ```bash
-   ncn-m001# cp [PATH_TO_docs-csm-*.noarch.rpm] /root/docs-csm-latest.noarch.rpm &&
+   ncn-m001# cp PATH_TO_DOCS_RPM /root/docs-csm-latest.noarch.rpm &&
              rpm -Uvh --force /root/docs-csm-latest.noarch.rpm
+   ```
+
+1. Set the `CSM_TAR_PATH` variable to the full path to the CSM `tar` file on `ncn-m001`.
+
+   ```bash
+   ncn-m001# CSM_TAR_PATH=/path/to/${CSM_RELEASE}.tar.gz
    ```
 
 1. Run the script.
 
    ```bash
-   ncn-m001# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version $CSM_RELEASE --tarball-file [PATH_TO_CSM_TARBALL_FILE]
+   ncn-m001# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version ${CSM_RELEASE} --tarball-file "${CSM_TAR_PATH}"
    ```
 
 <a name="update-sls"></a>
@@ -118,7 +140,7 @@ the correct options for the specific environment are used. Two examples are give
    ncn-m001# curl -k -H "Authorization: Bearer ${TOKEN}" https://api-gw-service-nmn.local/apis/sls/v1/dumpstate | jq -S . > sls_input_file.json
    ```
 
-### Migrate SLS Data JSON to CSM 1.2
+### Migrate SLS data JSON to CSM 1.2
 
 - Example 1: The CHN as the system default route (will by default output to `migrated_sls_file.json`).
 
@@ -150,9 +172,9 @@ the correct options for the specific environment are used. Two examples are give
 
 <a name="update-management-network"></a>
 
-## Stage 0.3 - Upgrade Management Network
+## Stage 0.3 - Upgrade management network
 
-### Verify That Switches Have 1.2 Configuration In Place
+### Verify that switches have 1.2 configuration in place
 
 1. Log in to each management switch.
 
@@ -171,23 +193,21 @@ the correct options for the specific environment are used. Two examples are give
    ##################################################################################
    ```
 
-   - If you see text like the above, then it means that the switches have a CANU-generated configuration for CSM 1.2 in place. In this case, follow the steps in
-     [Management Network 1.0 (`1.2 Preconfig`) to 1.2](https://github.com/Cray-HPE/docs-csm/blob/release/1.2/operations/network/management_network/1.0_to_1.2_upgrade.md).
-
+   - Output like the above text means that the switches have a CANU-generated configuration for CSM 1.2 in place. In this case, follow the steps in
+     [Management Network 1.0 (`1.2 Preconfig`) to 1.2](../../operations/network/management_network/1.0_to_1.2_upgrade.md).
    - If the banner does NOT contain text like the above, then contact support in order to get the `1.2 Preconfig` applied to the system.
-
    - See the [Management Network User Guide](../../operations/network/management_network/index.md) for more information on the management network.
 
 <a name="prerequisites-check"></a>
 
-## Stage 0.4 - Prerequisites Check
+## Stage 0.4 - Prerequisites check
 
 1. Set the `SW_ADMIN_PASSWORD` environment variable.
 
    Set it to the password for `admin` user on the switches. This is needed for preflight tests within the check script.
 
    ```bash
-   ncn-m001# export SW_ADMIN_PASSWORD=changeme
+   ncn-m001# export SW_ADMIN_PASSWORD=PutYourOwnPasswordHere
    ```
 
 1. Set the `NEXUS_PASSWORD` variable **only if needed**.
@@ -209,7 +229,7 @@ the correct options for the specific environment are used. Two examples are give
 1. Run the script.
 
    ```bash
-   ncn-m001# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prerequisites.sh --csm-version [CSM_RELEASE]
+   ncn-m001# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prerequisites.sh --csm-version ${CSM_RELEASE}
    ```
 
    **IMPORTANT:** If any errors are encountered, then potential fixes should be displayed where the error occurred. **If** the upgrade `prerequisites.sh` script fails and does
@@ -240,14 +260,14 @@ the correct options for the specific environment are used. Two examples are give
 
 <a name="backup_workload_manager"></a>
 
-## Stage 0.5 - Backup Workload Manager Data
+## Stage 0.5 - Backup workload manager data
 
-To prevent any possibility of losing workload manager configuration data or files, a backup is required. Execute all backup procedures (for the Workload manager in use) located in
+To prevent any possibility of losing workload manager configuration data or files, a backup is required. Execute all backup procedures (for the workload manager in use) located in
 the `Troubleshooting and Administrative Tasks` sub-section of the `Install a Workload Manager` section of the
 `HPE Cray Programming Environment Installation Guide: CSM on HPE Cray EX`. The resulting backup data should be stored in a safe location off of the system.
 
 <a name="stage_completed"></a>
 
-## Stage Completed
+## Stage completed
 
-Continue to [Stage 1 - Ceph image upgrade](https://github.com/Cray-HPE/docs-csm/blob/release/1.2/upgrade/1.2/Stage_1.md).
+This stage is completed. Continue to [Stage 1 - Ceph image upgrade](Stage_1.md).

--- a/upgrade/1.2/Stage_1.md
+++ b/upgrade/1.2/Stage_1.md
@@ -1,40 +1,43 @@
 # Stage 1 - Ceph image upgrade
 
+## Procedure
+
 1. Run `ncn-upgrade-ceph-nodes.sh` for `ncn-s001`. Follow output of the script carefully. The script will pause for manual interaction.
 
     ```bash
     ncn-m001# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/ncn-upgrade-ceph-nodes.sh ncn-s001
     ```
 
-    > NOTE: You may need to reset the root password for each node after it is rebooted
+    > **NOTE:** The root password for the node may need to be reset after it is rebooted.
 
     **Known Issues:**
-    * It is possible to encounter an error like shown below. If this is the case, then re-run the same command for the node upgrade. It will pick up at that point and continue.
+    * If the below error is observed, then re-run the same command for the node upgrade. It will pick up at that point and continue.
 
         ```text
         ====> REDEPLOY_CEPH ...
         /usr/bin/ssh-copy-id: INFO: Source of key(s) to be installed: "/root/ceph.pub"Number of key(s) added: 1Now try logging into the machine, with:   "ssh 'root@ncn-s003'"
         and check to make sure that only the key(s) you wanted were added.Error EINVAL: Traceback (most recent call last):
         ```
-    * During the storage node rebuild, it is possible that Ceph health may report `HEALTH_WARN 1 daemons have recently crashed`. This can occur occasionally as part of the shutdown process of the node being rebuilt. Refer to [Dump Ceph Crash Data](../../operations/utility_storage/Dump_Ceph_Crash_Data.md), located in the Operations/Utility Storage section of the CSM documentation.
 
-1. **IMPORTANT:** Ensure the Ceph cluster is healthy prior to continuing.
+    * During the storage node rebuild, Ceph health may report `HEALTH_WARN 1 daemons have recently crashed`. This occurs occasionally as part of the shutdown process of the node
+      being rebuilt. See [Dump Ceph Crash Data](../../operations/utility_storage/Dump_Ceph_Crash_Data.md).
 
-    If you have processes not running, then refer to [Utility Storage Operations](../../operations/utility_storage/Utility_Storage.md) for operational and troubleshooting procedures.
+1. **IMPORTANT:** Ensure that the Ceph cluster is healthy prior to continuing.
+
+    If there are processes not running, then see [Utility Storage Operations](../../operations/utility_storage/Utility_Storage.md) for operational and troubleshooting procedures.
 
 1. Repeat the previous steps for each other storage node, one at a time.
 
-1. After `ncn-upgrade-ceph-nodes.sh` has successfully run for all storage nodes, rescan the SSH keys on all storage nodes.
+1. After `ncn-upgrade-ceph-nodes.sh` has successfully run for all storage nodes, then rescan the SSH keys on all storage nodes.
 
     ```bash
     ncn-m001# grep -oP "(ncn-s\w+)" /etc/hosts | sort -u | xargs -t -i ssh {} 'truncate --size=0 ~/.ssh/known_hosts'
-
     ncn-m001# grep -oP "(ncn-s\w+)" /etc/hosts | sort -u | xargs -t -i ssh {} 'grep -oP "(ncn-s\w+|ncn-m\w+|ncn-w\w+)" /etc/hosts | sort -u | xargs -t -i ssh-keyscan -H \{\} >> /root/.ssh/known_hosts'
     ```
 
 1. Deploy `node-exporter` and `alertmanager`.
 
-    **NOTE:** This procedure will need to run on a node running `ceph-mon`, which in most cases will be `ncn-s001`, `ncn-s002`, and `ncn-s003`. It only needs to be run once, not on every one of these nodes.
+    **NOTE:** This procedure must run on a node running `ceph-mon`, which in most cases will be `ncn-s001`, `ncn-s002`, and `ncn-s003`. It only needs to be run once, not on every one of these nodes.
 
     1. Deploy `node-exporter` and `alertmanager`.
 
@@ -42,22 +45,24 @@
         ncn-s# ceph orch apply node-exporter && ceph orch apply alertmanager
         ```
 
-        Expected output should look similar to the following:
-        ```
+        Expected output looks similar to the following:
+
+        ```text
         Scheduled node-exporter update...
         Scheduled alertmanager update...
         ```
 
     1. Verify that `node-exporter` is running.
 
-        > **IMPORTANT:** There should be a `node-exporter` container per Ceph node.
+        > **IMPORTANT:** There should be one `node-exporter` container per Ceph node.
 
         ```bash
         ncn-s# ceph orch ps --daemon_type node-exporter
         ```
 
         Expected output on a system with three Ceph nodes should look similar to the following:
-        ```
+
+        ```text
         NAME                    HOST      STATUS         REFRESHED  AGE  VERSION  IMAGE NAME                                       IMAGE ID           CONTAINER ID
         node-exporter.ncn-s001  ncn-s001  running (57m)  3m ago     67m  0.18.1   docker.io/prom/node-exporter:v0.18.1             e5a616e4b9cf       3465eade21da
         node-exporter.ncn-s002  ncn-s002  running (57m)  3m ago     67m  0.18.1   registry.local/prometheus/node-exporter:v0.18.1  e5a616e4b9cf       7ed9b6cc9991
@@ -72,8 +77,9 @@
         ncn-s# ceph orch ps --daemon_type alertmanager
         ```
 
-        Expected output should look similar to the following:
-        ```
+        Expected output looks similar to the following:
+
+        ```text
         NAME                   HOST      STATUS         REFRESHED  AGE  VERSION  IMAGE NAME                                      IMAGE ID           CONTAINER ID
         alertmanager.ncn-s001  ncn-s001  running (66m)  3m ago     68m  0.20.0   registry.local/prometheus/alertmanager:v0.20.0  0881eb8f169f       775aa53f938f
         ```
@@ -85,4 +91,8 @@
     ncn-m001# update_bss_storage
     ```
 
- Once `Stage 1` is successfully completed, all the Ceph nodes have been rebooted into the new image. Proceed to [Stage 2](Stage_2.md).
+## Stage completed
+
+All the Ceph nodes have been rebooted into the new image.
+
+This stage is completed. Continue to [Stage 2](Stage_2.md).

--- a/upgrade/1.2/Stage_2.md
+++ b/upgrade/1.2/Stage_2.md
@@ -8,6 +8,8 @@
    ncn-m001# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/ncn-upgrade-master-nodes.sh ncn-m002
    ```
 
+   > **NOTE:** The root password for the node may need to be reset after it is rebooted.
+
 1. Repeat the previous step for each other master node **excluding `ncn-m001`**, one at a time.
 
 ## Stage 2.2
@@ -18,47 +20,45 @@
    ncn-m001# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/ncn-upgrade-worker-nodes.sh ncn-w001
    ```
 
-   > NOTE: You may need to reset the root password for each node after it is rebooted
+   > **NOTE:** The root password for the node may need to be reset after it is rebooted.
 
 1. Repeat the previous step for each other worker node, one at a time.
 
 ## Stage 2.3
 
-Up to this point, we have already upgraded all worker, storage and master nodes except `ncn-m001`. `ncn-m001` has been our stable node that we logged into the cluster with to upgrade the other nodes. The procedure at this stage will now use `ncn-m002` as a new **stable** node, to login to the cluster, and from it upgrade `ncn-m001`. During this process, ensure `ncn-m001` does not have its power state affected.
+All NCNs have been upgraded, except for `ncn-m001`. In the upgrade process so far, `ncn-m001` has been the "stable node" -- that is, the node
+from which the other nodes were upgraded. At this point, the upgrade procedure pivots to use `ncn-m002` as the new "stable node", in order to allow the upgrade of `ncn-m001`.
 
-For `ncn-m001`, use `ncn-m002` as the stable NCN. Use `bond0.cmn0`/CAN IP address to `ssh` to `ncn-m002` for this `ncn-m001` install
+1. Log in to `ncn-m002` from outside the cluster.
+
+   `ssh` to the `bond0.cmn0`/CAN IP address of `ncn-m002`.
 
 1. Authenticate with the Cray CLI on `ncn-m002`.
 
    See [Configure the Cray Command Line Interface](../../operations/configure_cray_cli.md) for details on how to do this.
 
-1. Set the `CSM_RELEASE` variable to the correct value for the CSM release upgrade being applied.
+1. Set the `CSM_RELEASE` variable to the **target** CSM version of this upgrade.
 
    ```bash
    ncn-m002# CSM_RELEASE=csm-1.2.0
    ```
-1. Copy arfifacts from `ncn-m001`
+
+1. Copy artifacts from `ncn-m001`.
+
+   A later stage of the upgrade expects the `docs-csm` RPM to be located at `/root/docs-csm-latest.noarch.rpm` on `ncn-m002`; that is why this command copies it there.
 
    ```bash
-   ncn-m002# mkdir -p /etc/cray/upgrade/csm/${CSM_RELEASE}
-
-   ncn-m002# scp ncn-m001:/etc/cray/upgrade/csm/myenv /etc/cray/upgrade/csm/myenv
-
-   ncn-m002# scp ncn-m001:/root/output.log /root/pre-m001-reboot-upgrade.log
-
-   ncn-m002# cray artifacts create config-data pre-m001-reboot-upgrade.log /root/pre-m001-reboot-upgrade.log
-
-   ncn-m002# csi_rpm=$(ssh ncn-m001 "find /etc/cray/upgrade/csm/${CSM_RELEASE}/tarball/${CSM_RELEASE}/rpm/cray/csm/ -name 'cray-site-init*.rpm'")
-
-   ncn-m002# scp ncn-m001:${csi_rpm} /tmp/cray-site-init.rpm
-
-   ncn-m002# scp ncn-m001:/root/docs-csm-*.noarch.rpm /root/docs-csm-latest.noarch.rpm
-
-
-   ncn-m002# rpm -Uvh --force /tmp/cray-site-init.rpm
+   ncn-m002# mkdir -pv /etc/cray/upgrade/csm/${CSM_RELEASE} &&
+             scp ncn-m001:/etc/cray/upgrade/csm/myenv /etc/cray/upgrade/csm/myenv &&
+             scp ncn-m001:/root/output.log /root/pre-m001-reboot-upgrade.log &&
+             cray artifacts create config-data pre-m001-reboot-upgrade.log /root/pre-m001-reboot-upgrade.log
+   ncn-m002# csi_rpm=$(ssh ncn-m001 "find /etc/cray/upgrade/csm/${CSM_RELEASE}/tarball/${CSM_RELEASE}/rpm/cray/csm/ -name 'cray-site-init*.rpm'") &&
+             scp ncn-m001:${csi_rpm} /tmp/cray-site-init.rpm
+             scp ncn-m001:/root/docs-csm-*.noarch.rpm /root/docs-csm-latest.noarch.rpm &&
+             rpm -Uvh --force /tmp/cray-site-init.rpm /root/docs-csm-latest.noarch.rpm
    ```
 
-1. Upgrade `ncn-m001`
+1. Upgrade `ncn-m001`.
 
    ```bash
    ncn-m002# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/ncn-upgrade-master-nodes.sh ncn-m001
@@ -66,7 +66,7 @@ For `ncn-m001`, use `ncn-m002` as the stable NCN. Use `bond0.cmn0`/CAN IP addres
 
 ## Stage 2.4
 
-Run the following command to complete the upgrade of the weave and multus manifest versions:
+Run the following command to complete the upgrade of the `weave` and `multus` manifest versions:
 
 ```bash
 ncn-m002# /srv/cray/scripts/common/apply-networking-manifests.sh
@@ -74,7 +74,7 @@ ncn-m002# /srv/cray/scripts/common/apply-networking-manifests.sh
 
 ## Stage 2.5
 
-Run the following script to apply anti-affinity to coredns pods:
+Run the following script to apply anti-affinity to `coredns` pods:
 
 ```bash
 ncn-m002# /usr/share/doc/csm/upgrade/1.2/scripts/k8s/apply-coredns-pod-affinity.sh
@@ -82,12 +82,18 @@ ncn-m002# /usr/share/doc/csm/upgrade/1.2/scripts/k8s/apply-coredns-pod-affinity.
 
 ## Stage 2.6
 
-Run the following script to complete the Kubernetes upgrade _(this will restart several pods on each master to their new docker containers)_:
+Run the following script to complete the Kubernetes upgrade _(this will restart several pods on each master to their new Docker containers)_:
 
 ```bash
 ncn-m002# /usr/share/doc/csm/upgrade/1.2/scripts/k8s/upgrade_control_plane.sh
 ```
 
-> **`NOTE`**: `kubelet` has been upgraded already, so you can ignore the warning to upgrade it
+> **`NOTE`**: `kubelet` has been upgraded already, ignore the warning to upgrade it.
 
-Once `Stage 2` is completed, all Kubernetes nodes have been rebooted into the new image. Now proceed to [Stage 3](Stage_3.md)
+<a name="stage_completed"></a>
+
+## Stage completed
+
+All Kubernetes nodes have been rebooted into the new image.
+
+This stage is completed. Continue to [Stage 3](Stage_3.md).

--- a/upgrade/1.2/Stage_3.md
+++ b/upgrade/1.2/Stage_3.md
@@ -1,52 +1,83 @@
 # Stage 3 - CSM Service Upgrades
 
-1. Prepare assets:
+## Prepare assets on `ncn-m002`
+
+1. Set the `CSM_RELEASE` variable to the **target** CSM version of this upgrade.
 
    ```bash
     ncn-m002# CSM_RELEASE=csm-1.2.0
    ```
 
-   - Internet Connected
+1. Follow either the [Direct download](#direct-download) or [Manual copy](#manual-copy) procedure.
 
-     1. Set the ENDPOINT variable to the URL of the directory containing the CSM release tarball.
+   - If there is a URL for the CSM `tar` file that is accessible from `ncn-m002`, then the [Direct download](#direct-download) procedure may be used.
+   - Alternatively, the [Manual copy](#manual-copy) procedure may be used, which includes manually copying the CSM `tar` file to `ncn-m002`.
 
-        In other words, the full URL to the CSM release tarball will be ${ENDPOINT}${CSM_RELEASE}.tar.gz
+<a name="direct-download">
 
-        **NOTE** This step is optional for Cray/HPE internal installs.
+### Direct download
 
-        ```bash
-        ncn-m002# ENDPOINT=https://put.the/url/here/
-        ```
+1. Set the `ENDPOINT` variable to the URL of the directory containing the CSM release `tar` file.
 
-     1. Run the script
+   In other words, the full URL to the CSM release `tar` file must be `${ENDPOINT}${CSM_RELEASE}.tar.gz`
 
-        ```bash
-        ncn-m002# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version [CSM_RELEASE] --endpoint [ENDPOINT]
-        ```
+   **NOTE** This step is optional for Cray/HPE internal installs, if `ncn-m002` can reach the internet.
 
-   - Air Gapped (replace the PATH_TO below with the location of the CSM release tarball)
+   ```bash
+   ncn-m002# ENDPOINT=https://put.the/url/here/
+   ```
 
-     1. Copy CSM release tarball to `ncn-m002`.
+1. Run the script.
 
-     1. Run the script
+   **NOTE** For Cray/HPE internal installs, if `ncn-m002` can reach the internet, then the `--endpoint` argument may be omitted.
 
-        ```bash
-        ncn-m002# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version [CSM_RELEASE] --tarball-file [PATH_TO_CSM_TARBALL_FILE]
-        ```
+   ```bash
+   ncn-m002# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version ${CSM_RELEASE} --endpoint "${ENDPOINT}"
+   ```
 
-1. Run `csm-upgrade.sh` to deploy upgraded CSM applications and services:
-   **IMPORTANT:**
+1. Skip the `Manual copy` subsection.
 
-   > During this stage there will be a brief (approximately 5 minutes) window where pods with Persistent Volumes(PVs) will not be able to migrate between nodes. This is due to a redeployment of the Ceph csi provisioners into namespaces to accommodate the newer charts and a better upgrade strategy.
+<a name="manual-copy">
 
-   > Set the `SW_ADMIN_PASSWORD` environment variable to the admin password for the switches. This is needed for post upgrade tests.
+### Manual copy
+
+1. Copy the CSM release `tar` file to `ncn-m002`.
+
+   See [Update Product Stream](../../update_product_stream/index.md).
+
+1. Set the `CSM_TAR_PATH` variable to the full path to the CSM `tar` file on `ncn-m002`.
+
+   ```bash
+   ncn-m002# CSM_TAR_PATH=/path/to/${CSM_RELEASE}.tar.gz
+   ```
+
+1. Run the script.
+
+   ```bash
+   ncn-m002# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version ${CSM_RELEASE} --tarball-file "${CSM_TAR_PATH}"
+   ```
+
+## Perform upgrade
+
+During this stage there will be a brief (approximately 5 minutes) window where pods with Persistent Volumes (`PV`s) will not be able to migrate between nodes.
+This is due to a redeployment of the Ceph `csi` provisioners into namespaces, in order to accommodate the newer charts and a better upgrade strategy.
+
+1. Set the `SW_ADMIN_PASSWORD` environment variable.
+
+   Set it to the `admin` user password for the switches. This is required for post-upgrade tests.
 
    ```bash
    ncn-m002# export SW_ADMIN_PASSWORD=PutYourOwnPasswordHere
    ```
 
+1. Perform the upgrade.
+
+   Run `csm-upgrade.sh` to deploy upgraded CSM applications and services.
+
    ```bash
    ncn-m002# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/csm-upgrade.sh
    ```
 
-Once `Stage 3` is completed, proceed to [Stage 4](Stage_4.md)
+## Stage completed
+
+This stage is completed. Continue to [Stage 4](Stage_4.md).

--- a/upgrade/1.2/Stage_5.md
+++ b/upgrade/1.2/Stage_5.md
@@ -65,7 +65,7 @@
             [--csm-release 1.2.0] [--git-commit COMMIT] [--ncn-config-file  /path/to/ncn-personalization.json]
    ```
 
-   For more information on this script, see [Automatically Apply CSM Configuration to NCNs](../../operations/CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md#auto_apply_csm_config)
+   For more information on this script, see [Automatically Apply CSM Configuration to NCNs](../../operations/CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md#auto_apply_csm_config).
 
 1. Review the new `ncn-personalization` configuration and write it to a JSON file.
 

--- a/upgrade/1.2/Stage_5.md
+++ b/upgrade/1.2/Stage_5.md
@@ -1,23 +1,29 @@
 # Stage 5 - Perform NCN Personalization
 
 ## Procedure
-1. Set the root user password and SSH keys before running NCN personalization.
+
+1. Set the `root` user password and SSH keys before running NCN personalization.
    The location where the password is stored in Vault has changed since previous
-   CSM versions. See [Configure the Root Password and Root SSH Keys in Vault](../../operations/CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md#configure-the-root-password-and-root-ssh-keys-in-vault).
+   CSM versions. See
+   [Configure the Root Password and Root SSH Keys in Vault](../../operations/CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md#set_root_password).
 
 1. If custom configuration content was merged with content from a previous CSM
-   installation, merge the new CSM configuration in with it in the `csm-config-management`
-   git repository. This is not necessary if the NCN personalization configuration
-   was using a commit on a `cray/csm/VERSION` branch (i.e using default
+   installation, then merge the new CSM configuration in with it in the `csm-config-management`
+   Git repository. This is not necessary if the NCN personalization configuration
+   was using a commit on a `cray/csm/VERSION` branch (that is, using the default
    configuration).
 
    The new CSM configuration content is found in the `cray-product-catalog`
-   config map. If using the default CSM configuration, simply note the value in
+   Kubernetes `ConfigMap`. If using the default CSM configuration, simply note the value in
    the `commit` field.
 
    ```bash
    ncn# kubectl -n services get cm cray-product-catalog -o jsonpath='{.data.csm}'
+   ```
 
+   The output will contain a section resembling the following:
+
+   ```yaml
    1.2.0:
      configuration:
        clone_url: https://vcs.cmn.SYSTEM_DOMAIN_NAME/vcs/cray/csm-config-management.git
@@ -25,14 +31,14 @@
        import_branch: cray/csm/1.9.24
        import_date: 2022-07-28 03:26:01.869501
        ssh_url: git@vcs.cmn.SYSTEM_DOMAIN_NAME:cray/csm-config-management.git
-   ...
+   ```
 
    The specific dates, commits, and other values may not be the same as the output above.
 
-1. Write out the current `ncn-personalization` configuration to a JSON file.
+1. View the current `ncn-personalization` configuration and write it to a JSON file.
 
    ```bash
-   ncn-m001# cray cfs configurations describe ncn-personalization --format json > ncn-personalization.json
+   ncn# cray cfs configurations describe ncn-personalization --format json | tee ncn-personalization.json
    ```
 
 1. Run the `apply_csm_configuration.sh` script. This script will update the CSM
@@ -41,18 +47,32 @@
 
    **IMPORTANT:**
 
-   > * If you are using a different branch than the default to include custom
-       changes, use the `--git-commit` option to override the commit to the
-       commit on your branch.
-   > * If you are using the default CSM configuration found in the product
-       catalog above, you may omit this option, but you should use the `--csm-release`
-       option to explicitly set the release version, otherwise the latest available
-       release will be applied.
+   > * If using a different branch than the default to include custom
+       changes, use the `--git-commit` argument to specify the desired commit on
+       the branch including the customizations. Otherwise this argument is not needed.
+   > * By default the latest available CSM release will be applied. Otherwise, the
+       release may be specified explicitly using the `--csm-release` argument.
+       This argument is not needed if using the default CSM configuration found in the
+       product catalog in the earlier step.
+   > * If the existing `ncn-personalization` configuration contains layers other than
+       the CSM layer from the `csm-config-management` repository, then the arguments
+       to the script should include `--ncn-config-file`. If this argument is not specified,
+       then any existing non-`csm` layers will not be preserved in the new
+       `ncn-personalization` configuration.
 
    ```bash
-   ncn-m001# /usr/share/doc/csm/scripts/operations/configuration/apply_csm_configuration.sh [--git-commit COMMIT]
+   ncn# /usr/share/doc/csm/scripts/operations/configuration/apply_csm_configuration.sh \
+            [--csm-release 1.2.0] [--git-commit COMMIT] [--ncn-config-file  /path/to/ncn-personalization.json]
    ```
 
-   For more information on this script, see [Automatically Apply CSM Configuration to NCNs](../../operations/CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md#automatically-apply-csm-configuration-to-ncns)
+   For more information on this script, see [Automatically Apply CSM Configuration to NCNs](../../operations/CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md#auto_apply_csm_config)
 
-Once `Stage 5` upgrade is complete, proceed to [*Validate CSM Health*](../index.md#validate_csm_health) on the main upgrade page.
+1. Review the new `ncn-personalization` configuration and write it to a JSON file.
+
+   ```bash
+   ncn# cray cfs configurations describe ncn-personalization --format json | tee ncn-personalization.json.new
+   ```
+
+## Stage completed
+
+This stage is completed. Continue to [Validate CSM Health](../index.md#validate_csm_health) on the main upgrade page.

--- a/upgrade/index.md
+++ b/upgrade/index.md
@@ -6,8 +6,6 @@ After the upgrade of CSM software, the CSM health checks will validate the syste
 tasks like the check and update of firmware on system components. Once the CSM upgrade has completed, other
 product streams for the HPE Cray EX system can be installed or upgraded.
 
-## Topics
-
 1. [Prepare for Upgrade](#prepare_for_upgrade)
 1. [Upgrade Management Nodes and CSM Services](#upgrade_management_nodes_csm_services)
 1. [Validate CSM Health](#validate_csm_health)
@@ -16,57 +14,39 @@ product streams for the HPE Cray EX system can be installed or upgraded.
 Note: If problems are encountered during the upgrade, some of the topics do have their own troubleshooting
 sections, but there is also a general troubleshooting topic.
 
-## Details
-
-<a name="prepare_for_upgrade"></a>
-
-1. Prepare for Upgrade
+1. <a name="prepare_for_upgrade"></a>Prepare for Upgrade
 
     See [Prepare for Upgrade](prepare_for_upgrade.md)
 
-   <a name="upgrade_management_nodes_csm_services"></a>
-
-1. Upgrade Management Nodes and CSM Services
+1. <a name="upgrade_management_nodes_csm_services"></a>Upgrade Management Nodes and CSM Services
 
     The upgrade of CSM software will do a controlled, rolling reboot of all management nodes before updating the CSM services.
 
     The upgrade is a guided process Starting with [Upgrade Management Nodes and CSM Services](1.2/README.md)
 
-    <a name="validate_csm_health"></a>
+1. <a name="validate_csm_health"></a>Validate CSM Health
 
-1. Validate CSM Health
+     **NOTE:**
 
-     > **`IMPORTANT:`** Wait at least 15 minutes after
-     > [`csm-upgrade.sh`](1.2/Stage_3.md) in stage 3 completes to let the various Kubernetes
-     > resources get initialized and started.
-
-     Run the following validation checks to ensure that everything is still working
-     properly after the upgrade:
-
-     > **`IMPORTANT:`** If your site does not use UAIs, skip UAS and UAI validation. If you do use
-     > UAIs, there are products that configure UAS like Cray Analytics and Cray Programming Environment that
-     > must be working correctly with UAIs and should be validated and corrected (the procedures for this are
-     > beyond the scope of this document) prior to validating UAS and UAI. Failures in UAI creation that result
-     > from incorrect or incomplete installation of these products will generally take the form of UAIs stuck in
-     > waiting state trying to set up volume mounts.
-
-     1. [Platform Health Checks](../operations/validate_csm_health.md#platform-health-checks)
-     2. [Hardware Management Services Health Checks](../operations/validate_csm_health.md#hms-health-checks)
-     3. [Software Management Services Validation Utility](../operations/validate_csm_health.md#sms-health-checks)
-     4. [Validate UAS and UAI Functionality](../operations/validate_csm_health.md#uas-uai-validate)
-
-     Booting the barebones image on the compute nodes should be skipped if the compute nodes have been running
-     application workload during the the CSM upgrade.
+     * Before performing the health validation, be sure that at least 15 minutes have elapsed
+       since the CSM services were upgraded. This allows the various Kubernetes resources to
+       initialize and start.
+     * If the site does not use UAIs, skip UAS and UAI validation. If UAIs are used, there are
+       products that configure UAS like Cray Analytics and Cray Programming Environment that
+       must be working correctly with UAIs, and should be validated (the procedures for this are
+       beyond the scope of this document) prior to validating UAS and UAI. Failures in UAI creation that result
+       from incorrect or incomplete installation of these products will generally take the form of UAIs stuck in
+       waiting state trying to set up volume mounts.
+     * Performing the `Booting CSM Barebones Image` test may be skipped if no compute nodes are available
+       (that is, if all compute nodes are active running application workloads).
 
      See [Validate CSM Health](../operations/validate_csm_health.md)
 
-    <a name="next_topic"></a>
-
-1. Next Topic
+1. <a name="next_topic"></a>Next topic
 
     After completion of the validation of CSM health, the CSM product stream has been fully upgraded and
-    configured. Refer to the 1.5 _HPE Cray EX System Software Getting Started Guide S-8000_
-    on the HPE Customer Support Center at https://www.hpe.com/support/ex-gsg
+    configured. Refer to the `1.5 HPE Cray EX System Software Getting Started Guide S-8000`
+    on the [`HPE Customer Support Center`](https://www.hpe.com/support/ex-gsg)
     for more information on other product streams to be upgraded and configured after CSM.
 
     > **Note:** If a newer version of the HPE Cray EX HPC Firmware Pack (HFP) is available, then the next step

--- a/upgrade/index.md
+++ b/upgrade/index.md
@@ -22,7 +22,7 @@ sections, but there is also a general troubleshooting topic.
 
     The upgrade of CSM software will do a controlled, rolling reboot of all management nodes before updating the CSM services.
 
-    The upgrade is a guided process Starting with [Upgrade Management Nodes and CSM Services](1.2/README.md)
+    The upgrade is a guided process starting with [Upgrade Management Nodes and CSM Services](1.2/README.md).
 
 1. <a name="validate_csm_health"></a>Validate CSM Health
 
@@ -37,7 +37,7 @@ sections, but there is also a general troubleshooting topic.
        beyond the scope of this document) prior to validating UAS and UAI. Failures in UAI creation that result
        from incorrect or incomplete installation of these products will generally take the form of UAIs stuck in
        waiting state trying to set up volume mounts.
-     * Performing the `Booting CSM Barebones Image` test may be skipped if no compute nodes are available
+     * Performing the [Booting CSM `barebones` image](../operations/validate_csm_health.md#booting-csm-barebones-image) test may be skipped if no compute nodes are available
        (that is, if all compute nodes are active running application workloads).
 
      See [Validate CSM Health](../operations/validate_csm_health.md)


### PR DESCRIPTION
## Summary and Scope

Much of this PR is linting, large and small. The most noteworthy non-linting changes are:
* The Stage 5 NCN personalization instructions, as written, resulted in existing layers being removed. This corrects that.
* The list of Ceph process types in Stage 4 omitted the "crash" type
* Changed some of the Stage 4 Ceph steps to be clearer and more explicit in what is being checked.
* Removed the outdated ncn-w001/UAI limitation from the health validation procedures.
* Added a note to the health validation procedures for the UAI gateway test that the docs-csm RPM must be installed.

There were a number of other small corrections.

## Issues and Related PRs

There will be backport PRs (although only a limited slice of the changes will be backported to csm-1.0).

## Testing

In any case where commands were altered, I tested them during the upgrade on vale.

## Risks and Mitigations

The risk of confusion and error with the current docs far outweighs the risk of making these changes, in my opinion.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
