### PR TITLE
CASMCMS-6989: Rename compute configuration to csm configuration

### DIFF
--- a/operations/CSM_product_management/Configure_CSM_Packages_with_CFS.md
+++ b/operations/CSM_product_management/Configure_CSM_Packages_with_CFS.md
@@ -21,7 +21,7 @@ To setup the compute configuration layer, first gather the following information
 | `name` | **Example:** `csm-<version>` | CSM configuration layer name |
 | `playbook` | `compute_nodes.yml` | Default Ansible playbook for CSM configuration of compute nodes |
 
-1. Retrieve the commit in the repository to use for configuration.
+1. (`ncn-mw#`) Retrieve the commit in the repository to use for configuration.
    * If changes have been made to the default branch that was imported during a CSM
      installation or upgrade, use the commit containing the changes.
 

--- a/operations/CSM_product_management/Configure_CSM_Packages_with_CFS.md
+++ b/operations/CSM_product_management/Configure_CSM_Packages_with_CFS.md
@@ -1,7 +1,7 @@
-# Configure Compute Nodes with CFS
+# Configure CSM packages with CFS
 
-CSM includes a playbook that should be applied to any Compute node images.
-The `compute_nodes.yml` playbook installs the packages for both the CFS and BOS reporters.
+CSM includes a playbook that should be applied to Compute and Application node images.
+The `csm_packages.yml` playbook installs the packages for both the CFS and BOS reporters.
 These packages are necessary for CFS and BOS to run, so a configuration layer containing the
 playbook must be included in the image customization for any nodes that are expected to be
 managed with CFS and BOS.
@@ -56,7 +56,7 @@ To setup the compute configuration layer, first gather the following information
     {
         "name": "csm-<version>",
         "cloneUrl": "https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git",
-        "playbook": "compute_nodes.yml",
+        "playbook": "csm_packages.yml",
         "commit": "<retrieved git commit>"
     }
     ```

--- a/operations/README.md
+++ b/operations/README.md
@@ -45,7 +45,7 @@ The following administrative topics can be found in this guide:
 - [Configure the Cray Command Line Interface (Cray CLI)](configure_cray_cli.md)
 - [Change Passwords and Credentials](CSM_product_management/Change_Passwords_and_Credentials.md)
 - [Configure Non-Compute Nodes with CFS](CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md)
-- [Configure Compute Nodes with CFS](CSM_product_management/Configure_Compute_Nodes_with_CFS.md)
+- [Configure CSM Packages with CFS](CSM_product_management/Configure_CSM_Packages_with_CFS.md)
 - [Perform NCN Personalization](CSM_product_management/Perform_NCN_Personalization.md)
 - [Access the LiveCD USB Device After Reboot](../install/livecd/Access_LiveCD_USB_Device_After_Reboot.md)
 - [Post-Install Customizations](CSM_product_management/Post_Install_Customizations.md)


### PR DESCRIPTION
# Description

Renames a section on compute configuration since the configuration will now also include application nodes.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams