### PR TITLE
CASMINST-4840: Add a CHECK_WEAVE stage to prerequisites.sh

### DIFF
--- a/upgrade/1.2/scripts/upgrade/prerequisites.sh
+++ b/upgrade/1.2/scripts/upgrade/prerequisites.sh
@@ -64,6 +64,12 @@ fi
 
 state_name="CHECK_WEAVE"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
+TOKEN=$(curl -s -S -d grant_type=client_credentials \
+                   -d client_id=admin-client \
+                   -d client_secret=$(kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d) \
+                   https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
+export TOKEN
+
 if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     echo "====> ${state_name} ..."
     {

--- a/upgrade/1.2/scripts/upgrade/prerequisites.sh
+++ b/upgrade/1.2/scripts/upgrade/prerequisites.sh
@@ -62,6 +62,41 @@ if [[ -z ${CSM_ARTI_DIR} ]]; then
     exit 1
 fi
 
+state_name="CHECK_WEAVE"
+state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
+if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
+    echo "====> ${state_name} ..."
+    {
+    SLEEVE_MODE="yes"
+    weave --local status connections | grep -q sleeve || SLEEVE_MODE="no"
+    if [ "${SLEEVE_MODE}" == "yes" ]; then
+        echo "Detected that weave is in sleeve mode with at least one peer.   Please consult FN6636 before proceeding with the upgrade."
+        exit 1
+    fi
+
+    # get bss global cloud-init data
+    curl -k -H "Authorization: Bearer $TOKEN" https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters?name=Global|jq .[] > cloud-init-global.json
+
+    CURRENT_MTU=$(jq '."cloud-init"."meta-data"."kubernetes-weave-mtu"' cloud-init-global.json)
+    echo "Current kubernetes-weave-mtu is $CURRENT_MTU"
+
+    # make sure kubernetes-weave-mtu is set to 1376
+    jq '."cloud-init"."meta-data"."kubernetes-weave-mtu" = "1376"' cloud-init-global.json > cloud-init-global-update.json
+
+    echo "Setting kubernetes-weave-mtu to 1376"
+    # post the update json to bss
+    curl -s -k -H "Authorization: Bearer ${TOKEN}" --header "Content-Type: application/json" \
+        --request PUT \
+        --data @cloud-init-global-update.json \
+        https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters
+
+    } >> ${LOG_FILE} 2>&1
+    record_state ${state_name} "$(hostname)"
+    echo
+else
+    echo "====> ${state_name} has been completed"
+fi
+
 state_name="UPDATE_SSH_KEYS"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
 if [[ $state_recorded == "0" ]]; then


### PR DESCRIPTION
# Description

This adds a weave check to prerequisites.sh to do two things:
1.  Check to see if weave is in sleeve mode and the hotfix hasn't been applied yet.
     If it does find weave in sleeve-mode with at least one peer, it will fail the upgrade and tell them to consult the weave MTU hotfix field notice.   We don't want to move forward and start upgrading nodes until this is fixed.
2.  Make sure kubernetes-weave-mtu is set to 1376 in BSS.

# Checklist Before Merging

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
