### PR TITLE
csm-1.2 backport: CASMINST-4744: Add missing backslash from ncn-image-modification.sh command example

### DIFF
--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md
@@ -102,7 +102,7 @@ This step is required. **There is no default root password and no default SSH ke
    ```
 
    The script will save the original SquashFS images in `./{k8s,ceph}/old`. The new image filenames will
-   have a `secure-` prefix. The initrd and kernel will retain their original filenames.
+   have a `secure-` prefix. The `initrd` and kernel will retain their original filenames.
 
 1. Set the boot links.
 


### PR DESCRIPTION
Backport (of just the bug fix part) of https://github.com/Cray-HPE/docs-csm/pull/1737