### PR TITLE
CASMINST-4744: Add missing backslash from ncn-image-modification.sh command example

### DIFF
--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md
@@ -79,7 +79,7 @@ This step is required. **There is no default root password and no default SSH ke
    each squashed image is unsquashed.
 
    ```bash
-   pit# cd /var/www/ephemeral/data/
+   pit# cd ${PITDATA}/data/
    pit# ${CSM_PATH}/ncn-image-modification.sh -p -z America/Chicago \
                                               -d /my/pre-existing/keys \
                                               -k $(find . -name "kubernetes-*.squashfs" | sort -V | tail -1) \
@@ -92,7 +92,7 @@ This step is required. **There is no default root password and no default SSH ke
    any input after it is invoked.
 
    ```bash
-   pit# cd /var/www/ephemeral/data/
+   pit# cd ${PITDATA}/data/
    pit# export SQUASHFS_ROOT_PW_HASH=$(awk -F':' /^root:/'{print $2}' < /etc/shadow)
    pit# ${CSM_PATH}/ncn-image-modification.sh -p \
                                               -t rsa \
@@ -107,8 +107,7 @@ This step is required. **There is no default root password and no default SSH ke
 1. Set the boot links.
 
    ```bash
-   pit# cd
-   pit# set-sqfs-links.sh
+   pit# cd && set-sqfs-links.sh
    ```
 
 ## Cleanup
@@ -118,5 +117,5 @@ This step is required. **There is no default root password and no default SSH ke
    These may be removed now, or after verifying that the nodes are able to boot successfully with the new images.
 
    ```bash
-   pit# cd /var/www/ephemeral/data && rm -rf ceph/old k8s/old
+   pit# cd ${PITDATA}/data/ && rm -rvf ceph/old k8s/old
    ```

--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md
@@ -97,7 +97,7 @@ This step is required. **There is no default root password and no default SSH ke
    pit# ${CSM_PATH}/ncn-image-modification.sh -p \
                                               -t rsa \
                                               -N "" \
-                                              -k $(find . -name "kubernetes-*.squashfs" | sort -V | tail -1)
+                                              -k $(find . -name "kubernetes-*.squashfs" | sort -V | tail -1) \
                                               -s $(find . -name "storage-ceph-*.squashfs" | sort -V | tail -1)
    ```
 


### PR DESCRIPTION
## Summary and Scope

One of the command examples for the ncn-image-modification.sh script is missing a backslash, which causes one of the arguments not to be passed to the script.

For the csm-1.3 version of this PR, I also replaced the hardcoded /var/www/ephemeral path with the $PITDATA variable, and I added the -v flag to the rm command. I am not backporting those changes into the csm-1.2 branch since they are not necessary changes, just slight improvements. The csm-1.2 backport only contains the fix for the broken command example.

## Issues and Related PRs

csm-1.2 backport PR forthcoming (for just the command example fix).

## Testing

We tested the corrected command during the tyr install.

## Risks and Mitigations

Riskier not to fix this.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
