### PR TITLE
CASMNET-1637/CASMNET-1368 - Improve documentation for updating the `external-dns` IP address.

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -622,6 +622,3 @@ pre-1
 
 - operations/network/external_dns/Update_the_cmn-external-dns_Value_Post-Installation.md
 LoadBalancer
-
-- upgrade/1.2/scripts/sls/README.SLS_Upgrade.md
-IP address(es)

--- a/.spelling
+++ b/.spelling
@@ -619,3 +619,9 @@ preconfig
 - upgrade/1.2/plan_and_coordinate_network_upgrade.md
 # To differentiate between old CAN and new CAN
 pre-1
+
+- operations/network/external_dns/Update_the_cmn-external-dns_Value_Post-Installation.md
+LoadBalancer
+
+- upgrade/1.2/scripts/sls/README.SLS_Upgrade.md
+IP address(es)

--- a/operations/network/external_dns/Update_the_cmn-external-dns_Value_Post-Installation.md
+++ b/operations/network/external_dns/Update_the_cmn-external-dns_Value_Post-Installation.md
@@ -72,7 +72,7 @@ The `external-dns` IP address reservation in the SLS CMN `cmn_metallb_static_poo
    }
    ```
 
-1. Upload the updated `NMN.json` file to SLS.
+1. Upload the updated `CMN.json` file to SLS.
 
    ```bash
    ncn-m001# curl -s -k -H "Authorization: Bearer ${TOKEN}" --header \

--- a/operations/network/external_dns/Update_the_cmn-external-dns_Value_Post-Installation.md
+++ b/operations/network/external_dns/Update_the_cmn-external-dns_Value_Post-Installation.md
@@ -72,7 +72,7 @@ The `external-dns` IP reservation in the SLS `CMN` network `cmn_metallb_static_p
    }
    ```
 
-1. Upload the updated NMN.json file to SLS.
+1. Upload the updated `NMN.json` file to SLS.
 
    ```bash
    ncn-m001# curl -s -k -H "Authorization: Bearer ${TOKEN}" --header \

--- a/operations/network/external_dns/Update_the_cmn-external-dns_Value_Post-Installation.md
+++ b/operations/network/external_dns/Update_the_cmn-external-dns_Value_Post-Installation.md
@@ -3,7 +3,7 @@
 By default, the `services/cray-dns-powerdns-cmn-tcp` and `services/cray-dns-powerdns-cmn-udp` services both share the same Customer Management Network \(CMN\) external IP address.
 This is defined by the `cmn-external-dns` value, which is specified during the `csi config init` input.
 
-The IP address must be in the static range reserved in MetalLB's `cmn-static-pool` subnet. Currently, this is the only CMN IP address that must be known external to the system, 
+The IP address must be in the static range reserved in MetalLB's `cmn-static-pool` subnet. Currently, this is the only CMN IP address that must be known external to the system,
 in order for external DNS to delegate the `system-name.site-domain` zone to `services/cray-dns-powerdns` deployment.
 
 Changing this value after install is relatively straightforward, and only requires the external IP address for `services/cray-dns-powerdns-cmn-tcp` and `services/cray-dns-powerdns-cmn-udp` services to be changed. This

--- a/operations/network/external_dns/Update_the_cmn-external-dns_Value_Post-Installation.md
+++ b/operations/network/external_dns/Update_the_cmn-external-dns_Value_Post-Installation.md
@@ -14,6 +14,8 @@ The system is installed.
 
 ## Procedure
 
+### Update the LoadBalancer IP
+
 1. Find the external IP address for the `services/cray-dns-powerdns-cmn-tcp` and `services/cray-dns-powerdns-cmn-tcp` services.
 
     ```bash
@@ -27,7 +29,7 @@ The system is installed.
     cray-dns-powerdns-cmn-udp                     LoadBalancer   10.25.156.88    10.102.14.113   53:32674/UDP                 2d2h
     ```
 
-2. Edit the services and change `spec.loadBalancerIP` to the desired CMN IP address.
+1. Edit the services and change `spec.loadBalancerIP` to the desired CMN IP address.
 
     1. Edit the `cray-dns-powerdns-cmn-tcp` service.
 
@@ -35,8 +37,71 @@ The system is installed.
         ncn-m001# kubectl -n services edit svc cray-dns-powerdns-cmn-tcp
         ```
 
-    2. Edit the `cray-dns-powerdns-cmn-udp` service.
+    1. Edit the `cray-dns-powerdns-cmn-udp` service.
 
         ```bash
         ncn-m001# kubectl -n services edit svc cray-dns-powerdns-cmn-udp
         ```
+
+### Update SLS
+
+The `external-dns` IP reservation in the SLS `CMN` network `cmn_metallb_static_pool` subnet should be updated to the desired CMN IP address.
+
+1.  Retrieve the SLS data for `CMN` network.
+
+    ```bash
+    ncn-m001# export TOKEN=$(curl -s -k -S -d grant_type=client_credentials \
+    -d client_id=admin-client -d client_secret=`kubectl get secrets admin-client-auth \
+    -o jsonpath='{.data.client-secret}' | base64 -d` \
+    https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token \
+    | jq -r '.access_token')
+
+    ncn-m001# curl -s -k -H "Authorization: Bearer ${TOKEN}" \
+    https://api-gw-service-nmn.local/apis/sls/v1/networks/CMN|jq > CMN.json
+
+    ncn-m001# cp CMN.json CMN.json.bak
+    ```
+
+1. Update the `external-dns` IP address in `CMN.json` to the desired CMN IP address.
+
+   ```json
+   {
+     "Comment": "site to system lookups",
+     "IPAddress": "x.x.x.x",
+     "Name": "external-dns"
+   }
+   ```
+
+3.  Upload the updated NMN.json file to SLS.
+
+    ```bash
+    ncn-m001# curl -s -k -H "Authorization: Bearer ${TOKEN}" --header \
+    "Content-Type: application/json" --request PUT --data @CMN.json \
+    https://api-gw-service-nmn.local/apis/sls/v1/networks/CMN
+    ```
+
+### Update `customizations.yaml`
+
+**IMPORTANT:** If this step is not performed, then the PowerDNS configuration will be overwritten with the previous value the next time CSM or the `cray-dns-powerdns` Helm chart is upgraded.
+
+1. Extract `customizations.yaml` from the `site-init` secret in the `loftsman` namespace.
+
+   ```bash
+   ncn-m001# kubectl -n loftsman get secret site-init -o json | jq -r '.data."customizations.yaml"' | base64 -d > customizations.yaml
+   ```
+
+1. Update `system_to_site_lookups` in `customizations.yaml` to the desired CMN IP address.
+
+   ```yaml
+   spec:
+     network:
+       netstaticips:
+         site_to_system_lookups: x.x.x.x
+   ```
+
+ 1. Update the `site-init` secret in the `loftsman` namespace.
+
+    ```bash
+    ncn-m001# kubectl delete secret -n loftsman site-init
+    ncn-m001# kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
+    ```

--- a/operations/network/external_dns/Update_the_cmn-external-dns_Value_Post-Installation.md
+++ b/operations/network/external_dns/Update_the_cmn-external-dns_Value_Post-Installation.md
@@ -45,19 +45,19 @@ The system is installed.
 
 ### Update SLS
 
-The `external-dns` IP reservation in the SLS `CMN` network `cmn_metallb_static_pool` subnet should be updated to the desired CMN IP address.
+The `external-dns` IP address reservation in the SLS CMN `cmn_metallb_static_pool` subnet should be updated to the desired CMN IP address.
 
-1. Retrieve the SLS data for `CMN` network.
+1. Retrieve the SLS data for CMN.
 
    ```bash
    ncn-m001# export TOKEN=$(curl -s -k -S -d grant_type=client_credentials \
-   -d client_id=admin-client -d client_secret=`kubectl get secrets admin-client-auth \
-   -o jsonpath='{.data.client-secret}' | base64 -d` \
-   https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token \
-   | jq -r '.access_token')
+                 -d client_id=admin-client -d client_secret=`kubectl get secrets admin-client-auth \
+                 -o jsonpath='{.data.client-secret}' | base64 -d` \
+                 https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token \
+               | jq -r '.access_token')
 
    ncn-m001# curl -s -k -H "Authorization: Bearer ${TOKEN}" \
-   https://api-gw-service-nmn.local/apis/sls/v1/networks/CMN|jq > CMN.json
+                 https://api-gw-service-nmn.local/apis/sls/v1/networks/CMN|jq > CMN.json
 
    ncn-m001# cp CMN.json CMN.json.bak
    ```
@@ -76,8 +76,8 @@ The `external-dns` IP reservation in the SLS `CMN` network `cmn_metallb_static_p
 
    ```bash
    ncn-m001# curl -s -k -H "Authorization: Bearer ${TOKEN}" --header \
-   "Content-Type: application/json" --request PUT --data @CMN.json \
-   https://api-gw-service-nmn.local/apis/sls/v1/networks/CMN
+                 "Content-Type: application/json" --request PUT --data @CMN.json \
+                 https://api-gw-service-nmn.local/apis/sls/v1/networks/CMN
    ```
 
 ### Update `customizations.yaml`

--- a/operations/network/external_dns/Update_the_cmn-external-dns_Value_Post-Installation.md
+++ b/operations/network/external_dns/Update_the_cmn-external-dns_Value_Post-Installation.md
@@ -47,20 +47,20 @@ The system is installed.
 
 The `external-dns` IP reservation in the SLS `CMN` network `cmn_metallb_static_pool` subnet should be updated to the desired CMN IP address.
 
-1.  Retrieve the SLS data for `CMN` network.
+1. Retrieve the SLS data for `CMN` network.
 
-    ```bash
-    ncn-m001# export TOKEN=$(curl -s -k -S -d grant_type=client_credentials \
-    -d client_id=admin-client -d client_secret=`kubectl get secrets admin-client-auth \
-    -o jsonpath='{.data.client-secret}' | base64 -d` \
-    https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token \
-    | jq -r '.access_token')
+   ```bash
+   ncn-m001# export TOKEN=$(curl -s -k -S -d grant_type=client_credentials \
+   -d client_id=admin-client -d client_secret=`kubectl get secrets admin-client-auth \
+   -o jsonpath='{.data.client-secret}' | base64 -d` \
+   https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token \
+   | jq -r '.access_token')
 
-    ncn-m001# curl -s -k -H "Authorization: Bearer ${TOKEN}" \
-    https://api-gw-service-nmn.local/apis/sls/v1/networks/CMN|jq > CMN.json
+   ncn-m001# curl -s -k -H "Authorization: Bearer ${TOKEN}" \
+   https://api-gw-service-nmn.local/apis/sls/v1/networks/CMN|jq > CMN.json
 
-    ncn-m001# cp CMN.json CMN.json.bak
-    ```
+   ncn-m001# cp CMN.json CMN.json.bak
+   ```
 
 1. Update the `external-dns` IP address in `CMN.json` to the desired CMN IP address.
 
@@ -72,13 +72,13 @@ The `external-dns` IP reservation in the SLS `CMN` network `cmn_metallb_static_p
    }
    ```
 
-3.  Upload the updated NMN.json file to SLS.
+1. Upload the updated NMN.json file to SLS.
 
-    ```bash
-    ncn-m001# curl -s -k -H "Authorization: Bearer ${TOKEN}" --header \
-    "Content-Type: application/json" --request PUT --data @CMN.json \
-    https://api-gw-service-nmn.local/apis/sls/v1/networks/CMN
-    ```
+   ```bash
+   ncn-m001# curl -s -k -H "Authorization: Bearer ${TOKEN}" --header \
+   "Content-Type: application/json" --request PUT --data @CMN.json \
+   https://api-gw-service-nmn.local/apis/sls/v1/networks/CMN
+   ```
 
 ### Update `customizations.yaml`
 
@@ -99,9 +99,10 @@ The `external-dns` IP reservation in the SLS `CMN` network `cmn_metallb_static_p
          site_to_system_lookups: x.x.x.x
    ```
 
- 1. Update the `site-init` secret in the `loftsman` namespace.
+1. Update the `site-init` secret in the `loftsman` namespace.
 
-    ```bash
-    ncn-m001# kubectl delete secret -n loftsman site-init
-    ncn-m001# kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
-    ```
+   ```bash
+   ncn-m001# kubectl delete secret -n loftsman site-init
+   ncn-m001# kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
+   ```
+

--- a/operations/network/external_dns/Update_the_cmn-external-dns_Value_Post-Installation.md
+++ b/operations/network/external_dns/Update_the_cmn-external-dns_Value_Post-Installation.md
@@ -1,11 +1,12 @@
 # Update the `cmn-external-dns` value post-installation
 
-By default, the `services/cray-dns-powerdns-cmn-tcp` and `services/cray-dns-powerdns-cmn-udp` services both share the same Customer Management Network \(CMN\) external IP as defined by the `cmn-external-dns` value.
-This value is specified during the `csi config init` input.
+By default, the `services/cray-dns-powerdns-cmn-tcp` and `services/cray-dns-powerdns-cmn-udp` services both share the same Customer Management Network \(CMN\) external IP address.
+This is defined by the `cmn-external-dns` value, which is specified during the `csi config init` input.
 
-It must be in the static range reserved in MetalLB's `cmn-static-pool` subnet. Currently, this is the only CMN IP address that must be known external to the system so IT DNS can delegate the `system-name.site-domain` zone to `services/cray-dns-powerdns` deployment.
+The IP address must be in the static range reserved in MetalLB's `cmn-static-pool` subnet. Currently, this is the only CMN IP address that must be known external to the system, 
+in order for external DNS to delegate the `system-name.site-domain` zone to `services/cray-dns-powerdns` deployment.
 
-Changing it after install is relatively straightforward, and only requires the external IP address for `services/cray-dns-powerdns-cmn-tcp` and `services/cray-dns-powerdns-cmn-udp` services to be changed. This
+Changing this value after install is relatively straightforward, and only requires the external IP address for `services/cray-dns-powerdns-cmn-tcp` and `services/cray-dns-powerdns-cmn-udp` services to be changed. This
 procedure will update the IP addresses that DNS queries.
 
 ## Prerequisites
@@ -14,7 +15,7 @@ The system is installed.
 
 ## Procedure
 
-### Update the LoadBalancer IP
+### Update the LoadBalancer IP address
 
 1. Find the external IP address for the `services/cray-dns-powerdns-cmn-tcp` and `services/cray-dns-powerdns-cmn-tcp` services.
 
@@ -24,7 +25,7 @@ The system is installed.
 
     Example output:
 
-    ```console
+    ```text
     cray-dns-powerdns-cmn-tcp                     LoadBalancer   10.25.211.48    10.102.14.113   53:31111/TCP                 2d2h
     cray-dns-powerdns-cmn-udp                     LoadBalancer   10.25.156.88    10.102.14.113   53:32674/UDP                 2d2h
     ```

--- a/operations/network/external_dns/Update_the_cmn-external-dns_Value_Post-Installation.md
+++ b/operations/network/external_dns/Update_the_cmn-external-dns_Value_Post-Installation.md
@@ -105,4 +105,3 @@ The `external-dns` IP reservation in the SLS `CMN` network `cmn_metallb_static_p
    ncn-m001# kubectl delete secret -n loftsman site-init
    ncn-m001# kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
    ```
-

--- a/upgrade/1.2/scripts/sls/README.SLS_Upgrade.md
+++ b/upgrade/1.2/scripts/sls/README.SLS_Upgrade.md
@@ -20,9 +20,9 @@ During the update of SLS, at a minimum, answers to the following questions must 
      case of preserving `external-dns` values, to prevent site-networking changes that might result in NCN IP addresses
      overlapping during the upgrade process. This requires network subnetting expertise and EXPERT mode below.
 
-     If the `external-dns` IP address is changed the `customizations.yaml` `site_to_system_lookups` value needs to be updated to 
-     the new IP address. See the "Update customizations.yaml" section of the 
-     [Update the `cmn-external-dns` value post-installation](../../../../operations/network/external_dns/Update_the_cmn-external-dns_Value_Post-Installation.md) 
+     If the `external-dns` IP address is changed the `customizations.yaml` `site_to_system_lookups` value needs to be updated to
+     the new IP address. See the "Update customizations.yaml" section of the
+     [Update the `cmn-external-dns` value post-installation](../../../../operations/network/external_dns/Update_the_cmn-external-dns_Value_Post-Installation.md)
      document for instructions on how to do this.
    * Another, mutually exclusive example is the need to preserve all NCN IP addresses related to the old CAN while migrating
      the new CMN. This preservation is not often needed as the transition of NCN IP addresses for the CAN-to-CMN is automatically

--- a/upgrade/1.2/scripts/sls/README.SLS_Upgrade.md
+++ b/upgrade/1.2/scripts/sls/README.SLS_Upgrade.md
@@ -20,7 +20,10 @@ During the update of SLS, at a minimum, answers to the following questions must 
      case of preserving `external-dns` values, to prevent site-networking changes that might result in NCN IP addresses
      overlapping during the upgrade process. This requires network subnetting expertise and EXPERT mode below.
 
-     If the `external-dns` IP address is changed the `customizations.yaml` `site_to_system_lookups` value needs to be updated to the new IP address. See the "Update customizations.yaml" section of the [Update the `cmn-external-dns` value post-installation](../../../../operations/network/external_dns/Update_the_cmn-external-dns_Value_Post-Installation.md) document for instructions on how to do this.
+     If the `external-dns` IP address is changed the `customizations.yaml` `site_to_system_lookups` value needs to be updated to 
+     the new IP address. See the "Update customizations.yaml" section of the 
+     [Update the `cmn-external-dns` value post-installation](../../../../operations/network/external_dns/Update_the_cmn-external-dns_Value_Post-Installation.md) 
+     document for instructions on how to do this.
    * Another, mutually exclusive example is the need to preserve all NCN IP addresses related to the old CAN while migrating
      the new CMN. This preservation is not often needed as the transition of NCN IP addresses for the CAN-to-CMN is automatically
      handled during the upgrade. The flag to preserve CAN-to-CMN NCN IP addresses is mutually exclusive with other preservations

--- a/upgrade/1.2/scripts/sls/README.SLS_Upgrade.md
+++ b/upgrade/1.2/scripts/sls/README.SLS_Upgrade.md
@@ -21,7 +21,7 @@ During the update of SLS, at a minimum, answers to the following questions must 
      overlapping during the upgrade process. This requires network subnetting expertise and EXPERT mode below.
 
      If the `external-dns` IP address is changed the `customizations.yaml` `site_to_system_lookups` value needs to be updated to
-     the new IP address. See the "Update customizations.yaml" section of the
+     the new IP address. See the "Update `customizations.yaml`" section of the
      [Update the `cmn-external-dns` value post-installation](../../../../operations/network/external_dns/Update_the_cmn-external-dns_Value_Post-Installation.md)
      document for instructions on how to do this.
    * Another, mutually exclusive example is the need to preserve all NCN IP addresses related to the old CAN while migrating
@@ -29,7 +29,7 @@ During the update of SLS, at a minimum, answers to the following questions must 
      handled during the upgrade. The flag to preserve CAN-to-CMN NCN IP addresses is mutually exclusive with other preservations
      and the flag is `--preserve-existing-subnet-for-cmn ncns`.
    * Should no preservation flag be set, the default behavior is to recalculate every IP address on the existing CAN while migrating
-     to the CMN. The behavior in this case is to calculate the subnet sizesbased on number of devices (with a bit of spare room),
+     to the CMN. The behavior in this case is to calculate the subnet sizes based on number of devices (with a bit of spare room),
      while maximizing IP address pool sizes for (dynamic) services.
 
 ## Procedure

--- a/upgrade/1.2/scripts/sls/README.SLS_Upgrade.md
+++ b/upgrade/1.2/scripts/sls/README.SLS_Upgrade.md
@@ -10,7 +10,7 @@ During the update of SLS, at a minimum, answers to the following questions must 
 
 1. What is the internal VLAN and the site-routable IP subnet for the new CAN or CHN?
 
-1. Is there a need to preserve any existing IP address(es) during the CAN-to-CMN migration?
+1. Is there a need to preserve any existing IP addresses during the CAN-to-CMN migration?
 
    * One example is the `external-dns` IP address used for DNS lookups of system resources from site DNS servers. Changes to
      `external-dns` often require changes to site resources with requisite process and timeframes from other groups. For

--- a/upgrade/1.2/scripts/sls/README.SLS_Upgrade.md
+++ b/upgrade/1.2/scripts/sls/README.SLS_Upgrade.md
@@ -2,11 +2,13 @@
 
 ## Abstract
 
-During the update of SLS, at a minimum, answers to the following questions must be known prior to upgrading:
+Prior to updating SLS, at a minimum, answers to the following questions must be known:
 
-1. By default in 1.2 non-administrative user traffic will be migrated from the CAN to the CHN while minimizing changes. If
-   you want it to continue to come in via the CAN, or if the site is air-gapped, specify the correct options Will user
-   traffic (non-administrative) come in via the CAN, CHN or is the site air-gapped?
+1. Will user traffic (non-administrative) come in via the CAN, CHN or is the site air-gapped?
+
+   By default when upgrading to CSM 1.2, non-administrative user traffic is migrated from the CAN to the CHN while minimizing changes. If
+   instead it is desired that the non-administrative user traffic continue to come in via the CAN, or if the site is air-gapped,
+   then this must be explicitly specified during the SLS update.
 
 1. What is the internal VLAN and the site-routable IP subnet for the new CAN or CHN?
 
@@ -16,25 +18,28 @@ During the update of SLS, at a minimum, answers to the following questions must 
      `external-dns` often require changes to site resources with requisite process and timeframes from other groups. For
      preserving `external-dns` IP addresses, the flag is `--preserve-existing-subnet-for-cmn external-dns`.
 
-     **WARNING:** It is up to the user to compare pre-upgraded and post-upgraded SLS files for sanity. Specifically, in the
-     case of preserving `external-dns` values, to prevent site-networking changes that might result in NCN IP addresses
-     overlapping during the upgrade process. This requires network subnetting expertise and EXPERT mode below.
+     **WARNING:** It is up to the administrator to compare pre-upgraded and post-upgraded SLS files for sanity. Specifically, in the
+     case of preserving `external-dns` values, the administrator must ensure there are no site-networking changes that might result in NCN IP addresses
+     overlapping during the upgrade process. This requires network subnetting expertise and "expert mode" (described below).
 
-     If the `external-dns` IP address is changed, then the `customizations.yaml` `site_to_system_lookups` value must be updated to
-     the new IP address. See the "Update `customizations.yaml`" section of the
-     [Update the `cmn-external-dns` value post-installation](../../../../operations/network/external_dns/Update_the_cmn-external-dns_Value_Post-Installation.md)
-     document for instructions on how to do this.
-   * Another, mutually exclusive example is the need to preserve all NCN IP addresses related to the old CAN while migrating
+     If the `external-dns` IP address is changed, then the `customizations.yaml` `site_to_system_lookups` value must be updated to the new IP address. For instructions on how to do this. see
+     [Update `customizations.yaml`](../../../../operations/network/external_dns/Update_the_cmn-external-dns_Value_Post-Installation.md#update-customizationsyaml).
+   * A mutually exclusive example is the need to preserve all NCN IP addresses related to the old CAN while migrating
      the new CMN. This preservation is not often needed as the transition of NCN IP addresses for the CAN-to-CMN is automatically
      handled during the upgrade. The flag to preserve CAN-to-CMN NCN IP addresses is mutually exclusive with other preservations
      and the flag is `--preserve-existing-subnet-for-cmn ncns`.
-   * Should no preservation flag be set, the default behavior is to recalculate every IP address on the existing CAN while migrating
+   * If no preservation flag is set, then the default behavior is to recalculate every IP address on the existing CAN while migrating
      to the CMN. The behavior in this case is to calculate the subnet sizes based on number of devices (with a bit of spare room),
-     while maximizing IP address pool sizes for (dynamic) services.
+     while maximizing IP address pool sizes for dynamic services.
+
+## Prerequisites
+
+* The latest CSM documentation RPM must be installed on the node where the procedure is being performed. See
+  [Check for Latest Documentation](../../../../update_product_stream/index.md#check-for-latest-documentation).
 
 ## Procedure
 
-1. Get a token:
+1. Get a token.
 
     ```bash
     ncn# export TOKEN=$(curl -s -k -S -d grant_type=client_credentials -d client_id=admin-client \
@@ -42,7 +47,7 @@ During the update of SLS, at a minimum, answers to the following questions must 
             https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
     ```
 
-1. Extract SLS data to a file:
+1. Extract SLS data to a file.
 
     ```bash
     ncn# curl -k -H "Authorization: Bearer ${TOKEN}" https://api-gw-service-nmn.local/apis/sls/v1/dumpstate | jq -S . > sls_input_file.json
@@ -53,7 +58,7 @@ During the update of SLS, at a minimum, answers to the following questions must 
     * Example 1: Upgrade, using the CHN as the system default route (will by default output to `migrated_sls_file.json`).
 
         ```bash
-        ncn# ./sls_updater_csm_1.2.py --sls-input-file sls_input_file.json \
+        ncn# /usr/share/doc/csm/upgrade/1.2/scripts/sls/sls_updater_csm_1.2.py --sls-input-file sls_input_file.json \
                 --bican-user-network-name CHN \
                 --customer-highspeed-network 5 10.103.11.192/26
         ```
@@ -61,31 +66,30 @@ During the update of SLS, at a minimum, answers to the following questions must 
     * Example 2: Upgrade, using the CAN as the system default route, keep the generated CHN (for testing), and preserve the existing external-dns entry.
 
         ```bash
-        ncn# ./sls_updater_csm_1.2.py --sls-input-file sls_input_file.json \
+        ncn# /usr/share/doc/csm/upgrade/1.2/scripts/sls/sls_updater_csm_1.2.py --sls-input-file sls_input_file.json \
                 --bican-user-network-name CAN \
                 --customer-highspeed-network 5 10.103.11.192/26 \
                 --preserve-existing-subnet-for-cmn external-dns \
                 --retain-unused-user-network
         ```
 
-    NOTE: A detailed review of the migrated/upgraded data (using `vimdiff` or otherwise) for production systems and for systems which have many add-on components
-    (UAN, login nodes, storage integration points, etc.) is strongly recommended. Particularly, ensure subnet reservations are correct to prevent any data loss.
+    **NOTE:** A detailed review of the migrated/upgraded data is strongly recommended. Particularly, ensure that subnet reservations are correct to prevent any data loss.
 
-1. Upload migrated SLS file to SLS service:
+1. Upload migrated SLS file to SLS service.
 
     ```bash
     ncn# curl -H "Authorization: Bearer ${TOKEN}" -k -L -X POST 'https://api-gw-service-nmn.local/apis/sls/v1/loadstate' -F 'sls_dump=@migrated_sls_file.json'
     ```
 
-## SLS Updater Help
+## SLS Updater help
 
 For help and all options, run the following:
 
 ```bash
-ncn# ./sls_updater_csm_1.2.py --help
+ncn# /usr/share/doc/csm/upgrade/1.2/scripts/sls/sls_updater_csm_1.2.py --help
 ```
 
-## Actions and Order
+## Actions and order
 
 This migration is performed offline for data security. The running SLS file is first dumped, then the
 migration script is run and a new, migrated output file is created.
@@ -95,13 +99,13 @@ migration script is run and a new, migrated output file is created.
 1. Remove `kubeapi-vip` reservations for all networks except NMN.
 1. Create the new BICAN "toggle" network.
 1. Migrate the existing CAN to CMN.
-1. Create the CHN network.
-1. Convert IP addresses of the CAN network.
-1. Create MetalLB Pools and ASN entries on CMN and NMN networks.
+1. Create the CHN.
+1. Convert IP addresses of the CAN.
+1. Create MetalLB Pools and ASN entries on CMN and NMN.
 1. Update `uai_macvlan` in NMN DHCP ranges and `uai_macvlan` VLAN.
 1. Remove unused user networks (CAN or CHN) if requested (`--retain-unused-user-network` to keep).
 
-## Migrate Switch Names
+### Migrate switch names
 
 Switch names change in CSM 1.2 and must be applied in the following order:
 
@@ -110,37 +114,37 @@ Switch names change in CSM 1.2 and must be applied in the following order:
 
 This needs to be done in the order listed above.
 
-## Remove `api-gateway` / `istio-ingress-gateway` Reservations from HMNLB Subnets
+### Remove `api-gateway` / `istio-ingress-gateway` reservations from HMNLB subnets
 
 For CSM 1.2, the API gateway will no longer listen on the HMNLB MetalLB address pool.
 These aliases provided DNS records and are being removed.
 
-## Create the BICAN Network "Toggle"
+### Create the BICAN network "toggle"
 
 New for CSM 1.2, the BICAN network `ExtraProperties` value of `SystemDefaultRoute` is used
 to point to the CAN, CHN, or CMN, and is used by utilities to systematically toggle routes.
 
-## Migrate (existing) CAN to (new) CMN
+### Migrate existing CAN to new CMN
 
 Using the existing CAN as a template, create the CMN.  The same IP addresses will be preserved for
 NCNs (`bootstrap_dhcp`).  A new `network_hardware` subnet will be created where the end of the previous
 `bootstrap_dhcp` subnet existed to contain switching hardware. MetalLB pools in the `bootstrap_dhcp`
 subnet will be shifted around to remain at the end of the new bootstrap subnet.
 
-## Create the CHN Network
+### Create the CHN
 
 With the original CAN as a template, the new CHN network will be created. IP addresses will come from the
 `--customer-highspeed-network <vlan> <ipaddress>` (or its defaults). This is be created by default, but
 can be removed (if not needed or desired) by using the `--retain-unused-user-network` flag.
 
-## Convert the IP Addresses of the CAN Network
+### Convert the IP addresses of the CAN
 
 Since the original/existing CAN has been converted to the new CMN, the CAN must have new IP addresses.
 These are provided using the `--customer-access-network <vlan> <ipaddress>` (or its defaults). This CAN
 conversion will happen by default, but the new CAN may be removed (if not needed or desired) by using the
 `--retain-unused-user-network` flag.
 
-## Add BGP Peering Information to CMN and NMN
+### Add BGP peering information to CMN and NMN
 
 MetalLB and switches now obtain BGP peers using SLS data.
 
@@ -165,18 +169,18 @@ In CMN and NMN:
     "Subnets": 
 ```
 
-## Remove `kubeapi-vip` Reservations For All Networks Except NMN
+### Remove `kubeapi-vip` reservations for all networks except NMN
 
 Self explanatory. This endpoint now exists only on the NMN.
 
-## Update `uai_macvlan` in NMN Ranges and `uai_macvlan` VLAN
+### Update `uai_macvlan` in NMN ranges and `uai_macvlan` VLAN
 
 Self explanatory. Ranges are used for the addresses of UAIs.
 
-## Remove Unused User Networks (Either CAN or CHN) if Desired
+### Remove unused user networks (either CAN or CHN) if desired
 
-By default the CAN will be removed if `--bican-user-network-name CHN` or the CHN will be removed if
-`--bican-user-network-name CAN`. In order to keep this network, use the `--retain-unused-user-network` flag.
+By default the CAN will be removed if `--bican-user-network-name CHN` is specified, or the CHN will be removed if
+`--bican-user-network-name CAN` is specified. In order to prevent this, use the `--retain-unused-user-network` flag.
 Retention of the unused network is not normal behavior.
 
 * Generally production systems will NOT want to use this flag unless active toggling between CAN and CHN is required. This is not usual behavior.

--- a/upgrade/1.2/scripts/sls/README.SLS_Upgrade.md
+++ b/upgrade/1.2/scripts/sls/README.SLS_Upgrade.md
@@ -20,7 +20,7 @@ During the update of SLS, at a minimum, answers to the following questions must 
      case of preserving `external-dns` values, to prevent site-networking changes that might result in NCN IP addresses
      overlapping during the upgrade process. This requires network subnetting expertise and EXPERT mode below.
 
-     If the `external-dns` IP address is changed the `customizations.yaml` `site_to_system_lookups` value needs to be updated to
+     If the `external-dns` IP address is changed, then the `customizations.yaml` `site_to_system_lookups` value must be updated to
      the new IP address. See the "Update `customizations.yaml`" section of the
      [Update the `cmn-external-dns` value post-installation](../../../../operations/network/external_dns/Update_the_cmn-external-dns_Value_Post-Installation.md)
      document for instructions on how to do this.

--- a/upgrade/1.2/scripts/sls/README.SLS_Upgrade.md
+++ b/upgrade/1.2/scripts/sls/README.SLS_Upgrade.md
@@ -19,6 +19,8 @@ During the update of SLS, at a minimum, answers to the following questions must 
      **WARNING:** It is up to the user to compare pre-upgraded and post-upgraded SLS files for sanity. Specifically, in the
      case of preserving `external-dns` values, to prevent site-networking changes that might result in NCN IP addresses
      overlapping during the upgrade process. This requires network subnetting expertise and EXPERT mode below.
+
+     If the `external-dns` IP address is changed the `customizations.yaml` `site_to_system_lookups` value needs to be updated to the new IP address. See the "Update customizations.yaml" section of the [Update the `cmn-external-dns` value post-installation](../../../../operations/network/external_dns/Update_the_cmn-external-dns_Value_Post-Installation.md) document for instructions on how to do this.
    * Another, mutually exclusive example is the need to preserve all NCN IP addresses related to the old CAN while migrating
      the new CMN. This preservation is not often needed as the transition of NCN IP addresses for the CAN-to-CMN is automatically
      handled during the upgrade. The flag to preserve CAN-to-CMN NCN IP addresses is mutually exclusive with other preservations

--- a/upgrade/1.2/scripts/sls/README.SLS_Upgrade.md
+++ b/upgrade/1.2/scripts/sls/README.SLS_Upgrade.md
@@ -126,8 +126,8 @@ to point to the CAN, CHN, or CMN, and is used by utilities to systematically tog
 
 ### Migrate existing CAN to new CMN
 
-Using the existing CAN as a template, create the CMN.  The same IP addresses will be preserved for
-NCNs (`bootstrap_dhcp`).  A new `network_hardware` subnet will be created where the end of the previous
+Using the existing CAN as a template, create the CMN. The same IP addresses will be preserved for
+NCNs (`bootstrap_dhcp`). A new `network_hardware` subnet will be created where the end of the previous
 `bootstrap_dhcp` subnet existed to contain switching hardware. MetalLB pools in the `bootstrap_dhcp`
 subnet will be shifted around to remain at the end of the new bootstrap subnet.
 


### PR DESCRIPTION
# Description

* Added steps to update `customizations.yaml` and SLS to the procedure to change the `external-dns` IP address.
* Added a link to the `externap-dns` IP address update procedure to the SLS Upgrade documentation.

Addresses the following JIRA tickets.

[CASMNET-1637](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1637) - Document process to change system_to_site_lookups if CAN isn't converted to CMN
[CASMNET-1638](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1638) - Add steps to update customizations and SLS to procedure to change external DNS IP

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/MTL-1695/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
