### PR TITLE
CASMINST-4702: Make sure the --format is specified in all cray commands in gateway tests

### DIFF
--- a/scripts/operations/gateway-test/uai-gateway-test.sh
+++ b/scripts/operations/gateway-test/uai-gateway-test.sh
@@ -137,7 +137,7 @@ echo "Got admin client secret"
 
 # Create the UAI pod
 echo "Creating Gateway Test UAI with image ${GATEWAY_IMAGE_NAME}"
-UAI_NAME=$(cray uas create --publickey ~/.ssh/id_rsa.pub --imagename ${GATEWAY_IMAGE_NAME} | grep uai_name | awk '{print $3}' | sed -e 's/"//g')
+UAI_NAME=$(cray uas create --publickey ~/.ssh/id_rsa.pub --imagename ${GATEWAY_IMAGE_NAME} --format json | jq '.uai_name' | sed -e 's/"//g')
 
 if [[ -z ${UAI_NAME} ]]; then
   error "Failure creating UAI"


### PR DESCRIPTION
## Summary and Scope

There was one cray command in the `uai-gateway-test.sh` that did not specify the output format and relied on the default `toml` format.   This causes problems when the `CRAY_FORMAT` environment is set and it is not `toml`.

I checked all other gateway tests to make sure there were no other cases of this.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMINST-4702

## Testing

### Tested on:

  * `hermod`

### Test description:

I ran the `uai-gateway-test.sh` with `CRAY_FORMAT` unset, with `CRAY_FORMAT=toml`, and with `CRAY_FORMAT=json`.   The test ran successfully in all cases.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

