### PR TITLE
NETETH-1987 CASMINST-4877: blacklist the `rpcrdma` kernel module

### DIFF
--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -211,7 +211,6 @@ If the following command does not complete successfully, check if the `TOKEN` en
    - See the [Management Network User Guide](../../operations/network/management_network/index.md) for more information on the management network.
    - With the 1.2 switch configuration in place, users will only be able to SSH into the switches over the HMN.  
 
-
 ## Stage 0.4 - Prerequisites check
 
 1. Set the `SW_ADMIN_PASSWORD` environment variable.
@@ -223,6 +222,17 @@ If the following command does not complete successfully, check if the `TOKEN` en
    ```bash
    ncn-m001# read -s SW_ADMIN_PASSWORD
    ncn-m001# export SW_ADMIN_PASSWORD
+   ```
+
+1. Blacklist the `rpcrdma` modules **only if needed**.
+
+   On worker nodes containing both ConnectX-4 and ConnectX-5 network interface cards, the
+   `rpcrdma` kernel module needs to be blacklisted so that it does not interfere with
+   Slingshot Host Software. Run the following script to add the necessary blacklist parameters
+   to the kernel command line on the worker nodes:
+
+   ```bash
+   ncn-m001# /usr/share/doc/csm/upgrade/1.2/scripts/k8s/blacklist-kernel-modules.sh
    ```
 
 1. Set the `NEXUS_PASSWORD` variable **only if needed**.

--- a/upgrade/1.2/scripts/k8s/blacklist-kernel-modules.sh
+++ b/upgrade/1.2/scripts/k8s/blacklist-kernel-modules.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+set -ueo pipefail
+
+NOW=$(date "+%Y%m%d%H%M%S")
+
+function get-admin-client-secret() {
+    kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d
+}
+
+function get-token() {
+    local client_secret
+    client_secret="$(get-admin-client-secret)"
+    curl -sSfk \
+        -d grant_type=client_credentials \
+        -d client_id=admin-client \
+        -d client_secret="${client_secret}" \
+        'https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token' \
+    | jq -r '.access_token'
+}
+
+function list-workers() {
+    local token
+    local workers
+
+    token="$(get-token)"
+    workers=$(curl -sSfk \
+        -H "Authorization: Bearer ${token}" \
+        'https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management' \
+    | jq -r '.[]| .ExtraProperties.Aliases[]' \
+    | sort -u | grep ncn-w)
+
+    echo "$workers"
+}
+
+function list-worker-xnames() {
+    local token
+
+    token="$(get-token)"
+
+    for worker in $(list-workers); do
+        curl -s -k -H "Authorization: Bearer ${token}" "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management" | \
+               jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"$worker\")) | .Xname"
+    done
+}
+
+module_blacklist="module_blacklist=rpcrdma"
+
+# update worker node boot params to include the module blacklist
+for worker in $(list-worker-xnames); do
+    # get current params
+    bootparams=$(cray bss bootparameters list --hosts "$worker" --format json)
+    params=$(cray bss bootparameters list --hosts "$worker" --format json | jq -r '.[]|.["params"]')
+
+    # save current params
+    echo "$bootparams" > /tmp/bootparams."$worker.$NOW"
+
+    # update params iff they're not already present
+    if ! [[ $params == *"$module_blacklist"* ]]; then
+        params="$params $module_blacklist"
+        cray bss bootparameters update --hosts "$worker" --params "$params"
+
+        # confirm the update was successful
+        params=$(cray bss bootparameters list --hosts "$worker" --format json | jq -r '.[]|.["params"]')
+        if [[ $params == *"$module_blacklist"* ]]; then
+            echo "bootparameters update successful for $worker"
+        else
+            echo "bootparameters update failed for $worker"
+        fi
+    else
+        echo "module blacklist already present for $worker, no action taken"
+    fi
+done


### PR DESCRIPTION
# Description

In order to not cause problems during the Slingshot Host Software
install we need to blacklist the rpcrdma kernel module.  This is
accomplished by added a kernel boot param to blacklist the module.

The doc change instructs the admin to run this script prior to
starting the upgrade.  This ensures that the worker nodes have
this module blacklisted on their first boot.  This also ensures
the boot params, including this new parameter, get automagically
added to the grub.cfg during the first network boot.


<!--- Describe what this change is and what it is for. -->

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
