### PR TITLE
CASMINST-4790: Reorganize and clarify NCN image modification instructions

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -517,6 +517,8 @@ unixODBC
 unmap
 unregister
 unregisters
+unset
+unsets
 unsquashed
 Unsuspend
 untainting

--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md
@@ -102,7 +102,7 @@ else
     read -s PW2
     echo
     if [[ $PW1 != $PW2 ]]; then
-        echo "ERROR: Passwords do not match"        
+        echo "ERROR: Passwords do not match"
     else
         export SQUASHFS_ROOT_PW_HASH=$(echo "$PW1" | openssl passwd -6 -salt $(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c4) --stdin)
         [[ -n $SQUASHFS_ROOT_PW_HASH ]] && echo "Password hash set and exported" || echo "ERROR: Problem generating hash"

--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md
@@ -1,122 +1,171 @@
 # Set NCN Image Root Password, SSH Keys, and Timezone on PIT Node
 
-Modify the NCN images by setting the root password and adding SSH keys for the root account.
-Optionally, changing the timezone for the NCNs can also be done at this time. This procedure shows this process being
-done on the PIT node during a first time installation of the CSM software.
+> **Note:** This procedure is **required** during initial CSM installs **before management nodes are first deployed**.
 
-***Note:*** This procedure **is required** to be done during an initial CSM software installation
-**before management nodes are first deployed**.
+Modify the NCN images by setting the `root` user password and adding SSH keys for the `root` user account.
+If desired, also change the timezone for the NCNs.
 
-## Set the root password and add SSH keys to the NCN images
+This page describes this procedure being performed on the PIT node during a first time installation of the CSM software.
+If wanting to perform this operation after the initial CSM install, then
+see [Set NCN Image Root Password, SSH Keys, and Timezone](Change_NCN_Image_Root_Password_and_SSH_Keys.md).
 
-This step is required. **There is no default root password and no default SSH keys in the NCN images.**
+- [Overview](#overview)
+- [SSH keys](#ssh-keys)
+  - [Script-generated keys](#script-generated-keys)
+  - [Administrator-provided keys](#administrator-provided-keys)
+- [Password](#password)
+  - [Use PIT node password](#use-pit-node-password)
+  - [Enter password and generate hash](#enter-password-and-generate-hash)
+- [Timezone](#timezone)
+- [Examples](#examples)
+  - [Example 1: New keys, copy PIT password, keep UTC](#example-1-new-keys-copy-pit-password-keep-utc)
+  - [Example 2: Provide keys, prompt for password, change timezone](#example-2-provide-keys-prompt-for-password-change-timezone)
+  - [Example 3: New keys, copy PIT password, keep UTC, no prompting](#example-3-new-keys-copy-pit-password-keep-utc-no-prompting)
+- [Cleanup](#cleanup)
 
-1. Add SSH keys and set the password in the SquashFS. Optionally, set the timezone.
+## Overview
 
-   If desired, create new SSH keys on the PIT node. These will be copied into the NCN SquashFS images in the next step. Alternatively,
-   copy an existing set of keys and `authorized_hosts` file into a directory for reference in the following step. It is assumed
-   that public keys have a `.pub` extension.
+Add SSH keys and the `root` password to the NCN SquashFS images. Optionally set their timezone, if a timezone other than UTC
+(the default) is desired. This is all done by running the `ncn-image-modification.sh` script, which is located at the top
+level of the CSM release tarball: `${CSM_PATH}/ncn-image-modification.sh`
 
-   Execute the `ncn-image-modification.sh` script located at the top level of the CSM release tarball in order to add SSH keys and
-   set the root password. Optionally, set a local timezone (UTC is the default). If you choose to create new SSH keys, then specify
-   the directory where these keys are located with the `-d` argument to the script, in addition to the other required options.
+This document provides common ways of using the script to accomplish this. However, specific environments may require
+deviations from these examples. In those cases, it may be helpful to view the complete script usage statement by running
+it with only the `-h` argument.
 
-   ```console
-   pit# ${$CSM_PATH}/ncn-image-modification.sh -h
-   Usage: ncn-image-modification.sh [-p] [-d dir] [ -z timezone] [-k kubernetes-squashfs-file] [-s storage-squashfs-file] [ssh-keygen arguments]
+The Kubernetes NCN image location is specified with the `-k` argument to the script, and the storage NCN image location is
+specified with the `-s` argument to the script. Both images should be customized with a single call to the script to ensure that
+they receive matching customizations.
 
-          This script semi-automates the process of changing the timezone, root
-          password, and adding new SSH keys for the root user to the NCN squashfs
-          image(s).
+The new customized images are created in their original image's directory. They have the same name as the original image, except
+with the `secure-` prefix added. The original image is moved into a subdirectory named `old`, for backup purposes.
 
-          The script will immediately prompt for a new passphrase for ssh-keygen.
-          The script will then proceed to unsquash the supplied squash files and
-          then prompt for a password. Once the password of the last squash has been
-          provided, the script will continue to completion without interruption.
+There are several choices to be made during this process:
 
-          The process can be fully automated by using the SQUASHFS_ROOT_PW_HASH
-          environment variable (see below) along with either -d or -N.
+- SSH key files can be provided to the script, or the script can generate them itself.
+- The hashed `root` password can be provided to the script, or the script can prompt for password entry when it is running.
+- To use a non-default timezone, that must be passed into the script.
 
-          -a             Do *not* modify the authorized_keys file in the squashfs.
-                         If modifying a previously modified image, or an
-                         authorized_keys file that contains the public key is already
-                         included in the directory used with the -d option, you may
-                         want to use this option.
+## SSH keys
 
-          -d dir         If provided, the contents will be copied into /root/.ssh/
-                         in the squashfs image. Do not supply ssh-keygen arguments
-                         when using -d. Assumes public keys have a .pub extension.
+### Script-generated keys
 
-          -p             Change or set the password in the squashfs. By default, the
-                         user prompted to enter the password after each squashfs file
-                         is unsquashed. Use the SQUASHFS_ROOT_PW_HASH environment
-                         variable (see below) to change or set the password without
-                         being prompted.
+To have the script generate the SSH keys automatically, it must be provided with the `ssh-keygen` options to use.
 
-          -z timezone    By default the timezone on NCNs is UTC. Use this option to
-                         override.
+- To view the complete list of supported `ssh-keygen` options, view the script usage statement by running it with the `-h` argument.
+- If the `-N` option is not used to specify the passphrase, then the script will prompt for the passphrase when it generates the keys.
+  - Even specifying an empty passphrase will prevent being prompted to enter the passphrase during script execution.
+    See [Example 3](#example-3-new-keys-copy-pit-password-keep-utc-no-prompting).
 
-   SUPPORTED SSH-KEYGEN ARGUMENTS
+### Administrator-provided keys
 
-          The following ssh-keygen(1) arguments are supported by this script:
-          [-b bits] [-t dsa | ecdsa | ecdsa-sk | ed25519 | ed25519-sk | rsa]
-          [-N new_passphrase] [-C comment]
+To provide SSH keys to the script, specify the directory containing them with the `-d` argument.
 
-   ENVIRONMENT VARIABLES
+- The script assumes that public keys in that directory have the `.pub` file extension.
+- The entire contents of this directory will be copied into the `/root/.ssh` directory in the images.
+- After copying the directory contents, the script updates the `/root/.ssh/authorized_keys` file in the images
+  with the new public keys.
+  - This is usually the desired behavior, but it can be overridden by specifying the `-a` argument. In that
+    case, the script will **not** update the `authorized_keys` file after copying the directory contents.
 
-          SQUASHFS_ROOT_PW_HASH    If set to the encrypted hash for a root password,
-                                   this hash will be injected into /etc/shadow in the
-                                   squashfs image and there will be no interactive prompt
-                                   to set it. When setting this variable, be sure to use
-                                   single quotes (') to ensure any '$' characters are not
-                                   interpreted.
+## Password
 
-          DEBUG                    If set, the script will be run with 'set -x'
-   ```
+In order for the script to set `root` passwords in the images, the `-p` argument must be included when calling it. **This is
+required for initial CSM installs.**
 
-   The following example references a directory with existing keys and setting the timezone to
-   `America/Chicago`. This example will prompt the administrator to enter a root password after
-   each squashed image is unsquashed.
+If the `SQUASHFS_ROOT_PW_HASH` environment variable is exported, the script will use that as the new `root` password hash for the images.
+Otherwise, the script will prompt for the password to be entered during its execution.
 
-   ```bash
-   pit# cd /var/www/ephemeral/data/
-   pit# ${CSM_PATH}/ncn-image-modification.sh -p -z America/Chicago \
-                                              -d /my/pre-existing/keys \
-                                              -k $(find . -name "kubernetes-*.squashfs" | sort -V | tail -1) \
-                                              -s $(find . -name "storage-ceph-*.squashfs" | sort -V | tail -1)
-   ```
+### Use PIT node password
 
-   The following example generates new keys with an empty passphrase, and the
-   `$SQUASHFS_ROOT_PW_HASH` variable set. This variable will be set to reuse the same root
-   password hash that exists on the PIT node. This example will not prompt the administrator for
-   any input after it is invoked.
+If wanting to use the same `root` user password that is being used on the PIT node where this procedure is being run, then
+the following command can be used to set the `SQUASHFS_ROOT_PW_HASH` variable.
 
-   ```bash
-   pit# cd /var/www/ephemeral/data/
-   pit# export SQUASHFS_ROOT_PW_HASH=$(awk -F':' /^root:/'{print $2}' < /etc/shadow)
-   pit# ${CSM_PATH}/ncn-image-modification.sh -p \
-                                              -t rsa \
-                                              -N "" \
-                                              -k $(find . -name "kubernetes-*.squashfs" | sort -V | tail -1) \
-                                              -s $(find . -name "storage-ceph-*.squashfs" | sort -V | tail -1)
-   ```
+```bash
+pit# export SQUASHFS_ROOT_PW_HASH=$(awk -F':' /^root:/'{print $2}' < /etc/shadow)
+```
 
-   The script will save the original SquashFS images in `./{k8s,ceph}/old`. The new image filenames will
-   have a `secure-` prefix. The `initrd` and kernel will retain their original filenames.
+### Enter password and generate hash
 
-1. Set the boot links.
+The following script can be used to manually enter a new password, and then generate its hash.
 
-   ```bash
-   pit# cd
-   pit# set-sqfs-links.sh
-   ```
+> The script uses `read -s` to prevent the password from being echoed to the screen or saved
+> in the shell history. It unsets the plaintext password variables at the end, so that only
+> the hash is preserved.
+
+```bash
+pit# \
+echo -n "Enter root password for NCN images: " ; read -s PW1 ; echo ; if [[ -z $PW1 ]]; then
+    echo "ERROR: Password cannot be blank"
+else
+    echo -n "Enter again: "
+    read -s PW2
+    echo
+    if [[ $PW1 != $PW2 ]]; then
+        echo "ERROR: Passwords do not match"        
+    else
+        export SQUASHFS_ROOT_PW_HASH=$(echo "$PW1" | openssl passwd -6 -salt $(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c4) --stdin)
+        [[ -n $SQUASHFS_ROOT_PW_HASH ]] && echo "Password hash set and exported" || echo "ERROR: Problem generating hash"
+    fi
+fi ; unset PW1 PW2
+```
+
+## Timezone
+
+The default timezone in the NCN images is UTC. This can optionally be changed by passing the `-z` argument to the
+script. Valid timezone options can be listed by running `timedatectl list-timezones`.
+
+## Examples
+
+### Example 1: New keys, copy PIT password, keep UTC
+
+This example has the script generate new SSH keys (prompting the administrator for the SSH key passphrase) and
+copies the `root` user password from the PIT node. It does not change the timezone from the UTC default.
+
+```bash
+pit# export SQUASHFS_ROOT_PW_HASH=$(awk -F':' /^root:/'{print $2}' < /etc/shadow)
+pit# cd ${PITDATA}/data/
+pit# ${CSM_PATH}/ncn-image-modification.sh -p \
+                                           -t rsa \
+                                           -k "${PITDATA}"/data/k8s/kubernetes-*.squashfs \
+                                           -s "${PITDATA}"/data/ceph/storage-ceph-*.squashfs
+```
+
+### Example 2: Provide keys, prompt for password, change timezone
+
+This example uses existing SSH keys located in the `/my/pre-existing/keys` directory. The script prompts the
+administrator for the `root` user password during execution. It changes the timezone to `America/Chicago`.
+
+```bash
+pit# cd ${PITDATA}/data/
+pit# ${CSM_PATH}/ncn-image-modification.sh -p \
+                                           -d /my/pre-existing/keys \
+                                           -z America/Chicago \
+                                           -k "${PITDATA}"/data/k8s/kubernetes-*.squashfs \
+                                           -s "${PITDATA}"/data/ceph/storage-ceph-*.squashfs
+```
+
+### Example 3: New keys, copy PIT password, keep UTC, no prompting
+
+This example has the script generate new SSH keys and copies the `root` user password from the PIT node. It does
+not change the timezone from the UTC default. It is identical to the first example except that a blank passphrase
+is provided, so that the script requires no input from the administrator while it is running.
+
+```bash
+pit# export SQUASHFS_ROOT_PW_HASH=$(awk -F':' /^root:/'{print $2}' < /etc/shadow)
+pit# cd ${PITDATA}/data/
+pit# ${CSM_PATH}/ncn-image-modification.sh -p \
+                                           -t rsa \
+                                           -N "" \
+                                           -k "${PITDATA}"/data/k8s/kubernetes-*.squashfs \
+                                           -s "${PITDATA}"/data/ceph/storage-ceph-*.squashfs
+```
 
 ## Cleanup
 
-1. Clean up temporary storage used to prepare images.
+Remove backups of NCN images, if desired. These may be removed now, or after verifying that the nodes are able to boot
+successfully with the new images.
 
-   These may be removed now, or after verifying that the nodes are able to boot successfully with the new images.
-
-   ```bash
-   pit# cd /var/www/ephemeral/data && rm -rf ceph/old k8s/old
-   ```
+```bash
+pit# cd "${PITDATA}"/data && rm -rvf ceph/old k8s/old
+```

--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md
@@ -1,6 +1,6 @@
 # Set NCN Image Root Password, SSH Keys, and Timezone on PIT Node
 
-> **Note:** This procedure is **required** during initial CSM installs **before management nodes are first deployed**.
+> **NOTE:** This procedure is **required** during initial CSM installs **before management nodes are first deployed**.
 
 Modify the NCN images by setting the `root` user password and adding SSH keys for the `root` user account.
 If desired, also change the timezone for the NCNs.


### PR DESCRIPTION
# Description

CASMTRIAGE-3411 was opened during the csm-1.2 install of tyr. The short version is that the NCN image modification script behaved in a way that the installer did not expect, and it resulted in a mismatch of SSH keys on the NCNs. This was not a bug in the script, but resulted because of how it was documented. After I determined the root cause of what had happened during that install, I opened CASMINST-4790 to address a couple of specific issues that helped cause the situation. However, in the course of making those changes I realized that the page as a whole is not easy to follow for people who are not that familiar with the process. So I used this PR to not only correct the specific problems we saw on tyr, but also to reorganize the page to make it more user friendly.

The actual procedure being following isn't significantly altered due to my changes. The biggest changes are:
- Added a pointer to the non-PIT version of this procedure, in case folks wanting to do it stumble across the wrong page.
- I removed the step to create the squashfs links. This step already exists on the deploy management nodes page, and is performed directly after this image modification step. So it was redundant.
- I slightly modified the examples given, mainly to stop using the find command (one of the causes of the tyr issue).
- I provided steps for the user to create their own root password hash, instead of just having the choice of using the PIT root password or entering the password during the script execution. Other than the small shell script wrapper (which just makes sure the user doesn't make a typo in the password), the password hashing command itself was lifted from a different operational procedure (so it's not untested code).
- I gave more details about how to view valid timezone options.
- I made it clear that both images should be modified with a single command to ensure they have matching SSH keys. Currently that is only kind of implied, in that our examples always both images.
- I removed the usage statement from the docs. Having it there meant that if we ever changed the script usage, we'd need to remember to update it here. I figured it was cleaner and more concise to just explain the high points, and to tell them how to run the script to view the usage.

I know we don't like to make changes like this so close to release, but I think this is one we need to make. I think that without this change, there will be some customer install issues. They are easy ones to solve, but they will cost time and cause frustration.

# Checklist Before Merging

- [X] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

