### PR TITLE
CASMTRIAGE-3668: add common error flags

### DIFF
--- a/operations/kubernetes/Troubleshoot_Intermittent_503s.md
+++ b/operations/kubernetes/Troubleshoot_Intermittent_503s.md
@@ -2,14 +2,14 @@
 
 There are cases where API calls or `cray` command invocations will fail (sometimes intermittently) with an HTTP 503 error code.
 In the event that this occurs, take the following actions according to specific error codes found in the pod or Envoy container
-log may be useful to remediate the issue. The Envoy container is typically named `istio-proxy`, it runs as a sidecar for Pods
-that are part of the Istio mesh. For these pods with sidecar, the logs can be viewed by running a command like:
+log may be useful to remediate the issue. The Envoy container is typically named `istio-proxy`, it runs as a sidecar for pods
+that are part of the Istio mesh. For these pods with sidecar, the logs can be viewed by running a command similar to the following (`ncn-m#`):
 
 ```bash
-ncn-m# kubectl logs <podname> -n <namespace> -c istio-proxy | grep 503
+kubectl logs <podname> -n <namespace> -c istio-proxy | grep 503
 ```
 
-1. `UF,URX` code with TLS error:
+1. (`ncn-m#`) Troubleshoot a `UF,URX` code with a TLS error.
 
    The logs include errors similar to the following:
 
@@ -22,12 +22,12 @@ ncn-m# kubectl logs <podname> -n <namespace> -c istio-proxy | grep 503
    or StatefulSet if it is part of a multiple replica exhibiting the issue, like:
 
    ```bash
-   ncn-m# kubectl rollout restart -n istio-system deployment istio-ingressgateway
+   kubectl rollout restart -n istio-system deployment istio-ingressgateway
    ```
 
    Once the roll out is complete, the HTTP 503 message should clear.
 
-1. `UAEX` code:
+1. (`ncn-m#`) Troubleshoot a `UAEX` error code.
 
    The logs include errors similar to the following:
 
@@ -35,22 +35,22 @@ ncn-m# kubectl logs <podname> -n <namespace> -c istio-proxy | grep 503
    [2022-06-24T14:16:27.229Z] "POST /apis/hbtd/hmi/v1/heartbeat HTTP/2" 503 UAEX "-" 131 0 30 - "10.34.0.0" "-" "1797b0d3-56f0-4674-8cf2-a8a61f9adaea" "api-gw-service-nmn.local" "-" - - 10.40.0.29:443 10.34.0.0:15995 api-gw-service-nmn.local -
    ```
 
-   This error code typically indicates an issue with the authorization service (i.e., spire). When this happens, perform a rolling restart of the following:
+   This error code typically indicates an issue with the authorization service (for example, Spire). When this happens, perform a rolling restart of the following:
 
    ```bash
-   ncn-m# kubectl rollout restart -n spire statefulset spire-server
-   ncn-m# kubectl rollout restart -n spire daemonset spire-agent
-   ncn-m# kubectl rollout restart -n spire deployment spire-jwks
-   ncn-m# kubectl rollout restart -n spire deployment spire-postgres
-   ncn-m# kubectl rollout restart -n spire deployment spire-postgres-pooler
-   ncn-m# kubectl rollout restart -n spire daemonset request-ncn-join-token
+   kubectl rollout restart -n spire statefulset spire-server
+   kubectl rollout restart -n spire daemonset spire-agent
+   kubectl rollout restart -n spire deployment spire-jwks
+   kubectl rollout restart -n spire deployment spire-postgres
+   kubectl rollout restart -n spire deployment spire-postgres-pooler
+   kubectl rollout restart -n spire daemonset request-ncn-join-token
    ```
 
    Once the roll out is complete, the HTTP 503 message should clear.
 
-1. Other error codes:
+1. Troubleshoot other error codes.
 
    Although `UF,URX` and `UAEX` codes are most common, various other issues such as networking or application errors can cause different errors in
    the pod or sidecar logs. Please refer to <https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#> for a list of
-   possible Envoy response flags. Generally you may try rolling restart of the application itself to see if it clears the error; otherwise, you need
-   to understand what the error message or response flag means to further troubleshoot the issue.
+   possible Envoy response flags. In general, running a rolling restart of the application itself to see if it clears the error is a good practice; otherwise,
+   an understanding of what the error message or response flag means is required to further troubleshoot the issue.

--- a/operations/kubernetes/Troubleshoot_Intermittent_503s.md
+++ b/operations/kubernetes/Troubleshoot_Intermittent_503s.md
@@ -1,56 +1,80 @@
 # Troubleshoot Intermittent HTTP 503 Code Failures
 
 There are cases where API calls or `cray` command invocations will fail (sometimes intermittently) with an HTTP 503 error code.
-In the event that this occurs, take the following actions according to specific error codes found in the pod or Envoy container
-log may be useful to remediate the issue. The Envoy container is typically named `istio-proxy`, it runs as a sidecar for pods
-that are part of the Istio mesh. For these pods with sidecar, the logs can be viewed by running a command similar to the following (`ncn-m#`):
+In the event that this occurs, attempt to remediate the issue by taking the following actions, according to specific error codes
+found in the pod or Envoy container log. 
+
+(`ncn-mw#`) The Envoy container is typically named `istio-proxy`, and it runs as a sidecar for pods that are part of the Istio mesh.
+For pods with this sidecar, the logs can be viewed by running a command similar to the following:
 
 ```bash
 kubectl logs <podname> -n <namespace> -c istio-proxy | grep 503
 ```
 
-1. (`ncn-m#`) Troubleshoot a `UF,URX` code with a TLS error.
+This page is broken into different sections, based on the errors found in the log.
 
-   The logs include errors similar to the following:
+## `UF,URX` with TLS error
 
-   ```text
-   [2022-05-10T16:27:29.232Z] "POST /apis/hbtd/hmi/v1/heartbeat HTTP/2" 503 UF,URX "-" "TLS error: Secret is not supplied by SDS"
-   ```
+### Symptom (`UF,URX` with TLS error)
 
-   Envoy container can occasionally get into this state when NCNs are being rebooted or upgraded, as well as when many deployments
-   are being created. When this happens, delete the pod if it is a single replica or perform a rolling restart of the Deployment
-   or StatefulSet if it is part of a multiple replica exhibiting the issue, like:
+```text
+[2022-05-10T16:27:29.232Z] "POST /apis/hbtd/hmi/v1/heartbeat HTTP/2" 503 UF,URX "-" "TLS error: Secret is not supplied by SDS"
+```
 
-   ```bash
-   kubectl rollout restart -n istio-system deployment istio-ingressgateway
-   ```
+### Description (`UF,URX` with a TLS error)
 
-   Once the roll out is complete, the HTTP 503 message should clear.
+Envoy container can occasionally get into this state when NCNs are being rebooted or upgraded, as well as when many deployments
+are being created.
 
-1. (`ncn-m#`) Troubleshoot a `UAEX` error code.
+### Remediation (`UF,URX` with a TLS error)
 
-   The logs include errors similar to the following:
+(`ncn-mw#`) Do a Kubernetes delete or rolling restart:
 
-   ```text
-   [2022-06-24T14:16:27.229Z] "POST /apis/hbtd/hmi/v1/heartbeat HTTP/2" 503 UAEX "-" 131 0 30 - "10.34.0.0" "-" "1797b0d3-56f0-4674-8cf2-a8a61f9adaea" "api-gw-service-nmn.local" "-" - - 10.40.0.29:443 10.34.0.0:15995 api-gw-service-nmn.local -
-   ```
+- If it is a single replica, then delete the pod.
+- If it is part of a multiple replica exhibiting the issue, then perform a rolling restart of the deployment or StatefulSet.
 
-   This error code typically indicates an issue with the authorization service (for example, Spire). When this happens, perform a rolling restart of the following:
+    For example:
 
-   ```bash
-   kubectl rollout restart -n spire statefulset spire-server
-   kubectl rollout restart -n spire daemonset spire-agent
-   kubectl rollout restart -n spire deployment spire-jwks
-   kubectl rollout restart -n spire deployment spire-postgres
-   kubectl rollout restart -n spire deployment spire-postgres-pooler
-   kubectl rollout restart -n spire daemonset request-ncn-join-token
-   ```
+    ```bash
+    kubectl rollout restart -n istio-system deployment istio-ingressgateway
+    kubectl rollout status -n istio-system deployment istio-ingressgateway
+    ```
 
-   Once the roll out is complete, the HTTP 503 message should clear.
+Once the roll out is complete, or the new pod is running, then the HTTP 503 message should clear.
 
-1. Troubleshoot other error codes.
+## `UAEX`
 
-   Although `UF,URX` and `UAEX` codes are most common, various other issues such as networking or application errors can cause different errors in
-   the pod or sidecar logs. Please refer to <https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#> for a list of
-   possible Envoy response flags. In general, running a rolling restart of the application itself to see if it clears the error is a good practice; otherwise,
-   an understanding of what the error message or response flag means is required to further troubleshoot the issue.
+### Symptom (`UAEX`)
+
+```text
+[2022-06-24T14:16:27.229Z] "POST /apis/hbtd/hmi/v1/heartbeat HTTP/2" 503 UAEX "-" 131 0 30 - "10.34.0.0" "-" "1797b0d3-56f0-4674-8cf2-a8a61f9adaea" "api-gw-service-nmn.local" "-" - - 10.40.0.29:443 10.34.0.0:15995 api-gw-service-nmn.local -
+```
+
+### Description (`UAEX`)
+
+This error code typically indicates an issue with the authorization service (for example, Spire).
+
+### Remediation (`UAEX`)
+
+(`ncn-mw#`) Perform a rolling restart of all of the following:
+
+```bash
+kubectl rollout restart -n spire statefulset spire-server
+kubectl rollout restart -n spire daemonset spire-agent request-ncn-join-token
+kubectl rollout restart -n spire deployment spire-jwks spire-postgres spire-postgres-pooler
+kubectl rollout status -n spire statefulset spire-server
+kubectl rollout status -n spire daemonset spire-agent
+kubectl rollout status -n spire daemonset request-ncn-join-token
+kubectl rollout status -n spire deployment spire-jwks
+kubectl rollout status -n spire deployment spire-postgres
+kubectl rollout status -n spire deployment spire-postgres-pooler
+```
+
+Once the roll out is complete, the HTTP 503 message should clear.
+
+## Other error codes
+
+Although the above codes are most common, various other issues such as networking or application errors can cause different errors in
+the pod or sidecar logs. Refer to the [Envoy access log documentation](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#)
+for a list of possible Envoy response flags. In general, running a rolling restart of the application itself to see if it clears the error is a good practice;
+otherwise, an understanding of what the error message or response flag means is required to further troubleshoot the issue.

--- a/operations/kubernetes/Troubleshoot_Intermittent_503s.md
+++ b/operations/kubernetes/Troubleshoot_Intermittent_503s.md
@@ -1,33 +1,56 @@
 # Troubleshoot Intermittent HTTP 503 Code Failures
 
-There are cases where API calls or `cray` command invocations will intermittently return an HTTP 503 code, even when the backing service is up and functional.
-In the event that this occurs, the following steps may be useful to remediate the issue.
+There are cases where API calls or `cray` command invocations will fail (sometimes intermittently) with an HTTP 503 error code.
+In the event that this occurs, take the following actions according to specific error codes found in the pod or Envoy container
+log may be useful to remediate the issue. The Envoy container is typically named `istio-proxy`, it runs as a sidecar for Pods
+that are part of the Istio mesh. For these pods with sidecar, the logs can be viewed by running a command like:
 
-1. Inspect the `istio-ingressgateway` pod logs:
+```bash
+ncn-m# kubectl logs <podname> -n <namespace> -c istio-proxy | grep 503
+```
 
-   ```bash
-   ncn-m # kubectl -n istio-system logs -l app=istio-ingressgateway
-   ```
+1. `UF,URX` code with TLS error:
 
-   If the logs include TLS errors similar to the following, then proceed to the next step to restart the `istio-ingressgateway` pods.
-   Istio can occasionally get into this state when NCNs are being rebooted, as well as when many deployments are being created.
+   The logs include errors similar to the following:
 
    ```text
-   [2022-05-10T16:27:29.232Z] "POST /apis/hbtd/hmi/v1/heartbeat HTTP/2" 503 UF,URX "-" "TLS error: Secret is not supplied by SDS" 132 91 25 - "10.39.0.0" "-"
-   "08274ec4-2d93-4070-8fe1-fc6946f1cf26" "api-gw-service-nmn.local" "10.33.0.90:28500" outbound|80||cray-hbtd.services.svc.cluster.local - 10.33.0.43:443 10.39.0.0:29543 api-gw-service-nmn.local -
+   [2022-05-10T16:27:29.232Z] "POST /apis/hbtd/hmi/v1/heartbeat HTTP/2" 503 UF,URX "-" "TLS error: Secret is not supplied by SDS"
    ```
 
-1. Perform a rolling restart of the `istio-ingressgateway` pods:
+   Envoy container can occasionally get into this state when NCNs are being rebooted or upgraded, as well as when many deployments
+   are being created. When this happens, delete the pod if it is a single replica or perform a rolling restart of the Deployment
+   or StatefulSet if it is part of a multiple replica exhibiting the issue, like:
 
-   ```bash
-   ncn-m # kubectl rollout restart -n istio-system deployment.apps/istio-ingressgateway
+   ```
+   ncn-m# kubectl rollout restart -n istio-system deployment istio-ingressgateway
    ```
 
-1. Wait for the roll out to complete:
+   Once the roll out is complete, the HTTP 503 message should clear.
 
-   ```bash
-   ncn-m # kubectl rollout status -n istio-system deployment.apps/istio-ingressgateway
-   deployment "istio-ingressgateway" successfully rolled out
+1. `UAEX` code:
+
+   The logs include errors similar to the following:
+
+   ```text
+   [2022-06-24T14:16:27.229Z] "POST /apis/hbtd/hmi/v1/heartbeat HTTP/2" 503 UAEX "-" 131 0 30 - "10.34.0.0" "-" "1797b0d3-56f0-4674-8cf2-a8a61f9adaea" "api-gw-service-nmn.local" "-" - - 10.40.0.29:443 10.34.0.0:15995 api-gw-service-nmn.local -
    ```
 
-Once the roll out is complete, the HTTP 503 messages should clear, and the intermittent API behavior should resolve.
+   This error code typically indicates an issue with the authorization service (i.e., spire). When this happens, perform a rolling restart of the following:
+
+   ```
+   ncn-m# kubectl rollout restart -n spire statefulset spire-server
+   ncn-m# kubectl rollout restart -n spire daemonset spire-agent
+   ncn-m# kubectl rollout restart -n spire deployment spire-jwks
+   ncn-m# kubectl rollout restart -n spire deployment spire-postgres
+   ncn-m# kubectl rollout restart -n spire deployment spire-postgres-pooler
+   ncn-m# kubectl rollout restart -n spire daemonset request-ncn-join-token
+   ```
+
+   Once the roll out is complete, the HTTP 503 message should clear.
+
+1. Other error codes:
+
+   Although `UF,URX` and `UAEX` codes are most common, various other issues such as networking or application errors can cause different errors in
+   the pod or sidecar logs. Please refer to <https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#> for a list of
+   possible Envoy response flags. Generally you may try rolling restart of the application itself to see if it clears the error; otherwise, you need
+   to understand what the error message or response flag means to further troubleshoot the issue.

--- a/operations/kubernetes/Troubleshoot_Intermittent_503s.md
+++ b/operations/kubernetes/Troubleshoot_Intermittent_503s.md
@@ -21,7 +21,7 @@ ncn-m# kubectl logs <podname> -n <namespace> -c istio-proxy | grep 503
    are being created. When this happens, delete the pod if it is a single replica or perform a rolling restart of the Deployment
    or StatefulSet if it is part of a multiple replica exhibiting the issue, like:
 
-   ```
+   ```bash
    ncn-m# kubectl rollout restart -n istio-system deployment istio-ingressgateway
    ```
 
@@ -37,7 +37,7 @@ ncn-m# kubectl logs <podname> -n <namespace> -c istio-proxy | grep 503
 
    This error code typically indicates an issue with the authorization service (i.e., spire). When this happens, perform a rolling restart of the following:
 
-   ```
+   ```bash
    ncn-m# kubectl rollout restart -n spire statefulset spire-server
    ncn-m# kubectl rollout restart -n spire daemonset spire-agent
    ncn-m# kubectl rollout restart -n spire deployment spire-jwks

--- a/operations/kubernetes/Troubleshoot_Intermittent_503s.md
+++ b/operations/kubernetes/Troubleshoot_Intermittent_503s.md
@@ -2,7 +2,7 @@
 
 There are cases where API calls or `cray` command invocations will fail (sometimes intermittently) with an HTTP 503 error code.
 In the event that this occurs, attempt to remediate the issue by taking the following actions, according to specific error codes
-found in the pod or Envoy container log. 
+found in the pod or Envoy container log.
 
 (`ncn-mw#`) The Envoy container is typically named `istio-proxy`, and it runs as a sidecar for pods that are part of the Istio mesh.
 For pods with this sidecar, the logs can be viewed by running a command similar to the following:
@@ -31,7 +31,7 @@ are being created.
 (`ncn-mw#`) Do a Kubernetes delete or rolling restart:
 
 - If it is a single replica, then delete the pod.
-- If it is part of a multiple replica exhibiting the issue, then perform a rolling restart of the deployment or StatefulSet.
+- If it is part of a multiple replica exhibiting the issue, then perform a rolling restart of the deployment or `StatefulSet`.
 
     For example:
 


### PR DESCRIPTION
# Description

Added common envoy response flags and corrective actions to help troubleshoot common issues.

# Checklist Before Merging

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
