### PR TITLE
CASMPET-5738 1.0 : DOCS: add enabling goss-servers as part of csm-1.0 power on

### DIFF
--- a/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
@@ -365,7 +365,7 @@ Verify that the Lustre file system is available from the management cluster.
 1. Determine whether the `cfs-state-reporter` service is failing to start on each manager/master and worker NCN while trying to contact CFS.
 
     ```bash
-    ncn# pdsh -w ncn-m00[1-3],ncn-w00[1-3] systemctl status cfs-state-reporter
+    ncn# for node in $(grep -oP "(ncn-[mw]\w+)" /etc/hosts | sort -u); do echo -n "$node: "; ssh $node systemctl status cfs-state-reporter; done
     ```
 
     Example output:
@@ -389,7 +389,7 @@ Verify that the Lustre file system is available from the management cluster.
     ncn-w001: Mar 19 19:34:50 ncn-w001 python3[5192]: Attempt 2484 of contacting CFS...
     ncn-w001: Mar 19 19:34:50 ncn-w001 python3[5192]: Unable to contact CFS to report component status: CFS returned a non-json response: Unauthorized Request
     ncn-w001: Mar 19 19:34:50 ncn-w001 python3[5192]: Expecting value: line 1 column 1 (char 0)
-    pdsh@ncn-m001: ncn-w001: ssh exited with exit code 3
+    ssh@ncn-m001: ncn-w001: ssh exited with exit code 3
     ```
 
     1. On each NCN where `cfs-state-reporter` is stuck in `activating` as shown in the preceding error messages, restart the `cfs-state-reporter` service. For example:
@@ -401,7 +401,8 @@ Verify that the Lustre file system is available from the management cluster.
     1. Check the status again.
 
         ```bash
-        ncn# pdsh -w ncn-m00[1-3],ncn-w00[1-3] systemctl status cfs-state-reporter
+
+        ncn# for node in $(grep -oP "(ncn-[mw]\w+)" /etc/hosts | sort -u); do echo -n "$node: "; ssh $node systemctl status cfs-state-reporter; done
         ```
 
 ### Verify BGP peering sessions
@@ -559,7 +560,15 @@ Verify that the Lustre file system is available from the management cluster.
     +----------------+------+--------+-------+------+---------+------+-------+------------+----------+
     ```
 
-1. To check the health and status of the management cluster after a power cycle, refer to the "Platform Health Checks" section in [Validate CSM Health](../validate_csm_health.md).
+1. Check the health and status of the management cluster after a power cycle.
+
+    1. Enable the `goss-servers` on all the NCNs. For example:
+
+        ```bash
+        ncn# for node in $(grep -oP "(ncn-[mws]\w+)" /etc/hosts | sort -u); do echo -n "$node: "; ssh $node systemctl enable --now goss-servers.service; done
+        ```
+
+    1. Follow the "Platform Health Checks" section in [Validate CSM Health](../validate_csm_health.md).
 
 1. If NCNs must have access to Lustre, start the Lustre file system. See [Power On the External Lustre File System](Power_On_the_External_Lustre_File_System.md).
 


### PR DESCRIPTION
# Description

Add a step to the 1.0 power on procedure to enable the goss-servers prior to running any goss tests.
This issue was fixed in the 1.2 image but the workaround needs to be documented in csm 1.0

Resolves [CASMPET-5738](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5738)
Relates to [CASMTRIAGE-3573](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3573)

Tested on fanta where the issue was reported

# Checklist Before Merging

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!---   checked checkbox: [x] -->
<!---   invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/MTL-1695/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
