### PR TITLE
CASMPET-5700 Add kafka upgrade failure docs

### DIFF
--- a/troubleshooting/index.md
+++ b/troubleshooting/index.md
@@ -8,6 +8,7 @@ This document provides links to troubleshooting information for services and fun
 * [HMS Discovery job not creating `RedfishEndpoint`s in Hardware State Manager](known_issues/discovery_job_not_creating_redfish_endpoints.md)
   * [`initrd.img.xz` not found](known_issues/initrd.img.zx_not_found.md)
 * [Platform CA Issues](known_issues/platform_ca_issues.md)
+* [Kafka Failure after CSM 1.2 Upgrade](known_issues/kafka_upgrade_failure.md)
 
 ## Troubleshooting topics
 

--- a/troubleshooting/known_issues/kafka_upgrade_failure.md
+++ b/troubleshooting/known_issues/kafka_upgrade_failure.md
@@ -1,12 +1,12 @@
 # Kafka Failure after CSM 1.2 Upgrade
 
-Occasionally the cray-shared-kafka-kafka pods will be restarted before the
-cray-shared-kafka-zookeeper pods are ready. If this happens then the shared
-kafka cluster will start to fail.
+Occasionally the `cray-shared-kafka-kafka` pods will be restarted before the
+`cray-shared-kafka-zookeeper` pods are ready. If this happens then the shared
+`kafka` cluster will start to fail.
 
 ## Error Messages
 
-### cray-shared-kafka-kafka-# pods
+### `cray-shared-kafka-kafka-#` pods
 
 ```text
 2022-05-20 19:43:02,242 INFO Socket connection established to localhost/127.0.0.1:2181, initiating session (org.apache.zookeeper.ClientCnxn) [main-SendThread(localhost:2181)]
@@ -14,7 +14,7 @@ kafka cluster will start to fail.
 java.io.IOException: Connection reset by peer
 ```
 
-### cray-shared-kafka-zookeeper-# pods
+### `cray-shared-kafka-zookeeper-#` pods
 
 ```text
 2022.05.20 19:44:06 LOG3[1:139846453499648]: SSL_connect: 1408F10B: error:1408F10B:SSL routines:SSL3_GET_RECORD:wrong version number
@@ -22,7 +22,7 @@ cray-shared-kafka-zookeeper-# logs:
 io.netty.handler.codec.DecoderException: javax.net.ssl.SSLHandshakeException: Client requested protocol TLSv1 is not enabled or supported in server context
 ```
 
-### strimzi-cluster-operator pod
+### `strimzi-cluster-operator` pod
 
 ```text
 Caused by: org.apache.kafka.common.errors.TimeoutException: Timed out waiting for a node assignment. Call: listTopics
@@ -32,7 +32,7 @@ io.strimzi.operator.cluster.operator.resource.KafkaRoller$ForceableProblem: An e
 
 ## Solution
 
-Run the kafka-restart.sh script to fix this issue
+Run the `kafka-restart.sh` script to fix this issue
 
 ```bash
 ncn# /usr/share/doc/csm/upgrade/1.2/scripts/strimzi/kafka-restart.sh

--- a/troubleshooting/known_issues/kafka_upgrade_failure.md
+++ b/troubleshooting/known_issues/kafka_upgrade_failure.md
@@ -1,0 +1,40 @@
+# Kafka Failure after CSM 1.2 Upgrade
+
+Occasionally the cray-shared-kafka-kafka pods will be restarted before the
+cray-shared-kafka-zookeeper pods are ready. If this happens then the shared
+kafka cluster will start to fail.
+
+## Error Messages
+
+### cray-shared-kafka-kafka-# pods
+
+```text
+2022-05-20 19:43:02,242 INFO Socket connection established to localhost/127.0.0.1:2181, initiating session (org.apache.zookeeper.ClientCnxn) [main-SendThread(localhost:2181)]
+2022-05-20 19:43:02,245 WARN Session 0x1001ec4c0730001 for server localhost/127.0.0.1:2181, unexpected error, closing socket connection and attempting reconnect (org.apache.zookeeper.ClientCnxn) [main-SendThread(localhost:2181)]
+java.io.IOException: Connection reset by peer
+```
+
+### cray-shared-kafka-zookeeper-# pods
+
+```text
+2022.05.20 19:44:06 LOG3[1:139846453499648]: SSL_connect: 1408F10B: error:1408F10B:SSL routines:SSL3_GET_RECORD:wrong version number
+cray-shared-kafka-zookeeper-# logs:
+io.netty.handler.codec.DecoderException: javax.net.ssl.SSLHandshakeException: Client requested protocol TLSv1 is not enabled or supported in server context
+```
+
+### strimzi-cluster-operator pod
+
+```text
+Caused by: org.apache.kafka.common.errors.TimeoutException: Timed out waiting for a node assignment. Call: listTopics
+2022-05-20 19:43:47 INFO  KafkaRoller:292 - Reconciliation #1395(timer) Kafka(services/cray-shared-kafka): Could not roll pod 1, giving up after 10 attempts. Total delay between attempts 127750ms
+io.strimzi.operator.cluster.operator.resource.KafkaRoller$ForceableProblem: An error while trying to determine rollability
+```
+
+## Solution
+
+Run the kafka-restart.sh script to fix this issue
+
+```bash
+ncn# /usr/share/doc/csm/upgrade/1.2/scripts/strimzi/kafka-restart.sh
+
+```

--- a/upgrade/1.2/README.md
+++ b/upgrade/1.2/README.md
@@ -51,7 +51,7 @@ For more information about modifying `customizations.yaml` and tuning for specif
 - Troubleshooting NTP
 
    During upgrades, clock skew may occur when rebooting nodes. If one node is rebooted and its clock differs significantly from those that have **not** been rebooted, it can
-   cause contention among the other nodes. Waiting for Chrony to slowly adjust the clocks can resolve intermittent clock skew issues. If it does not resolve on its own, follow the
+   cause contention among the other nodes. Waiting for `Chrony` to slowly adjust the clocks can resolve intermittent clock skew issues. If it does not resolve on its own, follow the
    [Configure NTP on NCNs](../../operations/node_management/Configure_NTP_on_NCNs.md) procedure to troubleshoot it further.
 
 - Bare-metal Etcd recovery
@@ -74,8 +74,8 @@ For more information about modifying `customizations.yaml` and tuning for specif
 
    See [Troubleshoot Spire Failing to Start on NCNs](../../operations/spire/Troubleshoot_Spire_Failing_to_Start_on_NCNs.md).
 
-- Fixing shared-kafka kafka cluster after upgrade
- 
+- Fixing `shared-kafka` `kafka` cluster after upgrade
+
    See [Kafka Failure after CSM 1.2 Upgrade](../../troubleshooting/known_issues/kafka_upgrade_failure.md)
 
 - Rerun a step

--- a/upgrade/1.2/README.md
+++ b/upgrade/1.2/README.md
@@ -74,6 +74,10 @@ For more information about modifying `customizations.yaml` and tuning for specif
 
    See [Troubleshoot Spire Failing to Start on NCNs](../../operations/spire/Troubleshoot_Spire_Failing_to_Start_on_NCNs.md).
 
+- Fixing shared-kafka kafka cluster after upgrade
+ 
+   See [Kafka Failure after CSM 1.2 Upgrade](../../troubleshooting/known_issues/kafka_upgrade_failure.md)
+
 - Rerun a step
 
    When running upgrade scripts, each script records what has been done successfully on a node. This is recorded in the

--- a/upgrade/1.2/Stage_3.md
+++ b/upgrade/1.2/Stage_3.md
@@ -81,9 +81,12 @@ This is due to a redeployment of the Ceph `csi` provisioners into namespaces, in
    ncn-m002# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/csm-upgrade.sh
    ```
 
-## Validate cray-shared-kafka was updated properly
+## Validate `cray-shared-kafka` was updated properly
 
-Occasionally the cray-shared-kafka-kafka pods will be restarted before the cray-shared-kafka-zookeeper pods are ready. Check to make sure that all cray-shared-kafka-kafka and cray-shared-kafka-zookeeper pods have a Ready status of 1/1. If any of them have a 2/2 then rerun the kafka-restart.sh script.
+Occasionally the `cray-shared-kafka-kafka` pods will be restarted before the
+`cray-shared-kafka-zookeeper` pods are ready. Check to make sure that all
+`cray-shared-kafka-kafka` and `cray-shared-kafka-zookeeper` pods have a Ready status
+of 1/1. If any of them have a 2/2 then rerun the `kafka-restart.sh` script.
 
 ```bash
 ncn# kubectl get pods -n services -l app.kubernetes.io/instance=cray-shared-kafka

--- a/upgrade/1.2/Stage_3.md
+++ b/upgrade/1.2/Stage_3.md
@@ -81,6 +81,24 @@ This is due to a redeployment of the Ceph `csi` provisioners into namespaces, in
    ncn-m002# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/csm-upgrade.sh
    ```
 
+## Validate cray-shared-kafka was updated properly
+
+Occasionally the cray-shared-kafka-kafka pods will be restarted before the cray-shared-kafka-zookeeper pods are ready. Check to make sure that all cray-shared-kafka-kafka and cray-shared-kafka-zookeeper pods have a Ready status of 1/1. If any of them have a 2/2 then rerun the kafka-restart.sh script.
+
+```bash
+ncn# kubectl get pods -n services -l app.kubernetes.io/instance=cray-shared-kafka
+NAME                                                 READY   STATUS    RESTARTS   AGE
+cray-shared-kafka-entity-operator-7f9895897d-zjgkm   3/3     Running   0          12m
+cray-shared-kafka-kafka-0                            2/2     Running   0          10m
+cray-shared-kafka-kafka-1                            2/2     Running   0          10m
+cray-shared-kafka-kafka-2                            2/2     Running   0          10m
+cray-shared-kafka-zookeeper-0                        1/1     Running   0          8m
+cray-shared-kafka-zookeeper-1                        1/1     Running   0          8m
+cray-shared-kafka-zookeeper-2                        1/1     Running   0          8m
+
+ncn# /usr/share/doc/csm/upgrade/1.2/scripts/strimzi/kafka-restart.sh
+```
+
 ## Verify Keycloak users
 
 Verify that the Keycloak users localize job has completed as expected.


### PR DESCRIPTION
# Description

This adds documentation for fixing the shared-kafka cluster if it fails to upgrade properly during upgrade due to a race condition.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/MTL-1695/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
