### PR TITLE
CASMNET-1588 - Update BGP/MetalLB reset procedure to incorporate config from customizations.yaml

### DIFF
--- a/operations/network/metallb_bgp/Check_BGP_Status_and_Reset_Sessions.md
+++ b/operations/network/metallb_bgp/Check_BGP_Status_and_Reset_Sessions.md
@@ -294,13 +294,13 @@ This procedure requires administrative privileges.
 1. Determine the `cray-metallb` chart version that is currently deployed.
 
     ```bash
-    ncn-m001# helm ls -A -a | grep cray-metallb
+    ncn-m001# helm ls -A -a --filter cray-metallb
     ```
 
     Example output:
 
     ```text
-    cray-metallb   metallb-system   1   2021-02-10 14:58:43.902752441 -0600 CST  deployed  cray-metallb-0.12.2   0.8.1
+    cray-metallb   metallb-system  1  022-06-06 16:17:42.684984475 +0000 UTC	deployed  cray-metallb-1.1.1  v0.11.0
     ```
 
 1. Create a manifest file that will be used to reapply the same chart version.
@@ -309,39 +309,22 @@ This procedure requires administrative privileges.
     ncn-m001# cat << EOF > ./metallb-manifest.yaml
     apiVersion: manifests/v1beta1
     metadata:
-      name: reapply-metallb
+      name: metallb
     spec:
+      sources:
+        charts:
+        - name: csm
+          type: repo
+          location: https://packages.local/repository/charts
       charts:
       - name: cray-metallb
+        source: csm
+        version: 1.1.1
         namespace: metallb-system
-        values:
-          imagesHost: dtr.dev.cray.com
-        version: 0.12.2
     EOF
     ```
 
 1. Open SSH sessions to all spine switches.
-
-1. Determine the `CSM_RELEASE` version that is currently running and set an environment variable.
-
-    For example:
-
-    ```bash
-    ncn-m001# CSM_RELEASE=0.8.0
-    ```
-
-1. Mount the `PITDATA` so that helm charts are available for the re-install \(it might already be mounted\) and verify that the chart with the expected version exists.
-
-    ```bash
-    ncn-m001# mkdir -pv /mnt/pitdata && mount -L PITDATA /mnt/pitdata && \
-              ls /mnt/pitdata/csm-${CSM_RELEASE}/helm/cray-metallb*
-    ```
-
-    Example output:
-
-    ```text
-    /mnt/pitdata/csm-0.8.0/helm/cray-metallb-0.12.2.tgz
-    ```
 
 1. Uninstall the current `cray-metallb` chart.
 
@@ -356,11 +339,22 @@ This procedure requires administrative privileges.
     * Refer to substeps [1-3](#mellanox-ssh) for Mellanox.
     * Refer to substeps [1-2](#aruba-ssh) for Aruba.
 
-1. Reapply the `cray-metallb` chart based on the `CSM_RELEASE`.
+1. Extract `customizations.yaml` from the `site-init` secret.
+
+   ```bash
+   ncn-m001# kubectl -n loftsman get secret site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d > customizations.yaml
+   ```
+
+1. Run `manifestgen` to incorporate the MetalLB configuration into the manifest.
+
+   ```bash
+   ncn-m001# manifestgen -c customizations.yaml -i metallb-manifest.yaml -o deploy.yaml
+   ```
+
+1. Reapply the `cray-metallb` chart.
 
     ```bash
-    ncn-m001# loftsman ship --manifest-path ./metallb-manifest.yaml \
-                --charts-path /mnt/pitdata/csm-${CSM_RELEASE}/helm
+    ncn-m001# loftsman ship --manifest-path ./deploy.yaml
     ```
 
 1. Check that the speaker pods are all running.

--- a/operations/network/metallb_bgp/Check_BGP_Status_and_Reset_Sessions.md
+++ b/operations/network/metallb_bgp/Check_BGP_Status_and_Reset_Sessions.md
@@ -344,7 +344,7 @@ This procedure requires administrative privileges.
 
    Example output:
 
-   ```text
+   ```yaml
    peers:
      - peer-address: 10.101.3.2
        peer-asn: 65533

--- a/operations/network/metallb_bgp/Check_BGP_Status_and_Reset_Sessions.md
+++ b/operations/network/metallb_bgp/Check_BGP_Status_and_Reset_Sessions.md
@@ -300,7 +300,7 @@ This procedure requires administrative privileges.
     Example output:
 
     ```text
-    cray-metallb   metallb-system  1  022-06-06 16:17:42.684984475 +0000 UTC	deployed  cray-metallb-1.1.1  v0.11.0
+    cray-metallb  metallb-system  1  022-06-06 16:17:42.684984475 +0000 UTC deployed cray-metallb-1.1.1  v0.11.0
     ```
 
 1. Create a manifest file that will be used to reapply the same chart version.
@@ -381,9 +381,9 @@ This procedure requires administrative privileges.
          - 10.101.3.64/26
    ```
 
-2. Open SSH sessions to all spine switches.
+1. Open SSH sessions to all spine switches.
 
-3. Uninstall the current `cray-metallb` chart.
+1. Uninstall the current `cray-metallb` chart.
 
     Until the chart is reapplied, this will also affect unbound name resolution, and all BGP sessions will be Idle for all of the worker nodes.
 
@@ -391,18 +391,18 @@ This procedure requires administrative privileges.
     ncn-m001# helm del cray-metallb -n metallb-system
     ```
 
-4. Use the open SSH sessions to the switches to clear the BGP sessions based on the above Mellanox or Aruba procedures.
+1. Use the open SSH sessions to the switches to clear the BGP sessions based on the above Mellanox or Aruba procedures.
 
     * Refer to substeps [1-3](#mellanox-ssh) for Mellanox.
     * Refer to substeps [1-2](#aruba-ssh) for Aruba.
 
-5. Reapply the `cray-metallb` chart.
+1. Reapply the `cray-metallb` chart.
 
     ```bash
     ncn-m001# loftsman ship --manifest-path ./deploy.yaml
     ```
 
-6. Check that the speaker pods are all running.
+1. Check that the speaker pods are all running.
 
     This may take a few minutes.
 
@@ -420,7 +420,7 @@ This procedure requires administrative privileges.
     cray-metallb-speaker-h7s7b                 1/1     Running   0          79m
     ```
 
-7. Use the open SSH sessions to the switches to check the status of the BGP sessions.
+1. Use the open SSH sessions to the switches to check the status of the BGP sessions.
 
     * Refer to substeps [1-3](#mellanox-ssh) for Mellanox.
     * Refer to substeps [1-2](#aruba-ssh) for Aruba.


### PR DESCRIPTION
## Summary and Scope

CSM 1.2 updates the version of the MetalLB chart and the MetalLB config is now passed into the chart via `customizations.yaml`.

The procedure to reset BGP/MetalLB does not take this into account and uninstalls the `cray-metallb` chart then redeploys it with no configuration.

## Issues and Related PRs

* Resolves [CASMTRIAGE-3449](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3449)
* Change will also be needed in `main`

## Testing

### Tested on:

  * `hermod`

### Test description:

Followed procedure and verified BGP sessions were established.

## Risks and Mitigations

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

