### PR TITLE
CASMINST-4917 Install docs-csm

### DIFF
--- a/install/pre-installation.md
+++ b/install/pre-installation.md
@@ -385,22 +385,46 @@ in `/etc/environment` from the [Download CSM tarball](#21-download-csm-tarball) 
    tar -C "${PITDATA}" -zxvf "csm-${CSM_RELEASE}.tar.gz"
    ```
 
-1. (`pit#`) Install or update `cray-site-init`, `csm-testing`, and `goss-servers` RPMs.
+1. (`pit#`) Install/update RPMs necessary for the CSM installation.
 
-   > **NOTE:** `--no-gpg-checks` is used because the repository contained within the tarball does not provide a GPG key.
+   > ***NOTE*** `--no-gpg-checks` is used because the repository contained within the tarball does not provide a GPG key.
 
-   ```bash
-   zypper \
-      --plus-repo "${CSM_PATH}/rpm/cray/csm/sle-15sp2/" \
-      --plus-repo "${CSM_PATH}/rpm/cray/csm/sle-15sp3/" \
-      --no-gpg-checks \
-      update -y cray-site-init
-   zypper \
-      --plus-repo "${CSM_PATH}/rpm/cray/csm/sle-15sp2/" \
-      --plus-repo "${CSM_PATH}/rpm/cray/csm/sle-15sp3/" \
-      --no-gpg-checks \
-      install -y csm-testing goss-servers
-   ```
+   - Install `docs-csm`:
+
+      > ***NOTE*** This installs necessary scripts for deployment checks, as well as the offline manual.
+
+       ```bash
+       zypper \
+           --plus-repo "${CSM_PATH}/rpm/cray/csm/sle-15sp2/" \
+           --plus-repo "${CSM_PATH}/rpm/cray/csm/sle-15sp3/" \
+           --no-gpg-checks \
+           install -y docs-csm
+       ```
+
+   - Update `cray-site-init`:
+
+       > ***NOTE*** This provides `csi`, a tool for creating and managing configurations as well as
+       > orchestrating the [handoff and deploy of the final non-compute node](deploy_final_non-compute_node.md).
+
+       ```bash
+       zypper \
+           --plus-repo "${CSM_PATH}/rpm/cray/csm/sle-15sp2/" \
+           --plus-repo "${CSM_PATH}/rpm/cray/csm/sle-15sp3/" \
+           --no-gpg-checks \
+           update -y cray-site-init
+       ```
+
+   - Install `csm-testing` and `goss-servers`:
+
+       > ***NOTE*** These packages provide necessary tests and their dependencies for validating the pre-installation, installation, and more.
+
+       ```bash
+       zypper \
+           --plus-repo "${CSM_PATH}/rpm/cray/csm/sle-15sp2/" \
+           --plus-repo "${CSM_PATH}/rpm/cray/csm/sle-15sp3/" \
+           --no-gpg-checks \
+           install -y csm-testing goss-servers
+      ```
 
 1. (`pit#`) Get the artifact versions.
 

--- a/install/pre-installation.md
+++ b/install/pre-installation.md
@@ -385,11 +385,11 @@ in `/etc/environment` from the [Download CSM tarball](#21-download-csm-tarball) 
    tar -C "${PITDATA}" -zxvf "csm-${CSM_RELEASE}.tar.gz"
    ```
 
-1. (`pit#`) Install/update RPMs necessary for the CSM installation.
+1. (`pit#`) Install/update the RPMs necessary for the CSM installation.
 
    > ***NOTE*** `--no-gpg-checks` is used because the repository contained within the tarball does not provide a GPG key.
 
-   - Install `docs-csm`:
+   1. Install `docs-csm`.
 
       > ***NOTE*** This installs necessary scripts for deployment checks, as well as the offline manual.
 
@@ -401,9 +401,9 @@ in `/etc/environment` from the [Download CSM tarball](#21-download-csm-tarball) 
            install -y docs-csm
        ```
 
-   - Update `cray-site-init`:
+   1. Update `cray-site-init`.
 
-       > ***NOTE*** This provides `csi`, a tool for creating and managing configurations as well as
+       > ***NOTE*** This provides `csi`, a tool for creating and managing configurations, as well as
        > orchestrating the [handoff and deploy of the final non-compute node](deploy_final_non-compute_node.md).
 
        ```bash
@@ -414,9 +414,9 @@ in `/etc/environment` from the [Download CSM tarball](#21-download-csm-tarball) 
            update -y cray-site-init
        ```
 
-   - Install `csm-testing` and `goss-servers`:
+   1. Install `csm-testing` and `goss-servers`.
 
-       > ***NOTE*** These packages provide necessary tests and their dependencies for validating the pre-installation, installation, and more.
+       > ***NOTE*** These packages provide the necessary tests and their dependencies for validating the pre-installation, installation, and more.
 
        ```bash
        zypper \


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
This includes `docs-csm` in the Zypper calls in the beginning of the pre-installation page. This also breaks the Zypper calls out into three steps, dividing the 3 groupings of packages up for easier stop-and-checking.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
