### PR TITLE
CASMUSER-3023 1.2

### DIFF
--- a/operations/UAS_user_and_admin_topics/Customize_End-User_UAI_Images.md
+++ b/operations/UAS_user_and_admin_topics/Customize_End-User_UAI_Images.md
@@ -89,7 +89,7 @@ Some of the steps are specific to that activity, others would be common to or si
         **IMPORTANT:** 99-slingshot-network.conf is omitted from the tarball as that prevents the UAI from running SSHD as the UAI user with the `su` command:
 
         ```bash
-        ncn-w001# (cd `pwd`/mount; tar --xattrs --xattrs-include='*' --exclude="99-slingshot-network.conf" -cf "../$SESSION_ID.tar" .) > /dev/null
+        ncn-w001# (cd `pwd`/mount; tar --xattrs --xattrs-include='*' --exclude="99-slingshot-network.conf" -cf "../$SESSION_ID.tar" .) 2> /dev/null
         ```
 
         This may take several minutes. Notice that this does not create a compressed tarball. Using an uncompressed format makes it possible to add files if needed once the tarball is made.

--- a/operations/UAS_user_and_admin_topics/Customize_End-User_UAI_Images.md
+++ b/operations/UAS_user_and_admin_topics/Customize_End-User_UAI_Images.md
@@ -141,7 +141,11 @@ Some of the steps are specific to that activity, others would be common to or si
 
     ncn-w001# podman import --change "ENTRYPOINT /usr/bin/uai-ssh.sh" $SESSION_ID.tar $UAI_IMAGE_NAME
 
-    ncn-w001# podman push $UAI_IMAGE_NAME
+    ncn-w001# PODMAN_USER=$(kubectl get secret -n nexus nexus-admin-credential -o json | jq -r '.data.username' | base64 -d)
+
+    ncn-w001# PODMAN_PASSWD=$(kubectl get secret -n nexus nexus-admin-credential -o json | jq -r '.data.password' | base64 -d)
+
+    ncn-w001# podman push --creds "$PODMAN_USER:$PODMAN_PASSWD" $UAI_IMAGE_NAME
     ```
 
 6. Register the new container image with UAS.

--- a/operations/UAS_user_and_admin_topics/Customize_End-User_UAI_Images.md
+++ b/operations/UAS_user_and_admin_topics/Customize_End-User_UAI_Images.md
@@ -1,9 +1,9 @@
 # Customize End-User UAI Images
 
-The provided End-User UAI image is a basic UAI image that includes an up-to-date version of the SLES Linux Distribution. It provides an entry point to using UAIs and an easy way for administrators to experiment with UAS configurations.
-To support building software to be run in compute nodes, or other HPC and Analytics workflows, it is necessary to create a custom End-User UAI image and use that.
+The provided end-user UAI image is a basic UAI image that includes an up-to-date version of the SLES Linux distribution. It provides an entry point to using UAIs and an easy way for administrators to experiment with UAS configurations.
+To support building software to be run in compute nodes, or other HPC and Analytics workflows, it is necessary to create a custom end-user UAI image and use that.
 
-A custom End-User UAI image can be any container image set up with the End-User UAI `entrypoint.sh` script.
+A custom end-user UAI image can be any container image set up with the end-user UAI `entrypoint.sh` script.
 Experimentation with the wide range of possible UAI images is beyond the scope of this document, but the example given here should offer a starting point for that kind of experimentation.
 
 The example provided here covers the most common use-case, which is building a UAI image from the SquashFS image used on compute nodes on the host system to support application development, workload management and analytics workflows.
@@ -16,11 +16,13 @@ Some of the steps are specific to that activity, others would be common to or si
 * The HPE Cray EX System CLI must be configured (initialized - `cray init` command) to reach the HPE Cray EX System API Gateway
 * The administrator must be logged in as an administrator to the HPE Cray EX System CLI (`cray auth login` command)
 
-**NOTE:** This procedure cannot be run from a PIT node or an external host, it must be run from a Kubernetes Worker or Master node.
+See [Configure the Cray CLI](../configure_cray_cli.md).
+
+**NOTE:** This procedure cannot be run from a PIT node or an external host, it must be run from a Kubernetes worker or master node.
 
 ## Procedure
 
-1. Choose a name for the custom image
+1. Choose a name for the custom image.
 
      This example names the custom End-User UAI image called `registry.local/cray/cray-uai-compute:latest`, and places that name in an environment variable for convenience. Alter the name as appropriate for the image to be created:
 
@@ -28,7 +30,7 @@ Some of the steps are specific to that activity, others would be common to or si
     ncn-w001# UAI_IMAGE_NAME=registry.local/cray/cray-uai-compute:latest
     ```
 
-2. Query BOS for a `sessiontemplate` ID.
+1. Query BOS for a `sessiontemplate` ID.
 
     Identify the `sessiontemplate` name to use. A full list may be found with the following command:
 
@@ -38,7 +40,7 @@ Some of the steps are specific to that activity, others would be common to or si
 
     Example output:
 
-    ```bash
+    ```yaml
     - boot_sets:
         compute:
         boot_ordinal: 2
@@ -57,14 +59,14 @@ Some of the steps are specific to that activity, others would be common to or si
     name: wlm-sessiontemplate-0.1.0
     ```
 
-    Alternatively, collect the sessiontemplate name used during the Cray Operating System (COS) install. Refer to the "Boot COS" procedure in the COS product stream documentation.
+    Alternatively, collect the `sessiontemplate` name used during the Cray Operating System (COS) install. Refer to the "Boot COS" procedure in the COS product stream documentation.
     Near the end of that procedure, the step to create a BOS session to boot the compute nodes should contain the name.
 
     ```bash
     ncn-w001# SESSION_NAME=wlm-sessiontemplate-0.1.0
     ```
 
-3. Download a compute node SquashFS.
+1. Download a compute node SquashFS.
 
     Use the `sessiontemplate` name to download a compute node SquashFS from a BOS `sessiontemplate` name:
 
@@ -74,9 +76,9 @@ Some of the steps are specific to that activity, others would be common to or si
     ncn-w001# cray artifacts get boot-images $SESSION_ID/rootfs rootfs.squashfs
     ```
 
-4. Mount the SquashFS and create a tarball.
+1. Mount the SquashFS and create a tarball.
 
-    1. Create a directory and mount the SquashFS on the directory:
+    1. Create a directory and mount the SquashFS on the directory.
 
         ```bash
         ncn-w001# mkdir -v mount
@@ -84,56 +86,91 @@ Some of the steps are specific to that activity, others would be common to or si
         ncn-w001# mount -v -o loop,ro rootfs.squashfs `pwd`/mount
         ```
 
-    2. Create the tarball.
+    1. Create the tarball.
 
-        **IMPORTANT:** 99-slingshot-network.conf is omitted from the tarball as that prevents the UAI from running SSHD as the UAI user with the `su` command:
+        **IMPORTANT:** `99-slingshot-network.conf` is omitted from the tarball, because that prevents the UAI from running `sshd` as the UAI user with the `su` command.
 
         ```bash
         ncn-w001# (cd `pwd`/mount; tar --xattrs --xattrs-include='*' --exclude="99-slingshot-network.conf" -cf "../$SESSION_ID.tar" .) 2> /dev/null
         ```
 
         This may take several minutes. Notice that this does not create a compressed tarball. Using an uncompressed format makes it possible to add files if needed once the tarball is made.
-        It also makes the procedure run just a bit more quickly. If warnings related to xattr are displayed, continue with the procedure as the resulting tarball should still result in a functioning UAI container image.
+        It also makes the procedure run slightly faster. Warnings related to `xattr` can be ignored; the resulting tarball should still result in a functioning UAI container image.
 
-    3. Check that the tarball contains `./usr/bin/uai-ssh.sh`.
+    1. Check that the tarball contains `./usr/bin/uai-ssh.sh`.
 
         ```bash
         ncn-w001# tar tf $SESSION_ID.tar | grep '[.]/usr/bin/uai-ssh[.]sh'
+        ```
+
+        Example output:
+
+        ```text
         ./usr/bin/uai-ssh.sh
         ```
 
-        If this script is not present, the easiest place to get a copy of the script is from a UAI built from the End-User UAI image provided with UAS, and it can be appended to the tarball:
+        If this script is not present, the easiest place to get a copy of the script is from a UAI built from the end-user UAI image provided with UAS.
+        After getting a copy of the script, it can be appended to the tarball.
 
-        ```bash
-        ncn-w001# mkdir -pv ./usr/bin
-        ncn-w001# cray uas create --publickey ~/.ssh/id_rsa.pub
-        uai_connect_string = "ssh vers@10.26.23.123"
-        uai_host = "ncn-w001"
-        uai_img = "dtr.dev.cray.com/cray/cray-uai-sles15sp1:latest"
-        uai_ip = "10.26.23.123"
-        uai_msg = ""
-        uai_name = "uai-vers-32079250"
-        uai_status = "Pending"
-        username = "vers"
+        1. Create a UAI.
 
-        [uai_portmap]
+            ```bash
+            ncn-w001# mkdir -pv ./usr/bin
+            ncn-w001# cray uas create --format toml --publickey ~/.ssh/id_rsa.pub
+            ```
 
-        ncn-w001# scp vers@10.26.23.123:/usr/bin/uai-ssh.sh ./usr/bin/uai-ssh.sh
-        The authenticity of host '10.26.23.123 (10.26.23.123)' can't be established.
-        ECDSA key fingerprint is SHA256:voQUCKDG4C9FGkmUcHZVrYJBXVKVYqcJ4kmTpe4tvOA.
-        Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
-        Warning: Permanently added '10.26.23.123' (ECDSA) to the list of known hosts.
-        uai-ssh.sh                                                                    100% 5035     3.0MB/s   00:00
+            Example output:
 
-        ncn-w001# cray uas delete --uai-list uai-vers-32079250
-        results = [ "Successfully deleted uai-vers-32079250",]
+            ```toml
+            uai_connect_string = "ssh vers@10.26.23.123"
+            uai_host = "ncn-w001"
+            uai_img = "dtr.dev.cray.com/cray/cray-uai-sles15sp1:latest"
+            uai_ip = "10.26.23.123"
+            uai_msg = ""
+            uai_name = "uai-vers-32079250"
+            uai_status = "Pending"
+            username = "vers"
 
-        ncn-w001# tar rvf 0c0d4081-2e8b-433f-b6f7-e1ef0b907be3.tar ./usr/bin/uai-ssh.sh
-        ```
+            [uai_portmap]
+            ```
 
-5. Create and push the container image.
+        1. Copy the script from the UAI.
 
-    Create a container image using podman or docker and push it to the site container registry. Any container-specific modifications may also be done here with a Dockerfile.
+            ```bash
+            ncn-w001# scp vers@10.26.23.123:/usr/bin/uai-ssh.sh ./usr/bin/uai-ssh.sh
+            ```
+
+            Example output:
+
+            ```text
+            The authenticity of host '10.26.23.123 (10.26.23.123)' can't be established.
+            ECDSA key fingerprint is SHA256:voQUCKDG4C9FGkmUcHZVrYJBXVKVYqcJ4kmTpe4tvOA.
+            Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
+            Warning: Permanently added '10.26.23.123' (ECDSA) to the list of known hosts.
+            uai-ssh.sh                                                                    100% 5035     3.0MB/s   00:00
+            ```
+
+        1. Delete the UAI.
+
+            ```bash
+            ncn-w001# cray uas delete --uai-list uai-vers-32079250 --format toml
+            ```
+
+            Example output:
+
+            ```toml
+            results = [ "Successfully deleted uai-vers-32079250",]
+            ```
+
+        1. Append the script to the tarball.
+
+            ```bash
+            ncn-w001# tar rvf 0c0d4081-2e8b-433f-b6f7-e1ef0b907be3.tar ./usr/bin/uai-ssh.sh
+            ```
+
+1. Create and push the container image.
+
+    Create a container image using Podman or Docker and push it to the site container registry. Any container-specific modifications may also be done here with a Dockerfile.
     The `ENTRYPOINT` layer must be `/usr/bin/uai-ssh.sh` as that starts SSHD for the user in the UAI container started by UAS.
 
     ```bash
@@ -148,13 +185,13 @@ Some of the steps are specific to that activity, others would be common to or si
     ncn-w001# podman push --creds "$PODMAN_USER:$PODMAN_PASSWD" $UAI_IMAGE_NAME
     ```
 
-6. Register the new container image with UAS.
+1. Register the new container image with UAS.
 
     ```bash
     ncn-w001# cray uas admin config images create --imagename $UAI_IMAGE_NAME
     ```
 
-7. Cleanup the mount directory and tarball.
+1. Cleanup the mount directory and tarball.
 
     ```bash
     ncn-w001# umount -v mount; rmdir -v mount

--- a/operations/UAS_user_and_admin_topics/Customize_End-User_UAI_Images.md
+++ b/operations/UAS_user_and_admin_topics/Customize_End-User_UAI_Images.md
@@ -203,7 +203,7 @@ See [Configure the Cray CLI](../configure_cray_cli.md).
     ```bash
     ncn-mw# umount -v mount; rmdir -v mount
 
-    ncn-mw# rm $ST_ID.tar rootfs.squashfs
+    ncn-mw# rm -v $ST_ID.tar rootfs.squashfs
 
     # NOTE: The next step could be done as an `rm -rf` but, because the user
     #       is `root` and the path is very similar to an important system

--- a/operations/UAS_user_and_admin_topics/Customize_End-User_UAI_Images.md
+++ b/operations/UAS_user_and_admin_topics/Customize_End-User_UAI_Images.md
@@ -24,7 +24,7 @@ See [Configure the Cray CLI](../configure_cray_cli.md).
 
 1. Choose a name for the custom image.
 
-     This example names the custom End-User UAI image called `registry.local/cray/cray-uai-compute:latest`, and places that name in an environment variable for convenience. Alter the name as appropriate for the image to be created:
+     This example names the custom end-user UAI image called `registry.local/cray/cray-uai-compute:latest`, and places that name in an environment variable for convenience. Alter the name as appropriate for the image to be created:
 
     ```bash
     ncn-w001# UAI_IMAGE_NAME=registry.local/cray/cray-uai-compute:latest

--- a/operations/UAS_user_and_admin_topics/Customize_End-User_UAI_Images.md
+++ b/operations/UAS_user_and_admin_topics/Customize_End-User_UAI_Images.md
@@ -171,7 +171,7 @@ See [Configure the Cray CLI](../configure_cray_cli.md).
 1. Create and push the container image.
 
     Create a container image using Podman or Docker and push it to the site container registry. Any container-specific modifications may also be done here with a Dockerfile.
-    The `ENTRYPOINT` layer must be `/usr/bin/uai-ssh.sh` as that starts SSHD for the user in the UAI container started by UAS.
+    The `ENTRYPOINT` layer must be `/usr/bin/uai-ssh.sh` as that starts `sshd` for the user in the UAI container started by UAS.
 
     ```bash
     ncn-w001# UAI_IMAGE_NAME=registry.local/cray/cray-uai-compute:latest


### PR DESCRIPTION
## Summary and Scope

Add nexus creds to podman push command that is used to push custom UAI images in the UAS/UAI Instructions.

Backwards compatible bugfix

## Issues and Related PRs

* Resolves [CASMUSER-3023](https://jira-pro.its.hpecorp.net:8443/browse/CASMUSER-3023)

## Testing

### Tested on:

  * `vale`

### Test description:

Ran through the procedure described on the change with the specified changes and verified that they worked as written.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? If not, why? N/A
- Was upgrade tested? If not, why? N/A
- Was downgrade tested? If not, why? N/A
- Were new tests (or test issues/Jiras) created for this change? N/A

## Risks and Mitigations

No known risks.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

