### PR TITLE
CASMHMS-5561 Update Resource Tuning Instructions for cray-hms-hmcollector 1.2

### DIFF
--- a/operations/hmcollector/adjust_hmcollector_resource_limits_requests.md
+++ b/operations/hmcollector/adjust_hmcollector_resource_limits_requests.md
@@ -1,19 +1,22 @@
 # Adjust HM Collector resource limits and requests
 
-* [Resource Limit Tuning Guidance](#resource-limit-tuning)
-* [Customize cray-hms-hmcollector resource limits and requests in customizations.yaml](#customize-resource-limits)
-* [Redeploy cray-hms-hmcollector with new resource limits and requests](#redeploy-cray-hms-hmcollector)
+* [Resource limit tuning guidance](#resource-limit-tuning-guidance)
+* [Customize `cray-hms-hmcollector` in `customizations.yaml`](#customize-cray-hms-hmcollector-in-customizationsyaml)
+* [Redeploy `cray-hms-hmcollector` with new customizations](#redeploy-cray-hms-hmcollector-with-new-customizations)
 
-<a name="resource-limit-tuning"></a>
+## Resource limit tuning guidance
 
-## Resource Limit Tuning Guidance
+### Inspect current resource usage
 
-### Inspect current resource usage in the cray-hms-hmcollector-ingress pods
+View resource usage of the containers in the `cray-hms-hmcollector-ingress` pods:
 
-View resource usage of the containers in the cray-hms-hmcollector-ingress pods:
+```bash
+ncn-mw# kubectl -n services top pod -l app.kubernetes.io/name=cray-hms-hmcollector-ingress --containers
+```
 
-```console
-ncn-m001# kubectl -n services top pod -l app.kubernetes.io/name=cray-hms-hmcollector-ingress --containers
+Example output:
+
+```text
 POD                                             NAME                           CPU(cores)   MEMORY(bytes)
 cray-hms-hmcollector-ingress-554bb46784-dvjzq   cray-hms-hmcollector-ingress   7m           99Mi
 cray-hms-hmcollector-ingress-554bb46784-dvjzq   istio-proxy                    5m           132Mi
@@ -23,29 +26,27 @@ cray-hms-hmcollector-ingress-554bb46784-zdhwc   cray-hms-hmcollector-ingress   5
 cray-hms-hmcollector-ingress-554bb46784-zdhwc   istio-proxy                    4m           133Mi
 ```
 
-The default resource limits for the cray-hms-hmcollector-ingress containers are:
+The default resource limits for the `cray-hms-hmcollector-ingress` containers are:
 
 * CPU: `4` or `4000m`
-
 * Memory: `5Gi`
 
-The default resource limits for the istio-proxy containers are:
+The default resource limits for the `istio-proxy` containers are:
 
 * CPU: `2` or `2000m`
-
 * Memory: `1Gi`
 
-### Inspect the cray-hms-hmcollector-ingress pods for OOMKilled events
+### Inspect pods for `OOMKilled` events
 
-Describe the cray-hms-hmcollector-ingress pods to determine if it has been OOMKilled in the recent past:
+Describe the `cray-hms-hmcollector-ingress` pods to determine if any have been `OOMKilled` in the recent past:
 
-```console
-ncn-m001# kubectl -n services describe pod -l app.kubernetes.io/name=cray-hms-hmcollector-ingress
+```bash
+ncn-mw# kubectl -n services describe pod -l app.kubernetes.io/name=cray-hms-hmcollector-ingress
 ```
 
-Look for the `cray-hms-hmcollector-ingress` containers and check their `Last State` (if present) to see if the container has been previously terminated due to it running out of memory:
+In the command output, look for the `cray-hms-hmcollector-ingress` and `isitio-proxy` containers. Check their `Last State` (if present) in order to see if the container has been previously terminated because it ran out of memory:
 
-```console
+```text
 [...]
 
 Containers:
@@ -64,16 +65,8 @@ Containers:
       Finished:     Tue, 21 Sep 2021 20:52:12 +0000
 
 [...]
-```
 
-> In the above example output the `cray-hms-hmcollector-ingress` container was previously OOMKilled, but the container is currently running.
-
-Look for the `isitio-proxy` containers and check their `Last State` (if present) to see if the container has been previously terminated due to it running out of memory:
-
-```console
-[...]
-
- istio-proxy:
+  istio-proxy:
     Container ID:  containerd://f7e778cf91eedfa86382aabe2c43f3ae1fcf8fea166013c96b8c6794a53cfe1e
     Image:         artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.8.6-cray2-distroless
     Image ID:      artifactory.algol60.net/csm-docker/stable/istio/proxyv2@sha256:824b59554d6e9765f6226faeaf78902e1df2206b747c05f5b8eb23933eb2e85d
@@ -102,106 +95,105 @@ Look for the `isitio-proxy` containers and check their `Last State` (if present)
 [...]
 ```
 
-> In the above example output the `istio-proxy` container was previously OOMKilled, but the container is currently running.
+In the above example output, the `cray-hms-hmcollector-ingress` and the `istio-proxy` containers were previously `OOMKilled`, but both containers are currently running.
 
-### How to adjust CPU and Memory limits
+### How to adjust resource limits
 
-If the `cray-hms-hmcollector-ingress` containers are hitting their CPU limit and memory usage is steadily increasing till they get OOMKilled, then the CPU limit for `cray-hms-hmcollector-ingress` should be increased.
-It can be increased in increments of `8` or `8000m` This is a situation were the collector is unable to process events fast enough and they start to collect build up inside of it.
+* If the `cray-hms-hmcollector-ingress` containers are hitting their CPU limit and memory usage is steadily increasing until they get `OOMKilled`, then their CPU limit should be increased.
+  It can be increased in increments of `8` or `8000m`. This is a situation were the collector is unable to process events fast enough and they start to build up inside of it.
+* If the `cray-hms-hmcollector-ingress` containers are consistently hitting their CPU limit, then their CPU limit should be increased. It can be increased in increments of `8` or `8000m`.
+* If the `cray-hms-hmcollector-ingress` containers are consistently hitting their memory limit, then their memory limit should be increased. It can be increased in increments of `5Gi`.
+* If the `istio-proxy` container is getting `OOMKilled`, then its memory limit should be increased. It can be increased in increments of `5Gi`.
+* Otherwise, if the `cray-hms-hmcollector-ingress` and `istio-proxy` containers are not hitting their CPU or memory limits, then nothing should be changed.
 
-If the `cray-hms-hmcollector-ingress` containers are consistency hitting their CPU limit, then their CPU limit should be increased. It can be increased in increments of `8` or `8000m`.
+For reference, on a system with four fully populated liquid-cooled cabinets, a single `cray-hms-hmcollector-ingress` pod (with a single replica) was consuming about `5000m` of CPU and
+about `300Mi` of memory.
 
-If the `cray-hms-hmcollector-ingress` containers are consistency hitting their memory limit, then their memory limit should be increased. It can be increased in increments of `5Gi`.
+## Customize `cray-hms-hmcollector` in `customizations.yaml`
 
-If the `istio-proxy` container is getting OOMKilled, then its memory limit should be increased in increments of 5 Gigabytes (`5Gi`) at a time.
+1. If the [`site-init` repository is available as a remote repository](../../install/prepare_site_init.md#push-to-a-remote-repository),
+   then clone it on the host orchestrating the upgrade.
 
-Otherwise, if the `cray-hms-hmcollector-ingress` and `istio-proxy` containers are not hitting their CPU or memory limits nothing needs to change.
-
-For reference, on a system with 4 fully populated liquid cooled cabinets a single `cray-hms-hmcollector-ingress` pod (replicas = 1) was consuming `~5` or `~5000m` of CPU and `~300Mi` of memory.
-
-<a name="customize-resource-limits"></a>
-
-## Customize cray-hms-hmcollector resource limits and requests in customizations.yaml
-
-1. If the [`site-init` repository is available as a remote repository](../../install/prepare_site_init.md#push-to-a-remote-repository)
-   then clone it on the host orchestrating the upgrade:
-
-   ```console
-   ncn-m001# git clone "$SITE_INIT_REPO_URL" site-init
+   ```bash
+   ncn-mw# git clone "$SITE_INIT_REPO_URL" site-init
    ```
 
    Otherwise, create a new `site-init` working tree:
 
-   ```console
-   ncn-m001# git init site-init
+   ```bash
+   ncn-mw# git init site-init
    ```
 
-2. Download `customizations.yaml`:
+1. Download `customizations.yaml`.
 
-   ```console
-   ncn-m001# kubectl get secrets -n loftsman site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d > site-init/customizations.yaml
+   ```bash
+   ncn-mw# kubectl get secrets -n loftsman site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d > site-init/customizations.yaml
    ```
 
-3. Review, add, and commit `customizations.yaml` to the local `site-init`
-   repository as appropriate.
+1. Review, add, and commit `customizations.yaml` to the local `site-init` repository as appropriate.
 
-   > **`NOTE:`** If `site-init` was cloned from a remote repository in step 1,
-   > there may not be any differences and hence nothing to commit. This is
+   > **`NOTE:`** If `site-init` was cloned from a remote repository, then
+   > there may not be any differences, and hence nothing to commit. This is
    > okay. If there are differences between what is in the repository and what
    > was stored in the `site-init`, then it suggests settings were improperly
-   > changed at some point. If that is the case then be cautious, _there may be
-   > dragons ahead_.
+   > changed at some point. If that is the case, then be cautious.
 
-   ```console
-   ncn-m001# cd site-init
-   ncn-m001# git diff
-   ncn-m001# git add customizations.yaml
-   ncn-m001# git commit -m 'Add customizations.yaml from site-init secret'
+   ```bash
+   ncn-mw# cd site-init
+   ncn-mw# git diff
+   ncn-mw# git add customizations.yaml
+   ncn-mw# git commit -m 'Add customizations.yaml from site-init secret'
    ```
 
-4. Update `customizations.yaml` with the existing `cray-hms-hmcollector-ingress` resource limits and requests settings:
+1. Update `customizations.yaml` with the existing `cray-hms-hmcollector-ingress` resource settings.
 
-   Persist resource requests and limits from the cray-hms-hmcollector-ingress deployment:
+   1. Persist resource requests and limits from the `cray-hms-hmcollector-ingress` deployment.
 
-   ```console
-   ncn-m001# kubectl -n services get deployments cray-hms-hmcollector-ingress \
-      -o jsonpath='{.spec.template.spec.containers[].resources}' | yq r -P - | \
-      yq w -f - -i ./customizations.yaml spec.kubernetes.services.cray-hms-hmcollector.collectorIngressConfig.resources
-   ```
+      ```bash
+      ncn-mw# kubectl -n services get deployments cray-hms-hmcollector-ingress \
+                 -o jsonpath='{.spec.template.spec.containers[].resources}' | yq r -P - | \
+                 yq w -f - -i ./customizations.yaml spec.kubernetes.services.cray-hms-hmcollector.collectorIngressConfig.resources
+      ```
 
-   Persist annotations manually added to `cray-hms-hmcollector-ingress` deployment:
+   1. Persist annotations manually added to `cray-hms-hmcollector-ingress` deployment.
 
-   ```console
-   ncn-m001# kubectl -n services get deployments cray-hms-hmcollector-ingress \
-      -o jsonpath='{.spec.template.metadata.annotations}' | \
-      yq d -P - '"traffic.sidecar.istio.io/excludeOutboundPorts"' | \
-      yq w -f - -i ./customizations.yaml spec.kubernetes.services.cray-hms-hmcollector.podAnnotations
-   ```
+      ```bash
+      ncn-mw# kubectl -n services get deployments cray-hms-hmcollector-ingress \
+                 -o jsonpath='{.spec.template.metadata.annotations}' | \
+                 yq d -P - '"traffic.sidecar.istio.io/excludeOutboundPorts"' | \
+                 yq w -f - -i ./customizations.yaml spec.kubernetes.services.cray-hms-hmcollector.podAnnotations
+      ```
 
-   View the updated overrides added to `customizations.yaml`. If the value overrides look different to the sample output below then the resource limits and requests have been manually modified in the past.
+   1. View the updated overrides added to `customizations.yaml`.
 
-   ```console
-   ncn-m001# yq r ./customizations.yaml spec.kubernetes.services.cray-hms-hmcollector
-   ```
+      If the value overrides look different to the sample output below, then the resource limits and requests have been manually modified in the past.
 
-   Example output:
+      ```bash
+      ncn-mw# yq r ./customizations.yaml spec.kubernetes.services.cray-hms-hmcollector
+      ```
 
-   ```yaml
-   hmcollector_external_ip: '{{ network.netstaticips.hmn_api_gw }}'
-   collectorIngressConfig:
-      resources:
-         limits:
-            cpu: "4"
-            memory: 5Gi
-         requests:
-            cpu: 500m
-            memory: 256Mi
-   podAnnotations: {}
-   ```
+      Example output:
 
-5. If desired adjust the resource limits and requests for `cray-hms-hmcollector-ingress`. Otherwise this step can be skipped. Refer to [Resource Limit Tuning Guidance](#resource-limit-tuning) for information on how the resource limits could be adjusted.
+      ```yaml
+      hmcollector_external_ip: '{{ network.netstaticips.hmn_api_gw }}'
+      collectorIngressConfig:
+         resources:
+            limits:
+               cpu: "4"
+               memory: 5Gi
+            requests:
+               cpu: 500m
+               memory: 256Mi
+      podAnnotations: {}
+      ```
 
-   Edit `customizations.yaml` and the value overrides for the `cray-hms-hmcollector-ingress` Helm chart are defined at `spec.kubernetes.services.cray-hms-hmcollector.collectorIngressConfig`
+1. If desired, adjust the resource limits and requests for `cray-hms-hmcollector-ingress`.
+
+   Otherwise this step can be skipped.
+
+   For information on possible adjustments, see [Resource limit tuning guidance](#resource-limit-tuning-guidance).
+
+   The value overrides for the `cray-hms-hmcollector-ingress` Helm chart are defined at `spec.kubernetes.services.cray-hms-hmcollector.collectorIngressConfig`.
 
    Adjust the resource limits and requests for the `cray-hms-hmcollector-ingress` deployment in `customizations.yaml`:
 
@@ -218,7 +210,8 @@ For reference, on a system with 4 fully populated liquid cooled cabinets a singl
                      memory: 256Mi
    ```
 
-   To specify a non-default memory limit for the Istio proxy used by all `cray-hms-hmcollector-*` pods,  `sidecar.istio.io/proxyMemoryLimit` can be added under `podAnnotations`. By default the Istio proxy memory limit is `1Gi`.
+   In order to specify a non-default memory limit for the Istio proxy used by all `cray-hms-hmcollector-*` pods,  add `sidecar.istio.io/proxyMemoryLimit` under `podAnnotations`.
+   By default, the Istio proxy memory limit is `1Gi`.
 
    ```yaml
          cray-hms-hmcollector:
@@ -226,78 +219,82 @@ For reference, on a system with 4 fully populated liquid cooled cabinets a singl
                sidecar.istio.io/proxyMemoryLimit: 5Gi
    ```
 
-6. Review the changes to `customizations.yaml` and verify [baseline system customizations](../../install/prepare_site_init.md#create-baseline-system-customizations)
+1. Review the changes to `customizations.yaml`.
+
+   Verify that [baseline system customizations](../../install/prepare_site_init.md#create-baseline-system-customizations)
    and any customer-specific settings are correct.
 
-   ```console
-   ncn-m001# git diff
+   ```bash
+   ncn-mw# git diff
    ```
 
-7. Add and commit `customizations.yaml` if there are any changes:
+1. Add and commit `customizations.yaml` if there are any changes.
 
-   ```console
-   ncn-m001# git add customizations.yaml
-   ncn-m001# git commit -m "Update customizations.yaml consistent with CSM $CSM_RELEASE_VERSION"
+   ```bash
+   ncn-mw# git add customizations.yaml
+   ncn-mw# git commit -m "Update customizations.yaml consistent with CSM $CSM_RELEASE_VERSION"
    ```
 
-8. Update `site-init` sealed secret in `loftsman` namespace:
+1. Update the `site-init` sealed secret in the `loftsman` namespace.
 
-   ```console
-   ncn-m001# kubectl delete secret -n loftsman site-init
-   ncn-m001# kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
+   ```bash
+   ncn-mw# kubectl delete secret -n loftsman site-init
+   ncn-mw# kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
    ```
 
-9. Push to the remote repository as appropriate:
+1. Push to the remote repository, if applicable.
 
-   ```console
-   ncn-m001# git push
+   ```bash
+   ncn-mw# git push
    ```
 
-10. **If this document was referenced during an upgrade procure, then skip.** Otherwise, continue on to [Redeploy cray-hms-hmcollector with new resource limits and requests](#redeploy-cray-hms-hmcollector)
-    for the the new resource limits and requests to take effect.
+1. **If this document was referenced during an upgrade procure, then skip the rest of this page.**
 
-<a name="redeploy-cray-hms-hmcollector"></a>
+   Otherwise, proceed to [Redeploy `cray-hms-hmcollector` with new customizations](#redeploy-cray-hms-hmcollector-with-new-customizations)
+   in order for the new resource limits and requests to take effect.
 
-## Redeploy cray-hms-hmcollector with new resource limits and requests
+## Redeploy `cray-hms-hmcollector` with new customizations
 
 1. Determine the version of HM Collector:
 
-    ```console
-    ncn-m001# HMCOLLECTOR_VERSION=$(kubectl -n loftsman get cm loftsman-sysmgmt -o jsonpath='{.data.manifest\.yaml}' | yq r - 'spec.charts.(name==cray-hms-hmcollector).version')
-    ncn-m001# echo $HMCOLLECTOR_VERSION
+    ```bash
+    ncn-mw# kubectl -n loftsman get cm loftsman-sysmgmt -o jsonpath='{.data.manifest\.yaml}' | yq r - 'spec.charts.(name==cray-hms-hmcollector).version'
     ```
 
-2. Create `hmcollector-manifest.yaml`:
+1. Create `hmcollector-manifest.yaml` with the following contents.
 
-    ```console
-    ncn-m001# cat > hmcollector-manifest.yaml << EOF
+    > Be sure to replace `<HMCOLLECTOR_VERSION>` with the version determined in the previous step.
+
+    ```yaml
     apiVersion: manifests/v1beta1
     metadata:
         name: hmcollector
     spec:
         charts:
         - name: cray-hms-hmcollector
-          version: $HMCOLLECTOR_VERSION
+          version: <HMCOLLECTOR_VERSION>
           namespace: services
-    EOF
     ```
 
-3. Acquire `customizations.yaml`:
+1. Acquire `customizations.yaml`.
 
-   ```console
-   ncn-m001# kubectl get secrets -n loftsman site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d > customizations.yaml
+   This step can be skipped if the `customizations.yaml` file is still available from the
+   [Customize `cray-hms-hmcollector` in `customizations.yaml`](#customize-cray-hms-hmcollector-in-customizationsyaml) procedure.
+
+   ```bash
+   ncn-mw# kubectl get secrets -n loftsman site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d > customizations.yaml
    ```
 
-4. Merge `customizations.yaml` with `hmcollector-manifest.yaml`:
+1. Merge `customizations.yaml` with `hmcollector-manifest.yaml`.
 
-    ```console
-    ncn-m001# manifestgen -c customizations.yaml -i ./hmcollector-manifest.yaml > ./hmcollector-manifest.out.yaml
+    ```bash
+    ncn-mw# manifestgen -c customizations.yaml -i ./hmcollector-manifest.yaml > ./hmcollector-manifest.out.yaml
     ```
 
-5. Redeploy the HM Collector helm chart:
+1. Redeploy the HM Collector Helm chart.
 
-    ```console
-    ncn-m001# loftsman ship \
-        --charts-repo https://packages.local/repository/charts \
-        --manifest-path hmcollector-manifest.out.yaml
+    ```bash
+    ncn-mw# loftsman ship \
+                --charts-repo https://packages.local/repository/charts \
+                --manifest-path hmcollector-manifest.out.yaml
     ```

--- a/operations/hmcollector/adjust_hmcollector_resource_limits_requests.md
+++ b/operations/hmcollector/adjust_hmcollector_resource_limits_requests.md
@@ -7,42 +7,46 @@
 <a name="resource-limit-tuning"></a>
 ## Resource Limit Tuning Guidance
 
-### Inspect current resource usage in the cray-hms-hmcollector pod
+### Inspect current resource usage in the cray-hms-hmcollector-ingress pods
 
-View resource usage of the containers in the cray-hms-hmcollector pod:
-```bash
-ncn-m001# kubectl -n services top pod -l app.kubernetes.io/name=cray-hms-hmcollector --containers
-POD                                     NAME                   CPU(cores)   MEMORY(bytes)
-cray-hms-hmcollector-7c5b797c5c-zxt67   istio-proxy            187m         275Mi
-cray-hms-hmcollector-7c5b797c5c-zxt67   cray-hms-hmcollector   4398m        296Mi
+View resource usage of the containers in the cray-hms-hmcollector-ingress pods:
+```console
+ncn-m001# kubectl -n services top pod -l app.kubernetes.io/name=cray-hms-hmcollector-ingress --containers
+POD                                             NAME                           CPU(cores)   MEMORY(bytes)
+cray-hms-hmcollector-ingress-554bb46784-dvjzq   cray-hms-hmcollector-ingress   7m           99Mi
+cray-hms-hmcollector-ingress-554bb46784-dvjzq   istio-proxy                    5m           132Mi
+cray-hms-hmcollector-ingress-554bb46784-hctwm   cray-hms-hmcollector-ingress   4m           82Mi
+cray-hms-hmcollector-ingress-554bb46784-hctwm   istio-proxy                    4m           120Mi
+cray-hms-hmcollector-ingress-554bb46784-zdhwc   cray-hms-hmcollector-ingress   5m           97Mi
+cray-hms-hmcollector-ingress-554bb46784-zdhwc   istio-proxy                    4m           133Mi
 ```
 
-The default resource limits for the cray-hms-hmcollector container are:
+The default resource limits for the cray-hms-hmcollector-ingress containers are:
    * CPU: `4` or `4000m`
    * Memory: `5Gi`
 
-The default resource limits for the istio-proxy container are:
+The default resource limits for the istio-proxy containers are:
    * CPU: `2` or `2000m`
    * Memory: `1Gi`
 
-### Inspect the cray-hms-hmcollector pod for OOMKilled events
+### Inspect the cray-hms-hmcollector-ingress pods for OOMKilled events
 
-Describe the collector-hms-hmcollector pod to determine if it has been OOMKilled in the recent past:
+Describe the cray-hms-hmcollector-ingress pods to determine if it has been OOMKilled in the recent past:
 
+```console
+ncn-m001# kubectl -n services describe pod -l app.kubernetes.io/name=cray-hms-hmcollector-ingress
 ```
-ncn-m001# kubectl -n services describe pod -l app.kubernetes.io/name=cray-hms-hmcollector
-```
 
-Look for the `cray-hms-hmcollector` container and check its `Last State` (if present) to see if the container has been previously terminated due to it running out of memory:
+Look for the `cray-hms-hmcollector-ingress` containers and check their `Last State` (if present) to see if the container has been previously terminated due to it running out of memory:
 
-```
+```console
 [...]
 
 Containers:
-  cray-hms-hmcollector:
+  cray-hms-hmcollector-ingress:
     Container ID:   containerd://a35853bacdcea350e70c57fe1667b5b9d3c82d41e1e7c1f901832bae97b722fb
-    Image:          dtr.dev.cray.com/cray/hms-hmcollector:2.10.6
-    Image ID:       dtr.dev.cray.com/cray/hms-hmcollector@sha256:b043617f83b9ff7e542e56af5bbf47f4ca35876f83b5eb07314054726c895b08
+    Image:          artifactory.algol60.net/csm-docker/stable/hms-hmcollector:2.17.0
+    Image ID:       artifactory.algol60.net/csm-docker/stable/hms-hmcollector@sha256:43aa7b7c2361a47e56d2ee05fbe37ace1faedc5292bbce4da5d2e79826a45f81
     Ports:          80/TCP, 443/TCP
     Host Ports:     0/TCP, 0/TCP
     State:          Running
@@ -55,16 +59,16 @@ Containers:
 
 [...]
 ```
-> In the above example output the `cray-hms-hmcollector` container was previously OOMKilled, but the container is currently running.
+> In the above example output the `cray-hms-hmcollector-ingress` container was previously OOMKilled, but the container is currently running.
 
-Look for the `isitio-proxy` container and check its `Last State` (if present) to see if the container has been previously terminated due to it running out of memory:
-```
+Look for the `isitio-proxy` containers and check their `Last State` (if present) to see if the container has been previously terminated due to it running out of memory:
+```console
 [...]
 
  istio-proxy:
-    Container ID:  containerd://f439317c16f7db43e87fbcec59b7d36a0254dabd57ab71865d9d7953d154bb1a
-    Image:         dtr.dev.cray.com/cray/proxyv2:1.7.8-cray1
-    Image ID:      dtr.dev.cray.com/cray/proxyv2@sha256:8f2bccd346381e0399564142f9534c6c76d8d0b8bd637e9440d53bf96a9d86c7
+    Container ID:  containerd://f7e778cf91eedfa86382aabe2c43f3ae1fcf8fea166013c96b8c6794a53cfe1e
+    Image:         artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.8.6-cray2-distroless
+    Image ID:      artifactory.algol60.net/csm-docker/stable/istio/proxyv2@sha256:824b59554d6e9765f6226faeaf78902e1df2206b747c05f5b8eb23933eb2e85d
     Port:          15090/TCP
     Host Port:     0/TCP
     Args:
@@ -92,17 +96,17 @@ Look for the `isitio-proxy` container and check its `Last State` (if present) to
 > In the above example output the `istio-proxy` container was previously OOMKilled, but the container is currently running.
 
 ### How to adjust CPU and Memory limits
-If the `cray-hms-hmcollector` container is hitting its CPU limit and memory usage is steadily increasing till it gets OOMKilled, then the CPU limit for the `cray-hms-hmcollector` should be increased. It can be increased in increments of `8` or `8000m` This is a situation were the collector is unable to process events fast enough and they start to collect build up inside of it.
+If the `cray-hms-hmcollector-ingress` containers are hitting their CPU limit and memory usage is steadily increasing till they get OOMKilled, then the CPU limit for `cray-hms-hmcollector-ingress` should be increased. It can be increased in increments of `8` or `8000m` This is a situation were the collector is unable to process events fast enough and they start to collect build up inside of it.
 
-If the `cray-hms-hmcollector` container is consistency hitting its CPU limit, then its CPU limit should be increased. It can be increased in increments of `8` or `8000m`.
+If the `cray-hms-hmcollector-ingress` containers are consistency hitting their CPU limit, then their CPU limit should be increased. It can be increased in increments of `8` or `8000m`.
 
-If the `cray-hms-hmcollector` container is consistency hitting its memory limit, then its memory limit should be increased. It can be increased in increments of `5Gi`.
+If the `cray-hms-hmcollector-ingress` containers are consistency hitting their memory limit, then their memory limit should be increased. It can be increased in increments of `5Gi`.
 
 If the `istio-proxy` container is getting OOMKilled, then its memory limit should be increased in increments of 5 Gigabytes (`5Gi`) at a time.
 
-Otherwise, if the `cray-hms-hmcollector` and `istio-proxy` containers are not hitting their CPU or memory limits
+Otherwise, if the `cray-hms-hmcollector-ingress` and `istio-proxy` containers are not hitting their CPU or memory limits nothing needs to change.
 
-For reference, on a system with 4 fully populated liquid cooled cabinets the cray-hms-hmcollector was consuming `~5` or `~5000m` of CPU and `~300Mi` of memory.
+For reference, on a system with 4 fully populated liquid cooled cabinets a single `cray-hms-hmcollector-ingress` pod (replicas = 1) was consuming `~5` or `~5000m` of CPU and `~300Mi` of memory.
 
 <a name="customize-resource-limits"></a>
 ## Customize cray-hms-hmcollector resource limits and requests in customizations.yaml
@@ -110,19 +114,19 @@ For reference, on a system with 4 fully populated liquid cooled cabinets the cra
 1. If the [`site-init` repository is available as a remote repository](../../install/prepare_site_init.md#push-to-a-remote-repository)
    then clone it on the host orchestrating the upgrade:
 
-   ```bash
+   ```console
    ncn-m001# git clone "$SITE_INIT_REPO_URL" site-init
    ```
 
    Otherwise, create a new `site-init` working tree:
 
-   ```bash
+   ```console
    ncn-m001# git init site-init
    ```
 
 2. Download `customizations.yaml`:
 
-   ```bash
+   ```console
    ncn-m001# kubectl get secrets -n loftsman site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d > site-init/customizations.yaml
    ```
 
@@ -136,27 +140,27 @@ For reference, on a system with 4 fully populated liquid cooled cabinets the cra
    > changed at some point. If that is the case then be cautious, _there may be
    > dragons ahead_.
 
-   ```bash
+   ```console
    ncn-m001# cd site-init
    ncn-m001# git diff
    ncn-m001# git add customizations.yaml
    ncn-m001# git commit -m 'Add customizations.yaml from site-init secret'
    ```
 
-4. Update `customizations.yaml` with the existing `cray-hms-hmcollector` resource limits and requests settings:
+4. Update `customizations.yaml` with the existing `cray-hms-hmcollector-ingress` resource limits and requests settings:
 
-   Persist resource requests and limits from the cray-hms-hmcollector deployment:
+   Persist resource requests and limits from the cray-hms-hmcollector-ingress deployment:
 
-   ```bash
-   ncn-m001# kubectl -n services get deployments cray-hms-hmcollector \
+   ```console
+   ncn-m001# kubectl -n services get deployments cray-hms-hmcollector-ingress \
       -o jsonpath='{.spec.template.spec.containers[].resources}' | yq r -P - | \
-      yq w -f - -i ./customizations.yaml spec.kubernetes.services.cray-hms-hmcollector.resources
+      yq w -f - -i ./customizations.yaml spec.kubernetes.services.cray-hms-hmcollector.collectorIngressConfig.resources
    ```
 
-   Persist annotations manually added to `cray-hms-hmcollector` deployment:
+   Persist annotations manually added to `cray-hms-hmcollector-ingress` deployment:
 
-   ```bash
-   ncn-m001# kubectl -n services get deployments cray-hms-hmcollector \
+   ```console
+   ncn-m001# kubectl -n services get deployments cray-hms-hmcollector-ingress \
       -o jsonpath='{.spec.template.metadata.annotations}' | \
       yq d -P - '"traffic.sidecar.istio.io/excludeOutboundPorts"' | \
       yq w -f - -i ./customizations.yaml spec.kubernetes.services.cray-hms-hmcollector.podAnnotations
@@ -164,42 +168,44 @@ For reference, on a system with 4 fully populated liquid cooled cabinets the cra
 
    View the updated overrides added to `customizations.yaml`. If the value overrides look different to the sample output below then the resource limits and requests have been manually modified in the past.
 
-   ```bash
+   ```console
    ncn-m001# yq r ./customizations.yaml spec.kubernetes.services.cray-hms-hmcollector
    ```
 
    Example output:
 
-   ```
+   ```yaml
    hmcollector_external_ip: '{{ network.netstaticips.hmn_api_gw }}'
-   resources:
-   limits:
-      cpu: "4"
-      memory: 5Gi
-   requests:
-      cpu: 500m
-      memory: 256Mi
+   collectorIngressConfig:
+      resources:
+         limits:
+            cpu: "4"
+            memory: 5Gi
+         requests:
+            cpu: 500m
+            memory: 256Mi
    podAnnotations: {}
    ```
 
-5. If desired adjust the resource limits and requests for the `cray-hms-hmcollector`. Otherwise this step can be skipped. Refer to [Resource Limit Tuning Guidance](#resource-limit-tuning) for information on how the resource limits could be adjusted.
+5. If desired adjust the resource limits and requests for `cray-hms-hmcollector-ingress`. Otherwise this step can be skipped. Refer to [Resource Limit Tuning Guidance](#resource-limit-tuning) for information on how the resource limits could be adjusted.
 
-   Edit `customizations.yaml` and the value overrides for the `cray-hms-hmcollector` Helm chart are defined at `spec.kubernetes.services.cray-hms-hmcollector`
+   Edit `customizations.yaml` and the value overrides for the `cray-hms-hmcollector-ingress` Helm chart are defined at `spec.kubernetes.services.cray-hms-hmcollector.collectorIngressConfig`
 
-   Adjust the resource limits and requests for the `cray-hms-hmcollector` deployment in `customizations.yaml`:
+   Adjust the resource limits and requests for the `cray-hms-hmcollector-ingress` deployment in `customizations.yaml`:
    ```yaml
          cray-hms-hmcollector:
             hmcollector_external_ip: '{{ network.netstaticips.hmn_api_gw }}'
-            resources:
-               limits:
-                  cpu: "4"
-                  memory: 5Gi
-               requests:
-                  cpu: 500m
-                  memory: 256Mi
+            collectorIngressConfig:
+               resources:
+                  limits:
+                     cpu: "4"
+                     memory: 5Gi
+                  requests:
+                     cpu: 500m
+                     memory: 256Mi
    ```
 
-   To specify a non-default memory limit for the Istio proxy used by the `cray-hms-hmcollector` to pod annotation `sidecar.istio.io/proxyMemoryLimit` can added under `podAnnotations`. By default the Istio proxy memory limit is `1Gi`.
+   To specify a non-default memory limit for the Istio proxy used by all `cray-hms-hmcollector-*` pods,  `sidecar.istio.io/proxyMemoryLimit` can be added under `podAnnotations`. By default the Istio proxy memory limit is `1Gi`.
 
    ```yaml
          cray-hms-hmcollector:
@@ -210,27 +216,27 @@ For reference, on a system with 4 fully populated liquid cooled cabinets the cra
 6. Review the changes to `customizations.yaml` and verify [baseline system customizations](../../install/prepare_site_init.md#create-baseline-system-customizations)
    and any customer-specific settings are correct.
 
-   ```
+   ```console
    ncn-m001# git diff
    ```
 
 7. Add and commit `customizations.yaml` if there are any changes:
 
-   ```
+   ```console
    ncn-m001# git add customizations.yaml
    ncn-m001# git commit -m "Update customizations.yaml consistent with CSM $CSM_RELEASE_VERSION"
    ```
 
 8. Update `site-init` sealed secret in `loftsman` namespace:
 
-   ```bash
+   ```console
    ncn-m001# kubectl delete secret -n loftsman site-init
    ncn-m001# kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
    ```
 
 9. Push to the remote repository as appropriate:
 
-   ```bash
+   ```console
    ncn-m001# git push
    ```
 
@@ -241,14 +247,14 @@ For reference, on a system with 4 fully populated liquid cooled cabinets the cra
 ## Redeploy cray-hms-hmcollector with new resource limits and requests
 1. Determine the version of HM Collector:
 
-    ```bash
+    ```console
     ncn-m001# HMCOLLECTOR_VERSION=$(kubectl -n loftsman get cm loftsman-sysmgmt -o jsonpath='{.data.manifest\.yaml}' | yq r - 'spec.charts.(name==cray-hms-hmcollector).version')
     ncn-m001# echo $HMCOLLECTOR_VERSION
     ```
 
 2. Create `hmcollector-manifest.yaml`:
 
-    ```bash
+    ```console
     ncn-m001# cat > hmcollector-manifest.yaml << EOF
     apiVersion: manifests/v1beta1
     metadata:
@@ -263,19 +269,19 @@ For reference, on a system with 4 fully populated liquid cooled cabinets the cra
 
 3. Acquire `customizations.yaml`:
 
-   ```bash
+   ```console
    ncn-m001# kubectl get secrets -n loftsman site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d > customizations.yaml
    ```
 
 4. Merge `customizations.yaml` with `hmcollector-manifest.yaml`:
 
-    ```bash
+    ```console
     ncn-m001# manifestgen -c customizations.yaml -i ./hmcollector-manifest.yaml > ./hmcollector-manifest.out.yaml
     ```
 
 5. Redeploy the HM Collector helm chart:
 
-    ```bash
+    ```console
     ncn-m001# loftsman ship \
         --charts-repo https://packages.local/repository/charts \
         --manifest-path hmcollector-manifest.out.yaml

--- a/operations/hmcollector/adjust_hmcollector_resource_limits_requests.md
+++ b/operations/hmcollector/adjust_hmcollector_resource_limits_requests.md
@@ -5,11 +5,13 @@
 * [Redeploy cray-hms-hmcollector with new resource limits and requests](#redeploy-cray-hms-hmcollector)
 
 <a name="resource-limit-tuning"></a>
+
 ## Resource Limit Tuning Guidance
 
 ### Inspect current resource usage in the cray-hms-hmcollector-ingress pods
 
 View resource usage of the containers in the cray-hms-hmcollector-ingress pods:
+
 ```console
 ncn-m001# kubectl -n services top pod -l app.kubernetes.io/name=cray-hms-hmcollector-ingress --containers
 POD                                             NAME                           CPU(cores)   MEMORY(bytes)
@@ -22,12 +24,16 @@ cray-hms-hmcollector-ingress-554bb46784-zdhwc   istio-proxy                    4
 ```
 
 The default resource limits for the cray-hms-hmcollector-ingress containers are:
-   * CPU: `4` or `4000m`
-   * Memory: `5Gi`
+
+* CPU: `4` or `4000m`
+
+* Memory: `5Gi`
 
 The default resource limits for the istio-proxy containers are:
-   * CPU: `2` or `2000m`
-   * Memory: `1Gi`
+
+* CPU: `2` or `2000m`
+
+* Memory: `1Gi`
 
 ### Inspect the cray-hms-hmcollector-ingress pods for OOMKilled events
 
@@ -59,9 +65,11 @@ Containers:
 
 [...]
 ```
+
 > In the above example output the `cray-hms-hmcollector-ingress` container was previously OOMKilled, but the container is currently running.
 
 Look for the `isitio-proxy` containers and check their `Last State` (if present) to see if the container has been previously terminated due to it running out of memory:
+
 ```console
 [...]
 
@@ -93,10 +101,13 @@ Look for the `isitio-proxy` containers and check their `Last State` (if present)
 
 [...]
 ```
+
 > In the above example output the `istio-proxy` container was previously OOMKilled, but the container is currently running.
 
 ### How to adjust CPU and Memory limits
-If the `cray-hms-hmcollector-ingress` containers are hitting their CPU limit and memory usage is steadily increasing till they get OOMKilled, then the CPU limit for `cray-hms-hmcollector-ingress` should be increased. It can be increased in increments of `8` or `8000m` This is a situation were the collector is unable to process events fast enough and they start to collect build up inside of it.
+
+If the `cray-hms-hmcollector-ingress` containers are hitting their CPU limit and memory usage is steadily increasing till they get OOMKilled, then the CPU limit for `cray-hms-hmcollector-ingress` should be increased.
+It can be increased in increments of `8` or `8000m` This is a situation were the collector is unable to process events fast enough and they start to collect build up inside of it.
 
 If the `cray-hms-hmcollector-ingress` containers are consistency hitting their CPU limit, then their CPU limit should be increased. It can be increased in increments of `8` or `8000m`.
 
@@ -109,6 +120,7 @@ Otherwise, if the `cray-hms-hmcollector-ingress` and `istio-proxy` containers ar
 For reference, on a system with 4 fully populated liquid cooled cabinets a single `cray-hms-hmcollector-ingress` pod (replicas = 1) was consuming `~5` or `~5000m` of CPU and `~300Mi` of memory.
 
 <a name="customize-resource-limits"></a>
+
 ## Customize cray-hms-hmcollector resource limits and requests in customizations.yaml
 
 1. If the [`site-init` repository is available as a remote repository](../../install/prepare_site_init.md#push-to-a-remote-repository)
@@ -192,6 +204,7 @@ For reference, on a system with 4 fully populated liquid cooled cabinets a singl
    Edit `customizations.yaml` and the value overrides for the `cray-hms-hmcollector-ingress` Helm chart are defined at `spec.kubernetes.services.cray-hms-hmcollector.collectorIngressConfig`
 
    Adjust the resource limits and requests for the `cray-hms-hmcollector-ingress` deployment in `customizations.yaml`:
+
    ```yaml
          cray-hms-hmcollector:
             hmcollector_external_ip: '{{ network.netstaticips.hmn_api_gw }}'
@@ -240,11 +253,13 @@ For reference, on a system with 4 fully populated liquid cooled cabinets a singl
    ncn-m001# git push
    ```
 
-10. __If this document was referenced during an upgrade procure, then skip__ Otherwise, continue on to [Redeploy cray-hms-hmcollector with new resource limits and requests](#redeploy-cray-hms-hmcollector) for the the new resource limits and requests to take effect.
-
+10. **If this document was referenced during an upgrade procure, then skip.** Otherwise, continue on to [Redeploy cray-hms-hmcollector with new resource limits and requests](#redeploy-cray-hms-hmcollector)
+    for the the new resource limits and requests to take effect.
 
 <a name="redeploy-cray-hms-hmcollector"></a>
+
 ## Redeploy cray-hms-hmcollector with new resource limits and requests
+
 1. Determine the version of HM Collector:
 
     ```console


### PR DESCRIPTION
# Description

hms-hmcollector has been split into ingress and poll pods so the ingress pods can run with 3 replicas. This mod updates the hmcollector resource tuning guide to reflect the change.

[CASMHMS-5561](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5561)

# Checklist Before Merging

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
