### PR TITLE
MTL-1817 This needs to be install

### DIFF
--- a/install/pre-installation.md
+++ b/install/pre-installation.md
@@ -403,7 +403,7 @@ in `/etc/environment` from the [Download CSM tarball](#21-download-csm-tarball) 
       --plus-repo "${CSM_PATH}/rpm/cray/csm/sle-15sp2/" \
       --plus-repo "${CSM_PATH}/rpm/cray/csm/sle-15sp3/" \
       --no-gpg-checks \
-      update -y csm-testing goss-servers
+      install -y csm-testing goss-servers
    ```
 
 1. (`pit#`) Log the currently installed PIT packages.


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
The `zypper update` command fails because neither `csm-testing` or `goss-servers` are installed on the LiveCD by default. This command needs to be `zypper install`.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
