### PR TITLE
CASMTRIAGE-3505 - Upload customizations.yaml to Kubernetes after the new credentials have been encrypted

### DIFF
--- a/operations/configuration_management/Version_Control_Service_VCS.md
+++ b/operations/configuration_management/Version_Control_Service_VCS.md
@@ -123,25 +123,25 @@ To change the password in the `vcs-user-credentials` Kubernetes secret, use the 
                   value: crayvcs
     ```
 
+1. Encrypt the values after changing the `customizations.yaml` file.
+
+    ```bash
+    ncn# ./utils/secrets-seed-customizations.sh customizations.yaml
+    ```
+
+   If the above command complains that it cannot find `certs/sealed_secrets.crt`, then you can run the following commands to create it:
+
+    ```bash
+    ncn# mkdir -p ./certs &&
+         ./utils/bin/linux/kubeseal --controller-name sealed-secrets --fetch-cert > ./certs/sealed_secrets.crt
+    ```
+
 1. Upload the modified `customizations.yaml` file to Kubernetes.
 
    ```bash
    ncn# kubectl delete secret -n loftsman site-init
    ncn# kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
    ```
-
-1. Encrypt the values after changing the `customizations.yaml` file.
-
-    ```bash
-    ncn# ./secrets-seed-customizations.sh customizations.yaml
-    ```
-
-   If the above command complains that it cannot find `certs/sealed_secrets.crt`, then you can run the following commands to create it:
-
-    ```bash
-    ncn# mkdir -p ../certs &&
-         ./bin/linux/kubeseal --controller-name sealed-secrets --fetch-cert > ../certs/sealed_secrets.crt
-    ```
 
 1. Get the current cached `sysmgmt` manifest and save it into a `gitea.yaml` file.
 


### PR DESCRIPTION
# Description

The procedure to change the VCS password uploads `customizations.yaml` to the loftsman namespace site-init secret before the new credentials have been encrypted resulting in an error next time `manifestgen` is run.

* Changed ordering of steps in the procedure so encrypted credentials are uploaded
* Fixed errors identified with directory paths relative to working directory while testing new procedure.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/MTL-1695/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
