### PR TITLE
CASMINST-4918 Remove Trailing Space

### DIFF
--- a/install/pre-installation.md
+++ b/install/pre-installation.md
@@ -272,7 +272,7 @@ These variables will need to be set for many procedures within the CSM installat
    ```bash
    cat << EOF >/etc/environment
    CSM_RELEASE=${CSM_RELEASE}
-   CSM_PATH=${PITDATA}/csm-${CSM_RELEASE} 
+   CSM_PATH=${PITDATA}/csm-${CSM_RELEASE}
    GOSS_BASE=${GOSS_BASE}
    PITDATA=${PITDATA}
    SYSTEM_NAME=${SYSTEM_NAME}


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
This trailing space breaks the `/etc/environment` file on subsequent logins for anyone using `CSM_PATH`.

```bash
surtur-ncn-m001-pit:/var/www/ephemeral/csm-1.3.0-alpha.13 # ls "${CSM_PATH}/images/kubernetes/"
ls: cannot access '/var/www/ephemeral/csm-1.3.0-alpha.13 /images/kubernetes/': No such file or directory
```

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
