### PR TITLE
CASMHMS-5572: Provide a procedure to recover from mismatched BMC Credentials 

### DIFF
--- a/operations/index.md
+++ b/operations/index.md
@@ -319,6 +319,7 @@ Mechanisms used by the system to ensure the security and authentication of inter
   - [Update Default ServerTech PDU Credentials used by the Redfish Translation Service](security_and_authentication/Update_Default_ServerTech_PDU_Credentials_used_by_the_Redfish_Translation_Service.md)
   - [Change Credentials on ServerTech PDUs](security_and_authentication/Change_Credentials_on_ServerTech_PDUs.md)
   - [Add Root Service Account for Gigabyte Controllers](security_and_authentication/Add_Root_Service_Account_for_Gigabyte_Controllers.md)
+  - [Recovering from Mismatched BMC Credentials](security_and_authentication/Recovering_from_Mismatched_BMC_Credentials.md)
 - [SSH Keys](security_and_authentication/SSH_Keys.md)
 - [Authenticate an Account with the Command Line](security_and_authentication/Authenticate_an_Account_with_the_Command_Line.md)
 - [Default Keycloak Realms, Accounts, and Clients](security_and_authentication/Default_Keycloak_Realms_Accounts_and_Clients.md)

--- a/operations/security_and_authentication/Recovering_from_Mismatched_BMC_Credentials.md
+++ b/operations/security_and_authentication/Recovering_from_Mismatched_BMC_Credentials.md
@@ -1,0 +1,135 @@
+# Recovering from Mismatched BMC Credentials
+
+This procedure is aimed recovering from the situation when new or replacement hardware has `root` credentials that do not match the system's current default `root` user credentials.
+
+This type of problem can occur in the following scenarios:
+
+- The Site has customized the default `root` credentials using either the
+  [Updating the Liquid-Cooled EX Cabinet CEC with Default Credentials after a CEC Password Change](Updating_the_Liquid-Cooled_EX_Cabinet_Default_Credentials_after_a_CEC_Password_Change.md) or
+  [Update Default Air-Cooled BMC and Leaf-BMC Switch SNMP Credentials](Update_Default_Air-Cooled_BMC_and_Leaf_BMC_Switch_SNMP_Credentials.md) procedures.
+- Hardware has the factory default `root` password or a different known `root` password configured. Such as a pieces of hardware that moved from a different system with customized default `root` password.
+
+## Procedure
+
+1. Specify the BMC hostname with the mismatched credentials:
+
+    ```bash
+    ncn-m001# BMC=x1000c0r1b0
+    ```
+
+1. Specify the current `root` user password for the BMC:
+
+    > Depending on the origin of the piece of hardware, this could be the factory default password or a different systems default password.
+
+    ```bash
+    ncn-m001# read -s CURRENT_ROOT_PASSWORD
+    ncn-m001# echo $CURRENT_ROOT_PASSWORD
+    ```
+
+1. Verify the credentials work with Redfish using curl:
+
+    ```bash
+    ncn-m001# curl -k -u "root:$CURRENT_ROOT_PASSWORD" https://$BMC/redfish/v1/Managers -i
+    ```
+
+    The following example output shows the `CURRENT_ROOT_PASSWORD` environment variable contains a valid root password for the BMC.
+
+    ```text
+    HTTP/1.1 200 OK
+    ...output truncated...
+    ```
+
+    Conversely the following output shows the `CURRENT_ROOT_PASSWORD` environment variable contains an **invalid** `root` user password for the BMC. Update the `CURRENT_ROOT_PASSWORD` environment variable to contain a valid `root` user password for the BMC.
+
+    ```text
+    HTTP/1.1 401 Unauthorized
+    ...output truncated...
+    ```
+
+1. Update the credentials for the Redfish endpoint stored in Vault using Hardware State Manager (HSM):
+
+    ```bash
+    ncn-m001# cray hsm inventory redfishEndpoint update $BMC --password $CURRENT_ROOT_PASSWORD 
+    ```
+
+1. Wait a few minutes for HSM to attempt to inventory the BMC:
+
+    ```bash
+    ncn-m001# sleep 120
+    ```
+
+1. Verify the BMC's discovery status is `DiscoverOK`:
+
+    ```bash
+    ncn-m001# cray hsm inventory redfishEndpoints describe $BMC
+    ```
+
+    If `DiscoveryStarted`, then wait and recheck the discovery status again. If `HTTPsGetFailed` examine the HSM logs to troubleshoot the issue.
+
+1. Determine the system's default BMC `root` user password:
+
+    ```bash
+    ncn-m001# VAULT_PASSWD=$(kubectl -n vault get secrets cray-vault-unseal-keys -o json | jq -r '.data["vault-root"]' |  base64 -d)
+    ncn-m001# alias vault='kubectl -n vault exec -i cray-vault-0 -c vault -- env VAULT_TOKEN=$VAULT_PASSWD VAULT_ADDR=http://127.0.0.1:8200 VAULT_FORMAT=json vault'
+    ```
+
+    1. Retrieve the default root password for liquid-cooled hardware:
+
+        ```bash
+        ncn-m001# SYSTEM_ROOT_PASSWORD=$(vault kv get secret/meds-cred/global/ipmi | jq .data.Password -r)
+        ```
+
+    1. Retrieve the default root password for air-cooled hardware:
+
+        ```bash
+        ncn-m001# SYSTEM_ROOT_PASSWORD=$(vault kv get secret/reds-creds/defaults | jq .data.Cray.password -r)
+        ```
+
+    Verify the systems's default `root` user password:
+
+    ```bash
+    ncn-m001# echo $SYSTEM_ROOT_PASSWORD
+    ```
+
+1. Create payload for the System Configuration Service (SCSD):
+
+    ```bash
+    ncn-m001# jq --arg BMC "$BMC" --arg PASSWORD "$SYSTEM_ROOT_PASSWORD" -n \
+        '{Targets:[{Xname: $BMC, Creds: {Username: "root", Password: $PASSWORD}}]}' > scsd_payload.json
+    ```
+
+1. Inspect the payload:
+
+    ```bash
+    ncn-m001# jq . scsd_payload.json
+    ```
+
+    Example payload contents:
+
+    ```json
+    {
+      "Targets": [
+        {
+        "Xname": "x1000c0r1b0",
+        "Creds": {
+            "Username": "root",
+            "Password": "foobar"
+          }
+        }
+      ]
+    }
+    ```
+
+1. Apply the the systems's default BMC `root` user credentials to the BMC:
+
+    ```bash
+    ncn-m001# cray scsd bmc discreetcreds create scsd_payload.json
+    ```
+
+    If the operation is not successful inspect the the SCSD logs.
+
+1. Remove SCSD payload file containing credentials from the file system:
+
+    ```bash
+    ncn-m001# rm scsd_payload.json
+    ```


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
Provide a procedure to recover from mismatched BMC Credentials, when new or replacement hardware is added to the system with the factory default BMC root credentials (or another known password) that is different then the systems current  default BMC root password.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
Backwards compatible

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMHMS-5572

## Testing

_List the environments in which these changes were tested._

### Tested on:
  * Testing in progress

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
Low risk

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

