### PR TITLE
Pawsey kbuckley triple backticks 20220531 backport 1.0

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -391,6 +391,7 @@ playbook
 playbooks
 plugin
 plugins
+Podman
 PoR
 post-Ceph
 post-Ceph-install

--- a/.spelling
+++ b/.spelling
@@ -433,6 +433,7 @@ respawns
 REST
 Restic
 Resync
+RFC-1305
 RFC5171-compliant
 Rivest-Shamir-Adleman
 RJ-45


### PR DESCRIPTION
Backport of just the spelling file change from: https://github.com/Cray-HPE/docs-csm/pull/1719

This is just to keep the spelling file consistent between the 3 branches. Not a huge deal, but seems desirable.