### PR TITLE
Add stale labels to PRs and Issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,29 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '38 10 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v5
+      env:
+        expiration: 30
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        days-before-close: -1
+        days-before-stale: 30
+        stale-issue-message: 'This issue has not had activity in over ${expiration} days and is being marked as stale.'
+        stale-pr-message: 'This pull-request has not had activity in over ${expiration} days and is being marked as stale.'


### PR DESCRIPTION
Add stale labels to PRs and issues.

The stale label will help reviewers, or at least the docs-team, in identifying PRs that have been sitting for a while. Otherwise I've been doing this in my personal notes, I think having a GH label would make them easier to identify with the human eye.