### PR TITLE
CASMPET-5783: Add note about new nexus export procedure

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -74,7 +74,7 @@ CSM 1.2 contains approximately 2000 changes spanning bug fixes, new feature deve
 * Improved CFS session resiliency after power outages
 * Pod priority class additions to improve upgrades and fail-over
 * New procedure for exporting and restoring Nexus data
-  * [Nexus Export and Restore](operations/package_repository_management/Nexus_Export_and_Restore.md) 
+  * [Nexus Export and Restore](operations/package_repository_management/Nexus_Export_and_Restore.md)
   * New recommendation to take and save off cluster an export of all data using the procedure
 
 ### New hardware support

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -73,6 +73,9 @@ CSM 1.2 contains approximately 2000 changes spanning bug fixes, new feature deve
 * Generic Ansible passthrough parameter added to CFS session API
 * Improved CFS session resiliency after power outages
 * Pod priority class additions to improve upgrades and fail-over
+* New procedure for exporting and restoring Nexus data
+  * [Nexus Export and Restore](operations/package_repository_management/Nexus_Export_and_Restore.md) 
+  * New recommendation to take and save off cluster an export of all data using the procedure
 
 ### New hardware support
 


### PR DESCRIPTION
# Description

This adds in a note in the release notes talking about the new Nexus export and restore procedure. It also gives the recommendation to take an export of Nexus and save it off system.

# Checklist Before Merging


- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
