### PR TITLE
CASMHMS-5367: Backport CSM 1.2 doc changes For ServerTech PDUs

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -525,6 +525,7 @@ untarred
 upgrader
 Upgrader
 upgrader's
+uppercase
 uptimes
 URIs
 v1

--- a/operations/security_and_authentication/Change_Credentials_on_ServerTech_PDUs.md
+++ b/operations/security_and_authentication/Change_Credentials_on_ServerTech_PDUs.md
@@ -1,145 +1,204 @@
 # Change Credentials on ServerTech PDUs
-This procedure changes password used by the `admn` user on ServerTech PDUs. Either a single PDU can be updated to a new credential, or update all ServerTech PDUs in the system to the same global credentials.
 
-**NOTE:** This procedure does not update the default credentials that RTS uses for new ServerTech PDUs added to a system. To change the default credentials, follow the [Update default ServerTech PDU Credentials used by the Redfish Translation Service](Update_Default_ServerTech_PDU_Credentials_used_by_the_Redfish_Translation_Service.md) procedure.
+This procedure changes password used by the `admn` user on ServerTech PDUs. Either a single PDU can be updated to a new credential, or
+all ServerTech PDUs in the system can be updated to the same global credentials.
+
+**NOTES:**
+
+- This procedure does not update the default credentials that RTS uses for new ServerTech PDUs added to a system. To change the default credentials, see
+  [Update default ServerTech PDU Credentials used by the Redfish Translation Service](Update_Default_ServerTech_PDU_Credentials_used_by_the_Redfish_Translation_Service.md).
+- ServerTech PDUs running firmware version `8.0q` or greater must have the password of the `admn` user changed before the JAWS REST API will function as expected.
 
 ## Prerequisites
--   The Cray command line interface \(CLI\) tool is initialized and configured on the system.
+
+- All of the commands in these procedures should be run from a master or worker node, unless otherwise indicated.
+- The Cray command line interface (CLI) is initialized and configured on the system. See [Configure the Cray CLI](../configure_cray_cli.md).
+- The PDU is accessible over the network. A PDU can be reachable by its component name (xname) hostname, but may not yet be discovered by HSM.
+- PDUs are manufactured by ServerTech.
+    This can be verified by the following command
+
+    ```bash
+    ncn-mw# PDU=x3000m0
+    ncn-mw# curl -k https://$PDU -i | grep Server
+    ```
+
+    Expected output for a ServerTech PDU:
+
+    ```text
+    Server: ServerTech-AWS/v8.0v
+    ```
 
 ## Procedure
 
-1. List the ServerTech PDUs currently discovered in the system:
+1. List the ServerTech PDUs currently discovered in the system.
 
     ```bash
-    ncn-m001# cray hsm inventory redfishEndpoints list --type CabinetPDUController --format json |
+    ncn-mw# cray hsm inventory redfishEndpoints list --type CabinetPDUController --format json |
         jq -r '.RedfishEndpoints[] | select(.FQDN | contains("rts")).ID'
     ```
 
-    Sample output:
-    ```
+    Example output:
+
+    ```text
     x3000m0
     ```
 
-2.  Specify the existing password for the `admn` user:
+1. Set up Vault password variable and command alias.
+
     ```bash
-    ncn-m001# read -s OLD_PDU_PASSWORD
-    ncn-m001# echo $OLD_PDU_PASSWORD
+    ncn-mw# VAULT_PASSWD=$(kubectl -n vault get secrets cray-vault-unseal-keys -o json | jq -r '.data["vault-root"]' |  base64 -d)
+    ncn-mw# alias vault='kubectl -n vault exec -i cray-vault-0 -c vault -- env VAULT_TOKEN=$VAULT_PASSWD VAULT_ADDR=http://127.0.0.1:8200 VAULT_FORMAT=json vault'
     ```
 
-    Expected output:
-    ```
-    secret
-    ```
+1. Look up the existing password for the `admn` user.
 
-3.  Specify the new desired password for the `admn` user. The new password must between 1 and 32 characters.
+    - To extract the global credentials from Vault for the PDUs:
+
+        ```bash
+        ncn-mw# vault kv get secret/pdu-creds/global/pdu
+        ```
+
+    - To extract the credentials from Vault for a single PDU:
+
+        ```bash
+        ncn-mw# PDU=x3000m0
+        ncn-mw# vault kv get secret/pdu-creds/$PDU
+        ```
+
+1. Store the existing password for the `admn` user.
+
     ```bash
-    ncn-m001# read -s NEW_PDU_PASSWORD
-    ncn-m001# echo $NEW_PDU_PASSWORD
+    ncn-mw# read -s OLD_PDU_PASSWORD
     ```
 
-    Expected output:
-    ```
-    supersecret
+1. Specify the new desired password for the `admn` user. The new password must follow the following criteria:
+
+    - Minimum of 8 characters
+    - At least 1 uppercase letter
+    - At least 1 lowercase letter
+    - At least 1 number character
+
+    ```bash
+    ncn-mw# read -s NEW_PDU_PASSWORD
     ```
 
-4.  Change password for the `admn` user on the ServerTech PDU.
+1. Change and update the password for ServerTech PDUs.
 
     Either change the credentials on a single PDU or change all ServerTech PDUs to the same global default value:
-    -   To update the password on a single ServerTech PDU in the system:
-        ```bash
-        ncn-m001# PDU=x3000m0
-        ncn-m001# curl -i -k -u "admn:$OLD_PDU_PASSWORD" -X PATCH https://$PDU/jaws/config/users/local/admn \
-            -d $(jq --arg PASSWORD "$NEW_PDU_PASSWORD" -nc '{password: $PASSWORD}')
-        ```
 
-        Expected output upon a successful password change:
-        ```
-        HTTP/1.1 204 No Content
-        Content-Type: text/html
-        Transfer-Encoding: chunked
-        Server: ServerTech-AWS/v8.0p
-        Set-Cookie: C5=1883488164; path=/
-        Connection: close
-        Pragma: JAWS v1.01
-        ```
+    - Update the password on a single ServerTech PDU
 
-    -   To update all ServerTech PDUs in the system to the same password:
-        ```bash
-        ncn-m001# for PDU in $(cray hsm inventory redfishEndpoints list --type CabinetPDUController --format json |
-          jq -r '.RedfishEndpoints[] | select(.FQDN | contains("rts")).ID'); do
-            echo "Updating password on $PDU"
-            curl -i -k -u "admn:$OLD_PDU_PASSWORD" -X PATCH https://$PDU/jaws/config/users/local/admn \
+        **NOTE**: To change the password on a single PDU, that PDU must be successfully discovered by HSM.
+
+        1. Set the PDU hostname to change the `admn` credentials:
+
+            ```bash
+            ncn-mw# PDU=x3000m0
+            ```
+
+        1. Verify that the PDU is reachable:
+
+            ```bash
+            ncn-mw# ping $PDU
+            ```
+
+        1. Change password for the `admn` user on the ServerTech PDU.
+
+            ```bash
+            ncn-mw# curl -i -k -u "admn:$OLD_PDU_PASSWORD" -X PATCH https://$PDU/jaws/config/users/local/admn \
                 -d $(jq --arg PASSWORD "$NEW_PDU_PASSWORD" -nc '{password: $PASSWORD}')
-        done
-        ```
+            ```
 
-        Expected output upon a successful password change:
-        ```
-        Updating password on x3000m0
-        HTTP/1.1 204 No Content
-        Content-Type: text/html
-        Transfer-Encoding: chunked
-        Server: ServerTech-AWS/v8.0p
-        Set-Cookie: C5=1883488164; path=/
-        Connection: close
-        Pragma: JAWS v1.01
-        Updating password on x3001m0
-        HTTP/1.1 204 No Content
-        Content-Type: text/html
-        Transfer-Encoding: chunked
-        Server: ServerTech-AWS/v8.0p
-        Set-Cookie: C5=1883488164; path=/
-        Connection: close
-        Pragma: JAWS v1.01
-        ```
+            Expected output upon a successful password change:
 
-    **NOTE**: After 5 minutes the previous credential should stop working, as the existing session timed out.
+            ```text
+            HTTP/1.1 204 No Content
+            Content-Type: text/html
+            Transfer-Encoding: chunked
+            Server: ServerTech-AWS/v8.0p
+            Set-Cookie: C5=1883488164; path=/
+            Connection: close
+            Pragma: JAWS v1.01
+            ```
 
-5.  Update the PDU credentials stored in Vault:
+        1. Update the PDU credentials stored in Vault.
+
+            ```bash
+            ncn-mw# vault kv get secret/pdu-creds/$PDU |
+                    jq --arg PASSWORD "$NEW_PDU_PASSWORD" '.data | .Password=$PASSWORD' |
+                    vault kv put secret/pdu-creds/$PDU -
+            ```
+
+    - Update all ServerTech PDUs in the system to the same password.
+
+        1. Change password for the `admn` user on the ServerTech PDUs currently discovered in the system.
+
+            ```bash
+            ncn-mw# for PDU in $(cray hsm inventory redfishEndpoints list --type CabinetPDUController --format json |
+                      jq -r '.RedfishEndpoints[] | select(.FQDN | contains("rts")).ID'); do
+                          echo "Updating password on $PDU"
+                          curl -i -k -u "admn:$OLD_PDU_PASSWORD" -X PATCH https://$PDU/jaws/config/users/local/admn \
+                                -d $(jq --arg PASSWORD "$NEW_PDU_PASSWORD" -nc '{password: $PASSWORD}')
+                    done
+            ```
+
+            Expected output upon a successful password change:
+
+            ```text
+            Updating password on x3000m0
+            HTTP/1.1 204 No Content
+            Content-Type: text/html
+            Transfer-Encoding: chunked
+            Server: ServerTech-AWS/v8.0p
+            Set-Cookie: C5=1883488164; path=/
+            Connection: close
+            Pragma: JAWS v1.01
+            Updating password on x3001m0
+            HTTP/1.1 204 No Content
+            Content-Type: text/html
+            Transfer-Encoding: chunked
+            Server: ServerTech-AWS/v8.0p
+            Set-Cookie: C5=1883488164; path=/
+            Connection: close
+            Pragma: JAWS v1.01
+            ```
+
+        1. Update Vault for all ServerTech PDUs in the system to the same password:
+
+            ```bash
+            ncn-mw# for PDU in $(cray hsm inventory redfishEndpoints list --type CabinetPDUController --format json |
+                      jq -r '.RedfishEndpoints[] | select(.FQDN | contains("rts")).ID'); do
+                          echo "Updating password on $PDU"
+                          vault kv get secret/pdu-creds/$PDU |
+                            jq --arg PASSWORD "$NEW_PDU_PASSWORD" '.data | .Password=$PASSWORD' |
+                            vault kv put secret/pdu-creds/$PDU -
+                    done
+            ```
+
+    **NOTE**: After five minutes, the previous credential should stop working as the existing sessions time out.
+
+1. Restart the Redfish Translation Service (RTS) to pickup the new PDU credentials.
+
     ```bash
-    ncn-m001# VAULT_PASSWD=$(kubectl -n vault get secrets cray-vault-unseal-keys -o json | jq -r '.data["vault-root"]' |  base64 -d)
-    ncn-m001# alias vault='kubectl -n vault exec -i cray-vault-0 -c vault -- env VAULT_TOKEN=$VAULT_PASSWD VAULT_ADDR=http://127.0.0.1:8200 VAULT_FORMAT=json vault'
+    ncn-mw# kubectl -n services rollout restart deployment cray-hms-rts
+    ncn-mw# kubectl -n services rollout status deployment cray-hms-rts
     ```
 
-    Either update the credentials in Vault for a single PDU or update Vault for all ServerTech PDUs to have same global default value:
-    -   To update Vault for a single PDU:
-        ```bash
-        ncn-m001# PDU=x3000m0
-        ncn-m001# vault kv get secret/pdu-creds/$PDU |
-            jq --arg PASSWORD "$NEW_PDU_PASSWORD" '.data | .Password=$PASSWORD' |
-            vault kv put secret/pdu-creds/$PDU -
-        ```
-
-    -   To update Vault for all ServerTech PDUs in the system to the same password:
-        ```bash
-        ncn-m001# for PDU in $(cray hsm inventory redfishEndpoints list --type CabinetPDUController --format json |
-          jq -r '.RedfishEndpoints[] | select(.FQDN | contains("rts")).ID'); do
-            echo "Updating password on $PDU"
-            vault kv get secret/pdu-creds/$PDU |
-                jq --arg PASSWORD "$NEW_PDU_PASSWORD" '.data | .Password=$PASSWORD' |
-                vault kv put secret/pdu-creds/$PDU -
-        done
-        ```
-
-6.  Restart the Redfish Translation Service (RTS) to pickup the new PDU credentials:
+1. Wait for RTS to initialize itself.
 
     ```bash
-    ncn-m001# kubectl -n services rollout restart deployment cray-hms-rts
-    ncn-m001# kubectl -n services rollout status deployment cray-hms-rts
+    ncn-mw# sleep 3m
     ```
 
-7.  Wait for RTS to initialize itself:
+1. Verify that RTS was able to communicate with the PDUs with the updated credentials.
+
     ```bash
-    ncn-m001# sleep 3m
+    ncn-mw# kubectl -n services exec -it deployment/cray-hms-rts -c cray-hms-rts-redis -- redis-cli keys '*/redfish/v1/Managers'
     ```
 
-8.  Verify RTS was able to communicate with the PDUs with the updated credentials:
-    ```bash
-    ncn-m001# kubectl -n services exec -it deployment/cray-hms-rts -c cray-hms-rts-redis -- redis-cli keys '*/redfish/v1/Managers'
-    ```
+    Expected output for a system with two PDUs.
 
-    Expected output for a system with 2 PDUs.
-    ```
+    ```text
     1) "x3000m0/redfish/v1/Managers"
     2) "x3001m0/redfish/v1/Managers"
     ```

--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -701,11 +701,9 @@ x3000c0s1b0  # No mgmt port association
    x3000c0s10b999  # No mgmt port association
    ```
 
-- HPE PDUs are not supported at this time and will likely show up as not being found in HSM. They can be ignored.
+- Cabinet PDU Controllers have component names (xnames) in the form of `xXmM`, where `X` is the cabinet and `M` is the ordinal of the Cabinet PDU Controller.
 
-   > Cabinet PDU Controllers have component names (xnames) in the form of `xXmM`, where `X` is the cabinet and `M` is the ordinal of the Cabinet PDU Controller.
-
-   Example mismatch for HPE PDU:
+   Example mismatch for a PDU:
 
    ```text
    =============== BMCs in SLS not in HSM components ===============
@@ -714,6 +712,28 @@ x3000c0s1b0  # No mgmt port association
    =============== BMCs in SLS not in HSM Redfish Endpoints ===============
    x3000m0
    ```
+
+   If the PDU is accessible over the network, the following can be used to determine the vendor of the PDU.
+
+   ```bash
+   ncn-m001# PDU=x3000m0
+   ncn-m001# curl -k -s --compressed  https://$PDU -i | grep Server:
+   ```
+
+  - Example ServerTech PDU output:
+
+     ```text
+     Server: ServerTech-AWS/v8.0v
+     ```
+  
+  - Example HPE PDU output:
+
+     ```text
+     Server: HPE/1.4.0
+     ```
+
+  - ServerTech PDUs may need passwords changed from their defaults to become functional. See [Change Credentials on ServerTech PDUs](security_and_authentication/Change_Credentials_on_ServerTech_PDUs.md).
+  - HPE PDUs are not supported at this time and will likely show up as not being found in HSM. They can be ignored.
 
 - BMCs having no association with a management switch port will be annotated as such, and should be investigated. Exceptions to this are in Mountain or Hill configurations where
   Mountain BMCs will show this condition on SLS/HSM mismatches, which is normal.


### PR DESCRIPTION

# Description
CSM 1.0 backport of: https://github.com/Cray-HPE/docs-csm/pull/1796 for ServerTech PDUs that fail discovery. The HPE PDU content was not backported, due to CSM 1.0 not supporting HPE PDUs.

# Issues and Related PRs
- CASMHMS-5367
- CSM 1.2 PR: https://github.com/Cray-HPE/docs-csm/pull/1796 
- main PR: https://github.com/Cray-HPE/docs-csm/pull/1865

# Checklist Before Merging
- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/MTL-1695/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
