### PR TITLE
CASMNET-1533 - Update troubleshooting doc to reflect that the Unbound records data is compressed

### DIFF
--- a/operations/network/dns/Troubleshoot_Common_DNS_Issues.md
+++ b/operations/network/dns/Troubleshoot_Common_DNS_Issues.md
@@ -6,7 +6,7 @@ Management Service \(HMS\), the System Layout Service \(SLS\), and the State Man
 
 The information below describes what to check when experiencing issues with DNS.
 
-## Troubleshoot an Invalid Hostname
+## Troubleshoot an invalid hostname
 
 It is important to verify if a hostname is correct. The values in the `networks.yml` or `networks_derived.yml` files are sometimes inaccurate.
 
@@ -19,21 +19,23 @@ The formats show below are valid hostnames:
   - Hardware Management Network \(HMN\):
     - `<xname\>-mgmt`
     - `<xname\>-mgmt.local`
-  - NID
+- NID
+  - Node Management Network \(NMN\):
     - `nid<nid\_number\>-nmn`
     - `nid<nid\_number\>-nmn.local`
 
-Additional steps are needed if a hostname or component name (xname) is either listed incorrectly or not listed at all in the `networks.yml` or `networks_derived.yml` files. The following actions need to be taken:
+Additional steps are needed if a hostname or component name (xname) is either listed incorrectly or not listed at all in the `networks.yml` or `networks_derived.yml` files.
+In that case, the following actions must be taken:
 
 1. Update the hostname in the Hardware State Manager \(HSM\).
-2. Re-run any Ansible plays that require the data in these files.
+1. Re-run any Ansible plays that require the data in these files.
 
-## Check if a Host is in DNS
+## Check if a host is in DNS
 
 Use the `dig` or `nslookup` commands directly against the Unbound resolver. A host is correctly in DNS if the response from the `dig` command includes the following:
 
-- The `ANSWER SECTION` value exists with a valid hostname and IP address
-- A `QUERY` value exists that has the `status: NOERROR` message
+- The `ANSWER SECTION` value exists with a valid hostname and IP address.
+- A `QUERY` value exists that has the `status: NOERROR` message.
 
 ```bash
 ncn# dig HOSTNAME @10.92.100.225
@@ -62,26 +64,22 @@ x3000c0r41b0.           3600    IN      A       10.254.127.200
 ;; MSG SIZE  rcvd: 57
 ```
 
-If either of the commands fail to meet the two conditions mentioned above, collect the logs to troubleshoot.
+If either of the commands fail to meet the two conditions mentioned above, then collect the logs to troubleshoot.
 
 If there no record in the Unbound pod, that is also an indication that the host is not in DNS.
 
 ```bash
 ncn# kubectl -n services get cm cray-dns-unbound -o jsonpath='{.binaryData.records\.json\.gz}' |
-     base64 --decode | gzip -dc | jq -c '.[]' | grep XNAME
+        base64 --decode | gzip -dc | jq -c '.[]' | grep XNAME
 ```
 
-Example output:
+Example output excerpt:
 
 ```text
-[...]
-
 {"hostname": "x1003c7s7b0", "ip-address": "10.104.12.191"}
-
-[...]
 ```
 
-## Check the `cray-dns-unbound` Logs for Errors
+## Check the `cray-dns-unbound` logs for errors
 
 Use the following command to check the logs. Any logs with a message saying `ERROR` or `Exception` are an indication that the Unbound service is not healthy.
 
@@ -89,36 +87,20 @@ Use the following command to check the logs. Any logs with a message saying `ERR
 ncn# kubectl logs -n services -l app.kubernetes.io/instance=cray-dns-unbound -c cray-dns-unbound
 ```
 
-Example output:
+Example output excerpt:
 
 ```text
 [1596224129] unbound[8:0] debug: using localzone health.check.unbound. transparent
 [1596224129] unbound[8:0] debug: using localzone health.check.unbound. transparent
 [1596224135] unbound[8:0] debug: using localzone health.check.unbound. transparent
 [1596224135] unbound[8:0] debug: using localzone health.check.unbound. transparent
-[1596224140] unbound[8:0] debug: using localzone health.check.unbound. transparent
-[1596224140] unbound[8:0] debug: using localzone health.check.unbound. transparent
-[1596224145] unbound[8:0] debug: using localzone health.check.unbound. transparent
-[1596224145] unbound[8:0] debug: using localzone health.check.unbound. transparent
-[1596224149] unbound[8:0] debug: using localzone health.check.unbound. transparent
-[1596224149] unbound[8:0] debug: using localzone health.check.unbound. transparent
-[1596224128] unbound[8:0] debug: using localzone health.check.unbound. transparent
-[1596224128] unbound[8:0] debug: using localzone health.check.unbound. transparent
-[1596224134] unbound[8:0] debug: using localzone health.check.unbound. transparent
-[1596224134] unbound[8:0] debug: using localzone health.check.unbound. transparent
-[1596224138] unbound[8:0] debug: using localzone health.check.unbound. transparent
-[1596224138] unbound[8:0] debug: using localzone health.check.unbound. transparent
-[1596224144] unbound[8:0] debug: using localzone health.check.unbound. transparent
-[1596224144] unbound[8:0] debug: using localzone health.check.unbound. transparent
-[1596224148] unbound[8:0] debug: using localzone health.check.unbound. transparent
-[1596224148] unbound[8:0] debug: using localzone health.check.unbound. transparent
 ```
 
 To view the DNS Helper logs:
 
 ```bash
-ncn# kubectl logs -n services pod/$(kubectl get -n services pods | \
-grep unbound | tail -n 1 | cut -f 1 -d ' ') -c manager | tail -n4
+ncn# kubectl logs -n services pod/$(kubectl get -n services pods |
+        grep unbound | tail -n 1 | cut -f 1 -d ' ') -c manager | tail -n4
 ```
 
 Example output:
@@ -130,14 +112,14 @@ Comparing new and existing DNS records.
     No differences found. Skipping DNS update
 ```
 
-## Verify that MetalLB/BGP Peering and Routes are Correct
+## Verify that MetalLB/BGP peering and routes are correct
 
-Log in to the spine switches and check that MetalLB is peering to the spines via BGP.
+Log in to the spine switches and verify that MetalLB is peering to the spines via BGP.
 
 Check both spines if they are available and powered up. All worker nodes should be peered with the spine BGP.
 
 ```text
-sw-spine-001 [standalone: master] # show ip bgp neighbors
+sw-spine-001# show ip bgp neighbors
 ```
 
 Example output:
@@ -164,10 +146,10 @@ BGP neighbor: 10.252.0.4, remote AS: 65533, link: internal:
   Minimum holdtime from neighbor in seconds            : 90
 ```
 
-Confirm that routes to Kea \(10.92.100.222\) via all the NCN worker nodes are available:
+Confirm that routes to Kea \(`10.92.100.222`\) via all the NCN worker nodes are available:
 
 ```text
-sw-spine-001 [standalone: master] # show ip route 10.92.100.222
+sw-spine-001# show ip route 10.92.100.222
 ```
 
 Example output:
@@ -190,17 +172,17 @@ VRF Name default:
                                       c        10.252.0.6        vlan2            bgp        200/0
 ```
 
-## TCPDUMP
+## `tcpdump`
 
-Verify if the NCN is receiving DNS queries. On an NCN worker or manager with `kubectl` installed, run the following command:
+Verify that the NCN is receiving DNS queries. On an NCN worker or manager with `kubectl` installed, run the following command:
 
 ```bash
 ncn-mw# tcpdump -envli bond0.nmn0 port 53
 ```
 
-## The ping and SSH Commands Fail for Hosts in DNS
+## The `ping` and `ssh` commands fail for hosts in DNS
 
-If the IP address returned by the `ping` command is different than the IP address returned by the `dig` command, restart `nscd` on the impacted node. This is done with the following command:
+If the IP address returned by the `ping` command is different than the IP address returned by the `dig` command, then restart `nscd` on the impacted node. This is done with the following command:
 
 ```bash
 ncn# systemctl restart nscd.service
@@ -208,23 +190,28 @@ ncn# systemctl restart nscd.service
 
 Attempt to `ping` or `ssh` to the IP address that was experiencing issues after restarting `nscd`.
 
-## Check for Missing DHCP Leases
+## Check for missing DHCP leases
 
 Search for a DHCP lease by checking active leases for the service:
 
 ```bash
 ncn# curl -s -k -H "Authorization: Bearer ${TOKEN}" -X POST -H \
-"Content-Type: application/json" \-d '{ "command": "lease4-get-all",  "service": \
-[ "dhcp4" ] }' https://api-gw-service-nmn.local/apis/dhcp-kea |jq
+        "Content-Type: application/json" \-d '{ "command": "lease4-get-all",  "service": \
+        [ "dhcp4" ] }' https://api-gw-service-nmn.local/apis/dhcp-kea | jq
 ```
 
 For example:
 
 ```bash
 ncn# curl -s -k -H "Authorization: Bearer ${TOKEN}" -X \
-POST -H "Content-Type: application/json" \-d '{ "command": "lease4-get-all",  "service": \
-[ "dhcp4" ] }' https://api-gw-service-nmn.local/apis/dhcp-kea \
-|jq|grep x3000c0s19b4  -A 6 -B 4
+        POST -H "Content-Type: application/json" \-d '{ "command": "lease4-get-all",  "service": \
+        [ "dhcp4" ] }' https://api-gw-service-nmn.local/apis/dhcp-kea \
+        | jq | grep x3000c0s19b4 -A 6 -B 4
+```
+
+Example output:
+
+```json
 {
 "cltt": 1597777241,
 "fqdn-fwd": true,

--- a/operations/network/dns/Troubleshoot_Common_DNS_Issues.md
+++ b/operations/network/dns/Troubleshoot_Common_DNS_Issues.md
@@ -69,8 +69,8 @@ If either of the commands fail to meet the two conditions mentioned above, then 
 If there no record in the Unbound pod, that is also an indication that the host is not in DNS.
 
 ```bash
-ncn# kubectl -n services get cm cray-dns-unbound -o jsonpath='{.binaryData.records\.json\.gz}' |
-        base64 --decode | gzip -dc | jq -c '.[]' | grep XNAME
+ncn-mw# kubectl -n services get cm cray-dns-unbound -o jsonpath='{.binaryData.records\.json\.gz}' |
+            base64 --decode | gzip -dc | jq -c '.[]' | grep XNAME
 ```
 
 Example output excerpt:
@@ -84,7 +84,7 @@ Example output excerpt:
 Use the following command to check the logs. Any logs with a message saying `ERROR` or `Exception` are an indication that the Unbound service is not healthy.
 
 ```bash
-ncn# kubectl logs -n services -l app.kubernetes.io/instance=cray-dns-unbound -c cray-dns-unbound
+ncn-mw# kubectl logs -n services -l app.kubernetes.io/instance=cray-dns-unbound -c cray-dns-unbound
 ```
 
 Example output excerpt:
@@ -99,8 +99,8 @@ Example output excerpt:
 To view the DNS Helper logs:
 
 ```bash
-ncn# kubectl logs -n services pod/$(kubectl get -n services pods |
-        grep unbound | tail -n 1 | cut -f 1 -d ' ') -c manager | tail -n4
+ncn-mw# kubectl logs -n services pod/$(kubectl get -n services pods |
+            grep unbound | tail -n 1 | cut -f 1 -d ' ') -c manager | tail -n4
 ```
 
 Example output:
@@ -119,7 +119,7 @@ Log in to the spine switches and verify that MetalLB is peering to the spines vi
 Check both spines if they are available and powered up. All worker nodes should be peered with the spine BGP.
 
 ```text
-sw-spine-001# show ip bgp neighbors
+sw-spine# show ip bgp neighbors
 ```
 
 Example output:
@@ -149,7 +149,7 @@ BGP neighbor: 10.252.0.4, remote AS: 65533, link: internal:
 Confirm that routes to Kea \(`10.92.100.222`\) via all the NCN worker nodes are available:
 
 ```text
-sw-spine-001# show ip route 10.92.100.222
+sw-spine# show ip route 10.92.100.222
 ```
 
 Example output:

--- a/operations/network/dns/Troubleshoot_Common_DNS_Issues.md
+++ b/operations/network/dns/Troubleshoot_Common_DNS_Issues.md
@@ -65,7 +65,8 @@ If either of the commands fail to meet the two conditions mentioned above, colle
 If there no record in the Unbound pod, that is also an indication that the host is not in DNS.
 
 ```bash
-ncn# kubectl describe -n services configmaps cray-dns-unbound | grep XNAME
+ncn# kubectl -n services get cm cray-dns-unbound -o jsonpath='{.binaryData.records\.json\.gz}' |
+     base64 --decode | gzip -dc | jq -c '.[]' | grep XNAME
 ```
 
 Example output:


### PR DESCRIPTION
# Description

The Unbound record data in the `cray-dns-unbound` documentation is compressed and the troubleshooting documentation does not have the correct command to extract it.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
