### PR TITLE
CASMTRIAGE-3665: Patch sma kafka cluster resource and add listeners

### DIFF
--- a/upgrade/1.2/scripts/strimzi/kafka-restart.sh
+++ b/upgrade/1.2/scripts/strimzi/kafka-restart.sh
@@ -1,14 +1,76 @@
-#!/bin/bash
-set -euo pipefail
+#!/usr/bin/env sh
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+cwd=$(cd -P -- "$(dirname -- "$(command -v -- "$0")")" && pwd -P || exit 126)
+set -eu
 
-for pod in $(kubectl get pods -n services -oname | grep kafka-kafka); do
-	echo "Deleting $pod"
-	kubectl delete -n services "$pod"
+# We expect this to look like:
+# NAME                        READY   STATUS    RESTARTS   AGE
+# cray-shared-kafka-kafka-0   1/1     Running   0          3m16s
+# cray-shared-kafka-kafka-1   1/1     Running   0          22s
+# cray-shared-kafka-kafka-2   1/1     Running   0          4m18s
+
+# Not:
+# NAME                        READY   STATUS    RESTARTS   AGE
+# cray-shared-kafka-kafka-0   2/2     Running   0          3h57m
+# cray-shared-kafka-kafka-1   2/2     Running   0          3h56m
+# cray-shared-kafka-kafka-2   2/2     Running   0          3h55m
+podsready() {
+    [ "1/1" = "$(kubectl get pods --no-headers=true --namespace services --selector strimzi.io/name=cray-shared-kafka-kafka --field-selector=status.phase=Running | awk '!/READY/ {print $2}' | sort -u)" ] &&
+	[ "Running" = "$(kubectl get pods --no-headers=true --namespace services --selector strimzi.io/name=cray-shared-kafka-kafka --field-selector="status.phase=Running" | awk '{print $3}' | sort -u)" ]
+}
+
+kafkaok() {
+    ok='[{"name":"plain","port":9092,"tls":false,"type":"internal"}]'
+    [ "${ok}" = "$(kubectl get kafka cluster -n sma -o=jsonpath='{.spec.kafka.listeners}')" ]
+}
+
+# Ensure we don't do anything if we're run without the resource in question
+if ! kubectl get kafka cluster --namespace sma > /dev/null 2>&1; then
+    printf "No kafka cluster resource found, nothing for this script to do\n" >&2
+    exit 0
+fi
+
+# Logic loop is loop/retrying things in order until ok, tries for 300 seconds
+# total and after that gives up, can be re-run.
+until kafkaok && podsready; do
+    if ! kafkaok; then
+	printf "Patching kafka cluster resource to include listeners\n" >&2
+	kubectl patch kafka cluster --namespace sma --type merge --patch-file "${cwd}/patch-listeners.yaml"
 	sleep 10
-	while ! kubectl get -n services "$pod" -o json | jq -r '.status.phase' | grep -q 'Running'; do
-		echo "Waiting for $pod to start"
-		sleep 10
+    fi
+
+    if ! podsready; then
+	printf "Found pods not at Ready = 1/1, deleting to force an update\n" >&2
+	for pod in $(kubectl get pods --no-headers=true --namespaces services --selector strimzi.io/name=cray-shared-kafka-kafka --field-selector="status.phase=Running" | grep -Ev '1/1'); do
+	    printf "Deleting %s\n" "${pod}" >&2
+	    kubectl delete -n services "$pod"
+	    sleep 10
 	done
-	echo "Waiting 30 seconds before continuing"
-	sleep 30
+    fi
+    printf "Sleeping for reconciliation\n" >&2
+    sleep 30
 done
+
+printf "Ok to continue\n" >&2

--- a/upgrade/1.2/scripts/strimzi/patch-listeners.yaml
+++ b/upgrade/1.2/scripts/strimzi/patch-listeners.yaml
@@ -1,0 +1,8 @@
+---
+spec:
+  kafka:
+    listeners:
+    - name: "plain"
+      port: 9092
+      tls: false
+      type: "internal"


### PR DESCRIPTION
During this part of the upgrade, if the kafka sma cluster object does not have
listeners setup correctly, the upgrade cannot continue.

So detect if/when the listeners are not setup yet, and if so json merge patch
the data in.

Additionally ensure that the kafka-kafka pods are at a Running status and Ready
state of 1/1. Old installs have two containers and we want to ensure we're
restarting the new setup at this point. So if there are any non Running pods or
pods not at 1/1 Ready, delete the pods as well.

# Description

Fix issues discovered while testing on rocket. Rewrote the script to be run at the step in the upgrade where when run it did not correct the issue. Script is rewritten to be idempotent and to reconcile loop until it detects a positive condition that is known good. Validated the logic circuit breaks by disabling any changes and running on rocket. 

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
