### PR TITLE
CASMINST-4883: Provide details on restoring CFS configuration for NCN worker nodes

### DIFF
--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -282,7 +282,7 @@ If the following command does not complete successfully, check if the `TOKEN` en
    If the failure persists, then open a support ticket for guidance before proceeding.
 
    `prerequisites.sh` clears the existing CFS configuration for each Management node. As each
-   Management node is upgraded, documentation will refer to the CFS configuration that should be
+   worker node is upgraded, the documentation will refer to the CFS configuration that should be
    assigned to the node at that time. If any Management node is unexpectedly rebooted prior to this,
    CFS will not automatically personalize the node after it has booted.
 

--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -281,6 +281,11 @@ If the following command does not complete successfully, check if the `TOKEN` en
    [Upgrade Troubleshooting](README.md#relevant-troubleshooting-links-for-upgrade-related-issues).
    If the failure persists, then open a support ticket for guidance before proceeding.
 
+   `prerequisites.sh` clears the existing CFS configuration for each Management node. As each
+   Management node is upgraded, documentation will refer to the CFS configuration that should be
+   assigned to the node at that time. If any Management node is unexpectedly rebooted prior to this,
+   CFS will not automatically personalize the node after it has booted.
+
 1. Unset the `NEXUS_PASSWORD` variable, if it was set in the earlier step.
 
    ```bash

--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -283,7 +283,8 @@ If the following command does not complete successfully, check if the `TOKEN` en
 
    `prerequisites.sh` clears the existing CFS configuration for each Management node. As each
    worker node is upgraded, the documentation will refer to the CFS configuration that should be
-   assigned to the node at that time. If any Management node is unexpectedly rebooted prior to this,
+   assigned to the node at that time. If any worker node is unexpectedly rebooted prior to this, or if any other
+   type of Management node is unexpectedly rebooted prior to the end of the CSM upgrade, then
    CFS will not automatically personalize the node after it has booted.
 
 1. Unset the `NEXUS_PASSWORD` variable, if it was set in the earlier step.

--- a/upgrade/1.2/Stage_2.md
+++ b/upgrade/1.2/Stage_2.md
@@ -59,6 +59,16 @@
 
    > **NOTE:** The root password for the node may need to be reset after it is rebooted.
 
+1. Assign a new CFS configuration to the worker node.
+
+   The content of the new CFS configuration is described in _HPE Cray EX System Software Getting Started Guide S-8000_, section
+   "HPE Cray EX Software Upgrade Workflow" subsection "Cray System Management (CSM)". Replace `${NEW_NCN_CONFIGURATION}` with
+   the name of the new CFS configuration and `${XNAME}` with the xname of ncn-w001.
+
+   ```bash
+   ncn-m001# cray cfs components update --desired-config ${NEW_NCN_CONFIGURATION} ${XNAME}
+   ```
+
 1. Repeat the previous steps for each other worker node, one at a time.
 
 ## Stage 2.3

--- a/upgrade/1.2/Stage_2.md
+++ b/upgrade/1.2/Stage_2.md
@@ -63,7 +63,7 @@
 
    The content of the new CFS configuration is described in _HPE Cray EX System Software Getting Started Guide S-8000_, section
    "HPE Cray EX Software Upgrade Workflow" subsection "Cray System Management (CSM)". Replace `${NEW_NCN_CONFIGURATION}` with
-   the name of the new CFS configuration and `${XNAME}` with the xname of ncn-w001.
+   the name of the new CFS configuration and `${XNAME}` with the component name (xname) of the worker node that was upgraded.
 
    ```bash
    ncn-m001# cray cfs components update --desired-config ${NEW_NCN_CONFIGURATION} ${XNAME}


### PR DESCRIPTION
# Description

Describe how the upgrade procedure clears the CFS configuration from worker nodes
and how to restore required configuration for other products to ensure the compute
nodes and UANs remain functional during the upgrade.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
