### PR TITLE
CASMNET-1022-12

### DIFF
--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -592,8 +592,6 @@ The external SSH access tests may be run on any system external to the cluster.
     external:/usr/share/doc/csm/scripts/operations/pyscripts# ./start.py test_bican_external
     ```
 
-1. When prompted by the test, enter the system domain and the `admin` client secret .
-
    By default, SSH access will be tested between master nodes , compute nodes, UANs, and spine switches. on all relevant networks.
    It is possible to customize which nodes and networks will be tested. See the test usage statement for details.
    The script usage statement is displayed by calling the test with the `--help` argument:
@@ -601,6 +599,8 @@ The external SSH access tests may be run on any system external to the cluster.
     ```bash
     external:/usr/share/doc/csm/scripts/operations/pyscripts# ./start.py test_bican_external --help
     ```
+
+1. When prompted by the test, enter the system domain and the `admin` client secret.
 
    The test will complete with an overall pass/failure status such as the following:
 

--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -30,7 +30,10 @@ The areas should be tested in the order they are listed on this page. Errors in 
   - [3.1 SMS test execution](#31-sms-test-execution)
   - [3.2 Interpreting `cmsdev` results](#32-interpreting-cmsdev-results)
   - [3.3 Known issues with SMS tests](#33-known-issues-with-sms-tests)
-- [4. Gateway health checks](#4-gateway-health-checks)
+- [4. Gateway health and SSH access checks](#4-gateway-health-and-ssh-access-checks)
+  - [4.1 Gateway health tests](#41-gateway-health-tests)
+  - [4.2 Internal SSH access test execution](#42-internal-ssh-access-test-execution)
+  - [4.3 External SSH access test execution](#43-external-ssh-access-test-execution)
 - [5. Booting CSM `barebones` image](#5-booting-csm-barebones-image)
   - [5.1 Run the test script](#51-run-the-test-script)
 - [6. UAS / UAI tests](#6-uas--uai-tests)
@@ -489,7 +492,9 @@ ERROR (run tag 1khv7-crus): persistentvolumeclaims "cray-crus-etcd-ffmszl7bvh" n
 In this case, these errors can be ignored, or the pod with the same name as the PVC mentioned in the output can be restarted
 (as long as the other two Etcd pods are healthy).
 
-## 4. Gateway health checks
+## 4. Gateway health and SSH access checks
+
+### 4.1 Gateway health tests
 
 The gateway tests check the health of the API Gateway on all of the relevant networks.  The gateway tests will check that the gateway is accessible on all networks where it should be accessible,
 and NOT accessible on all networks where it should NOT be accessible. It will also check several service endpoints to verify that they return the proper response
@@ -514,6 +519,90 @@ Overall Gateway Test Status:  PASS
 For more detailed information on the tests results and examples, see [Gateway Testing](network/gateway_testing.md).
 
 <a name="booting-csm-barebones-image"></a>
+
+### 4.2 Internal SSH access test execution
+
+The internal SSH access tests may be run on any NCN with the `docs-csm` RPM installed. For details on installing the `docs-csm` RPM,
+see [Check for Latest Documentation](../update_product_stream/index.md#documentation).
+
+Execute the tests by running the following command:
+
+```bash
+ncn# /usr/share/doc/csm/scripts/operations/pyscripts/start.py test_bican_internal
+```
+
+By default, SSH access will be tested between nodes of type `ncn_master`, `cn`, `uan`, `spine_switch` on all relevant networks. You
+can customize which nodes you want to test from and to, as well as the networks, by following the command line parameters as
+described in the help:
+
+```bash
+ncn# /usr/share/doc/csm/scripts/operations/pyscripts/start.py test_bican_internal --help
+```
+
+The test will complete with an overall pass/failure status such as the following:
+
+```text
+Overall status: PASSED (Passed: 40, Failed: 0)
+```
+
+### 4.3 External SSH access test execution
+
+The external SSH access tests may be run on any system external to the cluster.
+
+1. `python3` must be installed (if it is not already).
+
+1. Obtain the test code.
+
+   There are two options for doing this:
+
+    - Install the `docs-csm` RPM.
+
+      See [Check for Latest Documentation](../update_product_stream/index.md#documentation).
+
+    - Copy over the following folder from a system where the `docs-csm` RPM is installed:
+
+        - `/usr/share/doc/csm/scripts/operations/pyscripts`
+
+1. Install the python dependencies
+
+   Switch to the `pyscripts` working directory and run the following command to install the required python dependencies:
+
+    ```bash
+    external:/usr/share/doc/csm/scripts/operations/pyscripts# pip install .
+    ```
+
+1. Obtain the admin client secret.
+
+   Because we do not have access to `kubectl` outside of the cluster, obtain the admin client secret by running the
+   following command on an NCN.
+
+    ```bash
+    ncn# kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d
+    26947343-d4ab-403b-14e937dbd700
+    ```
+
+1. In the external system, execute the tests by running the following command:
+
+    ```bash
+    external:/usr/share/doc/csm/scripts/operations/pyscripts# ./start.py test_bican_external
+    ```
+
+1. The test will first ask you for the system domain. It will then ask for the admin client secret where you can enter the
+   secret that you obtained from the step above in the NCN. The tests will then run.
+
+   By default, external SSH access will be tested to nodes of type `ncn_master`, `cn`, `uan`, `spine_switch` on all relevant networks. You
+   can customize which nodes you want to test, as well as the networks to test on, by following the command line parameters as
+   described in the help:
+
+    ```bash
+    external:/usr/share/doc/csm/scripts/operations/pyscripts# ./start.py test_bican_external --help
+    ```
+
+   The test will complete with an overall pass/failure status such as the following:
+
+    ```text
+    Overall status: PASSED (Passed: 20, Failed: 0)
+    ```
 
 ## 5. Booting CSM `barebones` image
 

--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -531,9 +531,9 @@ Execute the tests by running the following command:
 ncn# /usr/share/doc/csm/scripts/operations/pyscripts/start.py test_bican_internal
 ```
 
-By default, SSH access will be tested between nodes of type `ncn_master`, `cn`, `uan`, `spine_switch` on all relevant networks. You
-can customize which nodes you want to test from and to, as well as the networks, by following the command line parameters as
-described in the help:
+By default, SSH access will be tested between master nodes , compute nodes, UANs, and spine switches. on all relevant networks.
+It is possible to customize which nodes and networks will be tested. See the test usage statement for details.
+The script usage statement is displayed by calling the test with the `--help` argument:
 
 ```bash
 ncn# /usr/share/doc/csm/scripts/operations/pyscripts/start.py test_bican_internal --help
@@ -563,36 +563,40 @@ The external SSH access tests may be run on any system external to the cluster.
 
         - `/usr/share/doc/csm/scripts/operations/pyscripts`
 
-1. Install the python dependencies
+1. Install the Python dependencies
 
-   Switch to the `pyscripts` working directory and run the following command to install the required python dependencies:
+   Run the following command from the `pyscripts` directory in order to install the required Python dependencies:
 
     ```bash
     external:/usr/share/doc/csm/scripts/operations/pyscripts# pip install .
     ```
 
-1. Obtain the admin client secret.
+1. Obtain the `admin` client secret.
 
-   Because we do not have access to `kubectl` outside of the cluster, obtain the admin client secret by running the
+   Because `kubectl` will not work outside of the cluster, obtain the `admin` client secret by running the
    following command on an NCN.
 
     ```bash
     ncn# kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d
+    ```
+
+    Example output:
+
+    ```text
     26947343-d4ab-403b-14e937dbd700
     ```
 
-1. In the external system, execute the tests by running the following command:
+1. On the external system, execute the tests.
 
     ```bash
     external:/usr/share/doc/csm/scripts/operations/pyscripts# ./start.py test_bican_external
     ```
 
-1. The test will first ask you for the system domain. It will then ask for the admin client secret where you can enter the
-   secret that you obtained from the step above in the NCN. The tests will then run.
+1. When prompted by the test, enter the system domain and the `admin` client secret .
 
-   By default, external SSH access will be tested to nodes of type `ncn_master`, `cn`, `uan`, `spine_switch` on all relevant networks. You
-   can customize which nodes you want to test, as well as the networks to test on, by following the command line parameters as
-   described in the help:
+   By default, SSH access will be tested between master nodes , compute nodes, UANs, and spine switches. on all relevant networks.
+   It is possible to customize which nodes and networks will be tested. See the test usage statement for details.
+   The script usage statement is displayed by calling the test with the `--help` argument:
 
     ```bash
     external:/usr/share/doc/csm/scripts/operations/pyscripts# ./start.py test_bican_external --help

--- a/scripts/operations/pyscripts/pyscripts/__init__.py
+++ b/scripts/operations/pyscripts/pyscripts/__init__.py
@@ -1,0 +1,23 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#

--- a/scripts/operations/pyscripts/pyscripts/cli.py
+++ b/scripts/operations/pyscripts/pyscripts/cli.py
@@ -1,0 +1,63 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+import os
+import sys
+import click
+from pyscripts.core import log_config
+
+CONTEXT_SETTINGS = dict(auto_envvar_prefix="PYSCRIPTS")
+
+
+class Environment:
+    def __init__(self):
+        pass
+
+pass_environment = click.make_pass_decorator(Environment, ensure=True)
+cmd_folder = os.path.abspath(os.path.join(os.path.dirname(__file__), "commands"))
+
+class PyscriptsCLI(click.MultiCommand):
+    def list_commands(self, ctx):
+        rv = []
+        for filename in os.listdir(cmd_folder):
+            if filename.endswith(".py") and filename.startswith("cmd_"):
+                rv.append(filename[4:-3])
+        rv.sort()
+        return rv
+
+    def get_command(self, ctx, name):
+        try:
+            mod = __import__(f"pyscripts.commands.cmd_{name}", None, None, ["cli"])
+        except ImportError as err:
+            print(err)
+            return
+        return mod.cli
+
+
+@click.command(cls=PyscriptsCLI, context_settings=CONTEXT_SETTINGS)
+@click.option("-v", "--verbose", is_flag=True, help="Enables verbose logging mode.")
+@pass_environment
+def cli(ctx, verbose):
+    """Command line interface to run various tests and tasks."""
+    log_config.set_logging_level(verbose)

--- a/scripts/operations/pyscripts/pyscripts/commands/__init__.py
+++ b/scripts/operations/pyscripts/pyscripts/commands/__init__.py
@@ -1,0 +1,23 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#

--- a/scripts/operations/pyscripts/pyscripts/commands/cmd_test_bican_external.py
+++ b/scripts/operations/pyscripts/pyscripts/commands/cmd_test_bican_external.py
@@ -1,0 +1,60 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+from pyscripts.cli import pass_environment
+from pyscripts.commands.test_bican_external import test_bican_external
+import logging
+import click
+import os
+
+
+@click.command("test_bican_external", short_help="Tests the isolation of external SSH access across networks in CAN-toggled or CHN-toggled environments.")
+@click.option(
+    "--system-domain", prompt=True,
+    default=lambda: os.environ.get("SYSTEM_DOMAIN", ""),
+    help="What is the system domain you want to test? E.g. eniac.dev.cray.com"
+)
+@click.option(
+    "--admin-client-secret", prompt=True,
+    default=lambda: os.environ.get("ADMIN_CLIENT_SECRET", ""),
+    help="What is the admin client secret? You can retrieve it from within the network by running the command:\n kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d'"
+)
+@click.option(
+    "--to-types",
+    type=click.Choice(["ncn_master", "ncn_worker", "ncn_storage", "cn", "uan", "spine_switch", "leaf_switch", "leaf_BMC", "CDU"], case_sensitive=False),
+    multiple=True,
+    default=["ncn_master", "cn", "uan", "spine_switch"],
+    help="What types of nodes to test SSH access to. Defaults: ('ncn_master', 'cn', 'uan', 'spine_switch')"
+)
+@click.option(
+    "--networks",
+    type=click.Choice(["can", "chn", "cmn", "nmn", "nmnlb", "hmn", "hmnlb"], case_sensitive=False),
+    multiple=True,
+    default=["can", "chn", "cmn", "nmn", "nmnlb", "hmn", "hmnlb"],
+    help="What networks to test with. Defaults: ('can', 'chn', 'cmn', 'nmn', 'nmnlb', 'hmn', 'hmnlb')"
+)
+@pass_environment
+def cli(ctx, system_domain, admin_client_secret, to_types, networks):
+    print(f"Testing external access to node types {to_types} on networks {networks}.")
+    test_bican_external.start_test(system_domain, admin_client_secret, to_types, networks)

--- a/scripts/operations/pyscripts/pyscripts/commands/cmd_test_bican_internal.py
+++ b/scripts/operations/pyscripts/pyscripts/commands/cmd_test_bican_internal.py
@@ -1,0 +1,56 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+from pyscripts.cli import pass_environment
+from pyscripts.commands.test_bican_internal import test_bican_internal
+import logging
+import click
+
+
+@click.command("test_bican_internal", short_help="Tests the isolation of internal SSH access across networks in CAN-toggled or CHN-toggled environments.")
+@click.option(
+    "--from-types",
+    type=click.Choice(["ncn_master", "ncn_worker", "ncn_storage", "cn", "uan", "spine_switch", "leaf_switch", "leaf_BMC", "CDU"], case_sensitive=False),
+    multiple=True,
+    default=["ncn_master", "cn", "uan", "spine_switch"],
+    help="What types of nodes to run the tests from. Defaults: ('ncn_master', 'cn', 'uan', 'spine_switch')"
+)
+@click.option(
+    "--to-types",
+    type=click.Choice(["ncn_master", "ncn_worker", "ncn_storage", "cn", "uan", "spine_switch", "leaf_switch", "leaf_BMC", "CDU"], case_sensitive=False),
+    multiple=True,
+    default=["ncn_master", "cn", "uan", "spine_switch"],
+    help="What types of nodes to test SSH access to. Defaults: ('ncn_master', 'cn', 'uan', 'spine_switch')"
+)
+@click.option(
+    "--networks",
+    type=click.Choice(["can", "chn", "cmn", "nmn", "nmnlb", "hmn", "hmnlb"], case_sensitive=False),
+    multiple=True,
+    default=["can", "chn", "cmn", "nmn", "nmnlb", "hmn", "hmnlb"],
+    help="What networks to test with. Defaults: ('can', 'chn', 'cmn', 'nmn', 'nmnlb', 'hmn', 'hmnlb')"
+)
+@pass_environment
+def cli(ctx, from_types, to_types, networks):
+    print(f"Going to test from node types {from_types} to node types {to_types} on networks {networks}.")
+    test_bican_internal.start_test(from_types, to_types, networks)

--- a/scripts/operations/pyscripts/pyscripts/commands/test_bican_external/__init__.py
+++ b/scripts/operations/pyscripts/pyscripts/commands/test_bican_external/__init__.py
@@ -1,0 +1,23 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#

--- a/scripts/operations/pyscripts/pyscripts/commands/test_bican_external/can_toggle_tests_external.yaml
+++ b/scripts/operations/pyscripts/pyscripts/commands/test_bican_external/can_toggle_tests_external.yaml
@@ -1,0 +1,79 @@
+tests:
+  can:
+    ncn_master: false
+    ncn_worker: false
+    ncn_storage: false
+    spine_switch: false
+    leaf_switch: false
+    leaf_BMC: false
+    CDU: false
+    uan: true
+    uai: true
+    cn: false
+  cmn:
+    ncn_master: true
+    ncn_worker: true
+    ncn_storage: true
+    spine_switch: true
+    leaf_switch: true
+    leaf_BMC: true
+    CDU: true
+    uan: false
+    uai: false
+    cn: false
+  chn:
+    ncn_master: false
+    ncn_worker: false
+    ncn_storage: false
+    spine_switch: false
+    leaf_switch: false
+    leaf_BMC: false
+    CDU: false
+    uan: false
+    uai: false
+    cn: false
+  nmn:
+    ncn_master: false
+    ncn_worker: false
+    ncn_storage: false
+    spine_switch: false
+    leaf_switch: false
+    leaf_BMC: false
+    CDU: false
+    uan: false
+    uai: false
+    cn: false
+  nmnlb:
+    ncn_master: false
+    ncn_worker: false
+    ncn_storage: false
+    spine_switch: false
+    leaf_switch: false
+    leaf_BMC: false
+    CDU: false
+    uan: false
+    uai: false
+    cn: false
+  hmn:
+    ncn_master: false
+    ncn_worker: false
+    ncn_storage: false
+    spine_switch: false
+    leaf_switch: false
+    leaf_BMC: false
+    CDU: false
+    uan: false
+    uai: false
+    cn: false
+  hmnlb:
+    ncn_master: false
+    ncn_worker: false
+    ncn_storage: false
+    spine_switch: false
+    leaf_switch: false
+    leaf_BMC: false
+    CDU: false
+    uan: false
+    uai: false
+    cn: false
+

--- a/scripts/operations/pyscripts/pyscripts/commands/test_bican_external/can_toggle_tests_external.yaml
+++ b/scripts/operations/pyscripts/pyscripts/commands/test_bican_external/can_toggle_tests_external.yaml
@@ -1,3 +1,26 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 tests:
   can:
     ncn_master: false

--- a/scripts/operations/pyscripts/pyscripts/commands/test_bican_external/chn_toggle_tests_external.yaml
+++ b/scripts/operations/pyscripts/pyscripts/commands/test_bican_external/chn_toggle_tests_external.yaml
@@ -1,0 +1,79 @@
+tests:
+  can:
+    ncn_master: false
+    ncn_worker: false
+    ncn_storage: false
+    spine_switch: false
+    leaf_switch: false
+    leaf_BMC: false
+    CDU: false
+    uan: false
+    uai: false
+    cn: false
+  cmn:
+    ncn_master: true
+    ncn_worker: true
+    ncn_storage: true
+    spine_switch: true
+    leaf_switch: true
+    leaf_BMC: true
+    CDU: true
+    uan: false
+    uai: false
+    cn: false
+  chn:
+    ncn_master: false
+    ncn_worker: false
+    ncn_storage: false
+    spine_switch: false
+    leaf_switch: false
+    leaf_BMC: false
+    CDU: false
+    uan: true
+    uai: true
+    cn: true
+  nmn:
+    ncn_master: false
+    ncn_worker: false
+    ncn_storage: false
+    spine_switch: false
+    leaf_switch: false
+    leaf_BMC: false
+    CDU: false
+    uan: false
+    uai: false
+    cn: false
+  nmnlb:
+    ncn_master: false
+    ncn_worker: false
+    ncn_storage: false
+    spine_switch: false
+    leaf_switch: false
+    leaf_BMC: false
+    CDU: false
+    uan: false
+    uai: false
+    cn: false
+  hmn:
+    ncn_master: false
+    ncn_worker: false
+    ncn_storage: false
+    spine_switch: false
+    leaf_switch: false
+    leaf_BMC: false
+    CDU: false
+    uan: false
+    uai: false
+    cn: false
+  hmnlb:
+    ncn_master: false
+    ncn_worker: false
+    ncn_storage: false
+    spine_switch: false
+    leaf_switch: false
+    leaf_BMC: false
+    CDU: false
+    uan: false
+    uai: false
+    cn: false
+  

--- a/scripts/operations/pyscripts/pyscripts/commands/test_bican_external/chn_toggle_tests_external.yaml
+++ b/scripts/operations/pyscripts/pyscripts/commands/test_bican_external/chn_toggle_tests_external.yaml
@@ -1,3 +1,26 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 tests:
   can:
     ncn_master: false
@@ -76,4 +99,4 @@ tests:
     uan: false
     uai: false
     cn: false
-  
+

--- a/scripts/operations/pyscripts/pyscripts/commands/test_bican_external/test_bican_external.py
+++ b/scripts/operations/pyscripts/pyscripts/commands/test_bican_external/test_bican_external.py
@@ -1,0 +1,159 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+from pyscripts.core.ssh.ssh_targets import SshTargets
+from pyscripts.core.ssh.ssh_connection import SshConnection
+from pyscripts.core import csm_api_utils
+import yaml
+import time
+import logging
+import sys
+import os
+
+TEST_PLAN = None
+SSH_TARGETS = None
+APPLICABLE_NETWORK_TYPES = ["can", "chn", "cmn", "nmn", "hmn", "hmnlb", "nmnlb"]
+APPLICABLE_NODE_TYPES = ["ncn_master", "uan", "cn", "spine_switch"]
+
+TOTAL_PASS = 0
+
+def start_test(system_domain, admin_client_secret, to_node_types, networks):
+    global APPLICABLE_NETWORK_TYPES
+    global APPLICABLE_NODE_TYPES
+
+    APPLICABLE_NETWORK_TYPES = networks
+    APPLICABLE_NODE_TYPES = to_node_types
+
+
+    csm_api_utils.set_system_domain(system_domain)
+    csm_api_utils.set_admin_secret(admin_client_secret)
+
+    load_test_plan()
+    execute_test_plan()
+
+
+def load_test_plan():
+    global TEST_PLAN
+    global SSH_TARGETS
+
+    if csm_api_utils.is_bican_chm():
+        print("BICAN:CHN detected.")
+        filename = "chn_toggle_tests_external.yaml"
+    else:
+        print("BICAN:CAN detected.")
+        filename = "can_toggle_tests_external.yaml"
+    
+    path = os.path.abspath(os.path.join(os.path.dirname(__file__), filename))
+    f = open(path, "r")
+    TEST_PLAN = yaml.safe_load(f.read())["tests"]
+
+    SSH_TARGETS = SshTargets()
+    SSH_TARGETS.refresh()
+
+def execute_test_plan():
+    for network in TEST_PLAN:
+        if network in APPLICABLE_NETWORK_TYPES:
+            config = TEST_PLAN[network]
+            for to_node_type in config:
+                if to_node_type in APPLICABLE_NODE_TYPES:
+                    collect_passwords_from_node_type(to_node_type, network)
+
+    total_ran = 0
+    start_time = time.time()
+
+    for network in TEST_PLAN:
+        if network in APPLICABLE_NETWORK_TYPES:
+            config = TEST_PLAN[network]
+            for to_node_type in config:
+                if to_node_type in APPLICABLE_NODE_TYPES:
+                    total_ran += execute_test(to_node_type, network, config[to_node_type])
+
+    total_time = time.time() - start_time
+
+    print(f"\n\nRan {total_ran} tests in {total_time:0.3f}s. Overall status: %s (Passed: {TOTAL_PASS}, Failed: {total_ran - TOTAL_PASS})" % ("PASSED" if TOTAL_PASS == total_ran else "FAILED"))
+
+def collect_passwords_from_node_type(from_node_type, network):
+    from_node = get_ssh_host_for_node_type(from_node_type, [])
+
+    if not from_node:
+        return
+
+    from_node.get_password() # this will ask for the password and cache it
+
+def execute_test(to_node_type, network, expected):
+    global TOTAL_PASS
+
+    network_suffix = "{}.{}".format(network, csm_api_utils.get_system_domain())
+    to_node = get_ssh_host_for_node_type(to_node_type, [])
+
+    if not to_node:
+        print("""\nTesting SSH access:
+To node type {}
+Over network {}""".format(
+            to_node_type, network_suffix))
+
+        print("\t\t^^^^ FAILED: Cannot find a suitable node for node type {} ^^^^".format(to_node_type))
+        return 1
+
+    to_node = to_node.with_domain_suffix(network_suffix)
+
+    toNodeSshConnection = SshConnection(to_node)
+
+    print("""\nTesting SSH access:
+        To node type {}, using {}
+        Over network {}
+        Expected to work: {}""".format(
+        to_node_type, to_node.get_full_domain_name(), network_suffix, expected))
+
+    try:
+        toNodeSshConnection = SshConnection(to_node)
+        toNodeSshConnection.connect()
+
+        if "switch" in to_node.type:
+            toNodeSshConnection.run_test_command("show hostname", to_node.hostname)
+        else:
+            toNodeSshConnection.run_test_command("echo hello", "hello")
+
+        if expected:
+            print("""\t\t^^^^ PASSED ^^^^""")
+            TOTAL_PASS += 1
+        else:
+            print(f"\t\t^^^^ FAILED: accessible but SHOULD NOT have been accessible ^^^^")
+    except Exception as err:
+        if not expected:
+            print("""\t\t^^^^ PASSED ^^^^""")
+            TOTAL_PASS += 1
+        else:
+            print("\t\t^^^^ FAILED: not accessible but SHOULD have been accessible ^^^^\n")
+            print("{}".format(str(err)))
+    finally:
+        toNodeSshConnection.close_connection(False)
+
+    return 1
+
+def get_ssh_host_for_node_type(node_type, excluded_hostnames):
+    target_list = SSH_TARGETS.__dict__[node_type]
+    for i in target_list:
+        if not i.hostname in excluded_hostnames and i.is_ready():
+            return i

--- a/scripts/operations/pyscripts/pyscripts/commands/test_bican_internal/__init__.py
+++ b/scripts/operations/pyscripts/pyscripts/commands/test_bican_internal/__init__.py
@@ -1,0 +1,23 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#

--- a/scripts/operations/pyscripts/pyscripts/commands/test_bican_internal/can_toggle_tests.yaml
+++ b/scripts/operations/pyscripts/pyscripts/commands/test_bican_internal/can_toggle_tests.yaml
@@ -1,0 +1,781 @@
+tests:
+  ncn_master:
+    can:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: true
+      uai: true
+      cn: true
+    cmn:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: true
+      leaf_switch: true
+      leaf_BMC: true
+      CDU: true
+      uan: false
+      uai: false
+      cn: false
+    chn:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    nmn:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    hmn:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: true
+      leaf_switch: true
+      leaf_BMC: true
+      CDU: true
+      uan: false
+      uai: false
+      cn: false
+    nmnlb:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    hmnlb:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+  ncn_worker:
+    can:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: true
+      uai: true
+      cn: true
+    cmn:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: true
+      leaf_switch: true
+      leaf_BMC: true
+      CDU: true
+      uan: false
+      uai: false
+      cn: false
+    chn:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    nmn:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    hmn:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: true
+      leaf_switch: true
+      leaf_BMC: true
+      CDU: true
+      uan: false
+      uai: false
+      cn: false
+    nmnlb:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    hmnlb:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+  ncn_storage:
+    can:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: true
+      uai: true
+      cn: true
+    cmn:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: true
+      leaf_switch: true
+      leaf_BMC: true
+      CDU: true
+      uan: false
+      uai: false
+      cn: false
+    chn:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    nmn:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    hmn:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: true
+      leaf_switch: true
+      leaf_BMC: true
+      CDU: true
+      uan: false
+      uai: false
+      cn: false
+    nmnlb:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    hmnlb:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+  spine_switch:
+    can:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: true
+      uai: true
+      cn: true
+    cmn:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: true
+      leaf_switch: true
+      leaf_BMC: true
+      CDU: true
+      uan: false
+      uai: false
+      cn: false
+    chn:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    nmn:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    hmn:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: true
+      leaf_switch: true
+      leaf_BMC: true
+      CDU: true
+      uan: false
+      uai: false
+      cn: false
+    nmnlb:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    hmnlb:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+  leaf_switch:
+    can:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: true
+      uai: true
+      cn: true
+    cmn:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: true
+      leaf_switch: true
+      leaf_BMC: true
+      CDU: true
+      uan: false
+      uai: false
+      cn: false
+    chn:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    nmn:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    hmn:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: true
+      leaf_switch: true
+      leaf_BMC: true
+      CDU: true
+      uan: false
+      uai: false
+      cn: false
+    nmnlb:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    hmnlb:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+  leaf_BMC:
+    can:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: true
+      uai: true
+      cn: true
+    cmn:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: true
+      leaf_switch: true
+      leaf_BMC: true
+      CDU: true
+      uan: false
+      uai: false
+      cn: false
+    chn:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    nmn:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    hmn:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: true
+      leaf_switch: true
+      leaf_BMC: true
+      CDU: true
+      uan: false
+      uai: false
+      cn: false
+    nmnlb:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    hmnlb:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+  CDU:
+    can:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: true
+      uai: true
+      cn: true
+    cmn:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: true
+      leaf_switch: true
+      leaf_BMC: true
+      CDU: true
+      uan: false
+      uai: false
+      cn: false
+    chn:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    nmn:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    hmn:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: true
+      leaf_switch: true
+      leaf_BMC: true
+      CDU: true
+      uan: false
+      uai: false
+      cn: false
+    nmnlb:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    hmnlb:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+  uan:
+    can:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: true
+      uai: true
+      cn: true
+    cmn:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    chn:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    nmn:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: true
+    hmn:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    nmnlb:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    hmnlb:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+  uai:
+    can:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: true
+      uai: true
+      cn: true
+    cmn:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    chn:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    nmn:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: true
+    hmn:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    nmnlb:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    hmnlb:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+  cn:
+    can:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: true
+      uai: true
+      cn: true
+    cmn:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    chn:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    nmn:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    hmn:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    nmnlb:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    hmnlb:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false

--- a/scripts/operations/pyscripts/pyscripts/commands/test_bican_internal/can_toggle_tests.yaml
+++ b/scripts/operations/pyscripts/pyscripts/commands/test_bican_internal/can_toggle_tests.yaml
@@ -1,3 +1,26 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 tests:
   ncn_master:
     can:

--- a/scripts/operations/pyscripts/pyscripts/commands/test_bican_internal/chn_toggle_tests.yaml
+++ b/scripts/operations/pyscripts/pyscripts/commands/test_bican_internal/chn_toggle_tests.yaml
@@ -1,0 +1,781 @@
+tests:
+  ncn_master:
+    can:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    cmn:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: true
+      leaf_switch: true
+      leaf_BMC: true
+      CDU: true
+      uan: false
+      uai: false
+      cn: false
+    chn:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: true
+      uai: true
+      cn: true
+    nmn:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    hmn:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: true
+      leaf_switch: true
+      leaf_BMC: true
+      CDU: true
+      uan: false
+      uai: false
+      cn: false
+    nmnlb:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    hmnlb:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+  ncn_worker:
+    can:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    cmn:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: true
+      leaf_switch: true
+      leaf_BMC: true
+      CDU: true
+      uan: false
+      uai: false
+      cn: false
+    chn:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: true
+      uai: true
+      cn: true
+    nmn:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    hmn:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: true
+      leaf_switch: true
+      leaf_BMC: true
+      CDU: true
+      uan: false
+      uai: false
+      cn: false
+    nmnlb:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    hmnlb:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+  ncn_storage:
+    can:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    cmn:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: true
+      leaf_switch: true
+      leaf_BMC: true
+      CDU: true
+      uan: false
+      uai: false
+      cn: false
+    chn:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: true
+      uai: true
+      cn: true
+    nmn:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    hmn:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: true
+      leaf_switch: true
+      leaf_BMC: true
+      CDU: true
+      uan: false
+      uai: false
+      cn: false
+    nmnlb:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    hmnlb:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+  spine_switch:
+    can:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    cmn:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: true
+      leaf_switch: true
+      leaf_BMC: true
+      CDU: true
+      uan: false
+      uai: false
+      cn: false
+    chn:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: true
+      uai: true
+      cn: true
+    nmn:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    hmn:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: true
+      leaf_switch: true
+      leaf_BMC: true
+      CDU: true
+      uan: false
+      uai: false
+      cn: false
+    nmnlb:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    hmnlb:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+  leaf_switch:
+    can:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    cmn:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: true
+      leaf_switch: true
+      leaf_BMC: true
+      CDU: true
+      uan: false
+      uai: false
+      cn: false
+    chn:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: true
+      uai: true
+      cn: true
+    nmn:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    hmn:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: true
+      leaf_switch: true
+      leaf_BMC: true
+      CDU: true
+      uan: false
+      uai: false
+      cn: false
+    nmnlb:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    hmnlb:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+  leaf_BMC:
+    can:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    cmn:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: true
+      leaf_switch: true
+      leaf_BMC: true
+      CDU: true
+      uan: false
+      uai: false
+      cn: false
+    chn:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: true
+      uai: true
+      cn: true
+    nmn:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    hmn:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: true
+      leaf_switch: true
+      leaf_BMC: true
+      CDU: true
+      uan: false
+      uai: false
+      cn: false
+    nmnlb:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    hmnlb:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+  CDU:
+    can:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    cmn:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: true
+      leaf_switch: true
+      leaf_BMC: true
+      CDU: true
+      uan: false
+      uai: false
+      cn: false
+    chn:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: true
+      uai: true
+      cn: true
+    nmn:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    hmn:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: true
+      leaf_switch: true
+      leaf_BMC: true
+      CDU: true
+      uan: false
+      uai: false
+      cn: false
+    nmnlb:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    hmnlb:
+      ncn_master: true
+      ncn_worker: true
+      ncn_storage: true
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+  uan:
+    can:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    cmn:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    chn:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: true
+      uai: true
+      cn: true
+    nmn:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: true
+    hmn:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    nmnlb:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    hmnlb:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+  uai:
+    can:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    cmn:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    chn:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: true
+      uai: true
+      cn: true
+    nmn:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: true
+    hmn:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    nmnlb:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    hmnlb:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+  cn:
+    can:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    cmn:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    chn:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: true
+      uai: true
+      cn: true
+    nmn:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    hmn:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    nmnlb:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false
+    hmnlb:
+      ncn_master: false
+      ncn_worker: false
+      ncn_storage: false
+      spine_switch: false
+      leaf_switch: false
+      leaf_BMC: false
+      CDU: false
+      uan: false
+      uai: false
+      cn: false

--- a/scripts/operations/pyscripts/pyscripts/commands/test_bican_internal/chn_toggle_tests.yaml
+++ b/scripts/operations/pyscripts/pyscripts/commands/test_bican_internal/chn_toggle_tests.yaml
@@ -1,3 +1,26 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 tests:
   ncn_master:
     can:

--- a/scripts/operations/pyscripts/pyscripts/commands/test_bican_internal/test_bican_internal.py
+++ b/scripts/operations/pyscripts/pyscripts/commands/test_bican_internal/test_bican_internal.py
@@ -1,0 +1,207 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+from pyscripts.core.ssh.ssh_targets import SshTargets
+from pyscripts.core.ssh.ssh_connection import SshConnection
+from pyscripts.core import csm_api_utils
+import yaml
+import time
+import logging
+import sys
+import os
+
+
+TEST_PLAN = None
+SSH_TARGETS = None
+FROM_APPLICABLE_NODE_TYPES = ["ncn_master", "uan", "cn", "spine_switch"]
+TO_APPLICABLE_NODE_TYPES = ["ncn_master", "uan", "cn", "spine_switch"]
+APPLICABLE_NETWORK_TYPES = ["can", "chn", "cmn", "nmn", "hmn", "hmnlb", "nmnlb"]
+
+TOTAL_PASS = 0
+
+def start_test(from_types, to_types, networks):
+    global FROM_APPLICABLE_NODE_TYPES
+    global TO_APPLICABLE_NODE_TYPES
+    global APPLICABLE_NETWORK_TYPES
+
+    FROM_APPLICABLE_NODE_TYPES = from_types
+    TO_APPLICABLE_NODE_TYPES = to_types
+    APPLICABLE_NETWORK_TYPES = networks
+
+    load_test_plan()
+    execute_test_plan()
+
+
+def load_test_plan():
+    global TEST_PLAN
+    global SSH_TARGETS
+
+    if csm_api_utils.is_bican_chm():
+        print("BICAN:CHN detected.")
+        filename = "chn_toggle_tests.yaml"
+    else:
+        print("BICAN:CAN detected.")
+        filename = "can_toggle_tests.yaml"
+    
+    path = os.path.abspath(os.path.join(os.path.dirname(__file__), filename))
+    f = open(path, "r")
+    TEST_PLAN = yaml.safe_load(f.read())["tests"]
+
+    SSH_TARGETS = SshTargets()
+    SSH_TARGETS.refresh()
+
+def execute_test_plan():
+    for from_node_type in TEST_PLAN:
+        if from_node_type in FROM_APPLICABLE_NODE_TYPES:
+            collect_passwords_from_node_type(from_node_type, TEST_PLAN[from_node_type])
+
+    total_ran = 0
+    start_time = time.time()
+
+    for from_node_type in TEST_PLAN:
+        if from_node_type in FROM_APPLICABLE_NODE_TYPES:
+            total_ran += test_from_node_type(from_node_type, TEST_PLAN[from_node_type])
+
+    total_time = time.time() - start_time
+
+    print(f"\n\nRan {total_ran} tests in {total_time:0.3f}s. Overall status: %s (Passed: {TOTAL_PASS}, Failed: {total_ran - TOTAL_PASS})" % ("PASSED" if TOTAL_PASS == total_ran else "FAILED"))
+
+def collect_passwords_from_node_type(from_node_type, config):
+    for network in config:
+        if network in APPLICABLE_NETWORK_TYPES:
+            collect_passwords_from_node_type_over_network(from_node_type, network, config[network])
+
+def test_from_node_type(from_node_type, config):
+    total_ran = 0
+    for network in config:
+        if network in APPLICABLE_NETWORK_TYPES:
+            total_ran += test_from_node_type_over_network(from_node_type, network, config[network])
+
+    return total_ran
+
+def collect_passwords_from_node_type_over_network(from_node_type, network, config):
+    for to_node_type in config:
+        if to_node_type in TO_APPLICABLE_NODE_TYPES:
+            from_node = get_ssh_host_for_node_type(from_node_type, ["ncn-m001"])
+
+            if not from_node:
+                continue
+
+            from_node.get_password() # this will ask for the password and cache it
+
+            collect_passwords_from_node_type_to_node_type_over_network(from_node_type, from_node, to_node_type, network)
+
+def test_from_node_type_over_network(from_node_type, network, config):
+    total_ran = 0
+    network_suffix = "{}.{}".format(network, csm_api_utils.get_system_domain())
+
+    for to_node_type in config:
+        if to_node_type in TO_APPLICABLE_NODE_TYPES:
+            from_node = get_ssh_host_for_node_type(from_node_type, ["ncn-m001"])
+
+            if not from_node:
+                print("""\nTesting SSH access:
+        From node type {}
+        Over network {}""".format(
+                    from_node_type, network_suffix))
+
+                print("\t\t^^^^ FAILED: Cannot find a suitable node for node type {} ^^^^".format(from_node_type))
+                continue
+
+            from_node = from_node.with_domain_suffix(None)
+
+            if from_node_type == "spine_switch" or from_node_type == "leaf_switch" or from_node_type == "leaf_BMC" or from_node_type == "CDU":
+                from_node.vrf = "Customer"
+                from_node.use_extra_params = False
+
+            fromNodeSshConnection = SshConnection(from_node)
+
+            total_ran += test_from_node_type_to_node_type_over_network(from_node_type, from_node, fromNodeSshConnection, to_node_type, network, config[to_node_type])
+
+    return total_ran
+
+def collect_passwords_from_node_type_to_node_type_over_network(from_node_type, from_node, to_node_type, network):
+    to_node = get_ssh_host_for_node_type(to_node_type, ["ncn-m001", from_node.hostname])
+
+    if to_node:
+        to_node.get_password()
+
+def test_from_node_type_to_node_type_over_network(from_node_type, from_node, fromNodeSshConnection, to_node_type, network, expected):
+    global TOTAL_PASS
+
+    network_suffix = "{}.{}".format(network, csm_api_utils.get_system_domain())
+
+    to_node = get_ssh_host_for_node_type(to_node_type, ["ncn-m001", from_node.hostname])
+
+    if not to_node:
+        print("""\nTesting SSH access:
+        From node type {}, using {}
+        Over network {}
+        To node type {}
+        Expected to work: {}""".format(
+            from_node_type, from_node.get_full_domain_name(), network_suffix, to_node_type, expected))
+
+        print("\t\t^^^^ FAILED: Cannot find a suitable node for node type {} ^^^^".format(to_node_type))
+        return 0
+
+    to_node = to_node.with_domain_suffix(network_suffix)
+
+    print("""\nTesting SSH access:
+        From node type {}, using {}
+        Over network {}
+        To node type {}, using {}
+        Expected to work: {}""".format(
+        from_node_type, from_node.get_full_domain_name(), network_suffix, to_node_type, to_node.get_full_domain_name(), expected))
+
+    try:
+        toNodeSshConnection = SshConnection(to_node, fromNodeSshConnection)
+        toNodeSshConnection.connect()
+
+        if "switch" in to_node.type:
+            toNodeSshConnection.run_test_command("show hostname", to_node.hostname)
+        else:
+            toNodeSshConnection.run_test_command("echo hello", "hello")
+
+        if expected:
+            print("""\t\t^^^^ PASSED ^^^^""")
+            TOTAL_PASS += 1
+        else:
+            print(f"\t\t^^^^ FAILED: accessible but SHOULD NOT have been accessible ^^^^")
+    except Exception as err:
+        if not expected:
+            print("""\t\t^^^^ PASSED ^^^^""")
+            TOTAL_PASS += 1
+        else:
+            print("\t\t^^^^ FAILED: not accessible but SHOULD have been accessible ^^^^\n")
+            print("{}".format(str(err)))
+    finally:
+        toNodeSshConnection.close_connection(False)
+
+    return 1
+
+def get_ssh_host_for_node_type(node_type, excluded_hostnames):
+    target_list = SSH_TARGETS.__dict__[node_type]
+    for i in target_list:
+        if not i.hostname in excluded_hostnames and i.is_ready():
+            return i

--- a/scripts/operations/pyscripts/pyscripts/core/__init__.py
+++ b/scripts/operations/pyscripts/pyscripts/core/__init__.py
@@ -1,0 +1,23 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#

--- a/scripts/operations/pyscripts/pyscripts/core/csm_api_utils.py
+++ b/scripts/operations/pyscripts/pyscripts/core/csm_api_utils.py
@@ -1,0 +1,234 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+"""
+Utilities to help retrieve system domain, K8s admin secret, Keycloak access tokens, and API urls, etc.
+"""
+
+import logging
+import base64
+import os
+import requests
+import urllib3
+from pexpect import run
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+class CsmApiError(Exception):
+    """
+    Anything related with fetching
+    """
+
+try:
+  from kubernetes import client, config
+except:
+  client = None
+  config = None
+
+SYSTEM_NAME = None
+SITE_DOMAIN = None
+SYSTEM_DOMAIN = None
+ADMIN_SECRET = None
+ACCESS_TOKEN = None
+API_GATEWAY_BASE_DOMAIN = None
+
+def get_system_domain():
+    """
+    Gets the system domain. Assumes this code is run on a machine with craysys installed or that set_system_domain is called
+    """
+
+    global SYSTEM_NAME
+    global SITE_DOMAIN
+    global SYSTEM_DOMAIN
+
+    if SYSTEM_DOMAIN:
+        return SYSTEM_DOMAIN
+
+    if not SYSTEM_NAME:
+        __calculate_system_name()
+
+    if not SITE_DOMAIN:
+        __calculate_site_domain()
+
+    SYSTEM_DOMAIN = "{}.{}".format(SYSTEM_NAME, SITE_DOMAIN)
+
+    return SYSTEM_DOMAIN
+
+def set_system_domain(system_domain):
+    """
+    Sets the system domain.
+    """
+
+    global SYSTEM_DOMAIN
+    SYSTEM_DOMAIN = system_domain
+
+def get_api_gateway_uri():
+    """
+    Gets the API Gateway base URI
+    """
+    return "https://{}.{}/apis".format("api", __get_api_gateway_base_domain())
+
+def get_auth_gateway_uri():
+    """
+    Gets the Auth gateway base URI
+    """
+    return "https://{}.{}/keycloak".format("auth", __get_api_gateway_base_domain())
+
+def get_admin_secret(force_refresh = False):
+    """
+    Get the admin secret from k8s for the api gateway - command line equivalent is:
+    #`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d`
+    """
+
+    global ADMIN_SECRET
+
+    if ADMIN_SECRET and not force_refresh:
+        return ADMIN_SECRET
+
+    try:
+        config.load_kube_config()
+        k8sClientApi = client.CoreV1Api()
+        sec = k8sClientApi.read_namespaced_secret("admin-client-auth", "default").data
+        ADMIN_SECRET = base64.b64decode(sec["client-secret"])
+        return ADMIN_SECRET
+    except Exception as err:
+        print(f"An unanticipated exception occurred while retrieving k8s secrets {err}")
+        logging.error(f"An unanticipated exception occurred while retrieving k8s secrets {err}")
+        raise CsmApiError from None
+
+def set_admin_secret(admin_secret):
+    """
+    Sets the admin secret for k8s.
+    """
+
+    global ADMIN_SECRET
+    ADMIN_SECRET = admin_secret
+
+def get_access_token(force_refresh = False):
+    """
+    Gets the API access token to access any Keycloak-protected API.
+    """
+
+    global ACCESS_TOKEN
+
+    if ACCESS_TOKEN and not force_refresh:
+        return ACCESS_TOKEN
+
+    # get an access token from keycloak
+    payload = {"grant_type":"client_credentials",
+            "client_id":"admin-client",
+            "client_secret": get_admin_secret()}
+
+    url = "{}/realms/shasta/protocol/openid-connect/token".format(get_auth_gateway_uri())
+
+    try:
+        r = requests.post(url, data = payload, verify = False)
+    except Exception as err:
+        print(f"An unanticipated exception occurred while retrieving gateway token {err}")
+        logging.error(f"An unanticipated exception occurred while retrieving gateway token {err}")
+        raise CsmApiError from None
+
+    # if the token was not provided, log the problem
+    if r.status_code != 200:
+        print(f"Error retrieving gateway token: keycloak return code: {r.status_code}"
+            f" text: {r.text}")
+        logging.error(f"Error retrieving gateway token: keycloak return code: {r.status_code}"
+            f" text: {r.text}")
+        raise CsmApiError from None
+
+    # pull the access token from the return data
+    ACCESS_TOKEN = r.json()['access_token']
+
+    return ACCESS_TOKEN
+
+def is_bican_chm():
+    headers = {
+        'Authorization': "Bearer " + get_access_token()
+    }
+
+    sls_networks_url = "{}/sls/v1/networks".format(get_api_gateway_uri())
+
+    try:
+        r = requests.request("GET", sls_networks_url, headers = headers, verify = False)
+    except Exception as err:
+        logging.error(f"An unanticipated exception occurred while retrieving SLS Networks {err}")
+        raise CsmApiError from None
+
+    if r.status_code != 200:
+        logging.error("Got HTTP {} when accessing {}".format(r.status_code, sls_networks_url))
+        raise CsmApiError from None
+
+    networks = r.json()
+
+    for network in networks:
+        if network["Name"] == "BICAN":
+            if network["ExtraProperties"]["SystemDefaultRoute"] == "CHN":
+                return True
+            else:
+                return False
+    
+    return False
+
+def __get_api_gateway_base_domain():
+    """
+    Gets the reachable and resolvable base API Gateway domain
+    """
+    global API_GATEWAY_BASE_DOMAIN
+
+    if API_GATEWAY_BASE_DOMAIN:
+        return API_GATEWAY_BASE_DOMAIN
+
+    system_domain = get_system_domain()
+
+    networks = ["cmn", "can", "chn", "nmnlb"]
+    for network in networks:
+        API_GATEWAY_BASE_DOMAIN = "{}.{}".format(network, system_domain)
+        test_domain = "{}.{}".format("auth", API_GATEWAY_BASE_DOMAIN)
+
+        if __resolvable(test_domain) or __reachable(test_domain):
+            return API_GATEWAY_BASE_DOMAIN
+
+    raise CsmApiError
+
+def __resolvable(service):
+    ret = os.system("nslookup {} >/dev/null".format(service))
+    if ret != 0:
+        return False
+    else:
+        return True
+
+def __reachable(service):
+    ret = os.system("ping -q -c 3 {} >/dev/null".format(service))
+    if ret != 0:
+        return False
+    else:
+        return True
+
+def __calculate_system_name():
+    global SYSTEM_NAME
+    SYSTEM_NAME = run("craysys metadata get system-name").decode()[:-2] # output ends with \r\n
+
+def __calculate_site_domain():
+    global SITE_DOMAIN
+    SITE_DOMAIN = run("craysys metadata get site-domain").decode()[:-2] # output ends with \r\n

--- a/scripts/operations/pyscripts/pyscripts/core/log_config.py
+++ b/scripts/operations/pyscripts/pyscripts/core/log_config.py
@@ -1,0 +1,41 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+import logging
+import sys
+
+__LOG_LEVEL = logging.ERROR
+
+def get_logging_level():
+    return __LOG_LEVEL
+
+def set_logging_level(verbose):
+    global __LOG_LEVEL
+    if (verbose):
+        __LOG_LEVEL = logging.INFO
+    else:
+        __LOG_LEVEL = logging.ERROR
+
+    logging.basicConfig(filename='/tmp/' + sys.argv[0].split('/')[-1] + '.log',  level=__LOG_LEVEL)
+    logging.getLogger().addHandler(logging.StreamHandler(sys.stdout))

--- a/scripts/operations/pyscripts/pyscripts/core/ssh/__init__.py
+++ b/scripts/operations/pyscripts/pyscripts/core/ssh/__init__.py
@@ -1,0 +1,23 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#

--- a/scripts/operations/pyscripts/pyscripts/core/ssh/ssh_connection.py
+++ b/scripts/operations/pyscripts/pyscripts/core/ssh/ssh_connection.py
@@ -1,0 +1,236 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+import json
+import sys
+import logging
+import requests
+import yaml
+import base64
+import subprocess
+import os.path
+import subprocess
+import pexpect
+from pyscripts.core.ssh.ssh_host import SshHost
+from pyscripts.core.log_config import get_logging_level
+import time
+import re
+
+try:
+    raw_input
+except NameError:
+    raw_input = input
+
+PASSWORD_PROMPT = r"((.|\n)*)password\:"
+COMMAND_PROMPT_ONE_LINE = r"((.|\n)*)\:\~ \#"
+SSH_NEWKEY = r"(?i)are you sure you want to continue connecting"
+UNRESOLVED_HOSTNAME = r"((.|\n)*)Could not resolve hostname((.|\n)*)"
+
+DEFAULT_TIMEOUT = 5
+
+class TimeoutException(Exception):
+    """
+    Timed out while trying to SSH into host.
+    """
+
+class SshConnectionException(Exception):
+    """
+    An unexpected SSH connection error occurred.
+    """
+
+class CannotLoginException(Exception):
+    """
+    Cannot login.
+    """
+
+class UnresolvedHostname(Exception):
+    """
+    Could not resolve the hostname.
+    """
+
+class UnexpectedRunCommandOutput(Exception):
+    """
+    Output of run command did not match what was expected.
+    """
+
+
+class SshConnection:
+    def __init__(self, ssh_host, ssh_conn = None):
+        self.ssh_host = ssh_host
+        self.ssh_conn = ssh_conn
+        self.child_process = None if not ssh_conn else ssh_conn.child_process
+        self.connected = False
+        self.command_prompt_host_pattern = ssh_host.get_target_hostname_command_prompt()
+
+    def connect(self):
+        if self.connected:
+            return # return silently because we are already connected
+
+        if not self.ssh_conn:
+            self.child_process = pexpect.spawn("ssh -o LogLevel=error -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null %s@%s" %
+                (self.ssh_host.username, self.ssh_host.get_full_domain_name()), encoding="utf-8")
+
+            if get_logging_level() == logging.INFO:
+                self.child_process.logfile = sys.stdout
+        else:
+            if not self.ssh_conn.connected:
+                # the base ssh connection hasn't connected yet
+                self.ssh_conn.connect()
+                self.child_process = self.ssh_conn.child_process
+
+            vrf = ""
+            extra_params = "  -o LogLevel=error -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+            hostname = self.ssh_host.get_full_domain_name()
+
+            if self.ssh_conn.ssh_host.vrf:
+                # add " vrf Customer" at the end of the SSH connection if the underlying connection requires it.
+                vrf = " vrf {}".format(self.ssh_conn.ssh_host.vrf)
+
+            if not self.ssh_conn.ssh_host.use_extra_params:
+                # Enable extra parameters if we are allowed to
+                extra_params = ""
+
+            # normalize the hostname if necessary
+            hostname = self.ssh_conn.ssh_host.get_target_hostname(self.ssh_host)
+
+            self.child_process.sendline("ssh%s %s@%s%s" %
+                (extra_params, self.ssh_host.username, hostname, vrf))
+
+        self.__open_connection_dance()
+
+    def close_connection(self, recursive = True):
+        """
+        Closes the connection. If recursive, then will close the original ssh_conn as well.
+        """
+
+        self.__close_connection_dance()
+        if recursive and self.ssh_conn:
+            self.ssh_conn.close_connection()
+
+    def run_test_command(self, command_to_run, expected):
+        self.__check_connected()
+        logging.info("Running command '{}' and expecting {} on {}".format(command_to_run, expected, self.ssh_host.get_full_domain_name()))
+        self.child_process.sendline(command_to_run)
+        i = self.__expect([r"{}((.|\n)*){}{}".format(re.escape(command_to_run), re.escape(expected), self.command_prompt_host_pattern), pexpect.TIMEOUT], timeout=DEFAULT_TIMEOUT)
+
+        if i != 0:
+            logging.error("Unexpected run_test_command output. See above for actual and expected outputs.")
+            raise UnexpectedRunCommandOutput
+
+    def __check_child_process(self):
+        if not self.child_process:
+            logging.error("No SSH child process has been spawned off yet.")
+            raise SshConnectionException
+
+    def __check_connected(self):
+        self.__check_child_process()
+        if not self.connected:
+            logging.error("Not connected yet.")
+            raise SshConnectionException
+
+    def __expect(self, regex_list, timeout=DEFAULT_TIMEOUT):
+        """
+        Ironically, pexpect.spawn.expect method is a really slow implementation. Most likely it is in O(m*n^2) as it matches
+        every item in the pattern list to each input character as it comes in. Sadly, using maxread and searchwindowsize has
+        no effect. As such, I have written an expect below that reads as much data as possible first and then just does a O(nm) search.
+        """
+
+        output = ""
+        try:
+            while True:
+                output += self.child_process.read_nonblocking(size=10240, timeout = timeout)
+        except Exception as err:
+            pass
+
+        logging.info("Expecting the following '{}' and actual '{}'".format(regex_list, output))
+
+        if output == "Timeout exceeded.":
+            # if all there is in output is timeout exceeded, then it is truly timeout exceeded
+            for i in range(len(regex_list)):
+                if regex_list[i] == pexpect.TIMEOUT:
+                    return i
+
+            raise TimeoutException
+
+        output = output.replace("Timeout exceeded.", "")
+
+        for i in range(len(regex_list)):
+            if regex_list[i] != pexpect.TIMEOUT and regex_list[i] != pexpect.EOF and re.match(regex_list[i], output, re.IGNORECASE):
+                return i
+
+    def __open_connection_dance(self):
+        self.__check_child_process()
+
+        logging.info("Connecting to {}".format(self.ssh_host.get_full_domain_name()))
+
+        pattern_list = [PASSWORD_PROMPT, pexpect.TIMEOUT, SSH_NEWKEY, UNRESOLVED_HOSTNAME, self.command_prompt_host_pattern]
+        if self.ssh_conn:
+            pattern_list.append(self.ssh_conn.command_prompt_host_pattern)
+
+        i = self.__expect(pattern_list)
+
+        if i == 4:
+            logging.info("Connected to {}".format(self.ssh_host.get_full_domain_name()))
+            self.connected = True
+            return
+        elif i == 3:
+            raise UnresolvedHostname
+        elif i == 2:
+            self.child_process.sendline("yes")
+            i = self.__expect([PASSWORD_PROMPT, pexpect.TIMEOUT], timeout=DEFAULT_TIMEOUT)
+            # fall through below...
+
+        # fall through code...
+        if i == 1:
+            raise TimeoutException
+
+        num_tries = 0
+        while i == 0 and num_tries < 3:
+            num_tries += 1
+            password = self.ssh_host.get_password(False if num_tries == 1 else True)
+            self.child_process.sendline(password)
+            i = self.__expect([PASSWORD_PROMPT, self.command_prompt_host_pattern, pexpect.TIMEOUT], timeout=DEFAULT_TIMEOUT)
+
+            if i == 1:
+                self.connected = True
+                return
+
+        logging.error("Could not login to {}.".format(self.ssh_host.get_full_domain_name()))
+        raise CannotLoginException
+
+    def __close_connection_dance(self):
+        # don't use self.__check_connected() or self.__check_child_process because this function is noop
+        # if there is no connection established
+        if self.connected and self.child_process:
+            logging.info("Exiting from {}".format(self.ssh_host.get_full_domain_name()))
+            self.child_process.sendline("exit")
+
+            if (self.ssh_conn):
+                self.__expect([pexpect.EOF, COMMAND_PROMPT_ONE_LINE, pexpect.TIMEOUT])
+            else:
+                self.__expect([pexpect.EOF, pexpect.TIMEOUT])
+                try:
+                    self.child_process.close(force=True)
+                except Exception as err:
+                    pass

--- a/scripts/operations/pyscripts/pyscripts/core/ssh/ssh_host.py
+++ b/scripts/operations/pyscripts/pyscripts/core/ssh/ssh_host.py
@@ -1,0 +1,139 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+import getpass
+import socket
+import re
+
+class SshHost:
+    """
+    Maintains details about an SSH Host.
+    """
+
+    def __init__(self, hostname, username, rawdata = None, domain_suffix = None):
+        if rawdata:
+            self.parent = rawdata["Parent"]
+            self.xname = rawdata["Xname"]
+            self.type = rawdata["Type"]
+            self.clazz = rawdata["Class"]
+            self.type_string = rawdata["TypeString"]
+            self.last_updated = rawdata["LastUpdated"]
+            self.last_updated_time = rawdata["LastUpdatedTime"]
+            self.rawdata = rawdata;
+
+        self.hostname = hostname
+        self.username = username
+        self.password = None
+        self.state = None
+        self.no_password_needed = False
+        self.domain_suffix = domain_suffix
+        self.original_host = None
+        self.vrf = None # whether to add a vrf suffix to commands executed on this host
+        self.use_extra_params = True # whether to connect to this host using parameters such as '-o LogLevel=error -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+
+    def get_password(self, reset_cached = False):
+        password = self.password
+        no_password_needed = self.no_password_needed
+        if self.original_host:
+            password = self.original_host.password
+            no_password_needed = self.original_host.no_password_needed
+
+        if reset_cached or (not password and not no_password_needed):
+            password = getpass.getpass('%s password (leave blank and hit Enter if not using password): ' % self.hostname)
+
+            if self.original_host:
+                self.original_host.password = password
+
+                if not password:
+                    self.original_host.no_password_needed = True
+            else:
+                self.password = password
+
+                if not password:
+                    self.no_password_needed = True
+
+        return password
+
+    def with_domain_suffix(self, domain_suffix):
+        newHost = SshHost(self.hostname, self.username, self.rawdata, domain_suffix)
+        newHost.original_host = self if not self.original_host else self.original_host
+        newHost.vrf = self.vrf
+        newHost.use_extra_params = self.use_extra_params
+        return newHost
+
+    def get_state(self):
+        if self.original_host:
+            return self.original_host.state
+        else:
+            return self.state
+
+    def set_state(self, state):
+        if self.original_host:
+            self.original_host.state = state
+        else:
+            self.state = state
+
+    def is_ready(self):
+        state = self.get_state()
+        return state == "Configured" or state == "Ready" or state == None # if None, state is unknown, so we'll assume it is ready
+
+    def get_full_domain_name(self):
+        if self.domain_suffix:
+            return "{}.{}".format(self.hostname, self.domain_suffix)
+        else:
+            return self.hostname
+
+    def get_target_hostname(self, target_ssh_host):
+        """
+        Normalizes the hostname of a target host to connect to by:
+
+        1. if using nmnlb or hmnlb, then always goes to api.nmnlb.<system-domain> and api.hmnlb.<system-domain> respectively.
+
+        2. When using vrf (i.e., this host is a switch) and going to cmn network, uses the IP instead.
+
+        (2) is a workaround that substitutes the IP of the target host instead of the hostname to connect.
+        It is so we can get around the bug https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1600
+
+        Once that bug is resolved, either this entire method and the logic to use this method in ssh_connection should be removed,
+        or everything except the last line in this method that returns target_ssh_host.hostname should be removed.
+        """
+        if self.vrf and "cmn." in target_ssh_host.domain_suffix and "switch" in target_ssh_host.type:
+            return socket.gethostbyname(target_ssh_host.get_full_domain_name())
+        elif "hmnlb." in target_ssh_host.domain_suffix:
+            return "hmcollector.{}".format(target_ssh_host.domain_suffix)
+        elif "nmnlb." in target_ssh_host.domain_suffix:
+            return "api.{}".format(target_ssh_host.domain_suffix)
+        else:
+            return target_ssh_host.get_full_domain_name()
+
+    def get_target_hostname_command_prompt(self):
+        """
+        Gets the string that is expected when successfully logged into the target host.
+        """
+        if self.domain_suffix and ("nmnlb." in self.domain_suffix or "hmnlb." in self.domain_suffix):
+            # nmnlb and hmnlb only refer to api gateways so we always get redirected to an ncn, although, we don't know which
+            # deterministically at compile time (maybe lb is doing round-robin or some other type of load balancing)
+            return r"((.|\n)*)(({})|({}))((.|\n)*)".format(re.escape("ncn-"), re.escape("ncn-"))
+        else:
+            return r"((.|\n)*)(({}\:)|({}\#))((.|\n)*)".format(re.escape(self.hostname), re.escape(self.hostname))

--- a/scripts/operations/pyscripts/pyscripts/core/ssh/ssh_targets.py
+++ b/scripts/operations/pyscripts/pyscripts/core/ssh/ssh_targets.py
@@ -1,0 +1,175 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+from pyscripts.core.csm_api_utils import get_api_gateway_uri, get_access_token, CsmApiError
+from pyscripts.core.ssh.ssh_host import SshHost
+import requests
+import urllib3
+import json
+import sys
+import logging
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+class SshTargets:
+    """
+    Maintains categorized lists of hardware that we can SSH into. Populated with SLS dumpstate.
+
+    Each item in an array is an SshHost that can be used with SshConnection.
+    """
+
+    def __init__(self):
+        self.ncn_master = []
+        self.ncn_worker = []
+        self.ncn_storage = []
+        self.cn = []
+        self.uan = []
+        self.uai = []
+        self.spine_switch = []
+        self.leaf_switch = []
+        self.leaf_BMC = []
+        self.CDU = []
+        self.byHostname = {}
+        self.byXname = {}
+
+    def refresh(self):
+        """
+        Refreshes the hardware state in memory
+        """
+
+        # first sync using the dumpstate API from SLS
+        self.__sync_sls_dump_state()
+
+        # now match up the actual state
+        self.__sync_hsm_state_component_list()
+
+    def __sync_hsm_state_component_list(self):
+        headers = {
+            'Authorization': "Bearer " + get_access_token()
+        }
+
+        hsm_state_list_url = "{}/smd/hsm/v2/State/Components".format(get_api_gateway_uri())
+
+        try:
+            r = requests.request("GET", hsm_state_list_url, headers = headers, verify = False)
+        except Exception as err:
+            logging.error(f"An unanticipated exception occurred while retrieving HSM State Components {err}")
+            raise CsmApiError from None
+
+        if r.status_code != 200:
+            logging.error("Got HTTP {} when accessing {}".format(r.status_code, hsm_state_list_url))
+            raise CsmApiError from None
+
+        data = r.json()["Components"]
+
+        for i in range(len(data)):
+            hsm_state = data[i]
+            xname = hsm_state["ID"]
+
+            if xname in self.byXname:
+                host = self.byXname[xname]
+                host.set_state(hsm_state["State"])
+
+    def __sync_sls_dump_state(self):
+        headers = {
+            'Authorization': "Bearer " + get_access_token()
+        }
+
+        dumpstate_url = "{}/sls/v1/dumpstate".format(get_api_gateway_uri())
+
+        try:
+            r = requests.request("GET", dumpstate_url, headers = headers, verify = False)
+        except Exception as err:
+            logging.error(f"An unanticipated exception occurred while dumping SLS hardware state {err}")
+            raise CsmApiError from None
+
+        if r.status_code != 200:
+            logging.error("Got HTTP {} when accessing {}".format(r.status_code, dumpstate_url))
+            raise CsmApiError from None
+
+        data = r.json()["Hardware"]
+
+        self.ncn_master = []
+        self.ncn_worker = []
+        self.ncn_storage = []
+        self.cn = []
+        self.uan = []
+        self.uai = []
+        self.spine_switch = []
+        self.leaf_switch = []
+        self.leaf_BMC = []
+        self.CDU = []
+        self.byHostname = {}
+        self.byXname = {}
+
+        with open('data.json', 'w', encoding='utf-8') as f:
+            json.dump(data, f, ensure_ascii=False, indent=4)
+
+        for xname in data:
+            x = data[xname]
+            if x["Type"] == "comptype_node" and x["ExtraProperties"]["Role"] == "Compute":
+                host = SshHost(x["ExtraProperties"]["Aliases"][0], "root", x)
+                self.cn.append(host)
+                self.byHostname[host.hostname] = host
+                self.byXname[xname] = host
+            elif x["Type"] == "comptype_node" and x["ExtraProperties"]["Role"] == "Management" and x["ExtraProperties"]["SubRole"] == "Master":
+                host = SshHost(x["ExtraProperties"]["Aliases"][0], "root", x)
+                self.ncn_master.append(host)
+                self.byHostname[host.hostname] = host
+                self.byXname[xname] = host
+            elif x["Type"] == "comptype_node" and x["ExtraProperties"]["Role"] == "Management" and x["ExtraProperties"]["SubRole"] == "Storage":
+                host = SshHost(x["ExtraProperties"]["Aliases"][0], "root", x)
+                self.ncn_storage.append(host)
+                self.byHostname[host.hostname] = host
+                self.byXname[xname] = host
+            elif x["Type"] == "comptype_node" and x["ExtraProperties"]["Role"] == "Management" and x["ExtraProperties"]["SubRole"] == "Worker":
+                host = SshHost(x["ExtraProperties"]["Aliases"][0], "root", x)
+                self.ncn_worker.append(host)
+                self.byHostname[host.hostname] = host
+                self.byXname[xname] = host
+            elif x["Type"] == "comptype_node" and x["ExtraProperties"]["Role"] == "Application" and x["ExtraProperties"]["SubRole"] == "UAN":
+                host = SshHost(x["ExtraProperties"]["Aliases"][0], "root", x)
+                self.uan.append(host)
+                self.byHostname[host.hostname] = host
+                self.byXname[xname] = host
+            elif x["Type"] == "comptype_hl_switch" and len(x["ExtraProperties"]["Aliases"]) > 0 and "leaf" in x["ExtraProperties"]["Aliases"][0]:
+                host = SshHost(x["ExtraProperties"]["Aliases"][0], "admin", x)
+                self.leaf_switch.append(host)
+                self.byHostname[host.hostname] = host
+                self.byXname[xname] = host
+            elif x["Type"] == "comptype_hl_switch" and len(x["ExtraProperties"]["Aliases"]) > 0 and "spine" in x["ExtraProperties"]["Aliases"][0]:
+                host = SshHost(x["ExtraProperties"]["Aliases"][0], "admin", x)
+                self.spine_switch.append(host)
+                self.byHostname[host.hostname] = host
+                self.byXname[xname] = host
+            elif x["Type"] == "comptype_mgmt_switch" and len(x["ExtraProperties"]["Aliases"]) > 0 and "leaf-bmc" in x["ExtraProperties"]["Aliases"][0]:
+                host = SshHost(x["ExtraProperties"]["Aliases"][0], "admin", x)
+                self.leaf_BMC.append(host)
+                self.byHostname[host.hostname] = host
+                self.byXname[xname] = host
+            elif x["Type"] == "comptype_cdu_mgmt_switch":
+                host = SshHost(x["ExtraProperties"]["Aliases"][0], "admin", x)
+                self.CDU.append(host)
+                self.byHostname[host.hostname] = host
+                self.byXname[xname] = host

--- a/scripts/operations/pyscripts/setup.py
+++ b/scripts/operations/pyscripts/setup.py
@@ -1,0 +1,37 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+from setuptools import setup
+
+setup(
+    name="pyscripts",
+    version="1.0",
+    packages=["pyscripts", "pyscripts.commands"],
+    include_package_data=True,
+    install_requires=["click", "PyYAML", "requests", "pexpect"],
+    entry_points="""
+        [console_scripts]
+        complex=complex.cli:cli
+    """,
+)

--- a/scripts/operations/pyscripts/start.py
+++ b/scripts/operations/pyscripts/start.py
@@ -1,0 +1,28 @@
+#! /usr/bin/env python3
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+import pyscripts.core.log_config
+from pyscripts.cli import cli
+
+cli()


### PR DESCRIPTION
# Description

This introduces automated SSH access tests for the BiCAN test plan. Features:

1. Internal and external testing of SSH access
2. Automatically detects whether using CHN or CAN bican toggle.
3. Customizable tests: choose which node types to test from, which node types to test to, and over which networks
4. Automatically selects nodes by querying SLS API and checking the status of each node through the HSM API
5. Framework for scripting and testing commands on multi-layered SSH connections.
6. Provisions to add more automated tests and tasks in the future, using existing utilities for APIs and SSH access
7. Docs on how to run these tests

# Checklist Before Merging

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!---   checked checkbox: [x] -->
<!---   invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/MTL-1695/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
