### PR TITLE
casmpet-5773: Docs: Remove inconsistent line. Update operations index.

### DIFF
--- a/operations/index.md
+++ b/operations/index.md
@@ -141,10 +141,9 @@ Procedures required for a full power on of an HPE Cray EX system.
 
 Additional links to power on sub-procedures provided for reference. Refer to the main procedure linked above before using any of these sub-procedures:
 
+- [Power On the External Lustre File System](power_management/Power_On_the_External_Lustre_File_System.md)
 - [Power On and Start the Management Kubernetes Cluster](power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md)
 - [Power On Compute and IO Cabinets](power_management/Power_On_Compute_and_IO_Cabinets.md)
-- [Power On the External Lustre File System](power_management/Power_On_the_External_Lustre_File_System.md)
-- [Bring Up the Slingshot Fabric](power_management/Bring_up_the_Slingshot_Fabric.md)
 - [Power On and Boot Compute and User Access Nodes](power_management/Power_On_and_Boot_Compute_Nodes_and_User_Access_Nodes.md)
 - [Recover from a Liquid Cooled Cabinet EPO Event](power_management/Recover_from_a_Liquid_Cooled_Cabinet_EPO_Event.md)
 

--- a/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
@@ -571,8 +571,6 @@ Verify that the Lustre file system is available from the management cluster.
 
 1. To check the health and status of the management cluster after a power cycle, refer to the "Platform Health Checks" section in [Validate CSM Health](../validate_csm_health.md).
 
-1. If NCNs must have access to Lustre, start the Lustre file system. See [Power On the External Lustre File System](Power_On_the_External_Lustre_File_System.md).
-
 ## Next step
 
 Return to [System Power On Procedures](System_Power_On_Procedures.md) and continue with next step.


### PR DESCRIPTION
### Summary and Scope
1.2 - CASMPET-5773: Docs: Remove inconsistent line. Update operations index.

Now that powering on the Lustre file system takes place before the **Power On and Start the Management Kubernetes Cluster** procedure, remove line at end of the **Power On and Start the Management Kubernetes Cluster** procedure referring to starting Lustre file system. 

At the same time update the **System Power On Procedures** links in the operations/index file to reflect recent changes.

### Issues and Related PRs
CASMPET-5773

### Testing
Discused changes.

Was a fresh Install tested? N - N/A
Was an Upgrade tested? N - N/A
Was a Downgrade tested? N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations
Low

### Requires:
N/A