### PR TITLE
CASMINST-4884 Prevent Duplicates

### DIFF
--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -320,7 +320,7 @@ be performed are in the [Deploy](#deploy) section.
     1. Patch the `set-sqfs-links.sh` script to include the blacklisting of an undesired kernel module.
 
     ```bash
-    pit# sed -i -E 's/rd.luks=0/rd.luks=0 module_blacklist=rpcrdma/g' /root/bin/set-sqfs-links.sh
+    pit# sed -i -E 's:rd.luks=0 /:rd.luks=0 module_blacklist=rpcrdma \/:g' /root/bin/set-sqfs-links.sh
     ```
 
     1. Invoke the script.


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->

The current line is not idempotent and if ran again will result in multiple instances of `module_blacklist`:
```bash
    if [[ "$ncn" =~ 'ncn-w' ]]; then
        sed -i -E 's/rd.luks(=1)?\s/rd.luks=0 module_blacklist=rpcrdma module_blacklist=rpcrdma module_blacklist=rpcrdma /g' script.ipxe
    fi
```

The resulting line if ran more than once remains the same:
```bash
    if [[ "$ncn" =~ 'ncn-w' ]]; then
        sed -i -E 's/rd.luks(=1)?\s/rd.luks=0 module_blacklist=rpcrdma /g' script.ipxe
    fi
```

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
