### PR TITLE
CASMINST-4954: Linting of BGP procedures

### DIFF
--- a/operations/network/metallb_bgp/Check_BGP_Status_and_Reset_Sessions.md
+++ b/operations/network/metallb_bgp/Check_BGP_Status_and_Reset_Sessions.md
@@ -1,7 +1,13 @@
 # Check BGP Status and Reset Sessions
 
 Check the Border Gateway Protocol \(BGP\) status on the Aruba and Mellanox switches and verify that all sessions are in an Established state.
-If the state of any session in the table is Idle, the BGP sessions must be reset.
+If the state of any session in the table is Idle, then the BGP sessions must be reset.
+
+* [Prerequisites](#prerequisites)
+* [Procedure](#procedure)
+  * [Mellanox](#mellanox)
+  * [Aruba](#aruba)
+* [Further steps](#further-steps)
 
 ## Prerequisites
 
@@ -9,25 +15,28 @@ This procedure requires administrative privileges.
 
 ## Procedure
 
-### MELLANOX
+The following procedures may not resolve the problem after just one attempt. In some cases, the procedures need to be followed multiple times before the situation resolves.
+If problems persist after several attempts, then proceed to the [Further steps](#further-steps) section for additional remediation steps.
+
+### Mellanox
 
 1. Verify that all BGP sessions are in an `ESTABLISHED` state for the Mellanox spine switches.
 
-    SSH to each spine switch to check the status of all BGP sessions.
+    SSH to each spine switch and check the status of all BGP sessions.
 
     1. SSH to a spine switch.
 
         For example:
 
         ```bash
-        ncn-m001# ssh admin@sw-spine-001.mtl
+        ncn# ssh admin@sw-spine-001.mtl
         ```
 
     1. View the status of the BGP sessions.
 
         ```text
-        sw-spine-001 [standalone: master] > enable
-        sw-spine-001 [standalone: master] # show ip bgp summary
+        sw-spine# enable
+        sw-spine# show ip bgp summary
         ```
 
         Example output:
@@ -52,7 +61,7 @@ This procedure requires administrative privileges.
         10.252.1.14       4    65533        3145      3572      50        0      0      1:01:50:41    ESTABLISHED/14
         ```
 
-        If any of the sessions are in an `IDLE` state, proceed to the next step.
+        If any of the sessions are in an `IDLE` state, then proceed to the next step.
 
 1. Reset BGP to re-establish the sessions.
 
@@ -63,21 +72,26 @@ This procedure requires administrative privileges.
         For example:
 
         ```bash
-        ncn-m001# ssh admin@sw-spine-001.mtl
+        ncn# ssh admin@sw-spine-001.mtl
         ```
 
     1. Verify that BGP is enabled.
 
         ```text
-        sw-spine-001 [standalone: master] > show protocols | include bgp
+        sw-spine# show protocols | include bgp
+        ```
+
+        If BGP is enabled, then the output should be similar to the following:
+
+        ```text
          bgp:                    enabled
         ```
 
     1. Clear the BGP sessions.
 
         ```text
-        sw-spine-001 [standalone: master] > enable
-        sw-spine-001 [standalone: master] # clear ip bgp all
+        sw-spine# enable
+        sw-spine# clear ip bgp all
         ```
 
     1. Check the status of the BGP sessions to see if they are now `ESTABLISHED`.
@@ -85,8 +99,8 @@ This procedure requires administrative privileges.
         It may take a few minutes for sessions to become `ESTABLISHED`.
 
         ```text
-        sw-spine-001 [standalone: master] > enable
-        sw-spine-001 [standalone: master] # show ip bgp summary
+        sw-spine# enable
+        sw-spine# show ip bgp summary
         ```
 
         Example output:
@@ -111,28 +125,27 @@ This procedure requires administrative privileges.
         10.252.1.14       4    65533        3145      3572      50        0      0      1:01:50:41    ESTABLISHED/14
         ```
 
-    Once all sessions are in an `ESTABLISHED` state, BGP reset is complete for the Mellanox switches.
+    Once all sessions are in an `ESTABLISHED` state, BGP reset is complete.
 
-    **Troubleshooting:** If some sessions remain `IDLE`, then re-run the Mellanox reset steps to clear and re-check status.
-    If some sessions still remain `IDLE`, then proceed to [reapply the `cray-metallb` helm chart](#reapply), along with the BGP reset,
-    in order to force the speaker pods to re-establish sessions with the switch.
+    **Troubleshooting:** If some sessions remain `Idle`, then re-run the above reset steps to clear and re-check status.
+    If some sessions still remain `Idle`, then proceed to the [Further steps](#further-steps) section.
 
 ### Aruba
 
 1. Verify that all BGP sessions are in an `Established` state for the Aruba spine switches.
 
-    SSH to each spine switch to check the status of all BGP sessions.
+    SSH to each spine switch and check the status of all BGP sessions.
 
     1. SSH to a spine switch.
 
         ```bash
-        ncn-m001# ssh admin@sw-spine-001.mtl
+        ncn# ssh admin@sw-spine-001.mtl
         ```
 
     1. View the status of the BGP sessions.
 
         ```text
-        sw-spine-001# show bgp ipv4 unicast summary
+        sw-spine# show bgp ipv4 unicast summary
         ```
 
         Example output:
@@ -153,7 +166,7 @@ This procedure requires administrative privileges.
          10.252.1.12     65533       34448   39415   00m:01w:04d  Established   Up
         ```
 
-        If any of the sessions are in an `Idle` state, proceed to the next step.
+        If any of the sessions are in an `Idle` state, then proceed to the next step.
 
 1. Reset BGP to re-establish the sessions.
 
@@ -164,13 +177,13 @@ This procedure requires administrative privileges.
         For example:
 
         ```bash
-        ncn-m001# ssh admin@sw-spine-001.mtl
+        ncn# ssh admin@sw-spine-001.mtl
         ```
 
     1. Clear the BGP sessions.
 
         ```text
-        sw-spine-001# clear bgp *
+        sw-spine# clear bgp *
         ```
 
     1. Check the status of the BGP sessions.
@@ -178,7 +191,7 @@ This procedure requires administrative privileges.
         It may take a few minutes for sessions to become `Established`.
 
         ```text
-        sw-spine-001# show bgp ipv4 unicast summary
+        sw-spine# show bgp ipv4 unicast summary
         ```
 
         Example output:
@@ -201,11 +214,12 @@ This procedure requires administrative privileges.
 
     Once all sessions are in an `Established` state, BGP reset is complete for the Aruba switches.
 
-    **Troubleshooting:** If some sessions remain `Idle`, then re-run the Aruba reset steps to clear and re-check status.
-    If some sessions still remain `Idle`, then proceed to the next step to reapply the `cray-metallb` helm chart, along with the
-    BGP reset, in order to force the speaker pods to re-establish sessions with the switch.
+    **Troubleshooting:** If some sessions remain `Idle`, then re-run the above reset steps to clear and re-check status.
+    If some sessions still remain `Idle`, then proceed to the [Further steps](#further-steps) section.
 
 <a name="reapply"></a>
+
+## Further steps
 
 1. Determine the `cray-metallb` chart version that is currently deployed.
 
@@ -219,10 +233,11 @@ This procedure requires administrative privileges.
     cray-metallb   metallb-system   1   2021-02-10 14:58:43.902752441 -0600 CST  deployed  cray-metallb-0.12.2   0.8.1
     ```
 
-1. Create a manifest file that will be used to reapply the same chart version.
+1. Create a manifest file on `ncn-m001` that will be used to reapply the same chart version.
 
-    ```console
-    ncn-m001# cat << EOF > ./metallb-manifest.yaml
+    Create a file named `metallb-manifest.yaml` in the current directory, with the following contents:
+
+    ```yaml
     apiVersion: manifests/v1beta1
     metadata:
       name: reapply-metallb
@@ -233,10 +248,7 @@ This procedure requires administrative privileges.
         values:
           imagesHost: dtr.dev.cray.com
         version: 0.12.2
-    EOF
     ```
-
-1. Open SSH sessions to all spine switches.
 
 1. Determine the `CSM_RELEASE` version that is currently running and set an environment variable.
 
@@ -246,7 +258,7 @@ This procedure requires administrative privileges.
     ncn-m001# CSM_RELEASE=0.8.0
     ```
 
-1. Mount the `PITDATA` so that helm charts are available for the re-install \(it might already be mounted\) and verify that the chart with the expected version exists.
+1. Mount the `PITDATA` so that Helm charts are available for the re-install \(it might already be mounted\) and verify that the chart with the expected version exists.
 
     ```bash
     ncn-m001# mkdir -pv /mnt/pitdata && mount -L PITDATA /mnt/pitdata && \
@@ -259,6 +271,8 @@ This procedure requires administrative privileges.
     /mnt/pitdata/csm-0.8.0/helm/cray-metallb-0.12.2.tgz
     ```
 
+1. Open SSH sessions to all spine switches in other windows.
+
 1. Uninstall the current `cray-metallb` chart.
 
     Until the chart is reapplied, this will also affect unbound name resolution, and all BGP sessions will be Idle for all of the worker nodes.
@@ -269,8 +283,10 @@ This procedure requires administrative privileges.
 
 1. Use the open SSH sessions to the switches to clear the BGP sessions based on the above Mellanox or Aruba procedures.
 
-    * Refer to substeps [1-3](#mellanox-ssh) for Mellanox.
-    * Refer to substeps [1-2](#aruba-ssh) for Aruba.
+    Follow the procedure based on the switch type:
+
+    * [Aruba](#aruba-ssh)
+    * [Mellanox](#mellanox-ssh)
 
 1. Reapply the `cray-metallb` chart based on the `CSM_RELEASE`.
 
@@ -297,7 +313,9 @@ This procedure requires administrative privileges.
     cray-metallb-speaker-h7s7b                 1/1     Running   0          79m
     ```
 
-1. Use the open SSH sessions to the switches to check the status of the BGP sessions.
+1. Use the open SSH sessions to the switches in order to check the status of the BGP sessions.
 
-    * Refer to substeps [1-3](#mellanox-ssh) for Mellanox.
-    * Refer to substeps [1-2](#aruba-ssh) for Aruba.
+    Follow the procedure based on the switch type:
+
+    * [Aruba](#aruba-ssh)
+    * [Mellanox](#mellanox-ssh)


### PR DESCRIPTION
This is a backport of https://github.com/Cray-HPE/docs-csm/pull/2029, but only the linting bits, since the bad command is not present in the 1.0 docs.