### PR TITLE
CASMINST-3717-csm-1.2 - update cray bss update param

### DIFF
--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
@@ -332,7 +332,7 @@ This step updates the entries in BSS for the NCNs to use the new images.
                 kernel=$(cat bss_$xname.json | jq '.[]  .kernel')
                 initrd=$(cat bss_$xname.json | jq '.[]  .initrd')
                 params=$(cat bss_$xname.json | jq '.[]  .params')
-                cray bss bootparameters update --initrd $initrd --kernel $kernel --params $params --name $xname --format json
+                cray bss bootparameters update --initrd $initrd --kernel $kernel --params $params --host $xname --format json
             done
     ```
 
@@ -350,7 +350,7 @@ This step updates the entries in BSS for the NCNs to use the new images.
                 kernel=$(cat bss_$xname.json | jq '.[]  .kernel')
                 initrd=$(cat bss_$xname.json | jq '.[]  .initrd')
                 params=$(cat bss_$xname.json | jq '.[]  .params')
-                cray bss bootparameters update --initrd $initrd --kernel $kernel --params $params --name $xname --format json
+                cray bss bootparameters update --initrd $initrd --kernel $kernel --params $params --host $xname --format json
             done
     ```
 

--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
@@ -332,7 +332,7 @@ This step updates the entries in BSS for the NCNs to use the new images.
                 kernel=$(cat bss_$xname.json | jq '.[]  .kernel')
                 initrd=$(cat bss_$xname.json | jq '.[]  .initrd')
                 params=$(cat bss_$xname.json | jq '.[]  .params')
-                cray bss bootparameters update --initrd $initrd --kernel $kernel --params $params --hosts $xname --format json
+                cray bss bootparameters update --initrd $initrd --kernel $kernel --params "$params" --hosts $xname --format json
             done
     ```
 

--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
@@ -332,7 +332,7 @@ This step updates the entries in BSS for the NCNs to use the new images.
                 kernel=$(cat bss_$xname.json | jq '.[]  .kernel')
                 initrd=$(cat bss_$xname.json | jq '.[]  .initrd')
                 params=$(cat bss_$xname.json | jq '.[]  .params')
-                cray bss bootparameters update --initrd $initrd --kernel $kernel --params $params --host $xname --format json
+                cray bss bootparameters update --initrd $initrd --kernel $kernel --params $params --hosts $xname --format json
             done
     ```
 
@@ -350,7 +350,7 @@ This step updates the entries in BSS for the NCNs to use the new images.
                 kernel=$(cat bss_$xname.json | jq '.[]  .kernel')
                 initrd=$(cat bss_$xname.json | jq '.[]  .initrd')
                 params=$(cat bss_$xname.json | jq '.[]  .params')
-                cray bss bootparameters update --initrd $initrd --kernel $kernel --params $params --host $xname --format json
+                cray bss bootparameters update --initrd $initrd --kernel $kernel --params $params --hosts $xname --format json
             done
     ```
 

--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
@@ -350,7 +350,7 @@ This step updates the entries in BSS for the NCNs to use the new images.
                 kernel=$(cat bss_$xname.json | jq '.[]  .kernel')
                 initrd=$(cat bss_$xname.json | jq '.[]  .initrd')
                 params=$(cat bss_$xname.json | jq '.[]  .params')
-                cray bss bootparameters update --initrd $initrd --kernel $kernel --params $params --hosts $xname --format json
+                cray bss bootparameters update --initrd $initrd --kernel $kernel --params "$params" --hosts $xname --format json
             done
     ```
 


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
- update cray bss update parameter for [operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md](https://github.com/Cray-HPE/docs-csm/blob/release/1.2/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md)
# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
