### PR TITLE
CASMNET-1628: Direct users to connect over the CMN vs. the CAN.

### DIFF
--- a/install/deploy_final_ncn.md
+++ b/install/deploy_final_ncn.md
@@ -45,7 +45,7 @@ and ready for reboot of the LiveCD:
 >
 > * The NCN **will never wipe a USB device** during installation.
 >
-> * Prior to shutting down the PIT node, learning the CAN IP addresses of the other NCNs will be helpful if
+> * Prior to shutting down the PIT node, learning the CMN IP addresses of the other NCNs will be helpful if
 >   troubleshooting is required.
 >
 > This procedure entails deactivating the LiveCD, meaning the LiveCD and all of its resources will be

--- a/upgrade/1.2/Stage_2.md
+++ b/upgrade/1.2/Stage_2.md
@@ -26,7 +26,7 @@
 
 Up to this point, we have already upgraded all worker, storage and master nodes except `ncn-m001`. `ncn-m001` has been our stable node that we logged into the cluster with to upgrade the other nodes. The procedure at this stage will now use `ncn-m002` as a new **stable** node, to login to the cluster, and from it upgrade `ncn-m001`. During this process, ensure `ncn-m001` does not have its power state affected.
 
-For `ncn-m001`, use `ncn-m002` as the stable NCN. Use `bond0.cmn0`/CAN IP address to `ssh` to `ncn-m002` for this `ncn-m001` install
+For `ncn-m001`, use `ncn-m002` as the stable NCN. Use `bond0.cmn0`/CMN IP address to `ssh` to `ncn-m002` for this `ncn-m001` install
 
 1. Authenticate with the Cray CLI on `ncn-m002`.
 


### PR DESCRIPTION
## Summary and Scope
**install/deploy_final_ncn.md** and **upgrade/1.2/Stage_2.md** updated to point users to connect using the CMN vs. the CAN.
