### PR TITLE
CASMINST-4818 Use New csm-releases Repository

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -62,6 +62,7 @@ Arista
 artifact
 artifact's
 artifacts
+Artifactory
 ArubaOS-CX
 ASes
 ASICs

--- a/upgrade/1.2/scripts/upgrade/prepare-assets.sh
+++ b/upgrade/1.2/scripts/upgrade/prepare-assets.sh
@@ -79,7 +79,7 @@ if [[ -z ${TARBALL_FILE} ]]; then
 
     if [[ -z ${ENDPOINT} ]]; then
         # default endpoint to internal artifactory
-        ENDPOINT=https://artifactory.algol60.net/artifactory/releases/csm/1.2/
+        ENDPOINT=https://artifactory.algol60.net/artifactory/csm-releases/csm/1.2/
         echo "Use internal endpoint: ${ENDPOINT}"
     fi
 


### PR DESCRIPTION
This changes the URL from `releases` to `csm-releases`, where tarballs will now be published.

This is a backport of: https://github.com/Cray-HPE/docs-csm/pull/1851