### PR TITLE
CASMTRIAGE-3673: Ensure Unbound DNS IPv4 address is correct in SLS

### DIFF
--- a/upgrade/1.2/scripts/sls/README.SLS_Upgrade.md
+++ b/upgrade/1.2/scripts/sls/README.SLS_Upgrade.md
@@ -192,6 +192,6 @@ Retention of the unused network is not normal behavior.
 * Generally production systems will NOT want to use this flag unless active toggling between CAN and CHN is required. This is not usual behavior.
 * Test/development systems may want to have all networks for testing purposes and might want to retain both user networks.
 
-For technical details on what the sls_update automation. Refer to [sls_udpater.py_technical_details](sls_updater.py_technical_details.md).
+For technical details on what the `sls_update` automation. Refer to [SLS Updater Technical Details](sls_updater.py_technical_details.md).
 
 [Go Back to Stage 0.2 - Update SLS](../../Stage_0_Prerequisites.md#update-sls)

--- a/upgrade/1.2/scripts/sls/README.SLS_Upgrade.md
+++ b/upgrade/1.2/scripts/sls/README.SLS_Upgrade.md
@@ -192,6 +192,6 @@ Retention of the unused network is not normal behavior.
 * Generally production systems will NOT want to use this flag unless active toggling between CAN and CHN is required. This is not usual behavior.
 * Test/development systems may want to have all networks for testing purposes and might want to retain both user networks.
 
-For technical details on what the `sls_update` automation. Refer to [SLS Updater Technical Details](sls_updater.py_technical_details.md).
+For technical details on what the `sls_update` automation, refer to [SLS Updater Technical Details](sls_updater.py_technical_details.md).
 
 [Go Back to Stage 0.2 - Update SLS](../../Stage_0_Prerequisites.md#update-sls)

--- a/upgrade/1.2/scripts/sls/README.SLS_Upgrade.md
+++ b/upgrade/1.2/scripts/sls/README.SLS_Upgrade.md
@@ -120,6 +120,11 @@ This needs to be done in the order listed above.
 For CSM 1.2, the API gateway will no longer listen on the HMNLB MetalLB address pool.
 These aliases provided DNS records and are being removed.
 
+### Correct any erroneous Unbound DNS IPv4 addresses
+
+Some systems installed Shasta 1.4 and prior contained a bug in CSI which created reservations
+with incorrect IP addresses.
+
 ### Create the BICAN network "toggle"
 
 New for CSM 1.2, the BICAN network `ExtraProperties` value of `SystemDefaultRoute` is used

--- a/upgrade/1.2/scripts/sls/sls_updater_csm_1.2.py
+++ b/upgrade/1.2/scripts/sls/sls_updater_csm_1.2.py
@@ -27,6 +27,7 @@ import sys
 
 import click
 from csm_1_2_upgrade.sls_updates import convert_can_ips
+from csm_1_2_upgrade.sls_updates import correct_unbound_dns_address
 from csm_1_2_upgrade.sls_updates import create_bican_network
 from csm_1_2_upgrade.sls_updates import create_chn_network
 from csm_1_2_upgrade.sls_updates import create_metallb_pools_and_asns
@@ -54,6 +55,7 @@ help = """Upgrade a system SLS file from CSM 1.0 to CSM 1.2.
     9. Rename uai_macvlan_bridge reservation to uai_nmn_blackhole
    10. Remove unused user networks (CAN or CHN) if requested [--retain-unused-user-network to keep].\n
    11. Create the new BICAN "toggle" network.\n
+   12. Correct Unbound IP addresses in HMNLB and NMNLB.\n
 """
 
 
@@ -261,6 +263,11 @@ def main(
     # Remove api-gw aliases from HMNLB reservations
     #   (not order dependent)
     remove_api_gw_from_hmnlb_reservations(networks)
+
+    #
+    # Correct Unbound IPv4 addresses in HMNLB and NMNLB reservations
+    #   (not order dependent)
+    correct_unbound_dns_address(networks)
 
     #
     # Clone (existing) CAN network to CMN


### PR DESCRIPTION
# Description

CSI versions prior to and including Shasta 1.4 contained the incorrect IPv4 addresses for Unbound DNS in both NMNLB and HMNLB subnets.  Prior to CSM 1.2 this data was not used, but currently CANU uses this data to configure management network switches.  This change looks for missing and incorrect Unbound DNS addresses and patches SLS as part of the overall SLS Upgrade strategy in CSM 1.2.

# Tested on/with:

- Surtur data which was a no-op
- Sif data which contained incorrect IPv4 addresses
- Locally with missing Unbound reservations

# Checklist Before Merging

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
