### PR TITLE
CASMTRIAGE-3642 - Internal SSH Test failing during Final Validation

### DIFF
--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -613,41 +613,49 @@ Overall status: PASSED (Passed: 40, Failed: 0)
 #### 4.2.1 Known issues with internal SSH access test execution
 
 - It is possible this test will fail if the procedure to deploy the final NCN has not been performed.
-  Before running this procedure, the static IP reservation data has not yet been loaded into the
+
+  Before running this procedure, the static IP address reservation data has not yet been loaded into the
   Hardware State Manager (HSM), so DNS records may be missing.
 
-- After deploying the final NCN this test may fail reporting an `UnresolvedHostname` error.
+- After deploying the final NCN, this test may fail with an `UnresolvedHostname` error.
 
-  To work around this issue inspect the `cray-powerdns-manager` pod log for `Failed to patch RRsets` errors.
+  To work around this issue, perform the following procedure:
 
-  ```bash
-  ncn# kubectl -n services logs -l app.kubernetes.io/name=cray-powerdns-manager -c cray-powerdns-manager
-  ```
+  1. Inspect the `cray-powerdns-manager` pod log for `Failed to patch RRsets` errors.
 
-  Example output:
+     ```bash
+     ncn-mw# kubectl -n services logs -l app.kubernetes.io/name=cray-powerdns-manager -c cray-powerdns-manager
+     ```
 
-  ```text
-  {"level":"error","ts":1644510069.0068583,"msg":"Failed to patch RRsets!",  "zone":"nmn.hela.dev.cray.com.",
-  "error":"RRset x3000c0s6b0n0.nmn.hela.dev.cray.com. IN CNAME: Conflicts with   pre-existing RRset",
-  "zone":"nmn.hela.dev.cray.com."}
-  ```
+     Example output:
 
-  Identify the `cray-dns-powerdns` pod.
+     ```text
+     {"level":"error","ts":1644510069.0068583,"msg":"Failed to patch RRsets!",  "zone":"nmn.hela.dev.cray.com.",
+     "error":"RRset x3000c0s6b0n0.nmn.hela.dev.cray.com. IN CNAME: Conflicts with   pre-existing RRset",
+     "zone":"nmn.hela.dev.cray.com."}
+     ```
 
-  ```bash
-  ncn# kubectl -n services get pod -l app.kubernetes.io/name=cray-dns-powerdns
-  NAME                                 READY   STATUS    RESTARTS   AGE
-  cray-dns-powerdns-86c9685d78-bxz2z   2/2     Running   0          13d
-  ```
+  1. Identify the `cray-dns-powerdns` pod.
 
-  Delete the zone reported in the `cray-powerdns-manager` log output.
+     ```bash
+     ncn-mw# kubectl -n services get pod -l app.kubernetes.io/name=cray-dns-powerdns
+     ```
 
-  ```bash
-  ncn# kubectl -n services exec -it cray-dns-powerdns-86c9685d78-bxz2z \
-  -c cray-dns-powerdns -- pdnsutil delete-zone nmn.hela.dev.cray.com
-  ```
+     Example output:
 
-  The `cray-powerdns-manager` reconciliation loop runs every 30 seconds and the next run will recreate the zone with the correct records.
+     ```text
+     NAME                                 READY   STATUS    RESTARTS   AGE
+     cray-dns-powerdns-86c9685d78-bxz2z   2/2     Running   0          13d
+     ```
+
+  1. Delete the zone reported in the `cray-powerdns-manager` log output.
+
+     ```bash
+     ncn-mw# kubectl -n services exec -it cray-dns-powerdns-86c9685d78-bxz2z \
+                 -c cray-dns-powerdns -- pdnsutil delete-zone nmn.hela.dev.cray.com
+     ```
+
+  The `cray-powerdns-manager` reconciliation loop runs every 30 seconds, and the next run will recreate the zone with the correct records.
 
 ### 4.3 External SSH access test execution
 

--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -650,6 +650,9 @@ Overall status: PASSED (Passed: 40, Failed: 0)
 
   1. Delete the zone reported in the `cray-powerdns-manager` log output.
 
+     In the following example command, be sure to replace `nmn.hela.dev.cray.com` with
+     the actual zone identified in the earlier step.
+
      ```bash
      ncn-mw# kubectl -n services exec -it cray-dns-powerdns-86c9685d78-bxz2z \
                  -c cray-dns-powerdns -- pdnsutil delete-zone nmn.hela.dev.cray.com

--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -612,8 +612,42 @@ Overall status: PASSED (Passed: 40, Failed: 0)
 
 #### 4.2.1 Known issues with internal SSH access test execution
 
-It is possible this test will fail if the procedure to deploy the final NCN has not been performed. Before running this procedure, the static IP reservation data has
-not yet been loaded into the Hardware State Manager (HSM), so DNS records may be missing.
+- It is possible this test will fail if the procedure to deploy the final NCN has not been performed.
+  Before running this procedure, the static IP reservation data has not yet been loaded into the
+  Hardware State Manager (HSM), so DNS records may be missing.
+
+- After deploying the final NCN this test may fail reporting an `UnresolvedHostname` error.
+
+  To work around this issue inspect the `cray-powerdns-manager` pod log for `Failed to patch RRsets` errors.
+
+  ```bash
+  ncn# kubectl -n services logs -l app.kubernetes.io/name=cray-powerdns-manager -c cray-powerdns-manager
+  ```
+
+  Example output:
+
+  ```text
+  {"level":"error","ts":1644510069.0068583,"msg":"Failed to patch RRsets!",  "zone":"nmn.hela.dev.cray.com.",
+  "error":"RRset x3000c0s6b0n0.nmn.hela.dev.cray.com. IN CNAME: Conflicts with   pre-existing RRset",
+  "zone":"nmn.hela.dev.cray.com."}
+  ```
+
+  Identify the `cray-dns-powerdns` pod.
+
+  ```bash
+  ncn# kubectl -n services get pod -l app.kubernetes.io/name=cray-dns-powerdns
+  NAME                                 READY   STATUS    RESTARTS   AGE
+  cray-dns-powerdns-86c9685d78-bxz2z   2/2     Running   0          13d
+  ```
+
+  Delete the zone reported in the `cray-powerdns-manager` log output.
+
+  ```bash
+  ncn# kubectl -n services exec -it cray-dns-powerdns-86c9685d78-bxz2z \
+  -c cray-dns-powerdns -- pdnsutil delete-zone nmn.hela.dev.cray.com
+  ```
+
+  The `cray-powerdns-manager` reconciliation loop runs every 30 seconds and the next run will recreate the zone with the correct records.
 
 ### 4.3 External SSH access test execution
 


### PR DESCRIPTION
# Description

It is possible for `cray-powerdns-manager` to get "stuck" updating a zone due to attempting to generate duplicate records based on SLS/SMD data. ([CASMNET-1143](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1143)).

This can result in the internal SSH test failing because it cannot resolve all of the hostnames for the test.

This change documents the workaround required to force the records to be created correctly.

This WAR has been successfully tested on `drax` by the QE team.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
