### PR TITLE
CASMINST-4915 ncn-image-modification

### DIFF
--- a/install/pre-installation.md
+++ b/install/pre-installation.md
@@ -418,23 +418,23 @@ in `/etc/environment` from the [Download CSM tarball](#21-download-csm-tarball) 
    rsync -rltDP --delete "${CSM_PATH}/images/storage-ceph/" --link-dest="${CSM_PATH}/images/storage-ceph/" "${PITDATA}/data/ceph/${ceph_version}"
    ```
 
-1. (`pit#`) Generate SSH Keys and invoke `ncn-image-modification.sh`:
+1. (`pit#`) Generate SSH keys and invoke `ncn-image-modification.sh`:
 
-   - Generate SSH Keys:
+   1. Generate SSH keys.
 
-       > ***NOTE*** The code block below assumes an RSA key without a passphrase. If the administrator wants to customize this step they may do so
+       > ***NOTE*** The code block below assumes there is an RSA key without a passphrase. This step can be customized to use a passphrase if desired.
 
        ```bash
        ssh-keygen -N "" -t rsa
        ```
 
-   - Export the password hash for `root`, this is needed by `ncn-image-modification.sh`:
+   1. Export the password hash for `root` that is needed for the `ncn-image-modification.sh` script:
 
        ```bash
        export SQUASHFS_ROOT_PW_HASH="$(awk -F':' /^root:/'{print $2}' < /etc/shadow)"
        ```
 
-   - Run `ncn-image-modification.sh` from the CSM Tarball:
+   1. Run `ncn-image-modification.sh` from the CSM tarball:
 
        ```bash
        "${PITDATA}/csm-${CSM_RELEASE}/ncn-image-modification.sh -p \


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->

This adds the `ncn-image-modification.sh` script call to the pre-installation.md page, that is necessary to invoke before invoking the preflight tests.

The call is added right after the images are extracted.

Additionally the step to extract the images was changed to extract images into a versioned directory by using a faster rsync command. The versioned directory will help keep things neat, and will align better with NCN smoke-testing/metal-testing.

The faster rsync command entails using hardlinks, which avoid wasting space by avoiding duplication of the NCN artifacts on the same file system.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
