### PR TITLE
CASMINST-4821: Validate SLS health before using CSI to set no-wipe during node rebuilds

### DIFF
--- a/upgrade/1.2/scripts/common/ncn-rebuild-common.sh
+++ b/upgrade/1.2/scripts/common/ncn-rebuild-common.sh
@@ -309,8 +309,12 @@ if [[ $target_ncn != ncn-s* ]]; then
 fi 
 
 {
+    # Validate SLS health before calling csi handoff bss-update-*, since
+    # it relies on SLS
+    check_sls_health
+
     set +e
-    while true ; do    
+    while true ; do
         csi handoff bss-update-param --set metal.no-wipe=1 --limit $TARGET_XNAME
         if [[ $? -eq 0 ]]; then
             break

--- a/upgrade/1.2/scripts/rebuild/ncn-rebuild-master-nodes.sh
+++ b/upgrade/1.2/scripts/rebuild/ncn-rebuild-master-nodes.sh
@@ -105,6 +105,10 @@ if [[ ${first_master_hostname} == ${target_ncn} ]]; then
         exit 1
       fi
 
+      # Validate SLS health before calling csi handoff bss-update-*, since
+      # it relies on SLS
+      check_sls_health
+
       scp /root/docs-csm-latest.noarch.rpm $promotingMaster:/root/docs-csm-latest.noarch.rpm
       ssh $promotingMaster "rpm --force -Uvh /root/docs-csm-latest.noarch.rpm"
       ssh $promotingMaster -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "/usr/share/doc/csm/upgrade/1.2/scripts/k8s/promote-initial-master.sh"
@@ -141,6 +145,10 @@ else
 fi
 
 drain_node $target_ncn
+
+# Validate SLS health before calling csi handoff bss-update-*, since
+# it relies on SLS
+check_sls_health
 
 set +e
 while true ; do    

--- a/upgrade/1.2/scripts/rebuild/ncn-rebuild-worker-nodes.sh
+++ b/upgrade/1.2/scripts/rebuild/ncn-rebuild-worker-nodes.sh
@@ -93,6 +93,10 @@ fi
 
 drain_node $target_ncn
 
+# Validate SLS health before calling csi handoff bss-update-*, since
+# it relies on SLS
+check_sls_health
+
 set +e
 while true ; do    
     csi handoff bss-update-param --set metal.no-wipe=0 --limit $TARGET_XNAME

--- a/upgrade/1.2/scripts/upgrade/ncn-upgrade-ceph-nodes.sh
+++ b/upgrade/1.2/scripts/upgrade/ncn-upgrade-ceph-nodes.sh
@@ -37,6 +37,10 @@ target_ncn=$1
 # kind of thing which may need to be re-done in case of problems.
 ssh_keys_done=0
 
+# Validate SLS health before calling csi handoff bss-update-*, since
+# it relies on SLS
+check_sls_health >> "${LOG_FILE}" 2>&1
+
 state_name="CEPH_NODES_SET_NO_WIPE"
 state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
 if [[ $state_recorded == "0" ]]; then

--- a/upgrade/1.2/scripts/upgrade/ncn-upgrade-master-nodes.sh
+++ b/upgrade/1.2/scripts/upgrade/ncn-upgrade-master-nodes.sh
@@ -109,6 +109,10 @@ if [[ ${first_master_hostname} == ${target_ncn} ]]; then
         exit 1
       fi
 
+      # Validate SLS health before calling csi handoff bss-update-*, since
+      # it relies on SLS
+      check_sls_health
+
       scp /root/docs-csm-latest.noarch.rpm $promotingMaster:/root/docs-csm-latest.noarch.rpm
       ssh $promotingMaster "rpm --force -Uvh /root/docs-csm-latest.noarch.rpm"
       ssh $promotingMaster -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "/usr/share/doc/csm/upgrade/1.2/scripts/k8s/promote-initial-master.sh"
@@ -147,6 +151,10 @@ else
 fi
 
 drain_node $target_ncn
+
+# Validate SLS health before calling csi handoff bss-update-*, since
+# it relies on SLS
+check_sls_health >> "${LOG_FILE}" 2>&1
 
 {
 set +e

--- a/upgrade/1.2/scripts/upgrade/ncn-upgrade-worker-nodes.sh
+++ b/upgrade/1.2/scripts/upgrade/ncn-upgrade-worker-nodes.sh
@@ -93,6 +93,10 @@ fi
 
 drain_node $target_ncn
 
+# Validate SLS health before calling csi handoff bss-update-*, since
+# it relies on SLS
+check_sls_health >> "${LOG_FILE}" 2>&1
+
 {
 set +e
 while true ; do    


### PR DESCRIPTION
# Description

[CASMTRIAGE-3255](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3255) documents a case we have seen twice now where SLS is not healthy when calling CSI to set the no-wipe flag, resulting in the upgrade hanging. Currently the root cause of the issue is not understood.

In order to provide a better failure condition (rather than an infinite loop), this PR adds a very simple SLS health check before making the CSI call to set the no-wipe flag.

In order to better isolate the problem, this PR also adds this same check just before the "drain node" step (because it would be helpful to know if it is the drain which is causing this problem).

At Di's suggestion, I added this logic for node rebuilds both inside and outside of the upgrade context.

The SLS health check consists of 2 API calls, to the liveness and health endpoints. It validates that the correct response status is given (204 and 200 respectively). To avoid cases where SLS will recover on its own, it will retry the SLS health checks for up to 5 minutes before declaring it a failure.

I have tested the SLS health check function on hela (csm-1.2) and frigg (csm-1.0) and  validated that it works as expected. I haven't tested it in a live upgrade.

# Checklist Before Merging

- [X] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.
