### PR TITLE
CASMPET-5767-main : DOCS: Fix typo in cert renewal step

### DIFF
--- a/operations/kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md
+++ b/operations/kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md
@@ -483,7 +483,7 @@ Run the following steps from a master node.
    1. Update the `etcd-client-cert` secret.
 
       ```bash
-      kubectl --namespace=sysmgmt-health create secret generic etcd-client-cert 
+      kubectl --namespace=sysmgmt-health create secret generic etcd-client-cert \
                      --from-file=etcd-client=/etc/kubernetes/pki/apiserver-etcd-client.crt \
                      --from-file=etcd-client-key=/etc/kubernetes/pki/apiserver-etcd-client.key \
                      --from-file=etcd-ca=/etc/kubernetes/pki/etcd/ca.crt \


### PR DESCRIPTION
# Description

Fixing typo for csm 1.0.x docs
backporting to release/1.2 and main

# Checklist Before Merging

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
