### PR TITLE
STP-3257: Updated GSG version in hyperlink text

### DIFF
--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -215,9 +215,8 @@ firmware requirement before starting.
    both been installed and configured. However, at that point a rolling reboot procedure for the management nodes will be needed,
    after the firmware has been updated.
 
-   See the [`HPE Cray EX System Software Getting Started Guide (S-8000) 22.06`](http://www.hpe.com/support/ex-gsg-042120221040)
+   See the [`HPE Cray EX System Software Getting Started Guide (S-8000) 22.07`](http://www.hpe.com/support/ex-gsg-042120221040)
    on the HPE Customer Support Center for information about the _HPE Cray EX HPC Firmware Pack_ (HFP) product.
-22.07
    In the HFP documentation there is information about the recommended firmware packages to be installed.
    See "Product Details" in the HPE Cray EX HPC Firmware Pack Installation Guide.
 

--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -217,7 +217,7 @@ firmware requirement before starting.
 
    See the [`HPE Cray EX System Software Getting Started Guide (S-8000) 22.06`](http://www.hpe.com/support/ex-gsg-042120221040)
    on the HPE Customer Support Center for information about the _HPE Cray EX HPC Firmware Pack_ (HFP) product.
-
+22.07
    In the HFP documentation there is information about the recommended firmware packages to be installed.
    See "Product Details" in the HPE Cray EX HPC Firmware Pack Installation Guide.
 

--- a/install/index.md
+++ b/install/index.md
@@ -211,7 +211,7 @@ sections, but there is also a [general troubleshooting topic](#troubleshooting_i
       communicates with at once, or specific devices can be targeted for a firmware update.
 
       **IMPORTANT:** Before FAS can be used to update firmware, refer to the
-      [`HPE Cray EX System Software Getting Started Guide (S-8000) 22.06`](http://www.hpe.com/support/ex-gsg-042120221040) for more information about how to install
+      [`HPE Cray EX System Software Getting Started Guide (S-8000) 22.07`](http://www.hpe.com/support/ex-gsg-042120221040) for more information about how to install
       the HPE Cray EX HPC Firmware Pack (HFP) product. The installation of HFP will inform FAS of the newest firmware
       available. Once FAS is aware that new firmware is available, then see
       [Update Firmware with FAS](../operations/firmware/Update_Firmware_with_FAS.md).
@@ -233,7 +233,7 @@ sections, but there is also a [general troubleshooting topic](#troubleshooting_i
 
       After completion of the firmware update with FAS and the preparation of compute nodes, the CSM product stream has
       been fully installed and configured.
-      Refer to the [`HPE Cray EX System Software Getting Started Guide (S-8000) 22.06`](http://www.hpe.com/support/ex-gsg-042120221040) on the HPE Customer Support Center
+      Refer to the [`HPE Cray EX System Software Getting Started Guide (S-8000) 22.07`](http://www.hpe.com/support/ex-gsg-042120221040) on the HPE Customer Support Center
       for more information on other product streams to be installed and configured after CSM.
    <a name="troubleshooting_installation"></a>
 

--- a/introduction/scenarios.md
+++ b/introduction/scenarios.md
@@ -45,7 +45,7 @@ the same regardless of the starting point in the workflow.
    1. [Prepare Compute Nodes](../install/index.md#prepare_compute_nodes)
 
 After completion of the firmware update with FAS and the preparation of compute nodes, the CSM product stream has
-been fully installed and configured. Refer to the [`HPE Cray EX System Software Getting Started Guide (S-8000) 22.06`](http://www.hpe.com/support/ex-gsg-042120221040) for more information on other product streams
+been fully installed and configured. Refer to the [`HPE Cray EX System Software Getting Started Guide (S-8000) 22.07`](http://www.hpe.com/support/ex-gsg-042120221040) for more information on other product streams
 to be installed and configured after CSM.
 
 See [Install CSM](../install/index.md) for the details on the installation process for either a first time install

--- a/operations/CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md
+++ b/operations/CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md
@@ -4,7 +4,7 @@ Non-compute node (NCN) personalization applies post-boot configuration to the
 HPE Cray EX management nodes. Several HPE Cray EX product environments outside
 of CSM require NCN personalization to function. Consult the manual for each
 product to configure them on NCNs by referring to the
-[`HPE Cray EX System Software Getting Started Guide (S-8000) 22.06`](http://www.hpe.com/support/ex-gsg-042120221040)
+[`HPE Cray EX System Software Getting Started Guide (S-8000) 22.07`](http://www.hpe.com/support/ex-gsg-042120221040)
 on the HPE Customer Support Center.
 
 This procedure defines the NCN personalization process for the CSM product using
@@ -154,7 +154,7 @@ documents for additional information, because role documentation is updated more
 changes are introduced.
 
 Consult the manual for each product in order to change the default configuration by
-referring to the [`HPE Cray EX System Software Getting Started Guide (S-8000) 22.06`](http://www.hpe.com/support/ex-gsg-042120221040)
+referring to the [`HPE Cray EX System Software Getting Started Guide (S-8000) 22.07`](http://www.hpe.com/support/ex-gsg-042120221040)
 on the HPE Customer Support Center. Similar configuration values for disabling the
 role will be required in these product-specific configuration repositories.
 

--- a/operations/CSM_product_management/Perform_NCN_Personalization.md
+++ b/operations/CSM_product_management/Perform_NCN_Personalization.md
@@ -15,7 +15,7 @@ to create a [configuration layer](../configuration_management/Configuration_Laye
 
 Products may supply multiple plays to run, in which case multiple configuration
 layers must be created. Consult the manual for each product to configure them on
-NCNs by referring to the [`HPE Cray EX System Software Getting Started Guide (S-8000) 22.06`](http://www.hpe.com/support/ex-gsg-042120221040) on the HPE Customer Support Center.
+NCNs by referring to the [`HPE Cray EX System Software Getting Started Guide (S-8000) 22.07`](http://www.hpe.com/support/ex-gsg-042120221040) on the HPE Customer Support Center.
 
 ## Procedure: Perform NCN Personalization
 
@@ -43,7 +43,7 @@ error. This error can be ignored.
 
 ### Add Layer(s) to the CFS Configuration
 
-CFS executes configuration layers in order. Refer to the [`HPE Cray EX System Software Getting Started Guide (S-8000) 22.06`](http://www.hpe.com/support/ex-gsg-042120221040) on the HPE Customer Support Center
+CFS executes configuration layers in order. Refer to the [`HPE Cray EX System Software Getting Started Guide (S-8000) 22.07`](http://www.hpe.com/support/ex-gsg-042120221040) on the HPE Customer Support Center
 to determine if the configuration layer requires special placement in the layer list.
 
 > **NOTE:** The CSM configuration layer _MUST_ be the first layer in the

--- a/upgrade/index.md
+++ b/upgrade/index.md
@@ -45,7 +45,7 @@ sections, but there is also a general troubleshooting topic.
 1. <a name="next_topic"></a>Next topic
 
     After completion of the validation of CSM health, the CSM product stream has been fully upgraded and configured.
-    Refer to the [`HPE Cray EX System Software Getting Started Guide (S-8000) 22.06`](http://www.hpe.com/support/ex-gsg-042120221040)
+    Refer to the [`HPE Cray EX System Software Getting Started Guide (S-8000) 22.07`](http://www.hpe.com/support/ex-gsg-042120221040)
     on the HPE Customer Support Center for more information on other product streams to be upgraded and configured after CSM.
 
     > **Note:** If a newer version of the HPE Cray EX HPC Firmware Pack (HFP) is available, then the next step


### PR DESCRIPTION
# Description

The hyperlink text for the GSG currently references 22.06 in the CSM 1.2 docs. The version has since changed to 22.07, so the text needs to be updated to reflect the correct version.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
