### PR TITLE
CASMINST-4870 - DOCS: Don't run Internal SSH test until final NCN deployment has been completed

### DIFF
--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -36,6 +36,7 @@ The areas should be tested in the order they are listed on this page. Errors in 
     - [4.1.2 Gateway health tests on an NCN](#412-gateway-health-tests-on-an-ncn)
     - [4.1.3 Gateway health tests from outside the system](#413-gateway-health-tests-from-outside-the-system)
   - [4.2 Internal SSH access test execution](#42-internal-ssh-access-test-execution)
+    - [4.2.1 Known issues with internal SSH access test execution](#421-known-issues-with-internal-ssh-access-test-execution)
   - [4.3 External SSH access test execution](#43-external-ssh-access-test-execution)
 - [5. Booting CSM `barebones` image](#5-booting-csm-barebones-image)
   - [5.1 Run the test script](#51-run-the-test-script)
@@ -608,6 +609,11 @@ The test will complete with an overall pass/failure status such as the following
 ```text
 Overall status: PASSED (Passed: 40, Failed: 0)
 ```
+
+#### 4.2.1 Known issues with internal SSH access test execution
+
+It is possible this test will fail if the procedure to deploy the final NCN has not been performed as the static IP reservation data has
+not been loaded into Hardware State Manager at this time so DNS records may be missing.
 
 ### 4.3 External SSH access test execution
 


### PR DESCRIPTION
# Description

It is possible that the Internal SSH test may fail until the steps to redeploy the final NCN have been run.

powerdns-manager partially relies on the HSM `ethernetInterfaces` records for the static IP reservations and those are not created until BSS handoff is run.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
