### PR TITLE
CASMUSER-3024-main-Update_Raspberry_upgrade_docs_to_warn_admins_about_UAN_CAN_network_outage

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -223,7 +223,7 @@ highspeed
 HM
 HMN
 HMNLB
-HMN_MTN 
+HMN_MTN
 HMN_RVR
 honored
 hostname
@@ -621,4 +621,8 @@ Admin
 - operations/network/management_network/upgrade.md
 Preconfig
 preconfig
+
+- upgrade/1.2/Stage_0_Prerequisites.md
+# To differentiate between old CAN and new CAN
+pre-1
 

--- a/.spelling
+++ b/.spelling
@@ -622,7 +622,7 @@ Admin
 Preconfig
 preconfig
 
-- upgrade/1.2/Stage_0_Prerequisites.md
+- upgrade/1.2/plan_and_coordinate_network_upgrade.md
 # To differentiate between old CAN and new CAN
 pre-1
 

--- a/upgrade/1.2/README.md
+++ b/upgrade/1.2/README.md
@@ -7,7 +7,7 @@ file should be followed top to bottom, and the content on this top level page is
 [`resource_material` directory](resource_material/README.md)
 for additional reference material in support of the processes and scripts mentioned explicitly on this page.
 
-## Notes for three worker systems
+## Notes
 
 For systems with only three worker nodes (typically Testing and  Development Systems (TDS)), prior to proceeding with this upgrade, CPU limits **MUST** be lowered on several
 services in order for this upgrade to succeed. This step is

--- a/upgrade/1.2/README.md
+++ b/upgrade/1.2/README.md
@@ -11,7 +11,7 @@ for additional reference material in support of the processes and scripts mentio
 
 For systems with only three worker nodes (typically Testing and  Development Systems (TDS)), prior to proceeding with this upgrade, CPU limits **MUST** be lowered on several
 services in order for this upgrade to succeed. This step is
-executed automatically as part of [Stage 0.4](Stage_0_Prerequisites.md#prerequisites-check). See [TDS Lower CPU Requests](../../operations/kubernetes/TDS_Lower_CPU_Requests.md) for more
+executed automatically as part of [Stage 0.4](Stage_0_Prerequisites.md#stage-05---prerequisites-check). See [TDS Lower CPU Requests](../../operations/kubernetes/TDS_Lower_CPU_Requests.md) for more
 information.
 
 Independently, the `customizations.yaml` file will be edited automatically during upgrade for three worker systems prior to deploying new CSM services. See the file

--- a/upgrade/1.2/README.md
+++ b/upgrade/1.2/README.md
@@ -7,11 +7,11 @@ file should be followed top to bottom, and the content on this top level page is
 [`resource_material` directory](resource_material/README.md)
 for additional reference material in support of the processes and scripts mentioned explicitly on this page.
 
-## Notes
+## Notes for three worker systems
 
 For systems with only three worker nodes (typically Testing and  Development Systems (TDS)), prior to proceeding with this upgrade, CPU limits **MUST** be lowered on several
 services in order for this upgrade to succeed. This step is
-executed automatically as part of [Stage 0.4](Stage_0_Prerequisites.md#stage-05---prerequisites-check). See [TDS Lower CPU Requests](../../operations/kubernetes/TDS_Lower_CPU_Requests.md) for more
+executed automatically as part of [Stage 0.4](Stage_0_Prerequisites.md#stage-04---prerequisites-check). See [TDS Lower CPU Requests](../../operations/kubernetes/TDS_Lower_CPU_Requests.md) for more
 information.
 
 Independently, the `customizations.yaml` file will be edited automatically during upgrade for three worker systems prior to deploying new CSM services. See the file
@@ -20,6 +20,15 @@ are desired in the `customizations.yaml` file for this system.
 
 For more information about modifying `customizations.yaml` and tuning for specific systems, see
 [Post Install Customizations](../../operations/CSM_product_management/Post_Install_Customizations.md).
+
+## Plan and coordinate network upgrade
+
+Prior to CSM 1.2, the single Customer Access Network (CAN) carried both the administrative network traffic and the user network
+traffic. CSM 1.2 introduces bifurcated CAN (BICAN), which is designed to separate administrative network traffic and user network traffic.
+
+[Plan and coordinate network upgrade](plan_and_coordinate_network_upgrade.md) shows the steps that need to be taken in order to prepare
+for this network upgrade. Follow these steps in order to plan and coordinate the network upgrade with your users, as well as to ensure
+undisrupted access to UANs during the upgrade.
 
 ## Upgrade stages
 

--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -20,7 +20,7 @@ backup of Workload Manager configuration data and files is created. Once complet
 - [Stage 0.3 - Update SLS](#stage-03---update-sls)
 - [Stage 0.4 - Upgrade Management Network](#stage-04---upgrade-management-network)
 - [Stage 0.5 - Prerequisites check](#stage-05---prerequisites-check)
-- [Stage 0.6 - Backup Workload Manager Data](#stage-06---backup-workload-manager-data)
+- [Stage 0.6 - Backup workload manager data](#stage-06---backup-workload-manager-data)
 - [Stage completed](#stage-completed)
 
 ## Stage 0.1 - Prepare assets

--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -148,7 +148,7 @@ With BICAN, the pre-1.2 CAN network is split into two separate networks:
 ### UAN migration
 
 Steps are taken in order to minimize disruption to UANs during the CSM 1.2 upgrade process. Read these steps
-carefully and follow any recommendations and warnings to minimize disruptions to user activity.  Note that these steps apply
+carefully and follow any recommendations and warnings to minimize disruptions to user activity. Note that these steps apply
 to all types of application nodes and not just UANs -- the term "UAN" just happens to be more commonly used and understood when
 referring to user activity.
 

--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -134,7 +134,7 @@ With BICAN, the pre-1.2 CAN network is split into two separate networks:
 
 1. Customer Access Network (CAN) / Customer High-speed Network (CHN)
 
-   For user traffic only (e.g. users running and monitoring jobs), CSM 1.2 allows you to pick one of two networks:
+   For user traffic only (e.g. users running and monitoring jobs), CSM 1.2 allows a choice of one of two networks:
 
       - Customer Access Network (CAN) \[Recommended\]: this is a new network (VLAN6 in switches) that runs over the management network. This
          network must not be confused with pre-1.2 CAN, which was a monolithic network that allowed both user and administrative

--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -117,7 +117,7 @@ backup of Workload Manager configuration data and files is created. Once complet
 ### Abstract (Stage 0.2)
 
 Prior to CSM 1.2, the single Customer Access Network (CAN) carried both the administrative network traffic and the user network
-traffic. CSM 1.2 introduces bifurcated CAN (BICAN), which is designed to separate admin network traffic and user network traffic.
+traffic. CSM 1.2 introduces bifurcated CAN (BICAN), which is designed to separate administrative network traffic and user network traffic.
 With BICAN, the pre-1.2 CAN network is split into two separate networks:
 
 1. Customer Management Network (CMN)

--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -179,8 +179,8 @@ referring to user activity.
    As a system administrator, you must inform your users to avoid UAN reboots during the CSM 1.2 upgrade process.
 
    If, however, a UAN is rebooted, then you need to patch the file `roles/uan_interfaces/tasks/can-v2.yml` for your current
-   CSM release in the `vcs/cray/uan-config-management.git` repository and re-run the CFS Ansible play to bring back the
-   CMN (pre-1.2 CAN) interface back in UAN. Use the following patch file and follow the instructions in
+   CSM release in the `vcs/cray/uan-config-management.git` repository and reboot again to bring back the
+   CMN (pre-1.2 CAN) interface back in the UAN. Use the following patch file and follow the instructions in
    [Configuration Management](../../operations/README.md#configuration-management) to restore CMN access in your UAN:
 
    ```text
@@ -215,7 +215,7 @@ referring to user activity.
    +  when: item.FullName == "CMN Bootstrap DHCP Subnet"
    ```
 
-1. Once the CSM 1.2 upgrade is complete, you may reboot the UANs for the new network configuration changes to take effect.
+1. Once UAN has been upgraded to 2.4, you may reboot the UANs for the new network configuration changes to take effect.
    UANs will not receive an IP on the CMN network and instead will default their traffic through the new CAN/CHN. For concrete
    details on UAN transition plan for your users, please refer to
    [Minimize UAN Downtime](../../operations/network/management_network/bican_enable.md#minimize-uan-downtime)

--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -142,7 +142,7 @@ With BICAN, the pre-1.2 CAN network is split into two separate networks:
 
       - Customer High-speed Network (CHN) \[CSM 1.2 Tech Preview\]: this is a new network (VLAN5 in switches) that runs over the high-speed fabric.
 
-   You must only pick either the new CAN or CHN, but not both. Please note that CHN is a tech preview in CSM 1.2, and the new CAN is
+   Either the new CAN or CHN must be chosen, but not both. Note that the CHN is a technical preview in CSM 1.2, and the new CAN is
    the recommended upgrade. The rest of the installation guide will provide you with options for configuring either the new CAN or CHN.
 
 ### UAN migration

--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -19,7 +19,7 @@ backup of Workload Manager configuration data and files is created. Once complet
 - [Stage 0.2 - Plan and coordinate network upgrade](#stage-02---plan-and-coordinate-network-upgrade)
 - [Stage 0.3 - Update SLS](#stage-03---update-sls)
 - [Stage 0.4 - Upgrade Management Network](#stage-04---upgrade-management-network)
-- [Stage 0.5 - Prerequisites Check](#stage-05---prerequisites-check)
+- [Stage 0.5 - Prerequisites check](#stage-05---prerequisites-check)
 - [Stage 0.6 - Backup Workload Manager Data](#stage-06---backup-workload-manager-data)
 - [Stage completed](#stage-completed)
 

--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -143,7 +143,7 @@ With BICAN, the pre-1.2 CAN network is split into two separate networks:
       - Customer High-speed Network (CHN) \[CSM 1.2 Tech Preview\]: this is a new network (VLAN5 in switches) that runs over the high-speed fabric.
 
    Either the new CAN or CHN must be chosen, but not both. Note that the CHN is a technical preview in CSM 1.2, and the new CAN is
-   the recommended upgrade. The rest of the installation guide provides options for configuring either the new CAN or CHN.
+   the recommended upgrade. The rest of the upgrade guide provides options for configuring either the new CAN or CHN.
 
 ### UAN migration
 

--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -153,7 +153,7 @@ to all types of application nodes and not just UANs -- the term "UAN" just happe
 referring to user activity.
 
 1. During the upgrade, the switch `1.2 Preconfig` will not remove UAN ports from the CMN VLAN (the pre-1.2 CAN), allowing UANs
-   to retain their existing IPs during the CSM 1.2 upgrade process. Traffic to and from UANs will still flow through CMN, but
+   to retain their existing IP addresses during the CSM 1.2 upgrade process. Traffic to and from UANs will still flow through CMN, but
    may also flow through CAN/CHN networks if desired.
 
 1. CFS will be temporarily disabled for UANs, so that running CFS plays does not remove CMN interfaces from UANs. As mentioned

--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -112,171 +112,20 @@ backup of Workload Manager configuration data and files is created. Once complet
    /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version csm-${CSM_RELEASE} --tarball-file "${CSM_TAR_PATH}"
    ```
 
-## Stage 0.2 - Plan and coordinate network upgrade
+## Stage 0.2 - Update SLS
 
 ### Abstract (Stage 0.2)
 
-Prior to CSM 1.2, the single Customer Access Network (CAN) carried both the administrative network traffic and the user network
-traffic. CSM 1.2 introduces bifurcated CAN (BICAN), which is designed to separate administrative network traffic and user network traffic.
-With BICAN, the pre-1.2 CAN network is split into two separate networks:
-
-1. Customer Management Network (CMN)
-
-   This network allows only system administrative access from the customer site. The pre-1.2 CAN is renamed to CMN. By
-   the end of the CSM 1.2 upgrade, all non-administrative access, such as from UANs, will be removed from CMN.
-
-   During the CSM 1.2 upgrade, UANs will retain their pre-1.2 CAN IP addresses in order to minimize disruption to UANs. However,
-   toward the end of the CSM 1.2 upgrade, UANs will stop registering themselves on CMN and will receive new IP addresses on the
-   CAN/CHN network. This process is described in more detail in [UAN Migration](#uan-migration).
-
-   Pivoting the pre-1.2 CAN to the new CMN allows administrative traffic (already on the pre-1.2 CAN) to remain as-is while
-   moving standard user traffic to a new site-routable network (CAN / CHN).
-
-1. Customer Access Network (CAN) / Customer High-speed Network (CHN)
-
-   For user traffic only (e.g. users running and monitoring jobs), CSM 1.2 allows a choice of one of two networks:
-
-      - Customer Access Network (CAN) \[Recommended\]: this is a new network (VLAN6 in switches) that runs over the management network. This
-         network must not be confused with pre-1.2 CAN, which was a monolithic network that allowed both user and administrative
-         traffic, was configured as VLAN7 in switches, and is now renamed to CMN. The new CAN allows only user traffic.
-
-      - Customer High-speed Network (CHN) \[CSM 1.2 Tech Preview\]: this is a new network (VLAN5 in switches) that runs over the high-speed fabric.
-
-   Either the new CAN or CHN must be chosen, but not both. Note that the CHN is a technical preview in CSM 1.2, and the new CAN is
-   the recommended upgrade. The rest of the upgrade guide provides options for configuring either the new CAN or CHN.
-
-### UAN migration
-
-Steps are taken in order to minimize disruption to UANs during the CSM 1.2 upgrade process. Read these steps
-carefully and follow any recommendations and warnings to minimize disruptions to user activity. Note that these steps apply
-to all types of application nodes and not just UANs -- the term "UAN" just happens to be more commonly used and understood when
-referring to user activity.
-
-1. During the upgrade, the switch `1.2 Preconfig` will not remove UAN ports from the CMN VLAN (the pre-1.2 CAN), allowing UANs
-   to retain their existing IP addresses during the CSM 1.2 upgrade process. Traffic to and from UANs will still flow through CMN, but
-   may also flow through CAN/CHN networks, if desired.
-
-1. CFS will be temporarily disabled for UANs, in order to prevent CFS plays from removing CMN interfaces from UANs. As mentioned
-   in [Abstract (Stage 0.3)](#abstract-stage-03), network configuration is controlled by data in SLS. However, CFS plays also pick up
-   the same SLS data, which can lead to UANs being prematurely removed from the CMN and causing UAN outages. As such, CFS plays
-   need to be disabled for UANs.
-
-   To disable CFS plays for UANs, remove CFS assignment for UANs by running the following command:
-
-   ```bash
-   ncn-m001# for xname in $(cray hsm state components list --role Application --subrole UAN --type node --format json | jq -r .Components[].ID) ; do
-                 cray cfs components update --enabled false --desired-config "" --format json $xname
-             done
-   ```
-
-   > Note that the above command will disable CFS plays for UANs only. If wishing to disable CFS plays for all types of
-   > application nodes (recommended), then remove the `--subrole UAN` portion in the snippet above.
-
-1. UAN reboots must be avoided and are not a supported operation during the CSM 1.2 upgrade. Rebooting a UAN during a CSM 1.2
-   upgrade can re-enable CFS and ultimately lead to removing the CMN interface from UANs, disrupting UAN access for users.
-   System administrators must inform users to avoid UAN reboots during the CSM 1.2 upgrade process.
-
-   However, if a UAN is rebooted, then the `roles/uan_interfaces/tasks/can-v2.yml` file in the `vcs/cray/uan-config-management.git` repository
-   must be patched for the current CSM release. After that, the UAN must be rebooted again to bring the
-   CMN (pre-1.2 CAN) interface back in the UAN. Use the following patch file and follow the instructions in
-   [Configuration Management](../../operations/README.md#configuration-management) to restore CMN access in your UAN:
-
-   ```text
-   --- a/roles/uan_interfaces/tasks/can-v2.yml
-   +++ b/roles/uan_interfaces/tasks/can-v2.yml
-   @@ -33,21 +33,16 @@
-   - name: Get Customer Access Network info from SLS
-     local_action:
-     module: uri
-   -    url: "http://cray-sls/v1/search/networks?name={{ sls_can_name }}"
-   +    url: "http://cray-sls/v1/search/networks?name=CMN"
-        method: GET
-        register: sls_can
-   
-   -- name: Get Customer Access Network CIDR from SLS, if network exists.
-   -  # This assumes that the CAN network is _always_ the third item in the array. This makes the
-   -  # implementation fragile. See CASMCMS-6714.
-   -  set_fact:
-   -    customer_access_network: "{{ sls_can.json[0].ExtraProperties.Subnets[2].CIDR }}"
-   -  when: sls_can.status == 200
-   -
-   -- name: Get Customer Access Network Gateway from SLS, if network exists
-   -  set_fact:
-   -    customer_access_gateway: "{{ sls_can.json[0].ExtraProperties.Subnets[2].Gateway }}"
-   -  when: sls_can.status == 200
-   
-   +- name: "Get {{ uan_user_access_cfg | upper }} CIDR from SLS, if network exists."
-   +  set_fact:
-   +    customer_access_network: "{{ item.CIDR }}"
-   +    customer_access_gateway: "{{ item.Gateway }}"
-   +  loop: "{{ sls_can.json[0].ExtraProperties.Subnets }}"
-   +  when: item.FullName == "CMN Bootstrap DHCP Subnet"
-   ```
-
-1. Once UAN has been upgraded to 2.4, the UANs may be rebooted for the new network configuration changes to take effect.
-   UANs will not receive an IP address on the CMN network and instead will default their traffic through the new CAN/CHN. For concrete
-   details on UAN transition plan for users, see
-   [Minimize UAN Downtime](../../operations/network/management_network/bican_enable.md#minimize-uan-downtime).
-
-1. Note that in CSM 1.2, UAN ports will not be removed from the CMN VLAN7 in switches. In the next CSM release, switch
-   configuration will be updated to remove UAN ports from the CMN VLAN7. This enables non-rebooted UANs to continue to work
-   and allows for better easing into BICAN in CSM 1.2. For more details about this transition plan, see
-   [Minimize UAN Downtime](../../operations/network/management_network/bican_enable.md#minimize-uan-downtime).
-
-### UAI migration
-
-Access to UAIs will be disrupted until CSM 1.2 upgrade completes. After the upgrade is completed, UAIs need to be restarted.
-
-### Decide on subnet ranges for new CAN/CHN
-
-After deciding whether to use the new CAN or to use CHN for user access, the subnet range must be decided. Refer
-to [Customer Accessible Networks](../../operations/network/customer_accessible_networks/Customer_Accessible_Networks.md)
-for subnet ranges and defaults for CAN/CHN.
-
-### Preserving CMN subnet range
-
-**It is vital** that the subnet range is preserved for the pre-1.2 CAN that is now being renamed to CMN. Changing the subnet
-size during the CSM 1.2 upgrade process is unsupported and will break the upgrade.
-
-### Changes to service endpoints
-
-With the introduction of BICAN, URLs for certain services are now different, as it is now necessary to include the network path in the
-fully qualified domain name. Furthermore, certain services are only available on CMN:
-
-- Access to administrative services is now restricted to the CMN.
-- API access is available via the CMN, new CAN, and CHN.
-
-The following table is a set of examples of how domain names of existing services are impacted. It assumes the system was
-configured with a `system-name` of `shasta` and a `site-domain` of `dev.cray.com`.
-
-| Old Name                           | New Name                                  |
-|------------------------------------|-------------------------------------------|
-| `auth.shasta.dev.cray.com`         | `auth.cmn.shasta.dev.cray.com`            |
-| `nexus.shasta.dev.cray.com`        | `nexus.cmn.shasta.dev.cray.com`           |
-| `grafana.shasta.dev.cray.com`      | `grafana.cmn.shasta.dev.cray.com`         |
-| `prometheus.shasta.dev.cray.com`   | `prometheus.cmn.shasta.dev.cray.com`      |
-| `alertmanager.shasta.dev.cray.com` | `alertmanager.cmn.shasta.dev.cray.com`    |
-| `vcs.shasta.dev.cray.com`          | `vcs.cmn.shasta.dev.cray.com`             |
-| `kiali-istio.shasta.dev.cray.com`  | `kiali-istio.cmn.shasta.dev.cray.com`     |
-| `s3.shasta.dev.cray.com`           | `s3.cmn.shasta.dev.cray.com`              |
-| `sma-grafana.shasta.dev.cray.com`  | `sma-grafana.cmn.shasta.dev.cray.com`     |
-| `sma-kibana.shasta.dev.cray.com`   | `sma-kibana.cmn.shasta.dev.cray.com`      |
-| `api.shasta.dev.cray.com`          | `api.cmn.shasta.dev.cray.com`, `api.chn.shasta.dev.cray.com`, `api.can.shasta.dev.cray.com` |
-
-Users must be informed of the change to the `api.*` endpoint to avoid any unexpected disruptions.
-
-Note that the `*.cmn.<system-domain>`, `*.can.<system-domain>`, and `*.chn.<system-domain>` suffixes are not configurable. That is,
-`*.cmn.<system-domain>` **cannot** be configured to instead be `*.my-mgmt-network.<system-domain>`, for example.
-
-## Stage 0.3 - Update SLS
-
-### Abstract (Stage 0.3)
-
-CSM 1.2 introduces network configuration controlled by data in SLS. An offline upgrade of SLS data is performed. For more details on the
+CSM 1.2 introduces the bifurcated CAN (BICAN) as well as network configuration controlled by data in SLS. An offline upgrade of SLS data is performed. For more details on the
 upgrade and its sequence of events, see the [SLS upgrade `README`](scripts/sls/README.SLS_Upgrade.md).
 
 The SLS data upgrade is a critical step in moving to CSM 1.2. Upgraded SLS data is used in DNS and management network configuration. For details to aid in understanding and
 decision making, see the [Management Network User Guide](../../operations/network/management_network/README.md).
+
+One detail which must not be overlooked is that the existing Customer Access Network (CAN) will be migrated or retrofitted into the new Customer Management Network (CMN) while
+minimizing changes. A new CAN (or CHN) network is then created. Pivoting the existing CAN to the new CMN allows administrative traffic (already on the CAN) to remain as-is while
+moving standard user traffic to a new site-routable network. You can read more about this, as well as steps to ensure undisrupted access to UANs during upgrade, in
+[Plan and coordinate network upgrade](plan_and_coordinate_network_upgrade.md).
 
 > **Important:** If this is the first time performing the SLS update to CSM 1.2, review the [SLS upgrade `README`](scripts/sls/README.SLS_Upgrade.md) in order to ensure
 the correct options for the specific environment are used. Two examples are given below. To see all options from the update script, run `./sls_updater_csm_1.2.py --help`.
@@ -338,7 +187,7 @@ If the following command does not complete successfully, check if the `TOKEN` en
 curl --fail -H "Authorization: Bearer ${TOKEN}" -k -L -X POST 'https://api-gw-service-nmn.local/apis/sls/v1/loadstate' -F 'sls_dump=@migrated_sls_file.json'
 ```
 
-## Stage 0.4 - Upgrade management network
+## Stage 0.3 - Upgrade management network
 
 ### Verify that switches have 1.2 configuration in place
 
@@ -364,7 +213,7 @@ curl --fail -H "Authorization: Bearer ${TOKEN}" -k -L -X POST 'https://api-gw-se
    - If the banner does NOT contain text like the above, then contact support in order to get the `1.2 Preconfig` applied to the system.
    - See the [Management Network User Guide](../../operations/network/management_network/README.md) for more information on the management network.
 
-## Stage 0.5 - Prerequisites check
+## Stage 0.4 - Prerequisites check
 
 1. (`ncn-m001#`) Set the `SW_ADMIN_PASSWORD` environment variable.
 
@@ -431,7 +280,7 @@ curl --fail -H "Authorization: Bearer ${TOKEN}" -k -L -X POST 'https://api-gw-se
    git push
    ```
 
-## Stage 0.6 - Backup workload manager data
+## Stage 0.5 - Backup workload manager data
 
 To prevent any possibility of losing workload manager configuration data or files, a backup is required. Execute all backup procedures (for the workload manager in use) located in
 the `Troubleshooting and Administrative Tasks` sub-section of the `Install a Workload Manager` section of the

--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -127,7 +127,7 @@ With BICAN, the pre-1.2 CAN network is split into two separate networks:
 
    During the CSM 1.2 upgrade, UANs will retain their pre-1.2 CAN IP addresses in order to minimize disruption to UANs. However,
    toward the end of the CSM 1.2 upgrade, UANs will stop registering themselves on CMN and will receive new IP addresses on the
-   CAN/CHN network below. This process is described in more detail in [UAN Migration](#uan-migration).
+   CAN/CHN network. This process is described in more detail in [UAN Migration](#uan-migration).
 
    Pivoting the pre-1.2 CAN to the new CMN allows administrative traffic (already on the pre-1.2 CAN) to remain as-is while
    moving standard user traffic to a new site-routable network (CAN / CHN).

--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -18,7 +18,7 @@ backup of Workload Manager configuration data and files is created. Once complet
 - [Stage 0.1 - Prepare assets](#stage-01---prepare-assets)
 - [Stage 0.2 - Plan and coordinate network upgrade](#stage-02---plan-and-coordinate-network-upgrade)
 - [Stage 0.3 - Update SLS](#stage-03---update-sls)
-- [Stage 0.4 - Upgrade Management Network](#stage-04---upgrade-management-network)
+- [Stage 0.4 - Upgrade management network](#stage-04---upgrade-management-network)
 - [Stage 0.5 - Prerequisites check](#stage-05---prerequisites-check)
 - [Stage 0.6 - Backup workload manager data](#stage-06---backup-workload-manager-data)
 - [Stage completed](#stage-completed)

--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -15,11 +15,12 @@ backup of Workload Manager configuration data and files is created. Once complet
 
 ### Stages
 
-- [Stage 0.1 - Prepare assets](#prepare-assets)
-- [Stage 0.2 - Update SLS](#update-sls)
-- [Stage 0.3 - Upgrade Management Network](#update-management-network)
-- [Stage 0.4 - Prerequisites Check](#prerequisites-check)
-- [Stage 0.5 - Backup Workload Manager Data](#backup-workload-manager)
+- [Stage 0.1 - Prepare assets](#stage-01---prepare-assets)
+- [Stage 0.2 - Plan and coordinate network upgrade](#stage-02---plan-and-coordinate-network-upgrade)
+- [Stage 0.3 - Update SLS](#stage-03---update-sls)
+- [Stage 0.4 - Upgrade Management Network](#stage-04---upgrade-management-network)
+- [Stage 0.5 - Prerequisites Check](#stage-05---prerequisites-check)
+- [Stage 0.6 - Backup Workload Manager Data](#stage-06---backup-workload-manager-data)
 - [Stage completed](#stage-completed)
 
 ## Stage 0.1 - Prepare assets
@@ -111,19 +112,127 @@ backup of Workload Manager configuration data and files is created. Once complet
    /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version csm-${CSM_RELEASE} --tarball-file "${CSM_TAR_PATH}"
    ```
 
-## Stage 0.2 - Update SLS
+## Stage 0.2 - Plan and coordinate network upgrade
 
 ### Abstract (Stage 0.2)
 
-CSM 1.2 introduces the bifurcated CAN (BICAN) as well as network configuration controlled by data in SLS. An offline upgrade of SLS data is performed. For more details on the
+Prior to CSM 1.2, the single Customer Access Network (CAN) carried both the admin network traffic and the user network
+traffic. CSM 1.2 introduces bifurcated CAN (BICAN), which is designed to separate admin network traffic and user network traffic.
+With BICAN, the pre-1.2 CAN network is split into two separate networks:
+
+1. Customer Management Network (CMN)
+
+   This network allows only system administrative access from the customer site. The pre-1.2 CAN is renamed to CMN. By
+   the end of the CSM 1.2 upgrade, all non-administrative access, such as from UANs, will be removed from CMN.
+
+   During the CSM 1.2 upgrade, UANs will retain their pre-1.2 CAN IPs in order to minimize disruption to UANs. However,
+   toward the end of the CSM 1.2 upgrade, UANs will stop registering themselves on CMN and will receive new IPs on the
+   CAN/CHN network below. This process is described in more detail in [UAN Migration](#uan-migration).
+
+1. Customer Access Network (CAN) / Customer High-speed Network (CHN)
+
+   For user traffic only (e.g. users running and monitoring jobs), CSM 1.2 allows you to pick one of two networks:
+
+      - Customer Access Network (CAN): this is a new network (VLAN6 in switches) that runs over the management network. This
+         network must not be confused with pre-1.2 CAN, which was a monolithic network that allowed both user and administrative
+         traffic, was configured as VLAN7 in switches, and is now renamed to CMN. The new CAN allows only user traffic.
+
+      - Customer High-speed Network (CHN): this is a new network (VLAN5 in switches) that runs over the high-speed fabric.
+
+   You must only pick either the new CAN or CHN, but not both. The rest of the installation guide will provide you with
+   options for configuring either the new CAN or CHN.
+
+Pivoting the pre-1.2 CAN to the new CMN allows administrative traffic (already on the pre-1.2 CAN) to remain as-is while
+moving standard user traffic to a new site-routable network.
+
+### UAN migration
+
+Certain steps are taken in order to minimize disruption to UANs during the CSM 1.2 upgrade process:
+
+1. During the upgrade, the switch `1.2 Preconfig` will not remove UAN ports from the CMN VLAN (the pre-1.2 CAN), allowing UANs
+   to retain their existing IPs during the CSM 1.2 upgrade process. Traffic to and from UANs will still flow through CMN, but
+   may also flow through CAN/CHN networks if desired.
+
+1. CFS will be temporarily disabled for UANs, so that running CFS plays does not remove CMN interfaces from UANs. As mentioned
+   in [Abstract (Stage 0.3)](#abstract-stage-03), network configuration is controlled by data in SLS, but CFS plays also pick up
+   the same SLS data, which can lead to UANs being prematurely removed from CMN and causing UAN outage. As such, CFS plays
+   need to be disabled for UANs.
+
+   To disable CFS plays for UANs, you must remove CFS assignment for UANs by running the following command:
+
+   ```bash
+   what-is-the-command-to-disable-CFS-for-UANs.sh
+   ```
+
+1. UAN reboots must be avoided. Rebooting a UAN can re-enable CFS and can ultimately lead to removing CMN interfaces from UANs.
+   As a system administrator, you must inform your users to avoid UAN reboots during the CSM 1.2 upgrade process. If, however,
+   a UAN is rebooted, you can run the following set of commands to add the CMN interface back on the UAN:
+
+   ```bash
+   what-is-the-command-to-readd-CMN-to-UANs-after-accidental-reboot.sh
+   ```
+
+1. Once the CSM 1.2 upgrade is complete, you may reboot the UANs for the new network configuration changes to take effect.
+   UANs will not receive an IP on the CMN network and instead will default their traffic through the new CAN/CHN.
+
+1. `{TODO: keepme?}` Note that in CSM 1.2, UAN ports will not be removed from the CMN VLAN7 in switches. In the next CSM release, switch
+   configuration will be updated to remove UAN ports from the CMN VLAN7. This enables non-rebooted UANs to continue to work
+   and allows for better easing into BICAN in CSM 1.2.
+
+### UAI migration
+
+Access to UAIs will be disrupted until CSM 1.2 upgrade completes. After the upgrade is completed, UAIs need to be restarted.
+
+### Decide on subnet ranges for new CAN/CHN
+
+Once you have decided whether to use the new CAN or to use CHN for user access, you must decide on the subnet range. Refer
+to [Customer Accessible Networks](../../operations/network/customer_accessible_networks/Customer_Accessible_Networks.md)
+for subnet ranges and defaults for CAN/CHN.
+
+### Preserving CMN subnet range
+
+It is vital that you preserve the subnet range for the pre-1.2 CAN that is now being renamed to CMN. Changing the subnet
+size during the CSM 1.2 upgrade process can have unintended consequences.
+
+### Changes to service endpoints
+
+With the introduction of BICAN, URLs for certain services are now different, as it is now necessary to include the network path in the
+fully qualified domain name. Furthermore, certain services are only available on CMN:
+
+- Access to administrative services is now restricted to the CMN.
+- API access is available via the CMN, new CAN, and CHN.
+
+The following table are a set of examples of how domain names of existing services are impacted. It assumes the system was
+configured with a `system-name` of `shasta` and a `site-domain` of `dev.cray.com`.
+
+| Old Name                           | New Name                                  |
+|------------------------------------|-------------------------------------------|
+| `auth.shasta.dev.cray.com`         | `auth.cmn.shasta.dev.cray.com`            |
+| `nexus.shasta.dev.cray.com`        | `nexus.cmn.shasta.dev.cray.com`           |
+| `grafana.shasta.dev.cray.com`      | `grafana.cmn.shasta.dev.cray.com`         |
+| `prometheus.shasta.dev.cray.com`   | `prometheus.cmn.shasta.dev.cray.com`      |
+| `alertmanager.shasta.dev.cray.com` | `alertmanager.cmn.shasta.dev.cray.com`    |
+| `vcs.shasta.dev.cray.com`          | `vcs.cmn.shasta.dev.cray.com`             |
+| `kiali-istio.shasta.dev.cray.com`  | `kiali-istio.cmn.shasta.dev.cray.com`     |
+| `s3.shasta.dev.cray.com`           | `s3.cmn.shasta.dev.cray.com`              |
+| `sma-grafana.shasta.dev.cray.com`  | `sma-grafana.cmn.shasta.dev.cray.com`     |
+| `sma-kibana.shasta.dev.cray.com`   | `sma-kibana.cmn.shasta.dev.cray.com`      |
+| `api.shasta.dev.cray.com`          | `api.cmn.shasta.dev.cray.com`, `api.chn.shasta.dev.cray.com`, `api.can.shasta.dev.cray.com` |
+
+You must inform your users of the change to the `api.*` endpoint to avoid any unexpected disruptions.
+
+Note that the `*.cmn.<system-domain>`, `*.can.<system-domain>`, `*.chn.<system-domain>` suffixes are not configurable. That is, you
+**cannot** configure, for example, `*.cmn.<system-domain>` to instead be `*.my-mgmt-network.<system-domain>`.
+
+## Stage 0.3 - Update SLS
+
+### Abstract (Stage 0.3)
+
+CSM 1.2 introduces network configuration controlled by data in SLS. An offline upgrade of SLS data is performed. For more details on the
 upgrade and its sequence of events, see the [SLS upgrade `README`](scripts/sls/README.SLS_Upgrade.md).
 
 The SLS data upgrade is a critical step in moving to CSM 1.2. Upgraded SLS data is used in DNS and management network configuration. For details to aid in understanding and
 decision making, see the [Management Network User Guide](../../operations/network/management_network/README.md).
-
-One detail which must not be overlooked is that the existing Customer Access Network (CAN) will be migrated or retrofitted into the new Customer Management Network (CMN) while
-minimizing changes. A new CAN (or CHN) network is then created. Pivoting the existing CAN to the new CMN allows administrative traffic (already on the CAN) to remain as-is while
-moving standard user traffic to a new site-routable network.
 
 > **Important:** If this is the first time performing the SLS update to CSM 1.2, review the [SLS upgrade `README`](scripts/sls/README.SLS_Upgrade.md) in order to ensure
 the correct options for the specific environment are used. Two examples are given below. To see all options from the update script, run `./sls_updater_csm_1.2.py --help`.
@@ -151,6 +260,9 @@ the correct options for the specific environment are used. Two examples are give
    ```
 
 ### Migrate SLS data JSON to CSM 1.2
+
+You can now migrate SLS data to CSM 1.2, using the `sls_input_file.json` obtained above, as well as using the desired
+network (new CAN or CHN) and its chosen subnet as per [Decide on subnet ranges for new CAN/CHN](#decide-on-subnet-ranges-for-new-canchn).
 
 - (`ncn-m001#`) Example 1: The CHN as the system default route (will by default output to `migrated_sls_file.json`).
 
@@ -182,7 +294,7 @@ If the following command does not complete successfully, check if the `TOKEN` en
 curl --fail -H "Authorization: Bearer ${TOKEN}" -k -L -X POST 'https://api-gw-service-nmn.local/apis/sls/v1/loadstate' -F 'sls_dump=@migrated_sls_file.json'
 ```
 
-## Stage 0.3 - Upgrade management network
+## Stage 0.4 - Upgrade management network
 
 ### Verify that switches have 1.2 configuration in place
 
@@ -208,7 +320,7 @@ curl --fail -H "Authorization: Bearer ${TOKEN}" -k -L -X POST 'https://api-gw-se
    - If the banner does NOT contain text like the above, then contact support in order to get the `1.2 Preconfig` applied to the system.
    - See the [Management Network User Guide](../../operations/network/management_network/README.md) for more information on the management network.
 
-## Stage 0.4 - Prerequisites check
+## Stage 0.5 - Prerequisites check
 
 1. (`ncn-m001#`) Set the `SW_ADMIN_PASSWORD` environment variable.
 
@@ -275,7 +387,7 @@ curl --fail -H "Authorization: Bearer ${TOKEN}" -k -L -X POST 'https://api-gw-se
    git push
    ```
 
-## Stage 0.5 - Backup workload manager data
+## Stage 0.6 - Backup workload manager data
 
 To prevent any possibility of losing workload manager configuration data or files, a backup is required. Execute all backup procedures (for the workload manager in use) located in
 the `Troubleshooting and Administrative Tasks` sub-section of the `Install a Workload Manager` section of the

--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -125,7 +125,7 @@ With BICAN, the pre-1.2 CAN network is split into two separate networks:
    This network allows only system administrative access from the customer site. The pre-1.2 CAN is renamed to CMN. By
    the end of the CSM 1.2 upgrade, all non-administrative access, such as from UANs, will be removed from CMN.
 
-   During the CSM 1.2 upgrade, UANs will retain their pre-1.2 CAN IPs in order to minimize disruption to UANs. However,
+   During the CSM 1.2 upgrade, UANs will retain their pre-1.2 CAN IP addresses in order to minimize disruption to UANs. However,
    toward the end of the CSM 1.2 upgrade, UANs will stop registering themselves on CMN and will receive new IPs on the
    CAN/CHN network below. This process is described in more detail in [UAN Migration](#uan-migration).
 

--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -116,7 +116,7 @@ backup of Workload Manager configuration data and files is created. Once complet
 
 ### Abstract (Stage 0.2)
 
-Prior to CSM 1.2, the single Customer Access Network (CAN) carried both the admin network traffic and the user network
+Prior to CSM 1.2, the single Customer Access Network (CAN) carried both the administrative network traffic and the user network
 traffic. CSM 1.2 introduces bifurcated CAN (BICAN), which is designed to separate admin network traffic and user network traffic.
 With BICAN, the pre-1.2 CAN network is split into two separate networks:
 

--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -143,7 +143,7 @@ With BICAN, the pre-1.2 CAN network is split into two separate networks:
       - Customer High-speed Network (CHN) \[CSM 1.2 Tech Preview\]: this is a new network (VLAN5 in switches) that runs over the high-speed fabric.
 
    Either the new CAN or CHN must be chosen, but not both. Note that the CHN is a technical preview in CSM 1.2, and the new CAN is
-   the recommended upgrade. The rest of the installation guide will provide you with options for configuring either the new CAN or CHN.
+   the recommended upgrade. The rest of the installation guide provides options for configuring either the new CAN or CHN.
 
 ### UAN migration
 

--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -129,25 +129,28 @@ With BICAN, the pre-1.2 CAN network is split into two separate networks:
    toward the end of the CSM 1.2 upgrade, UANs will stop registering themselves on CMN and will receive new IPs on the
    CAN/CHN network below. This process is described in more detail in [UAN Migration](#uan-migration).
 
+   Pivoting the pre-1.2 CAN to the new CMN allows administrative traffic (already on the pre-1.2 CAN) to remain as-is while
+   moving standard user traffic to a new site-routable network (CAN / CHN).
+
 1. Customer Access Network (CAN) / Customer High-speed Network (CHN)
 
    For user traffic only (e.g. users running and monitoring jobs), CSM 1.2 allows you to pick one of two networks:
 
-      - Customer Access Network (CAN): this is a new network (VLAN6 in switches) that runs over the management network. This
+      - Customer Access Network (CAN) \[Recommended\]: this is a new network (VLAN6 in switches) that runs over the management network. This
          network must not be confused with pre-1.2 CAN, which was a monolithic network that allowed both user and administrative
          traffic, was configured as VLAN7 in switches, and is now renamed to CMN. The new CAN allows only user traffic.
 
-      - Customer High-speed Network (CHN): this is a new network (VLAN5 in switches) that runs over the high-speed fabric.
+      - Customer High-speed Network (CHN) \[CSM 1.2 Tech Preview\]: this is a new network (VLAN5 in switches) that runs over the high-speed fabric.
 
-   You must only pick either the new CAN or CHN, but not both. The rest of the installation guide will provide you with
-   options for configuring either the new CAN or CHN.
-
-Pivoting the pre-1.2 CAN to the new CMN allows administrative traffic (already on the pre-1.2 CAN) to remain as-is while
-moving standard user traffic to a new site-routable network.
+   You must only pick either the new CAN or CHN, but not both. Please note that CHN is a tech preview in CSM 1.2, and the new CAN is
+   the recommended upgrade. The rest of the installation guide will provide you with options for configuring either the new CAN or CHN.
 
 ### UAN migration
 
-Certain steps are taken in order to minimize disruption to UANs during the CSM 1.2 upgrade process:
+Certain steps are taken in order to minimize disruption to UANs during the CSM 1.2 upgrade process. Please read these steps
+carefully and follow any recommendations and warnings to minimize disruptions to user activity.  Note that these steps apply
+to all types of application nodes and not just UANs -- the term "UAN" just happens to be more commonly used and understood when
+referring to user activity.
 
 1. During the upgrade, the switch `1.2 Preconfig` will not remove UAN ports from the CMN VLAN (the pre-1.2 CAN), allowing UANs
    to retain their existing IPs during the CSM 1.2 upgrade process. Traffic to and from UANs will still flow through CMN, but
@@ -158,26 +161,69 @@ Certain steps are taken in order to minimize disruption to UANs during the CSM 1
    the same SLS data, which can lead to UANs being prematurely removed from CMN and causing UAN outage. As such, CFS plays
    need to be disabled for UANs.
 
-   To disable CFS plays for UANs, you must remove CFS assignment for UANs by running the following command:
+   (`ncn-m001#`) To disable CFS plays for UANs, you must remove CFS assignment for UANs by running the following command:
 
    ```bash
-   what-is-the-command-to-disable-CFS-for-UANs.sh
+   export CRAY_FORMAT=json
+   for xname in $(cray hsm state components list --role Application --subrole UAN --type node | jq -r .Components[].ID)
+   do
+      cray cfs components update --enabled false --desired-config "" $xname
+   done
    ```
 
-1. UAN reboots must be avoided. Rebooting a UAN can re-enable CFS and can ultimately lead to removing CMN interfaces from UANs.
-   As a system administrator, you must inform your users to avoid UAN reboots during the CSM 1.2 upgrade process. If, however,
-   a UAN is rebooted, you can run the following set of commands to add the CMN interface back on the UAN:
+   > Note that the above command will disable CFS plays for UANs only. If you wish to disable CFS plays for all types of
+   > application nodes (recommended), then remove the `--subrole UAN` portion in the snippet above.
 
-   ```bash
-   what-is-the-command-to-readd-CMN-to-UANs-after-accidental-reboot.sh
+1. UAN reboots must be avoided and is not a supported operation during CSM 1.2 upgrade. Rebooting a UAN during a CSM 1.2
+   upgrade can re-enable CFS and ultimately lead to removing the CMN interface from UANs, disrupting UAN access for your users.
+   As a system administrator, you must inform your users to avoid UAN reboots during the CSM 1.2 upgrade process.
+
+   If, however, a UAN is rebooted, then you need to patch the file `roles/uan_interfaces/tasks/can-v2.yml` for your current
+   CSM release in the `vcs/cray/uan-config-management.git` repository and re-run the CFS Ansible play to bring back the
+   CMN (pre-1.2 CAN) interface back in UAN. Use the following patch file and follow the instructions in
+   [Configuration Management](../../operations/README.md#configuration-management) to restore CMN access in your UAN:
+
+   ```text
+   --- a/roles/uan_interfaces/tasks/can-v2.yml
+   +++ b/roles/uan_interfaces/tasks/can-v2.yml
+   @@ -33,21 +33,16 @@
+   - name: Get Customer Access Network info from SLS
+     local_action:
+     module: uri
+   -    url: "http://cray-sls/v1/search/networks?name={{ sls_can_name }}"
+   +    url: "http://cray-sls/v1/search/networks?name=CMN"
+        method: GET
+        register: sls_can
+   
+   -- name: Get Customer Access Network CIDR from SLS, if network exists.
+   -  # This assumes that the CAN network is _always_ the third item in the array. This makes the
+   -  # implementation fragile. See CASMCMS-6714.
+   -  set_fact:
+   -    customer_access_network: "{{ sls_can.json[0].ExtraProperties.Subnets[2].CIDR }}"
+   -  when: sls_can.status == 200
+   -
+   -- name: Get Customer Access Network Gateway from SLS, if network exists
+   -  set_fact:
+   -    customer_access_gateway: "{{ sls_can.json[0].ExtraProperties.Subnets[2].Gateway }}"
+   -  when: sls_can.status == 200
+   
+   +- name: "Get {{ uan_user_access_cfg | upper }} CIDR from SLS, if network exists."
+   +  set_fact:
+   +    customer_access_network: "{{ item.CIDR }}"
+   +    customer_access_gateway: "{{ item.Gateway }}"
+   +  loop: "{{ sls_can.json[0].ExtraProperties.Subnets }}"
+   +  when: item.FullName == "CMN Bootstrap DHCP Subnet"
    ```
 
 1. Once the CSM 1.2 upgrade is complete, you may reboot the UANs for the new network configuration changes to take effect.
-   UANs will not receive an IP on the CMN network and instead will default their traffic through the new CAN/CHN.
+   UANs will not receive an IP on the CMN network and instead will default their traffic through the new CAN/CHN. For concrete
+   details on UAN transition plan for your users, please refer to
+   [Minimize UAN Downtime](../../operations/network/management_network/bican_enable.md#minimize-uan-downtime)
 
-1. `{TODO: keepme?}` Note that in CSM 1.2, UAN ports will not be removed from the CMN VLAN7 in switches. In the next CSM release, switch
+1. Note that in CSM 1.2, UAN ports will not be removed from the CMN VLAN7 in switches. In the next CSM release, switch
    configuration will be updated to remove UAN ports from the CMN VLAN7. This enables non-rebooted UANs to continue to work
-   and allows for better easing into BICAN in CSM 1.2.
+   and allows for better easing into BICAN in CSM 1.2. More details about this transition plan are outlined in
+   [Minimize UAN Downtime](../../operations/network/management_network/bican_enable.md#minimize-uan-downtime)
 
 ### UAI migration
 
@@ -192,7 +238,7 @@ for subnet ranges and defaults for CAN/CHN.
 ### Preserving CMN subnet range
 
 It is vital that you preserve the subnet range for the pre-1.2 CAN that is now being renamed to CMN. Changing the subnet
-size during the CSM 1.2 upgrade process can have unintended consequences.
+size during the CSM 1.2 upgrade process is unsupported and will break the upgrade.
 
 ### Changes to service endpoints
 

--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -147,7 +147,7 @@ With BICAN, the pre-1.2 CAN network is split into two separate networks:
 
 ### UAN migration
 
-Certain steps are taken in order to minimize disruption to UANs during the CSM 1.2 upgrade process. Please read these steps
+Steps are taken in order to minimize disruption to UANs during the CSM 1.2 upgrade process. Read these steps
 carefully and follow any recommendations and warnings to minimize disruptions to user activity.  Note that these steps apply
 to all types of application nodes and not just UANs -- the term "UAN" just happens to be more commonly used and understood when
 referring to user activity.

--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -126,7 +126,7 @@ With BICAN, the pre-1.2 CAN network is split into two separate networks:
    the end of the CSM 1.2 upgrade, all non-administrative access, such as from UANs, will be removed from CMN.
 
    During the CSM 1.2 upgrade, UANs will retain their pre-1.2 CAN IP addresses in order to minimize disruption to UANs. However,
-   toward the end of the CSM 1.2 upgrade, UANs will stop registering themselves on CMN and will receive new IPs on the
+   toward the end of the CSM 1.2 upgrade, UANs will stop registering themselves on CMN and will receive new IP addresses on the
    CAN/CHN network below. This process is described in more detail in [UAN Migration](#uan-migration).
 
    Pivoting the pre-1.2 CAN to the new CMN allows administrative traffic (already on the pre-1.2 CAN) to remain as-is while

--- a/upgrade/1.2/plan_and_coordinate_network_upgrade.md
+++ b/upgrade/1.2/plan_and_coordinate_network_upgrade.md
@@ -1,0 +1,152 @@
+# Plan and coordinate network upgrade
+
+Prior to CSM 1.2, the single Customer Access Network (CAN) carried both the administrative network traffic and the user network
+traffic. CSM 1.2 introduces bifurcated CAN (BICAN), which is designed to separate administrative network traffic and user network traffic.
+With BICAN, the pre-1.2 CAN network is split into two separate networks:
+
+1. Customer Management Network (CMN)
+
+   This network allows only system administrative access from the customer site. The pre-1.2 CAN is renamed to CMN. By
+   the end of the CSM 1.2 upgrade, all non-administrative access, such as from UANs, will be removed from CMN.
+
+   During the CSM 1.2 upgrade, UANs will retain their pre-1.2 CAN IP addresses in order to minimize disruption to UANs. However,
+   toward the end of the CSM 1.2 upgrade, UANs will stop registering themselves on CMN and will receive new IP addresses on the
+   CAN/CHN network. This process is described in more detail in [UAN Migration](#uan-migration).
+
+   Pivoting the pre-1.2 CAN to the new CMN allows administrative traffic (already on the pre-1.2 CAN) to remain as-is while
+   moving standard user traffic to a new site-routable network (CAN / CHN).
+
+1. Customer Access Network (CAN) / Customer High-speed Network (CHN)
+
+   For user traffic only (e.g. users running and monitoring jobs), CSM 1.2 allows a choice of one of two networks:
+
+    - Customer Access Network (CAN) \[Recommended\]: this is a new network (VLAN6 in switches) that runs over the management network. This
+      network must not be confused with pre-1.2 CAN, which was a monolithic network that allowed both user and administrative
+      traffic, was configured as VLAN7 in switches, and is now renamed to CMN. The new CAN allows only user traffic.
+
+    - Customer High-speed Network (CHN) \[CSM 1.2 Tech Preview\]: this is a new network (VLAN5 in switches) that runs over the high-speed fabric.
+
+   Either the new CAN or CHN must be chosen, but not both. Note that the CHN is a technical preview in CSM 1.2, and the new CAN is
+   the recommended upgrade. The rest of the upgrade guide provides options for configuring either the new CAN or CHN.
+
+## UAN migration
+
+Steps are taken in order to minimize disruption to UANs during the CSM 1.2 upgrade process. Read these steps
+carefully and follow any recommendations and warnings to minimize disruptions to user activity. Note that these steps apply
+to all types of application nodes and not just UANs -- the term "UAN" just happens to be more commonly used and understood when
+referring to user activity.
+
+1. During the upgrade, the switch `1.2 Preconfig` will not remove UAN ports from the CMN VLAN (the pre-1.2 CAN), allowing UANs
+   to retain their existing IP addresses during the CSM 1.2 upgrade process. Traffic to and from UANs will still flow through CMN, but
+   may also flow through CAN/CHN networks, if desired.
+
+1. CFS will be temporarily disabled for UANs, in order to prevent CFS plays from removing CMN interfaces from UANs. Note that network
+   configuration is controlled by data in SLS but CFS plays also pick up the same SLS data, which can lead to UANs being prematurely
+   removed from the CMN and causing UAN outages. As such, CFS plays need to be disabled for UANs.
+
+   To disable CFS plays for UANs, remove CFS assignment for UANs by running the following command:
+
+   ```bash
+   ncn-m001# for xname in $(cray hsm state components list --role Application --subrole UAN --type node --format json | jq -r .Components[].ID) ; do
+                 cray cfs components update --enabled false --desired-config "" --format json $xname
+             done
+   ```
+
+   > Note that the above command will disable CFS plays for UANs only. If wishing to disable CFS plays for all types of
+   > application nodes (recommended), then remove the `--subrole UAN` portion in the snippet above.
+
+1. UAN reboots must be avoided and are not a supported operation during the CSM 1.2 upgrade. Rebooting a UAN during a CSM 1.2
+   upgrade can re-enable CFS and ultimately lead to removing the CMN interface from UANs, disrupting UAN access for users.
+   System administrators must inform users to avoid UAN reboots during the CSM 1.2 upgrade process.
+
+   However, if a UAN is rebooted, then the `roles/uan_interfaces/tasks/can-v2.yml` file in the `vcs/cray/uan-config-management.git` repository
+   must be patched for the current CSM release. After that, the UAN must be rebooted again to bring the
+   CMN (pre-1.2 CAN) interface back in the UAN. Use the following patch file and follow the instructions in
+   [Configuration Management](../../operations/README.md#configuration-management) to restore CMN access in the UAN:
+
+   ```text
+   --- a/roles/uan_interfaces/tasks/can-v2.yml
+   +++ b/roles/uan_interfaces/tasks/can-v2.yml
+   @@ -33,21 +33,16 @@
+   - name: Get Customer Access Network info from SLS
+     local_action:
+     module: uri
+   -    url: "http://cray-sls/v1/search/networks?name={{ sls_can_name }}"
+   +    url: "http://cray-sls/v1/search/networks?name=CMN"
+        method: GET
+        register: sls_can
+   
+   -- name: Get Customer Access Network CIDR from SLS, if network exists.
+   -  # This assumes that the CAN network is _always_ the third item in the array. This makes the
+   -  # implementation fragile. See CASMCMS-6714.
+   -  set_fact:
+   -    customer_access_network: "{{ sls_can.json[0].ExtraProperties.Subnets[2].CIDR }}"
+   -  when: sls_can.status == 200
+   -
+   -- name: Get Customer Access Network Gateway from SLS, if network exists
+   -  set_fact:
+   -    customer_access_gateway: "{{ sls_can.json[0].ExtraProperties.Subnets[2].Gateway }}"
+   -  when: sls_can.status == 200
+   
+   +- name: "Get {{ uan_user_access_cfg | upper }} CIDR from SLS, if network exists."
+   +  set_fact:
+   +    customer_access_network: "{{ item.CIDR }}"
+   +    customer_access_gateway: "{{ item.Gateway }}"
+   +  loop: "{{ sls_can.json[0].ExtraProperties.Subnets }}"
+   +  when: item.FullName == "CMN Bootstrap DHCP Subnet"
+   ```
+
+1. Once UAN has been upgraded to 2.4, the UANs may be rebooted for the new network configuration changes to take effect.
+   UANs will not receive an IP address on the CMN network and instead will default their traffic through the new CAN/CHN. For concrete
+   details on UAN transition plan for users, see
+   [Minimize UAN Downtime](../../operations/network/management_network/bican_enable.md#minimize-uan-downtime).
+
+1. Note that in CSM 1.2, UAN ports will not be removed from the CMN VLAN7 in switches. In the next CSM release, switch
+   configuration will be updated to remove UAN ports from the CMN VLAN7. This enables non-rebooted UANs to continue to work
+   and allows for better easing into BICAN in CSM 1.2. For more details about this transition plan, see
+   [Minimize UAN Downtime](../../operations/network/management_network/bican_enable.md#minimize-uan-downtime).
+
+## UAI migration
+
+Access to UAIs will be disrupted until CSM 1.2 upgrade completes. After the upgrade is completed, UAIs need to be restarted.
+
+## Decide on subnet ranges for new CAN/CHN
+
+After deciding whether to use the new CAN or to use CHN for user access, the subnet range must be decided. Refer
+to [Customer Accessible Networks](../../operations/network/customer_accessible_networks/Customer_Accessible_Networks.md)
+for subnet ranges and defaults for CAN/CHN.
+
+## Preserving CMN subnet range
+
+**It is vital** that the subnet range is preserved for the pre-1.2 CAN that is now being renamed to CMN. Changing the subnet
+size during the CSM 1.2 upgrade process is unsupported and will break the upgrade.
+
+## Changes to service endpoints
+
+With the introduction of BICAN, URLs for certain services are now different, as it is now necessary to include the network path in the
+fully qualified domain name. Furthermore, certain services are only available on CMN:
+
+- Access to administrative services is now restricted to the CMN.
+- API access is available via the CMN, new CAN, and CHN.
+
+The following table is a set of examples of how domain names of existing services are impacted. It assumes the system was
+configured with a `system-name` of `shasta` and a `site-domain` of `dev.cray.com`.
+
+| Old Name                           | New Name                                  |
+|------------------------------------|-------------------------------------------|
+| `auth.shasta.dev.cray.com`         | `auth.cmn.shasta.dev.cray.com`            |
+| `nexus.shasta.dev.cray.com`        | `nexus.cmn.shasta.dev.cray.com`           |
+| `grafana.shasta.dev.cray.com`      | `grafana.cmn.shasta.dev.cray.com`         |
+| `prometheus.shasta.dev.cray.com`   | `prometheus.cmn.shasta.dev.cray.com`      |
+| `alertmanager.shasta.dev.cray.com` | `alertmanager.cmn.shasta.dev.cray.com`    |
+| `vcs.shasta.dev.cray.com`          | `vcs.cmn.shasta.dev.cray.com`             |
+| `kiali-istio.shasta.dev.cray.com`  | `kiali-istio.cmn.shasta.dev.cray.com`     |
+| `s3.shasta.dev.cray.com`           | `s3.cmn.shasta.dev.cray.com`              |
+| `sma-grafana.shasta.dev.cray.com`  | `sma-grafana.cmn.shasta.dev.cray.com`     |
+| `sma-kibana.shasta.dev.cray.com`   | `sma-kibana.cmn.shasta.dev.cray.com`      |
+| `api.shasta.dev.cray.com`          | `api.cmn.shasta.dev.cray.com`, `api.chn.shasta.dev.cray.com`, `api.can.shasta.dev.cray.com` |
+
+Users must be informed of the change to the `api.*` endpoint to avoid any unexpected disruptions.
+
+Note that the `*.cmn.<system-domain>`, `*.can.<system-domain>`, and `*.chn.<system-domain>` suffixes are not configurable. That is,
+`*.cmn.<system-domain>` **cannot** be configured to instead be `*.my-mgmt-network.<system-domain>`, for example.

--- a/upgrade/1.2/plan_and_coordinate_network_upgrade.md
+++ b/upgrade/1.2/plan_and_coordinate_network_upgrade.md
@@ -40,16 +40,16 @@ referring to user activity.
    to retain their existing IP addresses during the CSM 1.2 upgrade process. Traffic to and from UANs will still flow through CMN, but
    may also flow through CAN/CHN networks, if desired.
 
-1. CFS will be temporarily disabled for UANs, in order to prevent CFS plays from removing CMN interfaces from UANs. Note that network
+1. (`ncn-m001#`) CFS will be temporarily disabled for UANs, in order to prevent CFS plays from removing CMN interfaces from UANs. Note that network
    configuration is controlled by data in SLS but CFS plays also pick up the same SLS data, which can lead to UANs being prematurely
    removed from the CMN and causing UAN outages. As such, CFS plays need to be disabled for UANs.
 
    To disable CFS plays for UANs, remove CFS assignment for UANs by running the following command:
 
    ```bash
-   ncn-m001# for xname in $(cray hsm state components list --role Application --subrole UAN --type node --format json | jq -r .Components[].ID) ; do
-                 cray cfs components update --enabled false --desired-config "" --format json $xname
-             done
+   for xname in $(cray hsm state components list --role Application --subrole UAN --type node --format json | jq -r .Components[].ID) ; do
+      cray cfs components update --enabled false --desired-config "" --format json $xname
+   done
    ```
 
    > Note that the above command will disable CFS plays for UANs only. If wishing to disable CFS plays for all types of


### PR DESCRIPTION
# Description

As per offline discussion about minimizing UAN disruption and a clear upgrade story for BICAN.

```
DOCS updates

1.  New CAN prep procedure - next NET person, possibly a no-op.
2.  Overview of UAN/UAI migration procedure to user segmented network. - Atif

   1.  Ahead of Raspberry upgrade

      1.  *[DONE]* Coordinate with casmnet for the application of the 1.2 preconfig for switches
      2.  *[DONE]* Identify subnet for new CAN
      3.  *[DONE]* Advise users that domain names will be changing, examples (in release notes already)

   2.  During Raspberry upgrade

      1.  At step 0.2

         1.  *[DONE]* Advise sysadmins that CFS will be temporarily disabled for UANs
         2.  *[DONE -- but need manual command to fix after reboot]* UAN reboots require rememdiation
         3.  *[DONE]* Access to UAIs will be disrupted until CSM upgrade completes and UAIs are restarted

   3.  After Raspberry upgrade

      1.  *[DONE: (pointer to https://github.com/Cray-HPE/docs-csm/pull/1854)]* Complete the migration of your users from CMN to new CAN
      2. *[DONE: (pointer to https://github.com/Cray-HPE/docs-csm/pull/1854)]* Run the operational procedure to remove CMN access to UANs.

3.  Warnings - Atif

   1.  *[NOT DONE: where is this getting started guide? -- don't think it is part of this repo]* Getting started guide
   2.  *[NOT DONE: Unsure what needs to be added here beyond the Step 0.2 warnings]* CSM 1.2 upgrade readme
   3.  *[DONE]* Step 0.2 warning
```

# Checklist Before Merging

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!---   checked checkbox: [x] -->
<!---   invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/MTL-1695/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
