### PR TITLE
CASMTRIAGE-3444 main : DOCS : keycloak-users-localize is not grabbing all of the user defined in LDAP

### DIFF
--- a/troubleshooting/known_issues/craycli_403_forbidden_errors.md
+++ b/troubleshooting/known_issues/craycli_403_forbidden_errors.md
@@ -16,11 +16,16 @@ To recover from this situation, the following can be done.
    ```bash
    ncn# kubectl get job -n services -l app.kubernetes.io/name=cray-keycloak-users-localize \
            -ojson | jq '.items[0]' > keycloak-users-localize-job.json
-
+   ncn# kubectl delete job -n services -l app.kubernetes.io/name=cray-keycloak-users-localize
    ncn# cat keycloak-users-localize-job.json | jq 'del(.spec.selector)' | \
-           jq 'del(.spec.template.metadata.labels)' | kubectl replace --force -f -
+           jq 'del(.spec.template.metadata.labels)' | kubectl apply -f -
+   ```
+
+   Expected output looks similar to:
+
+   ```text
    job.batch "keycloak-users-localize-1" deleted
-   job.batch/keycloak-users-localize-1 replaced
+   job.batch/keycloak-users-localize-1 created
    ```
 
 1. Check to see if the `keycloak-users-localize` job has completed.
@@ -44,11 +49,16 @@ To recover from this situation, the following can be done.
    ```bash
    ncn# kubectl get job -n services -l app.kubernetes.io/name=cray-keycloak-users-localize \
            -ojson | jq '.items[0]' > keycloak-users-localize-job.json
-
+   ncn# kubectl delete job -n services -l app.kubernetes.io/name=cray-keycloak-users-localize
    ncn# cat keycloak-users-localize-job.json | jq 'del(.spec.selector)' | \
-           jq 'del(.spec.template.metadata.labels)' | kubectl replace --force -f -
+           jq 'del(.spec.template.metadata.labels)' | kubectl apply -f -
+   ```
+
+   Expected output looks similar to:
+
+   ```text
    job.batch "keycloak-users-localize-1" deleted
-   job.batch/keycloak-users-localize-1 replaced
+   job.batch/keycloak-users-localize-1 created
    ```
 
 1. Check again to make sure the job has now completed.


### PR DESCRIPTION
## Summary and Scope

Modify the procedure to restart the keycloak-users-localize job to delete and re-create instead of re-apply.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-3444](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3444)
* Change will also be needed in main, release/1.2 and release/1.0
* Future work required by NA
* Documentation changes required in NA
* Merge with/before/after NA

## Testing

Testing in vale and vshasta

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

Vale hit a case where keycloak-users-localize job was incrementally added more users each time the job ran which is not the expected behavior. After deleting and re-creating the job, all LDAP users were successfully imported once the job completed.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? NA
- Was upgrade tested? If not, why? NA
- Was downgrade tested? If not, why? NA
- Were new tests (or test issues/Jiras) created for this change? NA

## Risks and Mitigations

Low


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

