### PR TITLE
CASMINST-4809: Update anti affinity for opa/spire on upgrades

### DIFF
--- a/upgrade/1.2/scripts/k8s/remove_opa_req_affinity.sh
+++ b/upgrade/1.2/scripts/k8s/remove_opa_req_affinity.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+function remove_opa_req_affinity() {
+    deployment=$1
+    shift
+    namespace="${1:-opa}"
+
+    if kubectl get deployment -n "${namespace}" "${deployment}" >/dev/null 2>&1; then
+       kubectl patch deployment -n "${namespace}" "${deployment}" -p '{
+           "spec": {
+           "template": {
+               "spec": {
+                   "affinity": {
+                       "podAntiAffinity": {
+                           "requiredDuringSchedulingIgnoredDuringExecution": null
+                       }
+                   }
+               }
+           }
+       }}'
+
+       kubectl rollout status deployment -n "${namespace}" "${deployment}"
+    fi
+}
+
+# cray-opa is 1.0
+# cray-opa-* is 1.2+
+for deploy in cray-opa cray-opa-ingressgateway cray-opa-ingressgateway-customer-admin cray-opa-ingressgateway-user; do
+  remove_opa_req_affinity "${deploy}"
+done

--- a/upgrade/1.2/scripts/k8s/remove_spire_req_affinity.sh
+++ b/upgrade/1.2/scripts/k8s/remove_spire_req_affinity.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+function remove_spire_req_affinity() {
+    deployment=$1
+    shift
+    namespace="${1:-spire}"
+
+    if kubectl get deployment -n "${namespace}" "${deployment}" >/dev/null 2>&1; then
+       kubectl patch deployment -n "${namespace}" "${deployment}" -p '{
+           "spec": {
+           "template": {
+               "spec": {
+                   "affinity": {
+                       "podAntiAffinity": {
+                           "requiredDuringSchedulingIgnoredDuringExecution": null
+                       }
+                   }
+               }
+           }
+       }}'
+
+       kubectl rollout status deployment -n "${namespace}" "${deployment}"
+    fi
+}
+
+for deploy in spire-jwks spire-postgres-pooler; do
+  remove_spire_req_affinity "${deploy}"
+done

--- a/upgrade/1.2/scripts/upgrade/csm-upgrade.sh
+++ b/upgrade/1.2/scripts/upgrade/csm-upgrade.sh
@@ -101,6 +101,30 @@ else
     echo "====> ${state_name} has been completed"
 fi
 
+state_name="REMOVE_OPA_REQ_ANTI_AFFINITY"
+state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
+if [[ $state_recorded == "0" ]]; then
+    echo "====> ${state_name} ..."
+    {
+    /usr/share/doc/csm/upgrade/1.2/scripts/k8s/remove_opa_req_affinity.sh
+    } >> ${LOG_FILE} 2>&1
+    record_state ${state_name} "$(hostname)"
+else
+    echo "====> ${state_name} has been completed"
+fi
+
+state_name="REMOVE_SPIRE_REQ_ANTI_AFFINITY"
+state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
+if [[ $state_recorded == "0" ]]; then
+    echo "====> ${state_name} ..."
+    {
+    /usr/share/doc/csm/upgrade/1.2/scripts/k8s/remove_spire_req_affinity.sh
+    } >> ${LOG_FILE} 2>&1
+    record_state ${state_name} "$(hostname)"
+else
+    echo "====> ${state_name} has been completed"
+fi
+
 state_name="CSM_SERVICE_UPGRADE"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
 if [[ $state_recorded == "0" ]]; then


### PR DESCRIPTION
# Description

Like with istio, update opa and spire deployments on upgrades with required pod affinity to improve resiliency on upgrades.

Validated as much as I could on a 1.2 system but the true test will be during an upgrade from 1.0 or 1.2.

# Checklist Before Merging

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!---   checked checkbox: [x] -->
<!---   invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/MTL-1695/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
