### PR TITLE
1.0 backport: CASMCMS-7991: Add/update CRUS deprecation notices

### DIFF
--- a/.github/config/markdown_style.yaml
+++ b/.github/config/markdown_style.yaml
@@ -93,7 +93,7 @@ MD013:
   # Number of characters for headings
   heading_line_length: 255
   # Number of characters for code blocks
-  code_block_line_length: 375
+  code_block_line_length: 400
   # Include code blocks
   code_blocks: true
   # Include tables

--- a/.spelling
+++ b/.spelling
@@ -132,6 +132,7 @@ ConMan
 ConnectX-4
 ConnectX-5
 ConnectX-5s
+CoreDNS
 Cray
 Cray-HPE
 CrayPort

--- a/.spelling
+++ b/.spelling
@@ -67,7 +67,7 @@ ASICs
 backdoor
 backend
 BardPeak
-Barebones
+barebones
 base-64
 base-64-encoded
 Basecamp
@@ -83,7 +83,6 @@ BMCs
 bootscript
 BOA
 BOS
-BOSv2
 BSS
 Burstable
 buses
@@ -537,6 +536,7 @@ V1.20.13
 v1.3
 v1.3.x
 v1.30.16
+V1.3.0
 v1.4
 v1.4.
 v1.4.0
@@ -571,6 +571,7 @@ workarea
 writable
 X.509
 XL645d
+XL675d
 xname
 xnames
 Yum

--- a/glossary.md
+++ b/glossary.md
@@ -151,11 +151,12 @@ and CDU status to the CMMs for evaluation and/or action.
 
 ## Compute Rolling Upgrade Service (CRUS)
 
-The Compute Rolling Upgrade Service (CRUS) upgrades sets of compute nodes without requiring an entire set of nodes to be out of service at once. CRUS manages the workload management status of nodes, handling each of the steps required to upgrade compute nodes.
+The Compute Rolling Upgrade Service (CRUS) upgrades sets of compute nodes without requiring an entire set of nodes to be out of service at once. CRUS manages the workload
+management status of nodes, handling each of the steps required to upgrade compute nodes.
 
 See [Compute Rolling Upgrades](operations/index.md#compute-rolling-upgrades).
 
-**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in CSM-1.3.0 and replaced with BOSv2, which will provide similar functionality.
+**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in CSM V1.3.0 and replaced with BOS V2, which will provide similar functionality.
 
 <a name="cray-advanced-platform-monitoring-and-control"></a>
 

--- a/glossary.md
+++ b/glossary.md
@@ -156,7 +156,7 @@ management status of nodes, handling each of the steps required to upgrade compu
 
 See [Compute Rolling Upgrades](operations/index.md#compute-rolling-upgrades).
 
-**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in CSM V1.3.0 and replaced with BOS V2, which will provide similar functionality.
+**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in a future CSM release and replaced with BOS V2, which will provide similar functionality.
 
 <a name="cray-advanced-platform-monitoring-and-control"></a>
 

--- a/glossary.md
+++ b/glossary.md
@@ -10,6 +10,7 @@ Glossary of terms used in CSM documentation.
 * [Cabinet Cooling Group](#cabinet-cooling-group)
 * [Cabinet Environmental Controller (CEC)](#cabinet-environmental-controller)
 * [CEC microcontroller (eC)](#cec-microcontroller)
+* [Compute Rolling Upgrade Service (CRUS)](#compute-rolling-upgrade-service)
 * [Cray Advanced Platform Monitoring and Control (CAPMC)](#cray-advanced-platform-monitoring-and-control)
 * [Customer Access Network](#customer-access-network)
 * [Chassis Management Module (CMM)](#chassis-management-module)
@@ -145,6 +146,16 @@ environmental sensors, and communicates cabinet status to the cooling distributi
 (CDU). The eC does not provide a REST endpoint on SMNet as do other embedded
 controllers, but simply monitors the cabinet sensors and provides the cabinet environmental
 and CDU status to the CMMs for evaluation and/or action.
+
+<a name="compute-rolling-upgrade-service"></a>
+
+## Compute Rolling Upgrade Service (CRUS)
+
+The Compute Rolling Upgrade Service (CRUS) upgrades sets of compute nodes without requiring an entire set of nodes to be out of service at once. CRUS manages the workload management status of nodes, handling each of the steps required to upgrade compute nodes.
+
+See [Compute Rolling Upgrades](operations/index.md#compute-rolling-upgrades).
+
+**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in CSM-1.3.0 and replaced with BOSv2, which will provide similar functionality.
 
 <a name="cray-advanced-platform-monitoring-and-control"></a>
 

--- a/introduction/differences.md
+++ b/introduction/differences.md
@@ -2,59 +2,65 @@
 
 The most noteworthy changes since the previous release are described here.
 
-### Topics
-
-   * [New Features](#new_features)
-   * [Deprecated Features](#deprecated_features)
-   * [Removed Features](#removed_features)
-   * [Other Changes](#other_changes)
-
-
-## Details
+* [New features](#new_features)
+* [Deprecated features](#deprecated_features)
+* [Removed features](#removed_features)
+* [Other changes](#other_changes)
 
 <a name="new_features"></a>
-### New Features
+
+## New features
 
 The following features are new in this release:
 
-   * Scaling improvements for larger systems
-      * BOS
-      * CAPMC
-      * FAS
-   * New hardware supported in this release:
-      * Compute nodes
-         * Milan-Based Grizzly Peak with A100 40 GB GPU
-         * Milan-Based Windom Liquid Cooled System
-         * Rome-Based HPE Apollo 6500 XL675d Gen10+ with A100 40 GB GPU
-         * Rome-Based HPE Apollo 6500 XL645d Gen10+ with A100 40 GB GPU
-      * User Access Nodes (UANs)
-         * Milan-Based HPE DL 385(v2) Gen10+
-         * Rome-Based HPE DL 385(v1) Gen10
-   * Node consoles are now managed by cray-console-node which is based on conman.
-   * HSM now has a v2 REST API
+* Scaling improvements for larger systems to the following services:
+  * BOS
+  * CAPMC
+  * FAS
+* New hardware supported in this release:
+  * Compute nodes
+    * Milan-Based Grizzly Peak with A100 40 GB GPU
+    * Milan-Based Windom Liquid Cooled System
+    * Rome-Based HPE Apollo 6500 XL675d Gen10+ with A100 40 GB GPU
+    * Rome-Based HPE Apollo 6500 XL645d Gen10+ with A100 40 GB GPU
+  * User Access Nodes (UANs)
+    * Milan-Based HPE DL 385(v2) Gen10+
+    * Rome-Based HPE DL 385(v1) Gen10
+* Node consoles are now managed by `cray-console-node` which is based on ConMan
+* HSM now has a v2 REST API
 
 <a name="deprecated_features"></a>
-### Deprecated Features
+
+## Deprecated features
 
 The following features are no longer supported and are planned to be removed in a future release:
 
-   * HSM v1 REST API has been deprecated as of CSM version 0.9.3. The v1 HSM APIs will be removed in the CSM version 1.3 release.
-   * Many CAPMC v1 REST API and CLI features are being deprecated as part of CSM version 1.0.1; Full removal of the deprecated CAPMC features will happen in CSM version 1.3. Further development of CAPMC service or CLI has stopped. CAPMC has entered end-of-life but will still be generally available. CAPMC is going to be replaced with the Power Control Service (PCS) in a future release. The current API/CLI portfolio for CAPMC are being pruned to better align with the future direction of PCS. More information about PCS and the CAPMC transition will be released as part of subsequent CSM releases.
-     * For more information on what features have been deprecated please view the CAPMC swagger doc or read the [CAPMC deprecation notice](../introduction/CAPMC_deprecation.md)
-
-   * The Boot Orchestration Service (BOS) API is changing in the upcoming CSM-1.2.0 release:
-        * The `--template-body` option for the Cray CLI `bos` command will be deprecated.
-        * Performing a GET on the session status for a boot set (i.e. `/v1/session/{session_id}/status/{boot_set_name}`) currently returns a status code of 201, but instead it should return a status code of 200. This will be corrected to return 200.
+* HSM v1 REST API has been deprecated as of CSM version 0.9.3. The v1 HSM APIs will be removed in the CSM version 1.3 release.
+* Many CAPMC v1 REST API and CLI features are being deprecated as part of CSM version 1.0.1; Full removal of the deprecated CAPMC features will happen in CSM version 1.3. Further
+  development of CAPMC service or CLI has stopped. CAPMC has entered end-of-life but will still be generally available. CAPMC is going to be replaced with the Power Control
+  Service (PCS) in a future release. The current API/CLI portfolio for CAPMC is being pruned to better align with the future direction of PCS. More information about PCS and
+  the CAPMC transition will be released as part of subsequent CSM releases.
+  * For more information on what features have been deprecated, see the [CAPMC deprecation notice](CAPMC_deprecation.md).
+* HMNFD v1 REST API will be deprecated in CSM version 1.2. The v1 HMNFD APIs will be removed in the CSM version 1.5 release.
+* The Boot Orchestration Service (BOS) API will change in the CSM V1.2.0 release:
+  * The `--template-body` option for the Cray CLI `bos` command will be deprecated.
+  * Prior to CSM V1.2.0, performing a successful `GET` on the session status for a boot set (i.e. `/v1/session/{session_id}/status/{boot_set_name}`) incorrectly returns
+    a status code of 201. In CSM V1.2.0 it will correctly return a status code of 200.
+* The Compute Rolling Upgrade Service (CRUS) is deprecated and will be removed in the CSM V1.3.0 release. Enhanced BOS functionality will replace CRUS. This includes the ability
+  to stage changes to nodes that can be acted upon later when the node reboots. It also includes the ability to reboot nodes without specifying any boot artifacts. This latter
+  ability relies on the artifacts already having been staged.
+* The Compute Rolling Upgrade Service (CRUS) will be deprecated in CSM 1.2.0 and will be removed in the CSM 1.3.0 release. Enhanced BOS functionality will replace CRUS.
 
 <a name="removed_features"></a>
-### Removed Features
+
+## Removed features
 
 The following features have been completely removed:
 
-   * cray-conman pod. This has been replaced by cray-console-node.
-   * The `csi config init` command has changed the option from `-ntp-pool` to `ntp-pools` to support a comma-separated list of NTP pools.
+* `cray-conman` pod. This has been replaced by `cray-console-node`.
+* The `csi config init` command has changed the option from `-ntp-pool` to `ntp-pools` to support a comma-separated list of NTP pools.
+* CFS v1 API and CLI will be removed in CSM V1.2.0. The v2 API and CLI have been the default since CSM 0.9 (Shasta 1.4).
 
 <a name="other_changes"></a>
-### Other Changes
 
-* The Compute Rolling Upgrade Service (CRUS) is deprecated in CSM 1.2.0 and will be removed in the CSM-1.3.0 release. Enhanced BOS functionality will replace CRUS.
+## Other changes

--- a/introduction/differences.md
+++ b/introduction/differences.md
@@ -46,10 +46,7 @@ The following features are no longer supported and are planned to be removed in 
   * The `--template-body` option for the Cray CLI `bos` command will be deprecated.
   * Prior to CSM V1.2.0, performing a successful `GET` on the session status for a boot set (i.e. `/v1/session/{session_id}/status/{boot_set_name}`) incorrectly returns
     a status code of 201. In CSM V1.2.0 it will correctly return a status code of 200.
-* The Compute Rolling Upgrade Service (CRUS) is deprecated and will be removed in the CSM V1.3.0 release. Enhanced BOS functionality will replace CRUS. This includes the ability
-  to stage changes to nodes that can be acted upon later when the node reboots. It also includes the ability to reboot nodes without specifying any boot artifacts. This latter
-  ability relies on the artifacts already having been staged.
-* The Compute Rolling Upgrade Service (CRUS) will be deprecated in CSM 1.2.0 and will be removed in the CSM 1.3.0 release. Enhanced BOS functionality will replace CRUS.
+* The Compute Rolling Upgrade Service (CRUS) will be deprecated in CSM 1.2.0 and will be removed in a future CSM release. Enhanced BOS functionality will replace CRUS.
 
 <a name="removed_features"></a>
 

--- a/introduction/differences.md
+++ b/introduction/differences.md
@@ -59,7 +59,7 @@ The following features have been completely removed:
 
 * `cray-conman` pod. This has been replaced by `cray-console-node`.
 * The `csi config init` command has changed the option from `-ntp-pool` to `ntp-pools` to support a comma-separated list of NTP pools.
-* CFS v1 API and CLI will be removed in CSM V1.2.0. The v2 API and CLI have been the default since CSM 0.9 (Shasta 1.4).
+* CFS v1 API and CLI will be removed in CSM 1.2.0. The v2 API and CLI have been the default since CSM 0.9 (Shasta 1.4).
 
 <a name="other_changes"></a>
 

--- a/introduction/differences.md
+++ b/introduction/differences.md
@@ -57,3 +57,4 @@ The following features have been completely removed:
 <a name="other_changes"></a>
 ### Other Changes
 
+* The Compute Rolling Upgrade Service (CRUS) is deprecated in CSM 1.2.0 and will be removed in the CSM-1.3.0 release. Enhanced BOS functionality will replace CRUS.

--- a/operations/compute_rolling_upgrades/CRUS_Workflow.md
+++ b/operations/compute_rolling_upgrades/CRUS_Workflow.md
@@ -1,6 +1,6 @@
 # CRUS Workflow
 
-**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in CSM 1.3.0 and replaced with BOS V2, which will provide similar functionality.
+**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in a future CSM release and replaced with BOS V2, which will provide similar functionality.
 
 The following workflow is intended to be a high-level overview of how to upgrade compute nodes. This workflow depicts how services interact with each other during the compute node
 upgrade process, and helps to provide a quicker and deeper understanding of how the system functions.

--- a/operations/compute_rolling_upgrades/CRUS_Workflow.md
+++ b/operations/compute_rolling_upgrades/CRUS_Workflow.md
@@ -1,5 +1,7 @@
 # CRUS Workflow
 
+**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in CSM-1.3.0 and replaced with BOSv2, which will provide similar functionality.
+
 The following workflow is intended to be a high-level overview of how to upgrade compute nodes. This workflow depicts how services interact with each other during the compute node upgrade process, and helps to provide a quicker and deeper understanding of how the system functions.
 
 ### Upgrade Compute Nodes

--- a/operations/compute_rolling_upgrades/Compute_Rolling_Upgrades.md
+++ b/operations/compute_rolling_upgrades/Compute_Rolling_Upgrades.md
@@ -1,5 +1,7 @@
 # Compute Rolling Upgrades
 
+**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in CSM-1.3.0 and replaced with BOSv2, which will provide similar functionality.
+
 The Compute Rolling Upgrade Service \(CRUS\) upgrades sets of compute nodes without requiring an entire set of nodes to be out of service at once. CRUS manages the workload management status of nodes, handling each of the following steps required to upgrade compute nodes:
 
 1.  Quiesce each node before taking the node out of service.

--- a/operations/compute_rolling_upgrades/Compute_Rolling_Upgrades.md
+++ b/operations/compute_rolling_upgrades/Compute_Rolling_Upgrades.md
@@ -1,6 +1,6 @@
 # Compute Rolling Upgrades
 
-**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in CSM 1.3.0 and replaced with BOS V2, which will provide similar functionality.
+**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in a future CSM release and replaced with BOS V2, which will provide similar functionality.
 
 The Compute Rolling Upgrade Service \(CRUS\) upgrades sets of compute nodes without requiring an entire set of nodes to be out of service at once. CRUS manages the workload
 management status of nodes, handling each of the following steps required to upgrade compute nodes:

--- a/operations/compute_rolling_upgrades/Compute_Rolling_Upgrades.md
+++ b/operations/compute_rolling_upgrades/Compute_Rolling_Upgrades.md
@@ -1,19 +1,20 @@
 # Compute Rolling Upgrades
 
-**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in CSM-1.3.0 and replaced with BOSv2, which will provide similar functionality.
+**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in CSM 1.3.0 and replaced with BOS V2, which will provide similar functionality.
 
-The Compute Rolling Upgrade Service \(CRUS\) upgrades sets of compute nodes without requiring an entire set of nodes to be out of service at once. CRUS manages the workload management status of nodes, handling each of the following steps required to upgrade compute nodes:
+The Compute Rolling Upgrade Service \(CRUS\) upgrades sets of compute nodes without requiring an entire set of nodes to be out of service at once. CRUS manages the workload
+management status of nodes, handling each of the following steps required to upgrade compute nodes:
 
-1.  Quiesce each node before taking the node out of service.
-2.  Upgrade the node.
-3.  Reboot the node into the upgraded state.
-4.  Return the node to service within its respective workload manager.
+1. Quiesce each node before taking the node out of service.
+1. Upgrade the node.
+1. Reboot the node into the upgraded state.
+1. Return the node to service within its respective workload manager.
 
-CRUS enables administrators to limit the impact on production caused from upgrading compute nodes by working through one step of the upgrade process at a time. The nodes in each step are taken out of service in the workload manager to prevent work from being scheduled, upgraded, rebooted, and put back into service in the workload manager.
+CRUS enables administrators to limit the impact on production caused from upgrading compute nodes by working through one step of the upgrade process at a time. The nodes in each
+step are first taken out of service in the workload manager to prevent work from being scheduled. They are then upgraded, rebooted, and put back into service in the workload manager.
 
 CRUS is built upon a few basic features of the system:
 
--   The grouping of nodes by label provided by the Hardware State Manager \(HSM\) groups mechanism.
--   Workload management that can gracefully take nodes out of service \(quiesce nodes\), declare nodes as failed, and return nodes to service.
--   The Boot Orchestration Service \(BOS\) and boot session templates.
-
+- The grouping of nodes by label provided by the Hardware State Manager \(HSM\) groups mechanism.
+- Workload management that can gracefully take nodes out of service \(quiesce nodes\), declare nodes as failed, and return nodes to service.
+- The Boot Orchestration Service \(BOS\) and boot session templates.

--- a/operations/compute_rolling_upgrades/Troubleshoot_Nodes_Failing_to_Upgrade_in_a_CRUS_Session.md
+++ b/operations/compute_rolling_upgrades/Troubleshoot_Nodes_Failing_to_Upgrade_in_a_CRUS_Session.md
@@ -4,7 +4,7 @@
 
 Troubleshoot compute nodes failing to upgrade during a Compute Rolling Upgrade Service \(CRUS\) session and rerun the session on the failed nodes.
 
-When a nodes are marked as failed they are added to the failed node group associated with the upgrade session, and the nodes are marked as down in the workload manager \(WLM\).
+When nodes are marked as failed they are added to the failed node group associated with the upgrade session, and the nodes are marked as down in the workload manager \(WLM\).
 If the WLM supports some kind of reason string, that string contains the cause of the down status.
 
 Complete a CRUS session that did not successfully upgrade all of the intended compute nodes.

--- a/operations/compute_rolling_upgrades/Troubleshoot_Nodes_Failing_to_Upgrade_in_a_CRUS_Session.md
+++ b/operations/compute_rolling_upgrades/Troubleshoot_Nodes_Failing_to_Upgrade_in_a_CRUS_Session.md
@@ -1,26 +1,30 @@
 # Troubleshoot Nodes Failing to Upgrade in a CRUS Session
 
-**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in CSM-1.3.0 and replaced with BOSv2, which will provide similar functionality.
+**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in CSM 1.3.0 and replaced with BOS V2, which will provide similar functionality.
 
 Troubleshoot compute nodes failing to upgrade during a Compute Rolling Upgrade Service \(CRUS\) session and rerun the session on the failed nodes.
 
-When a nodes are marked as failed they are added to the failed node group associated with the upgrade session, and the nodes are marked as down in the workload manager \(WLM\). If the WLM supports some kind of reason string, that string contains the cause of the down status.
+When a nodes are marked as failed they are added to the failed node group associated with the upgrade session, and the nodes are marked as down in the workload manager \(WLM\).
+If the WLM supports some kind of reason string, that string contains the cause of the down status.
 
 Complete a CRUS session that did not successfully upgrade all of the intended compute nodes.
 
+## Prerequisites
 
-### Prerequisites
+- A CRUS upgrade session has completed with a group of nodes that failed to upgrade.
+- The Cray command line interface \(CLI\) tool is initialized and configured on the system. See [Configure the Cray Command Line Interface](../configure_cray_cli.md).
 
--   A CRUS upgrade session has completed with a group of nodes that failed to upgrade.
--   The Cray command line interface \(CLI\) tool is initialized and configured on the system.
+## Procedure
 
-
-### Procedure
-
-1.  Determine which nodes failed the upgrade by listing the contents of the Hardware State Manager \(HSM\) group that was set up for failed nodes.
+1. Determine which nodes failed the upgrade by listing the contents of the Hardware State Manager \(HSM\) group that was set up for failed nodes.
 
     ```bash
     ncn# cray hsm groups describe FAILED_NODES_GROUP
+    ```
+
+    Example output:
+
+    ```toml
     label = "failed-nodes"
     description = ""
 
@@ -28,37 +32,44 @@ Complete a CRUS session that did not successfully upgrade all of the intended co
     ids = [ "x0c0s28b0n0",]
     ```
 
-2.  Determine the cause of the failed nodes and fix it.
+1. Determine the cause of the failed nodes and fix it.
 
     Failed nodes result from the following:
 
-    -   Failure of the BOS upgrade session for a given step of the upgrade causes all of the nodes in that step to be marked as failed.
-    -   Failure of any given node in a step to reach a ready state in the workload manager within 10 minutes of detecting that the BOS boot session has completed causes that node to be marked as failed.
-    -   Deletion of a CRUS session while the current step is at or beyond the 'Booting' stage causes all of the nodes in that step that have not reached a ready state in the workload manager to be marked as failed.
+    - Failure of the BOS upgrade session for a given step of the upgrade causes all of the nodes in that step to be marked as failed.
+    - Failure of any given node in a step to reach a ready state in the workload manager within 10 minutes of detecting that the BOS boot session has completed causes that node
+      to be marked as failed.
+    - Deletion of a CRUS session while the current step is at or beyond the `Booting` stage causes all of the nodes in that step that have not reached a ready state in the
+      workload manager to be marked as failed.
 
-3.  Create a new CRUS session on the failed nodes.
+1. Create a new CRUS session on the failed nodes.
 
-    1.  Create a new failed node group with a different name.
+    1. Create a new failed node group with a different name.
 
         This group should be empty.
 
         ```bash
-        ncn# cray hsm groups create --label NEW_FAILED_NODES_GROUP \
-        --description 'Failed Node Group for my Compute Node upgrade'
+        ncn# cray hsm groups create --label NEW_FAILED_NODES_GROUP --description 'Failed Node Group for my Compute Node upgrade'
         ```
 
-    2.  Create a new CRUS session.
+    1. Create a new CRUS session.
 
-        Use the label of the failed node group from the original upgrade session as the starting label, and use the new failed node group as the failed label. The rest of the parameters need to be the same ones that were used in the original upgrade.
+        Use the label of the failed node group from the original upgrade session as the starting label, and use the new failed node group as the failed label.
+        The rest of the parameters need to be the same ones that were used in the original upgrade.
 
         ```bash
         ncn# cray crus session create \
-        --starting-label OLD_FAILED_NODES_GROUP \
-        --upgrading-label node-group \
-        --failed-label NEW_FAILED_NODES_GROUP \
-        --upgrade-step-size 50 \
-        --workload-manager-type slurm \
-        --upgrade-template-id boot-template
+                --starting-label OLD_FAILED_NODES_GROUP \
+                --upgrading-label node-group \
+                --failed-label NEW_FAILED_NODES_GROUP \
+                --upgrade-step-size 50 \
+                --workload-manager-type slurm \
+                --upgrade-template-id boot-template
+        ```
+
+        Example output:
+
+        ```toml
         api_version = "1.0.0"
         completed = false
         failed_label = "NEW_FAILED_NODES_GROUP"
@@ -72,4 +83,3 @@ Complete a CRUS session that did not successfully upgrade all of the intended co
         upgrading_label = "node-group"
         workload_manager_type = "slurm"
         ```
-

--- a/operations/compute_rolling_upgrades/Troubleshoot_Nodes_Failing_to_Upgrade_in_a_CRUS_Session.md
+++ b/operations/compute_rolling_upgrades/Troubleshoot_Nodes_Failing_to_Upgrade_in_a_CRUS_Session.md
@@ -1,5 +1,7 @@
 # Troubleshoot Nodes Failing to Upgrade in a CRUS Session
 
+**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in CSM-1.3.0 and replaced with BOSv2, which will provide similar functionality.
+
 Troubleshoot compute nodes failing to upgrade during a Compute Rolling Upgrade Service \(CRUS\) session and rerun the session on the failed nodes.
 
 When a nodes are marked as failed they are added to the failed node group associated with the upgrade session, and the nodes are marked as down in the workload manager \(WLM\). If the WLM supports some kind of reason string, that string contains the cause of the down status.

--- a/operations/compute_rolling_upgrades/Troubleshoot_Nodes_Failing_to_Upgrade_in_a_CRUS_Session.md
+++ b/operations/compute_rolling_upgrades/Troubleshoot_Nodes_Failing_to_Upgrade_in_a_CRUS_Session.md
@@ -1,6 +1,6 @@
 # Troubleshoot Nodes Failing to Upgrade in a CRUS Session
 
-**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in CSM 1.3.0 and replaced with BOS V2, which will provide similar functionality.
+**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in a future CSM release and replaced with BOS V2, which will provide similar functionality.
 
 Troubleshoot compute nodes failing to upgrade during a Compute Rolling Upgrade Service \(CRUS\) session and rerun the session on the failed nodes.
 

--- a/operations/compute_rolling_upgrades/Troubleshoot_a_Failed_CRUS_Session_Due_to_Bad_Parameters.md
+++ b/operations/compute_rolling_upgrades/Troubleshoot_a_Failed_CRUS_Session_Due_to_Bad_Parameters.md
@@ -1,28 +1,35 @@
 # Troubleshoot a Failed CRUS Session Because of Bad Parameters
 
-**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in CSM-1.3.0 and replaced with BOSv2, which will provide similar functionality.
+**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in CSM 1.3.0 and replaced with BOS V2, which will provide similar functionality.
 
 A CRUS session must be deleted and recreated if it does not start or complete because of parameters having incorrect values.
 
 The following are examples of incorrect parameters:
 
--   Choosing the wrong Boot Orchestration Service \(BOS\) session template.
--   Choosing the wrong group labels.
--   Improperly defined BOS session template. For example, specifying nodes in the template instead of using the label of the upgrading group.
+- Choosing the wrong Boot Orchestration Service \(BOS\) session template.
+- Choosing the wrong group labels.
+- Improperly defined BOS session template. For example, specifying nodes in the template instead of using the label of the upgrading group.
 
-### Prerequisites
+## Prerequisites
 
--   A Compute Rolling Upgrade Service \(CRUS\) session was run and failed to complete.
--   The Cray command line interface \(CLI\) tool is initialized and configured on the system.
+- A Compute Rolling Upgrade Service \(CRUS\) session was run and failed to complete.
+- The Cray command line interface \(CLI\) tool is initialized and configured on the system. See [Configure the Cray Command Line Interface](../configure_cray_cli.md).
 
-### Procedure
+## Procedure
 
-1.  Delete the failed session.
+1. Delete the failed session.
 
-    Deleting a CRUS session that is in progress will terminate the session and move all of the unfinished nodes into the group said up for failed nodes. The time frame for recognizing a delete request, cleaning up, and deleting the session is roughly a minute. A session being deleted will move to a DELETING status immediately upon receiving a delete request, which will prevent further processing of the upgrade in that session.
+    Deleting a CRUS session that is in progress will terminate the session and move all of the unfinished nodes into the group said up for failed nodes. The time frame for
+    recognizing a delete request, cleaning up, and deleting the session is roughly a minute. A session being deleted will move to a `DELETING` status immediately upon receiving
+    a delete request, which will prevent further processing of the upgrade in that session.
 
     ```bash
     ncn# cray crus session delete CRUS_UPGRADE_ID
+    ```
+
+    Example output:
+
+    ```toml
     api_version = "1.0.0"
     completed = false
     failed_label = "failed-node-group"
@@ -37,18 +44,23 @@ The following are examples of incorrect parameters:
     workload_manager_type = "slurm"
     ```
 
-2.  Recreate the session that failed.
+1. Recreate the session that failed.
 
-    Ensure the correct parameters are used when restarting the session.
+    Ensure that the correct parameters are used when restarting the session.
 
     ```bash
     ncn# cray crus session create \
-    --starting-label slurm-nodes \
-    --upgrading-label node-group \
-    --failed-label failed-node-group \
-    --upgrade-step-size 50 \
-    --workload-manager-type slurm \
-    --upgrade-template-id boot-template
+            --starting-label slurm-nodes \
+            --upgrading-label node-group \
+            --failed-label failed-node-group \
+            --upgrade-step-size 50 \
+            --workload-manager-type slurm \
+            --upgrade-template-id boot-template
+    ```
+
+    Example output:
+
+    ```toml
     api_version = "1.0.0"
     completed = false
     failed_label = "failed-node-group"
@@ -62,4 +74,3 @@ The following are examples of incorrect parameters:
     upgrading_label = "node-group"
     workload_manager_type = "slurm"
     ```
-

--- a/operations/compute_rolling_upgrades/Troubleshoot_a_Failed_CRUS_Session_Due_to_Bad_Parameters.md
+++ b/operations/compute_rolling_upgrades/Troubleshoot_a_Failed_CRUS_Session_Due_to_Bad_Parameters.md
@@ -1,6 +1,6 @@
 # Troubleshoot a Failed CRUS Session Because of Bad Parameters
 
-**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in CSM 1.3.0 and replaced with BOS V2, which will provide similar functionality.
+**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in a future CSM release and replaced with BOS V2, which will provide similar functionality.
 
 A CRUS session must be deleted and recreated if it does not start or complete because of parameters having incorrect values.
 

--- a/operations/compute_rolling_upgrades/Troubleshoot_a_Failed_CRUS_Session_Due_to_Bad_Parameters.md
+++ b/operations/compute_rolling_upgrades/Troubleshoot_a_Failed_CRUS_Session_Due_to_Bad_Parameters.md
@@ -1,5 +1,7 @@
 # Troubleshoot a Failed CRUS Session Because of Bad Parameters
 
+**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in CSM-1.3.0 and replaced with BOSv2, which will provide similar functionality.
+
 A CRUS session must be deleted and recreated if it does not start or complete because of parameters having incorrect values.
 
 The following are examples of incorrect parameters:

--- a/operations/compute_rolling_upgrades/Troubleshoot_a_Failed_CRUS_Session_Due_to_Unmet_Conditions.md
+++ b/operations/compute_rolling_upgrades/Troubleshoot_a_Failed_CRUS_Session_Due_to_Unmet_Conditions.md
@@ -1,5 +1,7 @@
 # Troubleshoot a Failed CRUS Session Because of Unmet Conditions
 
+**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in CSM-1.3.0 and replaced with BOSv2, which will provide similar functionality.
+
 If a CRUS session has any unmet conditions, adding or fixing them will cause the session to continue from wherever it got stuck. Updating other parts of the system to meet the required conditions of a CRUS session will unblock the upgrade session.
 
 The following are examples of unmet conditions:

--- a/operations/compute_rolling_upgrades/Troubleshoot_a_Failed_CRUS_Session_Due_to_Unmet_Conditions.md
+++ b/operations/compute_rolling_upgrades/Troubleshoot_a_Failed_CRUS_Session_Due_to_Unmet_Conditions.md
@@ -1,6 +1,6 @@
 # Troubleshoot a Failed CRUS Session Because of Unmet Conditions
 
-**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in CSM 1.3.0 and replaced with BOS V2, which will provide similar functionality.
+**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in a future CSM release and replaced with BOS V2, which will provide similar functionality.
 
 If a CRUS session has any unmet conditions, adding or fixing them will cause the session to continue from wherever it got stuck. Updating other parts of the system to meet
 the required conditions of a CRUS session will unblock the upgrade session.

--- a/operations/compute_rolling_upgrades/Troubleshoot_a_Failed_CRUS_Session_Due_to_Unmet_Conditions.md
+++ b/operations/compute_rolling_upgrades/Troubleshoot_a_Failed_CRUS_Session_Due_to_Unmet_Conditions.md
@@ -1,26 +1,31 @@
 # Troubleshoot a Failed CRUS Session Because of Unmet Conditions
 
-**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in CSM-1.3.0 and replaced with BOSv2, which will provide similar functionality.
+**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in CSM 1.3.0 and replaced with BOS V2, which will provide similar functionality.
 
-If a CRUS session has any unmet conditions, adding or fixing them will cause the session to continue from wherever it got stuck. Updating other parts of the system to meet the required conditions of a CRUS session will unblock the upgrade session.
+If a CRUS session has any unmet conditions, adding or fixing them will cause the session to continue from wherever it got stuck. Updating other parts of the system to meet
+the required conditions of a CRUS session will unblock the upgrade session.
 
 The following are examples of unmet conditions:
 
--   Undefined groups in the Hardware State Manager \(HSM\).
--   No predefined Boot Orchestration Service \(BOS\) session template exists that describes the desired states of the nodes being upgraded.
+- Undefined groups in the Hardware State Manager \(HSM\).
+- No predefined Boot Orchestration Service \(BOS\) session template exists that describes the desired states of the nodes being upgraded.
 
+## Prerequisites
 
-### Prerequisites
+- A Compute Rolling Upgrade Service \(CRUS\) session was run and failed to complete.
+- The Cray command line interface \(CLI\) tool is initialized and configured on the system. See [Configure the Cray Command Line Interface](../configure_cray_cli.md).
 
--   A Compute Rolling Upgrade Service \(CRUS\) session was run and failed to complete.
--   The Cray command line interface \(CLI\) tool is initialized and configured on the system.
+## Procedure
 
-### Procedure
-
-1.  View the details for the CRUS session that failed.
+1. View the details for the CRUS session that failed.
 
     ```bash
     ncn# cray crus session describe CRUS_UPGRADE_ID
+    ```
+
+    Example output:
+
+    ```toml
     api_version = "1.0.0"
     completed = false
     failed_label = "failed-node-group"
@@ -35,22 +40,33 @@ The following are examples of unmet conditions:
     workload_manager_type = "slurm"
     ```
 
-    The messages value returned in the output will provide details explaining where the job failed. In this example, there is a note stating the failed node group could not be obtained. This implies that the user forgot to create the failed node group before starting the job.
+    The `messages` value returned in the output will provide details explaining where the job failed. In this example, there is a note stating the failed node group could not be
+    obtained. This implies that the user forgot to create the failed node group before starting the job.
 
-2.  Create a new node group for the missing group.
+1. Create a new node group for the missing group.
 
     Following the example in the previous step, the failed node group needs to be created.
 
     ```bash
     ncn# cray hsm groups create --label failed-node-group
+    ```
+
+    Example output:
+
+    ```toml
     [[results]]
     URI = "/hsm/v2/groups/failed-node-group"
     ```
 
-3.  View the details for the CRUS session again to see if the job started.
+1. View the details for the CRUS session again to see if the job started.
 
     ```bash
-    ncn-w001# cray crus session describe CRUS_UPGRADE_ID
+    ncn# cray crus session describe CRUS_UPGRADE_ID
+    ```
+
+    Example output:
+
+    ```toml
     api_version = "1.0.0"
     completed = false
     failed_label = "failed-node-group"
@@ -65,5 +81,4 @@ The following are examples of unmet conditions:
     workload_manager_type = "slurm"
     ```
 
-    The messages value states that the job has resumed now that the error has been fixed.
-
+    The `messages` value states that the job has resumed now that the error has been fixed.

--- a/operations/compute_rolling_upgrades/Upgrade_Compute_Nodes_with_CRUS.md
+++ b/operations/compute_rolling_upgrades/Upgrade_Compute_Nodes_with_CRUS.md
@@ -1,5 +1,7 @@
 # Upgrade Compute Nodes with CRUS
 
+**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in CSM-1.3.0 and replaced with BOSv2, which will provide similar functionality.
+
 Upgrade a set of compute nodes with the Compute Rolling Upgrade Service \(CRUS\). Manage the workload management status of nodes and quiesce each node before taking the node out of service and upgrading it. Then reboot it into the upgraded state and return it to service within the workload manager \(WLM\).
 
 ### Prerequisites

--- a/operations/compute_rolling_upgrades/Upgrade_Compute_Nodes_with_CRUS.md
+++ b/operations/compute_rolling_upgrades/Upgrade_Compute_Nodes_with_CRUS.md
@@ -1,73 +1,81 @@
 # Upgrade Compute Nodes with CRUS
 
-**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in CSM-1.3.0 and replaced with BOSv2, which will provide similar functionality.
+**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in CSM 1.3.0 and replaced with BOS V2, which will provide similar functionality.
 
-Upgrade a set of compute nodes with the Compute Rolling Upgrade Service \(CRUS\). Manage the workload management status of nodes and quiesce each node before taking the node out of service and upgrading it. Then reboot it into the upgraded state and return it to service within the workload manager \(WLM\).
+Upgrade a set of compute nodes with the Compute Rolling Upgrade Service \(CRUS\). Manage the workload management status of nodes and quiesce each node before taking the node
+out of service and upgrading it. Then reboot it into the upgraded state and return it to service within the workload manager \(WLM\).
 
-### Prerequisites
+## Prerequisites
 
--   The Cray command line interface \(CLI\) tool is initialized and configured on the system.
--   A Boot Orchestration Service \(BOS\) session template describing the desired states of the nodes being upgraded must exist.
+- The Cray command line interface \(CLI\) tool is initialized and configured on the system. See [Configure the Cray Command Line Interface](../configure_cray_cli.md).
+- A Boot Orchestration Service \(BOS\) session template describing the desired states of the nodes being upgraded must exist.
 
-### Procedure
+## Procedure
 
-1.  Create and populate the starting node group.
+1. Create and populate the starting node group.
 
     This will be the group of nodes that will be upgraded.
 
-    1.  Create a starting node group \(starting label\).
+    1. Create a starting node group \(starting label\).
 
-        Label names are defined by the user and the names used in this procedure are only examples. The label name used in this example is slurm-nodes.
+        Label names are defined by the user and the names used in this procedure are only examples. The label name used in this example is `slurm-nodes`.
 
         ```bash
-        ncn# cray hsm groups create --label slurm-nodes \
-        --description 'Starting Node Group for my Compute Node upgrade'
+        ncn# cray hsm groups create --label slurm-nodes --description 'Starting Node Group for my Compute Node upgrade'
         ```
 
-    2.  Add members to the group.
+    1. Add members to the group.
 
         Add compute nodes to the group by using the component name (xname) for each node being added.
 
         ```bash
         ncn# cray hsm groups members create slurm-nodes --id XNAME
+        ```
+
+        Example output:
+
+        ```toml
         [[results]]
         URI = "/hsm/v2/groups/slurm-nodes/members/x0c0s28b0n0"
         ```
 
-2.  Create a group for upgrading nodes \(upgrading label\).
+1. Create a group for upgrading nodes \(upgrading label\).
 
-    The label name used in this example is upgrading-nodes.
-
-    ```bash
-    ncn-w001# cray hsm groups create --label upgrading-nodes \
-    --description 'Upgrading Node Group for my Compute Node upgrade'
-    ```
-
-    There is no need to add members to this group because it should be empty when the compute rolling upgrade process begins.
-
-3.  Create a group for failed nodes \(failed label\).
-
-    The label name used in this example is failed-nodes.
+    The label name used in this example is `upgrading-nodes`.
 
     ```bash
-    ncn# cray hsm groups create --label failed-nodes \
-    --description 'Failed Node Group for my Compute Node upgrade'
+    ncn# cray hsm groups create --label upgrading-nodes --description 'Upgrading Node Group for my Compute Node upgrade'
     ```
 
-    There is no need to add members to this group because it should be empty when the compute rolling upgrade process begins.
+    Do not add members to this group; it should be empty when the compute rolling upgrade process begins.
 
-4.  Create an upgrade session with CRUS.
+1. Create a group for failed nodes \(failed label\).
+
+    The label name used in this example is `failed-nodes`.
+
+    ```bash
+    ncn# cray hsm groups create --label failed-nodes --description 'Failed Node Group for my Compute Node upgrade'
+    ```
+
+    Do not add members to this group; it should be empty when the compute rolling upgrade process begins.
+
+1. Create an upgrade session with CRUS.
 
     The following example is upgrading 50 nodes at a step. The --upgrade-template-id value should be the name of the Boot Orchestration Service \(BOS\) session template being used.
 
     ```bash
     ncn# cray crus session create \
-    --starting-label slurm-nodes \
-    --upgrading-label upgrading-nodes \
-    --failed-label failed-nodes \
-    --upgrade-step-size 50 \
-    --workload-manager-type slurm \
-    --upgrade-template-id=BOS_SESSION_TEMPLATE_NAME
+            --starting-label slurm-nodes \
+            --upgrading-label upgrading-nodes \
+            --failed-label failed-nodes \
+            --upgrade-step-size 50 \
+            --workload-manager-type slurm \
+            --upgrade-template-id=BOS_SESSION_TEMPLATE_NAME
+    ```
+
+    Example output:
+
+    ```toml
     api_version = "1.0.0"
     completed = false
     failed_label = "failed-nodes"
@@ -82,18 +90,24 @@ Upgrade a set of compute nodes with the Compute Rolling Upgrade Service \(CRUS\)
     workload_manager_type = "slurm"
     ```
 
-    If successful, note the upgrade\_id in the returned data.
+    If successful, note the `upgrade_id` in the returned data.
 
     ```bash
-    ncn-w001# export UPGRADE_ID=e0131663-dbee-47c2-aa5c-13fe9b110242
+    ncn# export UPGRADE_ID=e0131663-dbee-47c2-aa5c-13fe9b110242
     ```
 
-5.  Monitor the status of the upgrade session.
+1. Monitor the status of the upgrade session.
 
-    The progress of the session through the upgrade process is described in the messages field of the session. This is a list of messages, in chronological order, containing information about stage transitions, step transitions, and other conditions of interest encountered by the session as it progresses. It is cleared once the session completes.
+    The progress of the session through the upgrade process is described in the `messages` field of the session. This is a list of messages, in chronological order, containing
+    information about stage transitions, step transitions, and other conditions of interest encountered by the session as it progresses. It is cleared once the session completes.
 
     ```bash
-    ncn-w001# cray crus session describe $UPGRADE_ID
+    ncn# cray crus session describe $UPGRADE_ID
+    ```
+
+    Example output:
+
+    ```toml
     api_version = "1.0.0"
     completed = false
     failed_label = "failed-nodes"
@@ -108,23 +122,31 @@ Upgrade a set of compute nodes with the Compute Rolling Upgrade Service \(CRUS\)
     workload_manager_type = "slurm"
     ```
 
-    A CRUS session goes through a number of steps \(approximately the number of nodes to be upgraded divided by the requested step size\) to complete an upgrade. Each step moves through the following stages, unless the boot session is interrupted by being deleted.
+    A CRUS session goes through a number of steps \(approximately the number of nodes to be upgraded divided by the requested step size\) to complete an upgrade. Each step
+    moves through the following stages, unless the boot session is interrupted by being deleted.
 
-    1.  Starting - Preparation for the step and CRUS initiates WLM quiescing of nodes.
-    2.  Quiescing - Waits for all WLM nodes in the step to reach a quiesced \(not busy\) state.
-    3.  Quiesced - The nodes in the step are all quiesced and CRUS initiates booting the nodes into the upgraded environment.
-    4.  Booting - Waits for the boot session to complete.
-    5.  Booted - The boot session has completed. Check the success or failure of the boot session. Mark all nodes in the step as failed if the boot session failed.
-    6.  WLM Waiting - The boot session succeeded. Wait for nodes to reach a ready state in the WLM. All nodes in the step that fail to reach a ready state within 10 minutes of entering this stage are marked as failed.
-    7.  Cleanup - The upgrade step has finished. Clean up resources to prepare for the next step.
-    When a step moves from one stage to the next, CRUS adds a message to the messages field of the upgrade session to mark the progress.
+    1. `Starting` - Preparation for the step; CRUS initiates WLM quiescing of nodes.
+    1. `Quiescing` - Waits for all WLM nodes in the step to reach a quiesced \(not busy\) state.
+    1. `Quiesced` - The nodes in the step are all quiesced and CRUS initiates booting the nodes into the upgraded environment.
+    1. `Booting` - Waits for the boot session to complete.
+    1. `Booted` - The boot session has completed. Check the success or failure of the boot session. Mark all nodes in the step as failed if the boot session failed.
+    1. `WLM Waiting` - The boot session succeeded. Wait for nodes to reach a ready state in the WLM. All nodes in the step that fail to reach a ready state within 10 minutes of
+       entering this stage are marked as failed.
+    1. `Cleanup` - The upgrade step has finished. Clean up resources to prepare for the next step.
 
-6.  Optional: Delete the CRUS upgrade session.
+    When a step moves from one stage to the next, CRUS adds a message to the `messages` field of the upgrade session to mark the progress.
 
-    Once a CRUS upgrade session it is complete, it can no longer be used. It can be kept for historical purposes if desired, or it can be deleted.
+1. Delete the CRUS upgrade session. (Optional)
+
+    Once a CRUS upgrade session is complete, it can no longer be used. It can be kept for historical purposes if desired, or it can be deleted.
 
     ```bash
-    ncn-w001# cray crus session delete $UPGRADE_ID
+    ncn# cray crus session delete $UPGRADE_ID
+    ```
+
+    Example output:
+
+    ```toml
     api_version = "1.0.0"
     completed = true
     failed_label = "failed-nodes"
@@ -140,4 +162,3 @@ Upgrade a set of compute nodes with the Compute Rolling Upgrade Service \(CRUS\)
     ```
 
     The session may be visible briefly after it is deleted. This allows for orderly cleanup of the session.
-

--- a/operations/compute_rolling_upgrades/Upgrade_Compute_Nodes_with_CRUS.md
+++ b/operations/compute_rolling_upgrades/Upgrade_Compute_Nodes_with_CRUS.md
@@ -1,6 +1,6 @@
 # Upgrade Compute Nodes with CRUS
 
-**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in CSM 1.3.0 and replaced with BOS V2, which will provide similar functionality.
+**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in a future CSM release and replaced with BOS V2, which will provide similar functionality.
 
 Upgrade a set of compute nodes with the Compute Rolling Upgrade Service \(CRUS\). Manage the workload management status of nodes and quiesce each node before taking the node
 out of service and upgrading it. Then reboot it into the upgraded state and return it to service within the workload manager \(WLM\).

--- a/operations/index.md
+++ b/operations/index.md
@@ -180,7 +180,7 @@ Use the Ceph Object Gateway Simple Storage Service \(S3\) API to manage artifact
 Upgrade sets of compute nodes with the Compute Rolling Upgrade Service \(CRUS\) without requiring an entire set of nodes to be out of service at once. CRUS enables
 administrators to limit the impact on production caused from upgrading compute nodes by working through one step of the upgrade process at a time.
 
-**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in CSM 1.3.0 and replaced with BOS V2, which will provide similar functionality.
+**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in a future CSM release and replaced with BOS V2, which will provide similar functionality.
 
 - [Compute Rolling Upgrade Service (CRUS)](compute_rolling_upgrades/Compute_Rolling_Upgrades.md)
 - [CRUS Workflow](compute_rolling_upgrades/CRUS_Workflow.md)

--- a/operations/index.md
+++ b/operations/index.md
@@ -180,7 +180,7 @@ Use the Ceph Object Gateway Simple Storage Service \(S3\) API to manage artifact
 Upgrade sets of compute nodes with the Compute Rolling Upgrade Service \(CRUS\) without requiring an entire set of nodes to be out of service at once. CRUS enables
 administrators to limit the impact on production caused from upgrading compute nodes by working through one step of the upgrade process at a time.
 
-**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in CSM-1.3.0 and replaced with BOSv2, which will provide similar functionality.
+**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in CSM 1.3.0 and replaced with BOS V2, which will provide similar functionality.
 
 - [Compute Rolling Upgrade Service (CRUS)](compute_rolling_upgrades/Compute_Rolling_Upgrades.md)
 - [CRUS Workflow](compute_rolling_upgrades/CRUS_Workflow.md)

--- a/operations/index.md
+++ b/operations/index.md
@@ -180,6 +180,8 @@ Use the Ceph Object Gateway Simple Storage Service \(S3\) API to manage artifact
 Upgrade sets of compute nodes with the Compute Rolling Upgrade Service \(CRUS\) without requiring an entire set of nodes to be out of service at once. CRUS enables
 administrators to limit the impact on production caused from upgrading compute nodes by working through one step of the upgrade process at a time.
 
+**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in CSM-1.3.0 and replaced with BOSv2, which will provide similar functionality.
+
 - [Compute Rolling Upgrade Service (CRUS)](compute_rolling_upgrades/Compute_Rolling_Upgrades.md)
 - [CRUS Workflow](compute_rolling_upgrades/CRUS_Workflow.md)
 - [Upgrade Compute Nodes with CRUS](compute_rolling_upgrades/Upgrade_Compute_Nodes_with_CRUS.md)

--- a/operations/kubernetes/Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md
+++ b/operations/kubernetes/Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md
@@ -39,6 +39,8 @@ An etcd cluster was rebuilt. See [Rebuild Unhealthy etcd Clusters](Rebuild_Unhea
 
 ### CRUS
 
+**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in CSM-1.3.0 and replaced with BOSv2, which will provide similar functionality.
+
 1.  View the progress of existing CRUS sessions.
 
     1.  List the existing CRUS sessions to find the upgrade\_id for the desired session.

--- a/operations/kubernetes/Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md
+++ b/operations/kubernetes/Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md
@@ -39,7 +39,7 @@ An etcd cluster was rebuilt. See [Rebuild Unhealthy etcd Clusters](Rebuild_Unhea
 
 ## CRUS
 
-**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in CSM 1.3.0 and replaced with BOS V2, which will provide similar functionality.
+**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in a future CSM release and replaced with BOS V2, which will provide similar functionality.
 
 1. View the progress of existing CRUS sessions.
 

--- a/operations/kubernetes/Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md
+++ b/operations/kubernetes/Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md
@@ -5,15 +5,15 @@ the cluster to go back to a healthy state.
 
 The following services need their data repopulated in the etcd cluster:
 
--   Boot Orchestration Service \(BOS\)
--   Boot Script Service \(BSS\)
--   Content Projection Service \(CPS\)
--   Compute Rolling Upgrade Service \(CRUS\)
--   External DNS
--   Firmware Action Service \(FAS\)
--   HMS Notification Fanout Daemon \(HMNFD\)
--   Mountain Endpoint Discovery Service \(MEDS\)
--   River Endpoint Discovery Service \(REDS\)
+- Boot Orchestration Service \(BOS\)
+- Boot Script Service \(BSS\)
+- Content Projection Service \(CPS\)
+- Compute Rolling Upgrade Service \(CRUS\)
+- External DNS
+- Firmware Action Service \(FAS\)
+- HMS Notification Fanout Daemon \(HMNFD\)
+- Mountain Endpoint Discovery Service \(MEDS\)
+- River Endpoint Discovery Service \(REDS\)
 
 ## Prerequisites
 
@@ -27,7 +27,6 @@ An etcd cluster was rebuilt. See [Rebuild Unhealthy etcd Clusters](Rebuild_Unhea
 
     - UANs: Refer to the UAN product stream repository and search for the "PREPARE UAN BOOT SESSION TEMPLATES" header in the "Install and Configure UANs" procedure.
     - Cray Operating System \(COS\): Refer to the "Create a Boot Session Template" header in the "Boot COS" procedure in the COS product stream documentation.
-
 
 ## CPS
 

--- a/operations/kubernetes/Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md
+++ b/operations/kubernetes/Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md
@@ -1,6 +1,7 @@
 # Repopulate Data in etcd Clusters When Rebuilding Them
 
-When an etcd cluster is not healthy, it needs to be rebuilt. During that process, the pods that rely on etcd clusters lose data. That data needs to be repopulated in order for the cluster to go back to a healthy state.
+When an etcd cluster is not healthy, it needs to be rebuilt. During that process, the pods that rely on etcd clusters lose data. That data needs to be repopulated in order for
+the cluster to go back to a healthy state.
 
 The following services need their data repopulated in the etcd cluster:
 
@@ -14,39 +15,44 @@ The following services need their data repopulated in the etcd cluster:
 -   Mountain Endpoint Discovery Service \(MEDS\)
 -   River Endpoint Discovery Service \(REDS\)
 
-### Prerequisites
+## Prerequisites
 
 An etcd cluster was rebuilt. See [Rebuild Unhealthy etcd Clusters](Rebuild_Unhealthy_etcd_Clusters.md).
 
+## BOS
 
-### BOS
-
-1.  Reconstruct boot session templates for impacted product streams to repopulate data.
+1. Reconstruct boot session templates for impacted product streams to repopulate data.
 
     Boot preparation information for other product streams can be found in the following locations:
 
-    -   UANs: Refer to the UAN product stream repository and search for the "PREPARE UAN BOOT SESSION TEMPLATES" header in the "Install and Configure UANs" procedure.
-    -   Cray Operating System \(COS\): Refer to the "Create a Boot Session Template" header in the "Boot COS" procedure in the COS product stream documentation.
+    - UANs: Refer to the UAN product stream repository and search for the "PREPARE UAN BOOT SESSION TEMPLATES" header in the "Install and Configure UANs" procedure.
+    - Cray Operating System \(COS\): Refer to the "Create a Boot Session Template" header in the "Boot COS" procedure in the COS product stream documentation.
 
 
-### CPS
+## CPS
 
-1.  Repopulate clusters for CPS.
+1. Repopulate clusters for CPS.
 
-    -   If there are no clients using CPS when the etcd cluster is rebuilt, then nothing needs to be done other than to rebuild the cluster and make sure all of the components are up and running. See [Rebuild Unhealthy etcd Clusters](Rebuild_Unhealthy_etcd_Clusters.md) for more information.
-    -   If any clients have already mounted content provided by CPS, that content should be unmounted before rebuilding the etcd cluster, and then re-mounted after the etcd cluster is rebuilt. Compute nodes that use CPS to access their root file system must be shut down to unmount, and then booted to perform the re-mount.
+    - If there are no clients using CPS when the etcd cluster is rebuilt, then nothing needs to be done other than to rebuild the cluster and make sure all of the components are
+      up and running. See [Rebuild Unhealthy etcd Clusters](Rebuild_Unhealthy_etcd_Clusters.md) for more information.
+    - If any clients have already mounted content provided by CPS, that content should be unmounted before rebuilding the etcd cluster, and then re-mounted after the etcd cluster
+      is rebuilt. Compute nodes that use CPS to access their root file system must be shut down to unmount, and then booted to perform the re-mount.
 
+## CRUS
 
-### CRUS
+**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in CSM 1.3.0 and replaced with BOS V2, which will provide similar functionality.
 
-**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in CSM-1.3.0 and replaced with BOSv2, which will provide similar functionality.
+1. View the progress of existing CRUS sessions.
 
-1.  View the progress of existing CRUS sessions.
-
-    1.  List the existing CRUS sessions to find the upgrade\_id for the desired session.
+    1. List the existing CRUS sessions to find the upgrade\_id for the desired session.
 
         ```bash
-        ncn-w001# cray crus session list
+        ncn# cray crus session list
+        ```
+
+        Example output:
+
+        ```toml
         [[results]]
         api_version = "1.0.0"
         completed = false
@@ -62,12 +68,17 @@ An etcd cluster was rebuilt. See [Rebuild Unhealthy etcd Clusters](Rebuild_Unhea
         workload_manager_type = "slurm"
         ```
 
-    2.  Describe the CRUS session to see if the session failed or is stuck.
+    1. Describe the CRUS session to see if the session failed or is stuck.
 
         If the session continued and appears to be in a healthy state, proceed to the [BSS](#bss) section.
 
         ```bash
-        ncn-w001# cray crus session describe CRUS_UPGRADE_ID
+        ncn# cray crus session describe CRUS_UPGRADE_ID
+        ```
+
+        Example output:
+
+        ```toml
         api_version = "1.0.0"
         completed = false
         failed_label = "failed-nodes"
@@ -83,33 +94,38 @@ An etcd cluster was rebuilt. See [Rebuild Unhealthy etcd Clusters](Rebuild_Unhea
         workload_manager_type = "slurm"
         ```
 
-2.  Find the name of the running CRUS pod.
+1. Find the name of the running CRUS pod.
 
     ```bash
-    ncn-w001# kubectl get pods -n services | grep cray-crus
+    ncn# kubectl get pods -n services | grep cray-crus
+    ```
+
+    Example output:
+
+    ```text
     cray-crus-549cb9cb5d-jtpqg                                   3/4     Running   528        25h
     ```
 
-3.  Restart the CRUS pod.
+1. Restart the CRUS pod.
 
     Deleting the pod will restart CRUS and start the discovery process for any data recovered in etcd.
 
     ```bash
-    ncn-w001# kubectl delete pods -n services POD_NAME
+    ncn# kubectl delete pods -n services POD_NAME
     ```
 
-
-### External DNS
+## External DNS
 
 The etcd cluster for external DNS maintains an ephemeral cache for CoreDNS. There is no reason to back it up. If it is having any issues, delete it and recreate it.
 
-1.  Save the external DNS configuration.
+1. Save the external DNS configuration.
 
-2.  Edit the end of each .yaml file to remove the .status, .metadata.uid, .metadata.selfLink, .metadata.resourceVersion, .metadata.generation, and .metadata.creationTimestamp.
+1. Edit the end of each `.yaml` file to remove the `.status`, `.metadata.uid`, `.metadata.selfLink`, `.metadata.resourceVersion`, `.metadata.generation`,
+   and `.metadata.creationTimestamp`.
 
     For example:
 
-    ```bash
+    ```yaml
     apiVersion: etcd.database.coreos.com/v1beta2
     kind: EtcdCluster
     metadata:
@@ -138,75 +154,73 @@ The etcd cluster for external DNS maintains an ephemeral cache for CoreDNS. Ther
       version: 3.3.8
     ```
 
-3.  Delete the current cluster.
+1. Delete the current cluster.
 
     ```bash
-    ncn-w001# kubectl -n services delete etcd cray-externaldns-etcd
+    ncn# kubectl -n services delete etcd cray-externaldns-etcd
     ```
 
-4.  Recreate the cluster.
+1. Recreate the cluster.
 
     ```bash
-    ncn-w001# kubectl apply -f cray-externaldns-etcd.yaml
+    ncn# kubectl apply -f cray-externaldns-etcd.yaml
     ```
-
 
 <a name="bss"></a>
 
-### BSS
+## BSS
 
-Data is repopulated in BSS when the REDS init job is run.
+Data is repopulated in BSS when the REDS `init` job is run.
 
-1.  Get the current REDS job.
-
-    ```bash
-    ncn-w001# kubectl get -o json -n services job/cray-reds-init | \
-    jq 'del(.spec.template.metadata.labels["controller-uid"], .spec.selector)' > cray-reds-init.json
-    ```
-
-2. Delete the reds-client-init job.
+1. Get the current REDS job.
 
     ```bash
-    ncn-w001# kubectl delete -n services -f cray-reds-init.json
+    ncn# kubectl get -o json -n services job/cray-reds-init |
+            jq 'del(.spec.template.metadata.labels["controller-uid"], .spec.selector)' > cray-reds-init.json
     ```
 
-3.  Restart the reds-client-init job.
+1. Delete the `reds-client-init` job.
 
     ```bash
-    ncn-w001# kubectl apply -n services -f cray-reds-init.json
+    ncn# kubectl delete -n services -f cray-reds-init.json
     ```
 
-### REDS
-
-1.  Restart REDS.
+1. Restart the `reds-client-init` job.
 
     ```bash
-    ncn-w001# kubectl -n services delete pods --selector='app.kubernetes.io/name=cray-reds'
+    ncn# kubectl apply -n services -f cray-reds-init.json
     ```
 
+## REDS
 
-### MEDS
-
-1.  Restart MEDS.
+1. Restart REDS.
 
     ```bash
-    ncn-w001# kubectl -n services delete pods --selector='app.kubernetes.io/name=cray-meds'
+    ncn# kubectl -n services delete pods --selector='app.kubernetes.io/name=cray-reds'
     ```
 
-### FAS
+## MEDS
 
-1.  Run the `cray-fas-loader` Kubernetes job.
+1. Restart MEDS.
+
+    ```bash
+    ncn# kubectl -n services delete pods --selector='app.kubernetes.io/name=cray-meds'
+    ```
+
+## FAS
+
+1. Run the `cray-fas-loader` Kubernetes job.
 
     Refer to the "Use the `cray-fas-loader` Kubernetes Job" section in [FAS Admin Procedures](../firmware/FAS_Admin_Procedures.md) for more information.
 
-    When the etcd cluster is rebuilt, all historic data for firmware actions and all recorded snapshots will be lost. Image data will need to be reloaded by following the `cray-fas-loader` Kubernetes job procedure. After images are reloaded any running actions at time of failure will need to be recreated.
+    When the etcd cluster is rebuilt, all historic data for firmware actions and all recorded snapshots will be lost. Image data will need to be reloaded by following the
+    `cray-fas-loader` Kubernetes job procedure. After images are reloaded any running actions at time of failure will need to be recreated.
 
+## HMNFD
 
-### HMNFD
+1. Resubscribe the compute nodes and any NCNs that use the ORCA daemon for their State Change Notifications \(SCN\).
 
-1.  Resubscribe the compute nodes and any NCNs that use the ORCA daemon for their State Change Notifications \(SCN\).
-
-    1.  Resubscribe all compute nodes.
+    1. Resubscribe all compute nodes.
 
         ```bash
         ncn-m001# TMPFILE=$(mktemp)
@@ -217,12 +231,11 @@ Data is repopulated in BSS when the REDS init job is run.
         ncn-m001# rm -rf $TMPFILE
         ```
 
-    2.  Resubscribe the NCNs.
+    1. Resubscribe the NCNs.
+
+        **NOTE:** Modify the `-w` arguments in the following commands to reflect the number of worker and storage nodes in the system.
 
         ```bash
         ncn-m001# pdsh -w ncn-w00[0-4]-can.local "systemctl restart cray-dvs-orca"
         ncn-m001# pdsh -w ncn-s00[0-4]-can.local "systemctl restart cray-dvs-orca"
         ```
-
-        Note: on larger systems, [0-4] may have to be a larger range.
-

--- a/troubleshooting/index.md
+++ b/troubleshooting/index.md
@@ -41,7 +41,7 @@ This document provides links to troubleshooting information for services and fun
     * [Issues Related to Slow Boot Times](../operations/boot_orchestration/Troubleshoot_Compute_Node_Boot_Issues_Related_to_Slow_Boot_Times.md)
 * Compute Rolling Upgrades
   * CRUS is deprecated in CSM 1.2.0.
-    * It will be removed in CSM 1.3.0 and replaced with BOS V2, which will provide similar functionality.
+    * It will be removed in a future CSM release and replaced with BOS V2, which will provide similar functionality.
   * [Nodes Failing to Upgrade in a CRUS Session](../operations/compute_rolling_upgrades/Troubleshoot_Nodes_Failing_to_Upgrade_in_a_CRUS_Session.md)
   * [Failed CRUS Session Because of Unmet Conditions](../operations/compute_rolling_upgrades/Troubleshoot_a_Failed_CRUS_Session_Due_to_Unmet_Conditions.md)
   * [Failed CRUS Session Because of Bad Parameters](../operations/compute_rolling_upgrades/Troubleshoot_a_Failed_CRUS_Session_Due_to_Bad_Parameters.md)

--- a/troubleshooting/index.md
+++ b/troubleshooting/index.md
@@ -41,6 +41,8 @@ This document provides links to troubleshooting information for services and fun
     * [Log File Locations and Ports Used](../operations/boot_orchestration/Log_File_Locations_and_Ports_Used_in_Compute_Node_Boot_Troubleshooting.md)
     * [Issues Related to Slow Boot Times](../operations/boot_orchestration/Troubleshoot_Compute_Node_Boot_Issues_Related_to_Slow_Boot_Times.md)
 * Compute Rolling Upgrades
+  * CRUS is deprecated in CSM 1.2.0.
+    * It will be removed in CSM-1.3.0 and replaced with BOSv2, which will provide similar functionality.
   * [Nodes Failing to Upgrade in a CRUS Session](../operations/compute_rolling_upgrades/Troubleshoot_Nodes_Failing_to_Upgrade_in_a_CRUS_Session.md)
   * [Failed CRUS Session Because of Unmet Conditions](../operations/compute_rolling_upgrades/Troubleshoot_a_Failed_CRUS_Session_Due_to_Unmet_Conditions.md)
   * [Failed CRUS Session Because of Bad Parameters](../operations/compute_rolling_upgrades/Troubleshoot_a_Failed_CRUS_Session_Due_to_Bad_Parameters.md)

--- a/troubleshooting/index.md
+++ b/troubleshooting/index.md
@@ -2,16 +2,15 @@
 
 This document provides links to troubleshooting information for services and functionality provided by CSM.
 
-## Known Issues
+## Known issues
 
-* [Known Issues](#known-issues)
-  * [SAT/HSM/CAPMC Component Power State Mismatch](known_issues/component_power_state_mismatch.md)
-  * [HMS Discovery job not creating `RedfishEndpoint`s in Hardware State Manager](known_issues/discovery_job_not_creating_redfish_endpoints.md)
-  * [`initrd.img.xz` not found](known_issues/initrd.img.zx_not_found.md)
-  * [Console logs filling up available storage](known_issues/console_log_storage_filling.md)
-  * [Common Platform CA Issues](known_issues/platform_ca_issues.md)
+* [SAT/HSM/CAPMC Component Power State Mismatch](known_issues/component_power_state_mismatch.md)
+* [HMS Discovery job not creating `RedfishEndpoint`s in Hardware State Manager](known_issues/discovery_job_not_creating_redfish_endpoints.md)
+* [`initrd.img.xz` not found](known_issues/initrd.img.zx_not_found.md)
+* [Console logs filling up available storage](known_issues/console_log_storage_filling.md)
+* [Common Platform CA Issues](known_issues/platform_ca_issues.md)
 
-## Troubleshooting Topics
+## Troubleshooting topics
 
 * Kubernetes
   * [General Kubernetes Commands for Troubleshooting](kubernetes/Kubernetes_Troubleshooting_Information.md)
@@ -42,7 +41,7 @@ This document provides links to troubleshooting information for services and fun
     * [Issues Related to Slow Boot Times](../operations/boot_orchestration/Troubleshoot_Compute_Node_Boot_Issues_Related_to_Slow_Boot_Times.md)
 * Compute Rolling Upgrades
   * CRUS is deprecated in CSM 1.2.0.
-    * It will be removed in CSM-1.3.0 and replaced with BOSv2, which will provide similar functionality.
+    * It will be removed in CSM 1.3.0 and replaced with BOS V2, which will provide similar functionality.
   * [Nodes Failing to Upgrade in a CRUS Session](../operations/compute_rolling_upgrades/Troubleshoot_Nodes_Failing_to_Upgrade_in_a_CRUS_Session.md)
   * [Failed CRUS Session Because of Unmet Conditions](../operations/compute_rolling_upgrades/Troubleshoot_a_Failed_CRUS_Session_Due_to_Unmet_Conditions.md)
   * [Failed CRUS Session Because of Bad Parameters](../operations/compute_rolling_upgrades/Troubleshoot_a_Failed_CRUS_Session_Due_to_Bad_Parameters.md)


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/docs-csm/pull/1789

Modified the notification language to indicate the future deprecation (in csm-1.2).