### PR TITLE
CASMCMS-7991: Add/update CRUS deprecation notices

### DIFF
--- a/.github/config/markdown_style.yaml
+++ b/.github/config/markdown_style.yaml
@@ -93,7 +93,7 @@ MD013:
   # Number of characters for headings
   heading_line_length: 255
   # Number of characters for code blocks
-  code_block_line_length: 375
+  code_block_line_length: 400
   # Include code blocks
   code_blocks: true
   # Include tables

--- a/.spelling
+++ b/.spelling
@@ -132,6 +132,7 @@ ConMan
 ConnectX-4
 ConnectX-5
 ConnectX-5s
+CoreDNS
 Cray
 Cray-HPE
 CrayPort

--- a/.spelling
+++ b/.spelling
@@ -67,7 +67,7 @@ ASICs
 backdoor
 backend
 BardPeak
-Barebones
+barebones
 base-64
 base-64-encoded
 Basecamp
@@ -83,7 +83,6 @@ BMCs
 bootscript
 BOA
 BOS
-BOSv2
 BSS
 Burstable
 buses
@@ -537,6 +536,7 @@ V1.20.13
 v1.3
 v1.3.x
 v1.30.16
+V1.3.0
 v1.4
 v1.4.
 v1.4.0
@@ -571,6 +571,7 @@ workarea
 writable
 X.509
 XL645d
+XL675d
 xname
 xnames
 Yum

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,133 +1,147 @@
 # Cray System Management (CSM) - Release Notes
 
 ## CSM 1.2.0
-CSM 1.2 contains approximately 2000 changes spanning bug fixes, new feature development, and documentation improvements. Below are some of the highlights
+
+CSM 1.2 contains approximately 2000 changes spanning bug fixes, new feature development, and documentation improvements. This page lists some of the highlights.
 
 ## New
 
 ### Monitoring
-* New Dashboard for network traffic dashboard
-* New Dashboard for Kubernetes and microservice health dashboard
-* New Dashboard for Boot Dashboard
-* New command line Dashboard for critical services like smd, smd-postgres, capmc and hbtd
-* New Dashboard for Grafana dashboard for critical services like smd,capmc,smd-postgres and hbtd
+
+* New network traffic dashboard
+* New Kubernetes and microservice health dashboard
+* New boot dashboard
+* New command line dashboard for critical services like `smd`, `smd-postgres`, `capmc`, and `hbtd`
+* New Grafana dashboard for critical services like `smd`, `capmc`, `smd-postgres`, and `hbtd`
 * Management nodes sample SMART data and publish it to SMA/SMF
 * Support for HPE PDU telemetry
 
 ### Networking
-* Release Cray Automated Network Utility - CANU V1.0.0
-* Performance improvements to Unbound and DHCP Helper
-* Initial Release of Bifurcated CAN
 
-  The user and administrative traffic segregation introduced by Bifurcated CAN has changed the URLs for certain services as it is now necessary to include the network path in the fully qualified domain name. Access to administrative services is now restricted to the Customer Management Network (CMN). API access is available via the Customer Management Network (CMN), Customer Access Network (CAN), and Customer Highspeed Network (CHN).
+* Release Cray Automated Network Utility (CANU) V1.0.0
+* Performance improvements to Unbound and DHCP helper
+* Initial release of Bifurcated CAN
+
+  The user and administrative traffic segregation introduced by Bifurcated CAN has changed the URLs for certain services as it is now necessary to include the network path in the
+  fully qualified domain name. Access to administrative services is now restricted to the Customer Management Network (CMN). API access is available via the Customer Management
+  Network (CMN), Customer Access Network (CAN), and Customer Highspeed Network (CHN).
 
   The following table assumes the system was configured with a `system-name` of `shasta` and a `site-domain` of `dev.cray.com`.
 
-  | Old Name                         | New Name                                |
-  |----------------------------------|-----------------------------------------|
-  | auth.shasta.dev.cray.com         | auth.cmn.shasta.dev.cray.com            |
-  | nexus.shasta.dev.cray.com        | nexus.cmn.shasta.dev.cray.com           |
-  | grafana.shasta.dev.cray.com      | grafana.cmn.shasta.dev.cray.com         |
-  | prometheus.shasta.dev.cray.com   | prometheus.cmn.shasta.dev.cray.com      |
-  | alertmanager.shasta.dev.cray.com | alertmanager.cmn.shasta.dev.cray.com    |
-  | vcs.shasta.dev.cray.com          | vcs.cmn.shasta.dev.cray.com             |
-  | kiali-istio.shasta.dev.cray.com  | kiali-istio.cmn.shasta.dev.cray.com     |
-  | s3.shasta.dev.cray.com           | s3.cmn.shasta.dev.cray.com              |
-  | sma-grafana.shasta.dev.cray.com  | sma-grafana.cmn.shasta.dev.cray.com     |
-  | sma-kibana.shasta.dev.cray.com   | sma-kibana.cmn.shasta.dev.cray.com      |
-  | api.shasta.dev.cray.com          | api.cmn.shasta.dev.cray.com<br>api.chn.shasta.dev.cray.com<br>api.can.shasta.dev.cray.com |
+  | Old Name                           | New Name                                  |
+  |------------------------------------|-------------------------------------------|
+  | `auth.shasta.dev.cray.com`         | `auth.cmn.shasta.dev.cray.com`            |
+  | `nexus.shasta.dev.cray.com`        | `nexus.cmn.shasta.dev.cray.com`           |
+  | `grafana.shasta.dev.cray.com`      | `grafana.cmn.shasta.dev.cray.com`         |
+  | `prometheus.shasta.dev.cray.com`   | `prometheus.cmn.shasta.dev.cray.com`      |
+  | `alertmanager.shasta.dev.cray.com` | `alertmanager.cmn.shasta.dev.cray.com`    |
+  | `vcs.shasta.dev.cray.com`          | `vcs.cmn.shasta.dev.cray.com`             |
+  | `kiali-istio.shasta.dev.cray.com`  | `kiali-istio.cmn.shasta.dev.cray.com`     |
+  | `s3.shasta.dev.cray.com`           | `s3.cmn.shasta.dev.cray.com`              |
+  | `sma-grafana.shasta.dev.cray.com`  | `sma-grafana.cmn.shasta.dev.cray.com`     |
+  | `sma-kibana.shasta.dev.cray.com`   | `sma-kibana.cmn.shasta.dev.cray.com`      |
+  | `api.shasta.dev.cray.com`          | `api.cmn.shasta.dev.cray.com`, `api.chn.shasta.dev.cray.com`, `api.can.shasta.dev.cray.com` |
 
 * PowerDNS authoritative DNS server
   * Supports zone transfer to external DNS servers via AXFR query and DNSSEC
-  * Please refer to the [PowerDNS Migration Guide](./operations/network/dns/PowerDNS_migration.md) and [PowerDNS Configuration Guide](./operations/network/dns/PowerDNS_Configuration.md) for further information.
-
+  * Refer to the [PowerDNS Migration Guide](operations/network/dns/PowerDNS_migration.md) and
+    [PowerDNS Configuration Guide](operations/network/dns/PowerDNS_Configuration.md) for further information.
 * Management network switch hostname changes
 
   The management network switch hostnames have changed in CSM 1.2 to more accurately reflect the usage of each switch type.
 
-  | Old Name | New Name    | Usage                                                     |
-  |----------|-------------|-----------------------------------------------------------|
-  | sw-spine | Unchanged   | Network spine that links to other switches.               |
-  | sw-agg   | sw-leaf     | NMN connections for NCNs and Application nodes.           |
-  | sw-leaf  | sw-leaf-bmc | BMC connections, PDUs, Slingshot switches, Cooling doors. |
+  | Old Name   | New Name      | Usage                                                     |
+  |------------|---------------|-----------------------------------------------------------|
+  | `sw-spine` | Unchanged     | Network spine that links to other switches.               |
+  | `sw-agg`   | `sw-leaf`     | NMN connections for NCNs and application nodes.           |
+  | `sw-leaf`  | `sw-leaf-bmc` | BMC connections, PDUs, Slingshot switches, cooling doors  |
 
-### Miscellaneous Functionality
-* SLES15 SP3 Support for NCNs, UANs, Compute Nodes, and Barebones validation image
+### Miscellaneous functionality
+
+* SLES15 SP3 support for NCNs, UANs, Compute Nodes, and barebones validation image
 * S3FS added to master and worker nodes for storing SDU dumps and CPS content
 * Improved FAS (Firmware Action Service) error reporting
-* CFS State reporter added to storage nodes
-* Numerous new Goss tests added along with improved error logging
+* CFS State Reporter added to storage nodes
+* Numerous new tests added along with improved error logging
 * CAPMC support for HPE Apollo 6500 power capping
 * CAPMC support for new power schema for BardPeak power capping
-* CAPMC support for HPE G2 Metered 3Ph 39.9kVA 60A 480/277V FIO PDU
+* CAPMC support for HPE `G2 Metered 3Ph 39.9kVA 60A 480/277V FIO` PDU
 * Improved CAPMC error handling in BOA
-* Root user password and SSH keys now handled by NCN personalization after initial install; locations of data changed in Hashicorp Vault from previous releases
+* `root` user password and SSH keys now handled by NCN personalization after initial install; locations of data changed in HashiCorp Vault from previous releases
 * Generic Ansible passthrough parameter added to CFS session API
 * Improved CFS session resiliency after power outages
 * Pod priority class additions to improve upgrades and fail-over
 
-### New Hardware Support
+### New hardware support
+
 * Olympus Bard Peak Blade (AMD Trento with AMD MI200) with Slingshot 11 - Compute Node
 * Olympus Grizzly Peak NVidia A100 80GB GPU - Compute Node
 * Milan-Based DL385 Gen10+ with AMD Mi100 GPU - UAN and Application Node
 * Milan-Based Apollo 6500/XL675d Gen10+ with NVIDIA A100 40GB - Compute Node
 * Milan-Based Apollo 6500/XL645d Gen10+ with NVIDIA A100 80GB - Compute Node
-* HPE G2 Metered 3Ph 39.9kVA 60A 480/277V FIO PDU
+* HPE `G2 Metered 3Ph 39.9kVA 60A 480/277V FIO` PDU
 
-### Automation Improvements
-* Validation of CSM health in several areas
-* Automated Administrative Access configuration
-* Automated Installation of CFS set-up of passwordless SSH
-* Validation of Management Network cabling
-* Automated the firmware check on PIT
-* keycloak-installer is released
-* CSM Install and Upgrade automation improvements
+### Automation improvements
 
-### Base Platform Component Upgrades
-* istio V1.8 from istio V1.7
-* Release of Loftsman V1.2.0-1
-* Kubernetes V1.20.13 from Kubernetes V1.19.9
+* Automated validation of CSM health in several areas
+* Automated administrative access configuration
+* Automated installation of CFS set-up of passwordless SSH
+* Automated validation of Management Network cabling
+* Automated firmware check on PIT node
+* `keycloak-installer` is released
+* CSM install and upgrade automation improvements
+
+### Base platform component upgrades
+
+* `istio` V1.8 from V1.7
+* Loftsman V1.2.0-1
+* Kubernetes V1.20.13 from V1.19.9
 * Ceph V15.2.15 from V15.2.8
 
-### Security Improvements
-* Switch to non-root containers - A significant number of root user container images have been removed. The remainder have been identified for a future release
+### Security improvements
+
+* Switch to non-root containers - A significant number of `root` user container images have been removed. The remainder have been identified for removal in a future release
 * Verification of signed RPMs
-* CVE Remediation - A significant number of CVEs have been addressed, including a majority of the critical and High CVEs like `polkit` and `log4j`
+* CVE remediation - A significant number of CVEs have been addressed, including a majority of the critical and high CVEs, like `polkit` and `log4j`
 * Updates to Nexus require authentication
-* Remove of code injection vulnerability in `commit` and `cloneURL` fields of CFS configuration API
-* Further restrictions on allowed HTTP verbs in API requests coming from compute nodes
-* Option to restrict compute to only call URIs by machine identity
+* Removal of code injection vulnerability in `commit` and `cloneURL` fields of CFS configuration API
+* Further restrictions on allowed HTTP verbs in API requests coming from Compute Nodes
+* Option to restrict Compute Nodes to only call URIs by machine identity
 
-### Customer Requested Enhancements
+### Customer-requested enhancements
+
 * Ability to turn off slots without `hms-discovery` powering them on
-* Resilient way to reboot a compute node into its current configuration with a single API call
+* Resilient way to reboot a Compute Node into its current configuration with a single API call
 
-## Bug Fixes
-* Documented Optimized BIOS Boot Order for NCNs
-* Slingshot switches attempting dhcp renewal to unreachable address
-* Node will not reboot following upgrade of BMC and BIOS
-* Worker node container /var/lib/containerd is full and pods in 'ContainerCreating' state
-* Incorrect data or bad monitor filters in sysmgmt-health namespace
-* Hardware State Manager showing compute nodes in standby after cabinet level power down procedure
-* Cray hsm inventory hardware describe reports incorrect DIMM Id and Name
-* Image customization CFS jobs do not set an ansible limit when customizing
-* No /proc available in CFS image container
-* "conman" reconnects to nodes every hour, reissuing old messages with updated time stamps
-* CFS can leave sessions pending after a power outage
-* sonar-jobs-watcher not stopping orphaned CFS pods
-* fixed issues causing PXE boot failures during installs, upgrades, and NCN rebuilds
+## Bug fixes
+
+* Documented optimized BIOS boot order for NCNs
+* Fixed: Slingshot switches attempting DHCP renewal to unreachable address
+* Fixed: Node will not reboot following upgrade of BMC and BIOS
+* Fixed: Worker node container `/var/lib/containerd` is full and pods stuck in `ContainerCreating` state
+* Fixed: Incorrect data or bad monitor filters in `sysmgmt-health` namespace
+* Fixed: Hardware State Manager showing compute nodes in standby after cabinet-level power down procedure
+* Fixed: Cray HSM inventory reports incorrect DIMM `Id` and `Name`
+* Fixed: Image customization CFS jobs do not set an Ansible limit when customizing
+* Fixed: No `/proc` available in CFS image container
+* Fixed: ConMan reconnects to nodes every hour, reissuing old messages with updated time stamps
+* Fixed: CFS can leave sessions `pending` after a power outage
+* Fixed: `sonar-jobs-watcher` not stopping orphaned CFS pods
+* Fixed: PXE boot failures during installs, upgrades, and NCN rebuilds
 
 ## Deprecations
-* CRUS has been deprecated. It will be removed in CSM-1.3.0 and replaced with BOSv2, which will provide similar functionality.
+
+* CRUS has been deprecated. It will be removed in CSM V1.3.0 and replaced with BOS V2, which will provide similar functionality.
 * PowerDNS will replace Unbound as the authoritative DNS source in a future CSM release.
-  * The cray-dns-unbound-manager CronJob will be deprecated in a future release once all DNS records are migrated to PowerDNS.
+  * The `cray-dns-unbound-manager` CronJob will be deprecated in a future release once all DNS records are migrated to PowerDNS.
   * The introduction of PowerDNS and Bifurcated CAN will introduce some node and service naming changes.
-  * Please see the [PowerDNS Migration Guide](./operations/network/dns/PowerDNS_migration.md) for more information.
+  * See the [PowerDNS Migration Guide](operations/network/dns/PowerDNS_migration.md) for more information.
 
 See [Deprecated features](introduction/differences.md#deprecated_features).
 
 ## Removals
-* The V1 version of the CFS API was removed
-* The cray-externaldns-coredns, cray-externaldns-etcd, and cray-externaldns-wait-for-etcd pods have been removed. PowerDNS is now the provider of the external DNS service.
 
-## Known Issues
+* The V1 version of the CFS API has been removed
+* The `cray-externaldns-coredns`, `cray-externaldns-etcd`, and `cray-externaldns-wait-for-etcd` pods have been removed. PowerDNS is now the provider of the external DNS service.
+
+## Known issues

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -131,7 +131,7 @@ CSM 1.2 contains approximately 2000 changes spanning bug fixes, new feature deve
 
 ## Deprecations
 
-* CRUS has been deprecated. It will be removed in CSM V1.3.0 and replaced with BOS V2, which will provide similar functionality.
+* CRUS is deprecated in CSM 1.2.0. It will be removed in a future CSM release and replaced with BOS V2, which will provide similar functionality.
 * PowerDNS will replace Unbound as the authoritative DNS source in a future CSM release.
   * The `cray-dns-unbound-manager` CronJob will be deprecated in a future release once all DNS records are migrated to PowerDNS.
   * The introduction of PowerDNS and Bifurcated CAN will introduce some node and service naming changes.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -118,11 +118,14 @@ CSM 1.2 contains approximately 2000 changes spanning bug fixes, new feature deve
 * fixed issues causing PXE boot failures during installs, upgrades, and NCN rebuilds
 
 ## Deprecations
-* CRUS has been deprecated. It will be removed in a future release and replaced with BOSv2, which will provide similar functionality.
+* CRUS has been deprecated. It will be removed in CSM-1.3.0 and replaced with BOSv2, which will provide similar functionality.
 * PowerDNS will replace Unbound as the authoritative DNS source in a future CSM release.
   * The cray-dns-unbound-manager CronJob will be deprecated in a future release once all DNS records are migrated to PowerDNS.
   * The introduction of PowerDNS and Bifurcated CAN will introduce some node and service naming changes.
   * Please see the [PowerDNS Migration Guide](./operations/network/dns/PowerDNS_migration.md) for more information.
+
+See [Deprecated features](introduction/differences.md#deprecated_features).
+
 ## Removals
 * The V1 version of the CFS API was removed
 * The cray-externaldns-coredns, cray-externaldns-etcd, and cray-externaldns-wait-for-etcd pods have been removed. PowerDNS is now the provider of the external DNS service.

--- a/glossary.md
+++ b/glossary.md
@@ -156,7 +156,7 @@ management status of nodes, handling each of the steps required to upgrade compu
 
 See [Compute Rolling Upgrades](operations/index.md#compute-rolling-upgrades).
 
-**Note:** CRUS has been deprecated. It will be removed in CSM V1.3.0 and replaced with BOS V2, which will provide similar functionality. See
+**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in a future CSM release and replaced with BOS V2, which will provide similar functionality. See
 [Deprecated features](introduction/differences.md#deprecated_features).
 
 <a name="cray-advanced-platform-monitoring-and-control"></a>

--- a/glossary.md
+++ b/glossary.md
@@ -10,6 +10,7 @@ Glossary of terms used in CSM documentation.
 * [Cabinet Cooling Group](#cabinet-cooling-group)
 * [Cabinet Environmental Controller (CEC)](#cabinet-environmental-controller)
 * [CEC microcontroller (eC)](#cec-microcontroller)
+* [Compute Rolling Upgrade Service (CRUS)](#compute-rolling-upgrade-service)
 * [Cray Advanced Platform Monitoring and Control (CAPMC)](#cray-advanced-platform-monitoring-and-control)
 * [Customer Access Network](#customer-access-network)
 * [Chassis Management Module (CMM)](#chassis-management-module)
@@ -145,6 +146,17 @@ environmental sensors, and communicates cabinet status to the cooling distributi
 (CDU). The eC does not provide a REST endpoint on SMNet as do other embedded
 controllers, but simply monitors the cabinet sensors and provides the cabinet environmental
 and CDU status to the CMMs for evaluation and/or action.
+
+<a name="compute-rolling-upgrade-service"></a>
+
+## Compute Rolling Upgrade Service (CRUS)
+
+The Compute Rolling Upgrade Service (CRUS) upgrades sets of compute nodes without requiring an entire set of nodes to be out of service at once. CRUS manages the workload management status of nodes, handling each of the steps required to upgrade compute nodes.
+
+See [Compute Rolling Upgrades](operations/index.md#compute-rolling-upgrades).
+
+**Note:** CRUS has been deprecated. It will be removed in CSM-1.3.0 and replaced with BOSv2, which will provide similar functionality. See
+[Deprecated features](introduction/differences.md#deprecated_features).
 
 <a name="cray-advanced-platform-monitoring-and-control"></a>
 

--- a/glossary.md
+++ b/glossary.md
@@ -151,11 +151,12 @@ and CDU status to the CMMs for evaluation and/or action.
 
 ## Compute Rolling Upgrade Service (CRUS)
 
-The Compute Rolling Upgrade Service (CRUS) upgrades sets of compute nodes without requiring an entire set of nodes to be out of service at once. CRUS manages the workload management status of nodes, handling each of the steps required to upgrade compute nodes.
+The Compute Rolling Upgrade Service (CRUS) upgrades sets of compute nodes without requiring an entire set of nodes to be out of service at once. CRUS manages the workload
+management status of nodes, handling each of the steps required to upgrade compute nodes.
 
 See [Compute Rolling Upgrades](operations/index.md#compute-rolling-upgrades).
 
-**Note:** CRUS has been deprecated. It will be removed in CSM-1.3.0 and replaced with BOSv2, which will provide similar functionality. See
+**Note:** CRUS has been deprecated. It will be removed in CSM V1.3.0 and replaced with BOS V2, which will provide similar functionality. See
 [Deprecated features](introduction/differences.md#deprecated_features).
 
 <a name="cray-advanced-platform-monitoring-and-control"></a>

--- a/introduction/differences.md
+++ b/introduction/differences.md
@@ -2,61 +2,65 @@
 
 The most noteworthy changes since the previous release are described here.
 
-### Topics
-
-   * [New Features](#new_features)
-   * [Deprecated Features](#deprecated_features)
-   * [Removed Features](#removed_features)
-   * [Other Changes](#other_changes)
-
-
-## Details
+* [New features](#new_features)
+* [Deprecated features](#deprecated_features)
+* [Removed features](#removed_features)
+* [Other changes](#other_changes)
 
 <a name="new_features"></a>
-### New Features
+
+## New features
 
 The following features are new in this release:
 
-   * Scaling improvements for larger systems
-      * BOS
-      * CAPMC
-      * FAS
-   * New hardware supported in this release:
-      * Compute nodes
-         * Milan-Based Grizzly Peak with A100 40 GB GPU
-         * Milan-Based Windom Liquid Cooled System
-         * Rome-Based HPE Apollo 6500 XL675d Gen10+ with A100 40 GB GPU
-         * Rome-Based HPE Apollo 6500 XL645d Gen10+ with A100 40 GB GPU
-      * User Access Nodes (UANs)
-         * Milan-Based HPE DL 385(v2) Gen10+
-         * Rome-Based HPE DL 385(v1) Gen10
-   * Node consoles are now managed by cray-console-node which is based on conman.
-   * HSM now has a v2 REST API
-   * NCN user password and SSH key management is available for both root and
-     non-root users via NCN personalization. Please refer to [Configure Non-Compute Nodes with CFS](../operations/CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md).
+* Scaling improvements for larger systems to the following services:
+  * BOS
+  * CAPMC
+  * FAS
+* New hardware supported in this release:
+  * Compute nodes
+    * Milan-Based Grizzly Peak with A100 40 GB GPU
+    * Milan-Based Windom Liquid Cooled System
+    * Rome-Based HPE Apollo 6500 XL675d Gen10+ with A100 40 GB GPU
+    * Rome-Based HPE Apollo 6500 XL645d Gen10+ with A100 40 GB GPU
+  * User Access Nodes (UANs)
+    * Milan-Based HPE DL 385(v2) Gen10+
+    * Rome-Based HPE DL 385(v1) Gen10
+* Node consoles are now managed by `cray-console-node` which is based on ConMan
+* HSM now has a v2 REST API
+* NCN user password and SSH key management is available for both root and
+  non-root users via NCN personalization. See [Configure Non-Compute Nodes with CFS](../operations/CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md).
 
 <a name="deprecated_features"></a>
-### Deprecated Features
+
+## Deprecated features
 
 The following features are no longer supported and are planned to be removed in a future release:
 
-   * HSM v1 REST API has been deprecated as of CSM version 0.9.3. The v1 HSM APIs will be removed in the CSM version 1.3 release.
-   * Many CAPMC v1 REST API and CLI features are being deprecated as part of CSM version 1.0; Full removal of the deprecated CAPMC features will happen in CSM version 1.3. Further development of CAPMC service or CLI has stopped. CAPMC has entered end-of-life but will still be generally available. CAPMC is going to be replaced with the Power Control Service (PCS) in a future release. The current API/CLI portfolio for CAPMC are being pruned to better align with the future direction of PCS. More information about PCS and the CAPMC transition will be released as part of subsequent CSM releases.
-   * HMNFD v1 REST API has been deprecated as of CSM version 1.2. The v1 HMNFD APIs will be removed in the CSM version 1.5 release.
-     * For more information on what features have been deprecated please view the CAPMC swagger doc or read the [CAPMC deprecation notice](../introduction/CAPMC_deprecation.md)
-   * The Boot Orchestration Service (BOS) API is changing in the upcoming CSM-1.2.0 release:
-        * The `--template-body` option for the Cray CLI `bos` command will be deprecated.
-        * Performing a GET on the session status for a boot set (i.e. `/v1/session/{session_id}/status/{boot_set_name}`) currently returns a status code of 201, but instead it should return a status code of 200. This will be corrected to return 200.
-   * The Compute Rolling Upgrade Service (CRUS) is deprecated and will be removed in the CSM-1.3.0 release. Enhanced BOS functionality will replace CRUS. This includes the ability to stage changes to nodes that can be acted upon later when the node reboots. It also includes the ability to reboot nodes without specifying any boot artifacts. This latter ability relies on the artifacts already having been staged.
+* HSM v1 REST API has been deprecated as of CSM version 0.9.3. The v1 HSM APIs will be removed in the CSM version 1.3 release.
+* Many CAPMC v1 REST API and CLI features were deprecated as part of CSM version 1.0; Full removal of the deprecated CAPMC features will happen in CSM version 1.3. Further
+  development of CAPMC service or CLI has stopped. CAPMC has entered end-of-life but will still be generally available. CAPMC is going to be replaced with the Power Control
+  Service (PCS) in a future release. The current API/CLI portfolio for CAPMC is being pruned to better align with the future direction of PCS. More information about PCS and
+  the CAPMC transition will be released as part of subsequent CSM releases.
+  * For more information on what features have been deprecated, see the [CAPMC deprecation notice](CAPMC_deprecation.md).
+* HMNFD v1 REST API has been deprecated as of CSM version 1.2. The v1 HMNFD APIs will be removed in the CSM version 1.5 release.
+* The Boot Orchestration Service (BOS) API is changing in the CSM V1.2.0 release:
+  * The `--template-body` option for the Cray CLI `bos` command is deprecated.
+  * Prior to CSM V1.2.0, performing a successful `GET` on the session status for a boot set (i.e. `/v1/session/{session_id}/status/{boot_set_name}`) incorrectly returned
+    a status code of 201. It now correctly returns a status code of 200.
+* The Compute Rolling Upgrade Service (CRUS) is deprecated and will be removed in the CSM V1.3.0 release. Enhanced BOS functionality will replace CRUS. This includes the ability
+  to stage changes to nodes that can be acted upon later when the node reboots. It also includes the ability to reboot nodes without specifying any boot artifacts. This latter
+  ability relies on the artifacts already having been staged.
 
 <a name="removed_features"></a>
-### Removed Features
+
+## Removed features
 
 The following features have been completely removed:
 
-   * cray-conman pod. This has been replaced by cray-console-node.
-   * CFS v1 API and CLI. The v2 API/CLI has been the default since CSM 0.9 (Shasta 1.4).
+* `cray-conman` pod. This has been replaced by `cray-console-node`.
+* CFS v1 API and CLI. The v2 API and CLI have been the default since CSM 0.9 (Shasta 1.4).
 
 <a name="other_changes"></a>
-### Other Changes
 
+## Other changes

--- a/introduction/differences.md
+++ b/introduction/differences.md
@@ -48,7 +48,7 @@ The following features are no longer supported and are planned to be removed in 
   * The `--template-body` option for the Cray CLI `bos` command is deprecated.
   * Prior to CSM V1.2.0, performing a successful `GET` on the session status for a boot set (i.e. `/v1/session/{session_id}/status/{boot_set_name}`) incorrectly returned
     a status code of 201. It now correctly returns a status code of 200.
-* The Compute Rolling Upgrade Service (CRUS) is deprecated and will be removed in the CSM V1.3.0 release. Enhanced BOS functionality will replace CRUS. This includes the ability
+* The Compute Rolling Upgrade Service (CRUS) is deprecated in CSM 1.2.0 and will be removed in a future CSM release. Enhanced BOS functionality will replace CRUS. This includes the ability
   to stage changes to nodes that can be acted upon later when the node reboots. It also includes the ability to reboot nodes without specifying any boot artifacts. This latter
   ability relies on the artifacts already having been staged.
 

--- a/introduction/differences.md
+++ b/introduction/differences.md
@@ -47,7 +47,7 @@ The following features are no longer supported and are planned to be removed in 
    * The Boot Orchestration Service (BOS) API is changing in the upcoming CSM-1.2.0 release:
         * The `--template-body` option for the Cray CLI `bos` command will be deprecated.
         * Performing a GET on the session status for a boot set (i.e. `/v1/session/{session_id}/status/{boot_set_name}`) currently returns a status code of 201, but instead it should return a status code of 200. This will be corrected to return 200.
-   * The Compute Rolling Upgrade Service (CRUS) will be deprecated in the CSM-1.3.0 release. Enhanced BOS functionality will replace CRUS. This includes the ability to stage changes to nodes that can be acted upon later when the node reboots. It also includes the ability to reboot nodes without specifying any boot artifacts. This latter ability relies on the artifacts already having been staged.
+   * The Compute Rolling Upgrade Service (CRUS) is deprecated and will be removed in the CSM-1.3.0 release. Enhanced BOS functionality will replace CRUS. This includes the ability to stage changes to nodes that can be acted upon later when the node reboots. It also includes the ability to reboot nodes without specifying any boot artifacts. This latter ability relies on the artifacts already having been staged.
 
 <a name="removed_features"></a>
 ### Removed Features

--- a/operations/compute_rolling_upgrades/CRUS_Workflow.md
+++ b/operations/compute_rolling_upgrades/CRUS_Workflow.md
@@ -1,5 +1,8 @@
 # CRUS Workflow
 
+**Note:** CRUS has been deprecated. It will be removed in CSM-1.3.0 and replaced with BOSv2, which will provide similar functionality. See
+[Deprecated features](../../introduction/differences.md#deprecated_features).
+
 The following workflow is intended to be a high-level overview of how to upgrade compute nodes. This workflow depicts how services interact with each other during the compute node upgrade process, and helps to provide a quicker and deeper understanding of how the system functions.
 
 ### Upgrade Compute Nodes

--- a/operations/compute_rolling_upgrades/CRUS_Workflow.md
+++ b/operations/compute_rolling_upgrades/CRUS_Workflow.md
@@ -1,6 +1,6 @@
 # CRUS Workflow
 
-**Note:** CRUS has been deprecated. It will be removed in CSM V1.3.0 and replaced with BOS V2, which will provide similar functionality. See
+**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in a future CSM release and replaced with BOS V2, which will provide similar functionality. See
 [Deprecated features](../../introduction/differences.md#deprecated_features).
 
 The following workflow is intended to be a high-level overview of how to upgrade compute nodes. This workflow depicts how services interact with each other during the compute node

--- a/operations/compute_rolling_upgrades/CRUS_Workflow.md
+++ b/operations/compute_rolling_upgrades/CRUS_Workflow.md
@@ -1,98 +1,123 @@
 # CRUS Workflow
 
-**Note:** CRUS has been deprecated. It will be removed in CSM-1.3.0 and replaced with BOSv2, which will provide similar functionality. See
+**Note:** CRUS has been deprecated. It will be removed in CSM V1.3.0 and replaced with BOS V2, which will provide similar functionality. See
 [Deprecated features](../../introduction/differences.md#deprecated_features).
 
-The following workflow is intended to be a high-level overview of how to upgrade compute nodes. This workflow depicts how services interact with each other during the compute node upgrade process, and helps to provide a quicker and deeper understanding of how the system functions.
+The following workflow is intended to be a high-level overview of how to upgrade compute nodes. This workflow depicts how services interact with each other during the compute node
+upgrade process, and helps to provide a quicker and deeper understanding of how the system functions.
 
-### Upgrade Compute Nodes
+## Use cases
 
-**Use Cases:** Administrator upgrades select compute nodes \(around 500\) to a newer compute image by using Compute Rolling Upgrade Service \(CRUS\).
+Administrator upgrades select compute nodes to a newer compute image by using Compute Rolling Upgrade Service \(CRUS\).
 
-**Requirement** The compute nodes are up and running and their workloads are managed by Slurm.
+## Requirements
 
-**Components:** This workflow is based on the interaction of CRUS with Boot Orchestration Service \(BOS\) and Slurm \(Workload Manager\).
+- The compute nodes are up and running.
+- Compute node workloads are managed by Slurm.
 
-Mentioned in this workflow:
+## Components
 
--   Compute Rolling Upgrade Service \(CRUS\) allows an administrator to modify the boot image and/or configuration on a set of compute nodes without the need to take the entire set of nodes out of service at once. It manages the workload management status of nodes, quiescing each node before taking the node out of service, upgrading the node, rebooting the node into the upgraded state and then returning the node to service within the workload manager.
--   Boot Orchestration Service \(BOS\) is responsible for booting, configuring, and shutting down collections of nodes. The Boot Orchestration Service has the following components:
-    -   Boot Orchestration Session Template is a collection of one or more boot set objects. A boot set defines a collection of nodes and the information about the boot artifacts and parameters.
-    -   Boot Orchestration Session carries out an operation. The possible operations in a session are boot, shutdown, reboot, and configure.
-    -   Boot Orchestration Agent \(BOA\) is automatically launched to execute the session. A BOA executes the given operation, and if the operation is a boot or a reboot, it also configures the nodes post-boot \(if configure is enabled\).
--   Slurm has a component called slurmctld that runs on a non-compute node in a container. The Slurm control daemon or slurmctld is the central management daemon of Slurm. It monitors all other Slurm daemons and resources, accepts jobs, and allocates resources to those jobs. Slurm also has a component called slurmd that runs on all compute nodes. The Slurm daemon or slurmd monitors all tasks running on the compute node, accepts tasks, launches tasks, and kills running tasks upon request.
+This workflow is based on the interaction of CRUS with Boot Orchestration Service \(BOS\) and Slurm \(Workload Manager\).
+
+The following terms are mentioned in this workflow:
+
+- Compute Rolling Upgrade Service \(CRUS\) allows an administrator to modify the boot image and/or configuration on a set of compute nodes without the need to take the entire set
+  of nodes out of service at once. It manages the workload management status of nodes, quiescing each node before taking the node out of service, upgrading the node, rebooting
+  the node into the upgraded state and then returning the node to service within the workload manager.
+- Boot Orchestration Service \(BOS\) is responsible for booting, configuring, and shutting down collections of nodes. The Boot Orchestration Service has the following components:
+  - Boot Orchestration Session Template is a collection of one or more boot set objects. A boot set defines a collection of nodes and the information about the boot artifacts
+    and parameters.
+  - Boot Orchestration Session carries out an operation. The possible operations in a session are boot, shutdown, reboot, and configure.
+  - Boot Orchestration Agent \(BOA\) is automatically launched to execute the session. A BOA executes the given operation, and if the operation is a boot or a reboot, it also
+    configures the nodes post-boot \(if configure is enabled\).
+- The Slurm control daemon (`slurmctld`) is the central management daemon of Slurm. It runs on non-compute nodes in a container. It monitors all other Slurm daemons and
+  resources, accepts jobs, and allocates resources to those jobs.
+- The Slurm daemon (`slurmd`) monitors all tasks running on compute nodes, accepts tasks, launches tasks, and kills running tasks upon request. It runs on compute nodes.
+
+## Workflow
 
 ![CRUS Upgrade Workflow](../../img/operations/crus_upgrade.gif)
 
-**Workflow Overview:** The following sequence of steps occur during this workflow.
+The following sequence of steps occur during this workflow.
 
-1.  **Administrator creates HSM groups and populates the starting group**
+### 1. Administrator creates HSM groups and populates the starting group
 
-    Create three HSM groups with starting, failed, and upgrading labels.
+1. Create three HSM groups with starting, failed, and upgrading labels.
 
-    For example: crusfailed, crusupgrading, and crus\_starting.
+    Any names can be used for these groups.
+    For this example: `crus_starting`, `crusfailed`, and `crusupgrading`, respectively.
 
-    Add all of the 500 compute nodes to be updated to the crus\_starting group. Leave the failed and upgrading groups empty.
+1. Add all of the compute nodes to be updated to the `crus_starting` group.
 
-2.  **Administrator creates a session template**
+    Leave the `crusfailed`, and `crusupgrading` groups empty.
 
-    Create a BOS session template which points to the new image, the desired CFS configuration, and with a boot set which includes all the compute nodes to be updated. The boot set can include additional nodes, but it must contain all the nodes that need to be updated. The BOS session template you use should specify "upgrading\_label" in the "node\_groups" field of one of its boot sets.
+### 2. Administrator creates a session template
 
-    For example: newcomputetemplate.
+A session template is a collection of metadata for a group of nodes and their desired configuration.
 
-3.  **Administrator creates a CRUS session**
+Create a BOS session template which points to the new image, the desired CFS configuration, and with a boot set which includes all the compute nodes to be updated.
+The boot set can include additional nodes, but it must contain all the nodes that need to be updated. The BOS session template should specify `crusupgrading` in the
+`node_groups` field of one of its boot sets.
 
-    A new upgrade session is launched as a result of this call.
+This example will use the BOS session template named `newcomputetemplate`.
 
-    Specify the following parameters:
+### 3. Administrator creates a CRUS session
 
-    -   failed\_label: An empty Hardware State Manager \(HSM\) group which CRUS will populate with any nodes that fail their upgrades.
-    -   starting\_label: An HSM group which contains the total set of nodes to be upgraded. Example: 500.
-    -   upgrading\_label: An empty HSM group which CRUS will use to boot and configure the discrete sets of nodes.
-    -   upgradestepsize: The number of nodes to include in each discrete upgrade step.
+A new upgrade session is launched as a result of this call.
 
-        The upgrade steps will never exceed this quantity, although in some cases they may be smaller. Example: 50
+Specify the following parameters:
 
-    -   upgradetemplateid: The name of the BOS session template to use for the upgrades. A session template is a collection of metadata for a group of nodes and their desired configuration.
-    -   workloadmanagertype: Currently only slurm is supported.
+| Parameter             | Example              | Meaning                                                                                                         |
+|-----------------------|----------------------|-----------------------------------------------------------------------------------------------------------------|
+| `failed_label`        | `crusfailed`         | An empty Hardware State Manager \(HSM\) group which CRUS will populate with any nodes that fail their upgrades. |
+| `starting_label`      | `crus_starting`      | An HSM group which contains the total set of nodes to be upgraded.                                              |
+| `upgrading_label`     | `crusupgrading`      | An empty HSM group which CRUS will use to boot and configure subsets of the compute nodes.                      |
+| `upgradestepsize`     | `50`                 | The number of nodes to include in each discrete upgrade step.*                                                  |
+| `upgradetemplateid`   | `newcomputetemplate` | The name of the BOS session template to use for the upgrades.                                                   |
+| `workloadmanagertype` | `slurm`              | Only Slurm is supported.                                                                                        |
 
-4.  **CRUS to HSM**
+> \* Each group of concurrent upgrades will never exceed this number of compute nodes, although in some cases they may be smaller.
 
-    CRUS calls HSM to find the nodes in the starting\_label group.
+### 4. CRUS to HSM
 
-5.  **CRUS to HSM**
+CRUS calls HSM to find the nodes in the `crus_starting` group.
 
-    It then takes a number of these nodes equal to the step size \(50\), and calls HSM to put them into the upgrading\_label group.
+### 5. CRUS to HSM
 
-6.  **CRUS to Slurm**
+CRUS selects a number of these nodes equal to `upgradestepsize` and calls HSM to put them into the `crusupgrading` group.
 
-    CRUS tells Slurm to quiesce these nodes. As each node is quiesced, Slurm puts the node offline.
+### 6. CRUS to Slurm
 
-7.  **Slurm to CRUS**
+CRUS tells Slurm to quiesce these nodes. As each node is quiesced, Slurm puts the node offline.
 
-    Slurm reports back to CRUS that all of the nodes as offline.
+### 7. Slurm to CRUS
 
-8.  **CRUS to BOS**
+Slurm reports back to CRUS that all of the nodes as offline.
 
-    CRUS calls BOS to create a session with the following arguments:
+### 8. CRUS to BOS
 
-    -   operation: reboot
-    -   templateUuid: upgrade*template*id
-    -   limit: upgrading\_label
+CRUS calls BOS to create a session with the following arguments:
 
-9.  **CRUS retrieves the BOA job details from BOS**
+| Parameter      | Value                |
+|----------------|----------------------|
+| `operation`    | `reboot`             |
+| `templateUuid` | `newcomputetemplate` |
+| `limit`        | `crusupgrading`      |
 
-    CRUS retrieves the BOS session to get the BOA job name. CRUS waits for the BOA job to finish.
+### 9. CRUS retrieves the BOA job details from BOS
 
-    CRUS looks at the exit code of the BOA job to determine whether or not there were errors.
+1. CRUS retrieves the BOS session to get the BOA job name.
 
-    If there were errors, CRUS adds the nodes from the upgrading\_label group into the failed\_label group.
+1. CRUS waits for the BOA job to finish.
 
-10. **CRUS to HSM**
+1. CRUS looks at the exit code of the BOA job to determine whether or not there were errors.
 
-    After the BOA job is complete, CRUS calls HSM to empty the upgrading\_label group.
+    If there were errors, CRUS adds the nodes from the `crusupgrading` group into the `crusfailed` group.
 
-11. **CRUS repeats steps for remaining nodes, then updates status**
+1. CRUS calls HSM to empty the `crusupgrading` group.
 
-    CRUS repeats steps **5-10** until all of the nodes from the starting\_label group have gone through these steps. After this, CRUS marks the session status as "complete".
+### 10. CRUS repeats steps for remaining nodes, then updates status
 
+1. CRUS repeats steps 5-9 until all of the nodes from the `crus_starting` group have gone through these steps.
+
+1. CRUS marks the session status as `complete`.

--- a/operations/compute_rolling_upgrades/Compute_Rolling_Upgrades.md
+++ b/operations/compute_rolling_upgrades/Compute_Rolling_Upgrades.md
@@ -1,20 +1,21 @@
 # Compute Rolling Upgrades
 
-**Note:** CRUS has been deprecated. It will be removed in CSM-1.3.0 and replaced with BOSv2, which will provide similar functionality. See
+**Note:** CRUS has been deprecated. It will be removed in CSM V1.3.0 and replaced with BOS V2, which will provide similar functionality. See
 [Deprecated features](../../introduction/differences.md#deprecated_features).
 
-The Compute Rolling Upgrade Service \(CRUS\) upgrades sets of compute nodes without requiring an entire set of nodes to be out of service at once. CRUS manages the workload management status of nodes, handling each of the following steps required to upgrade compute nodes:
+The Compute Rolling Upgrade Service \(CRUS\) upgrades sets of compute nodes without requiring an entire set of nodes to be out of service at once. CRUS manages the workload
+management status of nodes, handling each of the following steps required to upgrade compute nodes:
 
-1.  Quiesce each node before taking the node out of service.
-2.  Upgrade the node.
-3.  Reboot the node into the upgraded state.
-4.  Return the node to service within its respective workload manager.
+1. Quiesce each node before taking the node out of service.
+1. Upgrade the node.
+1. Reboot the node into the upgraded state.
+1. Return the node to service within its respective workload manager.
 
-CRUS enables administrators to limit the impact on production caused from upgrading compute nodes by working through one step of the upgrade process at a time. The nodes in each step are taken out of service in the workload manager to prevent work from being scheduled, upgraded, rebooted, and put back into service in the workload manager.
+CRUS enables administrators to limit the impact on production caused from upgrading compute nodes by working through one step of the upgrade process at a time. The nodes in each
+step are first taken out of service in the workload manager to prevent work from being scheduled. They are then upgraded, rebooted, and put back into service in the workload manager.
 
 CRUS is built upon a few basic features of the system:
 
--   The grouping of nodes by label provided by the Hardware State Manager \(HSM\) groups mechanism.
--   Workload management that can gracefully take nodes out of service \(quiesce nodes\), declare nodes as failed, and return nodes to service.
--   The Boot Orchestration Service \(BOS\) and boot session templates.
-
+- The grouping of nodes by label provided by the Hardware State Manager \(HSM\) groups mechanism.
+- Workload management that can gracefully take nodes out of service \(quiesce nodes\), declare nodes as failed, and return nodes to service.
+- The Boot Orchestration Service \(BOS\) and boot session templates.

--- a/operations/compute_rolling_upgrades/Compute_Rolling_Upgrades.md
+++ b/operations/compute_rolling_upgrades/Compute_Rolling_Upgrades.md
@@ -1,5 +1,8 @@
 # Compute Rolling Upgrades
 
+**Note:** CRUS has been deprecated. It will be removed in CSM-1.3.0 and replaced with BOSv2, which will provide similar functionality. See
+[Deprecated features](../../introduction/differences.md#deprecated_features).
+
 The Compute Rolling Upgrade Service \(CRUS\) upgrades sets of compute nodes without requiring an entire set of nodes to be out of service at once. CRUS manages the workload management status of nodes, handling each of the following steps required to upgrade compute nodes:
 
 1.  Quiesce each node before taking the node out of service.

--- a/operations/compute_rolling_upgrades/Compute_Rolling_Upgrades.md
+++ b/operations/compute_rolling_upgrades/Compute_Rolling_Upgrades.md
@@ -1,6 +1,6 @@
 # Compute Rolling Upgrades
 
-**Note:** CRUS has been deprecated. It will be removed in CSM V1.3.0 and replaced with BOS V2, which will provide similar functionality. See
+**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in a future CSM release and replaced with BOS V2, which will provide similar functionality. See
 [Deprecated features](../../introduction/differences.md#deprecated_features).
 
 The Compute Rolling Upgrade Service \(CRUS\) upgrades sets of compute nodes without requiring an entire set of nodes to be out of service at once. CRUS manages the workload

--- a/operations/compute_rolling_upgrades/Troubleshoot_Nodes_Failing_to_Upgrade_in_a_CRUS_Session.md
+++ b/operations/compute_rolling_upgrades/Troubleshoot_Nodes_Failing_to_Upgrade_in_a_CRUS_Session.md
@@ -1,5 +1,8 @@
 # Troubleshoot Nodes Failing to Upgrade in a CRUS Session
 
+**Note:** CRUS has been deprecated. It will be removed in CSM-1.3.0 and replaced with BOSv2, which will provide similar functionality. See
+[Deprecated features](../../introduction/differences.md#deprecated_features).
+
 Troubleshoot compute nodes failing to upgrade during a Compute Rolling Upgrade Service \(CRUS\) session and rerun the session on the failed nodes.
 
 When a nodes are marked as failed they are added to the failed node group associated with the upgrade session, and the nodes are marked as down in the workload manager \(WLM\). If the WLM supports some kind of reason string, that string contains the cause of the down status.

--- a/operations/compute_rolling_upgrades/Troubleshoot_Nodes_Failing_to_Upgrade_in_a_CRUS_Session.md
+++ b/operations/compute_rolling_upgrades/Troubleshoot_Nodes_Failing_to_Upgrade_in_a_CRUS_Session.md
@@ -1,24 +1,23 @@
 # Troubleshoot Nodes Failing to Upgrade in a CRUS Session
 
-**Note:** CRUS has been deprecated. It will be removed in CSM-1.3.0 and replaced with BOSv2, which will provide similar functionality. See
+**Note:** CRUS has been deprecated. It will be removed in CSM V1.3.0 and replaced with BOS V2, which will provide similar functionality. See
 [Deprecated features](../../introduction/differences.md#deprecated_features).
 
 Troubleshoot compute nodes failing to upgrade during a Compute Rolling Upgrade Service \(CRUS\) session and rerun the session on the failed nodes.
 
-When a nodes are marked as failed they are added to the failed node group associated with the upgrade session, and the nodes are marked as down in the workload manager \(WLM\). If the WLM supports some kind of reason string, that string contains the cause of the down status.
+When a nodes are marked as failed they are added to the failed node group associated with the upgrade session, and the nodes are marked as down in the workload manager \(WLM\).
+If the WLM supports some kind of reason string, that string contains the cause of the down status.
 
 Complete a CRUS session that did not successfully upgrade all of the intended compute nodes.
 
-
-### Prerequisites
+## Prerequisites
 
 - A CRUS upgrade session has completed with a group of nodes that failed to upgrade.
-- The Cray command line interface \(CLI\) tool is initialized and configured on the system.
+- The Cray command line interface \(CLI\) tool is initialized and configured on the system. See [Configure the Cray Command Line Interface](../configure_cray_cli.md).
 
+## Procedure
 
-### Procedure
-
-1.  Determine which nodes failed the upgrade by listing the contents of the Hardware State Manager \(HSM\) group that was set up for failed nodes.
+1. Determine which nodes failed the upgrade by listing the contents of the Hardware State Manager \(HSM\) group that was set up for failed nodes.
 
     ```bash
     ncn# cray hsm groups describe FAILED_NODES_GROUP
@@ -26,7 +25,7 @@ Complete a CRUS session that did not successfully upgrade all of the intended co
 
     Example output:
 
-    ```
+    ```toml
     label = "failed-nodes"
     description = ""
 
@@ -34,42 +33,44 @@ Complete a CRUS session that did not successfully upgrade all of the intended co
     ids = [ "x0c0s28b0n0",]
     ```
 
-2.  Determine the cause of the failed nodes and fix it.
+1. Determine the cause of the failed nodes and fix it.
 
     Failed nodes result from the following:
 
     - Failure of the BOS upgrade session for a given step of the upgrade causes all of the nodes in that step to be marked as failed.
-    - Failure of any given node in a step to reach a ready state in the workload manager within 10 minutes of detecting that the BOS boot session has completed causes that node to be marked as failed.
-    - Deletion of a CRUS session while the current step is at or beyond the 'Booting' stage causes all of the nodes in that step that have not reached a ready state in the workload manager to be marked as failed.
+    - Failure of any given node in a step to reach a ready state in the workload manager within 10 minutes of detecting that the BOS boot session has completed causes that node
+      to be marked as failed.
+    - Deletion of a CRUS session while the current step is at or beyond the `Booting` stage causes all of the nodes in that step that have not reached a ready state in the
+      workload manager to be marked as failed.
 
-3.  Create a new CRUS session on the failed nodes.
+1. Create a new CRUS session on the failed nodes.
 
-    1.  Create a new failed node group with a different name.
+    1. Create a new failed node group with a different name.
 
         This group should be empty.
 
         ```bash
-        ncn# cray hsm groups create --label NEW_FAILED_NODES_GROUP \
-        --description 'Failed Node Group for my Compute Node upgrade'
+        ncn# cray hsm groups create --label NEW_FAILED_NODES_GROUP --description 'Failed Node Group for my Compute Node upgrade'
         ```
 
-    2.  Create a new CRUS session.
+    1. Create a new CRUS session.
 
-        Use the label of the failed node group from the original upgrade session as the starting label, and use the new failed node group as the failed label. The rest of the parameters need to be the same ones that were used in the original upgrade.
+        Use the label of the failed node group from the original upgrade session as the starting label, and use the new failed node group as the failed label.
+        The rest of the parameters need to be the same ones that were used in the original upgrade.
 
         ```bash
         ncn# cray crus session create \
-        --starting-label OLD_FAILED_NODES_GROUP \
-        --upgrading-label node-group \
-        --failed-label NEW_FAILED_NODES_GROUP \
-        --upgrade-step-size 50 \
-        --workload-manager-type slurm \
-        --upgrade-template-id boot-template
+                --starting-label OLD_FAILED_NODES_GROUP \
+                --upgrading-label node-group \
+                --failed-label NEW_FAILED_NODES_GROUP \
+                --upgrade-step-size 50 \
+                --workload-manager-type slurm \
+                --upgrade-template-id boot-template
         ```
 
         Example output:
 
-        ```
+        ```toml
         api_version = "1.0.0"
         completed = false
         failed_label = "NEW_FAILED_NODES_GROUP"
@@ -83,4 +84,3 @@ Complete a CRUS session that did not successfully upgrade all of the intended co
         upgrading_label = "node-group"
         workload_manager_type = "slurm"
         ```
-

--- a/operations/compute_rolling_upgrades/Troubleshoot_Nodes_Failing_to_Upgrade_in_a_CRUS_Session.md
+++ b/operations/compute_rolling_upgrades/Troubleshoot_Nodes_Failing_to_Upgrade_in_a_CRUS_Session.md
@@ -5,7 +5,7 @@
 
 Troubleshoot compute nodes failing to upgrade during a Compute Rolling Upgrade Service \(CRUS\) session and rerun the session on the failed nodes.
 
-When a nodes are marked as failed they are added to the failed node group associated with the upgrade session, and the nodes are marked as down in the workload manager \(WLM\).
+When nodes are marked as failed they are added to the failed node group associated with the upgrade session, and the nodes are marked as down in the workload manager \(WLM\).
 If the WLM supports some kind of reason string, that string contains the cause of the down status.
 
 Complete a CRUS session that did not successfully upgrade all of the intended compute nodes.

--- a/operations/compute_rolling_upgrades/Troubleshoot_Nodes_Failing_to_Upgrade_in_a_CRUS_Session.md
+++ b/operations/compute_rolling_upgrades/Troubleshoot_Nodes_Failing_to_Upgrade_in_a_CRUS_Session.md
@@ -1,6 +1,6 @@
 # Troubleshoot Nodes Failing to Upgrade in a CRUS Session
 
-**Note:** CRUS has been deprecated. It will be removed in CSM V1.3.0 and replaced with BOS V2, which will provide similar functionality. See
+**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in a future CSM release and replaced with BOS V2, which will provide similar functionality. See
 [Deprecated features](../../introduction/differences.md#deprecated_features).
 
 Troubleshoot compute nodes failing to upgrade during a Compute Rolling Upgrade Service \(CRUS\) session and rerun the session on the failed nodes.

--- a/operations/compute_rolling_upgrades/Troubleshoot_a_Failed_CRUS_Session_Due_to_Bad_Parameters.md
+++ b/operations/compute_rolling_upgrades/Troubleshoot_a_Failed_CRUS_Session_Due_to_Bad_Parameters.md
@@ -1,6 +1,6 @@
 # Troubleshoot a Failed CRUS Session Because of Bad Parameters
 
-**Note:** CRUS has been deprecated. It will be removed in CSM V1.3.0 and replaced with BOS V2, which will provide similar functionality. See
+**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in a future CSM release and replaced with BOS V2, which will provide similar functionality. See
 [Deprecated features](../../introduction/differences.md#deprecated_features).
 
 A CRUS session must be deleted and recreated if it does not start or complete because of parameters having incorrect values.

--- a/operations/compute_rolling_upgrades/Troubleshoot_a_Failed_CRUS_Session_Due_to_Bad_Parameters.md
+++ b/operations/compute_rolling_upgrades/Troubleshoot_a_Failed_CRUS_Session_Due_to_Bad_Parameters.md
@@ -1,26 +1,28 @@
 # Troubleshoot a Failed CRUS Session Because of Bad Parameters
 
-**Note:** CRUS has been deprecated. It will be removed in CSM-1.3.0 and replaced with BOSv2, which will provide similar functionality. See
+**Note:** CRUS has been deprecated. It will be removed in CSM V1.3.0 and replaced with BOS V2, which will provide similar functionality. See
 [Deprecated features](../../introduction/differences.md#deprecated_features).
 
 A CRUS session must be deleted and recreated if it does not start or complete because of parameters having incorrect values.
 
 The following are examples of incorrect parameters:
 
--   Choosing the wrong Boot Orchestration Service \(BOS\) session template.
--   Choosing the wrong group labels.
--   Improperly defined BOS session template. For example, specifying nodes in the template instead of using the label of the upgrading group.
+- Choosing the wrong Boot Orchestration Service \(BOS\) session template.
+- Choosing the wrong group labels.
+- Improperly defined BOS session template. For example, specifying nodes in the template instead of using the label of the upgrading group.
 
-### Prerequisites
+## Prerequisites
 
--   A Compute Rolling Upgrade Service \(CRUS\) session was run and failed to complete.
--   The Cray command line interface \(CLI\) tool is initialized and configured on the system.
+- A Compute Rolling Upgrade Service \(CRUS\) session was run and failed to complete.
+- The Cray command line interface \(CLI\) tool is initialized and configured on the system. See [Configure the Cray Command Line Interface](../configure_cray_cli.md).
 
-### Procedure
+## Procedure
 
-1.  Delete the failed session.
+1. Delete the failed session.
 
-    Deleting a CRUS session that is in progress will terminate the session and move all of the unfinished nodes into the group said up for failed nodes. The time frame for recognizing a delete request, cleaning up, and deleting the session is roughly a minute. A session being deleted will move to a DELETING status immediately upon receiving a delete request, which will prevent further processing of the upgrade in that session.
+    Deleting a CRUS session that is in progress will terminate the session and move all of the unfinished nodes into the group said up for failed nodes. The time frame for
+    recognizing a delete request, cleaning up, and deleting the session is roughly a minute. A session being deleted will move to a `DELETING` status immediately upon receiving
+    a delete request, which will prevent further processing of the upgrade in that session.
 
     ```bash
     ncn# cray crus session delete CRUS_UPGRADE_ID
@@ -28,7 +30,7 @@ The following are examples of incorrect parameters:
 
     Example output:
 
-    ```
+    ```toml
     api_version = "1.0.0"
     completed = false
     failed_label = "failed-node-group"
@@ -43,23 +45,23 @@ The following are examples of incorrect parameters:
     workload_manager_type = "slurm"
     ```
 
-2.  Recreate the session that failed.
+1. Recreate the session that failed.
 
-    Ensure the correct parameters are used when restarting the session.
+    Ensure that the correct parameters are used when restarting the session.
 
     ```bash
     ncn# cray crus session create \
-    --starting-label slurm-nodes \
-    --upgrading-label node-group \
-    --failed-label failed-node-group \
-    --upgrade-step-size 50 \
-    --workload-manager-type slurm \
-    --upgrade-template-id boot-template
+            --starting-label slurm-nodes \
+            --upgrading-label node-group \
+            --failed-label failed-node-group \
+            --upgrade-step-size 50 \
+            --workload-manager-type slurm \
+            --upgrade-template-id boot-template
     ```
 
     Example output:
 
-    ```
+    ```toml
     api_version = "1.0.0"
     completed = false
     failed_label = "failed-node-group"
@@ -73,4 +75,3 @@ The following are examples of incorrect parameters:
     upgrading_label = "node-group"
     workload_manager_type = "slurm"
     ```
-

--- a/operations/compute_rolling_upgrades/Troubleshoot_a_Failed_CRUS_Session_Due_to_Bad_Parameters.md
+++ b/operations/compute_rolling_upgrades/Troubleshoot_a_Failed_CRUS_Session_Due_to_Bad_Parameters.md
@@ -1,5 +1,8 @@
 # Troubleshoot a Failed CRUS Session Because of Bad Parameters
 
+**Note:** CRUS has been deprecated. It will be removed in CSM-1.3.0 and replaced with BOSv2, which will provide similar functionality. See
+[Deprecated features](../../introduction/differences.md#deprecated_features).
+
 A CRUS session must be deleted and recreated if it does not start or complete because of parameters having incorrect values.
 
 The following are examples of incorrect parameters:

--- a/operations/compute_rolling_upgrades/Troubleshoot_a_Failed_CRUS_Session_Due_to_Unmet_Conditions.md
+++ b/operations/compute_rolling_upgrades/Troubleshoot_a_Failed_CRUS_Session_Due_to_Unmet_Conditions.md
@@ -1,24 +1,24 @@
 # Troubleshoot a Failed CRUS Session Because of Unmet Conditions
 
-**Note:** CRUS has been deprecated. It will be removed in CSM-1.3.0 and replaced with BOSv2, which will provide similar functionality. See
+**Note:** CRUS has been deprecated. It will be removed in CSM V1.3.0 and replaced with BOS V2, which will provide similar functionality. See
 [Deprecated features](../../introduction/differences.md#deprecated_features).
 
-If a CRUS session has any unmet conditions, adding or fixing them will cause the session to continue from wherever it got stuck. Updating other parts of the system to meet the required conditions of a CRUS session will unblock the upgrade session.
+If a CRUS session has any unmet conditions, adding or fixing them will cause the session to continue from wherever it got stuck. Updating other parts of the system to meet
+the required conditions of a CRUS session will unblock the upgrade session.
 
 The following are examples of unmet conditions:
 
--   Undefined groups in the Hardware State Manager \(HSM\).
--   No predefined Boot Orchestration Service \(BOS\) session template exists that describes the desired states of the nodes being upgraded.
+- Undefined groups in the Hardware State Manager \(HSM\).
+- No predefined Boot Orchestration Service \(BOS\) session template exists that describes the desired states of the nodes being upgraded.
 
+## Prerequisites
 
-### Prerequisites
+- A Compute Rolling Upgrade Service \(CRUS\) session was run and failed to complete.
+- The Cray command line interface \(CLI\) tool is initialized and configured on the system. See [Configure the Cray Command Line Interface](../configure_cray_cli.md).
 
--   A Compute Rolling Upgrade Service \(CRUS\) session was run and failed to complete.
--   The Cray command line interface \(CLI\) tool is initialized and configured on the system.
+## Procedure
 
-### Procedure
-
-1.  View the details for the CRUS session that failed.
+1. View the details for the CRUS session that failed.
 
     ```bash
     ncn# cray crus session describe CRUS_UPGRADE_ID
@@ -26,7 +26,7 @@ The following are examples of unmet conditions:
 
     Example output:
 
-    ```
+    ```toml
     api_version = "1.0.0"
     completed = false
     failed_label = "failed-node-group"
@@ -41,9 +41,10 @@ The following are examples of unmet conditions:
     workload_manager_type = "slurm"
     ```
 
-    The messages value returned in the output will provide details explaining where the job failed. In this example, there is a note stating the failed node group could not be obtained. This implies that the user forgot to create the failed node group before starting the job.
+    The `messages` value returned in the output will provide details explaining where the job failed. In this example, there is a note stating the failed node group could not be
+    obtained. This implies that the user forgot to create the failed node group before starting the job.
 
-2.  Create a new node group for the missing group.
+1. Create a new node group for the missing group.
 
     Following the example in the previous step, the failed node group needs to be created.
 
@@ -53,20 +54,20 @@ The following are examples of unmet conditions:
 
     Example output:
 
-    ```
+    ```toml
     [[results]]
     URI = "/hsm/v2/groups/failed-node-group"
     ```
 
-3.  View the details for the CRUS session again to see if the job started.
+1. View the details for the CRUS session again to see if the job started.
 
     ```bash
-    ncn-w001# cray crus session describe CRUS_UPGRADE_ID
+    ncn# cray crus session describe CRUS_UPGRADE_ID
     ```
 
     Example output:
 
-    ```
+    ```toml
     api_version = "1.0.0"
     completed = false
     failed_label = "failed-node-group"
@@ -81,5 +82,4 @@ The following are examples of unmet conditions:
     workload_manager_type = "slurm"
     ```
 
-    The messages value states that the job has resumed now that the error has been fixed.
-
+    The `messages` value states that the job has resumed now that the error has been fixed.

--- a/operations/compute_rolling_upgrades/Troubleshoot_a_Failed_CRUS_Session_Due_to_Unmet_Conditions.md
+++ b/operations/compute_rolling_upgrades/Troubleshoot_a_Failed_CRUS_Session_Due_to_Unmet_Conditions.md
@@ -1,6 +1,6 @@
 # Troubleshoot a Failed CRUS Session Because of Unmet Conditions
 
-**Note:** CRUS has been deprecated. It will be removed in CSM V1.3.0 and replaced with BOS V2, which will provide similar functionality. See
+**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in a future CSM release and replaced with BOS V2, which will provide similar functionality. See
 [Deprecated features](../../introduction/differences.md#deprecated_features).
 
 If a CRUS session has any unmet conditions, adding or fixing them will cause the session to continue from wherever it got stuck. Updating other parts of the system to meet

--- a/operations/compute_rolling_upgrades/Troubleshoot_a_Failed_CRUS_Session_Due_to_Unmet_Conditions.md
+++ b/operations/compute_rolling_upgrades/Troubleshoot_a_Failed_CRUS_Session_Due_to_Unmet_Conditions.md
@@ -1,5 +1,8 @@
 # Troubleshoot a Failed CRUS Session Because of Unmet Conditions
 
+**Note:** CRUS has been deprecated. It will be removed in CSM-1.3.0 and replaced with BOSv2, which will provide similar functionality. See
+[Deprecated features](../../introduction/differences.md#deprecated_features).
+
 If a CRUS session has any unmet conditions, adding or fixing them will cause the session to continue from wherever it got stuck. Updating other parts of the system to meet the required conditions of a CRUS session will unblock the upgrade session.
 
 The following are examples of unmet conditions:

--- a/operations/compute_rolling_upgrades/Upgrade_Compute_Nodes_with_CRUS.md
+++ b/operations/compute_rolling_upgrades/Upgrade_Compute_Nodes_with_CRUS.md
@@ -1,5 +1,8 @@
 # Upgrade Compute Nodes with CRUS
 
+**Note:** CRUS has been deprecated. It will be removed in CSM-1.3.0 and replaced with BOSv2, which will provide similar functionality. See
+[Deprecated features](../../introduction/differences.md#deprecated_features).
+
 Upgrade a set of compute nodes with the Compute Rolling Upgrade Service \(CRUS\). Manage the workload management status of nodes and quiesce each node before taking the node out of service and upgrading it. Then reboot it into the upgraded state and return it to service within the workload manager \(WLM\).
 
 ### Prerequisites

--- a/operations/compute_rolling_upgrades/Upgrade_Compute_Nodes_with_CRUS.md
+++ b/operations/compute_rolling_upgrades/Upgrade_Compute_Nodes_with_CRUS.md
@@ -1,6 +1,6 @@
 # Upgrade Compute Nodes with CRUS
 
-**Note:** CRUS has been deprecated. It will be removed in CSM V1.3.0 and replaced with BOS V2, which will provide similar functionality. See
+**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in a future CSM release and replaced with BOS V2, which will provide similar functionality. See
 [Deprecated features](../../introduction/differences.md#deprecated_features).
 
 Upgrade a set of compute nodes with the Compute Rolling Upgrade Service \(CRUS\). Manage the workload management status of nodes and quiesce each node before taking the node

--- a/operations/compute_rolling_upgrades/Upgrade_Compute_Nodes_with_CRUS.md
+++ b/operations/compute_rolling_upgrades/Upgrade_Compute_Nodes_with_CRUS.md
@@ -1,31 +1,31 @@
 # Upgrade Compute Nodes with CRUS
 
-**Note:** CRUS has been deprecated. It will be removed in CSM-1.3.0 and replaced with BOSv2, which will provide similar functionality. See
+**Note:** CRUS has been deprecated. It will be removed in CSM V1.3.0 and replaced with BOS V2, which will provide similar functionality. See
 [Deprecated features](../../introduction/differences.md#deprecated_features).
 
-Upgrade a set of compute nodes with the Compute Rolling Upgrade Service \(CRUS\). Manage the workload management status of nodes and quiesce each node before taking the node out of service and upgrading it. Then reboot it into the upgraded state and return it to service within the workload manager \(WLM\).
+Upgrade a set of compute nodes with the Compute Rolling Upgrade Service \(CRUS\). Manage the workload management status of nodes and quiesce each node before taking the node
+out of service and upgrading it. Then reboot it into the upgraded state and return it to service within the workload manager \(WLM\).
 
-### Prerequisites
+## Prerequisites
 
-- The Cray command line interface \(CLI\) tool is initialized and configured on the system.
+- The Cray command line interface \(CLI\) tool is initialized and configured on the system. See [Configure the Cray Command Line Interface](../configure_cray_cli.md).
 - A Boot Orchestration Service \(BOS\) session template describing the desired states of the nodes being upgraded must exist.
 
-### Procedure
+## Procedure
 
-1.  Create and populate the starting node group.
+1. Create and populate the starting node group.
 
     This will be the group of nodes that will be upgraded.
 
-    1.  Create a starting node group \(starting label\).
+    1. Create a starting node group \(starting label\).
 
-        Label names are defined by the user and the names used in this procedure are only examples. The label name used in this example is slurm-nodes.
+        Label names are defined by the user and the names used in this procedure are only examples. The label name used in this example is `slurm-nodes`.
 
         ```bash
-        ncn# cray hsm groups create --label slurm-nodes \
-        --description 'Starting Node Group for my Compute Node upgrade'
+        ncn# cray hsm groups create --label slurm-nodes --description 'Starting Node Group for my Compute Node upgrade'
         ```
 
-    2.  Add members to the group.
+    1. Add members to the group.
 
         Add compute nodes to the group by using the component name (xname) for each node being added.
 
@@ -35,50 +35,48 @@ Upgrade a set of compute nodes with the Compute Rolling Upgrade Service \(CRUS\)
 
         Example output:
 
-        ```
+        ```toml
         [[results]]
         URI = "/hsm/v2/groups/slurm-nodes/members/x0c0s28b0n0"
         ```
 
-2.  Create a group for upgrading nodes \(upgrading label\).
+1. Create a group for upgrading nodes \(upgrading label\).
 
-    The label name used in this example is upgrading-nodes.
-
-    ```bash
-    ncn-w001# cray hsm groups create --label upgrading-nodes \
-    --description 'Upgrading Node Group for my Compute Node upgrade'
-    ```
-
-    There is no need to add members to this group because it should be empty when the compute rolling upgrade process begins.
-
-3.  Create a group for failed nodes \(failed label\).
-
-    The label name used in this example is failed-nodes.
+    The label name used in this example is `upgrading-nodes`.
 
     ```bash
-    ncn# cray hsm groups create --label failed-nodes \
-    --description 'Failed Node Group for my Compute Node upgrade'
+    ncn# cray hsm groups create --label upgrading-nodes --description 'Upgrading Node Group for my Compute Node upgrade'
     ```
 
-    There is no need to add members to this group because it should be empty when the compute rolling upgrade process begins.
+    Do not add members to this group; it should be empty when the compute rolling upgrade process begins.
 
-4.  Create an upgrade session with CRUS.
+1. Create a group for failed nodes \(failed label\).
+
+    The label name used in this example is `failed-nodes`.
+
+    ```bash
+    ncn# cray hsm groups create --label failed-nodes --description 'Failed Node Group for my Compute Node upgrade'
+    ```
+
+    Do not add members to this group; it should be empty when the compute rolling upgrade process begins.
+
+1. Create an upgrade session with CRUS.
 
     The following example is upgrading 50 nodes at a step. The `--upgrade-template-id` value should be the name of the Boot Orchestration Service \(BOS\) session template being used.
 
     ```bash
     ncn# cray crus session create \
-    --starting-label slurm-nodes \
-    --upgrading-label upgrading-nodes \
-    --failed-label failed-nodes \
-    --upgrade-step-size 50 \
-    --workload-manager-type slurm \
-    --upgrade-template-id=BOS_SESSION_TEMPLATE_NAME
+            --starting-label slurm-nodes \
+            --upgrading-label upgrading-nodes \
+            --failed-label failed-nodes \
+            --upgrade-step-size 50 \
+            --workload-manager-type slurm \
+            --upgrade-template-id=BOS_SESSION_TEMPLATE_NAME
     ```
 
     Example output:
 
-    ```
+    ```toml
     api_version = "1.0.0"
     completed = false
     failed_label = "failed-nodes"
@@ -93,23 +91,24 @@ Upgrade a set of compute nodes with the Compute Rolling Upgrade Service \(CRUS\)
     workload_manager_type = "slurm"
     ```
 
-    If successful, note the upgrade\_id in the returned data.
+    If successful, note the `upgrade_id` in the returned data.
 
     ```bash
-    ncn-w001# export UPGRADE_ID=e0131663-dbee-47c2-aa5c-13fe9b110242
+    ncn# export UPGRADE_ID=e0131663-dbee-47c2-aa5c-13fe9b110242
     ```
 
-5.  Monitor the status of the upgrade session.
+1. Monitor the status of the upgrade session.
 
-    The progress of the session through the upgrade process is described in the messages field of the session. This is a list of messages, in chronological order, containing information about stage transitions, step transitions, and other conditions of interest encountered by the session as it progresses. It is cleared once the session completes.
+    The progress of the session through the upgrade process is described in the `messages` field of the session. This is a list of messages, in chronological order, containing
+    information about stage transitions, step transitions, and other conditions of interest encountered by the session as it progresses. It is cleared once the session completes.
 
     ```bash
-    ncn-w001# cray crus session describe $UPGRADE_ID
+    ncn# cray crus session describe $UPGRADE_ID
     ```
 
     Example output:
 
-    ```
+    ```toml
     api_version = "1.0.0"
     completed = false
     failed_label = "failed-nodes"
@@ -124,28 +123,31 @@ Upgrade a set of compute nodes with the Compute Rolling Upgrade Service \(CRUS\)
     workload_manager_type = "slurm"
     ```
 
-    A CRUS session goes through a number of steps \(approximately the number of nodes to be upgraded divided by the requested step size\) to complete an upgrade. Each step moves through the following stages, unless the boot session is interrupted by being deleted.
+    A CRUS session goes through a number of steps \(approximately the number of nodes to be upgraded divided by the requested step size\) to complete an upgrade. Each step
+    moves through the following stages, unless the boot session is interrupted by being deleted.
 
-    1.  Starting - Preparation for the step and CRUS initiates WLM quiescing of nodes.
-    2.  Quiescing - Waits for all WLM nodes in the step to reach a quiesced \(not busy\) state.
-    3.  Quiesced - The nodes in the step are all quiesced and CRUS initiates booting the nodes into the upgraded environment.
-    4.  Booting - Waits for the boot session to complete.
-    5.  Booted - The boot session has completed. Check the success or failure of the boot session. Mark all nodes in the step as failed if the boot session failed.
-    6.  WLM Waiting - The boot session succeeded. Wait for nodes to reach a ready state in the WLM. All nodes in the step that fail to reach a ready state within 10 minutes of entering this stage are marked as failed.
-    7.  Cleanup - The upgrade step has finished. Clean up resources to prepare for the next step.
-    When a step moves from one stage to the next, CRUS adds a message to the messages field of the upgrade session to mark the progress.
+    1. `Starting` - Preparation for the step; CRUS initiates WLM quiescing of nodes.
+    1. `Quiescing` - Waits for all WLM nodes in the step to reach a quiesced \(not busy\) state.
+    1. `Quiesced` - The nodes in the step are all quiesced and CRUS initiates booting the nodes into the upgraded environment.
+    1. `Booting` - Waits for the boot session to complete.
+    1. `Booted` - The boot session has completed. Check the success or failure of the boot session. Mark all nodes in the step as failed if the boot session failed.
+    1. `WLM Waiting` - The boot session succeeded. Wait for nodes to reach a ready state in the WLM. All nodes in the step that fail to reach a ready state within 10 minutes of
+       entering this stage are marked as failed.
+    1. `Cleanup` - The upgrade step has finished. Clean up resources to prepare for the next step.
 
-6.  Optional: Delete the CRUS upgrade session.
+    When a step moves from one stage to the next, CRUS adds a message to the `messages` field of the upgrade session to mark the progress.
 
-    Once a CRUS upgrade session it is complete, it can no longer be used. It can be kept for historical purposes if desired, or it can be deleted.
+1. Delete the CRUS upgrade session. (Optional)
+
+    Once a CRUS upgrade session is complete, it can no longer be used. It can be kept for historical purposes if desired, or it can be deleted.
 
     ```bash
-    ncn-w001# cray crus session delete $UPGRADE_ID
+    ncn# cray crus session delete $UPGRADE_ID
     ```
 
     Example output:
 
-    ```
+    ```toml
     api_version = "1.0.0"
     completed = true
     failed_label = "failed-nodes"
@@ -161,4 +163,3 @@ Upgrade a set of compute nodes with the Compute Rolling Upgrade Service \(CRUS\)
     ```
 
     The session may be visible briefly after it is deleted. This allows for orderly cleanup of the session.
-

--- a/operations/index.md
+++ b/operations/index.md
@@ -192,7 +192,7 @@ Use the Ceph Object Gateway Simple Storage Service \(S3\) API to manage artifact
 Upgrade sets of compute nodes with the Compute Rolling Upgrade Service \(CRUS\) without requiring an entire set of nodes to be out of service at once. CRUS enables
 administrators to limit the impact on production caused from upgrading compute nodes by working through one step of the upgrade process at a time.
 
-**Note:** CRUS has been deprecated. It will be removed in CSM-1.3.0 and replaced with BOSv2, which will provide similar functionality.
+**Note:** CRUS has been deprecated. It will be removed in CSM V1.3.0 and replaced with BOS V2, which will provide similar functionality.
 See [Deprecated features](../introduction/differences.md#deprecated_features).
 
 - [Compute Rolling Upgrade Service (CRUS)](compute_rolling_upgrades/Compute_Rolling_Upgrades.md)

--- a/operations/index.md
+++ b/operations/index.md
@@ -192,7 +192,8 @@ Use the Ceph Object Gateway Simple Storage Service \(S3\) API to manage artifact
 Upgrade sets of compute nodes with the Compute Rolling Upgrade Service \(CRUS\) without requiring an entire set of nodes to be out of service at once. CRUS enables
 administrators to limit the impact on production caused from upgrading compute nodes by working through one step of the upgrade process at a time.
 
-**Note:** CRUS will be deprecated in an upcoming release.
+**Note:** CRUS has been deprecated. It will be removed in CSM-1.3.0 and replaced with BOSv2, which will provide similar functionality.
+See [Deprecated features](../introduction/differences.md#deprecated_features).
 
 - [Compute Rolling Upgrade Service (CRUS)](compute_rolling_upgrades/Compute_Rolling_Upgrades.md)
 - [CRUS Workflow](compute_rolling_upgrades/CRUS_Workflow.md)

--- a/operations/index.md
+++ b/operations/index.md
@@ -192,7 +192,7 @@ Use the Ceph Object Gateway Simple Storage Service \(S3\) API to manage artifact
 Upgrade sets of compute nodes with the Compute Rolling Upgrade Service \(CRUS\) without requiring an entire set of nodes to be out of service at once. CRUS enables
 administrators to limit the impact on production caused from upgrading compute nodes by working through one step of the upgrade process at a time.
 
-**Note:** CRUS has been deprecated. It will be removed in CSM V1.3.0 and replaced with BOS V2, which will provide similar functionality.
+**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in a future CSM release and replaced with BOS V2, which will provide similar functionality.
 See [Deprecated features](../introduction/differences.md#deprecated_features).
 
 - [Compute Rolling Upgrade Service (CRUS)](compute_rolling_upgrades/Compute_Rolling_Upgrades.md)

--- a/operations/kubernetes/Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md
+++ b/operations/kubernetes/Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md
@@ -1,6 +1,7 @@
 # Repopulate Data in etcd Clusters When Rebuilding Them
 
-When an etcd cluster is not healthy, it needs to be rebuilt. During that process, the pods that rely on etcd clusters lose data. That data needs to be repopulated in order for the cluster to go back to a healthy state.
+When an etcd cluster is not healthy, it needs to be rebuilt. During that process, the pods that rely on etcd clusters lose data. That data needs to be repopulated in order for
+the cluster to go back to a healthy state.
 
 The following services need their data repopulated in the etcd cluster:
 
@@ -14,44 +15,44 @@ The following services need their data repopulated in the etcd cluster:
 - Mountain Endpoint Discovery Service \(MEDS\)
 - River Endpoint Discovery Service \(REDS\)
 
-### Prerequisites
+## Prerequisites
 
 An etcd cluster was rebuilt. See [Rebuild Unhealthy etcd Clusters](Rebuild_Unhealthy_etcd_Clusters.md).
 
+## BOS
 
-### BOS
-
-1.  Reconstruct boot session templates for impacted product streams to repopulate data.
+1. Reconstruct boot session templates for impacted product streams to repopulate data.
 
     Boot preparation information for other product streams can be found in the following locations:
 
     - UANs: Refer to the UAN product stream repository and search for the "PREPARE UAN BOOT SESSION TEMPLATES" header in the "Install and Configure UANs" procedure.
     - Cray Operating System \(COS\): Refer to the "Create a Boot Session Template" header in the "Boot COS" procedure in the COS product stream documentation.
 
-### CPS
+## CPS
 
-1.  Repopulate clusters for CPS.
+1. Repopulate clusters for CPS.
 
-    - If there are no clients using CPS when the etcd cluster is rebuilt, then nothing needs to be done other than to rebuild the cluster and make sure all of the components are up and running. See [Rebuild Unhealthy etcd Clusters](Rebuild_Unhealthy_etcd_Clusters.md) for more information.
-    - If any clients have already mounted content provided by CPS, that content should be unmounted before rebuilding the etcd cluster, and then re-mounted after the etcd cluster is rebuilt. Compute nodes that use CPS to access their root file system must be shut down to unmount, and then booted to perform the re-mount.
+    - If there are no clients using CPS when the etcd cluster is rebuilt, then nothing needs to be done other than to rebuild the cluster and make sure all of the components are
+      up and running. See [Rebuild Unhealthy etcd Clusters](Rebuild_Unhealthy_etcd_Clusters.md) for more information.
+    - If any clients have already mounted content provided by CPS, that content should be unmounted before rebuilding the etcd cluster, and then re-mounted after the etcd cluster
+      is rebuilt. Compute nodes that use CPS to access their root file system must be shut down to unmount, and then booted to perform the re-mount.
 
+## CRUS
 
-### CRUS
-
-**Note:** CRUS has been deprecated. It will be removed in CSM-1.3.0 and replaced with BOSv2, which will provide similar functionality. See
+**Note:** CRUS has been deprecated. It will be removed in CSM V1.3.0 and replaced with BOS V2, which will provide similar functionality. See
 [Deprecated features](../../introduction/differences.md#deprecated_features).
 
-1.  View the progress of existing CRUS sessions.
+1. View the progress of existing CRUS sessions.
 
-    1.  List the existing CRUS sessions to find the upgrade\_id for the desired session.
+    1. List the existing CRUS sessions to find the upgrade\_id for the desired session.
 
         ```bash
-        ncn-w001# cray crus session list
+        ncn# cray crus session list
         ```
 
         Example output:
 
-        ```
+        ```toml
         [[results]]
         api_version = "1.0.0"
         completed = false
@@ -67,17 +68,17 @@ An etcd cluster was rebuilt. See [Rebuild Unhealthy etcd Clusters](Rebuild_Unhea
         workload_manager_type = "slurm"
         ```
 
-    2.  Describe the CRUS session to see if the session failed or is stuck.
+    1. Describe the CRUS session to see if the session failed or is stuck.
 
         If the session continued and appears to be in a healthy state, proceed to the [BSS](#bss) section.
 
         ```bash
-        ncn-w001# cray crus session describe CRUS_UPGRADE_ID
+        ncn# cray crus session describe CRUS_UPGRADE_ID
         ```
 
         Example output:
 
-        ```
+        ```toml
         api_version = "1.0.0"
         completed = false
         failed_label = "failed-nodes"
@@ -93,78 +94,79 @@ An etcd cluster was rebuilt. See [Rebuild Unhealthy etcd Clusters](Rebuild_Unhea
         workload_manager_type = "slurm"
         ```
 
-2.  Find the name of the running CRUS pod.
+1. Find the name of the running CRUS pod.
 
     ```bash
-    ncn-w001# kubectl get pods -n services | grep cray-crus
+    ncn# kubectl get pods -n services | grep cray-crus
     ```
 
     Example output:
 
-    ```
+    ```text
     cray-crus-549cb9cb5d-jtpqg                                   3/4     Running   528        25h
     ```
 
-3.  Restart the CRUS pod.
+1. Restart the CRUS pod.
 
     Deleting the pod will restart CRUS and start the discovery process for any data recovered in etcd.
 
     ```bash
-    ncn-w001# kubectl delete pods -n services POD_NAME
+    ncn# kubectl delete pods -n services POD_NAME
     ```
 
-### BSS
+## BSS
 
-Data is repopulated in BSS when the REDS init job is run.
+Data is repopulated in BSS when the REDS `init` job is run.
 
-1.  Get the current REDS job.
+1. Get the current REDS job.
 
     ```bash
-    ncn-w001# kubectl get -o json -n services job/cray-reds-init | \
-    jq 'del(.spec.template.metadata.labels["controller-uid"], .spec.selector)' > cray-reds-init.json
+    ncn# kubectl get -o json -n services job/cray-reds-init |
+            jq 'del(.spec.template.metadata.labels["controller-uid"], .spec.selector)' > cray-reds-init.json
     ```
 
-2. Delete the reds-client-init job.
+1. Delete the `reds-client-init` job.
 
     ```bash
-    ncn-w001# kubectl delete -n services -f cray-reds-init.json
+    ncn# kubectl delete -n services -f cray-reds-init.json
     ```
 
-3.  Restart the reds-client-init job.
+1. Restart the `reds-client-init` job.
 
     ```bash
-    ncn-w001# kubectl apply -n services -f cray-reds-init.json
+    ncn# kubectl apply -n services -f cray-reds-init.json
     ```
 
-### REDS
+## REDS
 
-1.  Restart REDS.
+1. Restart REDS.
 
     ```bash
-    ncn-w001# kubectl -n services delete pods --selector='app.kubernetes.io/name=cray-reds'
+    ncn# kubectl -n services delete pods --selector='app.kubernetes.io/name=cray-reds'
     ```
 
-### MEDS
+## MEDS
 
-1.  Restart MEDS.
+1. Restart MEDS.
 
     ```bash
-    ncn-w001# kubectl -n services delete pods --selector='app.kubernetes.io/name=cray-meds'
+    ncn# kubectl -n services delete pods --selector='app.kubernetes.io/name=cray-meds'
     ```
 
-### FAS
+## FAS
 
-1.  Run the `cray-fas-loader` Kubernetes job.
+1. Run the `cray-fas-loader` Kubernetes job.
 
     Refer to the "Use the `cray-fas-loader` Kubernetes Job" section in [FAS Admin Procedures](../firmware/FAS_Admin_Procedures.md) for more information.
 
-    When the etcd cluster is rebuilt, all historic data for firmware actions and all recorded snapshots will be lost. Image data will need to be reloaded by following the `cray-fas-loader` Kubernetes job procedure. After images are reloaded any running actions at time of failure will need to be recreated.
+    When the etcd cluster is rebuilt, all historic data for firmware actions and all recorded snapshots will be lost. Image data will need to be reloaded by following the
+    `cray-fas-loader` Kubernetes job procedure. After images are reloaded any running actions at time of failure will need to be recreated.
 
-### HMNFD
+## HMNFD
 
-1.  Resubscribe the compute nodes and any NCNs that use the ORCA daemon for their State Change Notifications \(SCN\).
+1. Resubscribe the compute nodes and any NCNs that use the ORCA daemon for their State Change Notifications \(SCN\).
 
-    1.  Resubscribe all compute nodes.
+    1. Resubscribe all compute nodes.
 
         ```bash
         ncn-m001# TMPFILE=$(mktemp)
@@ -175,12 +177,11 @@ Data is repopulated in BSS when the REDS init job is run.
         ncn-m001# rm -rf $TMPFILE
         ```
 
-    2.  Resubscribe the NCNs.
+    1. Resubscribe the NCNs.
+
+        **NOTE:** Modify the `-w` arguments in the following commands to reflect the number of worker and storage nodes in the system.
 
         ```bash
         ncn-m001# pdsh -w ncn-w00[0-4]-can.local "systemctl restart cray-dvs-orca"
         ncn-m001# pdsh -w ncn-s00[0-4]-can.local "systemctl restart cray-dvs-orca"
         ```
-
-        **NOTE:** On larger systems, [0-4] may have to be a larger range.
-

--- a/operations/kubernetes/Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md
+++ b/operations/kubernetes/Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md
@@ -38,6 +38,9 @@ An etcd cluster was rebuilt. See [Rebuild Unhealthy etcd Clusters](Rebuild_Unhea
 
 ### CRUS
 
+**Note:** CRUS has been deprecated. It will be removed in CSM-1.3.0 and replaced with BOSv2, which will provide similar functionality. See
+[Deprecated features](../../introduction/differences.md#deprecated_features).
+
 1.  View the progress of existing CRUS sessions.
 
     1.  List the existing CRUS sessions to find the upgrade\_id for the desired session.

--- a/operations/kubernetes/Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md
+++ b/operations/kubernetes/Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md
@@ -39,7 +39,7 @@ An etcd cluster was rebuilt. See [Rebuild Unhealthy etcd Clusters](Rebuild_Unhea
 
 ## CRUS
 
-**Note:** CRUS has been deprecated. It will be removed in CSM V1.3.0 and replaced with BOS V2, which will provide similar functionality. See
+**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in a future CSM release and replaced with BOS V2, which will provide similar functionality. See
 [Deprecated features](../../introduction/differences.md#deprecated_features).
 
 1. View the progress of existing CRUS sessions.

--- a/troubleshooting/index.md
+++ b/troubleshooting/index.md
@@ -41,6 +41,9 @@ This document provides links to troubleshooting information for services and fun
     * [Log File Locations and Ports Used](../operations/boot_orchestration/Log_File_Locations_and_Ports_Used_in_Compute_Node_Boot_Troubleshooting.md)
     * [Issues Related to Slow Boot Times](../operations/boot_orchestration/Troubleshoot_Compute_Node_Boot_Issues_Related_to_Slow_Boot_Times.md)
 * Compute Rolling Upgrades
+  * CRUS has been deprecated.
+    * It will be removed in CSM-1.3.0 and replaced with BOSv2, which will provide similar functionality.
+    * See [Deprecated features](../introduction/differences.md#deprecated_features).
   * [Nodes Failing to Upgrade in a CRUS Session](../operations/compute_rolling_upgrades/Troubleshoot_Nodes_Failing_to_Upgrade_in_a_CRUS_Session.md)
   * [Failed CRUS Session Because of Unmet Conditions](../operations/compute_rolling_upgrades/Troubleshoot_a_Failed_CRUS_Session_Due_to_Unmet_Conditions.md)
   * [Failed CRUS Session Because of Bad Parameters](../operations/compute_rolling_upgrades/Troubleshoot_a_Failed_CRUS_Session_Due_to_Bad_Parameters.md)

--- a/troubleshooting/index.md
+++ b/troubleshooting/index.md
@@ -2,15 +2,14 @@
 
 This document provides links to troubleshooting information for services and functionality provided by CSM.
 
-## Known Issues
+## Known issues
 
-* [Known Issues](#known-issues)
-  * [SAT/HSM/CAPMC Component Power State Mismatch](known_issues/component_power_state_mismatch.md)
-  * [HMS Discovery job not creating `RedfishEndpoint`s in Hardware State Manager](known_issues/discovery_job_not_creating_redfish_endpoints.md)
-    * [`initrd.img.xz` not found](known_issues/initrd.img.zx_not_found.md)
-  * [Platform CA Issues](known_issues/platform_ca_issues.md)
+* [SAT/HSM/CAPMC Component Power State Mismatch](known_issues/component_power_state_mismatch.md)
+* [HMS Discovery job not creating `RedfishEndpoint`s in Hardware State Manager](known_issues/discovery_job_not_creating_redfish_endpoints.md)
+  * [`initrd.img.xz` not found](known_issues/initrd.img.zx_not_found.md)
+* [Platform CA Issues](known_issues/platform_ca_issues.md)
 
-## Troubleshooting Topics
+## Troubleshooting topics
 
 * Kubernetes
   * [General Kubernetes Commands for Troubleshooting](kubernetes/Kubernetes_Troubleshooting_Information.md)
@@ -42,7 +41,7 @@ This document provides links to troubleshooting information for services and fun
     * [Issues Related to Slow Boot Times](../operations/boot_orchestration/Troubleshoot_Compute_Node_Boot_Issues_Related_to_Slow_Boot_Times.md)
 * Compute Rolling Upgrades
   * CRUS has been deprecated.
-    * It will be removed in CSM-1.3.0 and replaced with BOSv2, which will provide similar functionality.
+    * It will be removed in CSM V1.3.0 and replaced with BOS V2, which will provide similar functionality.
     * See [Deprecated features](../introduction/differences.md#deprecated_features).
   * [Nodes Failing to Upgrade in a CRUS Session](../operations/compute_rolling_upgrades/Troubleshoot_Nodes_Failing_to_Upgrade_in_a_CRUS_Session.md)
   * [Failed CRUS Session Because of Unmet Conditions](../operations/compute_rolling_upgrades/Troubleshoot_a_Failed_CRUS_Session_Due_to_Unmet_Conditions.md)

--- a/troubleshooting/index.md
+++ b/troubleshooting/index.md
@@ -40,8 +40,8 @@ This document provides links to troubleshooting information for services and fun
     * [Log File Locations and Ports Used](../operations/boot_orchestration/Log_File_Locations_and_Ports_Used_in_Compute_Node_Boot_Troubleshooting.md)
     * [Issues Related to Slow Boot Times](../operations/boot_orchestration/Troubleshoot_Compute_Node_Boot_Issues_Related_to_Slow_Boot_Times.md)
 * Compute Rolling Upgrades
-  * CRUS has been deprecated.
-    * It will be removed in CSM V1.3.0 and replaced with BOS V2, which will provide similar functionality.
+  * CRUS is deprecated in CSM 1.2.0.
+    * It will be removed in a future CSM release and replaced with BOS V2, which will provide similar functionality.
     * See [Deprecated features](../introduction/differences.md#deprecated_features).
   * [Nodes Failing to Upgrade in a CRUS Session](../operations/compute_rolling_upgrades/Troubleshoot_Nodes_Failing_to_Upgrade_in_a_CRUS_Session.md)
   * [Failed CRUS Session Because of Unmet Conditions](../operations/compute_rolling_upgrades/Troubleshoot_a_Failed_CRUS_Session_Due_to_Unmet_Conditions.md)


### PR DESCRIPTION
## Summary and Scope

Make sure the messaging is consistent and visible that CRUS is deprecated in csm-1.2 and will be removed in a future release.

This needs to make it into the csm-1.2 docs that we ship with.

## Issues and Related PRs

- Resolves [CASMCMS-7991](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7991)
- Relates to [CASMCMS-7704](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7704)
- [main backport](https://github.com/Cray-HPE/docs-csm/pull/1790)
- Backport PRs forthcoming
