### PR TITLE
MTL-1678: advise on steps to take when interactive login fails

### DIFF
--- a/upgrade/1.2/Stage_2.md
+++ b/upgrade/1.2/Stage_2.md
@@ -113,7 +113,7 @@ ncn-m002# /usr/share/doc/csm/upgrade/1.2/scripts/k8s/upgrade_control_plane.sh
 
 All Kubernetes nodes have been rebooted into the new image.
 
-> **NOTE**: If password for `ncn-m002` was reset during Stage 2.3, then also reset the password
+> **REMINDER**: If password for `ncn-m002` was reset during Stage 2.3, then also reset the password
 > on `ncn-m001` at this time.
 
 This stage is completed. Continue to [Stage 3](Stage_3.md).


### PR DESCRIPTION
## Summary and Scope

Very rarely, a password hash for the root user that works on an
SP2 node (csm-1.0.x) does not work on an SP3 node (csm-1.2.x).

Provide guidance on how to correct the issue and proceed with the
upgrade.

## Issues and Related PRs

* Relates to MTL-1678

## Testing

This procedure has been tested on surtur and drax.
