### PR TITLE
CASMPET-5769: Review and update System Shutdown and Startup Procedure

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -625,6 +625,9 @@ LoadBalancer
 Preconfig
 preconfig
 
+- operations/power_management/Power_Off_Compute_and_IO_Cabinets.md
+lockout-tagout
+
 - operations/security_and_authentication/Change_Air-Cooled_Node_BMC_Credentials.md
 # To allow System Admin Toolkit
 Admin

--- a/operations/power_management/Power_Off_Compute_and_IO_Cabinets.md
+++ b/operations/power_management/Power_Off_Compute_and_IO_Cabinets.md
@@ -2,36 +2,48 @@
 
 Power off HPE Cray EX liquid-cooled and standard racks.
 
-**Liquid-cooled Cabinets** - HPE Cray EX liquid-cooled cabinet CDU and PDU circuit breakers are controlled manually.
+## Cabinet/rack types
 
-When the PDU breakers are switched to OFF, the Chassis Management Modules \(CMMs\) and Cabinet Environmental Controllers \(CECs\) are also powered off.
+### Liquid-cooled cabinets
+
+HPE Cray EX liquid-cooled cabinet CDU and PDU circuit breakers are controlled manually.
+
+When the PDU breakers are switched to `OFF`, the Chassis Management Modules \(CMMs\) and Cabinet Environmental Controllers \(CECs\) are also powered off.
 
 **Warning:** The cabinet 480VAC power bus bars remain energized. Facility power must be disconnected to completely remove power from the cabinet. Follow lockout-tagout procedures for the site before maintenance.
 
-**Standard Racks** - HPE Cray standard EIA racks typically include 2 redundant PDUs. Some PDU models may require a flat-blade screw driver to open or close the PDU circuit breakers.
+### Standard racks
 
-**Warning:** The cabinet PDUs remain energized when circuit breakers are OFF. Facility power must be disconnected or the PDUs must be unplugged to completely remove power from the rack. Follow lockout-tagout procedures for the site before maintenance.
+HPE Cray standard EIA racks typically include two redundant PDUs. Some PDU models may require a flat-blade screwdriver to open or close the PDU circuit breakers.
+
+**Warning:** The cabinet PDUs remain energized when circuit breakers are `OFF`. Facility power must be disconnected or the PDUs must be unplugged to completely remove power from the rack. Follow
+lockout-tagout procedures for the site before maintenance.
 
 ## Prerequisites
 
-* An authentication token is required to access the API gateway and to use the `sat` command. See the "SAT Authentication" section of the HPE Cray EX System Admin Toolkit (SAT) product stream documentation (S-8031) for instructions on how to acquire a SAT authentication token.
-* This procedure assumes all system software and user jobs were shut down using the [Shut Down and Power Off Compute and User Access Nodes (UAN)](Shut_Down_and_Power_Off_Compute_and_User_Access_Nodes.md) procedure.
+* An authentication token is required to access the API gateway and to use the `sat` command. See the "SAT Authentication" section of the HPE Cray EX System Admin Toolkit (SAT) product stream
+  documentation (`S-8031`) for instructions on how to acquire a SAT authentication token.
+* This procedure assumes all system software and user jobs were shut down. See
+  [Shut Down and Power Off Compute and User Access Nodes (UAN)](Shut_Down_and_Power_Off_Compute_and_User_Access_Nodes.md).
 
 ## Procedure
 
-1. If the system does not include Cray EX liquid-cooled cabinets, proceed to [POWER OFF STANDARD RACK PDU CIRCUIT BREAKERS]("power-off-standard") below.
+If the system does not include HPE Cray EX liquid-cooled cabinets, then skip the next section and proceed to
+[Power off standard rack PDU circuit breakers](#power-off-standard-rack-pdu-circuit-breakers).
 
-### POWER OFF CRAY EX LIQUID-COOLED CABINETS
+### Power off HPE Cray EX liquid-cooled cabinets
 
-1.  Check CDU control panel for alerts or warnings and resolve any issues before continuing.
+1. Check CDU control panel for alerts or warnings and resolve any issues before continuing.
 
-1.  Check the power status before shutdown, this example shows cabinets 1000-1003.
+1. (`ncn-m#`) Check the power status before shutdown.
+
+    This example shows cabinets 1000 - 1003.
 
     ```bash
     cray capmc get_xname_status create --xnames x[1000-1003]c[0-7] --format json
     ```
 
-1.  Use `sat bootsys shutdown` to shut down services and power off liquid-cooled cabinets.
+1. (`ncn-m#`) Shut down services and power off liquid-cooled cabinets.
 
     ```bash
     sat bootsys shutdown --stage cabinet-power
@@ -39,13 +51,15 @@ When the PDU breakers are switched to OFF, the Chassis Management Modules \(CMMs
 
     This command suspends the `hms-discovery` cron job and recursively powers off the liquid-cooled cabinet chassis.
 
-    The `sat bootsys shutdown` command may fail to power off some cabinets and indicate that requests to CAPMC have timed out. In this case, the `sat` command may be run with an increased `--api-timeout` option.
+    The `sat bootsys shutdown` command may fail to power off some cabinets and indicate that requests to CAPMC have timed out. In this case, the `sat` command may be run with an increased `--api-timeout` option:
 
     ```bash
     sat --api-timeout 180 bootsys shutdown --stage cabinet-power
     ```
 
-1.  Verify that the `hms-discovery` cron job has been suspended \(`SUSPEND` column = `True`\).
+1. (`ncn-m#`) Verify that the `hms-discovery` cron job has been suspended.
+
+    If that is the case, then the `SUSPEND` column should be `True` in the output of the following command:
 
     ```bash
     kubectl get cronjobs -n services hms-discovery
@@ -53,56 +67,59 @@ When the PDU breakers are switched to OFF, the Chassis Management Modules \(CMMs
 
     Example output:
 
-    ```
+    ```text
     NAME            SCHEDULE      SUSPEND   ACTIVE   LAST SCHEDULE   AGE^M
     hms-discovery   */3 * * * *   True      0        117s            15d
     ```
 
-1.  Check the power off status, this example shows cabinets 1000-1003.
+1. (`ncn-m#`) Check the power off status.
+
+    This example shows cabinets 1000 - 1003.
 
     ```bash
     cray capmc get_xname_status create --xnames x[1000-1003]c[0-7] --format json
     ```
 
-    Rectifiers \(PSUs\) should indicate that DC power is OFF \(AC OK is on\).
+    Rectifiers \(PSUs\) should indicate that DC power is `OFF` \(`AC OK` means the power is on\).
 
-1.  Set the cabinet PDU circuit breakers to OFF for each shelf.
+1. Set the cabinet PDU circuit breakers to `OFF` for each shelf.
 
-    The AC OK LED on each PSU will remain amber for about 30 seconds \(AC lost\) until the system de-energizes, then extinguish.
+    The `AC OK` LED on each PSU will remain amber for about 30 seconds \(`AC lost`\) until the system de-energizes, then it will extinguish.
 
     ![Liquid-cooled Cabinet PDU](../../img/operations/Liquid_Cooled_Cabinet_PDU.svg)
 
-    **`NOTE`** If the TDS cabinet rack-mounted coolant distribution unit \(MCDU\) is receiving power from the PDUs in the management cabinet, the MCDU may stay on after the TDS cabinet PDU circuit breakers are set to OFF. This is expected.
+    **`NOTE`** If the TDS cabinet rack-mounted coolant distribution unit \(MCDU\) is receiving power from the PDUs in the management cabinet, then the MCDU may stay on after the TDS cabinet PDU
+    circuit breakers are set to `OFF`. This is expected.
 
     ![Liquid-cooled TDS Cabinet PDU](../../img/operations/Liquid_Cooled_TDS_Cabinet_PDU.svg)
 
     **CAUTION:** Do not power off the CDU if it is actively cooling other equipment.
 
-1.  If other systems are **not** being cooled by the floor-standing CDU, open the CDU rear door to access the control panel and set the circuit breakers to OFF.
+1. If other systems are **not** being cooled by the floor-standing CDU, then open the CDU rear door to access the control panel and set the circuit breakers to `OFF`.
 
     ![CDU Circuit Breakers](../../img/operations/CDU_Circuit_Breakers.png)
 
-<a name="power-off-standard"></a>
+### Power off standard rack PDU circuit breakers
 
-### POWER OFF STANDARD RACK PDU CIRCUIT BREAKERS
+1. (`ncn-m#`) Check the power status before shutdown.
 
-1. Check the power status before shutdown, this example shows nodes in cabinets 3001-3003.
+    This example shows nodes in cabinets 3001 - 3003.
 
     ```bash
     cray capmc get_xname_status create --xnames x300[1-3]c0s[1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31,33,35]b[1-4]n0 --format json
     ```
 
-    The `get_xname_status` command requires that the list of components be explicitly listed. In this example, the system includes only 2U servers and there are no state manager entries for even-numbered U-positions \(slots\), which would return an error.
+    The `get_xname_status` command requires that the list of components be explicitly listed. In this example, the system includes only 2U servers and there are no state manager entries for even-numbered U-positions \(slots\); those would return an error.
 
     The command does not filter nonexistent component names \(xnames\) and displays an error when invalid component names are specified. Use `--filter` `show_all` option to filter all the output:
 
     ```bash
-    cray capmc get_xname_status create --filter show_all
+    cray capmc get_xname_status create --filter show_all --format json
     ```
 
     Example output:
 
-    ```
+    ```json
     {
       "e": 0,
       "err_msg": "",
@@ -130,30 +147,30 @@ When the PDU breakers are switched to OFF, the Chassis Management Modules \(CMMs
     }
     ```
 
-1.  Use CAPMC to power off **non-management** nodes HPE Cray standard racks.
+1. (`ncn-m#`) Use CAPMC to power off HPE Cray standard racks for **non-management** nodes.
 
-    CAUTION: **Do not power off the management cabinet**. Verify the components names \(xnames\) specified in the following command line do not accidentally power off management cabinets.
+    **CAUTION: Do not power off the management cabinet**. Verify that the components names \(xnames\) specified in the following command line do not accidentally power off management cabinets.
 
-    This example shuts down racks 3001-3003.
+    This example shuts down racks 3001 - 3003.
 
     ```bash
     cray capmc xname_off create --xnames x300[1-3]c0s[1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31,33,35]b[1-4]n0
     ```
 
-1.  Check the status of the CAPMC power off command.
+1. (`ncn-m#`) Check the status of the CAPMC power off command.
 
     ```bash
     cray capmc get_xname_status create --xnames x300[1-3]c0s[1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31,33,35]b[1-4]n0 --format json
     ```
 
-1.  Set each cabinet PDU circuit breaker to off.
+1. Set each cabinet PDU circuit breaker to `OFF`.
 
-    A slotted screw driver may be required to open PDU circuit breakers.
+    A slotted screwdriver may be required to open PDU circuit breakers.
 
-1.  To power off Motivair liquid-cooled chilled doors and CDU, locate the power off switch on the CDU control panel and set it to OFF as shown in step 8.
+1. To power off Motivair liquid-cooled chilled doors and CDUs, locate the power off switch on the CDU control panel and set it to `OFF`.
 
     Refer to vendor documentation for the chilled-door cooling system for power control procedures when chilled doors are installed on standard racks.
 
-## Next Step
+## Next step
 
 Return to [System Power Off Procedures](System_Power_Off_Procedures.md) and continue with next step.

--- a/operations/power_management/Power_Off_Compute_and_IO_Cabinets.md
+++ b/operations/power_management/Power_Off_Compute_and_IO_Cabinets.md
@@ -19,7 +19,7 @@ When the PDU breakers are switched to OFF, the Chassis Management Modules \(CMMs
 
 ## Procedure
 
-1. If the system does not include Cray EX liquid-cooled cabinets, proceed to step 9.
+1. If the system does not include Cray EX liquid-cooled cabinets, proceed to [POWER OFF STANDARD RACK PDU CIRCUIT BREAKERS]("power-off-standard") below.
 
 ### POWER OFF CRAY EX LIQUID-COOLED CABINETS
 
@@ -81,6 +81,8 @@ When the PDU breakers are switched to OFF, the Chassis Management Modules \(CMMs
 1.  If other systems are **not** being cooled by the floor-standing CDU, open the CDU rear door to access the control panel and set the circuit breakers to OFF.
 
     ![CDU Circuit Breakers](../../img/operations/CDU_Circuit_Breakers.png)
+
+<a name="power-off-standard"></a>
 
 ### POWER OFF STANDARD RACK PDU CIRCUIT BREAKERS
 

--- a/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
@@ -4,7 +4,7 @@ Power on and start management services on the HPE Cray EX management Kubernetes 
 
 ## Prerequisites
 
-* All management rack PDUs are connected to facility power and facility power is ON.
+* All management rack PDUs are connected to facility power and facility power is on.
 * An authentication token is required to access the API gateway and to use the `sat` command. See the "SAT Authentication" section of the HPE Cray EX System Admin Toolkit (SAT)
   product stream documentation (`S-8031`) for instructions on how to acquire a SAT authentication token.
 
@@ -12,7 +12,7 @@ Power on and start management services on the HPE Cray EX management Kubernetes 
 
 1. If necessary, power on the management cabinet CDU and chilled doors.
 
-1. Set all management cabinet PDU circuit breakers to ON \(all cabinets that contain Kubernetes master nodes, worker nodes, or storage nodes\).
+1. Set all management cabinet PDU circuit breakers to `ON` \(all cabinets that contain Kubernetes master nodes, worker nodes, or storage nodes\).
 
 1. Power on the HPE Cray EX cabinet PDUs and standard rack cabinet PDUs.
 
@@ -20,53 +20,63 @@ Power on and start management services on the HPE Cray EX management Kubernetes 
 
 1. From a remote system, start the Lustre file system, if it was stopped.
 
-1. Activate the serial console window to `ncn-m001`.
+1. (`remote#`) Activate the serial console window to `ncn-m001`.
 
     > `read -s` is used to prevent the password from being written to the screen or the shell history.
 
     ```bash
-    remote$ USERNAME=root
-    remote$ read -s IPMI_PASSWORD
-    remote$ export IPMI_PASSWORD
-    remote$ ipmitool -I lanplus -U $USERNAME -E -H NCN_M001_BMC_HOSTNAME sol activate
+    USERNAME=root
+    read -s IPMI_PASSWORD
+    export IPMI_PASSWORD
+    ipmitool -I lanplus -U $USERNAME -E -H NCN_M001_BMC_HOSTNAME sol activate
     ```
 
-1. In a separate window, power on the master node 1 \(`ncn-m001`\) chassis using IPMI tool.
+1. (`remote#`) In a separate window, power on the master node 1 \(`ncn-m001`\) chassis using IPMI tool.
 
     > `read -s` is used to prevent the password from being written to the screen or the shell history.
 
     ```bash
-    remote$ USERNAME=root
-    remote$ read -s IPMI_PASSWORD
-    remote$ export IPMI_PASSWORD
-    remote$ ipmitool -I lanplus -U $USERNAME -E -H NCN_M001_BMC_HOSTNAME chassis power on
+    USERNAME=root
+    read -s IPMI_PASSWORD
+    export IPMI_PASSWORD
+    ipmitool -I lanplus -U $USERNAME -E -H NCN_M001_BMC_HOSTNAME chassis power on
     ```
 
     Wait for the login prompt.
 
-    If `ncn-m001` boots into the PIT (ncn-m001-pit), [Set Boot Order](../../background/ncn_boot_workflow.md) to boot from disk, shutdown the PIT node, and power cycle again to boot into `ncn-m001`.
+    If `ncn-m001` boots into the PIT node, then perform the following procedure:
+
+    1. Set boot order to boot from disk.
+
+        See [NCN Boot Workflow](../../background/ncn_boot_workflow.md).
+
+    1. (`pit#`) Shutdown the PIT node.
+
+        ```bash
+        shutdown -h now
+        ```
+
+    1. (`remote#`) Power cycle again to boot into `ncn-m001`.
+
+        ```bash
+        ipmitool -I lanplus -U $USERNAME -E -H NCN_M001_BMC_HOSTNAME chassis power on
+        ```
+
+1. (`remote#`) Wait for `ncn-m001` to boot, then `ping` the node to check status.
 
     ```bash
-    ncn-m001-pit:~ # shutdown -h now
-
-    remote$ ipmitool -I lanplus -U $USERNAME -E -H NCN_M001_BMC_HOSTNAME chassis power on
+    ping NCN_M001_HOSTNAME
     ```
 
-1. Wait for `ncn-m001` to boot, then `ping` the node to check status.
-
-    ```bash
-    remote$ ping NCN_M001_HOSTNAME
-    ```
-
-1. Log in to `ncn-m001` as `root`.
+1. (`remote#`) Log in to `ncn-m001` as `root`.
 
    ```bash
-   remote$ ssh root@NCN_M001_HOSTNAME
+   ssh root@NCN_M001_HOSTNAME
    ```
 
 ### Power on all other management NCNs
 
-1. Power on and boot other management NCNs.
+1. (`ncn-m001#`) Power on and boot other management NCNs.
 
    ```bash
    sat bootsys boot --stage ncn-power
@@ -105,7 +115,7 @@ Power on and start management services on the HPE Cray EX management Kubernetes 
 
    In the preceding example, the `ssh` command to the NCN nodes timed out and reported `ERROR` messages. Repeat the above step until you see `Succeeded with boot of other management NCNs.` Each iteration should get further in the process.
 
-1. Use `tail` to monitor the log files in `/var/log/cray/console_logs` for each NCN.
+1. (`ncn-m001#`) Use `tail` to monitor the log files in `/var/log/cray/console_logs` for each NCN.
 
     Alternatively, attach to the screen session \(screen sessions real time, but not saved\):
 
@@ -137,10 +147,11 @@ Verify that the Lustre file system is available from the management cluster.
 
 ### Start Kubernetes and other services
 
-1. Use `sat bootsys` to start the Kubernetes cluster. Note that the default timeout
-    for Ceph to become healthy is 600 seconds, which is excessive. To work
-    around this issue, set the timeout to a more reasonable value like 60
-    seconds using the `--ceph-timeout` option as shown below.
+1. (`ncn-m001#`) Start the Kubernetes cluster.
+
+    Note that the default timeout for Ceph to become healthy is 600 seconds, which is excessive. To work
+    around this issue, set the timeout to a more reasonable value (like 60 seconds) using the `--ceph-timeout`
+    option, as shown below.
 
     ```bash
     sat bootsys boot --stage platform-services --ceph-timeout 60
@@ -166,7 +177,7 @@ Verify that the Lustre file system is available from the management cluster.
     Are the above NCN groupings correct? [yes,no] yes
     ```
 
-1. The previous step may fail with a message like the following:
+    The `sat bootsys boot` command may fail with a message like the following:
 
     ```text
     Executing step: Start inactive Ceph services, unfreeze Ceph cluster and wait for Ceph health.
@@ -175,9 +186,9 @@ Verify that the Lustre file system is available from the management cluster.
     ERROR: Fatal error in step "Start inactive Ceph services, unfreeze Ceph cluster and wait for Ceph health." of platform services start: Ceph is not healthy. Please correct Ceph health and try again.
     ```
 
-    If a failure like the above occurs, see the info-level log messages for
+    (`ncn-m001#`) If a failure like the above occurs, then see the info-level log messages for
     details about the Ceph health check failure. Depending on the configured log
-    level for `sat`, the log messages may appear in stderr or only in the log
+    level for SAT, the log messages may appear in `stderr`, or only in the log
     file. For example:
 
     ```bash
@@ -198,9 +209,9 @@ Verify that the Lustre file system is available from the management cluster.
 
     * If the Ceph services did not start, then see [Manage Ceph Services](../utility_storage/Manage_Ceph_Services.md)for instruction on starting Ceph services.
 
-    Once Ceph is healthy, repeat the previous step to finish starting the Kubernetes cluster.
+    Once Ceph is healthy, repeat the `sat bootsys boot` to finish starting the Kubernetes cluster.
 
-1. Check the space available on the Ceph cluster.
+1. (`ncn-m001#`) Check the space available on the Ceph cluster.
 
     ```bash
     ceph df
@@ -233,7 +244,7 @@ Verify that the Lustre file system is available from the management cluster.
 
     To resolve the space issue, see [Troubleshoot Ceph OSDs Reporting Full](../utility_storage/Troubleshoot_Ceph_OSDs_Reporting_Full.md).
 
-1. Monitor the status of the management cluster and which pods are restarting as indicated by either a `Running` or `Completed` state.
+1. (`ncn-m001#`) Monitor the status of the management cluster and which pods are restarting as indicated by either a `Running` or `Completed` state.
 
     ```bash
     kubectl get pods -A -o wide | grep -v -e Running -e Completed
@@ -246,15 +257,14 @@ Verify that the Lustre file system is available from the management cluster.
 
     If there are pods in the `MatchNodeSelector` state, delete these pods. Then verify that the pods restart and are in the `Running` state.
 
-1. Check the status of the `slurmctld` and `slurmdbd` pods to determine if they are starting:
+1. (`ncn-m001#`) Check the status of the `slurmctld` and `slurmdbd` pods to determine if they are starting:
 
     ```bash
     kubectl describe pod -n user -lapp=slurmctld
-    ```
-
-    ```bash
     kubectl describe pod -n user -lapp=slurmdbd
     ```
+
+    An error similar to the following may be seen:
 
     ```text
     Events:
@@ -274,7 +284,7 @@ Verify that the Lustre file system is available from the management cluster.
     * `/var/lib/cni/networks/macvlan-slurmctld-nmn-conf`
     * `/var/lib/cni/networks/macvlan-slurmdbd-nmn-conf`
 
-1. Check that `spire` pods have started.
+1. (`ncn-m001#`) Check that `spire` pods have started.
 
     ```bash
     kubectl get pods -n spire -o wide | grep spire-jwks
@@ -288,13 +298,13 @@ Verify that the Lustre file system is available from the management cluster.
     spire-jwks-6b97457548-lvqmf    2/3  CrashLoopBackOff   9    23h   10.39.0.79   ncn-w001 <none>   <none>
     ```
 
-1. If `spire` pods indicate `CrashLoopBackOff`, then restart the `spire` pods.
+1. (`ncn-m001#`) If `spire` pods indicate `CrashLoopBackOff`, then restart the `spire` pods.
 
     ```bash
     kubectl rollout restart -n spire deployment spire-jwks
     ```
 
-1. Check if any pods are in `CrashLoopBackOff` because of errors connecting to Vault. If so, restart the Vault operator, the Vault pods, and finally the pod which is in `CrashLoopBackOff`. For example:
+1. (`ncn-m001#`) Check if any pods are in `CrashLoopBackOff` because of errors connecting to Vault. If so, restart the Vault operator, the Vault pods, and finally the pod which is in `CrashLoopBackOff`. For example:
 
     1. Find the pods in `CrashLoopBackOff`.
 
@@ -308,7 +318,7 @@ Verify that the Lustre file system is available from the management cluster.
         services     cray-console-node-1        2/3     CrashLoopBackOff   206        6d21h
         ```
 
-    2. View the logs for the pods in `CrashLoopBackOff`.
+    1. View the logs for the pods in `CrashLoopBackOff`.
 
         ```bash
         kubectl -n services logs cray-console-node-1 cray-console-node | grep "connection failure" | grep vault
@@ -321,13 +331,13 @@ Verify that the Lustre file system is available from the management cluster.
         panic: Error: &api.ResponseError{HTTPMethod:"PUT", URL:"http://cray-vault.vault:8200/v1/auth/kubernetes/login", StatusCode:503, RawError:true, Errors:[]string{"upstream connect error or disconnect/reset before headers. reset reason: connection failure"}}
         ```
 
-    3. Restart the `vault-operator`.
+    1. Restart the `vault-operator`.
 
         ```bash
         kubectl delete pods -n vault -l app.kubernetes.io/name=vault-operator
         ```
 
-    4. Wait for the `cray-vault` pods to restart with `5/5` ready and `Running`.
+    1. Wait for the `cray-vault` pods to restart with `5/5` ready and `Running`.
 
         ```bash
          kubectl get pods -n vault -l app.kubernetes.io/name=vault-operator
@@ -340,7 +350,7 @@ Verify that the Lustre file system is available from the management cluster.
         cray-vault-operator-69b4b6887-dfn2f   2/2     Running   2          1m
         ```
 
-    5. Restart the pod(s).
+    1. Restart the pod(s).
 
         In this example, `cray-console-node-1` is the pod.
 
@@ -348,7 +358,7 @@ Verify that the Lustre file system is available from the management cluster.
         kubectl delete pod cray-console-node-1 -n services
         ```
 
-    6. Wait for the pod(s) to restart with `3/3` ready and `Running`.
+    1. Wait for the pod(s) to restart with `3/3` ready and `Running`.
 
         In this example, `cray-console-node-1` is the pod.
 
@@ -362,7 +372,7 @@ Verify that the Lustre file system is available from the management cluster.
         cray-console-node-1      3/3     Running            0          2m
         ```
 
-1. Determine whether the `cfs-state-reporter` service is failing to start on each manager/master and worker NCN while trying to contact CFS.
+1. (`ncn-m001#`) Determine whether the `cfs-state-reporter` service is failing to start on each manager/master and worker NCN while trying to contact CFS.
 
     ```bash
     pdsh -w ncn-m00[1-3],ncn-w00[1-3] systemctl status cfs-state-reporter
@@ -392,13 +402,13 @@ Verify that the Lustre file system is available from the management cluster.
     pdsh@ncn-m001: ncn-w001: ssh exited with exit code 3
     ```
 
-    1. On each NCN where `cfs-state-reporter` is stuck in `activating` as shown in the preceding error messages, restart the `cfs-state-reporter` service. For example:
+    1. (`ncn#`) On each NCN where `cfs-state-reporter` is stuck in `activating` as shown in the preceding error messages, restart the `cfs-state-reporter` service. For example:
 
         ```bash
         systemctl restart cfs-state-reporter
         ```
 
-    1. Check the status again.
+    1. (`ncn-m001#`) Check the status again.
 
         ```bash
         pdsh -w ncn-m00[1-3],ncn-w00[1-3] systemctl status cfs-state-reporter
@@ -412,7 +422,7 @@ Verify that the Lustre file system is available from the management cluster.
 
 ### Check `cronjob`s
 
-1. Display all the Kubernetes `cronjob`s.
+1. (`ncn-m001#`) Display all the Kubernetes `cronjob`s.
 
     ```bash
     kubectl get cronjobs.batch -A
@@ -434,11 +444,11 @@ Verify that the Lustre file system is available from the management cluster.
     ```
 
     **Attention:** It is normal for the `hms-discovery` service to be suspended at this point if liquid-cooled cabinets have not been powered on. The `hms-discovery` service is
-    un-suspended during the liquid-cooled cabinet power on procedure. Do not re-create the `hms-discovery` `cronjob` at this point.
+    un-suspended during the liquid-cooled cabinet power on procedure. Do not recreate the `hms-discovery` `cronjob` at this point.
 
 1. Check for `cronjob`s that have a `LAST SCHEDULE` time that is older than the `SCHEDULE` time. These `cronjob`s must be restarted.
 
-1. Check any `cronjob`s in question for errors.
+1. (`ncn-m001#`) Check any `cronjob`s in question for errors.
 
     ```bash
     kubectl describe cronjobs.batch -n kube-system kube-etcdbackup | egrep -A 15 Events
@@ -456,7 +466,7 @@ Verify that the Lustre file system is available from the management cluster.
                                                                               or check clock skew
     ```
 
-1. For any `cronjob`s producing errors, get the YAML representation of the `cronjob` and edit the YAML file:
+1. (`ncn-m001#`) For any `cronjob`s producing errors, get the YAML representation of the `cronjob` and edit the YAML file:
 
     ```bash
     cd ~/k8s
@@ -470,19 +480,19 @@ Verify that the Lustre file system is available from the management cluster.
 
     1. Save the file and quit the editor.
 
-1. Delete the `cronjob`.
+1. (`ncn-m001#`) Delete the `cronjob`.
 
     ```bash
     kubectl delete -f CRON_JOB_NAME-cronjob.yaml
     ```
 
-1. Apply the `cronjob`.
+1. (`ncn-m001#`) Apply the `cronjob`.
 
     ```bash
     kubectl apply -f CRON_JOB_NAME-cronjob.yaml
     ```
 
-1. Verify that the `cronjob` has been scheduled.
+1. (`ncn-m001#`) Verify that the `cronjob` has been scheduled.
 
     ```bash
     kubectl get cronjobs -n backups benji-k8s-backup-backups-namespace
@@ -497,7 +507,7 @@ Verify that the Lustre file system is available from the management cluster.
 
 ### Check the HSM inventory status of NCNs
 
-1. Use the `sat` command to check for management NCNs in an `Off` state.
+1. (`ncn-m001#`) Use the `sat` command to check for management NCNs in an `Off` state.
 
     ```bash
     sat status --filter role=management
@@ -522,10 +532,10 @@ Verify that the Lustre file system is available from the management cluster.
 
     **Attention:** When the NCNs are brought back online after a power outage or planned shutdown, `sat status` may report them as being `Off`.
 
-1. Run a manual discovery of any NCNs in the `Off` state.
+1. (`ncn-m001#`) Run a manual discovery of any NCNs in the `Off` state.
 
     ```bash
-    cray hsm inventory discover create --xnames x3000c0s12b0,x3000c0s20b0
+    cray hsm inventory discover create --xnames x3000c0s12b0,x3000c0s20b0 --format toml
     ```
 
     Example output:
@@ -535,7 +545,7 @@ Verify that the Lustre file system is available from the management cluster.
     URI = "/hsm/v2/Inventory/DiscoveryStatus/0"
     ```
 
-1. Check for NCN status.
+1. (`ncn-m001#`) Check for NCN status.
 
     ```bash
     sat status --filter Role=Management

--- a/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
@@ -14,7 +14,7 @@ Power on and start management services on the HPE Cray EX management Kubernetes 
 
 1. Set all management cabinet PDU circuit breakers to ON \(all cabinets that contain Kubernetes master nodes, worker nodes, or storage nodes\).
 
-1. Power on the HPE Cray EX cabinets and standard rack cabinet PDUs.
+1. Power on the HPE Cray EX cabinet PDUs and standard rack cabinet PDUs.
 
     Be sure that management switches in all racks and CDU cabinets are powered on and healthy.
 

--- a/operations/power_management/System_Power_On_Procedures.md
+++ b/operations/power_management/System_Power_On_Procedures.md
@@ -2,40 +2,41 @@
 
 The procedures in this section detail the high-level tasks required to power on an HPE Cray EX system.
 
-**Important:** If an emergency power off \(EPO\) event occurred, see [Recover from a Liquid Cooled Cabinet EPO Event](Recover_from_a_Liquid_Cooled_Cabinet_EPO_Event.md) for recovery procedures.
+**Important:** If an emergency power off \(EPO\) event occurred, then see [Recover from a Liquid-Cooled Cabinet EPO Event](Recover_from_a_Liquid_Cooled_Cabinet_EPO_Event.md) for recovery procedures.
 
-If user IDs and/or passwords are needed, see step 1 of the [Prepare_the_System_for_Power_Off](Prepare_the_System_for_Power_Off.md#procedure) procedure.
+If user IDs or passwords are needed, then see step 1 of the [Prepare the System for Power Off](Prepare_the_System_for_Power_Off.md#procedure) procedure.
 
-## Note about Services Used During System Power On
+## Note about services used during system power on
 
--   The Cray Advanced Platform Monitoring and Control \(CAPMC\) service controls power to major components. CAPMC sequences the power on tasks in the correct order, but **does not** determine if the required software services are running on the components.
--   The Boot Orchestration Service \(BOS\) manages and configures power on and boot tasks.
--   The System Admin Toolkit \(SAT\) automates boot and shutdown services by stage.
+- The Cray Advanced Platform Monitoring and Control \(CAPMC\) service controls power to major components. CAPMC sequences the power on tasks in the correct order, but **does not** determine if the required software services are running on the components.
+- The Boot Orchestration Service \(BOS\) manages and configures power on and boot tasks.
+- The System Admin Toolkit \(SAT\) automates boot and shutdown services by stage.
 
-## Power on Cabinet Circuit Breakers and PDUs
+## Power on cabinet circuit breakers and PDUs
 
 Always use the cabinet power-on sequence for the site.
 
-The management cabinet is the first part of the system that must be powered on and booted. Management network and Slingshot fabric switches power on and boot when cabinet power is applied. After cabinets are powered on, wait at least 10 minutes for systems to initialize.
+The management cabinet is the first part of the system that must be powered on and booted. Management network and Slingshot fabric switches power on and boot when cabinet power is applied. After
+cabinets are powered on, wait at least 10 minutes for systems to initialize.
 
-After all the system cabinets are powered on, be sure that all management network and Slingshot network switches are powered on and there are no error LEDS or hardware failures.
+After all the system cabinets are powered on, be sure that all management network and Slingshot network switches are powered on, and that there are no error LEDS or hardware failures.
 
-## Power on the External Lustre File System
+## Power on the external Lustre file system
 
-To power an external Lustre file system (ClusterStor), refer to [Power On the External Lustre File System](Power_On_the_External_Lustre_File_System.md).
+To power on an external Lustre file system (ClusterStor), refer to [Power On the External Lustre File System](Power_On_the_External_Lustre_File_System.md).
 
-## Power on and Boot the Kubernetes Management Cluster
+## Power on and boot the Kubernetes management cluster
 
 To power on the management cabinet and bring up the management Kubernetes cluster, refer to [Power On and Start the Management Kubernetes Cluster](Power_On_and_Start_the_Management_Kubernetes_Cluster.md).
 
-## Power on Compute and IO Cabinets
+## Power on compute and IO cabinets
 
 To power on all liquid-cooled cabinet CDUs and cabinet PDUs, refer to [Power On Compute and IO Cabinets](Power_On_Compute_and_IO_Cabinets.md).
 
-## Power On and Boot Compute Nodes and User Access Nodes \(UANs\)
+## Power on and boot compute nodes and user access nodes \(UANs\)
 
-To power on and boot compute nodes and UANs, refer to [Power On and Boot Compute and User Access Nodes](Power_On_and_Boot_Compute_Nodes_and_User_Access_Nodes.md) and make nodes available to customers.
+To power on and boot compute nodes and UANs, refer to [Power On and Boot Compute and User Access Nodes](Power_On_and_Boot_Compute_Nodes_and_User_Access_Nodes.md) and make nodes available to users.
 
-## Run System Health Checks
+## Run system health checks
 
 After power on, refer to [Validate CSM Health](../validate_csm_health.md) to check system health and status.

--- a/operations/power_management/System_Power_On_Procedures.md
+++ b/operations/power_management/System_Power_On_Procedures.md
@@ -20,6 +20,10 @@ The management cabinet is the first part of the system that must be powered on a
 
 After all the system cabinets are powered on, be sure that all management network and Slingshot network switches are powered on and there are no error LEDS or hardware failures.
 
+## Power on the External Lustre File System
+
+To power an external Lustre file system (ClusterStor), refer to [Power On the External Lustre File System](Power_On_the_External_Lustre_File_System.md).
+
 ## Power on and Boot the Kubernetes Management Cluster
 
 To power on the management cabinet and bring up the management Kubernetes cluster, refer to [Power On and Start the Management Kubernetes Cluster](Power_On_and_Start_the_Management_Kubernetes_Cluster.md).
@@ -27,17 +31,6 @@ To power on the management cabinet and bring up the management Kubernetes cluste
 ## Power on Compute and IO Cabinets
 
 To power on all liquid-cooled cabinet CDUs and cabinet PDUs, refer to [Power On Compute and IO Cabinets](Power_On_Compute_and_IO_Cabinets.md).
-
-## Power on the External Lustre File System
-
-To power an external Lustre file system (ClusterStor), refer to [Power On the External Lustre File System](Power_On_the_External_Lustre_File_System.md).
-
-## Bring up the Slingshot Fabric
-
-To bring up the Slingshot fabric, see:
-
--   The *Slingshot Administration Guide* for Cray EX systems PDF.
--   The *Slingshot Troubleshooting Guide* PDF.
 
 ## Power On and Boot Compute Nodes and User Access Nodes \(UANs\)
 


### PR DESCRIPTION
### Summary and Scope
Main - CASMPET-5769: Review and update System Shutdown and Startup Procedure

Update System Power On/Off procedure with changes that resulted from review of the procedures.

**System Power On Procedures**
Reordered sequence of tasks in System_Power_On_Procedures such that Lustre is powered on before the Kubernetes Management Cluster.
Removed "Bring up the Slingshot Fabric" section.

Clarified Procedure step #3 in **Power on and Start the Management Kubernetes Cluster**.

Corrected Procedure step #1 in **Power Off Compute and IO Cabinets** by adding a link to correct section.

### Issues and Related PRs
CASMPET-5769

### Testing
Discussed changes.

Was a fresh Install tested? N - N/A
Was an Upgrade tested? N - N/A
Was a Downgrade tested? N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations
Low

### Requires:
N/A
