### PR TITLE
Update csm-1.3 install docs and scripts to reflect changed PIT variables

### DIFF
--- a/install/deploy_final_non-compute_node.md
+++ b/install/deploy_final_non-compute_node.md
@@ -62,8 +62,8 @@ The steps in this section load hand-off data before a later procedure reboots th
     1. Start a new typescript on the PIT node.
 
         ```bash
-        mkdir -pv /var/www/ephemeral/prep/admin &&
-             pushd /var/www/ephemeral/prep/admin &&
+        mkdir -pv "${PITDATA}"/prep/admin &&
+             pushd "${PITDATA}"/prep/admin &&
              script -af csm-livecd-reboot.$(date +%Y-%m-%d).txt
         export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
         ```
@@ -73,7 +73,7 @@ The steps in this section load hand-off data before a later procedure reboots th
     > **`NOTE`** The environment variable `SYSTEM_NAME` must be set.
 
     ```bash
-    csi upload-sls-file --sls-file /var/www/ephemeral/prep/${SYSTEM_NAME}/sls_input_file.json
+    csi upload-sls-file --sls-file "${PITDATA}"/prep/${SYSTEM_NAME}/sls_input_file.json
     ```
 
     Expected output looks similar to the following:
@@ -114,7 +114,7 @@ The steps in this section load hand-off data before a later procedure reboots th
     > **`NOTE`** This step will prompt for the root password of the NCNs.
 
     ```bash
-    csi handoff bss-metadata --data-file "$PITDATA/configs/data.json" || echo "ERROR: csi handoff bss-metadata failed"
+    csi handoff bss-metadata --data-file "${PITDATA}/configs/data.json" || echo "ERROR: csi handoff bss-metadata failed"
     ```
 
 1. (`pit#`) Patch the metadata for the Ceph nodes to have the correct run commands.
@@ -139,7 +139,7 @@ The steps in this section load hand-off data before a later procedure reboots th
     The following commands create a `tar` archive of these files, storing it in a directory that will be backed up in the next step.
 
     ```bash
-    mkdir -pv /var/www/ephemeral/prep/logs &&
+    mkdir -pv "${PITDATA}"/prep/logs &&
          ls -d \
                     /etc/dnsmasq.d \
                     /etc/os-release \
@@ -155,7 +155,7 @@ The steps in this section load hand-off data before a later procedure reboots th
                     /var/log/conman \
                     /var/log/zypper.log 2>/dev/null |
          sed 's_^/__' |
-         xargs tar -C / -czvf /var/www/ephemeral/prep/logs/pit-backup-$(date +%Y-%m-%d_%H-%M-%S).tgz
+         xargs tar -C / -czvf "${PITDATA}"/prep/logs/pit-backup-$(date +%Y-%m-%d_%H-%M-%S).tgz
     ```
 
 1. (`pit#`) Backup the bootstrap information from `ncn-m001`.
@@ -180,8 +180,8 @@ The steps in this section load hand-off data before a later procedure reboots th
         ```bash
         ssh ncn-m002 \
             "mkdir -pv /metal/bootstrap
-            rsync -e 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' -rltD -P --delete pit.nmn:/var/www/ephemeral/prep /metal/bootstrap/
-            rsync -e 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' -rltD -P --delete pit.nmn:${CSM_PATH}/cray-pre-install-toolkit*.iso /metal/bootstrap/"
+            rsync -e 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' -rltD -P --delete pit.nmn:'${PITDATA}'/prep /metal/bootstrap/
+            rsync -e 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' -rltD -P --delete pit.nmn:'${CSM_PATH}'/cray-pre-install-toolkit*.iso /metal/bootstrap/"
         ```
 
     1. Back up files from the PIT to `ncn-m003`.
@@ -189,8 +189,8 @@ The steps in this section load hand-off data before a later procedure reboots th
         ```bash
         ssh ncn-m003 \
             "mkdir -pv /metal/bootstrap
-            rsync -e 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' -rltD -P --delete pit.nmn:/var/www/ephemeral/prep /metal/bootstrap/
-            rsync -e 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' -rltD -P --delete pit.nmn:${CSM_PATH}/cray-pre-install-toolkit*.iso /metal/bootstrap/"
+            rsync -e 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' -rltD -P --delete pit.nmn:'${PITDATA}'/prep /metal/bootstrap/
+            rsync -e 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' -rltD -P --delete pit.nmn:'${CSM_PATH}'/cray-pre-install-toolkit*.iso /metal/bootstrap/"
         ```
 
 ### 3.3 Prepare for Rebooting

--- a/install/deploy_non-compute_nodes.md
+++ b/install/deploy_non-compute_nodes.md
@@ -206,7 +206,7 @@ for all nodes, the Ceph storage will have been initialized and the Kubernetes cl
     1. Determine the first Kubernetes master.
 
         ```bash
-        FM=$(cat /var/www/ephemeral/configs/data.json | jq -r '."Global"."meta-data"."first-master-hostname"')
+        FM=$(cat "${PITDATA}"/configs/data.json | jq -r '."Global"."meta-data"."first-master-hostname"')
         echo $FM
         ```
 
@@ -331,7 +331,7 @@ If the check fails after doing the rebuild, contact support.
 1. (`pit#`) Install tests and test server on NCNs.
 
     ```bash
-    pushd /var/www/ephemeral && ${CSM_RELEASE}/lib/install-goss-tests.sh && popd
+    "${CSM_PATH}"/lib/install-goss-tests.sh
     ```
 
 1. (`pit#`) Remove the default NTP pool.

--- a/install/install_csm_services.md
+++ b/install/install_csm_services.md
@@ -16,7 +16,7 @@ This procedure will install CSM applications and services into the CSM Kubernete
 
 > **`NOTE`**: During this step, only on systems with only three worker nodes (typically Testing and  Development Systems (TDS)), the `customizations.yaml` file will be
 > automatically edited to lower pod CPU requests for some services, in order to better facilitate scheduling on smaller systems. See the file
-> `/var/www/ephemeral/${CSM_RELEASE}/tds_cpu_requests.yaml` for these settings. This file can be modified with different values (prior to executing the
+> `${CSM_PATH}/tds_cpu_requests.yaml` for these settings. This file can be modified with different values (prior to executing the
 > `yapl` command below), if other settings are desired in the `customizations.yaml` file for this system. For more information about modifying `customizations.yaml`
 > and tuning for specific systems, see
 > [Post-Install Customizations](../operations/CSM_product_management/Post_Install_Customizations.md).
@@ -24,7 +24,7 @@ This procedure will install CSM applications and services into the CSM Kubernete
 1. (`pit#`) Install YAPL.
 
    ```bash
-   rpm -Uvh /var/www/ephemeral/${CSM_RELEASE}/rpm/cray/csm/sle-15sp2/x86_64/yapl-*.x86_64.rpm
+   rpm -Uvh "${CSM_PATH}"/rpm/cray/csm/sle-15sp2/x86_64/yapl-*.x86_64.rpm
    ```
 
 1. (`pit#`) Install CSM services using YAPL.

--- a/install/scripts/csm_services/steps/1.initialize_bootstrap_registry.yaml
+++ b/install/scripts/csm_services/steps/1.initialize_bootstrap_registry.yaml
@@ -60,7 +60,7 @@ spec:
         command: |-
           podman load -i /var/lib/cray/container-images/pit-nexus/skopeo-stable-latest.tar quay.io/skopeo/stable
 
-          podman run --rm --network host -v /var/www/ephemeral/{{ getEnv "CSM_RELEASE" }}/docker:/images:ro \
+          podman run --rm --network host -v {{ getEnv "CSM_PATH" }}/docker:/images:ro \
               quay.io/skopeo/stable sync --scoped --src dir --dest docker --dest-tls-verify=false --dest-creds admin:admin123 \
               /images localhost:5000
 
@@ -68,13 +68,13 @@ spec:
           # XXX dtr.dev.cray.com and quay.io are also uploaded to the root of
           # XXX registry.local. This is only necessary while charts and procedures still
           # XXX reference dtr.dev.cray.com or quay.io/skopeo/stable:latest.
-          if [ -d "/var/www/ephemeral/{{ getEnv "CSM_RELEASE" }}/docker/dtr.dev.cray.com" ]; then
-              podman run --rm --network host -v /var/www/ephemeral/{{ getEnv "CSM_RELEASE" }}/docker/dtr.dev.cray.com:/images:ro \
+          if [ -d "{{ getEnv "CSM_PATH" }}/docker/dtr.dev.cray.com" ]; then
+              podman run --rm --network host -v {{ getEnv "CSM_PATH" }}/docker/dtr.dev.cray.com:/images:ro \
                   quay.io/skopeo/stable sync --scoped --src dir --dest docker --dest-tls-verify=false --dest-creds admin:admin123 \
                   /images localhost:5000
           fi
-          if [ -d "/var/www/ephemeral/{{ getEnv "CSM_RELEASE" }}/docker/quay.io/skopeo/stable:latest" ]; then
-              podman run --rm --network host -v /var/www/ephemeral/{{ getEnv "CSM_RELEASE" }}/docker/quay.io:/image:ro \
+          if [ -d "{{ getEnv "CSM_PATH" }}/docker/quay.io/skopeo/stable:latest" ]; then
+              podman run --rm --network host -v {{ getEnv "CSM_PATH" }}/docker/quay.io:/image:ro \
                   quay.io/skopeo/stable copy --dest-tls-verify=false --dest-creds admin:admin123 \
                   dir:/image/skopeo/stable:latest docker://localhost:5000/skopeo/stable:latest
           fi

--- a/install/scripts/csm_services/steps/2.create_site_init_secret.yaml
+++ b/install/scripts/csm_services/steps/2.create_site_init_secret.yaml
@@ -28,26 +28,26 @@ metadata:
     # Create Site-Init Secret
 
     The `site-init` secret in the `loftsman` namespace makes
-    `/var/www/ephemeral/prep/site-init/customizations.yaml` available to product
+    `${PITDATA}/prep/site-init/customizations.yaml` available to product
     installers. The `site-init` secret should only be updated when the
     corresponding `customizations.yaml` data is changed, such as during system
     installation or upgrade. Create the `site-init` secret to contain
-    `/var/www/ephemeral/prep/site-init/customizations.yaml`:
+    `${PITDATA}/prep/site-init/customizations.yaml`:
 spec:
   jobs:
     - preCondition:
         description: |-
-          `/var/www/ephemeral/prep/site-init/customizations.yaml` exists
+          `${PITDATA}/prep/site-init/customizations.yaml` exists
         command: |-
-          [[ -f /var/www/ephemeral/prep/site-init/customizations.yaml ]] || exit 1
+          [[ -f {{ getEnv "PITDATA" }}/prep/site-init/customizations.yaml ]] || exit 1
         troubleshooting: |-
-          Make sure `/var/www/ephemeral/prep/site-init/customizations.yaml` exists
+          Make sure `${PITDATA}/prep/site-init/customizations.yaml` exists
       action:
         description: |-
-          1. Create the site-init secret to contain /var/www/ephemeral/prep/site-init/customizations.yaml
+          1. Create the site-init secret to contain ${PITDATA}/prep/site-init/customizations.yaml
         command: |-
           kubectl delete secret -n loftsman site-init || true
-          kubectl create secret -n loftsman generic site-init --from-file=/var/www/ephemeral/prep/site-init/customizations.yaml
+          kubectl create secret -n loftsman generic site-init --from-file={{ getEnv "PITDATA" }}/prep/site-init/customizations.yaml
         troubleshooting: |-
           > **`NOTE`** If the `site-init` secret already exists then `kubectl` will error
           > with a message similar to:
@@ -73,7 +73,7 @@ spec:
           > 2. Then recreate it:
           >
           >    ```bash
-          >    pit# kubectl create secret -n loftsman generic site-init --from-file=/var/www/ephemeral/prep/site-init/customizations.yaml
+          >    pit# kubectl create secret -n loftsman generic site-init --from-file=${PITDATA}/prep/site-init/customizations.yaml
           >    ```
           >
           >    Expected output looks similar to the following:

--- a/install/scripts/csm_services/steps/3.deploy_sealed_secret_decryption_key.yaml
+++ b/install/scripts/csm_services/steps/3.deploy_sealed_secret_decryption_key.yaml
@@ -42,7 +42,7 @@ spec:
         description: |-
            Nothing
         command: |-
-          /var/www/ephemeral/prep/site-init/deploy/deploydecryptionkey.sh
+          {{ getEnv "PITDATA" }}/prep/site-init/deploy/deploydecryptionkey.sh
         troubleshooting: |-
           An error similar to the following may occur when deploying the key:
 

--- a/install/scripts/csm_services/steps/4.deploy_csm_application_and_services.yaml
+++ b/install/scripts/csm_services/steps/4.deploy_csm_application_and_services.yaml
@@ -30,7 +30,7 @@ metadata:
     Run `install.sh` to deploy CSM applications services. This command may take 25 minutes or more to run.
 
     ```bash
-    pit# cd /var/www/ephemeral/$CSM_RELEASE
+    pit# cd "${CSM_PATH}"
     pit# ./install.sh
     ```
 
@@ -47,35 +47,36 @@ spec:
   jobs:
     - preCondition:
         description: |-
-          Verify that the `SYSTEM_NAME` and `CSM_RELEASE` environment variables are set:
+          Verify that the `SYSTEM_NAME` and `CSM_PATH` environment variables are set:
         command: |-
           [[ ! -z $SYSTEM_NAME ]] || exit 1
-          [[ ! -z $CSM_RELEASE ]] || exit 1
+          [[ ! -z $CSM_PATH ]] || exit 1
         troubleshooting: |-
           > **`NOTE`** `install.sh` requires various system configuration which are
           > expected to be found in the locations used in proceeding documentation;
           > however, it needs to know `SYSTEM_NAME` in order to find `metallb.yaml` and
           > `sls_input_file.json` configuration files.
           >
-          > Some commands will also need to have the CSM_RELEASE variable set.
+          > Some commands will also need to have the CSM_PATH variable set to the
+          > path of the expanded CSM release tarball.
           >
-          > Verify that the `SYSTEM_NAME` and `CSM_RELEASE` environment variables are set:
+          > Verify that the `SYSTEM_NAME` and `CSM_PATH` environment variables are set:
           >
           > ```bash
           > pit# echo $SYSTEM_NAME
-          > pit# echo $CSM_RELEASE
+          > pit# echo $CSM_PATH
           > ```
           > If they are not set, perform the following:
           >
           > ```bash
           > pit# export SYSTEM_NAME=eniac
-          > pit# export CSM_RELEASE=csm-x.y.z
+          > pit# export CSM_PATH=$PITDATA/csm-x.y.z
           > ```
       action:
         description: |-
           Nothing
         command: |-
-          cd /var/www/ephemeral/{{ getEnv "CSM_RELEASE" }}
+          cd {{ getEnv "CSM_PATH" }}
           ./install.sh
         troubleshooting: |-
           In the event that `install.sh` does not complete successfully, consult the

--- a/install/scripts/csm_services/steps/5.setup_nexus.yaml
+++ b/install/scripts/csm_services/steps/5.setup_nexus.yaml
@@ -89,7 +89,7 @@ spec:
         description: |-
           Nothing
         command: |-
-          cd /var/www/ephemeral/{{ getEnv "CSM_RELEASE" }}
+          cd {{ getEnv "CSM_PATH" }}
           ./lib/setup-nexus.sh
         troubleshooting: |-
           Note that subsequent runs of `setup-nexus.sh` may report `FAIL` when uploading

--- a/install/scripts/csm_services/steps/6.set_management_NCN_to_use_unbound.yaml
+++ b/install/scripts/csm_services/steps/6.set_management_NCN_to_use_unbound.yaml
@@ -113,18 +113,18 @@ spec:
           TODO: make sure passwordless ssh is enabled
           TODO: make sure passwordless ssh to m001 is enabled
         command: |-
-          cd /var/www/ephemeral/{{ getEnv "CSM_RELEASE" }}
+          cd {{ getEnv "CSM_PATH" }}
           ./lib/list-ncns.sh
         troubleshooting: |-
           If any management NCNs are missing from the output, take corrective action before proceeding.
           
-          {{ readFile "../../../install/csm_installation_failure.md" | indent 10 }}
+          {{ readFile "../../csm_installation_failure.md" | indent 10 }}
       action:
         description: |-
           Next, run `lib/set-ncns-to-unbound.sh` to SSH to each management NCN and update
           /etc/resolv.conf to use Unbound as the nameserver.
         command: |-
-          cd /var/www/ephemeral/{{ getEnv "CSM_RELEASE" }}
+          cd {{ getEnv "CSM_PATH" }}
           ./lib/set-ncns-to-unbound.sh
         troubleshooting: |-
           > **`NOTE`** If passwordless SSH is not configured, the administrator will have


### PR DESCRIPTION
# Description

No Jira for this because Jira is sad. This fixes several places in the docs where paths are hardcoded and should be using the PIT variables. It also corrects places where the old CSM_RELEASE format is being assumed.

The install is broken without some of these fixes.

Of course, even with all of these fixes it is currently broken, but less so.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
