### PR TITLE
CASMINST-4786 Rework shell check [release/1.2]

### DIFF
--- a/.github/workflows/shell-check.yaml
+++ b/.github/workflows/shell-check.yaml
@@ -1,0 +1,46 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+name: Check Shell Scripts
+on:
+  pull_request:
+
+jobs:
+  shell-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Get changed files
+      id: changed-files
+      uses: tj-actions/changed-files@v18.7
+      with:
+        files: "**/*.sh"
+        files_ignore: ".github/**/*"
+
+    - uses: docker://koalaman/shellcheck:stable
+      if: ${{ steps.changed-files.outputs.all_changed_files }}
+      id: shell-check
+      with:
+        args: --severity=warning --color=always ${{ steps.changed-files.outputs.all_changed_files }}
+


### PR DESCRIPTION
## Summary and Scope

Existing shell check causes confusion - it checks all sh files in repo, and error result is hard for interpretation. This PR changes behavior:

* Only files changed within current PR are checked (inline with other checks)
* Output is easy to interpret

## Issues and Related PRs

* Resolves [CASMINST-4786](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4786)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing
### Tested on:

  * Github action runs

### Test description:

Temporarily added a commit to this PR, which introduces shell check violation. Violation was successfully detected and clearly explained - this tests for false positive:
https://github.com/Cray-HPE/docs-csm/actions/runs/2470232516
![image](https://user-images.githubusercontent.com/320082/172913617-186cde38-5f2a-443b-b487-d4957faf0908.png)

Also, theres known that there's shell check violation in another file in this repo, `./upgrade/1.2/scripts/rebuild/prerequisites.sh`. This file is not reported as violation, because it was not changed in current PR. It is a check for false negative.
## Risks and Mitigations

Low - non mandatory CI/CD check

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

