### PR TITLE
CASMINST-4910: Remove superfluous tests that were mistakenly added back during docs overhaul

### DIFF
--- a/install/deploy_non-compute_nodes.md
+++ b/install/deploy_non-compute_nodes.md
@@ -403,27 +403,6 @@ If the check fails after doing the rebuild, contact support.
 
    If these total lines report any failed tests, then look through the full output of the test in `csi-pit-validate-k8s.log` to see which node had the failed test and what the details are for that test.
 
-1. (`pit#`) Ensure that `weave` has not become split-brained.
-
-   To ensure that `weave` is operating as a single cluster, run the following command to check each member of the Kubernetes cluster:
-
-   ```bash
-   pdsh -b -S -w "$(grep -oP 'ncn-[mw][0-9]{3}' /etc/dnsmasq.d/statics.conf | grep -v '^ncn-m001$' | sort -u |  tr -t '\n' ',')" \
-           'weave --local status connections | grep -i failed || true'
-   ```
-
-1. (`pit#`) Verify that all the pods in the `kube-system` namespace are `Running` or `Completed`. (Optional)
-
-   ```bash
-   kubectl get pods -o wide -n kube-system | grep -Ev '(Running|Completed)'
-   ```
-
-   If any pods are listed by this command, it means they are not in the `Running` or `Completed` state. That needs to be investigated before proceeding.
-
-1. Verify that the `ceph-csi` requirements are in place. (Optional)
-
-   See [Ceph CSI Troubleshooting](troubleshooting_ceph_csi.md) for details.
-
 ## Next topic
 
 After completing the deployment of the management nodes, the next step is to install the CSM services.


### PR DESCRIPTION
# Description

Some of the checks had been removed from the deploy NCNs step in the main branch prior to the docs overhaul, and it looks like they accidentally got added back in when that merged. They had been removed because they are replaced by Goss tests which run at the same time. This PR re-removes them.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
