### PR TITLE
Add 1.0 version of opa envoy image to the list of key images to pre-cache during NCN rebuilds

### DIFF
--- a/upgrade/1.2/scripts/upgrade/prerequisites.sh
+++ b/upgrade/1.2/scripts/upgrade/prerequisites.sh
@@ -622,7 +622,7 @@ EOF
     # needs so it can move around on an upgraded NCN (before we deploy
     # the new nexus chart)
     #
-    kubectl get configmap -n nexus cray-precache-images -o yaml | sed '/kind: ConfigMap/i\    docker.io/sonatype/nexus3:3.25.0\n    dtr.dev.cray.com/baseos/busybox:1\n    dtr.dev.cray.com/cray/istio/proxyv2:1.7.8-cray2-distroless' | kubectl apply -f -
+    kubectl get configmap -n nexus cray-precache-images -o yaml | sed '/kind: ConfigMap/i\    docker.io/sonatype/nexus3:3.25.0\n    dtr.dev.cray.com/baseos/busybox:1\n    dtr.dev.cray.com/cray/istio/proxyv2:1.7.8-cray2-distroless\n    docker.io/openpolicyagent/opa:0.24.0-envoy-1' | kubectl apply -f -
 
     } >> ${LOG_FILE} 2>&1
     #shellcheck disable=SC2046


### PR DESCRIPTION
# Description

Fix for https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4898 to ensure the opa envoy image (1.0 version) is pre-cached on newly built workers during NCN rebuilds, ensuring opa can start (and subsequently nexus calls work, preventing IPBO's).

# Testing

```
ncn-m001-48d9c509:/home/bklein # kubectl get configmap -n nexus cray-precache-images -o yaml | sed '/kind: ConfigMap/i\    docker.io/sonatype/nexus3:3.25.0\n    dtr.dev.cray.com/baseos/busybox:1\n    dtr.dev.cray.com/cray/istio/proxyv2:1.7.8-cray2-distroless\n    docker.io/openpolicyagent/opa:0.24.0-envoy-1' | kubectl apply -f -

configmap/cray-precache-images configured
```

```
  images_to_cache: |-
    artifactory.algol60.net/csm-docker/stable/docker.io/nfvpe/multus:v3.7
    artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/coredns:1.7.0
    artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-apiserver:v1.20.13
    artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-controller-manager:v1.20.13
    artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-scheduler:v1.20.13
    artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/kube-proxy:v1.20.13
    artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/pause:3.2
    artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.9.9-cray1-distroless
    artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.26.0-envoy-6
    artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.10.9
    artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.7.7
    artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.2.5
    artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.5.5
    artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
    artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0
    artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
    artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.0
    artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.4.0
    artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/sig-storage/csi-resizer:v1.3.0
    artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi:v3.5.1
    artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.25.0
    artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.6.1
    docker.io/sonatype/nexus3:3.25.0
    dtr.dev.cray.com/baseos/busybox:1
    dtr.dev.cray.com/cray/istio/proxyv2:1.7.8-cray2-distroless
    docker.io/openpolicyagent/opa:0.24.0-envoy-1
```

# Checklist Before Merging

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
