### PR TITLE
csm-1.2 backport: CASMINST-4747: Collect NCN MAC addresses: Fix command error and add missing step to recovery procedure

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -583,6 +583,10 @@ bs
 # To allow Site Init
 Init
 
+- install/collecting_ncn_mac_addresses.md
+# To allow Site Init
+Init
+
  - install/prepare_configuration_payload.md
 # To allow Site Init
 Init

--- a/.spelling
+++ b/.spelling
@@ -445,6 +445,7 @@ RSAv1
 RSAv2
 Runbook
 S-8000
+S-8024
 sC
 SCSD
 sC-ToR

--- a/install/collecting_ncn_mac_addresses.md
+++ b/install/collecting_ncn_mac_addresses.md
@@ -258,7 +258,7 @@ If the  `ncn_metadata.csv` file is incorrect, the NCNs will be unable to deploy.
 
     ```bash
     pit# \
-    cp -p /var/www/ephemeral/prep/$SYSTEM_NAME/dnsmasq.d/* /etc/dnsmasq.d/*
+    cp -p /var/www/ephemeral/prep/$SYSTEM_NAME/dnsmasq.d/* /etc/dnsmasq.d/
     cp -p /var/www/ephemeral/prep/$SYSTEM_NAME/basecamp/* /var/www/ephemeral/configs/
     cp -p /var/www/ephemeral/prep/$SYSTEM_NAME/conman.conf /etc/
     cp -p /var/www/ephemeral/prep/$SYSTEM_NAME/pit-files/* /etc/sysconfig/network/

--- a/install/collecting_ncn_mac_addresses.md
+++ b/install/collecting_ncn_mac_addresses.md
@@ -294,3 +294,8 @@ If the  `ncn_metadata.csv` file is incorrect, the NCNs will be unable to deploy.
 1. Wipe the disks before relaunching the NCNs.
 
    See [full wipe from Wipe NCN Disks for Reinstallation](wipe_ncn_disks_for_reinstallation.md#full-wipe).
+
+1. Set BMCs to DHCP, if needed.
+
+   For any NCNs which booted far enough to begin running `cloud-init`, set their BMCs to DHCP. If in doubt, it does no
+   harm to perform this step. See [Set node BMCs to DHCP](prepare_management_nodes.md#set_node_bmcs_to_dhcp).


### PR DESCRIPTION
Backport PR for: https://github.com/Cray-HPE/docs-csm/pull/1743
(just the fixes, without the linting and other minor improvements)