### PR TITLE
CASMINST-4960

### DIFF
--- a/scripts/hotfixes/kdump/create-kdump-artifacts.sh
+++ b/scripts/hotfixes/kdump/create-kdump-artifacts.sh
@@ -176,6 +176,7 @@ function build_initrd {
         fi
     done
     kdump_cmdline+=( "rd.info" )
+    kdump_cmdline+=( "rd.debug=1" )
     
     # Resolve the filesystem and the live directory dynamically.
     [ -n "${sqfs_label_arg:-''}" ] && sqfs_label="${sqfs_label_arg#*=}"
@@ -192,7 +193,6 @@ function build_initrd {
     # kdump-specific modules to add
     kdump_add=${ADD[*]}
     kdump_add+=( 'kdump' )
-    kdump_add+=( 'rd.debug=1' )
 
     # modules to remove
     kdump_omit=${OMIT[*]}


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
Fixes bad cmdline argument, the argument was not added to the cmdline but the list of modules instead. This adds the debug argument to the cmdline.

The following error is observed without this change:
```bash
dracut: Executing: /usr/bin/dracut -L 4 --force --hostonly --omit "btrfs cifs dmraid dmsquash-live-ntfs fcoe fcoe-uefi iscsi modsign multipath nbd nfs ntfs-3g plymouth resume metalmdsquash metaldmk8s metalluksetcd usrmount" --omit-drivers "ecb mlx5_core mlx5_ib sunrpc xhci_hcd" --add "mdraid kdump rd.debug=1" --fstab --nohardlink --mount "LABEL=SQFSRAID /kdump/live xfs ro" --mount "/kdump/live/LiveOS/filesystem.squashfs /kdump/rootfsbase squashfs ro" --mount "LABEL=ROOTRAID /kdump/overlay xfs" --filesystems xfs --compress "xz -0 --check=crc32" --no-hostonly-default-device --kernel-cmdline "kernel initrd=initrd ifname=mgmt0:14:02:ec:da:50:98 ifname=sun0:14:02:ec:da:50:99 ifname=mgmt1:b4:7a:f1:17:01:3c ifname=sun1:b4:7a:f1:17:01:3d biosdevname=1 pcie_ports=native transparent_hugepage=never console=tty0 console=ttyS0,115200 iommu=pt ds=nocloud-net\;s=http://10.92.100.81:8888/ rootfallback=LABEL=BOOTRAID root=live:LABEL=SQFSRAID rd.live.ram=0 rd.writable.fsimg=0 rd.skipfsck rd.live.squashimg=filesystem.squashfs rd.live.overlay=LABEL=ROOTRAID rd.live.overlay.thin=1 rd.live.overlay.overlayfs=1 rd.luks rd.luks.crypttab=0 rd.lvm.conf=0 rd.lvm=1 rd.auto=1 rd.md=1 rd.dm=0 rd.neednet=0 rd.md.waitclean=1 rd.multipath=0 rd.md.conf=1 rd.bootif=0 hostname=ncn-m002 rd.net.timeout.carrier=120 rd.net.timeout.ifup=120 rd.net.timeout.iflink=120 rd.net.timeout.ipv6auto=0 rd.net.timeout.ipv6dad=0 append nosplash quiet crashkernel=360M log_buf_len=1 rd.retry=10 rd.shell rd.peerdns=0 rd.net.dhcp.retry=5 xname=x3000c0s2b0n0 nid=100008 rd.info" --persistent-policy by-label --mdadmconf --printsize --force-drivers raid1 /boot/initrd-5.3.18-150300.59.43-default-kdump
dracut: dracut module 'modsign' will not be installed, because it's in the list to be omitted!
dracut: dracut module 'plymouth' will not be installed, because it's in the list to be omitted!
dracut: dracut module 'btrfs' will not be installed, because it's in the list to be omitted!
dracut: dracut module 'dmraid' will not be installed, because it's in the list to be omitted!
dracut: dracut module 'dmsquash-live-ntfs' will not be installed, because it's in the list to be omitted!
dracut: dracut module 'metalmdsquash' will not be installed, because it's in the list to be omitted!
dracut: dracut module 'multipath' will not be installed, because it's in the list to be omitted!
dracut: dracut module 'metaldmk8s' will not be installed, because it's in the list to be omitted!
dracut: dracut module 'metalluksetcd' will not be installed, because it's in the list to be omitted!
dracut: dracut module 'cifs' will not be installed, because it's in the list to be omitted!
dracut: dracut module 'fcoe' will not be installed, because it's in the list to be omitted!
dracut: dracut module 'fcoe-uefi' will not be installed, because it's in the list to be omitted!
dracut: dracut module 'iscsi' will not be installed, because it's in the list to be omitted!
dracut: dracut module 'nbd' will not be installed, because it's in the list to be omitted!
dracut: dracut module 'nfs' will not be installed, because it's in the list to be omitted!
dracut: dracut module 'nvmf' will not be installed, because command 'nvme' could not be found!
dracut: dracut module 'resume' will not be installed, because it's in the list to be omitted!
dracut: dracut module 'usrmount' will not be installed, because it's in the list to be omitted!
dracut: dracut module 'rd.debug=1' cannot be found or installed.
```

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
