### PR TITLE
CASMINST-4892: Add casmrel-631_multus-image_hotfix option

### DIFF
--- a/troubleshooting/known_issues/kube_multus_pod_in_ImagePullBackOff.md
+++ b/troubleshooting/known_issues/kube_multus_pod_in_ImagePullBackOff.md
@@ -14,6 +14,10 @@ kube-multus-ds-amd64-4wkb5   0/1    ImagePullBackOff    0          18h
 
 ## Fix
 
+### Option 1
+
+If you have access to the `quay.io/skopeo/stable` image in nexus or an outside repository, you can use skopeo to retag the multus image in nexus.
+
 1. Re-tag the `multus` image in Nexus.
 
    ```bash
@@ -31,3 +35,19 @@ kube-multus-ds-amd64-4wkb5   0/1    ImagePullBackOff    0          18h
    ```bash
    ncn# kubectl get pods -n kube-system -l app=multus
    ```
+
+### Option 2
+
+If you do not have access to the `quay.io/skopeo/stable` image, you can use this hotfix.
+
+1. Download `https://storage.googleapis.com/csm-release-public/hotfix/casmrel-631_multus-image_hotfix-0.0.1.tar.gz` on a device that has access to the internet and transfer the file to one of the management NCNs. 
+
+1. Untar the hotfix tarball.
+
+   ```bash
+   ncn# tar -zxvf casmrel-631_multus-image_hotfix-0.0.1.tar.gz
+   ```
+
+1. Follow the instructions in `./casmrel-631_multus-image_hotfix/README.md`
+
+ 

--- a/troubleshooting/known_issues/kube_multus_pod_in_ImagePullBackOff.md
+++ b/troubleshooting/known_issues/kube_multus_pod_in_ImagePullBackOff.md
@@ -16,7 +16,7 @@ kube-multus-ds-amd64-4wkb5   0/1    ImagePullBackOff    0          18h
 
 ### Option 1
 
-If you have access to the `quay.io/skopeo/stable` image in nexus or an outside repository, you can use skopeo to retag the multus image in nexus.
+If you have access to the `quay.io/skopeo/stable` image in nexus or an outside repository, you can use `skopeo` to re-tag the `multus` image in nexus.
 
 1. Re-tag the `multus` image in Nexus.
 
@@ -40,7 +40,7 @@ If you have access to the `quay.io/skopeo/stable` image in nexus or an outside r
 
 If you do not have access to the `quay.io/skopeo/stable` image, you can use this hotfix.
 
-1. Download `https://storage.googleapis.com/csm-release-public/hotfix/casmrel-631_multus-image_hotfix-0.0.1.tar.gz` on a device that has access to the internet and transfer the file to one of the management NCNs. 
+1. Download `https://storage.googleapis.com/csm-release-public/hotfix/casmrel-631_multus-image_hotfix-0.0.1.tar.gz` on a device that has access to the internet and transfer the file to one of the management NCNs.
 
 1. Untar the hotfix tarball.
 
@@ -49,5 +49,3 @@ If you do not have access to the `quay.io/skopeo/stable` image, you can use this
    ```
 
 1. Follow the instructions in `./casmrel-631_multus-image_hotfix/README.md`
-
- 


### PR DESCRIPTION
# Description

This multus IPBO issue was encountered at a customer site.   They found that the documented workaround in troubleshooting/known_issues/kube_multus_pod_in_ImagePullBackOff.md did not work because they are airgapped.   They found the casmrel-631_multus-image_hotfix-0.0.1.tar.gz mentioned in a JIRA and that allowed them to resolve the issue.  They are asking that this option get added to the documentation.

This page only in the 1.0 branch so backports are not needed for any other branch.

# Checklist Before Merging

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
