### PR TITLE
CASMTRIAGE-3591 kernel dump fix

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,7 @@
 /install/*                                               @Cray-HPE/metal
 /install/livecd                                          @Cray-HPE/metal
 /operations/bare_metal                                   @Cray-HPE/metal
+/scripts/hotfixes/kdump                                  @Cray-HPE/metal
 
 # Continuous Integration Items
 Jenkinsfile.github                                       @Cray-HPE/ci

--- a/install/deploy_final_ncn.md
+++ b/install/deploy_final_ncn.md
@@ -7,14 +7,14 @@ join the Kubernetes cluster as the final of three master nodes, forming a quorum
 **IMPORTANT:** While the node is rebooting, it will only be available through Serial-Over-LAN (SOL) and local terminals. This
 procedure entails deactivating the LiveCD, meaning the LiveCD and all of its resources will be unavailable.
 
-1. [Required services](#required-services)
-2. [Notice of danger](#notice-of-danger)
-3. [Hand-off](#hand-off)
-4. [Reboot](#reboot)
-5. [Enable NCN disk wiping safeguard](#enable-ncn-disk-wiping-safeguard)
-6. [Clean up `chrony` configurations](#clean-up-chrony-configurations)
-7. [Configure DNS and NTP on each BMC](#configure-dns-and-ntp-on-each-bmc)
-8. [Next topic](#next-topic)
+1. [Required services](#1-required-services)
+1. [Notice of danger](#2-notice-of-danger)
+1. [Hand-off](#3-hand-off)
+1. [Reboot](#4-reboot)
+1. [Enable NCN disk wiping safeguard](#5-enable-ncn-disk-wiping-safeguard)
+1. [Clean up `chrony` configurations](#6-clean-up-chrony-configurations)
+1. [Configure DNS and NTP on each BMC](#7-configure-dns-and-ntp-on-each-bmc)
+1. [Next topic](#8-next-topic)
 
 <a name="required-services"></a>
 
@@ -459,6 +459,47 @@ The steps in this section load hand-off data before a later procedure reboots th
     # typescript exited
     ncn-m002# rsync -rltDv -P /metal/bootstrap ncn-m001:/metal/ && rm -rfv /metal/bootstrap
     ncn-m002# exit
+    ```
+
+1. Apply the `kdump` hotfix.
+
+    `kdump` assists in taking a dump of the NCN if it encounters a kernel panic.
+    `kdump` does not work properly in CSM 1.2. Until this hotfix is applied, `kdump` may not produce a proper dump.
+    Earlier in the install, this hotfix was applied to all of the NCNs except for `ncn-m001`, because it was the PIT
+    node. Running it now applies the fix to `ncn-m001` as well.
+
+    ```bash
+    ncn-m001# /usr/share/doc/csm/scripts/hotfixes/kdump/hotfix.sh
+    ```
+
+    Example output:
+
+    ```text
+    Uploading hotfix files to ncn-m001:/srv/cray/scripts/common/ ... Done
+    Uploading hotfix files to ncn-m002:/srv/cray/scripts/common/ ... Done
+    Uploading hotfix files to ncn-m003:/srv/cray/scripts/common/ ... Done
+    Uploading hotfix files to ncn-s001:/srv/cray/scripts/common/ ... Done
+    Uploading hotfix files to ncn-s002:/srv/cray/scripts/common/ ... Done
+    Uploading hotfix files to ncn-s003:/srv/cray/scripts/common/ ... Done
+    Uploading hotfix files to ncn-s004:/srv/cray/scripts/common/ ... Done
+    Uploading hotfix files to ncn-w001:/srv/cray/scripts/common/ ... Done
+    Uploading hotfix files to ncn-w002:/srv/cray/scripts/common/ ... Done
+    Uploading hotfix files to ncn-w003:/srv/cray/scripts/common/ ... Done
+    Uploading hotfix files to ncn-w004:/srv/cray/scripts/common/ ... Done
+    Running updated create-kdump-artifacts.sh script on [11] NCNs ... Done
+    The following NCNs contain the kdump patch:
+    ncn-m001
+    ncn-m002
+    ncn-m003
+    ncn-s001
+    ncn-s002
+    ncn-s003
+    ncn-s004
+    ncn-w001
+    ncn-w002
+    ncn-w003
+    ncn-w004
+    This hotfix has completed.
     ```
 
 <a name="enable-ncn-disk-wiping-safeguard"></a>

--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -22,20 +22,20 @@ the number of storage and worker nodes.
 
    1. [Prepare for management node deployment](#1-prepare-for-management-node-deployment)
       1. [Tokens and IPMI password](#11-tokens-and-ipmi-password)
-      2. [Ensure time is accurate before Deploying NCNs](#12-ensure-time-is-accurate-before-deploying-ncns)
-   2. [Update management node firmware](#2-update-management-node-firmware)
-   3. [Deploy management nodes](#3-deploy-management-nodes)
+      1. [Ensure time is accurate before Deploying NCNs](#12-ensure-time-is-accurate-before-deploying-ncns)
+   1. [Update management node firmware](#2-update-management-node-firmware)
+   1. [Deploy management nodes](#3-deploy-management-nodes)
       1. [Deploy workflow](#31-deploy-workflow)
-      2. [Deploy](#32-deploy)
-      3. [Check LVM on Kubernetes NCNs](#33-check-lvm-on-kubernetes-ncns)
-      4. [Check for unused drives on utility storage nodes](#34-check-for-unused-drives-on-utility-storage-nodes)
-   4. [Configure after management node deployment](#4-configure-after-management-node-deployment)
+      1. [Deploy](#32-deploy)
+      1. [Check LVM on Kubernetes NCNs](#33-check-lvm-on-kubernetes-ncns)
+      1. [Check for unused drives on utility storage nodes](#34-check-for-unused-drives-on-utility-storage-nodes)
+   1. [Configure after management node deployment](#4-configure-after-management-node-deployment)
       1. [LiveCD cluster authentication](#41-livecd-cluster-authentication)
-      2. [Install tests and test server on NCNs](#42-install-tests-and-test-server-on-ncns)
-      3. [Clean up `chrony` configurations](#43-clean-up-chrony-configurations)
-   5. [Validate management node deployment](#5-validate-management-node-deployment)
-   6. [Important checkpoint](#important-checkpoint)
-   7. [Next topic](#next-topic)
+      1. [Install tests and test server on NCNs](#42-install-tests-and-test-server-on-ncns)
+      1. [Clean up `chrony` configurations](#43-clean-up-chrony-configurations)
+   1. [Validate management node deployment](#5-validate-management-node-deployment)
+   1. [Important checkpoint](#important-checkpoint)
+   1. [Next topic](#next-topic)
 
 <a name="prepare_for_management_node_deployment"></a>
 
@@ -564,6 +564,46 @@ be performed are in the [Deploy](#deploy) section.
     ```text
     &.
     pit#
+    ```
+
+1. Apply the `kdump` hotfix.
+
+    `kdump` assists in taking a dump of the NCN if it encounters a kernel panic.
+    `kdump` does not work properly in CSM 1.2. Until this hotfix is applied, `kdump` may not produce a proper dump.
+    Running this script applies the hotfix on all of the NCNs that were just deployed.
+
+    ```bash
+    pit# /usr/share/doc/csm/scripts/hotfixes/kdump/hotfix.sh
+    ```
+
+    Example output:
+
+    ```text
+    Uploading hotfix files to ncn-m001:/srv/cray/scripts/common/ ... Done
+    Uploading hotfix files to ncn-m002:/srv/cray/scripts/common/ ... Done
+    Uploading hotfix files to ncn-m003:/srv/cray/scripts/common/ ... Done
+    Uploading hotfix files to ncn-s001:/srv/cray/scripts/common/ ... Done
+    Uploading hotfix files to ncn-s002:/srv/cray/scripts/common/ ... Done
+    Uploading hotfix files to ncn-s003:/srv/cray/scripts/common/ ... Done
+    Uploading hotfix files to ncn-s004:/srv/cray/scripts/common/ ... Done
+    Uploading hotfix files to ncn-w001:/srv/cray/scripts/common/ ... Done
+    Uploading hotfix files to ncn-w002:/srv/cray/scripts/common/ ... Done
+    Uploading hotfix files to ncn-w003:/srv/cray/scripts/common/ ... Done
+    Uploading hotfix files to ncn-w004:/srv/cray/scripts/common/ ... Done
+    Running updated create-kdump-artifacts.sh script on [11] NCNs ... Done
+    The following NCNs contain the kdump patch:
+    ncn-m001
+    ncn-m002
+    ncn-m003
+    ncn-s001
+    ncn-s002
+    ncn-s003
+    ncn-s004
+    ncn-w001
+    ncn-w002
+    ncn-w003
+    ncn-w004
+    This hotfix has completed.
     ```
 
 <a name="check-lvm-on-masters-and-workers"></a>

--- a/operations/node_management/Rebuild_NCNs/Rebuild_NCNs.md
+++ b/operations/node_management/Rebuild_NCNs/Rebuild_NCNs.md
@@ -22,6 +22,8 @@ ncn# echo $XNAME
 
 Only follow the steps in the section for the node type that is being rebuilt.
 
+***NOTE*** After rebuilding an NCN, kernel dump will need to be fixed. See [Kernel Dump Hotfix](../../../scripts/hotfixes/kdump/README.md) for more information.
+
 ### Worker node
 
 1. Make sure that not all pods of `ingressgateway-hmn` or `spire-server` are running on the same worker node.

--- a/scripts/hotfixes/kdump/README.md
+++ b/scripts/hotfixes/kdump/README.md
@@ -1,0 +1,48 @@
+# Kernel Dump Hotfix
+
+This directory includes the script and the library necessary for applying the hotfix to all reachable NCNs.
+
+## Usage
+
+1. Run `hotfix.sh`.
+
+    ```bash
+    ncn# /usr/share/doc/csm/scripts/hotfixes/kdump/hotfix.sh
+    ```
+
+   Example output:
+
+   ```text
+   Uploading hotfix files to ncn-m001:/srv/cray/scripts/common/ ... Done
+   Uploading hotfix files to ncn-m002:/srv/cray/scripts/common/ ... Done
+   Uploading hotfix files to ncn-m003:/srv/cray/scripts/common/ ... Done
+   Uploading hotfix files to ncn-s001:/srv/cray/scripts/common/ ... Done
+   Uploading hotfix files to ncn-s002:/srv/cray/scripts/common/ ... Done
+   Uploading hotfix files to ncn-s003:/srv/cray/scripts/common/ ... Done
+   Uploading hotfix files to ncn-s004:/srv/cray/scripts/common/ ... Done
+   Uploading hotfix files to ncn-w001:/srv/cray/scripts/common/ ... Done
+   Uploading hotfix files to ncn-w002:/srv/cray/scripts/common/ ... Done
+   Uploading hotfix files to ncn-w003:/srv/cray/scripts/common/ ... Done
+   Uploading hotfix files to ncn-w004:/srv/cray/scripts/common/ ... Done
+   Running updated create-kdump-artifacts.sh script on [11] NCNs ... Done
+   The following NCNs contain the kdump patch:
+   ncn-m001
+   ncn-m002
+   ncn-m003
+   ncn-s001
+   ncn-s002
+   ncn-s003
+   ncn-s004
+   ncn-w001
+   ncn-w002
+   ncn-w003
+   ncn-w004
+   This hotfix has completed.
+   ```
+
+## Origin
+
+The original script and library used live in [metal-provision](https://github.com/Cray-HPE/metal-provision/tree/v1.0.6):
+
+- [`create-kdump-artifacts.sh`](https://github.com/Cray-HPE/metal-provision/blob/v1.0.6/roles/ncn-common-setup/files/srv/cray/scripts/common/create-kdump-artifacts.sh)
+- [`dracut-lib.sh`](https://github.com/Cray-HPE/metal-provision/blob/v1.0.6/roles/ncn-common-setup/files/srv/cray/scripts/common/dracut-lib.sh)

--- a/scripts/hotfixes/kdump/create-kdump-artifacts.sh
+++ b/scripts/hotfixes/kdump/create-kdump-artifacts.sh
@@ -1,0 +1,258 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+set -euo pipefail
+
+# Source common dracut parameters.
+. "$(dirname $0)/dracut-lib.sh"
+
+# show the line that we failed and on and exit non-zero
+
+trap 'catch $? $LINENO; cleanup; exit 1' ERR
+
+# if the script is interrupted, run the cleanup function
+trap 'cleanup' INT EXIT
+
+# catch() prints what line the script failed on, runs the cleanup function, and then exits non-zero
+catch() {
+    # Show what line the error occurred on because it can be difficult to detect in a dracut environment
+    echo "CATCH: exit code $1 occurred on line $2 in $(basename "${0}")"
+    cleanup
+    exit 1
+}
+
+
+# cleanup() removes temporary files, puts things back where they belong, etc.
+cleanup() {
+    echo "CLEANUP: cleanup function running ..."
+
+    # Restore the dracut config if it was removed.
+    [ ! -f /etc/dracut.conf.d/05-metal.conf ] && cp -v /run/rootfsbase/etc/dracut.conf.d/05-metal.conf /etc/dracut.conf.d/05-metal.conf
+
+    # Stops re-running this script on reboot
+    # TODO: This script should move to the pipeline, and the service can then be removed (MTL-1830).
+    systemctl disable kdump-cray
+}
+
+
+# check_size() offers a CAUTION message if the initrd is larger then 20MB
+# this is just a soft warning since several factors can influence running out of memory including:
+# crashkernel= parameters, drivers that are loaded, modules that are loaded, etc.
+# so it's more of a your mileage may vary message
+check_size() {
+
+    local initrd="$1"
+    local max=20000000 # kdump initrds larger than 20M may run into issues with memory
+    
+    if [[ "$(stat --format=%s $initrd)" -ge "$max" ]]; then
+        echo >&2 "CAUTION: initrd might be too large ($(stat --format=%s $initrd)) and may exceed available memory (OOM) if used"
+    else
+        echo "initrd size is $(stat --format=%s $initrd) bytes"
+    fi
+}
+
+
+# FIXME: Remove this function, see notes on each block of code contained for prerequites for removal.
+function update_fstab {
+
+    local initrd="$1"
+    local sqfs_label="${2:-'SQFSRAID'}"
+    local live_dir="${3:-'LiveOS'}"
+
+    echo "Unpacking generated initrd [$initrd] to amend fstab ..."
+
+    local temp=/tmp/ktmp
+
+    [ -d $temp ] && rm -rf $temp
+    mkdir -p $temp
+    pushd $temp || exit 1
+    /usr/lib/dracut/skipcpio ${initrd} | xzcat | cpio -id
+    
+    # This hack removes the automated entry for mnt0, we have been unable to resolve where it came from.
+    # It seems to come from kdump source, likely the C code.
+    tail -n +2 etc/fstab > etc/fstab.new
+    mv etc/fstab.new etc/fstab
+
+    # kdump/boot points to mnt0 assuming it is the `/` partition, this corrects it to point
+    # to the actual boot directory from the squash.
+    # NOTE: The boot directory won't contain the kdump initrd until we run this script in the NCN pipeline.
+    #       We assume that this directory is mounted to provide access
+    #       to the kdump initrd (not that it needs to be accessed).
+    rm -rf kdump/boot
+    ln -snf rootfsbase/boot kdump/boot
+
+    # /etc/sysconfig/kdump differs between the running system and in the kdump initrd.
+    # in the initrd the value is this: KDUMP_SAVEDIR="file:///mnt0/var/crash"
+    # in runtime it's KDUMP_SAVEDIR="file:////var/crash"
+    # instead of modifying KDUMP_SAVEDIR since the values don't match between each context, this symlinks
+    # where /var/crash exists in runtime to `/kdump/mnt0.
+    sqfs_uuid=$(blkid -lt LABEL=$sqfs_label | tr ' ' '\n' | awk -F '"' ' /UUID/ {print $2}')
+    rm -rf kdump/mnt0
+    ln -snf overlay/${live_dir}/overlay-$sqfs_label-$sqfs_uuid/ kdump/mnt0
+
+    echo "Regenerating modified kdump initrd ..."
+    rm -f ${initrd}
+    find . | cpio -oac | xz -C crc32 -z -c > ${initrd}
+    popd
+    rm -rf $temp
+}
+
+
+function build_initrd {
+
+    local init_cmdline    
+    local kdump_cmdline
+    local kdump_add
+    local kdump_omit
+    local kdump_omit_drivers
+
+    local live_dir=''
+    local live_dir_arg=''
+    local live_img=''
+    local live_img_arg=''
+    local overlay_label=''
+    local overlay_label_arg=''
+    local root=''
+    local root_arg=''
+    local sqfs_drive_url=''
+    local sqfs_label=''
+    local sqfs_label_arg=''
+    local sqfs_label_arg=''
+
+    # kdump-specific kernel parameters
+    init_cmdline=$(cat /proc/cmdline)
+    kdump_cmdline=()
+    for cmd in $init_cmdline; do
+        # cleans up first argument when running this script on a disk-booted system
+        if [[ $cmd =~ kernel$ ]]; then
+            cmd=$(basename "$(echo $cmd  | awk '{print $1}')")
+        fi
+        if [[ $cmd =~ ^rd\.live\.dir=.* ]]; then
+            live_dir_arg="${cmd//;/\\;}"
+        fi
+        if [[ $cmd =~ ^rd\.live\.squashimg=.* ]]; then
+            live_img_arg="${cmd//;/\\;}"
+        fi
+        if [[ $cmd =~ ^root=.* ]]; then
+            root_arg="${cmd//;/\\;}"
+            root=${root_arg#*=}
+            case "$root" in
+                live:*)
+                    sqfs_drive_url=${root#live:}
+                    sqfs_label_arg=${sqfs_drive_url#*:}
+                    ;;
+                *)
+                    echo >&2 "This kdump script does not support a root type of $root"
+                    ;;
+            esac
+        fi
+        if [[ $cmd =~ ^rd.live.overlay=.* ]]; then
+            overlay_label_arg="${cmd//;/\\;}"
+        fi
+        if [[ $cmd =~ ^rd.live.overlay.reset ]] ; then :
+        elif [[ ! $cmd =~ ^metal. ]] && [[ ! $cmd =~ ^ip=.* ]] && [[ ! $cmd =~ ^bootdev=.* ]] ; then
+            kdump_cmdline+=( "${cmd//;/\\;}" )
+        fi
+    done
+    kdump_cmdline+=( "rd.info" )
+    
+    # Resolve the filesystem and the live directory dynamically.
+    [ -n "${sqfs_label_arg:-''}" ] && sqfs_label="${sqfs_label_arg#*=}"
+    [ -z "$sqfs_label" ] && sqfs_label='SQFSRAID'
+    [ -n "${overlay_label_arg:-''}" ] && overlay_label="${overlay_label_arg##*=}"
+    [ -z "$overlay_label" ] && overlay_label='ROOTRAID'
+    [ -n "${live_dir_arg:-''}" ] && live_dir="${live_dir_arg#*=}"
+    [ -z "$live_dir" ] && live_dir='LiveOS'
+    [ -n "${live_img_arg:-''}" ] && live_img="${live_img_arg#*=}"
+    [ -z "$live_img" ] && live_img='filesystem.squashfs'
+    
+    initrd_name="/boot/initrd-${KVER}-kdump"
+
+    # kdump-specific modules to add
+    kdump_add=${ADD[*]}
+    kdump_add+=( 'kdump' )
+
+    # modules to remove
+    kdump_omit=${OMIT[*]}
+    kdump_omit+=( "plymouth" )
+    kdump_omit+=( "resume" )
+    kdump_omit+=( "metalmdsquash" )
+    kdump_omit+=( "metaldmk8s" )
+    kdump_omit+=( "metalluksetcd" )
+    kdump_omit+=( "usrmount" )
+
+    # Omit these drivers to make a smaller initrd.
+    kdump_omit_drivers=$OMIT_DRIVERS
+    kdump_omit_drivers+=( "mlx5_core" )
+    kdump_omit_drivers+=( "mlx5_ib" )
+    kdump_omit_drivers+=( "sunrpc" )
+    kdump_omit_drivers+=( "xhci_hcd" )
+
+    # move the 05-metal.conf file out of the way while the initrd is generated
+    # it causes some conflicts if it's in place when 'dracut' is called.
+    # This is restored by the cleanup function at the end.
+    rm -f /etc/dracut.conf.d/05-metal.conf
+
+    # generate the kdump initrd
+    # Special notes for specific parameters:
+    # - hostonly makes a smaller initrd for the system; if this script is ran in the pipeline this should be swapped for --no-hostonly.
+    # - fstab is used to mitigate risk from reading /proc/mounts
+    # - mount these are given to support mounting both /kdump/boot and /kdump/mnt0, /kdump/boot is meaningless so this is done as a formality
+    # - filesystems only xfs is needed
+    # - no-hostonly-default-device removes auto-resolution of root, this neatens the dracut output
+    # - nohardlink is needed to provide init properly, hardlinking does not work since init exists on a different filesystem
+    # - force-drivers raid1 is necessary to be able to view the raids we have
+    echo "Creating initrd/kernel artifacts ..."
+    dracut \
+        -L 4 \
+        --force \
+        --hostonly \
+        --omit "$(printf '%s' "${kdump_omit[*]}")" \
+        --omit-drivers "$(printf '%s' "${kdump_omit_drivers[*]}")" \
+        --add "$(printf '%s' "${kdump_add[*]}")" \
+        --fstab \
+        --nohardlink \
+        --mount "LABEL=${sqfs_label} /kdump/live xfs ro" \
+        --mount "/kdump/live/${live_dir}/${live_img} /kdump/rootfsbase squashfs ro" \
+        --mount "LABEL=${overlay_label} /kdump/overlay xfs" \
+        --filesystems 'xfs' \
+        --compress 'xz -0 --check=crc32' \
+        --no-hostonly-default-device \
+        --kernel-cmdline "$(printf '%s' "${kdump_cmdline[*]}")" \
+        --persistent-policy by-label \
+        --mdadmconf \
+        --printsize \
+        --force-drivers 'raid1' \
+        ${initrd_name}
+
+    update_fstab ${initrd_name} ${sqfs_label} ${live_dir}
+    check_size ${initrd_name}
+    
+    # restart kdump to apply the change
+    echo "Restarting kdump ..."
+    systemctl restart kdump
+    echo "Done!"
+}
+
+build_initrd

--- a/scripts/hotfixes/kdump/dracut-lib.sh
+++ b/scripts/hotfixes/kdump/dracut-lib.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# Dracut Arguments
+export OMIT=( "btrfs" "cifs" "dmraid" "dmsquash-live-ntfs" "fcoe" "fcoe-uefi" "iscsi" "modsign" "multipath" "nbd" "nfs" "ntfs-3g" )
+export OMIT_DRIVERS=( "ecb" "hmac" "md5" )
+export ADD=( "mdraid" )
+export FORCE_ADD=( "dmsquash-live" "livenet" "mdraid" )
+export INSTALL=( "less" "rmdir" "sgdisk" "vgremove" "wipefs" )
+
+# Kernel Version
+# This won't work well if multiple kernels are installed, because this'll return the highest installed, which might not what's actually running.
+version_full=$(rpm -q --queryformat "%{VERSION}-%{RELEASE}.%{ARCH}\n" kernel-default)
+version_base=${version_full%%-*}
+version_suse=${version_full##*-}
+version_suse=${version_suse%.*.*}
+export KVER="${version_base}-${version_suse}-default"

--- a/scripts/hotfixes/kdump/hotfix.sh
+++ b/scripts/hotfixes/kdump/hotfix.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# Origin of hotfix: https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3591
+
+set -euo pipefail
+
+workdir=$(dirname $0)
+
+if [[ $(hostname) == *-pit ]]; then
+    # Exclude ncn-m001 if this is run from the PIT node.
+    readarray -t EXPECTED_NCNS < <(conman -q | grep -v m001 | sort -u | awk -F - '{print $1"-"$2}')
+    if [ ${#EXPECTED_NCNS[@]} = 0 ]; then
+        echo >&2 "No NCNs found in 'conman -q', $0 can only be invoked after pit-init.sh has completed successfully."
+        exit 1
+    fi
+else
+    readarray -t EXPECTED_NCNS < <(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u)
+    if [ ${#EXPECTED_NCNS[@]} = 0 ]; then
+        echo >&2 "No NCNs found in /etc/hosts! This NCN is not initialized, /etc/hosts should have content."
+        exit 1
+    fi
+fi
+
+NCNS=()
+for ncn in "${EXPECTED_NCNS[@]}"; do
+    if ping -c 1 $ncn >/dev/null 2>&1 ; then
+        NCNS+=( "$ncn" )
+    else
+        echo >&2 "Failed to ping [$ncn]; skipping hotfix for [$ncn]"
+    fi
+done
+
+for ncn in "${NCNS[@]}"; do
+    printf "Uploading hotfix files to $ncn:/srv/cray/scripts/common/ ... "
+    scp ${workdir}/create-kdump-artifacts.sh ${ncn}:/srv/cray/scripts/common/create-kdump-artifacts.sh >/dev/null
+    scp ${workdir}/dracut-lib.sh ${ncn}:/srv/cray/scripts/common/dracut-lib.sh >/dev/null
+    echo "Done" 
+done
+
+printf "Running updated create-kdump-artifacts.sh script on [${#NCNS[@]}] NCNs ... "
+pdsh -S -b -w "$(printf '%s,' "${NCNS[@]}")" '/srv/cray/scripts/common/create-kdump-artifacts.sh > /var/log/metal-kdump-hotfix.log 2>/var/log/metal-kdump-hotfix.error.log'
+echo "Done"
+
+echo "The following NCNs contain the kdump patch:"
+printf "\t%s\n" "${NCNS[@]}"
+echo "This hotfix has completed."
+

--- a/upgrade/1.2/README.md
+++ b/upgrade/1.2/README.md
@@ -35,7 +35,7 @@ For detailed BICAN documentation, see the [BICAN Technical Details](../../operat
 
 ## Known issues
 
-- `kdump` (kernel dump) may hang and fail on NCNs in CSM 1.2 (HPE Cray EX System Software 22.07 release).
+- `kdump` (kernel dump) may hang and fail on NCNs in CSM 1.2 (HPE Cray EX System Software 22.07 release). During the upgrade, a hotfix is applied to fix this.
 
 ## Plan and coordinate network upgrade
 

--- a/upgrade/1.2/Stage_1.md
+++ b/upgrade/1.2/Stage_1.md
@@ -15,7 +15,7 @@
 
     **Known Issues:**
 
-    * If the below error is observed, then re-run the same command for the node upgrade. It will pick up at that point and continue.
+    - If the below error is observed, then re-run the same command for the node upgrade. It will pick up at that point and continue.
 
         ```text
         ====> REDEPLOY_CEPH ...
@@ -23,10 +23,10 @@
         and check to make sure that only the key(s) you wanted were added.Error EINVAL: Traceback (most recent call last):
         ```
 
-    * During the storage node rebuild, Ceph health may report `HEALTH_WARN 1 daemons have recently crashed`. This occurs occasionally as part of the shutdown process of the node
+    - During the storage node rebuild, Ceph health may report `HEALTH_WARN 1 daemons have recently crashed`. This occurs occasionally as part of the shutdown process of the node
       being rebuilt. See [Dump Ceph Crash Data](../../operations/utility_storage/Dump_Ceph_Crash_Data.md).
 
-    * The CSM validation test for detecting clock skew (`Title: Check clock skew on k8s and storage nodes`) can have a false failure. To determine if the clock for an
+    - The CSM validation test for detecting clock skew (`Title: Check clock skew on k8s and storage nodes`) can have a false failure. To determine if the clock for an
       NCN is in sync, run the following command:
 
       ```bash
@@ -85,9 +85,9 @@
 
         The `VERSION` may be reported as `<unknown>`. This is not an error. The three things to verify in the output are:
 
-        * The number of `node-exporter` pods matches the number of Ceph nodes.
-        * The `STATUS` for each pod is `running`.
-        * The `REFRESHED` time for each pod is low enough that it indicates the refresh did not happen **before** the `ceph orch apply` commands issued earlier in this procedure.
+        - The number of `node-exporter` pods matches the number of Ceph nodes.
+        - The `STATUS` for each pod is `running`.
+        - The `REFRESHED` time for each pod is low enough that it indicates the refresh did not happen **before** the `ceph orch apply` commands issued earlier in this procedure.
 
     1. Verify that `alertmanager` is running.
 
@@ -106,9 +106,9 @@
 
         The `VERSION` may be reported as `<unknown>`. This is not an error. The three things to verify in the output are:
 
-        * There is exactly one `alertmanager` pod.
-        * The `STATUS` for each pod is `running`.
-        * The `REFRESHED` time for each pod is low enough that it indicates the refresh did not happen **before** the `ceph orch apply` commands issued earlier in this procedure.
+        - There is exactly one `alertmanager` pod.
+        - The `STATUS` for each pod is `running`.
+        - The `REFRESHED` time for each pod is low enough that it indicates the refresh did not happen **before** the `ceph orch apply` commands issued earlier in this procedure.
 
 1. Update BSS to ensure that the Ceph images are loaded if a node is rebuilt.
 

--- a/upgrade/1.2/Stage_2.md
+++ b/upgrade/1.2/Stage_2.md
@@ -125,13 +125,51 @@ upgrade procedure pivots to use `ncn-m002` as the new "stable node", in order to
 
 ## Stage 2.4
 
+Apply the hotfix for `kdump`:
+
+```bash
+ncn-m002# /usr/share/doc/csm/scripts/hotfixes/kdump/hotfix.sh
+```
+
+Example output:
+
+```text
+Uploading hotfix files to ncn-m001:/srv/cray/scripts/common/ ... Done
+Uploading hotfix files to ncn-m002:/srv/cray/scripts/common/ ... Done
+Uploading hotfix files to ncn-m003:/srv/cray/scripts/common/ ... Done
+Uploading hotfix files to ncn-s001:/srv/cray/scripts/common/ ... Done
+Uploading hotfix files to ncn-s002:/srv/cray/scripts/common/ ... Done
+Uploading hotfix files to ncn-s003:/srv/cray/scripts/common/ ... Done
+Uploading hotfix files to ncn-s004:/srv/cray/scripts/common/ ... Done
+Uploading hotfix files to ncn-w001:/srv/cray/scripts/common/ ... Done
+Uploading hotfix files to ncn-w002:/srv/cray/scripts/common/ ... Done
+Uploading hotfix files to ncn-w003:/srv/cray/scripts/common/ ... Done
+Uploading hotfix files to ncn-w004:/srv/cray/scripts/common/ ... Done
+Running updated create-kdump-artifacts.sh script on [11] NCNs ... Done
+The following NCNs contain the kdump patch:
+ncn-m001
+ncn-m002
+ncn-m003
+ncn-s001
+ncn-s002
+ncn-s003
+ncn-s004
+ncn-w001
+ncn-w002
+ncn-w003
+ncn-w004
+This hotfix has completed.
+```
+
+## Stage 2.5
+
 Run the following command to complete the upgrade of the `weave` and `multus` manifest versions:
 
 ```bash
 ncn-m002# /srv/cray/scripts/common/apply-networking-manifests.sh
 ```
 
-## Stage 2.5
+## Stage 2.6
 
 Run the following script to apply anti-affinity to `coredns` pods:
 
@@ -139,7 +177,7 @@ Run the following script to apply anti-affinity to `coredns` pods:
 ncn-m002# /usr/share/doc/csm/upgrade/1.2/scripts/k8s/apply-coredns-pod-affinity.sh
 ```
 
-## Stage 2.6
+## Stage 2.7
 
 Complete the Kubernetes upgrade. This script will restart several pods on each master node to their new Docker containers.
 

--- a/upgrade/1.2/Stage_3.md
+++ b/upgrade/1.2/Stage_3.md
@@ -16,8 +16,6 @@
    - If there is a URL for the CSM `tar` file that is accessible from `ncn-m002`, then the [Direct download](#direct-download) procedure may be used.
    - Alternatively, the [Manual copy](#manual-copy) procedure may be used, which includes manually copying the CSM `tar` file to `ncn-m002`.
 
-<a name="direct-download">
-
 ### Direct download
 
 1. Set the `ENDPOINT` variable to the URL of the directory containing the CSM release `tar` file.
@@ -39,8 +37,6 @@
    ```
 
 1. Skip the `Manual copy` subsection and proceed to [Perform upgrade](#perform-upgrade).
-
-<a name="manual-copy">
 
 ### Manual copy
 


### PR DESCRIPTION
# Description

**DO NOT BACKPORT THIS TO `main`**, a fix for `main` is merging imminently and this hot-fix is not important for the current 1.3.0.alpha builds.

<!--- Describe what this change is and what it is for. -->
This includes a hotfix for fixing kernel-dump for NCNs during install, rebuilds, and upgrade.

This was tested on fanta (CSM 1.2 with no pit), and surtur (CSM 1.3, but with a pit).

Output example:
```bash
/usr/share/doc/csm/scripts/hotfixes/kdump/hotfix.sh
Uploading hotfix files to ncn-m001:/srv/cray/scripts/common/ ... Done
Uploading hotfix files to ncn-m002:/srv/cray/scripts/common/ ... Done
Uploading hotfix files to ncn-m003:/srv/cray/scripts/common/ ... Done
Uploading hotfix files to ncn-s001:/srv/cray/scripts/common/ ... Done
Uploading hotfix files to ncn-s002:/srv/cray/scripts/common/ ... Done
Uploading hotfix files to ncn-s003:/srv/cray/scripts/common/ ... Done
Uploading hotfix files to ncn-s004:/srv/cray/scripts/common/ ... Done
Uploading hotfix files to ncn-w001:/srv/cray/scripts/common/ ... Done
Uploading hotfix files to ncn-w002:/srv/cray/scripts/common/ ... Done
Uploading hotfix files to ncn-w003:/srv/cray/scripts/common/ ... Done
Uploading hotfix files to ncn-w004:/srv/cray/scripts/common/ ... Done
Running updated create-kdump-artifacts.sh script on [11] NCNs ... Done
The following NCNs contain the kdump patch:
	ncn-m001
	ncn-m002
	ncn-m003
	ncn-s001
	ncn-s002
	ncn-s003
	ncn-s004
	ncn-w001
	ncn-w002
	ncn-w003
	ncn-w004
This hotfix has completed.
```

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
