### PR TITLE
CASMTRIAGE-3536: time hack

### DIFF
--- a/upgrade/1.2/scripts/common/ncn-rebuild-common.sh
+++ b/upgrade/1.2/scripts/common/ncn-rebuild-common.sh
@@ -49,34 +49,24 @@ else
 fi
 
 state_name="ELIMINATE_NTP_CLOCK_SKEW"
-state_recorded=$(is_state_recorded "${state_name}" "${target_ncn}")
-if [[ $state_recorded == "0" && $2 != "--rebuild" ]]; then
-    echo "====> ${state_name} ..."
+state_recorded=$(is_state_recorded "${state_name}" "$target_ncn")
+in_sync=$(ssh "${target_ncn}" timedatectl | awk /synchronized:/'{print $NF}')
+if [[ "$in_sync" == "no" ]]; then
     {
-    if [[ "${target_ncn}" != "ncn-m001" ]]; then
-      # ensure the directory exists
-      ssh "${target_ncn}" 'mkdir -p /srv/cray/scripts/common/'
-      # copy the NTP script and template to the node
-      scp -pr "${CSM_ARTI_DIR}"/chrony/ "${target_ncn}":/srv/cray/scripts/common/
-      # run the script
-      #shellcheck disable=SC2029
-      if ! ssh "${target_ncn}" "TOKEN=$TOKEN /srv/cray/scripts/common/chrony/csm_ntp.py"; then
-          echo "${target_ncn} csm_ntp failed"
-          exit 1
-      fi
-
-      # if the node is not in sync after two minutes, fail
-      if ! ssh "${target_ncn}" 'chronyc waitsync 6 0.5 0.5 20'; then
-          echo "${target_ncn} the clock is not in sync.  Wait a bit more or try again."
-          exit 1
-      else
-          record_state "${state_name}" "${target_ncn}"
-      fi
+    ssh "$target_ncn" chronyc makestep
+    sleep 5
+    in_sync=$(ssh "${target_ncn}" timedatectl | awk /synchronized:/'{print $NF}')
+    if [[ "$in_sync" == "no" ]]; then
+        echo "The clock on ${target_ncn} is not in sync.  Wait a bit more or try again."
+        exit 1
+    else
+        record_state "${state_name}" "${target_ncn}"
     fi
     } >> ${LOG_FILE} 2>&1
 else
     echo "====> ${state_name} has been completed"
 fi
+
 
 state_name="WIPE_NODE_DISK"
 state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
@@ -308,6 +298,24 @@ if [[ $target_ncn != ncn-s* ]]; then
     } >> ${LOG_FILE} 2>&1
 fi 
 
+state_name="FORCE_TIME_SYNC"
+state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
+{
+if [[ $state_recorded == "0" ]]; then
+    echo "====> ${state_name} ..."
+    # force time to sync immediately
+      ssh "${target_ncn}" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null chronyc makestep
+      sleep 5
+      in_sync=$(ssh "${target_ncn}" timedatectl | awk /synchronized:/'{print $NF}')
+      if [[ "$in_sync" == "no" ]]; then
+          echo "The clock for ${target_ncn} is not in sync."
+      fi
+      record_state "${state_name}" "${target_ncn}"
+else
+    echo "====> ${state_name} has been completed"
+fi
+} >> ${LOG_FILE} 2>&1
+
 {
     set +e
     while true ; do    
@@ -356,4 +364,10 @@ if [[ ${target_ncn} != ncn-s* ]]; then
     else
         echo "====> ${state_name} has been completed"
     fi
+fi
+
+if [[ "$in_sync" == "no" ]]; then
+    echo "The clock for ${target_ncn} is not in sync. Please verify $target_ncn:/etc/chrony.d/cray.conf"
+    echo "contains a server that is reachable. See also: chronyc sources -v"
+    exit 1
 fi

--- a/upgrade/1.2/scripts/rebuild/prerequisites.sh
+++ b/upgrade/1.2/scripts/rebuild/prerequisites.sh
@@ -57,36 +57,4 @@ else
     echo "====> ${state_name} has been completed"
 fi
 
-state_name="ELIMINATE_NTP_CLOCK_SKEW_M001"
-state_recorded=$(is_state_recorded "${state_name}" "${target_ncn}")
-if [[ $state_recorded == "0" && $2 != "--rebuild" ]]; then
-    echo "====> ${state_name} ..."
-    {
-    if [[ "${target_ncn}" == "ncn-m001" ]]; then
-      # ensure the directory exists
-      mkdir -p /srv/cray/scripts/common/
-      # copy the NTP script and template to ncn-m001
-      cp -r --preserve=mode "${CSM_ARTI_DIR}"/chrony/ /srv/cray/scripts/common/
-      # run the script
-      if ! TOKEN=$TOKEN /srv/cray/scripts/common/chrony/csm_ntp.py; then
-          echo "${target_ncn} csm_ntp failed"
-          exit 1
-      else
-          record_state "${state_name}" "${target_ncn}"
-      fi
-
-      # if the node is not in sync after three minutes, fail
-      # ncn-m001 can take a little longer to syncrhonize, so it waits longer than the normal test
-      if ! ssh "${target_ncn}" 'chronyc waitsync 6 0.5 0.5 30'; then
-          echo "${target_ncn} the clock is not in sync.  Wait a bit more or try again."
-          exit 1
-      else
-          record_state "${state_name}" "${target_ncn}"
-      fi
-    fi
-    } >> ${LOG_FILE} 2>&1
-else
-    echo "====> ${state_name} has been completed"
-fi
-
 ok_report

--- a/upgrade/1.2/scripts/upgrade/prerequisites.sh
+++ b/upgrade/1.2/scripts/upgrade/prerequisites.sh
@@ -84,6 +84,56 @@ else
     echo "====> ${state_name} has been completed"
 fi
 
+state_name="REPAIR_AND_VERIFY_CHRONY_CONFIG"
+state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
+TOKEN=$(curl -s -S -d grant_type=client_credentials \
+                   -d client_id=admin-client \
+                   -d client_secret=$(kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d) \
+                   https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
+export TOKEN
+if [[ $state_recorded == "0" ]]; then
+    echo "====> ${state_name} ..."
+    {
+    if [[ "$(hostname)" == "ncn-m002" ]]; then
+        # we already did this from ncn-m001
+        echo "====> ${state_name} has been completed"
+    else
+      # shellcheck disable=SC2013
+      for target_ncn in $(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u); do
+
+        # ensure host is accessible, skip it if not
+        if ! ssh "$target_ncn" hostname > /dev/null; then
+            continue
+        fi
+
+        # ensure the directory exists
+        ssh "$target_ncn" mkdir -p /srv/cray/scripts/common/
+
+        # copy the NTP script and template to the target ncn
+        rsync -aq "${CSM_ARTI_DIR}"/chrony/ "$target_ncn":/srv/cray/scripts/common/
+
+        # shellcheck disable=SC2029 # it's ok that $TOKEN expands on the client side
+        # run the script
+        if ! ssh "$target_ncn" "TOKEN=$TOKEN /srv/cray/scripts/common/chrony/csm_ntp.py"; then
+            echo "${target_ncn} csm_ntp failed"
+            exit 1
+        fi
+
+        ssh "$target_ncn" chronyc makestep
+        sleep 5
+        in_sync=$(ssh "${target_ncn}" timedatectl | awk /synchronized:/'{print $NF}')
+        if [[ "$in_sync" == "no" ]]; then
+            echo "The clock for ${target_ncn} is not in sync.  Wait a bit more or try again."
+            exit 1
+        fi
+      done
+      record_state "${state_name}" "$(hostanme)"
+    fi
+    } >> ${LOG_FILE} 2>&1
+else
+    echo "====> ${state_name} has been completed"
+fi
+
 state_name="CHECK_CLOUD_INIT_PREREQ"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
 if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then


### PR DESCRIPTION
# Description

This commit makes the following changes:

1. In upgrade/prerequisites.sh, correct/verify the chrony config
for every node. Do this instead of doing it one node at a time
as they are upgraded. After `csm_ntp.py` has been run on a node,
use `chronyc makestep` to force time to sync immediately. With
this approach, time should be in sync across the cluster prior
to the upgrade beginning in earnest.

2. Once an upgraded node is online and settled, use `chronyc makestep`
to force time to sync immediately.
