### PR TITLE
CASMINST-4797: Preserve UAN IPs during upgrade

### DIFF
--- a/upgrade/1.2/scripts/sls/csm_1_2_upgrade/sls_updates.py
+++ b/upgrade/1.2/scripts/sls/csm_1_2_upgrade/sls_updates.py
@@ -449,10 +449,10 @@ def migrate_can_to_cmn(networks, preserve=None, overrides=None):
     destination_network_name = "CMN"
     destination_network_full_name = "Customer Management Network"
     subnet_names = [
-        "network_hardware",
         "bootstrap_dhcp",
         "metallb_address_pool",
         "metallb_static_pool",
+        "network_hardware",
     ]
     clone_subnet_and_pivot(
         networks,
@@ -553,10 +553,10 @@ def clone_subnet_and_pivot(
     #
     if subnet_names is None:
         subnet_names = [
-            "network_hardware",
             "bootstrap_dhcp",
             "metallb_address_pool",
             "metallb_static_pool",
+            "network_hardware",
         ]
     preserve_subnet = None
     if preserve == "external-dns":


### PR DESCRIPTION
# Description

To minimize UAN downtime during upgrade from CSM 1.0 to CSM 1.2, the IPv4 address of a UAN should be maintained while the CSM 1.0 CAN is converted to the CSM 1.2 CMN.  This is accomplished by prioritizing the`bootstrap_dhcp` subnet in the transition/migration from old CAN to new CMN.

* Relates to CASMTRIAGE-3402 and CASMUSER-3025 switch-related changes.
* Tested with Hela and Loki data.
* Tested with data from one large customer.

This is part of a larger strategy of minimizing the state changes on UANs and allowing the Customer to self-select the required outage timing.

# Checklist Before Merging

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/MTL-1695/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
