### PR TITLE
CASMINST-4707: Specify Cray CLI output format when it matters

### DIFF
--- a/upgrade/1.2/scripts/rebuild/ncn-rebuild-worker-nodes.sh
+++ b/upgrade/1.2/scripts/rebuild/ncn-rebuild-worker-nodes.sh
@@ -116,14 +116,15 @@ if [[ $redeploy == "1" ]];then
     tmpfile=/tmp/cray-cps-deployment-list.${target_ncn}.$$.$(date +%Y-%m-%d_%H-%M-%S.%N).tmp
     count=0
     while [ true ]; do
-        if ! cray cps deployment list --nodes $target_ncn > $tmpfile ; then
+        # Our grep on the output of this CLI command only works if the output is in TOML format, so specify that explicitly with the --format argument
+        if ! cray cps deployment list --nodes $target_ncn --format toml > $tmpfile ; then
             # This command can fail when a node is first being brought up and deploying its CPS pods.
             if [[ $count -gt 30 ]]; then
                 rm -f "$tmpfile" >/dev/null 2>&1 || true
-                echo "ERROR: Command still failing after retries: Command failed: cray cps deployment list --nodes $target_ncn"
+                echo "ERROR: Command still failing after retries: Command failed: cray cps deployment list --nodes $target_ncn --format toml"
                 exit 1
             fi
-            echo "Command failed: cray cps deployment list --nodes $target_ncn; retrying in 5 seconds"
+            echo "Command failed: cray cps deployment list --nodes $target_ncn --format toml; retrying in 5 seconds"
             sleep 5
             let "count += 1"
             continue
@@ -132,7 +133,8 @@ if [[ $redeploy == "1" ]];then
         if [[ $cps_state -ne 0 ]];then
             if [[ $count -gt 30 ]]; then
                 echo "ERROR: CPS is not running on $target_ncn"
-                cray cps deployment list --nodes $target_ncn |grep -E "state ="
+                # Our grep on the output of this CLI command only works if the output is in TOML format, so specify that explicitly with the --format argument
+                cray cps deployment list --nodes $target_ncn --format toml |grep -E "state ="
                 rm -f "$tmpfile" >/dev/null 2>&1 || true
                 exit 1
             fi

--- a/upgrade/1.2/scripts/upgrade/prerequisites.sh
+++ b/upgrade/1.2/scripts/upgrade/prerequisites.sh
@@ -636,7 +636,7 @@ if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     {
 
     #shellcheck disable=SC2046
-    cray bss bootparameters list --format=json > bss-backup-$(date +%Y-%m-%d).json
+    cray bss bootparameters list --format json > bss-backup-$(date +%Y-%m-%d).json
 
     backupBucket="config-data"
     set +e
@@ -735,7 +735,8 @@ if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     {
     
     export CRAY_FORMAT=json
-    for xname in $(cray hsm state components list --role Management --type node | jq -r .Components[].ID)
+    # Even though we export the CRAY_FORMAT environment variable, it still is safest to also specify the --format command line argument
+    for xname in $(cray hsm state components list --role Management --type node --format json | jq -r .Components[].ID)
     do
         cray cfs components update --enabled false --desired-config "" $xname
     done


### PR DESCRIPTION
## Summary and Scope

I found a few cases in our scripts where we rely on the Cray CLI output being in a specific format, but we do not use the --format command line argument. This ticket just adds that argument in those cases. The changes are tiny and it is very clear that these commands will fail if the wrong format is used.

## Issues and Related PRs

csm-1.2 backport: https://github.com/Cray-HPE/docs-csm/pull/1702

## Risks and Mitigations

The risk of not fixing this is worse than the tiny risk of this accidentally introducing an error. The changes are so small that it is very easy to see their impact.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
