### PR TITLE
CASMPET-5773: Docs: Remove inconsistent line. Update operations index.

### DIFF
--- a/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
@@ -571,8 +571,6 @@ Verify that the Lustre file system is available from the management cluster.
 
 1. To check the health and status of the management cluster after a power cycle, refer to the "Platform Health Checks" section in [Validate CSM Health](../validate_csm_health.md).
 
-1. If NCNs must have access to Lustre, start the Lustre file system. See [Power On the External Lustre File System](Power_On_the_External_Lustre_File_System.md).
-
 ## Next step
 
 Return to [System Power On Procedures](System_Power_On_Procedures.md) and continue with next step.


### PR DESCRIPTION
### Summary and Scope
Main - CASMPET-5773: Docs: Remove inconsistent line. Update operations index.

Now that powering on the Lustre file system takes place before the **Power On and Start the Management Kubernetes Cluster** procedure, remove line at end of the **Power On and Start the Management Kubernetes Cluster** procedure referring to starting Lustre file system. 

### Issues and Related PRs
CASMPET-5773

### Testing
Discussed changes.

Was a fresh Install tested? N - N/A
Was an Upgrade tested? N - N/A
Was a Downgrade tested? N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations
Low

### Requires:
N/A