### PR TITLE
CASMUSER-3027: Include warning about CPE instructions converting macvlan to hsn

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -256,6 +256,7 @@ iPDU
 iPDUs
 IPMI-based
 IPMI-enabled
+ipvlan
 IPv4
 IPv6
 iPXE
@@ -300,6 +301,7 @@ lowercase
 lowercased
 Luks
 macOS
+macvlan
 maneuver
 maneuvers
 Mbs

--- a/operations/UAS_user_and_admin_topics/UAI_macvlans_Network_Attachments.md
+++ b/operations/UAS_user_and_admin_topics/UAI_macvlans_Network_Attachments.md
@@ -9,10 +9,11 @@ This network attachment integrates the UAI into the HPE Cray EX internal network
 The network attachment also installs a set of routes in the UAI used to reach the compute nodes in the HPE Cray EX platform.
 
 **WARNING**
-This release sets a route over the nmn by default. In CPE release 22.04, instructions for Workload Managers specify that macvlan be changed to use the high speed network. This was found to have a negative impact on the slingshot fabric, as unknown MAC addresses would result in broadcast traffic.
-If macvlan is being changed to use the hsn, make sure the CPE instructions specify how to use iplvan instead of macvlan. In a future CSM release, the network attachment definition will be using ipvlan instead of macvlan to avoid this issue.
+This release sets a route over the NMN by default. In CPE release 22.04, instructions for Workload Managers specify that macvlan be changed to use the high speed network. This was found to have a negative impact on the slingshot fabric, as unknown MAC addresses would result in broadcast traffic.
+If macvlan is being changed to use the HSN, make sure the CPE instructions specify how to use iplvan instead of macvlan. In a future CSM release, the network attachment definition will be using ipvlan instead of macvlan to avoid this issue.
 
-Check how the network attachment is configured with
+Check how the network attachment is configured with:
+
 ```bash
 kubectl describe net-attach-def -n user macvlan-uas-nmn-conf
 ```

--- a/operations/UAS_user_and_admin_topics/UAI_macvlans_Network_Attachments.md
+++ b/operations/UAS_user_and_admin_topics/UAI_macvlans_Network_Attachments.md
@@ -9,7 +9,7 @@ This network attachment integrates the UAI into the HPE Cray EX internal network
 The network attachment also installs a set of routes in the UAI used to reach the compute nodes in the HPE Cray EX platform.
 
 **WARNING**
-This release sets a route over the NMN by default. In CPE release 22.04, instructions for Workload Managers specify that macvlan be changed to use the high speed network. 
+This release sets a route over the NMN by default. In CPE release 22.04, instructions for Workload Managers specify that macvlan be changed to use the high speed network.
 This was found to have a negative impact on the slingshot fabric, as unknown MAC addresses would result in broadcast traffic.
 If macvlan is being changed to use the HSN, make sure the CPE instructions specify how to use ipvlan instead of macvlan. In a future CSM release, the network attachment definition will be using ipvlan instead of macvlan to avoid this issue.
 

--- a/operations/UAS_user_and_admin_topics/UAI_macvlans_Network_Attachments.md
+++ b/operations/UAS_user_and_admin_topics/UAI_macvlans_Network_Attachments.md
@@ -8,6 +8,15 @@ The type of network attachment used on HPE Cray EX hardware for this purpose is 
 This network attachment integrates the UAI into the HPE Cray EX internal networks on the [UAI host node](UAI_Host_Nodes.md) where the UAI is running and assigns the UAI an IP address on the network defined by the network attachment.
 The network attachment also installs a set of routes in the UAI used to reach the compute nodes in the HPE Cray EX platform.
 
+**WARNING**
+This release sets a route over the nmn by default. In CPE release 22.04, instructions for Workload Managers specify that macvlan be changed to use the high speed network. This was found to have a negative impact on the slingshot fabric, as unknown MAC addresses would result in broadcast traffic.
+If macvlan is being changed to use the hsn, make sure the CPE instructions specify how to use iplvan instead of macvlan. In a future CSM release, the network attachment definition will be using ipvlan instead of macvlan to avoid this issue.
+
+Check how the network attachment is configured with
+```bash
+kubectl describe net-attach-def -n user macvlan-uas-nmn-conf
+```
+
 [Top: User Access Service (UAS)](index.md)
 
 [Next Topic: UAI Network Attachment Customization](UAI_Network_Attachments.md)

--- a/operations/UAS_user_and_admin_topics/UAI_macvlans_Network_Attachments.md
+++ b/operations/UAS_user_and_admin_topics/UAI_macvlans_Network_Attachments.md
@@ -9,8 +9,9 @@ This network attachment integrates the UAI into the HPE Cray EX internal network
 The network attachment also installs a set of routes in the UAI used to reach the compute nodes in the HPE Cray EX platform.
 
 **WARNING**
-This release sets a route over the NMN by default. In CPE release 22.04, instructions for Workload Managers specify that macvlan be changed to use the high speed network. This was found to have a negative impact on the slingshot fabric, as unknown MAC addresses would result in broadcast traffic.
-If macvlan is being changed to use the HSN, make sure the CPE instructions specify how to use iplvan instead of macvlan. In a future CSM release, the network attachment definition will be using ipvlan instead of macvlan to avoid this issue.
+This release sets a route over the NMN by default. In CPE release 22.04, instructions for Workload Managers specify that macvlan be changed to use the high speed network. 
+This was found to have a negative impact on the slingshot fabric, as unknown MAC addresses would result in broadcast traffic.
+If macvlan is being changed to use the HSN, make sure the CPE instructions specify how to use ipvlan instead of macvlan. In a future CSM release, the network attachment definition will be using ipvlan instead of macvlan to avoid this issue.
 
 Check how the network attachment is configured with:
 


### PR DESCRIPTION
# Description

Add warning about CPE instructions changing UAS defaults from nmn to hsn.

# Checklist Before Merging

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/MTL-1695/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
