### PR TITLE
CASMINST-3806 - add management network steps for adding mountain cabinet

### DIFF
--- a/operations/node_management/Add_additional_Liquid-Cooled_Cabinets_to_a_System.md
+++ b/operations/node_management/Add_additional_Liquid-Cooled_Cabinets_to_a_System.md
@@ -9,20 +9,33 @@ This top level procedure outlines the process for adding additional liquid-coole
 - Follow the procedure [Create a Backup of the HSM Postgres Database](../hardware_state_manager/Create_a_Backup_of_the_HSM_Postgres_Database.md)
 
 ## Procedure
-1.  Perform procedures in [Add Liquid-Cooled Cabinets to SLS](../system_layout_service/Add_Liquid-Cooled_Cabinets_To_SLS.md)
+1. Perform procedures in [Add Liquid-Cooled Cabinets to SLS](../system_layout_service/Add_Liquid-Cooled_Cabinets_To_SLS.md)
 
-2.  Perform procedures in [Updating Cabinet Routes on Management NCNs](Updating_Cabinet_Routes_on_Management_NCNs.md)
+2. Perform procedures in [Updating Cabinet Routes on Management NCNs](Updating_Cabinet_Routes_on_Management_NCNs.md)
 
-3.  Reconfigure management network.
+3. Reconfigure management network.
+    * Validate SHCD with CANU.
+    * Validate cabling with CANU.
+    * Generate new switch configs with CANU and updated SLS.
+    * Review generated switch configs.
+    * Apply switch configs.
+    * Update CEC vlan(if required).
+    
+  CANU documentation can be found here: [link](https://github.com/Cray-HPE/canu/blob/1.6.5/readme.md)
+ 
+  **DISCLAIMER:** This procedure is for standard mountain cabinet network configurations and does not account for any site customizations that have been made to the management network.
+  Site administrators and support teams are responsible for knowing the customizations in effect in Shasta/CSM and configuring CANU to respect them when generating new network configurations.
 
-    **NOTE:** Placeholder: Provide a link to the procedure once ready.
+  See examples of using CANU custom switch configs and examples of other CSM features that require custom configs in the following documentation
+   * [Manual Switch Config Example](https://github.com/Cray-HPE/docs-csm/blob/421aa9be9910b1b8cf677776951b72c92c3ddc53/operations/network/management_network/manual_switch_config.md)
+   * [Custom Switch Config Example](https://github.com/Cray-HPE/canu/blob/7e0cb58b6253b4c02be1bd420a619befab1f33ca/docs/network_configuration_and_upgrade/custom_config.md)
 
-4.  Verify new hardware has been discovered by performing the [Hardware State Manager Discovery Validation](../validate_csm_health.md#hms-smd-discovery-validation) procedure.
+6. Verify new hardware has been discovered by performing the [Hardware State Manager Discovery Validation](../validate_csm_health.md#hms-smd-discovery-validation) procedure.
     After the management network has been reconfigured, it may take up to 10 minutes for the hardware in the new cabinets to become discovered.
 
-5.  Perform procedures in [Update Firmware with FAS](../firmware/Update_Firmware_with_FAS.md) to validate BIOS and BMC firmware levels in the new nodes, and perform updates as needed with FAS.
+7. Perform procedures in [Update Firmware with FAS](../firmware/Update_Firmware_with_FAS.md) to validate BIOS and BMC firmware levels in the new nodes, and perform updates as needed with FAS.
     > Slingshot Switches are updated with procedures from the *Slingshot Operations Guide*.
 
-6.  Continue on to the *Slingshot Operations Guide* to bring up the additional cabinets.
+8. Continue on to the *Slingshot Operations Guide* to bring up the additional cabinets.
 
     **NOTE:** Placeholder: Provide a link to the procedure once ready.

--- a/operations/node_management/Add_additional_Liquid-Cooled_Cabinets_to_a_System.md
+++ b/operations/node_management/Add_additional_Liquid-Cooled_Cabinets_to_a_System.md
@@ -48,4 +48,3 @@ This top level procedure outlines the process for adding additional liquid-coole
 
 1. Continue on to the *Slingshot Operations Guide* to bring up the additional cabinets.
 
-    **NOTE:** Placeholder: Provide a link to the procedure once ready.

--- a/operations/node_management/Add_additional_Liquid-Cooled_Cabinets_to_a_System.md
+++ b/operations/node_management/Add_additional_Liquid-Cooled_Cabinets_to_a_System.md
@@ -47,4 +47,3 @@ This top level procedure outlines the process for adding additional liquid-coole
     > Slingshot switches are updated with procedures from the *Slingshot Operations Guide*.
 
 1. Continue on to the *Slingshot Operations Guide* to bring up the additional cabinets.
-

--- a/operations/node_management/Add_additional_Liquid-Cooled_Cabinets_to_a_System.md
+++ b/operations/node_management/Add_additional_Liquid-Cooled_Cabinets_to_a_System.md
@@ -23,16 +23,16 @@ This top level procedure outlines the process for adding additional liquid-coole
     1. Review generated switch configurations.
     1. Apply switch configurations.
     1. Update CEC VLAN (if required).
-    
+
     For more information on CANU, see the [CANU `v1.6.5` documentation](https://github.com/Cray-HPE/canu/blob/1.6.5/readme.md).
- 
+
     **DISCLAIMER:** This procedure is for standard mountain cabinet network configurations and does not account for any site customizations that have been made to the management network.
     Site administrators and support teams are responsible for knowing the customizations in effect in Shasta/CSM and configuring CANU to respect them when generating new network configurations.
 
-    See examples of using CANU custom switch configurations and examples of other CSM features that require custom configurationss in the following documentation:
+    See examples of using CANU custom switch configurations and examples of other CSM features that require custom configurations in the following documentation:
 
-    * [Manual Switch Configuration Example](../network/management_network/manual_switch_config.md)
-    * [Custom Switch Configuration Example](https://github.com/Cray-HPE/canu/blob/7e0cb58b6253b4c02be1bd420a619befab1f33ca/docs/network_configuration_and_upgrade/custom_config.md)
+    - [Manual Switch Configuration Example](../network/management_network/manual_switch_config.md)
+    - [Custom Switch Configuration Example](https://github.com/Cray-HPE/canu/blob/7e0cb58b6253b4c02be1bd420a619befab1f33ca/docs/network_configuration_and_upgrade/custom_config.md)
 
 1. Verify that new hardware has been discovered.
 

--- a/operations/node_management/Add_additional_Liquid-Cooled_Cabinets_to_a_System.md
+++ b/operations/node_management/Add_additional_Liquid-Cooled_Cabinets_to_a_System.md
@@ -3,39 +3,49 @@
 This top level procedure outlines the process for adding additional liquid-cooled cabinets to a currently installed system.
 
 ## Prerequisites
-- The System's SHCD file has been updated with the new cabinets and cabling changes.
-- The new cabinets have been cabled up to the system, and the system's cabling has been validated to be correct.
+
+- The system's SHCD file has been updated with the new cabinets and cabling changes.
+- The new cabinets have been cabled to the system, and the system's cabling has been validated to be correct.
 - Follow the procedure [Create a Backup of the SLS Postgres Database](../system_layout_service/Create_a_Backup_of_the_SLS_Postgres_Database.md).
 - Follow the procedure [Create a Backup of the HSM Postgres Database](../hardware_state_manager/Create_a_Backup_of_the_HSM_Postgres_Database.md)
 
 ## Procedure
-1. Perform procedures in [Add Liquid-Cooled Cabinets to SLS](../system_layout_service/Add_Liquid-Cooled_Cabinets_To_SLS.md)
 
-2. Perform procedures in [Updating Cabinet Routes on Management NCNs](Updating_Cabinet_Routes_on_Management_NCNs.md)
+1. Perform procedures in [Add Liquid-Cooled Cabinets to SLS](../system_layout_service/Add_Liquid-Cooled_Cabinets_To_SLS.md).
 
-3. Reconfigure management network.
-    * Validate SHCD with CANU.
-    * Validate cabling with CANU.
-    * Generate new switch configs with CANU and updated SLS.
-    * Review generated switch configs.
-    * Apply switch configs.
-    * Update CEC vlan(if required).
+1. Perform procedures in [Updating Cabinet Routes on Management NCNs](Updating_Cabinet_Routes_on_Management_NCNs.md).
+
+1. Reconfigure management network.
+
+    1. Validate SHCD with CANU.
+    1. Validate cabling with CANU.
+    1. Generate new switch configurations with CANU and updated SLS.
+    1. Review generated switch configurations.
+    1. Apply switch configurations.
+    1. Update CEC VLAN (if required).
     
-  CANU documentation can be found here: [link](https://github.com/Cray-HPE/canu/blob/1.6.5/readme.md)
+    For more information on CANU, see the [CANU `v1.6.5` documentation](https://github.com/Cray-HPE/canu/blob/1.6.5/readme.md).
  
-  **DISCLAIMER:** This procedure is for standard mountain cabinet network configurations and does not account for any site customizations that have been made to the management network.
-  Site administrators and support teams are responsible for knowing the customizations in effect in Shasta/CSM and configuring CANU to respect them when generating new network configurations.
+    **DISCLAIMER:** This procedure is for standard mountain cabinet network configurations and does not account for any site customizations that have been made to the management network.
+    Site administrators and support teams are responsible for knowing the customizations in effect in Shasta/CSM and configuring CANU to respect them when generating new network configurations.
 
-  See examples of using CANU custom switch configs and examples of other CSM features that require custom configs in the following documentation
-   * [Manual Switch Config Example](https://github.com/Cray-HPE/docs-csm/blob/421aa9be9910b1b8cf677776951b72c92c3ddc53/operations/network/management_network/manual_switch_config.md)
-   * [Custom Switch Config Example](https://github.com/Cray-HPE/canu/blob/7e0cb58b6253b4c02be1bd420a619befab1f33ca/docs/network_configuration_and_upgrade/custom_config.md)
+    See examples of using CANU custom switch configurations and examples of other CSM features that require custom configurationss in the following documentation:
 
-6. Verify new hardware has been discovered by performing the [Hardware State Manager Discovery Validation](../validate_csm_health.md#hms-smd-discovery-validation) procedure.
+    * [Manual Switch Configuration Example](../network/management_network/manual_switch_config.md)
+    * [Custom Switch Configuration Example](https://github.com/Cray-HPE/canu/blob/7e0cb58b6253b4c02be1bd420a619befab1f33ca/docs/network_configuration_and_upgrade/custom_config.md)
+
+1. Verify that new hardware has been discovered.
+
+    Perform the [Hardware State Manager Discovery Validation](../validate_csm_health.md#hms-smd-discovery-validation) procedure.
+
     After the management network has been reconfigured, it may take up to 10 minutes for the hardware in the new cabinets to become discovered.
 
-7. Perform procedures in [Update Firmware with FAS](../firmware/Update_Firmware_with_FAS.md) to validate BIOS and BMC firmware levels in the new nodes, and perform updates as needed with FAS.
-    > Slingshot Switches are updated with procedures from the *Slingshot Operations Guide*.
+1. Validate BIOS and BMC firmware levels in the new nodes.
 
-8. Continue on to the *Slingshot Operations Guide* to bring up the additional cabinets.
+    Perform the procedures in [Update Firmware with FAS](../firmware/Update_Firmware_with_FAS.md). Perform updates as needed with FAS.
+
+    > Slingshot switches are updated with procedures from the *Slingshot Operations Guide*.
+
+1. Continue on to the *Slingshot Operations Guide* to bring up the additional cabinets.
 
     **NOTE:** Placeholder: Provide a link to the procedure once ready.


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
added general guidelines for the networking portion of adding a liquid cooled mountain cabinet
# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
