### PR TITLE
CASMTRIAGE-3628 - Fix for missing directory required for upgrades

### DIFF
--- a/upgrade/1.2/scripts/upgrade/csm-upgrade.sh
+++ b/upgrade/1.2/scripts/upgrade/csm-upgrade.sh
@@ -58,6 +58,7 @@ state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
 if [[ $state_recorded == "0" ]]; then
     echo "====> ${state_name} ..."
     {
+    mkdir -p /srv/cray/tmp
     . /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/csi-configuration.sh
     create_ceph_rbd_1.2_csi_configmap
     create_ceph_cephfs_1.2_csi_configmap


### PR DESCRIPTION
# Description

The master servers to do not have /srv/cray/tmp which is required for
the csi-configuration.sh script.  (ceph-csi)

# Checklist Before Merging

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
