### PR TITLE
CASMNET-1533 - Update troubleshooting doc to reflect that the Unbound records data is compressed

### DIFF
--- a/operations/network/dns/Troubleshoot_Common_DNS_Issues.md
+++ b/operations/network/dns/Troubleshoot_Common_DNS_Issues.md
@@ -1,37 +1,39 @@
 # Troubleshoot Common DNS Issues
 
-The Domain Name Service \(DNS\) is part of an integrated infrastructure set designed to provide dynamic host discovery, addressing, and naming. There are several different place to look for troubleshooting as DNS interacts with Dynamic Host Configuration Protocol \(DHCP\), the Hardware Management Service \(HMS\), the System Layout Service \(SLS\), and the State Manager Daemon \(SMD\).
+The Domain Name Service \(DNS\) is part of an integrated infrastructure set designed to provide dynamic host discovery, addressing, and naming.
+There are several different place to look for troubleshooting as DNS interacts with Dynamic Host Configuration Protocol \(DHCP\), the Hardware
+Management Service \(HMS\), the System Layout Service \(SLS\), and the State Manager Daemon \(SMD\).
 
 The information below describes what to check when experiencing issues with DNS.
 
-### Troubleshoot an Invalid Hostname
+## Troubleshoot an Invalid Hostname
 
 It is important to verify if a hostname is correct. The values in the `networks.yml` or `networks_derived.yml` files are sometimes inaccurate.
 
 The formats show below are valid hostnames:
 
-- component names (xnames)
+- Component names (xnames)
   - Node Management Network \(NMN\):
-    - <xname\>
-    - <xname\>.local
+    - `<xname\>`
+    - `<xname\>.local`
   - Hardware Management Network \(HMN\):
-    - <xname\>-mgmt
-    - <xname\>-mgmt.local
-  - nid
-    - <nid\_number\>-nmn
-    - <nid\_number\>-nmn.local
+    - `<xname\>-mgmt`
+    - `<xname\>-mgmt.local`
+  - NID
+    - `nid<nid\_number\>-nmn`
+    - `nid<nid\_number\>-nmn.local`
 
 Additional steps are needed if a hostname or component name (xname) is either listed incorrectly or not listed at all in the `networks.yml` or `networks_derived.yml` files. The following actions need to be taken:
 
-1.  Update the hostname in the Hardware State Manager \(HSM\).
-2.  Re-run any Ansible plays that require the data in these files.
+1. Update the hostname in the Hardware State Manager \(HSM\).
+2. Re-run any Ansible plays that require the data in these files.
 
-### Check if a Host is in DNS
+## Check if a Host is in DNS
 
 Use the `dig` or `nslookup` commands directly against the Unbound resolver. A host is correctly in DNS if the response from the `dig` command includes the following:
 
--   The `ANSWER SECTION` value exists with a valid hostname and IP address
--   A `QUERY` value exists that has the `status: NOERROR` message
+- The `ANSWER SECTION` value exists with a valid hostname and IP address
+- A `QUERY` value exists that has the `status: NOERROR` message
 
 ```bash
 ncn# dig HOSTNAME @10.92.100.225
@@ -39,7 +41,7 @@ ncn# dig HOSTNAME @10.92.100.225
 
 Example output:
 
-```
+```text
 ; <<>> DiG 9.11.2 <<>> x3000c0r41b0 @10.92.100.225
 ;; global options: +cmd
 ;; Got answer:
@@ -65,25 +67,31 @@ If either of the commands fail to meet the two conditions mentioned above, colle
 If there no record in the Unbound pod, that is also an indication that the host is not in DNS.
 
 ```bash
-ncn# kubectl describe -n services configmaps cray-dns-unbound | grep XNAME
+ncn# kubectl -n services get cm cray-dns-unbound -o jsonpath='{.binaryData.records\.json\.gz}' |
+     base64 --decode | gzip -dc | jq -c '.[]' | grep XNAME
 ```
 
 Example output:
 
-```
+```text
 [...]
 
 {"hostname": "x1003c7s7b0", "ip-address": "10.104.12.191"}
-...
+
+[...]
 ```
 
-### Check the `cray-dns-unbound` Logs for Errors
+## Check the `cray-dns-unbound` Logs for Errors
 
 Use the following command to check the logs. Any logs with a message saying `ERROR` or `Exception` are an indication that the Unbound service is not healthy.
 
 ```bash
-ncn# kubectl logs -n services -l \
-app.kubernetes.io/instance=cray-dns-unbound -c unbound
+ncn# kubectl logs -n services -l app.kubernetes.io/instance=cray-dns-unbound -c cray-dns-unbound
+```
+
+Example output:
+
+```text
 [1596224129] unbound[8:0] debug: using localzone health.check.unbound. transparent
 [1596224129] unbound[8:0] debug: using localzone health.check.unbound. transparent
 [1596224135] unbound[8:0] debug: using localzone health.check.unbound. transparent
@@ -111,20 +119,30 @@ To view the DNS Helper logs:
 ```bash
 ncn# kubectl logs -n services pod/$(kubectl get -n services pods | \
 grep unbound | tail -n 1 | cut -f 1 -d ' ') -c manager | tail -n4
+```
+
+Example output:
+
+```text
   uid: bc1e8b7f-39e2-49e5-b586-2028953d2940
 
 Comparing new and existing DNS records.
     No differences found. Skipping DNS update
 ```
 
-### Verify that MetalLB/BGP Peering and Routes are Correct
+## Verify that MetalLB/BGP Peering and Routes are Correct
 
 Log in to the spine switches and check that MetalLB is peering to the spines via BGP.
 
 Check both spines if they are available and powered up. All worker nodes should be peered with the spine BGP.
 
-```
+```text
 sw-spine-001 [standalone: master] # show ip bgp neighbors
+```
+
+Example output:
+
+```text
 BGP neighbor: 10.252.0.4, remote AS: 65533, link: internal:
   Route-map (in/out)                                   : rm-ncn-w001
   BGP version                                          : 4
@@ -148,8 +166,13 @@ BGP neighbor: 10.252.0.4, remote AS: 65533, link: internal:
 
 Confirm that routes to Kea \(10.92.100.222\) via all the NCN worker nodes are available:
 
-```
+```text
 sw-spine-001 [standalone: master] # show ip route 10.92.100.222
+```
+
+Example output:
+
+```text
 Flags:
   F: Failed to install in H/W
   B: BFD protected (static route)
@@ -167,15 +190,15 @@ VRF Name default:
                                       c        10.252.0.6        vlan2            bgp        200/0
 ```
 
-### TCPDUMP
+## TCPDUMP
 
 Verify if the NCN is receiving DNS queries. On an NCN worker or manager with `kubectl` installed, run the following command:
 
 ```bash
-ncn-mw# tcpdump -envli vlan002 port 53
+ncn-mw# tcpdump -envli bond0.nmn0 port 53
 ```
 
-### The ping and SSH Commands Fail for Hosts in DNS
+## The ping and SSH Commands Fail for Hosts in DNS
 
 If the IP address returned by the `ping` command is different than the IP address returned by the `dig` command, restart `nscd` on the impacted node. This is done with the following command:
 
@@ -185,7 +208,7 @@ ncn# systemctl restart nscd.service
 
 Attempt to `ping` or `ssh` to the IP address that was experiencing issues after restarting `nscd`.
 
-### Check for Missing DHCP Leases
+## Check for Missing DHCP Leases
 
 Search for a DHCP lease by checking active leases for the service:
 
@@ -217,6 +240,5 @@ POST -H "Content-Type: application/json" \-d '{ "command": "lease4-get-all",  "s
 
 If there is not a DHCP lease found, then:
 
--   Ensure the system is running and that its DHCP client is still sending requests. Reboot the system via Redfish/IPMI if required.
--   See [Troubleshoot DHCP Issues](../dhcp/Troubleshoot_DHCP_Issues.md) for more information.
-
+- Ensure the system is running and that its DHCP client is still sending requests. Reboot the system via Redfish/IPMI if required.
+- See [Troubleshoot DHCP Issues](../dhcp/Troubleshoot_DHCP_Issues.md) for more information.


### PR DESCRIPTION
# Description

The Unbound record data in the `cray-dns-unbound` documentation is compressed and the troubleshooting documentation does not have the correct command to extract it.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams