### PR TITLE
CASMNET-1640 Update config files as per updated access matrix

### DIFF
--- a/scripts/operations/pyscripts/pyscripts/commands/test_bican_external/test_bican_external.py
+++ b/scripts/operations/pyscripts/pyscripts/commands/test_bican_external/test_bican_external.py
@@ -113,8 +113,8 @@ To node type {}
 Over network {} ({})""".format(
             to_node_type, network, network_suffix))
 
-        print("\t\t^^^^ FAILED: Cannot find a suitable node for node type {} ^^^^".format(to_node_type))
-        return 1
+        print("\t\t^^^^ SKIPPED: Cannot find a suitable node for node type {} ^^^^".format(to_node_type))
+        return 0
 
     to_node = to_node.with_domain_suffix(network_suffix)
 

--- a/scripts/operations/pyscripts/pyscripts/commands/test_bican_internal/can_toggle_tests.yaml
+++ b/scripts/operations/pyscripts/pyscripts/commands/test_bican_internal/can_toggle_tests.yaml
@@ -64,9 +64,9 @@ tests:
       leaf_switch: false
       leaf_BMC: false
       CDU: false
-      uan: false
+      uan: true
       uai: false
-      cn: false
+      cn: true
     hmn:
       ncn_master: true
       ncn_worker: true
@@ -142,9 +142,9 @@ tests:
       leaf_switch: false
       leaf_BMC: false
       CDU: false
-      uan: false
+      uan: true
       uai: false
-      cn: false
+      cn: true
     hmn:
       ncn_master: true
       ncn_worker: true
@@ -220,9 +220,9 @@ tests:
       leaf_switch: false
       leaf_BMC: false
       CDU: false
-      uan: false
+      uan: true
       uai: false
-      cn: false
+      cn: true
     hmn:
       ncn_master: true
       ncn_worker: true
@@ -298,9 +298,9 @@ tests:
       leaf_switch: false
       leaf_BMC: false
       CDU: false
-      uan: false
+      uan: true
       uai: false
-      cn: false
+      cn: true
     hmn:
       ncn_master: true
       ncn_worker: true
@@ -376,9 +376,9 @@ tests:
       leaf_switch: false
       leaf_BMC: false
       CDU: false
-      uan: false
+      uan: true
       uai: false
-      cn: false
+      cn: true
     hmn:
       ncn_master: true
       ncn_worker: true
@@ -454,9 +454,9 @@ tests:
       leaf_switch: false
       leaf_BMC: false
       CDU: false
-      uan: false
+      uan: true
       uai: false
-      cn: false
+      cn: true
     hmn:
       ncn_master: true
       ncn_worker: true
@@ -532,9 +532,9 @@ tests:
       leaf_switch: false
       leaf_BMC: false
       CDU: false
-      uan: false
+      uan: true
       uai: false
-      cn: false
+      cn: true
     hmn:
       ncn_master: true
       ncn_worker: true
@@ -610,8 +610,8 @@ tests:
       leaf_switch: false
       leaf_BMC: false
       CDU: false
-      uan: false
-      uai: false
+      uan: true
+      uai: true
       cn: true
     hmn:
       ncn_master: false
@@ -688,8 +688,8 @@ tests:
       leaf_switch: false
       leaf_BMC: false
       CDU: false
-      uan: false
-      uai: false
+      uan: true
+      uai: true
       cn: true
     hmn:
       ncn_master: false
@@ -766,9 +766,9 @@ tests:
       leaf_switch: false
       leaf_BMC: false
       CDU: false
-      uan: false
-      uai: false
-      cn: false
+      uan: true
+      uai: true
+      cn: true
     hmn:
       ncn_master: false
       ncn_worker: false

--- a/scripts/operations/pyscripts/pyscripts/commands/test_bican_internal/chn_toggle_tests.yaml
+++ b/scripts/operations/pyscripts/pyscripts/commands/test_bican_internal/chn_toggle_tests.yaml
@@ -53,9 +53,9 @@ tests:
       leaf_switch: false
       leaf_BMC: false
       CDU: false
-      uan: true
-      uai: true
-      cn: true
+      uan: false
+      uai: false
+      cn: false
     nmn:
       ncn_master: true
       ncn_worker: true
@@ -64,9 +64,9 @@ tests:
       leaf_switch: false
       leaf_BMC: false
       CDU: false
-      uan: false
+      uan: true
       uai: false
-      cn: false
+      cn: true
     hmn:
       ncn_master: true
       ncn_worker: true
@@ -142,9 +142,9 @@ tests:
       leaf_switch: false
       leaf_BMC: false
       CDU: false
-      uan: false
+      uan: true
       uai: false
-      cn: false
+      cn: true
     hmn:
       ncn_master: true
       ncn_worker: true
@@ -209,9 +209,9 @@ tests:
       leaf_switch: false
       leaf_BMC: false
       CDU: false
-      uan: true
-      uai: true
-      cn: true
+      uan: false
+      uai: false
+      cn: false
     nmn:
       ncn_master: true
       ncn_worker: true
@@ -220,9 +220,9 @@ tests:
       leaf_switch: false
       leaf_BMC: false
       CDU: false
-      uan: false
+      uan: true
       uai: false
-      cn: false
+      cn: true
     hmn:
       ncn_master: true
       ncn_worker: true
@@ -298,9 +298,9 @@ tests:
       leaf_switch: false
       leaf_BMC: false
       CDU: false
-      uan: false
+      uan: true
       uai: false
-      cn: false
+      cn: true
     hmn:
       ncn_master: true
       ncn_worker: true
@@ -376,9 +376,9 @@ tests:
       leaf_switch: false
       leaf_BMC: false
       CDU: false
-      uan: false
+      uan: true
       uai: false
-      cn: false
+      cn: true
     hmn:
       ncn_master: true
       ncn_worker: true
@@ -454,9 +454,9 @@ tests:
       leaf_switch: false
       leaf_BMC: false
       CDU: false
-      uan: false
+      uan: true
       uai: false
-      cn: false
+      cn: true
     hmn:
       ncn_master: true
       ncn_worker: true
@@ -532,9 +532,9 @@ tests:
       leaf_switch: false
       leaf_BMC: false
       CDU: false
-      uan: false
+      uan: true
       uai: false
-      cn: false
+      cn: true
     hmn:
       ncn_master: true
       ncn_worker: true
@@ -610,8 +610,8 @@ tests:
       leaf_switch: false
       leaf_BMC: false
       CDU: false
-      uan: false
-      uai: false
+      uan: true
+      uai: true
       cn: true
     hmn:
       ncn_master: false
@@ -688,8 +688,8 @@ tests:
       leaf_switch: false
       leaf_BMC: false
       CDU: false
-      uan: false
-      uai: false
+      uan: true
+      uai: true
       cn: true
     hmn:
       ncn_master: false
@@ -766,9 +766,9 @@ tests:
       leaf_switch: false
       leaf_BMC: false
       CDU: false
-      uan: false
-      uai: false
-      cn: false
+      uan: true
+      uai: true
+      cn: true
     hmn:
       ncn_master: false
       ncn_worker: false

--- a/scripts/operations/pyscripts/pyscripts/commands/test_bican_internal/test_bican_internal.py
+++ b/scripts/operations/pyscripts/pyscripts/commands/test_bican_internal/test_bican_internal.py
@@ -126,8 +126,7 @@ def test_from_node_type_over_network(from_node_type, network, config):
         Over network {} ({})""".format(
                     from_node_type, network, network_suffix))
 
-                print("\t\t^^^^ FAILED: Cannot find a suitable node for node type {} ^^^^".format(from_node_type))
-                total_ran += 1
+                print("\t\t^^^^ SKIPPED: Cannot find a suitable node for node type {} ^^^^".format(from_node_type))
                 continue
 
             from_node = from_node.with_domain_suffix(None)
@@ -163,8 +162,8 @@ def test_from_node_type_to_node_type_over_network(from_node_type, from_node, fro
         Expected to work: {}""".format(
             from_node_type, from_node.get_full_domain_name(), network, network_suffix, to_node_type, expected))
 
-        print("\t\t^^^^ FAILED: Cannot find a suitable node for node type {} ^^^^".format(to_node_type))
-        return 1
+        print("\t\t^^^^ SKIPPED: Cannot find a suitable node for node type {} ^^^^".format(to_node_type))
+        return 0
 
     to_node = to_node.with_domain_suffix(network_suffix)
 

--- a/scripts/operations/pyscripts/pyscripts/core/ssh/ssh_host.py
+++ b/scripts/operations/pyscripts/pyscripts/core/ssh/ssh_host.py
@@ -167,7 +167,7 @@ class SshHost:
 
         target_host_network = target_ssh_host.get_network_type()
 
-        if "cmn" == target_host_network and self.is_aruba_switch():
+        if ("cmn" == target_host_network or "chn" == target_host_network or "can" == target_host_network) and self.is_aruba_switch():
             # Condition 1 from above docs
             return socket.gethostbyname(target_ssh_host.get_full_domain_name())
         elif "hmnlb" == target_host_network and target_ssh_host.is_management_node():


### PR DESCRIPTION
# Description

Some SSH access tests are failing because they are incorrectly configured.

Note:

- These tests are run as per docs "Validate CSM Health" so it is important we configure these correctly for the release.
- The changes are confined to SSH access automated tests
 
Changes are as per the analysis of CASMTRIAGE-3586 and CASMTRIAGE-3587:
- NCN master and storage nodes should not be able to access UANs/UAIs/CNs over CHN
- All NCNs and switches must be able to access UANs and CNs over NMNs.
- UANs/UAIs/CNs must be able to access other UANs/UAIs/CNs over NMN.
- When on an Aruba switch, should resolve host names to IPs for all customer network target hostnames (CHN/CAN/CMN) as the workaround for CASMNET-1599 (previously, this was only doing it for CMN)

# Checklist Before Merging

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!---   checked checkbox: [x] -->
<!---   invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/MTL-1695/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
