### PR TITLE
CASMINST-3039: add a couple reinstall-specific steps

### DIFF
--- a/install/re-installation.md
+++ b/install/re-installation.md
@@ -11,6 +11,8 @@ the NCNs have been deployed (e.g. there is no more PIT node).
 1. [Power Off Booted Nodes](#power-off-booted-nodes)
 1. [Set Node BMCs to DHCP](#set-node-bmcs-to-dhcp)
 1. [Power off the PIT Node](#power-off-pit-node)
+1. [Configure DNS](#configure-dns)
+1. [Check Disk Space](#check-disk-space)
 
 ## Quiesce Application and Compute Nodes
 
@@ -155,6 +157,16 @@ BMCs to be set back to DHCP before proceeding.
    ```
 
 The process is now done, the NCNs are ready for a new deployment.
+
+## Configure DNS
+
+If `ncn-m001` is being used to prepare the USB LiveCD, remove the Kubernetes IP addresses from `/etc/resolv.conf` and add a
+valid external DNS server.
+
+## Check Disk Space
+
+If `ncn-m001` is being used to prepare the USB LiveCD, ensure there is enough free disk space for the CSM tar archive to be
+downloaded and unpacked.
 
 ## Next topic
 


### PR DESCRIPTION
# Description

Add two steps to the reinstall scenario
1. Ensure there is a valid DNS server configured for m001 if it's being used to prepare the USB stick.
2. Add a note that the admin should ensure there's enough disk space for what they're about to do in the case of using m001 to prepare the USB stick.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
