### PR TITLE
CASMCMS-6989: Add docs for applying CSM configuration to compute images

### DIFF
--- a/operations/CSM_product_management/Configure_Compute_Nodes_with_CFS.md
+++ b/operations/CSM_product_management/Configure_Compute_Nodes_with_CFS.md
@@ -1,0 +1,62 @@
+# Configure Compute Nodes with CFS
+
+CSM includes a playbook that should be applied to any Compute node images.
+The `compute_nodes.yml` playbook installs the packages for both the CFS and BOS reporters.
+These packages are necessary for CFS and BOS to run, so a configuration layer containing the
+playbook must be included in the image customization for any nodes that are expected to be
+managed with CFS and BOS.
+
+## Setting up the CSM configuration layer
+
+To setup the compute configuration layer, first gather the following information:
+
+* HTTP clone URL for the configuration repository in [VCS](../configuration_management/Version_Control_Service_VCS.md).
+* Path to the Ansible play to run in the repository.
+* Commit ID in the repository for CFS to pull and run on the nodes.
+
+| Field | Value  | Description  |
+|:----------|:----------|:----------|
+| `cloneUrl` | `https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git` | CSM configuration repository |
+| `commit`  | **Example:** `5081c1ecea56002df41218ee39f6030c3eebdf27` | CSM configuration commit hash |
+| `name` | **Example:** `csm-<version>` | CSM configuration layer name |
+| `playbook` | `compute_nodes.yml` | Default Ansible playbook for CSM configuration of compute nodes |
+
+1. Retrieve the commit in the repository to use for configuration.
+   * If changes have been made to the default branch that was imported during a CSM
+     installation or upgrade, use the commit containing the changes.
+
+   * If no changes have been made, the latest commit on the default branch for
+     this version of CSM should be used. Find the commit in the
+     `cray-product-catalog` for the current version of CSM. For example:
+
+       ```bash
+       ncn# kubectl -n services get cm cray-product-catalog -o jsonpath='{.data.csm}'
+       ```
+
+       Part of the output will be a section resembling the following:
+
+       ```yaml
+       1.2.0:
+          configuration:
+             clone_url: https://vcs.cmn.SYSTEM_DOMAIN_NAME/vcs/cray/csm-config-management.git
+             commit: 43ecfa8236bed625b54325ebb70916f55884b3a4
+             import_branch: cray/csm/1.9.24
+             import_date: 2021-07-28 03:26:01.869501
+             ssh_url: git@vcs.cmn.SYSTEM_DOMAIN_NAME:cray/csm-config-management.git
+       ```
+
+     The commit will be different for each system and version of CSM. In the above
+     example it is `43ecfa8236bed625b54325ebb70916f55884b3a4`.
+
+1. Craft a new configuration layer entry for CSM using the procedure in [Update a CFS Configuration](../configuration_management/Update_a_CFS_Configuration.md):
+
+  The following is an example entry for the JSON configuration file:
+
+  ```json
+     {
+        "name": "csm-<version>",
+        "cloneUrl": "https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git",
+        "playbook": "compute_nodes.yml",
+        "commit": "<retrieved git commit>"
+     }
+  ```

--- a/operations/index.md
+++ b/operations/index.md
@@ -48,6 +48,7 @@ The following administrative topics can be found in this guide:
 - [Configure the Cray Command Line Interface (Cray CLI)](configure_cray_cli.md)
 - [Change Passwords and Credentials](CSM_product_management/Change_Passwords_and_Credentials.md)
 - [Configure Non-Compute Nodes with CFS](CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md)
+- [Configure Compute Nodes with CFS](CSM_product_management/Configure_Compute_Nodes_with_CFS.md)
 - [Perform NCN Personalization](CSM_product_management/Perform_NCN_Personalization.md)
 - [Access the LiveCD USB Device After Reboot](Access_LiveCD_USB_Device_After_Reboot.md)
 - [Post-Install Customizations](CSM_product_management/Post_Install_Customizations.md)


### PR DESCRIPTION
## Summary and Scope

This adds documentation for adding a new playbook (https://github.com/Cray-HPE/csm-config/pull/54/files) to the configuration that is applied to Compute images.  This will be the new method of deploying the CFS and BOS reporters.

## Issues and Related PRs

* Resolves CASMCMS-6989

## Testing

### Tested on:

  * NA, docs only.  Code from other PR was tested on Hela

### Test description:

NA, docs only

## Risks and Mitigations

None

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

