### PR TITLE
CASMINST-4709 export token for ntp script

### DIFF
--- a/operations/node_management/Configure_NTP_on_NCNs.md
+++ b/operations/node_management/Configure_NTP_on_NCNs.md
@@ -77,6 +77,12 @@ The following steps are structured to be executed on one node at a time. However
 
 1. Set a token as described in [Identify Nodes and Update Metadata](Rebuild_NCNs/Identify_Nodes_and_Update_Metadata.md).
 
+1. Export the token.
+
+    ```bash
+    export TOKEN
+    ```
+
 1. On each affected NCN, run:
 
 ```bash

--- a/operations/node_management/Configure_NTP_on_NCNs.md
+++ b/operations/node_management/Configure_NTP_on_NCNs.md
@@ -75,15 +75,17 @@ The following steps are structured to be executed on one node at a time. However
 
 ## Fix broken configuration
 
+On each affected NCN run the following:
+
 1. Set a token as described in [Identify Nodes and Update Metadata](Rebuild_NCNs/Identify_Nodes_and_Update_Metadata.md).
 
 1. Export the token.
 
     ```bash
-    export TOKEN
+    ncn# export TOKEN
     ```
 
-1. On each affected NCN, run:
+1. Run the script:
 
 ```bash
 ncn# /srv/cray/scripts/common/chrony/csm_ntp.py


### PR DESCRIPTION
Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>

## Summary and Scope

Adds an explicit step to export the token for use in `csm_ntp.py`

## Issues and Related PRs


* Resolves CASMINST-4709

## Testing


### Tested on:

  * `#redbull`

### Test description:

```
ncn-s004:~ # TOKEN=token
ncn-s004:~ # /srv/cray/scripts/common/chrony/csm_ntp.py
You must set BSS TOKEN environment variable
ncn-s004:~ # export TOKEN
ncn-s004:~ # /srv/cray/scripts/common/chrony/csm_ntp.py
Chrony configuration created
Problematic config found: /etc/chrony.d/cray.conf.dist
Problematic config found: /etc/chrony.d/pool.conf
Restarted chronyd
```

## Risks and Mitigations

Low.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
