### PR TITLE
CASMPET-5641 1.0 : DOCS: Regenerate the 'etcd-client-cert' secret in the sysmgmt-health namespace

### DIFF
--- a/operations/kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md
+++ b/operations/kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md
@@ -1,6 +1,7 @@
 # Kubernetes and Bare Metal EtcD Certificate Renewal
 
-As part of the installation, Kubernetes generates certificates for the required subcomponents. This document will help walk through the process of renewing the certificates.
+As part of the installation, Kubernetes generates certificates for the required subcomponents.
+This document will help walk through the process of renewing the certificates.
 
 **IMPORTANT:**
 
@@ -278,7 +279,7 @@ Run the following steps on each master node.
    - As noted in the above output, all certificates including those for Etcd were updated. Note that `apiserver-etcd-client.crt` is a Kubernetes API certificate, not an Etcd only certificate.
      Also, the `/var/lib/kubelet/pki/` certificates will be updated in the Kubernetes client section that follows.
 
-1. Restart etcd.
+1. Restart `etcd`.
 
    Once the steps to renew the needed certificates have been completed on all the master nodes, log into each master node one at a time and run the following:
 
@@ -340,7 +341,7 @@ Run the following steps on each master node.
 
 1. Distribute the client certificate to the rest of the cluster.
 
-   **NOTE:** There may be errors when copying files. The target may or may not exist depending on the version of Shasta.
+   **NOTE:** There may be errors when copying files. The target may or may not exist depending on the version of CSM.
 
    - **DO NOT** copy this to the master node where this work is being performed.
    - Copy `/etc/kubernetes/admin.conf` to all master and worker nodes.
@@ -353,7 +354,7 @@ Run the following steps on each master node.
    ncn-m# pdcp -w ncn-m00[2-3] -w ncn-w00[1-3] /etc/kubernetes/admin.conf /etc/kubernetes/
    ```
 
-## Regenerate kubelet `.pem` Certificates
+### Regenerate `kubelet` `.pem` Certificates
 
 1. Backup certificates for `kubelet` on each master and worker node:
 
@@ -409,7 +410,7 @@ Run the following steps on each master node.
 
 5. Check the expiration of the `kubectl` certificate files. See [File Locations](#file-locations) for the list of files.
 
-   **This task is for each master and worker node. The example checks each kubelet certificate in [File Locations](#file-locations).**
+   **This task is for each master and worker node. The example checks each `kubelet` certificate in [File Locations](#file-locations).**
 
    ```bash
    ncn# for i in $(ls /var/lib/kubelet/pki/*.crt;ls /var/lib/kubelet/pki/*.pem);do echo ${i}; openssl x509 -enddate -noout -in ${i};done
@@ -436,7 +437,11 @@ Run the following steps on each master node.
 
    Follow the [Reboot NCNs](../node_management/Reboot_NCNs.md) process.
 
-8. Update the client certificate for `kube-etcdbackup`.
+### Update client secrets
+
+Run the following steps from a master node.
+
+1. Update the client certificate for `kube-etcdbackup`.
 
    1. Update the `kube-etcdbackup-etcd` secret.
 
@@ -448,7 +453,7 @@ Run the following steps on each master node.
                      --save-config --dry-run=client -o yaml | kubectl apply -f -
       ```
 
-   1. Check that the certificate's expiration date has been updated.
+   1. Check the certificate's expiration date to verify that the certificate is not expired.
 
       ```bash
       ncn-m# kubectl get secret -n kube-system kube-etcdbackup-etcd -o json | jq -r '.data."tls.crt" | @base64d' | openssl x509 -noout -enddate
@@ -457,7 +462,7 @@ Run the following steps on each master node.
       Example output:
 
       ```text
-      notAfter=Apr 21 07:18:51 2023 GMT
+      notAfter=May  4 22:37:16 2023 GMT
       ```
 
    1. Check that the next `kube-etcdbackup` cronjob `Completed`. This cronjob runs every 10 minutes.
@@ -471,4 +476,69 @@ Run the following steps on each master node.
       ```text
       NAME                               READY   STATUS      RESTARTS   AGE
       kube-etcdbackup-1652201400-czh5p   0/1     Completed   0          107s
+      ```
+
+1. Update the client certificate for `etcd-client`.
+
+   1. Update the `etcd-client-cert` secret.
+
+      ```bash
+      ncn-m# kubectl --namespace=sysmgmt-health create secret generic etcd-client-cert 
+                     --from-file=etcd-client=/etc/kubernetes/pki/apiserver-etcd-client.crt \
+                     --from-file=etcd-client-key=/etc/kubernetes/pki/apiserver-etcd-client.key \
+                     --from-file=etcd-ca=/etc/kubernetes/pki/etcd/ca.crt \
+                     --save-config --dry-run=client -o yaml | kubectl apply -f -
+      ```
+
+   1. Check the certificates' expiration dates to verify that none of the certificate are expired.
+
+      1. Check the `etcd-ca` expiration date.
+
+         ```bash
+         ncn-m# kubectl get secret -n sysmgmt-health etcd-client-cert -o json | jq -r '.data."etcd-ca" | @base64d' | openssl x509 -noout -enddate
+         ```
+
+         Example output:
+
+         ```text
+         notAfter=May  1 18:20:23 2032 GMT
+         ```
+
+      1. Check the `etcd-client` expiration date.
+
+         ```bash
+         ncn-m# kubectl get secret -n sysmgmt-health etcd-client-cert -o json | jq -r '.data."etcd-client" | @base64d' | openssl x509 -noout -enddate
+         ```
+
+         Example output:
+
+         ```text
+         notAfter=May  4 18:20:24 2023 GMT
+         ```
+
+   1. Restart Prometheus.
+
+      ```bash
+      ncn-m# kubectl rollout restart -n sysmgmt-health statefulSet/prometheus-cray-sysmgmt-health-promet-prometheus
+      ncn-m# kubectl rollout status -n sysmgmt-health statefulSet/prometheus-cray-sysmgmt-health-promet-prometheus
+      ```
+
+      Example output:
+
+      ```text
+      Waiting for 1 pods to be ready...
+      statefulset rolling update complete ...
+      ```
+
+   1. Check for any `tls` errors from the active Prometheus targets. No errors are expected.
+
+      ```bash
+      ncn-m# PROM_IP=$(kubectl get services -n sysmgmt-health cray-sysmgmt-health-promet-prometheus -o json | jq -r '.spec.clusterIP')
+      ncn-m# curl -s http://${PROM_IP}:9090/api/v1/targets | jq -r '.data.activeTargets[] | select(."scrapePool" == "sysmgmt-health/cray-sysmgmt-health-promet-kube-etcd/0")' | grep lastError | sort -u
+      ```
+
+      Example output:
+
+      ```text
+        "lastError": "",
       ```


### PR DESCRIPTION
## Summary and Scope

This relates to CAST-29991 - During cert renewal, the etcd-client-cert secret used by the prometheus active targets to connect from the worker node to the master nodes to check etcd metrics also needed to be updated. 

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5641](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5641)
* Change will also be needed in main, 1.2 and 1.0 branches
* Future work required by NA
* Documentation changes required in NA
* Merge with/before/after NA

## Testing

vshasta

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
