### PR TITLE
CASMINST-4902 fix naming issue

### DIFF
--- a/upgrade/1.2.6/scripts/update-customization.sh
+++ b/upgrade/1.2.6/scripts/update-customization.sh
@@ -39,3 +39,4 @@ pushd "${SITE_INIT_DIR}"
 cp "${CUSTOMIZATIONS_YAML}" customizations.yaml
 kubectl delete secret -n loftsman site-init
 kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
+popd

--- a/upgrade/1.2.6/scripts/update-customization.sh
+++ b/upgrade/1.2.6/scripts/update-customization.sh
@@ -33,5 +33,8 @@ kubectl -n loftsman get secret site-init -o jsonpath='{.data.customizations\.yam
 cp "${CUSTOMIZATIONS_YAML}" "${CUSTOMIZATIONS_YAML}.bak"
 yq w -i --style=single "${CUSTOMIZATIONS_YAML}" spec.kubernetes.services.cray-nls.externalHostname 'cmn.{{ network.dns.external }}'
 yq w -i --style=single "${CUSTOMIZATIONS_YAML}" spec.proxiedWebAppExternalHostnames.customerManagement[+] 'argo.cmn.{{ network.dns.external }}'
+
+# rename customazations file so k8s secret name stays the same
+mv "${CUSTOMIZATIONS_YAML}" customizations.yaml
 kubectl delete secret -n loftsman site-init
-kubectl create secret -n loftsman generic site-init --from-file="${CUSTOMIZATIONS_YAML}"
+kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml

--- a/upgrade/1.2.6/scripts/update-customization.sh
+++ b/upgrade/1.2.6/scripts/update-customization.sh
@@ -35,6 +35,7 @@ yq w -i --style=single "${CUSTOMIZATIONS_YAML}" spec.kubernetes.services.cray-nl
 yq w -i --style=single "${CUSTOMIZATIONS_YAML}" spec.proxiedWebAppExternalHostnames.customerManagement[+] 'argo.cmn.{{ network.dns.external }}'
 
 # rename customazations file so k8s secret name stays the same
-mv "${CUSTOMIZATIONS_YAML}" customizations.yaml
+pushd "${SITE_INIT_DIR}"
+cp "${CUSTOMIZATIONS_YAML}" customizations.yaml
 kubectl delete secret -n loftsman site-init
 kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml


### PR DESCRIPTION
# Description
https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4902
fix file name issue introduced in last PR:
    we appended timestamp to the file name which is used as "key" when uploading to k8s secret. our loftsman and other tools are using hardcoded "customizations.yaml" which leads to loftsman fail to find the secret

> NOTE: this is only for 1.2.6 so please do not backport to main

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
