### PR TITLE
MTL-1816 Fix link to point to main

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,14 +4,14 @@
 
 # Checklist Before Merging
 
-<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
+<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
 <!--- unchecked checkbox: [ ] -->
-<!---   checked checkbox: [x] -->
-<!---   invalid checkbox: [] -->
+<!--- checked checkbox: [x] -->
+<!--- invalid checkbox: [] -->
 
 - [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
 - [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
 - [ ] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.
 
-[1]: https://github.com/Cray-HPE/docs-csm/blob/MTL-1695/introduction/documentation_conventions.md#using-prompts
+[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
 [2]: https://github.com/Cray-HPE/teams


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->

This PR fixes the PR Template link for the documentation and conventions to point to `main`.

# Checklist Before Merging

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!---     checked checkbox: [x] -->
<!---         invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/MTL-1695/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
