### PR TITLE
csm-1.2 backport: CASMINST-4759: Correct minor install docs issues

### DIFF
--- a/install/configure_administrative_access.md
+++ b/install/configure_administrative_access.md
@@ -1,119 +1,129 @@
 # Configure Administrative Access
 
 There are several operations which configure administrative access to different parts of the system.
-Ensuring that the `cray` CLI can be used by administrative credentials enables use of many management
+Ensuring that the `cray` CLI can be used with administrative credentials enables use of many management
 services via commands. The management nodes can be locked from accidental manipulation by the
 `cray capmc` and `cray fas` commands when the intent is to work on the entire system except the
-management nodes. The `cray scsd` command can change the SSH keys, NTP server, syslog server, and
+management nodes. The `cray scsd` command can change the SSH keys, NTP server, `syslog` server, and
 BMC/controller passwords.
 
 ## Topics
 
-   1. [Configure Keycloak Account](#configure_keycloak_account)
-   1. [Configure the Cray Command Line Interface (cray CLI)](#configure_cray_cli)
-   1. [Set Management Role on the BMCs of Management Nodes](#set_bmc_management_role)
-   1. [Lock Management Nodes](#lock_management_nodes)
-   1. [Configure BMC and Controller Parameters with SCSD](#configure_with_scsd)
-   1. [Configure Non-compute Nodes with CFS](#configure-ncns)
-   1. [Upload Olympus BMC Recovery Firmware into TFTP server](#cray_upload_recovery_images)
-   1. [Next Topic](#next-topic)
+1. [Configure Keycloak account](#configure_keycloak_account)
+2. [Configure the Cray command line interface](#configure_cray_cli)
+3. [Set `Management` role on the BMCs of management nodes](#set_bmc_management_role)
+4. [Lock management nodes](#lock_management_nodes)
+5. [Configure BMC and controller parameters with SCSD](#configure_with_scsd)
+6. [Configure non-compute nodes with CFS](#configure-ncns)
+7. [Upload Olympus BMC recovery firmware into TFTP server](#cray_upload_recovery_images)
+8. [Proceed to next topic](#next-topic)
 
-   **NOTE:** The procedures in this section of installation documentation are intended to be done in order, even though the topics are
-   administrative or operational procedures. The topics themselves do not have navigational links to the next topic in the sequence.
+**NOTE:** The procedures in this section of installation documentation are intended to be done in order, even though the topics are
+administrative or operational procedures. The topics themselves do not have navigational links to the next topic in the sequence.
 
-## Details
+<a name="configure_keycloak_account"></a>
 
-   <a name="configure_keycloak_account"></a>
+## 1. Configure Keycloak account
 
-   1. Configure Keycloak Account
+Upcoming steps in the installation workflow require an account to be configured in Keycloak for
+authentication. This can be either a local Keycloak account or an external Identity Provider (IdP),
+such as LDAP. Having an account in Keycloak with administrative credentials enables the use of many
+management services via the `cray` command.
 
-      Upcoming steps in the installation workflow require an account to be configured in Keycloak for
-      authentication. This can be either a local Keycloak account or an external Identity Provider (IdP),
-      such as LDAP. Having an account in Keycloak with administrative credentials enables the use of many
-      management services via the `cray` command.
+See [Configure Keycloak Account](../operations/CSM_product_management/Configure_Keycloak_Account.md).
 
-      See [Configure Keycloak Account](../operations/CSM_product_management/Configure_Keycloak_Account.md)
-   <a name="configure_cray_cli"></a>
-   1. Configure the Cray Command Line Interface (cray CLI)
+<a name="configure_cray_cli"></a>
 
-      The `cray` command line interface (CLI) is a framework created to integrate all of the system management REST
-      APIs into easily usable commands.
+## 2. Configure the Cray command line interface
 
-      Later procedures in the installation workflow use the `cray` command to interact with multiple services.
-      The `cray` CLI configuration needs to be initialized for the Linux account. The Keycloak user who initializes the
-      CLI configuration needs to be authorized for administrative actions.
+The `cray` command line interface (CLI) is a framework created to integrate all of the system management REST
+APIs into easily usable commands.
 
-      See [Configure the Cray Command Line Interface (cray CLI)](../operations/configure_cray_cli.md)
-   <a name="set_bmc_management_role"></a>
-   1. Set Management Role on the BMCs of Management Nodes
+Later procedures in the installation workflow use the `cray` command to interact with multiple services.
+The `cray` CLI configuration needs to be initialized for the Linux account. The Keycloak user who initializes the
+CLI configuration needs to be authorized for administrative actions.
 
-      The BMCs that control management nodes will not have been marked with the *Management* role in HSM. It is important
-      to mark them with the *Management* role so they can be easily included in the locking/unlocking operations required
-      as protections for FAS and CAPMC actions.
-      **Set BMC Management Roles Now!**
+See [Configure the Cray command line interface](../operations/configure_cray_cli.md).
 
-      See [Set BMC Management Role](../operations/hardware_state_manager/Set_BMC_Management_Role.md)
+<a name="set_bmc_management_role"></a>
 
-      For more info on the importance of locking these components, see [Lock Management Nodes](#lock_management_nodes).
+## 3. Set `Management` role on the BMCs of management nodes
 
-   <a name="lock_management_nodes"></a>
+The BMCs that control management nodes will not have been marked with the `Management` role in HSM. It is important
+to mark them with the `Management` role so that they can be easily included in the locking/unlocking operations required
+as protections for FAS and CAPMC actions.
 
-   1. Lock Management Nodes
+**Set BMC `Management` roles now!**
 
-      The management nodes are unlocked at this point in the installation. Locking the management nodes and their BMCs will
-      prevent actions from FAS to update their firmware or CAPMC to power off or do a power reset. Doing any of these by
-      accident will take down a management node. If the management node is a Kubernetes master or worker node, this can have
-      serious negative effects on system operation.
+See [Set BMC `Management` Role](../operations/hardware_state_manager/Set_BMC_Management_Role.md).
 
-      If a single node is taken down by mistake, it is possible that things will recover. However, if all management
-      nodes are taken down, or all Kubernetes worker nodes are taken down by mistake, the system is dead and has to be
-      completely restarted.
-      **Lock the management nodes now!**
+<a name="lock_management_nodes"></a>
 
-      Run the `lock_management_nodes.py` script to lock all management nodes and their BMCs that are not already locked:
+## 4. Lock management nodes
 
-      ```bash
-      ncn# /opt/cray/csm/scripts/admin_access/lock_management_nodes.py
-      ```
+The management nodes are unlocked at this point in the installation. Locking the management nodes and their BMCs will
+prevent actions from FAS to update their firmware or CAPMC to power off or do a power reset. Doing any of these by
+accident will take down a management node. If the management node is a Kubernetes master or worker node, this can have
+serious negative effects on system operation.
 
-      The return value of the script is 0 if locking was successful. Otherwise, a non-zero return means that manual intervention may be needed to lock the nodes and their BMCs.
+If a single node is taken down by mistake, it is possible that things will recover. However, if all management
+nodes are taken down, or all Kubernetes worker nodes are taken down by mistake, the system is dead and has to be
+completely restarted.
 
-      For more information see [Lock and Unlock Nodes](../operations/hardware_state_manager/Lock_and_Unlock_Management_Nodes.md)
-   <a name="configure_with_scsd"></a>
-   1. Configure BMC and Controller Parameters with SCSD
+**Lock the management nodes now!**
 
-      **NOTE:** If there are no liquid-cooled cabinets present in the HPE Cray EX system, then this step can be skipped.
+Run the `lock_management_nodes.py` script to lock all management nodes and their BMCs that are not already locked:
 
-      The System Configuration Service (SCSD) allows administrators to set various BMC and controller parameters for
-      components in liquid-cooled cabinets. At this point in the install, SCSD should be used to set the
-      SSH key in the node controllers (BMCs) to enable troubleshooting. If any of the nodes fail to power
-      down or power up as part of the compute node booting process, it may be necessary to look at the logs
-      on the BMC for node power down or node power up.
+```bash
+ncn# /opt/cray/csm/scripts/admin_access/lock_management_nodes.py
+```
 
-      See [Configure BMC and Controller Parameters with SCSD](../operations/system_configuration_service/Configure_BMC_and_Controller_Parameters_with_scsd.md)
-   <a name="configure-ncns"></a>
-   1. Configure Non-compute Nodes with CFS
+The return value of the script is 0 if locking was successful. Otherwise, a non-zero return means that manual intervention may be needed to lock the nodes and their BMCs.
 
-      Non-compute Nodes (NCN) need to be configured after booting for administrative access, security, and other
-      purposes. The [Configuration Framework Service (CFS)](../operations/configuration_management/Configuration_Management.md)
-      is used to apply post-boot configuration in a decoupled, layered manner. Individual software products including
-      CSM provide one or more layers of configuration in a process called "NCN personalization".
+For more information about locking and unlocking nodes, see [Lock and Unlock Nodes](../operations/hardware_state_manager/Lock_and_Unlock_Management_Nodes.md).
 
-      See [Configure Non-Compute Nodes with CFS](../operations/CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md)
-   <a name="cray_upload_recovery_images"></a>
-   1. Upload Olympus BMC Recovery Firmware into TFTP server
+<a name="configure_with_scsd"></a>
 
-      The Olympus hardware (NodeBMCs, ChassisBMCs, RouterBMCs) needs to have recovery firmware loaded to the cray-tftp server in case the BMC loses its firmware.
-      The BMCs are configured to load a recovery firmware from a TFTP server.
-      This procedure does not modify any BMC firmware, but only stages the firmware on the TFTP server for download in the event it is needed.
+## 5. Configure BMC and controller parameters with SCSD
 
-      This step requires the CSM software, Cray CLI, and HPC Firmware Pack (HFP) to be installed.
-      If these are not currently installed, then this step will need to be skipped and run later in the install process.
+**NOTE:** If there are no liquid-cooled cabinets present in the HPE Cray EX system, then this step can be skipped.
 
-      See [Load Olympus BMC Recovery Firmware into TFTP server](../operations/firmware/Upload_Olympus_BMC_Recovery_Firmware_into_TFTP_Server.md)
-   <a name="next-topic"></a>
-   1. Next Topic
+The System Configuration Service (SCSD) allows administrators to set various BMC and controller parameters for
+components in liquid-cooled cabinets. At this point in the install, SCSD should be used to set the
+SSH key in the node controllers (BMCs) to enable troubleshooting. If any of the nodes fail to power
+down or power up as part of the compute node booting process, it may be necessary to look at the logs
+on the BMC for node power down or node power up.
 
-      After completing the operational procedures above which configure administrative access, the next step is to validate the health of management nodes and CSM services.
+See [Configure BMC and Controller Parameters with SCSD](../operations/system_configuration_service/Configure_BMC_and_Controller_Parameters_with_scsd.md).
 
-      See [Validate CSM Health](index.md#validate_csm_health)
+<a name="configure-ncns"></a>
+
+## 6. Configure non-compute nodes with CFS
+
+Non-compute Nodes (NCN) need to be configured after booting for administrative access, security, and other
+purposes. The [Configuration Framework Service (CFS)](../operations/configuration_management/Configuration_Management.md)
+is used to apply post-boot configuration in a decoupled, layered manner. Individual software products including
+CSM provide one or more layers of configuration in a process called "NCN personalization".
+
+See [Configure Non-Compute Nodes with CFS](../operations/CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md).
+
+<a name="cray_upload_recovery_images"></a>
+
+## 7. Upload Olympus BMC recovery firmware into TFTP server
+
+**NOTE:** This step requires the CSM software, Cray CLI, and HPC Firmware Pack (HFP) to be installed.
+If these are not currently installed, then skip this step and perform it later.
+
+The Olympus hardware needs to have recovery firmware loaded to the `cray-tftp` server in case the BMC loses its firmware.
+The BMCs are configured to load a recovery firmware from a TFTP server.
+This procedure does not modify any BMC firmware, but only stages the firmware on the TFTP server for download in the event it is needed.
+
+See [Load Olympus BMC Recovery Firmware into TFTP server](../operations/firmware/Upload_Olympus_BMC_Recovery_Firmware_into_TFTP_Server.md).
+
+<a name="next-topic"></a>
+
+## 8. Proceed to next topic
+
+After completing the operational procedures above which configure administrative access, the next step is to validate the health of management nodes and CSM services.
+
+See [Validate CSM Health](index.md#validate_csm_health).

--- a/operations/CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md
+++ b/operations/CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md
@@ -13,23 +13,23 @@ the [Configuration Framework Service (CFS)](../configuration_management/Configur
 During a fresh install, carry out these procedures in order. Later, individual
 procedures may be re-run as needed.
 
-1. [Set Up Passwordless SSH](#set_up_passwordless_ssh)
-   - [Option 1: Use the CSM-provided SSH Keys](#set_up_passwordless_ssh_option_1)
-   - [Option 2: Option 2: Provide Custom SSH Keys](#set_up_passwordless_ssh_option_2)
-   - [Option 3: Disable CSM-provided Passwordless SSH](#set_up_passwordless_ssh_option_3)
-   - [Restore CSM-provided SSH Keys](#set_up_passwordless_ssh_restore)
-2. [Configure the Root Password and Root SSH Keys in Vault](#set_root_password)
-   - [Option 1: Automated Default](#set_root_password_option_1)
+1. [Set up passwordless SSH](#set_up_passwordless_ssh)
+   - [Option 1: Use the CSM-provided SSH keys](#set_up_passwordless_ssh_option_1)
+   - [Option 2: Provide custom SSH keys](#set_up_passwordless_ssh_option_2)
+   - [Option 3: Disable CSM-provided passwordless SSH](#set_up_passwordless_ssh_option_3)
+   - [Restore CSM-provided SSH keys](#set_up_passwordless_ssh_restore)
+2. [Configure the `root` password and SSH keys in Vault](#set_root_password)
+   - [Option 1: Automated default](#set_root_password_option_1)
    - [Option 2: Manual](#set_root_password_option_2)
-3. [Perform NCN Personalization](#perform_ncn_personalization)
-   - [Option 1: Automatically Apply CSM Configuration](#auto_apply_csm_config)
-     - [Automatic CSM Configuration Steps](#auto_apply_csm_config_steps)
-     - [Automatic CSM Configuration Overrides](#auto_apply_csm_config_overrides)
-   - [Option 2: Manually Apply CSM Configuration](#manual_apply_csm_config)
+3. [Perform NCN personalization](#perform_ncn_personalization)
+   - [Option 1: Automatically apply CSM configuration](#auto_apply_csm_config)
+     - [Automatic CSM configuration steps](#auto_apply_csm_config_steps)
+     - [Automatic CSM Configuration overrides](#auto_apply_csm_config_overrides)
+   - [Option 2: Manually apply CSM configuration](#manual_apply_csm_config)
 
 <a name="set_up_passwordless_ssh"></a>
 
-## 1. Set Up Passwordless SSH
+## 1. Set up passwordless SSH
 
 This procedure should be run during CSM installation and any later time when
 the SSH keys need to be changed per site requirements.
@@ -54,15 +54,15 @@ The SSH keypair is applied to management nodes using NCN personalization.
 
 <a name="set_up_passwordless_ssh_option_1"></a>
 
-### Option 1: Use the CSM-provided SSH Keys
+### Option 1: Use the CSM-provided SSH keys
 
 The default CSM Ansible plays are already configured to enable Passwordless SSH
-by default. No further action is necessary before running NCN personalization
-with CFS.
+by default. No further action is necessary before proceeding to
+[Configure the `root` password and SSH keys in Vault](#set_root_password).
 
 <a name="set_up_passwordless_ssh_option_2"></a>
 
-### Option 2: Provide Custom SSH Keys
+### Option 2: Provide custom SSH keys
 
 Administrators may elect to replace the CSM-provided keys with their own custom
 keys.
@@ -73,8 +73,8 @@ keys.
     > key files on the system.
 
     ```bash
-    ncn# PUBLIC_KEY_FILE=/root/.ssh/id_rsa-csm.pub
-    ncn# PRIVATE_KEY_FILE=/root/.ssh/id_rsa-csm
+    ncn# PUBLIC_KEY_FILE=/path/to/id_rsa-csm.pub
+    ncn# PRIVATE_KEY_FILE=/path/to/id_rsa-csm
     ```
 
 1. Provide the custom keys by script or manually.
@@ -118,13 +118,14 @@ keys.
 Passwordless SSH with the provided keys will be set up once NCN personalization
 runs on the NCNs.
 
-**NOTE**: This keypair may or may not be the same keypair used for the NCN
-`root` user. See the [Configure the Root Password and Root SSH Keys in Vault](#set_root_password)
-procedure below for setting the root user SSH keys on NCNs.
+**NOTE**: This keypair may be the same keypair used for the NCN `root` user, but it
+is not required to be the same. Either option is valid.
+
+Proceed [Configure the `root` password and SSH keys in Vault](#set_root_password).
 
 <a name="set_up_passwordless_ssh_option_3"></a>
 
-### Option 3: Disable CSM-provided Passwordless SSH
+### Option 3: Disable CSM-provided passwordless SSH
 
 Local site security requirements may preclude use of passwordless SSH access between
 management nodes. A variable has been added to the associated Ansible roles that
@@ -165,12 +166,14 @@ associated with the product.
 > to make connections between nodes. CFS will continue to function if
 > passwordless SSH is disabled between CSM and other product environments.
 
+Proceed [Configure the `root` password and SSH keys in Vault](#set_root_password).
+
 <a name="set_up_passwordless_ssh_restore"></a>
 
-### Restore CSM-provided SSH Keys
+### Restore CSM-provided SSH keys
 
 > Use this procedure if switching from custom keys to the default CSM SSH keys
-> only; otherwise it can be skipped.
+> only; otherwise it should be skipped.
 
 In order to restore the default CSM keys, there are two options:
 
@@ -205,26 +208,27 @@ In order to restore the default CSM keys, there are two options:
 
 <a name="set_root_password"></a>
 
-## 2. Configure the Root Password and Root SSH Keys in Vault
+## 2. Configure the `root` password and SSH keys in Vault
 
-The root user password and SSH keys are managed on NCNs by using the
+The `root` user password and SSH keys are managed on NCNs by using the
 `csm.password` and `csm.ssh_keys` Ansible roles, respectively, located in the
-CSM configuration management repository. Root user passwords and SSH keys are
+CSM configuration management repository. `root` user passwords and SSH keys are
 set and managed in Vault.
 
-There are two options for setting the root password and SSH keys in Vault: automated default or manual.
+There are two options for setting the `root` password and SSH keys in Vault:
+[automated default](#set_root_password_option_1) or [manual](#set_root_password_option_2).
 
 After these have been set in Vault, they will automatically be applied to NCNs during NCN personalization.
 For more information on how to configure and run NCN personalization, see the
-[Perform NCN Personalization](#perform_ncn_personalization) procedure later in this page.
+[Perform NCN personalization](#perform_ncn_personalization) procedure later in this page.
 
 <a name="set_root_password_option_1"></a>
 
-### Option 1: Automated Default
+### Option 1: Automated default
 
 The automated default method uses the `write_root_secrets_to_vault.py` script to read in the current
-root password and SSH keys from the NCN where it is run, and write those to Vault. All of the NCNs are
-booted from images which already had their root passwords and SSH keys customized during the
+`root` user password and SSH keys from the NCN where it is run, and write those to Vault. All of the NCNs are
+booted from images which already had their `root` passwords and SSH keys customized during the
 [Deploy Management Nodes](../../install/deploy_management_nodes.md#deploy)
 procedure of the CSM install. In most cases, these are the same password and keys that should be
 written to Vault, and this script provides an easy way to do that.
@@ -274,6 +278,8 @@ All secrets successfully written to Vault
 SUCCESS
 ```
 
+Proceed to [Perform NCN personalization](#perform_ncn_personalization).
+
 <a name="set_root_password_option_2"></a>
 
 ### Option 2: Manual
@@ -290,9 +296,11 @@ Set the `root` user password and SSH keys in Vault by combining the following tw
 - The `Configure Root Password in Vault` procedure in [Update NCN User Passwords](../security_and_authentication/Update_NCN_Passwords.md#configure_root_password_in_vault).
 - The `Configure Root SSH Keys in Vault` procedure in [Update NCN User SSH Keys](../security_and_authentication/SSH_Keys.md#configure_root_keys_in_vault).
 
+Proceed to [Perform NCN personalization](#perform_ncn_personalization).
+
 <a name="perform_ncn_personalization"></a>
 
-## 3. Perform NCN Personalization
+## 3. Perform NCN personalization
 
 After completing the previous procedures, apply the configuration to the NCNs
 by running NCN personalization with [CFS](../configuration_management/Configuration_Management.md).
@@ -301,7 +309,7 @@ running the steps manually.
 
 <a name="auto_apply_csm_config"></a>
 
-### Option 1: Automatically Apply CSM Configuration
+### Option 1: Automatically apply CSM configuration
 
 > The `docs-csm` RPM must be installed in order to use this script. See
 > [Check for Latest Documentation](../../update_product_stream/index.md#documentation)
@@ -315,7 +323,7 @@ ncn# /usr/share/doc/csm/scripts/operations/configuration/apply_csm_configuration
 
 <a name="auto_apply_csm_config_steps"></a>
 
-#### Automatic CSM Configuration Steps
+#### Automatic CSM configuration steps
 
 By default, the script will perform the following steps:
 
@@ -331,7 +339,7 @@ By default, the script will perform the following steps:
 
 <a name="auto_apply_csm_config_overrides"></a>
 
-#### Automatic CSM Configuration Overrides
+#### Automatic CSM configuration overrides
 
 The script also supports several flags to override these behaviors:
 
@@ -359,7 +367,7 @@ The script also supports several flags to override these behaviors:
 
 <a name="manual_apply_csm_config"></a>
 
-### Option 2: Manually Apply CSM Configuration
+### Option 2: Manually apply CSM configuration
 
 In order to manually run NCN personalization, first gather the following information:
 

--- a/operations/configure_cray_cli.md
+++ b/operations/configure_cray_cli.md
@@ -2,7 +2,7 @@
 
 The `cray` command line interface (CLI) is a framework created to integrate all of the system management REST APIs into easily usable commands.
 
-Later procedures in the installation workflow use the `cray` CLI to interact with multiple services.
+Procedures in the CSM installation workflow use the `cray` CLI to interact with multiple services.
 The `cray` CLI configuration needs to be initialized for the Linux account, and the Keycloak user running
 the procedure needs to be authorized. This section describes how to initialize the `cray` CLI for use by
 a user and how to authorize that user.
@@ -11,36 +11,36 @@ The `cray` CLI only needs to be initialized once per user on a node.
 
 ## Procedure
 
-1. Unset the CRAY_CREDENTIALS environment variable, if previously set.
+1. Unset the `CRAY_CREDENTIALS` environment variable, if previously set.
 
-   Some of the installation procedures leading up to this point use the CLI with a Kubernetes managed service
+   Some CSM installation procedures use the CLI with a Kubernetes managed service
    account that is normally used for internal operations. There is a procedure for extracting the OAUTH token for
    this service account and assigning it to the `CRAY_CREDENTIALS` environment variable to permit simple CLI operations.
+   It must be unset in order to validate that the CLI is working with user authentication.
 
    ```bash
    ncn# unset CRAY_CREDENTIALS
    ```
 
-1. Initialize the `cray` CLI for the root account.
+1. Initialize the `cray` CLI for the `root` account.
 
    The `cray` CLI needs to know what host to use to obtain authorization and what user is requesting authorization,
-   so it can obtain an OAUTH token to talk to the API Gateway. This is accomplished by initializing the CLI
-   configuration. In this example, the 'vers' username and its password are used.
+   so it can obtain an OAUTH token to talk to the API gateway. This is accomplished by initializing the CLI
+   configuration.
 
-   If LDAP configuration was enabled, then use a valid account in LDAP instead of the example account 'vers'.
+   In this example, the `vers` username is used. It should be replaced with an appropriate user account:
 
-   If LDAP configuration was not enabled, or is not working, then a Keycloak local account could be created.
-   See [Configure Keycloak Account](CSM_product_management/Configure_Keycloak_Account.md) to create this local account in Keycloak
-   and then use it instead of the example account 'vers'.
+   - If LDAP configuration was enabled, then use a valid account in LDAP.
+   - If LDAP configuration was not enabled, or is not working, then a Keycloak local account may be created.
+     See [Configure Keycloak Account](CSM_product_management/Configure_Keycloak_Account.md) to create this local account in Keycloak.
 
    ```bash
-   ncn# cray init
+   ncn# cray init --hostname api-gw-service-nmn.local
    ```
 
-   When prompted, remember to use the correct username instead of 'vers'.
    Expected output (including the typed input) should look similar to the following:
-   ```
-   Cray Hostname: api-gw-service-nmn.local
+
+   ```text
    Username: vers
    Password:
    Success!
@@ -48,13 +48,15 @@ The `cray` CLI only needs to be initialized once per user on a node.
    Initialization complete.
    ```
 
-1. Verify the `cray` CLI is operational.
+1. Verify that the `cray` CLI is operational.
+
     ```bash
     ncn# cray artifacts buckets list -vvv
     ```
 
-    Expected output, if an error occurs see the troubleshooting section below in this topic.
-    ```
+    Expected output looks similar to the following:
+
+    ```text
     Loaded token: /root/.config/cray/tokens/api_gw_service_nmn_local.vers
     REQUEST: PUT to https://api-gw-service-nmn.local/apis/sts/token
     OPTIONS: {'verify': False}
@@ -63,80 +65,98 @@ The `cray` CLI only needs to be initialized once per user on a node.
     "prs", "sat", "sds", "sls", "sma", "ssd", "ssm", "vbis", "velero", "wlm",]
     ```
 
+    If an error occurs, then continue to the troubleshooting section below.
+
 ## Troubleshooting
 
-**NOTE:**  While resolving these issues is beyond the scope of this section, more information about what is failing can be found by adding `-vvvvv` to the `cray init ...` commands.
+More information about what is failing can be found by adding `-vvvvv` to the `cray init ...` commands.
 
-   If initialization fails in the above step, there are several common causes:
+### Initialization fails
 
-   * DNS failure looking up `api-gw-service-nmn.local` may be preventing the CLI from reaching the API Gateway and Keycloak for authorization
-   * Network connectivity issues with the NMN may be preventing the CLI from reaching the API Gateway and Keycloak for authorization
-   * Certificate mismatch or trust issues may be preventing a secure connection to the API Gateway
-   * Istio failures may be preventing traffic from reaching Keycloak
-   * Keycloak may not yet be set up to authorize the user
+If CLI initialization fails, there are several common causes:
 
-   If the initialization fails and the reason output is similar to the following example, restart radosgw on the storage nodes.
+- DNS failure looking up `api-gw-service-nmn.local` may be preventing the CLI from reaching the API Gateway and Keycloak for authorization
+- Network connectivity issues with the NMN may be preventing the CLI from reaching the API Gateway and Keycloak for authorization
+- Certificate mismatch or trust issues may be preventing a secure connection to the API Gateway
+- Istio failures may be preventing traffic from reaching Keycloak
+- Keycloak may not yet be set up to authorize the user
 
-   ```bash
-   ncn-m002# cray artifacts buckets list -vvv
-   Loaded token: /root/.config/cray/tokens/api_gw_service_nmn_local.vers
-   REQUEST: PUT to https://api-gw-service-nmn.local/apis/sts/token
+### Internal error
 
-   OPTIONS: {'verify': False}
+If an error similar to the following is seen, then restart `radosgw` on the storage nodes.
 
-   ERROR: {
-    "detail": "The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application.",
-     "status": 500,
-     "title": "Internal Server Error",
-     "type": "about:blank"
-    }
+```text
+The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application.
+```
 
-    Usage: cray artifacts buckets list [OPTIONS]
+Restart `radosgw` using the following steps. These steps must be run on one of the storage nodes running the Ceph `radosgw` process.
+By default these nodes are `ncn-s001`, `ncn-s002`, and `ncn-s003`.
 
-    Try 'cray artifacts buckets list --help' for help.
+1. Restart the Ceph `radosgw` process.
 
-    Error: Internal Server Error: The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application.
-   ```
+    > The expected output will be similar to the following, but it will vary based on the nodes running `radosgw`.
 
-   1.  SSH to ncn-s001/2/3.
-   1.  Restart the Ceph radosgw process.
+    ```bash
+    ncn-s# ceph orch restart rgw.site1.zone1
+    ```
 
-       ***The expected output will be similar to the following, but it will vary based on the number of nodes running radosgw.***
+    Example output:
 
-       ```bash
-       ncn-s00(1/2/3)# ceph orch restart rgw.site1.zone1
-       restart rgw.site1.zone1.ncn-s001.cshvbb from host 'ncn-s001'
-       restart rgw.site1.zone1.ncn-s002.tlegbb from host 'ncn-s002'
-       restart rgw.site1.zone1.ncn-s003.vwjwew from host 'ncn-s003'
-       ```
-   1.  Check to see that the processes restarted.
+    ```text
+    restart rgw.site1.zone1.ncn-s001.cshvbb from host 'ncn-s001'
+    restart rgw.site1.zone1.ncn-s002.tlegbb from host 'ncn-s002'
+    restart rgw.site1.zone1.ncn-s003.vwjwew from host 'ncn-s003'
+    ```
 
-       ***The "running" time should be in seconds. Restarting all of them could require a couple of minutes depending on how many.***
+1. Check to see that the processes restarted.
 
-       ```bash
-       ncn-s001# ceph orch ps --daemon_type rgw
-       NAME                             HOST      STATUS         REFRESHED  AGE  VERSION  IMAGE NAME                        IMAGE ID      CONTAINER ID
-       rgw.site1.zone1.ncn-s001.cshvbb  ncn-s001  running (29s)  23s ago    9h   15.2.8   registry.local/ceph/ceph:v15.2.8  5553b0cb212c  2a712824adc1
-       rgw.site1.zone1.ncn-s002.tlegbb  ncn-s002  running (29s)  28s ago    9h   15.2.8   registry.local/ceph/ceph:v15.2.8  5553b0cb212c  e423f22d06a5
-       rgw.site1.zone1.ncn-s003.vwjwew  ncn-s003  running (29s)  23s ago    9h   15.2.8   registry.local/ceph/ceph:v15.2.8  5553b0cb212c  1e6ad6bc2c62
-       ```
-   1.  In the event that more than 5 minutes has passed and the radosgw services have not restarted, fail the ceph-mgr process to the standby.
+    ```bash
+    ncn-s# ceph orch ps --daemon_type rgw
+    ```
 
-       ***There are cases where an orchestration task gets stuck and our current remediation is to fail the Ceph manager process.***
-       ```bash
-       # Get active ceph-mgr
-       ncn-s00(1/2/3)#ceph mgr dump | jq -r .active_name
-       ncn-s002.zozbqp
+    Example output:
 
-       # Fail the active ceph-mgr
-       ncn-s00(1/2/3)# ceph mgr fail $(ceph mgr dump | jq -r .active_name)
+    ```text
+    NAME                             HOST      STATUS         REFRESHED  AGE  VERSION  IMAGE NAME                        IMAGE ID      CONTAINER ID
+    rgw.site1.zone1.ncn-s001.cshvbb  ncn-s001  running (29s)  23s ago    9h   15.2.8   registry.local/ceph/ceph:v15.2.8  5553b0cb212c  2a712824adc1
+    rgw.site1.zone1.ncn-s002.tlegbb  ncn-s002  running (29s)  28s ago    9h   15.2.8   registry.local/ceph/ceph:v15.2.8  5553b0cb212c  e423f22d06a5
+    rgw.site1.zone1.ncn-s003.vwjwew  ncn-s003  running (29s)  23s ago    9h   15.2.8   registry.local/ceph/ceph:v15.2.8  5553b0cb212c  1e6ad6bc2c62
+    ```
 
-       #Confirm ceph-mgr has moved to a different ceph-mgr container
-       ncn-s00(1/2/3)# ceph mgr dump | jq -r .active_name
-       ncn-s001.qucrpr
-       ```
+    > A process which has restarted should have an `AGE` in seconds. Restarting all of them could require a couple of minutes depending on how many.
 
-   1.  Verify that the processes restarted using the command from step 3.
+1. In the event that more than 5 minutes have passed and the `radosgw` processes have not restarted, then fail the `ceph-mgr` process.
 
-        At this point the processes should restart. If they do not, it is possible that steps 2 and 3 will need to be done again.
+    1. Determine the active `ceph-mgr`.
 
+        ```bash
+        ncn-s#ceph mgr dump | jq -r .active_name
+        ```
+
+        Example output:
+
+        ```text
+        ncn-s002.zozbqp
+        ```
+
+    1. Fail the active `ceph-mgr`.
+
+        ```bash
+        ncn-s# ceph mgr fail $(ceph mgr dump | jq -r .active_name)
+        ```
+
+    1. Confirm that `ceph-mgr` has moved to a different `ceph-mgr` container.
+
+        ```bash
+        ncn-s# ceph mgr dump | jq -r .active_name
+        ```
+
+        Example output:
+
+        ```text
+        ncn-s001.qucrpr
+        ```
+
+    1. Verify that the `radosgw` processes restarted using the command from the previous step.
+
+        At this point the processes should restart. If they do not, then attempt this remediation procedure a second time.

--- a/operations/configure_cray_cli.md
+++ b/operations/configure_cray_cli.md
@@ -125,7 +125,7 @@ By default these nodes are `ncn-s001`, `ncn-s002`, and `ncn-s003`.
 
     > A process which has restarted should have an `AGE` in seconds. Restarting all of them could require a couple of minutes depending on how many.
 
-1. In the event that more than 5 minutes have passed and the `radosgw` processes have not restarted, then fail the `ceph-mgr` process.
+1. In the event that more than five minutes have passed and the `radosgw` processes have not restarted, then fail the `ceph-mgr` process.
 
     1. Determine the active `ceph-mgr`.
 


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/docs-csm/pull/1749