### PR TITLE
CASMINST-4847: Minor improvements related to CSM health validation

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -256,7 +256,6 @@ iPDU
 iPDUs
 IPMI-based
 IPMI-enabled
-ipvlan
 IPv4
 IPv6
 iPXE
@@ -301,7 +300,6 @@ lowercase
 lowercased
 Luks
 macOS
-macvlan
 maneuver
 maneuvers
 Mbs

--- a/.spelling
+++ b/.spelling
@@ -586,7 +586,8 @@ zeroization
 zeroize
 Zypper
 
-# Per-file spelling exceptions
+# Per-file spelling exceptions. Please keep this section sorted in order by filepath, so help make it easier to
+# see if a file already is listed.
 
 - glossary.md
 # To allow 802.3cd/bs
@@ -606,17 +607,17 @@ Init
 # To allow Site Init
 Init
 
-- operations/security_and_authentication/Updating_the_Liquid-Cooled_EX_Cabinet_Default_Credentials_after_a_CEC_Password_Change.md
-# To allow Site Init
-Init
+- operations/network/external_dns/Update_the_cmn-external-dns_Value_Post-Installation.md
+LoadBalancer
 
 - operations/network/management_network/upgrade.md
 Preconfig
 preconfig
 
+- operations/security_and_authentication/Updating_the_Liquid-Cooled_EX_Cabinet_Default_Credentials_after_a_CEC_Password_Change.md
+# To allow Site Init
+Init
+
 - upgrade/1.2/plan_and_coordinate_network_upgrade.md
 # To differentiate between old CAN and new CAN
 pre-1
-
-- operations/network/external_dns/Update_the_cmn-external-dns_Value_Post-Installation.md
-LoadBalancer

--- a/install/index.md
+++ b/install/index.md
@@ -26,7 +26,7 @@ Once the CSM installation has completed, other product streams for the HPE Cray 
 1. [Collect MAC addresses for NCNs](#collect_mac_addresses_for_ncns)
 1. [Deploy management nodes](#deploy_management_nodes)
 1. [Install CSM services](#install_csm_services)
-1. [Validate CSM Health before final NCN deployment](#validate_csm_health_before_final_ncn_deploy)
+1. [Validate CSM health](#validate_csm_health_before_final_ncn_deploy)
 1. [Deploy final NCN](#deploy_final_ncn)
 1. [Configure administrative access](#configure_administrative_access)
 1. [Validate CSM health](#validate_csm_health)
@@ -52,11 +52,11 @@ sections, but there is also a [general troubleshooting topic](#troubleshooting_i
       Having the data in the SHCD which matches the physical cabling will be needed later in both
       [Prepare configuration payload](#prepare_configuration_payload) and [Configure management network switches](#configure_management_network).
 
-      See [Validate SHCD](../operations/network/management_network/validate_shcd.md)
+      See [Validate SHCD](../operations/network/management_network/validate_shcd.md).
 
       **Note**: If a reinstall or fresh install of this software release is being done on this system and the management
-      network cabling has already been validated, then this topic could be skipped and instead move to
-      [Prepare configuration payload](#prepare_configuration_payload)
+      network cabling has already been validated, then skip this step and move to
+      [Prepare configuration payload](#prepare_configuration_payload).
    <a name="prepare_configuration_payload"></a>
 
    1. Prepare configuration payload
@@ -77,7 +77,7 @@ sections, but there is also a [general troubleshooting topic](#troubleshooting_i
       and application nodes, scaling back DHCP on the management nodes, wiping the storage on the management nodes,
       powering off the management nodes, and possibly powering off the PIT node.
 
-      See [Prepare Management Nodes](prepare_management_nodes.md)
+      See [Prepare Management Nodes](prepare_management_nodes.md).
    <a name="bootstrap_pit_node"></a>
 
    1. Bootstrap PIT node
@@ -87,7 +87,7 @@ sections, but there is also a [general troubleshooting topic](#troubleshooting_i
       because it does not require any physical media to prepare. However, remotely mounting an ISO on a BMC does not
       work smoothly for nodes from all vendors. It is recommended to try the RemoteISO first.
 
-      Use one of these procedures to bootstrap the PIT node from the LiveCD.
+      Use one of these procedures to bootstrap the PIT node from the LiveCD:
       * [Bootstrap PIT Node from LiveCD Remote ISO](bootstrap_livecd_remote_iso.md) (recommended)
          * **Gigabyte BMCs** should not use the RemoteISO method.
          * **Intel BMCs** should not use the RemoteISO method.
@@ -101,11 +101,11 @@ sections, but there is also a [general troubleshooting topic](#troubleshooting_i
       Now that the PIT node has been booted with the LiveCD environment and CSI has generated the switch IP addresses,
       the management network switches can be configured.
 
-      See [Management Network User Guide](../operations/network/management_network/index.md)
+      See [Management Network User Guide](../operations/network/management_network/index.md).
 
       **Note**: If a reinstall of this software release is being done on this system and the management network switches
-      have already been configured, then this topic could be skipped and instead move to
-      [Collect MAC addresses for NCNs](#collect_mac_addresses_for_ncns)
+      have already been configured, then skip this step and move to
+      [Collect MAC addresses for NCNs](#collect_mac_addresses_for_ncns).
    <a name="collect_mac_addresses_for_ncns"></a>
 
    1. Collect MAC addresses for NCNs
@@ -115,7 +115,7 @@ sections, but there is also a [general troubleshooting topic](#troubleshooting_i
       of the steps done up to this point because `csi config init` will need to be run with the proper
       MAC addresses.
 
-      See [Collect MAC Addresses for NCNs](collect_mac_addresses_for_ncns.md)
+      See [Collect MAC Addresses for NCNs](collect_mac_addresses_for_ncns.md).
 
       **Note**: If a reinstall of this software release is being done on this system and the `ncn_metadata.csv`
       file already had valid MAC addresses for both BMC and node interfaces before `csi config init` was run, then
@@ -134,27 +134,27 @@ sections, but there is also a [general troubleshooting topic](#troubleshooting_i
       except for the PIT node. The PIT node will join Kubernetes after it is rebooted later in
       [Deploy final NCN](#deploy_final_ncn).
 
-      See [Deploy Management Nodes](deploy_management_nodes.md)
+      See [Deploy Management Nodes](deploy_management_nodes.md).
    <a name="install_csm_services"></a>
 
    1. Install CSM services
 
-      Now that deployment of management nodes is complete with initialized Ceph storage and a running Kubernetes
-      cluster on all worker and master nodes, except the PIT node, the CSM services can be installed. The Nexus
-      repository will be populated with artifacts, containerized CSM services will be installed, and a few other configuration steps taken.
+      Deployment of management nodes is complete with initialized Ceph storage and a running Kubernetes
+      cluster on all worker and master nodes, except the PIT node. The Nexus
+      repository will be populated with artifacts, containerized CSM services will be installed, and a few other configuration steps will be taken.
 
-      See [Install CSM Services](install_csm_services.md)
+      See [Install CSM Services](install_csm_services.md).
    <a name="validate_csm_health_before_final_ncn_deploy"></a>
 
-   1. Validate CSM health before final NCN deployment
+   1. Validate CSM health
 
-      After installing all of the CSM services, now validate the health of the management nodes and all CSM services.
+      Validate the health of the management nodes and all CSM services.
       The reason to do it now is that if there are any problems detected with the core infrastructure or the nodes, it is
-      easy to rewind the installation to [Deploy management nodes](#deploy_management_nodes) because the PIT node has not
-      yet been redeployed. In addition, redeploying the PIT node successfully requires several CSM services to be working
-      properly, so validating this is important.
+      easy to rewind the installation to [Deploy management nodes](#deploy_management_nodes), because the PIT node has not
+      yet been rebooted. In addition, rebooting the PIT node and deploying the final NCN successfully requires several CSM
+      services to be working properly, so validating this is important.
 
-      To run the CSM health checks, see [Validate CSM Health](../operations/validate_csm_health.md)
+      See [Validate CSM Health](../operations/validate_csm_health.md).
    <a name="deploy_final_ncn"></a>
 
    1. Deploy final NCN
@@ -163,7 +163,7 @@ sections, but there is also a [general troubleshooting topic](#troubleshooting_i
       of Booting the CSM Barebones Image and the UAS/UAI tests, the PIT node can be rebooted to leave the LiveCD
       environment and assume its intended role as one the Kubernetes master nodes.
 
-      See [Deploy Final NCN](deploy_final_ncn.md)
+      See [Deploy Final NCN](deploy_final_ncn.md).
    <a name="configure_administrative_access"></a>
 
    1. Configure administrative access
@@ -175,7 +175,7 @@ sections, but there is also a [general troubleshooting topic](#troubleshooting_i
       CAPMC, configuring the CSM layer of configuration by CFS in NCN personalization,and configuring the node BMCs (node
       controllers) for nodes in liquid cooled cabinets.
 
-      See [Configure Administrative Access](configure_administrative_access.md)
+      See [Configure Administrative Access](configure_administrative_access.md).
    <a name="validate_csm_health"></a>
 
    1. Validate CSM health
@@ -188,7 +188,7 @@ sections, but there is also a [general troubleshooting topic](#troubleshooting_i
       a management node, checking the health after a management node has rebooted because of a crash, as part of doing
       a full system power down or power up, or after other types of system maintenance.
 
-      See [Validate CSM Health](../operations/validate_csm_health.md)
+      See [Validate CSM Health](../operations/validate_csm_health.md).
    <a name="configure_prometheus_alert_notifications"></a>
 
    1. Configure Prometheus alert notifications
@@ -199,8 +199,8 @@ sections, but there is also a [general troubleshooting topic](#troubleshooting_i
       as well as [Notification Template Examples](https://prometheus.io/docs/alerting/latest/notification_examples/). Currently supported notification
       types include Slack, Pager Duty, email, or a custom integration via a generic webhook interface.
 
-      See [Configure Prometheus Email Alert Notifications](../operations/system_management_health/Configure_Prometheus_Email_Alert_Notifications.md) for example
-      configuration of an email alert notification for Postgres replication alerts that are defined on the system.
+      See [Configure Prometheus Email Alert Notifications](../operations/system_management_health/Configure_Prometheus_Email_Alert_Notifications.md) for an example
+      configuration of an email alert notification for the Postgres replication alerts that are defined on the system.
    <a name="update_firmware_with_fas"></a>
 
    1. Update firmware with FAS
@@ -222,9 +222,10 @@ sections, but there is also a [general troubleshooting topic](#troubleshooting_i
       After completion of the firmware update with FAS, compute nodes can be prepared. Some compute node
       types have special preparation steps, but most compute nodes are ready to be used now.
 
-      These compute node types require preparation.
-         * HPE Apollo 6500 XL645D Gen10 Plus
-         * Gigabyte
+      These compute node types require preparation:
+
+      * HPE Apollo 6500 XL645D Gen10 Plus
+      * Gigabyte
 
       See [Prepare Compute Nodes](prepare_compute_nodes.md)
    <a name="next_topic"></a>
@@ -242,4 +243,4 @@ sections, but there is also a [general troubleshooting topic](#troubleshooting_i
       The installation of the Cray System Management (CSM) product requires knowledge of the various nodes and
       switches for the HPE Cray EX system. The procedures in this section should be referenced during the CSM install
       for additional information on system hardware, troubleshooting, and administrative tasks related to CSM.
-      See [Troubleshooting Installation Problems](troubleshooting_installation.md)
+      See [Troubleshooting Installation Problems](troubleshooting_installation.md).

--- a/operations/system_management_health/Access_System_Management_Health_Services.md
+++ b/operations/system_management_health/Access_System_Management_Health_Services.md
@@ -3,7 +3,7 @@
 All System Management Health services are exposed outside the cluster through the OAuth2 Proxy and Istio's ingress gateway to enforce the authentication and authorization policies. The URLs to access these
 services are available on any system with CMN, BGP, MetalLB, and external DNS properly configured.
 
-The `SYSTEM_DOMAIN_NAME` value in the examples below is an Ansible variable defined as follows and is expected to be the systems' FQDN.
+The `SYSTEM_DOMAIN_NAME` value in the examples below is an Ansible variable defined as follows and is expected to be the system's FQDN.
 
 ```bash
 ncn-mw# kubectl get secret site-init -n loftsman -o jsonpath='{.data.customizations\.yaml}' | base64 -d | grep "external:"

--- a/operations/system_management_health/Access_System_Management_Health_Services.md
+++ b/operations/system_management_health/Access_System_Management_Health_Services.md
@@ -5,9 +5,13 @@ services are available on any system with CMN, BGP, MetalLB, and external DNS pr
 
 The `SYSTEM_DOMAIN_NAME` value in the examples below is an Ansible variable defined as follows and is expected to be the systems' FQDN.
 
-```screen
-ncn-m001# kubectl get secret site-init -n loftsman -o jsonpath='{.data.customizations\.yaml}' \
-| base64 -d | grep "external:"
+```bash
+ncn-mw# kubectl get secret site-init -n loftsman -o jsonpath='{.data.customizations\.yaml}' | base64 -d | grep "external:"
+```
+
+Example output:
+
+```yaml
       external: SYSTEM_DOMAIN_NAME
 ```
 

--- a/operations/system_management_health/Access_System_Management_Health_Services.md
+++ b/operations/system_management_health/Access_System_Management_Health_Services.md
@@ -1,9 +1,19 @@
 # Access System Management Health Services
 
-All System Management Health services are exposed outside the cluster through the OAuth2 Proxy and Istio's ingress gateway to enforce the authentication and authorization policies. The URLs to access these
-services are available on any system with CMN, BGP, MetalLB, and external DNS properly configured.
+All System Management Health services are exposed outside the cluster through the OAuth2 Proxy and Istio's ingress gateway to enforce the authentication and authorization policies. The URLs
+to access these services are available on any system with CMN, BGP, MetalLB, and external DNS properly configured.
 
-The `SYSTEM_DOMAIN_NAME` value in the examples below is an Ansible variable defined as follows and is expected to be the system's FQDN.
+- [System domain name](#system-domain-name)
+- [Prerequisites](#prerequisites)
+- [System Management Health service links](#system-management-health-service-links)
+  - [Prometheus](#prometheus)
+  - [Alertmanager](#alertmanager)
+  - [Grafana](#grafana)
+  - [Kiali](#kiali)
+
+## System domain name
+
+The `SYSTEM_DOMAIN_NAME` value in the URLs on this page is an Ansible variable that can be retrieved as follows. It is expected to be the system's fully qualified domain name (FQDN).
 
 ```bash
 ncn-mw# kubectl get secret site-init -n loftsman -o jsonpath='{.data.customizations\.yaml}' | base64 -d | grep "external:"
@@ -15,12 +25,10 @@ Example output:
       external: SYSTEM_DOMAIN_NAME
 ```
 
-This procedure enables administrators to set up the service and access its components via the Grafana and Kiali applications.
-
 ## Prerequisites
 
 - Access to the System Management Health web UIs is through Istio's ingress gateway and requires clients \(browsers\) to set the appropriate HTTP Host header to route traffic to the desired service.
-- This procedure requires administrative privileges on the workstation running the user's web browser.
+- Access to these URLs may require administrative privileges on the workstation running the user's web browser.
 - The Customer Management Network \(CMN\), Border Gateway Protocol \(BGP\), MetalLB, and external DNS are properly configured.
 
 ## System Management Health service links

--- a/operations/system_management_health/Access_System_Management_Health_Services.md
+++ b/operations/system_management_health/Access_System_Management_Health_Services.md
@@ -23,47 +23,58 @@ This procedure enables administrators to set up the service and access its compo
 - This procedure requires administrative privileges on the workstation running the user's web browser.
 - The Customer Management Network \(CMN\), Border Gateway Protocol \(BGP\), MetalLB, and external DNS are properly configured.
 
-## Procedure
+## System Management Health service links
 
-1. Access any System Management Health service with the provided links.
+Access any System Management Health service with the provided links.
 
-    When accessing the URLs listed below, it will be necessary to accept one or more browser security warnings in order to proceed to the login screen and navigate through the application after successfully
-    logging in. The details of the security warning will indicate that a self-signed certificate/unknown issuer is being used for the site. Support for incorporation of certificates from Trusted Certificate
-    Authorities is planned for a future release.
+When accessing the URLs listed below, it will be necessary to accept one or more browser security warnings in order to proceed to the login screen and navigate through the application after successfully
+logging in. The details of the security warning will indicate that a self-signed certificate/unknown issuer is being used for the site. Support for incorporation of certificates from Trusted Certificate
+Authorities is planned for a future release.
 
-    - `https://prometheus.cmn.SYSTEM_DOMAIN_NAME/`
+### Prometheus
 
-        Central Prometheus instance scrapes metrics from Kubernetes, Ceph, and the hosts (part of `prometheus-operator` Helm chart).
+URL: `https://prometheus.cmn.SYSTEM_DOMAIN_NAME/`
 
-        Prometheus generates alerts based on metrics and reports them to the Alertmanager. The 'Alerts' link at the top of the page will show all of the inactive, pending, and firing alerts on the system. Clicking
-        on any of the alerts will expand them, enabling users to use the 'Labels' data to discern the details of the alert. The details will also show the state of the alert, how long it has been active, and the
-        value for the alert.
+Central Prometheus instance scrapes metrics from Kubernetes, Ceph, and the hosts (part of `prometheus-operator` Helm chart).
 
-        For more information regarding the use of the Prometheus interface, see [https://prometheus.io/docs/prometheus/latest/getting_started/](https://prometheus.io/docs/prometheus/latest/getting_started/).
+Prometheus generates alerts based on metrics and reports them to the Alertmanager. The 'Alerts' link at the top of the page will show all of the inactive, pending, and firing alerts on the system.
+Clicking on any of the alerts will expand them, enabling users to use the 'Labels' data to discern the details of the alert. The details will also show the state of the alert, how long it has been
+active, and the value for the alert.
 
-        Some alerts may be falsely triggered. This occurs if they are alerts which will be improved in the future, or if they are alerts impacted by whether all software products have been installed yet.
-        See [Troubleshoot Prometheus Alerts](Troubleshoot_Prometheus_Alerts.md).
+For more information regarding the use of the Prometheus interface, see
+[Getting Started/](https://prometheus.io/docs/prometheus/latest/getting_started/) in the Prometheus online documentation.
 
-    - `https://alertmanager.cmn.SYSTEM_DOMAIN_NAME/`
+Some alerts may be falsely triggered. This occurs if they are alerts which will be improved in the future, or if they are alerts impacted by whether all software products have been installed yet.
+See [Troubleshoot Prometheus Alerts](Troubleshoot_Prometheus_Alerts.md).
 
-        Central Alertmanager instance that manages Prometheus alerts.
+### Alertmanager
 
-        The Alertmanager manages the alerts it receives and generates notifications to users or applications. For more information about `alert-manager`, refer to the following documentation: [https://prometheus.io/docs/prometheus/latest/getting_started/](https://prometheus.io/docs/prometheus/latest/getting_started/).
+URL: `https://alertmanager.cmn.SYSTEM_DOMAIN_NAME/`
 
-        Some alerts may be falsely triggered. This occurs if they are alerts which will be improved in the future, or if they are alerts impacted by whether all software products have been installed yet. See [Troubleshoot Prometheus Alerts](Troubleshoot_Prometheus_Alerts.md).
+Central Alertmanager instance that manages Prometheus alerts.
 
-    - `https://grafana.cmn.SYSTEM_DOMAIN_NAME/`
+The Alertmanager manages the alerts it receives and generates notifications to users or applications. For more information about `alert-manager`, see
+[Getting Started/](https://prometheus.io/docs/prometheus/latest/getting_started/) in the Prometheus online documentation.
 
-        Central Grafana instance that includes numerous dashboards for visualizing metrics from `prometheus` and `prometheus-istio`.
+Some alerts may be falsely triggered. This occurs if they are alerts which will be improved in the future, or if they are alerts impacted by whether all software products have been installed yet. See
+[Troubleshoot Prometheus Alerts](Troubleshoot_Prometheus_Alerts.md).
 
-        For more information about Grafana's features and dashboard creation, see the online documentation here: [https://grafana.com/docs/grafana/latest/](https://grafana.com/docs/grafana/latest/).
+### Grafana
 
-        For a description of the Grafana Panel: [https://grafana.com/docs/grafana/latest/features/panels/panels/](https://grafana.com/docs/grafana/latest/features/panels/panels/).
+URL: `https://grafana.cmn.SYSTEM_DOMAIN_NAME/`
 
-        For a description of the Grafana Dashboard: [https://grafana.com/docs/grafana/latest/features/dashboard/dashboards/](https://grafana.com/docs/grafana/latest/features/dashboard/dashboards/).
+Central Grafana instance that includes numerous dashboards for visualizing metrics from `prometheus` and `prometheus-istio`.
 
-    - `https://kiali-istio.cmn.SYSTEM_DOMAIN_NAME/`
+For more information, see the Grafana online documentation:
 
-        Kiali provides real-time introspection into the Istio service mesh using metrics and traces from Istio.
+- For more information about Grafana's features and dashboard creation, see [the latest Grafana online documentation](https://grafana.com/docs/grafana/latest/).
+- For a description of the Grafana Panel, see [Grafana panels](https://grafana.com/docs/grafana/latest/features/panels/panels/).
+- For a description of the Grafana Dashboard, see [Grafana dashboards/](https://grafana.com/docs/grafana/latest/features/dashboard/dashboards/).
 
-        For more information about the features of this interface, refer to the following documentation: [https://kiali.io/documentation/](https://kiali.io/documentation/).
+### Kiali
+
+URL: `https://kiali-istio.cmn.SYSTEM_DOMAIN_NAME/`
+
+Kiali provides real-time introspection into the Istio service mesh using metrics and traces from Istio.
+
+For more information about the features of this interface, refer to the [Kiali online documentation/](https://kiali.io/documentation/).

--- a/operations/system_management_health/Access_System_Management_Health_Services.md
+++ b/operations/system_management_health/Access_System_Management_Health_Services.md
@@ -56,7 +56,7 @@ This procedure enables administrators to set up the service and access its compo
 
         Central Grafana instance that includes numerous dashboards for visualizing metrics from `prometheus` and `prometheus-istio`.
 
-        For more information about Grafana's features and dashboard creation, please see the online documentation here: [https://grafana.com/docs/grafana/latest/](https://grafana.com/docs/grafana/latest/).
+        For more information about Grafana's features and dashboard creation, see the online documentation here: [https://grafana.com/docs/grafana/latest/](https://grafana.com/docs/grafana/latest/).
 
         For a description of the Grafana Panel: [https://grafana.com/docs/grafana/latest/features/panels/panels/](https://grafana.com/docs/grafana/latest/features/panels/panels/).
 

--- a/operations/system_management_health/Configure_Prometheus_Email_Alert_Notifications.md
+++ b/operations/system_management_health/Configure_Prometheus_Email_Alert_Notifications.md
@@ -5,19 +5,22 @@ Configure an email alert notification for all Prometheus Postgres replication al
 
 ## Procedure
 
-1. Save the current alert notification configuration in case a rollback is needed.
+This procedure can be performed on any master or worker NCN.
+
+1. Save the current alert notification configuration, in case a rollback is needed.
 
     ```bash
-    ncn# kubectl get secret -n sysmgmt-health alertmanager-cray-sysmgmt-health-promet-alertmanager \
-            -ojsonpath='{.data.alertmanager.yaml}' | base64 --decode > /tmp/alertmanager-default.yaml
+    ncn-mw# kubectl get secret -n sysmgmt-health alertmanager-cray-sysmgmt-health-promet-alertmanager \
+                -ojsonpath='{.data.alertmanager.yaml}' | base64 --decode > /tmp/alertmanager-default.yaml
     ```
 
 1. Create a secret and an alert configuration that will be used to add email notifications for the alerts.
 
     1. Create the secret file.
 
-        ```console
-        ncn# cat << 'EOF' > /tmp/alertmanager-secret.yaml
+        Create a file named `/tmp/alertmanager-secret.yaml` with the following contents:
+
+        ```yaml
         apiVersion: v1
         data:
           alertmanager.yaml: ALERTMANAGER_CONFIG
@@ -31,16 +34,16 @@ Configure an email alert notification for all Prometheus Postgres replication al
           name: alertmanager-cray-sysmgmt-health-promet-alertmanager
           namespace: sysmgmt-health
         type: Opaque
-        EOF
         ```
 
     1. Create the alert configuration file.
 
         In the following example file, the Gmail SMTP server is used in this example to relay the notification to `receiver-email@yourcompany.com`.
-        Update the fields under `email_configs:` accordingly before running the following command.
+        Update the fields under `email_configs:` to reflect the desired configuration.
 
-        ```console
-        ncn# cat << 'EOF' > /tmp/alertmanager-new.yaml
+        Create a file named `/tmp/alertmanager-new.yaml` with the following contents:
+
+        ```yaml
         global:
           resolve_timeout: 5m
         route:
@@ -77,13 +80,12 @@ Configure an email alert notification for all Prometheus Postgres replication al
             auth_username: sender-email@gmail.com
             auth_identity: sender-email@gmail.com
             auth_password: xxxxxxxxxxxxxxxx
-        EOF
         ```
 
-1. Replace the alert notification configuration based on the files created in the previous step.
+1. Replace the alert notification configuration based on the files created in the previous steps.
 
     ```bash
-    ncn# sed "s/ALERTMANAGER_CONFIG/$(cat /tmp/alertmanager-new.yaml \
+    ncn-mw# sed "s/ALERTMANAGER_CONFIG/$(cat /tmp/alertmanager-new.yaml \
                 | base64 -w0)/g" /tmp/alertmanager-secret.yaml \
                 | kubectl replace --force -f -
     ```
@@ -93,14 +95,14 @@ Configure an email alert notification for all Prometheus Postgres replication al
     1. View the current configuration.
 
         ```bash
-        ncn# kubectl exec alertmanager-cray-sysmgmt-health-promet-alertmanager-0 \
-                -n sysmgmt-health -c alertmanager -- cat /etc/alertmanager/config/alertmanager.yaml
+        ncn-mw# kubectl exec alertmanager-cray-sysmgmt-health-promet-alertmanager-0 \
+                    -n sysmgmt-health -c alertmanager -- cat /etc/alertmanager/config/alertmanager.yaml
         ```
 
-    1. Check the logs for any errors if the configuration does not look accurate.
+    1. If the configuration does not look accurate, check the logs for errors.
 
         ```bash
-        ncn# kubectl logs -f -n sysmgmt-health pod/alertmanager-cray-sysmgmt-health-promet-alertmanager-0 alertmanager
+        ncn-mw# kubectl logs -f -n sysmgmt-health pod/alertmanager-cray-sysmgmt-health-promet-alertmanager-0 alertmanager
         ```
 
 An email notification will be sent once either of the alerts set in this procedure is `FIRING` in Prometheus.

--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -12,37 +12,6 @@ The following are examples of when to run health checks:
 
 The areas should be tested in the order they are listed on this page. Errors in an earlier check may cause errors in later checks because of dependencies.
 
-**NOTE:** It can take up to 15 minutes, and sometimes longer, for NCN clocks to synchronize after an upgrade or when a system is brought back up. If a clock skew test
-fails, wait 15 minutes and try again. To check status, run the following command, preferably on `ncn-m001`:
-
-```bash
-ncn-m001# chronyc sources -v
-```
-
-```text
-210 Number of sources = 9
-
-  .-- Source mode  '^' = server, '=' = peer, '#' = local clock.
- / .- Source state '*' = current synced, '+' = combined , '-' = not combined,
-| /   '?' = unreachable, 'x' = time may be in error, '~' = time too variable.
-||                                                 .- xxxx [ yyyy ] +/- zzzz
-||      Reachability register (octal) -.           |  xxxx = adjusted offset,
-||      Log2(Polling interval) --.      |          |  yyyy = measured offset,
-||                                \     |          |  zzzz = estimated error.
-||                                 |    |           \
-MS Name/IP address         Stratum Poll Reach LastRx Last sample
-===============================================================================
-^* ntp.hpecorp.net               2  10   377   650   -421us[ -571us] +/-   30ms
-=? ncn-m002.nmn                 10   4   377   213    +82us[  +82us] +/-  367us
-=- ncn-m003.nmn                  3   1   377     1  -2033us[-2033us] +/-   28ms
-=- ncn-s001.nmn                  6   5   377    20    +53us[  +53us] +/-  193us
-=- ncn-s002.nmn                  5   5   377    25    +29us[  +29us] +/-  275us
-=- ncn-s003.nmn                  6   6   377    27    +47us[  +47us] +/-  237us
-=- ncn-w001.nmn                  5   9   377  234m  +8305us[  +10ms] +/-   38ms
-=- ncn-w002.nmn                  3   5   377     8  -1910us[-1910us] +/-   27ms
-=- ncn-w003.nmn                  3   8   377   74m  -1122us[-1002us] +/-   31ms
-```
-
 ## Topics
 
 - [0. Cray command line interface](#0-cray-command-line-interface)
@@ -56,18 +25,21 @@ MS Name/IP address         Stratum Poll Reach LastRx Last sample
   - [2.1 HMS CT test execution](#21-hms-ct-test-execution)
   - [2.2 Hardware State Manager discovery validation](#22-hardware-state-manager-discovery-validation)
     - [2.2.1 Interpreting HSM discovery results](#221-interpreting-hsm-discovery-results)
-    - [2.2.2 Known issues with HSM discovery validation](#222-known-issues-with-hsm-discovery)
+    - [2.2.2 Known issues with HSM discovery validation](#222-known-issues-with-hsm-discovery-validation)
 - [3. Software Management Services health checks](#3-software-management-services-health-checks)
   - [3.1 SMS test execution](#31-sms-test-execution)
   - [3.2 Interpreting `cmsdev` results](#32-interpreting-cmsdev-results)
   - [3.3 Known issues with SMS tests](#33-known-issues-with-sms-tests)
 - [4. Gateway health and SSH access checks](#4-gateway-health-and-ssh-access-checks)
   - [4.1 Gateway health tests](#41-gateway-health-tests)
+    - [4.1.1 Gateway health tests overview](#411-gateway-health-tests-overview)
+    - [4.1.2 Gateway health tests on an NCN](#412-gateway-health-tests-on-an-ncn)
+    - [4.1.3 Gateway health tests from outside the system](#413-gateway-health-tests-from-outside-the-system)
   - [4.2 Internal SSH access test execution](#42-internal-ssh-access-test-execution)
   - [4.3 External SSH access test execution](#43-external-ssh-access-test-execution)
 - [5. Booting CSM `barebones` image](#5-booting-csm-barebones-image)
   - [5.1 Run the test script](#51-run-the-test-script)
-- [6. UAS / UAI tests](#6-uas--uai-tests)
+- [6. UAS/UAI tests](#6-uasuai-tests)
   - [6.1 Validate the basic UAS installation](#61-validate-the-basic-uas-installation)
   - [6.2 Validate UAI creation](#62-validate-uai-creation)
   - [6.3 Test UAI gateway health](#63-test-uai-gateway-health)
@@ -230,6 +202,39 @@ If `ncn-m001` is the PIT node, then run these checks on `ncn-m001`; otherwise ru
         ```
 
      1. Then re-run the check to see if the problem has been resolved.
+
+- Clock skew test failures
+
+   It can take up to 15 minutes, and sometimes longer, for NCN clocks to synchronize after an upgrade or when a system is brought back up. If a clock skew test
+   fails, wait 15 minutes and try again. To check status, run the following command, preferably on `ncn-m001`:
+
+   ```bash
+   ncn-m001# chronyc sources -v
+   ```
+
+   ```text
+   210 Number of sources = 9
+
+     .-- Source mode  '^' = server, '=' = peer, '#' = local clock.
+    / .- Source state '*' = current synced, '+' = combined , '-' = not combined,
+   | /   '?' = unreachable, 'x' = time may be in error, '~' = time too variable.
+   ||                                                 .- xxxx [ yyyy ] +/- zzzz
+   ||      Reachability register (octal) -.           |  xxxx = adjusted offset,
+   ||      Log2(Polling interval) --.      |          |  yyyy = measured offset,
+   ||                                \     |          |  zzzz = estimated error.
+   ||                                 |    |           \
+   MS Name/IP address         Stratum Poll Reach LastRx Last sample
+   ===============================================================================
+   ^* ntp.hpecorp.net               2  10   377   650   -421us[ -571us] +/-   30ms
+   =? ncn-m002.nmn                 10   4   377   213    +82us[  +82us] +/-  367us
+   =- ncn-m003.nmn                  3   1   377     1  -2033us[-2033us] +/-   28ms
+   =- ncn-s001.nmn                  6   5   377    20    +53us[  +53us] +/-  193us
+   =- ncn-s002.nmn                  5   5   377    25    +29us[  +29us] +/-  275us
+   =- ncn-s003.nmn                  6   6   377    27    +47us[  +47us] +/-  237us
+   =- ncn-w001.nmn                  5   9   377  234m  +8305us[  +10ms] +/-   38ms
+   =- ncn-w002.nmn                  3   5   377     8  -1910us[-1910us] +/-   27ms
+   =- ncn-w003.nmn                  3   8   377   74m  -1122us[-1002us] +/-   31ms
+   ```
 
 <a name="pet-optional-ncnhealthchecks-resources"></a>
 
@@ -498,7 +503,7 @@ Known issues that may prevent hardware from getting discovered by Hardware State
 
 <a name="sms-checks"></a>
 
-### 3.1 SMS Test execution
+### 3.1 SMS test execution
 
 The test in this section requires that the [Cray CLI is configured](#cray-command-line-interface) on nodes where the test is executed.
 
@@ -550,19 +555,11 @@ In this case, these errors can be ignored, or the pod with the same name as the 
 
 ### 4.1 Gateway health tests
 
-The gateway tests check the health of the API Gateway on all of the relevant networks.  The gateway tests will check that the gateway is accessible on all networks where it should be accessible,
-and NOT accessible on all networks where it should NOT be accessible. It will also check several service endpoints to verify that they return the proper response
+#### 4.1.1 Gateway health tests overview
+
+The gateway tests check the health of the API Gateway on all of the relevant networks. The gateway tests check that the gateway is accessible on all networks where it should be accessible,
+and NOT accessible on all networks where it should NOT be accessible. They also check several service endpoints to verify that they return the proper response
 on each accessible network.
-
-The gateway tests can be run from various locations.   For this part of the CSM validation, we will check gateway access from the NCNs and from outside the system.
-Externally, the API gateway is accessible on the CMN network and either the CAN or CHN user network depending on the configuration of the system.
-On NCNs, the API gateway is accessible on the same networks (CMN and CAN/CHN) and it is also accessible on the NMNLB network.
-
-Follow these instructions for executing the gateway tests from an NCN and from outside the system.
-
-- [Running Gateway Tests on an NCN Management Node](network/gateway_testing.md#running-gateway-tests-on-an-ncn-management-node)
-  - The gateway tests may be run on any NCN with the `docs-csm` RPM installed. For details on installing the `docs-csm` RPM, see [Check for Latest Documentation](../update_product_stream/index.md#documentation).
-- [Running Gateway Tests on a Device Outside the System](network/gateway_testing.md#running-gateway-tests-on-a-device-outside-the-system)
 
 The test will complete with an overall test status based on the result of the individual health checks on all of the networks.
 
@@ -572,12 +569,24 @@ Overall Gateway Test Status:  PASS
 
 For more detailed information on the tests results and examples, see [Gateway Testing](network/gateway_testing.md).
 
-<a name="booting-csm-barebones-image"></a>
+The gateway tests can be run from various locations. For this part of the CSM validation, check gateway access from the NCNs and from outside the system.
+Externally, the API gateway is accessible on the CMN and either the CAN or CHN, depending on the configuration of the system.
+On NCNs, the API gateway is accessible on the same networks (CMN and CAN/CHN) and it is also accessible on the NMNLB network.
+
+#### 4.1.2 Gateway health tests on an NCN
+
+The gateway tests may be run on any NCN with the `docs-csm` RPM installed. For details on installing the `docs-csm` RPM, see [Check for Latest Documentation](../update_product_stream/index.md#check-for-latest-documentation).
+
+To execute the tests, see [Running Gateway Tests on an NCN Management Node](network/gateway_testing.md#running-gateway-tests-on-an-ncn-management-node).
+
+#### 4.1.3 Gateway health tests from outside the system
+
+To execute the tests, see [Running Gateway Tests on a Device Outside the System](network/gateway_testing.md#running-gateway-tests-on-a-device-outside-the-system).
 
 ### 4.2 Internal SSH access test execution
 
 The internal SSH access tests may be run on any NCN with the `docs-csm` RPM installed. For details on installing the `docs-csm` RPM,
-see [Check for Latest Documentation](../update_product_stream/index.md#documentation).
+see [Check for Latest Documentation](../update_product_stream/index.md#check-for-latest-documentation).
 
 Execute the tests by running the following command:
 
@@ -585,9 +594,9 @@ Execute the tests by running the following command:
 ncn# /usr/share/doc/csm/scripts/operations/pyscripts/start.py test_bican_internal
 ```
 
-By default, SSH access will be tested between master nodes and spine switches on all relevant networks.
-It is possible to customize which nodes and networks will be tested. For example, you may wish to include configured
-UANs as part of the tests. See the test usage statement for details. The test usage statement is displayed by calling the
+By default, SSH access will be tested on all relevant networks between master nodes, spine switches, compute nodes, and UANs.
+It is possible to customize which nodes and networks will be tested. For example, it is possible to include storage nodes, to exclude
+UANs, or to exclude the HMN. See the test usage statement for details. The test usage statement is displayed by calling the
 test with the `--help` argument:
 
 ```bash
@@ -604,7 +613,7 @@ Overall status: PASSED (Passed: 40, Failed: 0)
 
 The external SSH access tests may be run on any system external to the cluster.
 
-1. `python3` must be installed (if it is not already).
+1. Python version 3 must be installed (if it is not already).
 
 1. Obtain the test code.
 
@@ -612,7 +621,7 @@ The external SSH access tests may be run on any system external to the cluster.
 
     - Install the `docs-csm` RPM.
 
-      See [Check for Latest Documentation](../update_product_stream/index.md#documentation).
+      See [Check for Latest Documentation](../update_product_stream/index.md#check-for-latest-documentation).
 
     - Copy over the following folder from a system where the `docs-csm` RPM is installed:
 
@@ -647,10 +656,10 @@ The external SSH access tests may be run on any system external to the cluster.
     external:/usr/share/doc/csm/scripts/operations/pyscripts# ./start.py test_bican_external
     ```
 
-   By default, SSH access will be tested to master nodes and spine switches on all relevant networks.
-   It is possible to customize which nodes and networks will be tested. For example, you may wish to include configured
-   UANs as part of the tests. See the test usage statement for details. The test usage statement is displayed by calling the
-   test with the `--help` argument:
+    By default, SSH access will be tested on all relevant networks between master nodes, spine switches, compute nodes, and UANs.
+    It is possible to customize which nodes and networks will be tested. For example, it is possible to include storage nodes, to exclude
+    UANs, or to exclude the HMN. See the test usage statement for details. The test usage statement is displayed by calling the
+    test with the `--help` argument:
 
     ```bash
     external:/usr/share/doc/csm/scripts/operations/pyscripts# ./start.py test_bican_external --help
@@ -664,6 +673,8 @@ The external SSH access tests may be run on any system external to the cluster.
     Overall status: PASSED (Passed: 20, Failed: 0)
     ```
 
+<a name="booting-csm-barebones-image"></a>
+
 ## 5. Booting CSM `barebones` image
 
 Included with the Cray System Management (CSM) release is a pre-built node image that can be used
@@ -672,8 +683,8 @@ image contains only the minimal set of RPMs and configuration required to boot a
 suitable for production usage. To run production work loads, it is suggested that an image from
 the Cray OS (COS) product, or similar, be used.
 
-- This test is **very important to run** during the CSM install prior to redeploying the PIT node
-because it validates all of the services required for that operation.
+- This test is **very important to run**, particularly during the CSM install prior to rebooting the PIT node,
+because it validates all of the services required for nodes to PXE boot from the cluster.
 - The CSM Barebones image included with the release will not successfully complete
 beyond the `dracut` stage of the boot process. However, if the `dracut` stage is reached, the
 boot can be considered successful and shows that the necessary CSM services needed to
@@ -724,7 +735,7 @@ ncn# /opt/cray/tests/integration/csm/barebonesImageTest --xname x3000c0s10b4n0
 
 <a name="uas-uai-tests"></a>
 
-## 6. UAS / UAI tests
+## 6. UAS/UAI tests
 
 The commands in this section require that the [Cray CLI is configured](#cray-command-line-interface) on nodes where the commands are being executed.
 
@@ -734,14 +745,14 @@ In either case, the CLI configuration needs to be initialized on the node and th
 
 The following procedures run on separate nodes of the system.
 
-1. [Validate Basic UAS Installation](#uas-uai-validate-install)
-1. [Validate UAI Creation](#uas-uai-validate-create)
-1. [Test UAI Gateway Health](#test-uai-gateway-health)
-1. [UAS/UAI Troubleshooting](#uas-uai-validate-debug)
-   1. [Authorization Issues](#uas-uai-validate-debug-auth)
-   1. [UAS Cannot Access Keycloak](#uas-uai-validate-debug-keycloak)
-   1. [UAI Images not in Registry](#uas-uai-validate-debug-registry)
-   1. [Missing Volumes and Other Container Startup Issues](#uas-uai-validate-debug-container)
+1. [Validate the basic UAS installation](#61-validate-the-basic-uas-installation)
+2. [Validate UAI creation](#62-validate-uai-creation)
+3. [Test UAI gateway health](#63-test-uai-gateway-health)
+4. [UAS/UAI troubleshooting](#64-uas-uai-validate-debug)
+   1. [Authorization issues](#641-authorization-issues)
+   2. [UAS cannot access Keycloak](#642-uas-cannot-access-keycloak)
+   3. [UAI images not in registry](#643-uai-images-not-in-registry)
+   4. [Missing volumes and other container startup issues](#644-missing-volumes-and-other-container-startup-issues)
 
 <a name="uas-uai-validate-install"></a>
 
@@ -752,7 +763,7 @@ This section can be run on any NCN or the PIT node.
 1. Show information about `cray-uas-mgr`.
 
     ```bash
-    ncn# cray uas mgr-info list
+    ncn# cray uas mgr-info list --format toml
     ```
 
     Expected output looks similar to the following:
@@ -767,7 +778,7 @@ This section can be run on any NCN or the PIT node.
 1. List UAIs on the system.
 
     ```bash
-    ncn# cray uas list
+    ncn# cray uas list --format toml
     ```
 
     Expected output looks similar to the following:
@@ -782,7 +793,7 @@ This section can be run on any NCN or the PIT node.
 1. Verify that the pre-made UAI images are registered with UAS
 
    ```bash
-   ncn# cray uas images list
+   ncn# cray uas images list --format toml
    ```
 
    Expected output looks similar to the following:
@@ -813,7 +824,7 @@ This procedure must run on a master or worker node (**not the PIT node**).
 1. Verify that a UAI can be created:
 
    ```bash
-   ncn# cray uas create --publickey ~/.ssh/id_rsa.pub
+   ncn# cray uas create --publickey ~/.ssh/id_rsa.pub --format toml
    ```
 
    Expected output looks similar to the following:
@@ -843,7 +854,7 @@ This procedure must run on a master or worker node (**not the PIT node**).
 1. Check the current status of the UAI:
 
    ```bash
-   ncn# cray uas list
+   ncn# cray uas list --format toml
    ```
 
    Expected output looks similar to the following:
@@ -900,7 +911,7 @@ This procedure must run on a master or worker node (**not the PIT node**).
 1. Clean up the UAI.
 
    ```bash
-   ncn# cray uas delete --uai-list $UAINAME
+   ncn# cray uas delete --uai-list $UAINAME --format toml
    ```
 
    Expected output looks similar to the following:
@@ -915,13 +926,13 @@ If the commands ran with similar results, then the basic functionality of the UA
 
 Like the NCN gateway health check, the gateway tests check the health of the API Gateway on all of the relevant networks.
 On UAIs, the API gateway should only be accessible on the user network (either CAN or CHN depending on the configuration of the system).
-The gateway tests will check that the gateway is accessible on all networks where it should be accessible, and NOT accessible on all
-networks where it should NOT be accessible. It will also check several service endpoints to verify that they return the proper response
+The gateway tests check that the gateway is accessible on all networks where it should be accessible, and NOT accessible on all
+networks where it should NOT be accessible. They also check several service endpoints to verify that they return the proper response
 on each accessible network.
 
 #### 6.3.1 Gateway test execution
 
-The UAI gateway tests may be run on any NCN with the `docs-csm` RPM installed. For details on installing the `docs-csm` RPM, see [Check for Latest Documentation](../update_product_stream/index.md#documentation).
+The UAI gateway tests may be run on any NCN with the `docs-csm` RPM installed. For details on installing the `docs-csm` RPM, see [Check for Latest Documentation](../update_product_stream/index.md#check-for-latest-documentation).
 
 The UAI gateway tests are executed by running the following command.
 

--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -594,9 +594,9 @@ Execute the tests by running the following command:
 ncn# /usr/share/doc/csm/scripts/operations/pyscripts/start.py test_bican_internal
 ```
 
-By default, SSH access will be tested on all relevant networks between master nodes, spine switches, compute nodes, and UANs.
-It is possible to customize which nodes and networks will be tested. For example, it is possible to include storage nodes, to exclude
-UANs, or to exclude the HMN. See the test usage statement for details. The test usage statement is displayed by calling the
+By default, SSH access will be tested on all relevant networks between master nodes and spine switches.
+It is possible to customize which nodes and networks will be tested. For example, it is possible to include UANs, to exclude
+master nodes, or to exclude the HMN. See the test usage statement for details. The test usage statement is displayed by calling the
 test with the `--help` argument:
 
 ```bash
@@ -656,9 +656,9 @@ The external SSH access tests may be run on any system external to the cluster.
     external:/usr/share/doc/csm/scripts/operations/pyscripts# ./start.py test_bican_external
     ```
 
-    By default, SSH access will be tested on all relevant networks between master nodes, spine switches, compute nodes, and UANs.
-    It is possible to customize which nodes and networks will be tested. For example, it is possible to include storage nodes, to exclude
-    UANs, or to exclude the HMN. See the test usage statement for details. The test usage statement is displayed by calling the
+    By default, SSH access will be tested on all relevant networks between master nodes and spine switches.
+    It is possible to customize which nodes and networks will be tested. For example, it is possible to include compute nodes, to exclude
+    spine switches, or to exclude the NMN. See the test usage statement for details. The test usage statement is displayed by calling the
     test with the `--help` argument:
 
     ```bash

--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -1008,7 +1008,7 @@ The following shows an example of looking at UAS logs effectively (this example 
 1. Determine the pod name of the `uas-mgr` pod
 
    ```bash
-   ncn# kubectl get po -n services | grep "^cray-uas-mgr" | grep -v etcd
+   ncn-mw# kubectl get po -n services | grep "^cray-uas-mgr" | grep -v etcd
    ```
 
    Expected output looks similar to:
@@ -1020,13 +1020,13 @@ The following shows an example of looking at UAS logs effectively (this example 
 1. Set `PODNAME` to the name of the manager pod whose logs are going to be viewed.
 
    ```bash
-   ncn# export PODNAME=cray-uas-mgr-6bbd584ccb-zg8vx
+   ncn-mw# export PODNAME=cray-uas-mgr-6bbd584ccb-zg8vx
    ```
 
 1. View the last 25 log entries of the `cray-uas-mgr` container in that pod, excluding `GET` events:
 
    ```bash
-   ncn# kubectl logs -n services $PODNAME cray-uas-mgr | grep -v 'GET ' | tail -25
+   ncn-mw# kubectl logs -n services $PODNAME cray-uas-mgr | grep -v 'GET ' | tail -25
    ```
 
    Example output:
@@ -1066,7 +1066,7 @@ The following shows an example of looking at UAS logs effectively (this example 
 When listing or describing a UAI, an error in the `uai_msg` field may be returned. For example:
 
 ```bash
-ncn# cray uas list
+ncn# cray uas list --format toml
 ```
 
 There may be something similar to the following output:
@@ -1098,13 +1098,13 @@ using `kubectl describe`.
 1. Locate the pod.
 
    ```bash
-   ncn# kubectl get po -n user | grep <uai-name>
+   ncn-mw# kubectl get po -n user | grep <uai-name>
    ```
 
 1. Investigate the problem using the pod name from the previous step.
 
    ```bash
-   ncn# kubectl describe pod -n user <pod-name>
+   ncn-mw# kubectl describe pod -n user <pod-name>
    ```
 
    If volumes are missing they will show up in the `Events:` section of the output. Other problems may show up there as well. The names of the missing volumes or other issues


### PR DESCRIPTION
# Description

Minor improvements related to CSM health validation, based on things I noticed when helping SSI do CSM upgrades.

I also pulled in a couple of linting commits that I did for this main branch PR for [CASMMON-127](https://jira-pro.its.hpecorp.net:8443/browse/CASMMON-127):
https://github.com/Cray-HPE/docs-csm/pull/1904

That's because that PR is not being backported to the earlier branches, but some of my linting applies to the earlier branches.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
