### PR TITLE
CASMNET-1549: Switch 'CAN' to 'CMN'

### DIFF
--- a/install/deploy_final_ncn.md
+++ b/install/deploy_final_ncn.md
@@ -45,7 +45,7 @@ and ready for reboot of the LiveCD:
 >
 > * The NCN **will never wipe a USB device** during installation.
 >
-> * Prior to shutting down the PIT node, learning the CAN IP addresses of the other NCNs will be helpful if
+> * Prior to shutting down the PIT node, learning the CMN IP addresses of the other NCNs will be helpful if
 >   troubleshooting is required.
 >
 > This procedure entails deactivating the LiveCD, meaning the LiveCD and all of its resources will be

--- a/upgrade/1.2/Stage_2.md
+++ b/upgrade/1.2/Stage_2.md
@@ -31,7 +31,7 @@ from which the other nodes were upgraded. At this point, the upgrade procedure p
 
 1. Log in to `ncn-m002` from outside the cluster.
 
-   `ssh` to the `bond0.cmn0`/CAN IP address of `ncn-m002`.
+   `ssh` to the `bond0.cmn0`/CMN IP address of `ncn-m002`.
 
 1. Authenticate with the Cray CLI on `ncn-m002`.
 


### PR DESCRIPTION
## Summary and Scope

Switches CAN to CMN in 2 spots where appropriate.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMNET-1549](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1549)

## Testing
### Tested on:

  * `Redbull`

### Test description:

Tested on Redbull by booting the images and manually running the template file.
