### PR TITLE
CASMTRIAGE-3697: Update podman load command for newer podman

### DIFF
--- a/install/scripts/csm_services/steps/1.initialize_bootstrap_registry.yaml
+++ b/install/scripts/csm_services/steps/1.initialize_bootstrap_registry.yaml
@@ -58,7 +58,7 @@ spec:
           > password `admin123`) in order to upload to the bootstrap registry, which
           > is listening on localhost:5000.
         command: |-
-          podman load -i /var/lib/cray/container-images/pit-nexus/skopeo-stable-latest.tar quay.io/skopeo/stable
+          podman load -i /var/lib/cray/container-images/pit-nexus/skopeo-stable-latest.tar
 
           podman run --rm --network host -v {{ getEnv "CSM_PATH" }}/docker:/images:ro \
               quay.io/skopeo/stable sync --scoped --src dir --dest docker --dest-tls-verify=false --dest-creds admin:admin123 \


### PR DESCRIPTION
podman as installed with 1.3 no longer accepts a registry location we now put
that information into the pit-nexus tarball directly.

# Description

Fix for 1.3 issues observed on surtur. Depends on https://github.com/Cray-HPE/pit-nexus/pull/13 going in to work however.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
