### PR TITLE
CASMTRIAGE-359[7-9]: fixup NTP issues in prereq.sh

### DIFF
--- a/upgrade/1.2/scripts/upgrade/prerequisites.sh
+++ b/upgrade/1.2/scripts/upgrade/prerequisites.sh
@@ -134,7 +134,7 @@ if [[ $state_recorded == "0" ]]; then
             exit 1
         fi
       done
-      record_state "${state_name}" "$(hostanme)"
+      record_state "${state_name}" "$(hostname)"
     fi
     } >> ${LOG_FILE} 2>&1
 else

--- a/upgrade/1.2/scripts/upgrade/prerequisites.sh
+++ b/upgrade/1.2/scripts/upgrade/prerequisites.sh
@@ -120,8 +120,15 @@ if [[ $state_recorded == "0" ]]; then
         fi
 
         ssh "$target_ncn" chronyc makestep
-        sleep 5
+        loop_idx=0
         in_sync=$(ssh "${target_ncn}" timedatectl | awk /synchronized:/'{print $NF}')
+        # wait up to 90s for the node to be in sync
+        while [[ $loop_idx -lt 18 && "$in_sync" == "no" ]]; do
+            sleep 5
+            in_sync=$(ssh "${target_ncn}" timedatectl | awk /synchronized:/'{print $NF}')
+            loop_idx=$(( loop_idx+1 ))
+        done
+
         if [[ "$in_sync" == "no" ]]; then
             echo "The clock for ${target_ncn} is not in sync.  Wait a bit more or try again."
             exit 1

--- a/upgrade/1.2/scripts/upgrade/prerequisites.sh
+++ b/upgrade/1.2/scripts/upgrade/prerequisites.sh
@@ -110,7 +110,7 @@ if [[ $state_recorded == "0" ]]; then
         ssh "$target_ncn" mkdir -p /srv/cray/scripts/common/
 
         # copy the NTP script and template to the target ncn
-        rsync -aq "${CSM_ARTI_DIR}"/chrony/ "$target_ncn":/srv/cray/scripts/common/
+        rsync -aq "${CSM_ARTI_DIR}"/chrony "$target_ncn":/srv/cray/scripts/common/
 
         # shellcheck disable=SC2029 # it's ok that $TOKEN expands on the client side
         # run the script


### PR DESCRIPTION
# Description

* CASMTRIAGE-3597: Correct a bad rsync
* CASMTRIAGE-3598: wait up to 90s for a node to be in sync
* CASMTRIAGE-3599: spelling is hard...

# Checklist Before Merging

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!---   checked checkbox: [x] -->
<!---   invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/MTL-1695/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
