### PR TITLE
CASMINST-4833 Updates

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -26,7 +26,14 @@
 @Library('csm-shared-library') _
 
 def sleVersion = '15.3'
+def major
+def minor
+def patch
 def isStable = env.TAG_NAME != null ? true : false
+if ( isStable ) {
+    (major, minor, patch) = env.TAG_NAME.tokenize('.')
+    major = major.replaceAll("^v","")
+}
 
 pipeline {
     agent {
@@ -35,12 +42,13 @@ pipeline {
 
     options {
         buildDiscarder(logRotator(numToKeepStr: "10"))
+        disableConcurrentBuilds()
+        timeout(time: 20, unit: 'MINUTES')
         timestamps()
     }
 
     environment {
         GIT_REPO_NAME = getRepoName()
-        RELEASE_BRANCH_VERSION = getReleaseBranchVersion()
         VERSION = sh(returnStdout: true, script: "git describe --tags | tr -s '-' '~' | tr -d '^v'").trim()
     }
     
@@ -56,6 +64,8 @@ pipeline {
                 script {
                     withCredentials([gitUsernamePassword(credentialsId: 'jenkins-algol60-cray-hpe-github-integration')]) {
                         runLibraryScript("addRpmMetaData.sh", "${env.GIT_REPO_NAME}.spec")
+                        sh "echo ${env.BRANCH_NAME}"
+                        sh "env"
                         sh "make prepare"
                     }
                 }
@@ -84,8 +94,10 @@ pipeline {
       stage('Publish') {
           steps {
             script {
-                if(env.RELEASE_BRANCH_VERSION){
-                    RELEASE_FOLDER = "/" + env.RELEASE_BRANCH_VERSION
+                if( isStable ){
+                    RELEASE_FOLDER = "/${major}.${minor}"
+                    sh "find dist/rpmbuild/RPMS/noarch/ -name *.rpm -exec cp {} dist/rpmbuild/RPMS/noarch/${env.GIT_REPO_NAME}-latest.noarch.rpm \\;"
+                    sh "find dist/rpmbuild/SRPMS/ -name *.rpm -exec cp {}  dist/rpmbuild/SRPMS/${env.GIT_REPO_NAME}-latest.src.rpm \\;"
                 } else {
                     RELEASE_FOLDER = ""
                 }

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,3 @@ rpm_build_source:
 
 rpm_build:
 	rpmbuild -ba $(SPEC_FILE) --define "_topdir $(BUILD_DIR)"
-
-rpm_latest: 
-	cp $(wildcard $(BUILD_DIR)/RPMS/noarch/docs-csm-$(VERSION)-*.noarch.rpm) "$(BUILD_DIR)/RPMS/noarch/docs-csm-latest.noarch.rpm" 


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
Git-tags are stable builds that should publish to a sub-directory containing their major and minor versions (e.g. v1.2.6 
docs-csm/1.2).

Every git-tag should also push a latest RPM. This means there is a risk that rebuilding a previous tag will overwrite the latest RPM, this can be remedied by rebuilding the latest tag for the CSM release.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
