### PR TITLE
CASMINST-4736: Export environment variables to make them available after starting typescript

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -391,6 +391,7 @@ playbook
 playbooks
 plugin
 plugins
+Podman
 PoR
 post-Ceph
 post-Ceph-install

--- a/install/bootstrap_livecd_usb.md
+++ b/install/bootstrap_livecd_usb.md
@@ -713,11 +713,13 @@ On first log in (over SSH or at local console), the LiveCD will prompt the admin
    pit# mount -vL PITDATA
    ```
 
-1. Set new environment variables and save them to `/etc/environment`.
+1. Set and export new environment variables.
+
+   The commands below save them to `/etc/environment` as well, which makes them available in all new shell sessions on the PIT node.
 
    ```bash
-   pit# PITDATA=$(lsblk -o MOUNTPOINT -nr /dev/disk/by-label/PITDATA)
-   pit# CSM_PATH=${PITDATA}/${CSM_RELEASE}
+   pit# export PITDATA=$(lsblk -o MOUNTPOINT -nr /dev/disk/by-label/PITDATA)
+   pit# export CSM_PATH=${PITDATA}/${CSM_RELEASE}
    pit# echo "
    PITDATA=${PITDATA}
    CSM_PATH=${CSM_PATH}" | tee -a /etc/environment


### PR DESCRIPTION
## Summary and Scope

**This is a fix for a RELEASE_CRITICAL ticket -- prompt reviews appreciated**

When setting variables after booting to the USB PIT node, they must also be exported, in order to make them available after the typescript is started. This PR just does that (and slightly rewords the description of the step, to include that we are exporting them).

## Issues and Related PRs

Backport PRs:
This fix is not needed in 1.0, because the USB bootstrap procedure is different for that release. However, this PR also adds Podman to the spelling file. We should keep the three spelling files common, I think, so the 1.0 backport PR contains just that commit.

csm-1.2: https://github.com/Cray-HPE/docs-csm/pull/1726
csm-1.0 (spelling file addition only): https://github.com/Cray-HPE/docs-csm/pull/1725

## Testing

I tested that exporting the variables is all we need in order to make them available inside the typescript, but I did not test this during an actual install. However, the scope of the change is limited enough that I do not consider this a big risk.

## Risks and Mitigations

Very low risk -- just adding export directives to variable assignments.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
