### PR TITLE
CASMINST-4820: Add troubleshooting/remediation steps for SLS postgres SyncFailed

### DIFF
--- a/troubleshooting/index.md
+++ b/troubleshooting/index.md
@@ -9,6 +9,7 @@ This document provides links to troubleshooting information for services and fun
   * [`initrd.img.xz` not found](known_issues/initrd.img.zx_not_found.md)
 * [Platform CA Issues](known_issues/platform_ca_issues.md)
 * [Kafka Failure after CSM 1.2 Upgrade](known_issues/kafka_upgrade_failure.md)
+* [SLS Not Working During Node Rebuild](known_issues/SLS_Not_Working_During_Node_Rebuild.md)
 
 ## Troubleshooting topics
 

--- a/troubleshooting/known_issues/SLS_Not_Working_During_Node_Rebuild.md
+++ b/troubleshooting/known_issues/SLS_Not_Working_During_Node_Rebuild.md
@@ -1,0 +1,151 @@
+# SLS Not Working During Node Rebuild
+
+During some node rebuilds (including those that happen during [Stage 1](../../upgrade/1.2/Stage_1.md) and [Stage 2](../../upgrade/1.2/Stage_2.md) of the CSM upgrade process),
+the SLS Postgres database gets into a bad state, causing SLS to become unhealthy. This page outlines how to detect if this has happened and provides a remediation procedure.
+
+**Note:** If encountering this during a CSM upgrade, then at this point of the upgrade process, the system has not yet upgraded the CSM services
+themselves. Because of that, the documentation for the source CSM version still applies, and this page includes links for both the current
+CSM version (1.2) and for the previous CSM version (1.0).
+
+## Detection
+
+This procedure can be run on any master or worker NCN (unless it is the node being rebuilt).
+
+1. Get a token to use for API requests to SLS.
+
+    ```bash
+    ncn-mw# TOKEN=$(\
+              set -o pipefail
+              secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` &&
+              curl -s -S -d grant_type=client_credentials \
+                -d client_id=admin-client \
+                -d client_secret="$secret" \
+                https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token |
+              jq -r '.access_token') ; [[ -n $TOKEN ]] && echo "Token obtained" || echo "Error getting token"
+    ```
+
+    Expected output:
+
+    ```text
+    Token obtained
+    ```
+
+1. Perform basic SLS health check.
+
+    ```bash
+    ncn-mw# curl -iskH "Authorization: Bearer $TOKEN" https://api-gw-service-nmn.local/apis/sls/v1/health ; echo
+    ```
+
+    Example output if SLS is healthy:
+
+    ```text
+    HTTP/2 200
+    date: Fri, 17 Jun 2022 16:23:22 GMT
+    content-length: 58
+    content-type: text/plain; charset=utf-8
+    x-envoy-upstream-service-time: 4
+    server: istio-envoy
+
+    {"Vault":"Enabled and initialized","DBConnection":"Ready"}
+    ```
+
+    Note that the first line of expected output includes `200` as the status code of the response. If that
+    is not the case, or if other errors are seen, proceed to [Remediation](#remediation).
+
+1. Perform a basic SLS liveness check.
+
+    ```bash
+    ncn-mw# curl -iskH "Authorization: Bearer $TOKEN" https://api-gw-service-nmn.local/apis/sls/v1/liveness ; echo
+    ```
+
+    Example output if SLS is functioning:
+
+    ```text
+    HTTP/2 204
+    date: Fri, 17 Jun 2022 16:25:26 GMT
+    x-envoy-upstream-service-time: 3
+    server: istio-envoy
+    ```
+
+    As with the previous command, validate that the status code on the first line matches the expected output (`204` in
+    this case). If a different status code is returned, or other errors are seen, proceed to [Remediation](#remediation).
+
+1. Perform a basic SLS query.
+
+    This query lists all nodes in the system with the `Management` role.
+
+    ```bash
+    ncn-mw# curl -skH "Authorization: Bearer $TOKEN" https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management | jq
+    ```
+
+    Example output if SLS is working:
+
+    ```json
+    [
+      {
+        "Parent": "x3000c0s1b0",
+        "Xname": "x3000c0s1b0n0",
+        "Type": "comptype_node",
+        "Class": "River",
+        "TypeString": "Node",
+        "LastUpdated": 1654191069,
+        "LastUpdatedTime": "2022-06-02 17:31:09.155802 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "ncn-m001"
+          ],
+          "NID": 100010,
+          "Role": "Management",
+          "SubRole": "Master"
+        }
+      },
+
+      ["...omitting many lines for readability..."],
+
+      {
+        "Parent": "x3000c0s7b0",
+        "Xname": "x3000c0s7b0n0",
+        "Type": "comptype_node",
+        "Class": "River",
+        "TypeString": "Node",
+        "LastUpdated": 1654191069,
+        "LastUpdatedTime": "2022-06-02 17:31:09.155802 +0000 +0000",
+        "ExtraProperties": {
+          "Aliases": [
+            "ncn-w004"
+          ],
+          "NID": 100004,
+          "Role": "Management",
+          "SubRole": "Worker"
+        }
+      }
+    ]
+    ```
+
+    If the query fails, proceed to [Remediation](#remediation).
+
+If all of the API calls provide expected output, then SLS appears to be working properly. In that case, the rest of this page should be skipped.
+
+## Remediation
+
+If a check in the previous section indicates that SLS is not working properly, then check the status of the SLS Postgres database.
+
+```bash
+ncn-mw# kubectl get postgresql cray-sls-postgres -n services
+```
+
+Expected output if the database is healthy:
+
+```text
+NAME                TEAM       VERSION   PODS   VOLUME   CPU-REQUEST   MEMORY-REQUEST   AGE    STATUS
+cray-sls-postgres   cray-sls   11        3      1Gi                                     157d   Running
+```
+
+* If the `STATUS` is `SyncFailed`:
+  * If currently doing a CSM upgrade, then see
+    [(CSM 1.0) Postgres status `SyncFailed`](https://github.com/Cray-HPE/docs-csm/blob/release/1.0/operations/kubernetes/Troubleshoot_Postgres_Database.md#postgres-status-syncfailed).
+  * Otherwise, see [Postgres status `SyncFailed`](../../operations/kubernetes/Troubleshoot_Postgres_Database.md#postgres-status-syncfailed).
+* Otherwise, see the standard Postgres troubleshooting procedures for further avenues of investigation.
+  * If currently doing a CSM upgrade, then see
+    [(CSM 1.0) Troubleshoot Postgres Database](https://github.com/Cray-HPE/docs-csm/blob/release/1.0/operations/kubernetes/Troubleshoot_Postgres_Database.md).
+  * Otherwise, see [Troubleshoot Postgres Database](../../operations/kubernetes/Troubleshoot_Postgres_Database.md).

--- a/upgrade/1.2/README.md
+++ b/upgrade/1.2/README.md
@@ -78,6 +78,10 @@ For more information about modifying `customizations.yaml` and tuning for specif
 
    See [Kafka Failure after CSM 1.2 Upgrade](../../troubleshooting/known_issues/kafka_upgrade_failure.md)
 
+- Troubleshoot SLS not working
+
+    See [SLS Not Working During Node Rebuild](../../troubleshooting/known_issues/SLS_Not_Working_During_Node_Rebuild.md).
+
 - Rerun a step
 
    When running upgrade scripts, each script records what has been done successfully on a node. This is recorded in the

--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -1,6 +1,10 @@
 # Stage 0 - Prerequisites and Preflight Checks
 
-> **Note:** CSM 1.0.1 or higher is required in order to upgrade to CSM 1.2.0.
+> **Reminders:**
+>
+> - CSM 1.0.1 or higher is required in order to upgrade to CSM 1.2.0.
+> - If any problems are encountered and the procedure or command output does not provide relevant guidance, see
+>   [Relevant troubleshooting links for upgrade-related issues](README.md#relevant-troubleshooting-links-for-upgrade-related-issues).
 
 ## Abstract (Stage 0)
 

--- a/upgrade/1.2/Stage_1.md
+++ b/upgrade/1.2/Stage_1.md
@@ -1,5 +1,8 @@
 # Stage 1 - Ceph image upgrade
 
+**Reminder:** If any problems are encountered and the procedure or command output does not provide relevant guidance, see
+[Relevant troubleshooting links for upgrade-related issues](README.md#relevant-troubleshooting-links-for-upgrade-related-issues).
+
 ## Procedure
 
 1. Run `ncn-upgrade-ceph-nodes.sh` for `ncn-s001`. Follow output of the script carefully. The script will pause for manual interaction.

--- a/upgrade/1.2/Stage_2.md
+++ b/upgrade/1.2/Stage_2.md
@@ -1,5 +1,8 @@
 # Stage 2 - Kubernetes Upgrade from 1.19.9 to 1.20.13
 
+**Reminder:** If any problems are encountered and the procedure or command output does not provide relevant guidance, see
+[Relevant troubleshooting links for upgrade-related issues](README.md#relevant-troubleshooting-links-for-upgrade-related-issues).
+
 ## Stage 2.1
 
 1. Run `ncn-upgrade-master-nodes.sh` for `ncn-m002`.

--- a/upgrade/1.2/Stage_3.md
+++ b/upgrade/1.2/Stage_3.md
@@ -1,5 +1,8 @@
 # Stage 3 - CSM Service Upgrades
 
+**Reminder:** If any problems are encountered and the procedure or command output does not provide relevant guidance, see
+[Relevant troubleshooting links for upgrade-related issues](README.md#relevant-troubleshooting-links-for-upgrade-related-issues).
+
 ## Prepare assets on `ncn-m002`
 
 1. Set the `CSM_RELEASE` variable to the **target** CSM version of this upgrade.

--- a/upgrade/1.2/Stage_4.md
+++ b/upgrade/1.2/Stage_4.md
@@ -1,5 +1,8 @@
 # Stage 4 - Ceph Upgrade
 
+**Reminder:** If any problems are encountered and the procedure or command output does not provide relevant guidance, see
+[Relevant troubleshooting links for upgrade-related issues](README.md#relevant-troubleshooting-links-for-upgrade-related-issues).
+
 ## Addresses CVEs
 
 * `CVE-2021-3531`: Swift API denial of service.

--- a/upgrade/1.2/Stage_5.md
+++ b/upgrade/1.2/Stage_5.md
@@ -1,5 +1,8 @@
 # Stage 5 - Perform NCN Personalization
 
+**Reminder:** If any problems are encountered and the procedure or command output does not provide relevant guidance, see
+[Relevant troubleshooting links for upgrade-related issues](README.md#relevant-troubleshooting-links-for-upgrade-related-issues).
+
 ## Procedure
 
 1. Set the `root` user password and SSH keys before running NCN personalization.


### PR DESCRIPTION
# Description

[CASMTRIAGE-3255](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3255) documents a case we have seen twice now where SLS is not healthy when calling CSI to set the no-wipe flag, resulting in the upgrade hanging. Currently the root cause of the issue is not understood.

[CASMINST-4821]https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4821) is adding better checking for this condition to the upgrade scripts.

This PR is adding documentation on how to detect if a system is in this situation, and the remediation steps that have worked in the cases where this was seen.

I wrote up the procedure so that it should apply whether this is seen during an upgrade or otherwise. Until we know the root cause, we don't know if this can only happen during upgrades, or if it can happen during any node rebuild. If we do get clarity on this, the page can be refined accordingly.

# Checklist Before Merging

- [X] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.
