### PR TITLE
CASMPET-5786 1.3 : DOCS: Update postgres kubectl exec/logs calls to include postgres container

### DIFF
--- a/operations/kubernetes/Troubleshoot_Postgres_Database.md
+++ b/operations/kubernetes/Troubleshoot_Postgres_Database.md
@@ -2,36 +2,47 @@
 
 This page contains general Postgres troubleshooting topics.
 
-- [The `patronictl` tool](#patronictl)
-- [Database unavailable](#Unavailable)
-- [Database disk full](#Diskfull)
-- [Replication lagging](#Lag)
-- [Postgres status `SyncFailed`](#syncfailed)
-- [Cluster member missing](#Missing)
-- [Postgres leader missing](#leader)
+- [The `patronictl` tool](#the-patronictl-tool)
+- [Database unavailable](#database-unavailable)
+- [Database disk full](#database-disk-full)
+- [Replication lagging](#replication-lagging)
+  - [Check if replication is working](#check-if-replication-is-working)
+  - [Recover replication](#recover-replication)
+  - [Setup alerts for replication lag](#setup-alerts-for-replication-lag)
+- [Postgres status `SyncFailed`](#postgres-status-syncfailed)
+  - [Check all the `postgresql` resources](#check-all-the-postgresql-resources)
+    - [Case 1: `some persistent volumes are not compatible with existing resizing providers`](#case-1-some-persistent-volumes-are-not-compatible-with-existing-resizing-providers)
+    - [Case 2: `could not init db connection`](#case-2-could-not-init-db-connection)
+    - [Case 3: `password authentication failed for user`](#case-3-password-authentication-failed-for-user)
+- [Cluster member missing](#cluster-member-missing)
+  - [Determine if a cluster member is missing](#determine-if-a-cluster-member-is-missing)
+  - [Recover from a missing member](#recover-from-a-missing-member)
+- [Postgres leader missing](#postgres-leader-missing)
+  - [Determine if the Postgres leader is missing](#determine-if-the-postgres-leader-is-missing)
+  - [Recover from a missing Postgres leader](#recover-from-a-missing-postgres-leader)
 
 ## The `patronictl` tool
 
 The `patronictl` tool is used to call a REST API that interacts with Postgres databases. It handles a variety of tasks, such as listing cluster members and the replication
 status, configuring and restarting databases, and more.
 
-The tool is installed in the database containers:
+(`ncn-mw#`) The tool is installed in the database containers:
 
 ```bash
 kubectl exec -it -n services keycloak-postgres-0 -c postgres -- su postgres
 ```
 
-Use the following command for more information on the `patronictl` command:
+(`postgres-container#`) Use the following command for more information on the `patronictl` command:
 
 ```bash
-postgres@keycloak-postgres-0:~$ patronictl --help
+patronictl --help
 ```
 
 ## Database unavailable
 
-If there are no endpoints for the main service, Patroni will mark the database as unavailable.
+If there are no endpoints for the main service, then Patroni will mark the database as unavailable.
 
-The following is an example for `keycloak-postgres` where no endpoints are listed, which means the database is unavailable.
+(`ncn-mw#`) The following is an example for `keycloak-postgres` where no endpoints are listed, which means the database is unavailable.
 
 ```bash
 kubectl get endpoints keycloak-postgres -n services
@@ -44,7 +55,9 @@ NAME                ENDPOINTS         AGE
 keycloak-postgres   <none>            3d22h
 ```
 
-If the database is unavailable, check if [Disk Full](#diskfull) is the cause of the issue. Otherwise, check the `postgres-operator` logs for errors.
+If the database is unavailable, then check if [Database disk full](#database-disk-full) is the cause of the issue.
+
+(`ncn-mw#`) Otherwise, check the `postgres-operator` logs for errors.
 
 ```bash
 kubectl logs -l app.kubernetes.io/name=postgres-operator -n services
@@ -52,8 +65,8 @@ kubectl logs -l app.kubernetes.io/name=postgres-operator -n services
 
 ## Database disk full
 
-The following is an example for `keycloak-postgres`. One cluster member is failing to start because of a full `pgdata` disk. This was likely due to replication issues,
-which caused the `pg_wal` files to grow.
+(`ncn-mw#`) The following is an example for `keycloak-postgres`. One cluster member is failing to start because of a full `pgdata` disk. This was likely due to
+replication issues, which caused the `pg_wal` files to grow.
 
 ```bash
 POSTGRESQL=keycloak-postgres
@@ -92,7 +105,7 @@ Filesystem      Size  Used Avail Use% Mounted on
 ```
 
 ```bash
- kubectl logs "${POSTGRESQL}-0" -n ${NAMESPACE} -c postgres | grep FATAL
+kubectl logs "${POSTGRESQL}-0" -n ${NAMESPACE} -c postgres | grep FATAL
 ```
 
 Example output:
@@ -109,7 +122,7 @@ To recover the cluster member that had failed to start because of disk pressure,
 
 `kubectl exec` into that pod, copy the logs off (optional), and then clear the logs in order to recover some disk space. Finally, restart the Postgres cluster and `postgres-operator`.
 
-1. Copy off the logs (optional).
+1. (`ncn-mw#`) Copy off the logs (optional).
 
     ```bash
     kubectl cp "${POSTGRESQL}-1":/home/postgres/pgdata/pgroot/pg_log /tmp -c postgres -n ${NAMESPACE}
@@ -117,18 +130,26 @@ To recover the cluster member that had failed to start because of disk pressure,
 
 1. Clear the logs.
 
-    ```bash
-    kubectl exec "${POSTGRESQL}-1" -n ${NAMESPACE} -c postgres -it -- bash
-    root@cray-smd-postgres-1:/home/for i in {0..7}; do > /home/postgres/pgdata/pgroot/pg_log/postgresql-$i.csv; done
-    ```
+    1. (`ncn-mw#`) Open a shell in the database container.
 
-1. Restart the pods by deleting them.
+        ```bash
+        kubectl exec "${POSTGRESQL}-1" -n ${NAMESPACE} -c postgres -it -- bash
+        ```
+
+    1. (`postgres-container#`) Clear the logs and exit the container.
+
+        ```bash
+        for i in {0..7}; do > /home/postgres/pgdata/pgroot/pg_log/postgresql-$i.csv; done
+        exit
+        ```
+
+1. (`ncn-mw#`) Restart the pods by deleting them.
 
     ```bash
     kubectl delete pod "${POSTGRESQL}-0" "${POSTGRESQL}-1" "${POSTGRESQL}-2" -n ${NAMESPACE}
     ```
 
-1. Restart the operator by deleting it.
+1. (`ncn-mw#`) Restart the operator by deleting it.
 
     ```bash
     kubectl delete pod -l app.kubernetes.io/name=postgres-operator -n services
@@ -150,7 +171,7 @@ The `patronictl list` command will show the status of replication.
 
 #### Replication is working
 
-The following is an example where replication is working:
+(`ncn-mw#`) The following is an example where replication is working:
 
 ```bash
 kubectl exec keycloak-postgres-0 -c postgres -n services -it -- patronictl list
@@ -194,11 +215,16 @@ A reinitialize will get the lagging replica member re-synced and replicating aga
 
 For example:
 
-1. Reinitialize the first lagging replica member.
+1. (`ncn-mw#`) Open a shell into the Postgres container.
 
     ```bash
     kubectl exec keycloak-postgres-1 -c postgres -n services -it -- bash
-    root@keycloak-postgres-1:/home/patronictl reinit keycloak-postgres keycloak-postgres-0
+    ```
+
+1. (`postgres-container#`) Reinitialize the first lagging replica member.
+
+    ```bash
+    patronictl reinit keycloak-postgres keycloak-postgres-0
     ```
 
     Example output:
@@ -210,10 +236,10 @@ For example:
     Success: reinitialize for member keycloak-postgres-0
     ```
 
-1. Reinitialize the next lagging replica member.
+1. (`postgres-container#`) Reinitialize the next lagging replica member.
 
     ```bash
-    root@keycloak-postgres-1:/home/patronictl reinit keycloak-postgres keycloak-postgres-2
+    patronictl reinit keycloak-postgres keycloak-postgres-2
     ```
 
     Example output:
@@ -225,7 +251,7 @@ For example:
     Success: reinitialize for member keycloak-postgres-2
     ```
 
-1. Verify that replication has recovered.
+1. (`ncn-mw#`) Verify that replication has recovered.
 
     ```bash
     kubectl exec keycloak-postgres-0 -c postgres -n services -it -- patronictl list
@@ -247,11 +273,10 @@ For example:
 
 - If `patronictl reinit` fails with `Failed: reinitialize for member` ... `status code=503, (Cluster has no leader, can not reinitialize)`:
 
-    For example:
+    (`ncn-mw#`) For example:
 
     ```bash
-    kubectl exec cray-console-data-postgres-0 -c postgres -n services -- bash
-    root@cray-console-data-postgres-0:~# patronictl reinit cray-console-data-postgres cray-console-data-postgres-1
+    kubectl exec -it cray-console-data-postgres-0 -c postgres -n services -- patronictl reinit cray-console-data-postgres cray-console-data-postgres-1
     ```
 
     Example output:
@@ -270,13 +295,13 @@ For example:
 
     1. Delete the Postgres leader pod and wait for the leader to restart.
 
-        1. Delete the leader pod.
+        1. (`ncn-mw#`) Delete the leader pod.
 
             ```bash
             kubectl delete pod cray-console-data-postgres-0 -n services
             ```
 
-        1. Wait for the leader to restart.
+        1. (`ncn-mw#`) Wait for the leader to restart.
 
             Re-run the following command until it succeeds and reports that the leader pod is `running`.
 
@@ -296,11 +321,11 @@ For example:
             +------------------------------+------------+--------+---------+----+-----------+
             ```
 
-    1. Re-run [Is Replication Lagging?](#lag) to `reinit` any lagging members.
+    1. Re-run [Recover replication](#recover-replication) to `reinit` any lagging members.
 
     1. If the `reinit` still fails, then delete member pods that are still reporting lag. This should clear up any remaining lag.
 
-        1. Determine which pods are reporting lag.
+        1. (`ncn-mw#`) Determine which pods are reporting lag.
 
             ```bash
             kubectl exec cray-console-postgres-0 -c postgres -n services -it -- patronictl list
@@ -318,13 +343,13 @@ For example:
             +------------------------------+------------+--------+---------+----+-----------+
             ```
 
-        1. Delete the pods that are still reporting lag.
+        1. (`ncn-mw#`) Delete the pods that are still reporting lag.
 
             ```bash
             kubectl delete pod cray-console-data-postgres-1 cray-console-data-postgres-2 -n services
             ```
 
-        1. Once the pods restart, verify that the lag has resolved.
+        1. (`ncn-mw#`) Once the pods restart, verify that the lag has resolved.
 
             ```bash
             kubectl exec cray-console-postgres-0 -c postgres -n services -it -- patronictl list
@@ -345,7 +370,7 @@ For example:
 - If a cluster member is `stopped` after a successful reinitialization, check for `pg_internal.init.*` files that may need to be cleaned up. This can occur if the `pgdata`
   disk was full prior to the reinitialization, leaving truncated `pg_internal.init.*` files in the `pgdata` directory.
 
-    1. Determine if any pods are `stopped`.
+    1. (`ncn-mw#`) Determine if any pods are `stopped`.
 
         ```bash
         kubectl exec keycloak-postgres-0 -c postgres -n services -it -- patronictl list
@@ -365,26 +390,31 @@ For example:
 
     1. Check the most recent Postgres log in the `stopped` pod.
 
-        `kubectl exec` into that pod that is `stopped` and check the most recent Postgres log for any `invalid segment number 0` errors relating to `pg_internal.init.*` files.
+        1. (`ncn-mw#`) Open a shell into that pod that is `stopped`.
 
-        ```bash
-        kubectl exec keycloak-postgres-2 -c postgres -n services -it -- bash
-        postgres@keycloak-postgres-2:~$ export LOG=`ls -t /home/postgres/pgdata/pgroot/pg_log/*.csv | head -1`
-        postgres@keycloak-postgres-2:~$ grep pg_internal.init $LOG | grep "invalid segment number 0" | tail -1
-        ```
+            ```bash
+            kubectl exec keycloak-postgres-2 -c postgres -n services -it -- bash
+            ```
 
-        Example output:
+        1. (`postgres-container#`) Check the most recent Postgres log for any `invalid segment number 0` errors relating to `pg_internal.init.*` files.
 
-        ```text
-        2022-02-01 16:59:35.529 UTC,"standby","",227600,"127.0.0.1:42264",61f966f7.37910,3,"sending backup ""pg_basebackup base backup""",2022-02-01 16:59:35 UTC,7/0,0,ERROR,XX000,"invalid segment number 0 in file ""pg_internal.init.2239188""",,,,,,,,,"pg_basebackup"
-        ```
+            ```bash
+            LOG=`ls -t /home/postgres/pgdata/pgroot/pg_log/*.csv | head -1`
+            grep pg_internal.init "$LOG" | grep "invalid segment number 0" | tail -1
+            ```
 
-    1. If the check in the previous step finds such files, then first find any zero length `pg_internal.init.*` files.
+            Example output:
+
+            ```text
+            2022-02-01 16:59:35.529 UTC,"standby","",227600,"127.0.0.1:42264",61f966f7.37910,3,"sending backup ""pg_basebackup base backup""",2022-02-01 16:59:35 UTC,7/0,0,ERROR,XX000,"invalid segment number 0 in file ""pg_internal.init.2239188""",,,,,,,,,"pg_basebackup"
+            ```
+
+    1. (`postgres-container#`) If the check in the previous step finds such files, then first find any zero length `pg_internal.init.*` files.
 
         This command should be run inside the `kubectl exec` session from the previous steps.
 
         ```bash
-        postgres@keycloak-postgres-2:~$ find /home/postgres/pgdata -name pg_internal.init.* -size 0
+        find /home/postgres/pgdata -name pg_internal.init.* -size 0
         ```
 
         Example output:
@@ -395,21 +425,21 @@ For example:
         ./pgroot/data/base/16622/pg_internal.init.2239010
         ```
 
-    1. Delete the zero length `pg_internal.init.*` files.
+    1. (`postgres-container#`) Delete the zero length `pg_internal.init.*` files.
 
         This command should be run inside the `kubectl exec` session from the previous steps.
         Double check the syntax of the command in this step before executing it.
 
         ```bash
-        postgres@keycloak-postgres-2:~$ find /home/postgres/pgdata -name pg_internal.init.* -size 0 -exec rm {} \;
+        find /home/postgres/pgdata -name pg_internal.init.* -size 0 -exec rm {} \;
         ```
 
-    1. Find any non-zero length `pg_internal.init.*` files that were truncated when the file system filled up.
+    1. (`postgres-container#`) Find any non-zero length `pg_internal.init.*` files that were truncated when the file system filled up.
 
         This command should be run inside the `kubectl exec` session from the previous step.
 
         ```bash
-        postgres@keycloak-postgres-2:~$ grep pg_internal.init $LOG | grep "invalid segment number 0" | tail -1
+        grep pg_internal.init $LOG | grep "invalid segment number 0" | tail -1
         ```
 
         Example output:
@@ -418,12 +448,12 @@ For example:
         2022-02-01 16:59:35.529 UTC,"standby","",227600,"127.0.0.1:42264",61f966f7.37910,3,"sending backup ""pg_basebackup base backup""",2022-02-01 16:59:35 UTC,7/0,0,ERROR,XX000,"invalid segment number 0 in file ""pg_internal.init.2239188""",,,,,,,,,"pg_basebackup"
         ```
 
-    1. Locate the non-zero length `pg_internal.init.*` file.
+    1. (`postgres-container#`) Locate the non-zero length `pg_internal.init.*` file.
 
         This command should be run inside the `kubectl exec` session from the previous step.
 
         ```bash
-        postgres@keycloak-postgres-2:~$ find ~/pgdata -name pg_internal.init.2239188
+        find ~/pgdata -name pg_internal.init.2239188
         ```
 
         Example output:
@@ -432,17 +462,17 @@ For example:
         /home/postgres/pgdata/pgroot/data/base/16622/pg_internal.init.2239188
         ```
 
-    1. Delete (or move to a different location) the non-zero length `pg_internal.init.*` file.
+    1. (`postgres-container#`) Delete (or move to a different location) the non-zero length `pg_internal.init.*` file.
 
         This command should be run inside the `kubectl exec` session from the previous step.
 
         ```bash
-        postgres@keycloak-postgres-2:~$ rm /home/postgres/pgdata/pgroot/data/base/16622/pg_internal.init.2239188
+        rm -v /home/postgres/pgdata/pgroot/data/base/16622/pg_internal.init.2239188
         ```
 
     1. Repeat the above steps to find, locate, and delete non-zero length `pg_internal.init.*` files until there are no more new `invalid segment number 0` messages.
 
-    1. Verify that the cluster member has started.
+    1. (`ncn-mw#`) Verify that the cluster member has started.
 
         ```bash
         kubectl exec keycloak-postgres-0 -c postgres -n services -it -- patronictl list
@@ -484,7 +514,7 @@ cause of the issue.
 Other `STATUS` values such as `Updating` are a non-issue. It is expected that this will eventually change to `Running` or possibly `SyncFailed`, if the `postgres-operator`
 encounters issues syncing updates to the `postgresql` cluster.
 
-1. Check for any `postgresql` resource that has a `STATUS` of `SyncFailed`.
+1. (`ncn-mw#`) Check for any `postgresql` resource that has a `STATUS` of `SyncFailed`.
 
     ```bash
     kubectl get postgresql -A
@@ -502,7 +532,7 @@ encounters issues syncing updates to the `postgresql` cluster.
     spire       spire-postgres               spire               11        3      20Gi     1             4Gi              4h10m   Running
     ```
 
-1. Find the the `postgres-operator` pod name.
+1. (`ncn-mw#`) Find the the `postgres-operator` pod name.
 
     ```bash
     kubectl get pods -l app.kubernetes.io/name=postgres-operator -n services
@@ -515,11 +545,11 @@ encounters issues syncing updates to the `postgresql` cluster.
     cray-postgres-operator-6fffc48b4c-mqz7z   2/2     Running   0          5h26m
     ```
 
-1. Check the logs for the `postgres-operator`.
+1. (`ncn-mw#`) Check the logs for the `postgres-operator`.
 
     ```bash
     kubectl logs cray-postgres-operator-6fffc48b4c-mqz7z -n services \
-                -c postgres-operator | grep -i sync | grep -i msg
+        -c postgres-operator | grep -i sync | grep -i msg
     ```
 
 #### Case 1: `some persistent volumes are not compatible with existing resizing providers`
@@ -537,20 +567,34 @@ actual PVCs was not done so the operator and the Postgres cluster are not able t
 underlying Postgres PVCs, additional steps are needed.
 
 The following example assumes that `cray-smd-postgres` is in `SyncFailed` and the volume size was recently increased to `100Gi` (possibly by editing the volume size of
-`postgresql` `cray-smd-postgres` resource), but the `pgdata-cray-smd-postgres` PVC's storage capacity was not updated to align with the change. To confirm this is the case:
+`postgresql` `cray-smd-postgres` resource), but the `pgdata-cray-smd-postgres` PVC's storage capacity was not updated to align with the change.
+
+(`ncn-mw#`) To confirm that this is the case:
 
 ```bash
 kubectl get postgresql cray-smd-postgres -n services -o jsonpath="{.spec.volume.size}"
-100Gi
+```
 
+Example output:
+
+```text
+100Gi
+```
+
+```bash
 kubectl get pvc -n services -l application=spilo,cluster-name=cray-smd-postgres
+```
+
+Example output:
+
+```text
 NAME                         STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS           AGE
 pgdata-cray-smd-postgres-0   Bound    pvc-020cf339-e372-46ae-bc37-de2b55320e88   30Gi       RWO            k8s-block-replicated   70m
 pgdata-cray-smd-postgres-1   Bound    pvc-3d42598a-188e-4301-a58e-0f0ce3944c89   30Gi       RWO            k8s-block-replicated   27m
 pgdata-cray-smd-postgres-2   Bound    pvc-0d659080-7d39-409a-9ee5-1a1806971054   30Gi       RWO            k8s-block-replicated   27m
 ```
 
-To resolve this `SyncFailed` case, resize the `pgdata` PVCs for the selected Postgres cluster. Create the following function in the shell and execute the function by
+(`ncn-mw#`) To resolve this `SyncFailed` case, resize the `pgdata` PVCs for the selected Postgres cluster. Create the following function in the shell and execute the function by
 calling it with the appropriate arguments. For this example the `pgdata-cray-smd-postgres` PVCs will be resized to `100Gi` to match that of the `postgresql`
 `cray-smd-postgres` volume size.
 
@@ -622,13 +666,13 @@ This generally means that some state in the Postgres operator is out of sync wit
 
 To resolve this `SyncFailed` case, restarting the Postgres operator by deleting the pod may clear up the issue.
 
-1. Delete the pod.
+1. (`ncn-mw#`) Delete the pod.
 
     ```bash
     kubectl delete pod -l app.kubernetes.io/name=postgres-operator -n services
     ```
 
-1. Wait for the `postgres-operator` to restart.
+1. (`ncn-mw#`) Wait for the `postgres-operator` to restart.
 
     ```bash
     kubectl get pods -l app.kubernetes.io/name=postgres-operator -n services
@@ -648,7 +692,7 @@ the cluster and the `postgres-operator` may be needed for the service to reconne
 `cray-gitea` service is not able to connect to the Postgres database and the connection has been failing for many hours, restart
 the cluster and operator.
 
-1. Set necessary variables.
+1. (`ncn-mw#`) Set necessary variables.
 
     Replace the values of these variables for the appropriate ones for the particular cluster being remediated.
 
@@ -658,23 +702,23 @@ the cluster and operator.
     NAMESPACE=services
     ```
 
-1. Scale the service to 0.
+1. (`ncn-mw#`) Scale the service to 0.
 
     ```bash
     kubectl scale deployment ${CLIENT} -n ${NAMESPACE} --replicas=0
     ```
 
-1. Restart the Postgres cluster and the `postgres-operator`.
+1. (`ncn-mw#`) Restart the Postgres cluster and the `postgres-operator`.
 
     ```bash
     kubectl delete pod "${POSTGRESQL}-0" "${POSTGRESQL}-1" "${POSTGRESQL}-2" -n ${NAMESPACE}
     kubectl delete pods -n services -lapp.kubernetes.io/name=postgres-operator
     while [ $(kubectl get postgresql ${POSTGRESQL} -n ${NAMESPACE} -o json | jq -r '.status.PostgresClusterStatus') != "Running" ]; do
-                echo "waiting for ${POSTGRESQL} to start running"; sleep 2
-            done
+        echo "waiting for ${POSTGRESQL} to start running"; sleep 2
+    done
     ```
 
-1. Scale the service back to 1 (for different services this may be to 3).
+1. (`ncn-mw#`) Scale the service back to 1 (for different services this may be to 3).
 
     ```bash
     kubectl scale deployment ${CLIENT} -n ${NAMESPACE} --replicas=1
@@ -696,7 +740,7 @@ gather the username and password for the credential from Kubernetes, and update 
 failing to authenticate between the `cray-smd` services and the `cray-smd-postgres` cluster, then get the password for the `postgres` user from the
 Kubernetes secret and update the password in the database.
 
-1. Set necessary variables.
+1. (`ncn-mw#`) Set necessary variables.
 
     ```bash
     CLIENT=cray-smd
@@ -704,17 +748,17 @@ Kubernetes secret and update the password in the database.
     NAMESPACE=services
     ```
 
-1. Scale the service to 0.
+1. (`ncn-mw#`) Scale the service to 0.
 
     ```bash
     kubectl scale deployment ${CLIENT} -n ${NAMESPACE} --replicas=0
     while [ $(kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/name="${CLIENT}" | grep -v NAME | wc -l) != 0 ] ; do
-                echo "  waiting for pods to terminate"
-                sleep 2
-            done
+        echo "  waiting for pods to terminate"
+        sleep 2
+    done
     ```
 
-1. Determine what secrets are associated with the `postgresql` credentials.
+1. (`ncn-mw#`) Determine what secrets are associated with the `postgresql` credentials.
 
     ```bash
     kubectl get secrets -n ${NAMESPACE} | grep "${POSTGRESQL}.credentials"
@@ -731,7 +775,7 @@ Kubernetes secret and update the password in the database.
 
 1. Gather the decoded username and password for the user that is failing to authenticate.
 
-    1. Save the name of the secret with the failing authentication in a variable.
+    1. (`ncn-mw#`) Save the name of the secret with the failing authentication in a variable.
 
         Replace the secret name in this command with the secret determined in the previous step.
 
@@ -739,7 +783,7 @@ Kubernetes secret and update the password in the database.
         SECRET=postgres.cray-smd-postgres.credentials
         ```
 
-    1. Decode the username.
+    1. (`ncn-mw#`) Decode the username.
 
         ```bash
         kubectl get secret ${SECRET} -n ${NAMESPACE} -ojsonpath='{.data.username}' | base64 -d
@@ -751,7 +795,7 @@ Kubernetes secret and update the password in the database.
         postgres
         ```
 
-    1. Decode the password.
+    1. (`ncn-mw#`) Decode the password.
 
         ```bash
         kubectl get secret ${SECRET} -n ${NAMESPACE} -ojsonpath='{.data.password}'| base64 -d
@@ -765,7 +809,7 @@ Kubernetes secret and update the password in the database.
 
 1. Update the username and password in the database.
 
-    1. Determine which pod is the leader.
+    1. (`ncn-mw#`) Determine which pod is the leader.
 
         ```bash
         kubectl exec "${POSTGRESQL}-0" -n ${NAMESPACE} -c postgres -it -- patronictl list
@@ -783,35 +827,46 @@ Kubernetes secret and update the password in the database.
         +-------------------+---------------------+------------+--------+---------+----+-----------+
         ```
 
-    1. `kubectl exec` into the Postgres leader and update the username and password in the database.
+    1. Update the username and password in the database in the Postgres leader container.
 
-        ```console
-        POSTGRES_LEADER=cray-smd-postgres-0
-        kubectl exec ${POSTGRES_LEADER} -n ${NAMESPACE} -c postgres -it -- bash
-        root@cray-smd-postgres-0:/home//usr/bin/psql postgres postgres
-        postgres=# ALTER USER postgres WITH PASSWORD 'ABCXYZ';
-        ALTER ROLE
-        postgres=#
-        ```
+        1. (`ncn-mw#`) Open a shell into the leader container.
 
-1. Restart the `postgresql` cluster.
+            ```bash
+            POSTGRES_LEADER=cray-smd-postgres-0
+            kubectl exec ${POSTGRES_LEADER} -n ${NAMESPACE} -c postgres -it -- bash
+            ```
+
+        1. (`postgres-container#`) Open Postgres.
+
+            ```bash
+            /usr/bin/psql postgres postgres
+            ```
+
+        1. (`postgres#`) Update the username and password in the database.
+
+            ```text
+            ALTER USER postgres WITH PASSWORD 'ABCXYZ';
+            ALTER ROLE
+            ```
+
+1. (`ncn-mw#`) Restart the `postgresql` cluster.
 
     ```bash
     kubectl delete pod "${POSTGRESQL}-0" "${POSTGRESQL}-1" "${POSTGRESQL}-2" -n ${NAMESPACE}
     while [ $(kubectl get postgresql ${POSTGRESQL} -n ${NAMESPACE} -o json | jq -r '.status.PostgresClusterStatus') != "Running" ]; do
-                echo "waiting for ${POSTGRESQL} to start running"
-                sleep 2
-            done
+        echo "waiting for ${POSTGRESQL} to start running"
+        sleep 2
+    done
     ```
 
-1. Scale the service back to 3.
+1. (`ncn-mw#`) Scale the service back to 3.
 
     ```bash
     kubectl scale deployment ${CLIENT} -n ${NAMESPACE} --replicas=3
     while [ $(kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/name="${CLIENT}" | grep -v NAME | wc -l) != 3 ] ; do
-                echo "  waiting for pods to start running"
-                sleep 2
-            done
+        echo "  waiting for pods to start running"
+        sleep 2
+    done
     ```
 
 ## Cluster member missing
@@ -820,7 +875,7 @@ Most services expect to maintain a Postgres cluster consisting of three pods for
 
 ### Determine if a cluster member is missing
 
-For a given Postgres cluster, check how many pods are running.
+(`ncn-mw#`) For a given Postgres cluster, check how many pods are running.
 
 ```bash
 POSTGRESQL=keycloak-postgres
@@ -833,21 +888,21 @@ kubectl get pods -A -l "application=spilo,cluster-name=${POSTGRESQL}"
 If the number of Postgres pods for the given cluster is more or less than expected, increase or decrease as needed. This example will patch
 the `keycloak-postgres` cluster resource so that three pods are running.
 
-1. Set the `POSTGRESQL` and `NAMESPACE` variables.
+1. (`ncn-mw#`) Set the `POSTGRESQL` and `NAMESPACE` variables.
 
     ```bash
     POSTGRESQL=keycloak-postgres
     NAMESPACE=services
     ```
 
-1. Patch the `keycloak-postgres` cluster resource to ensure three pods are running.
+1. (`ncn-mw#`) Patch the `keycloak-postgres` cluster resource to ensure three pods are running.
 
     ```bash
     kubectl patch postgresql "${POSTGRESQL}" -n "${NAMESPACE}" --type='json' \
-                -p='[{"op" : "replace", "path":"/spec/numberOfInstances", "value" : 3}]'
+        -p='[{"op" : "replace", "path":"/spec/numberOfInstances", "value" : 3}]'
     ```
 
-1. Confirm the number of cluster members, otherwise known as pods, by checking the `postgresql` resource.
+1. (`ncn-mw#`) Confirm the number of cluster members, otherwise known as pods, by checking the `postgresql` resource.
 
     ```bash
     kubectl get postgresql ${POSTGRESQL} -n ${NAMESPACE}
@@ -863,7 +918,7 @@ the `keycloak-postgres` cluster resource so that three pods are running.
 1. If a pod is starting but remains in `Pending`, `CrashLoopBackOff`, `ImagePullBackOff`, or other non-`Running` states, then describe
    the pod and get logs from the pod for further analysis.
 
-    1. Find the pod name.
+    1. (`ncn-mw#`) Find the pod name.
 
         ```bash
         kubectl get pods -A -l "application=spilo,cluster-name=${POSTGRESQL}"
@@ -878,13 +933,13 @@ the `keycloak-postgres` cluster resource so that three pods are running.
         services    keycloak-postgres-2   3/3     Running   0          34m
         ```
 
-    1. Describe the pod.
+    1. (`ncn-mw#`) Describe the pod.
 
         ```bash
         kubectl describe pod "${POSTGRESQL}-0" -n ${NAMESPACE}
         ```
 
-    1. View the pod logs.
+    1. (`ncn-mw#`) View the pod logs.
 
         ```bash
         kubectl logs "${POSTGRESQL}-0" -c postgres -n ${NAMESPACE}
@@ -896,14 +951,14 @@ If a Postgres cluster no longer has a leader, the database will need to be recov
 
 ### Determine if the Postgres leader is missing
 
-1. Set the `POSTGRESQL` and `NAMESPACE` variables.
+1. (`ncn-mw#`) Set the `POSTGRESQL` and `NAMESPACE` variables.
 
     ```bash
     POSTGRESQL=cray-smd-postgres
     NAMESPACE=services
     ```
 
-1. Check if the leader is missing.
+1. (`ncn-mw#`) Check if the leader is missing.
 
     ```bash
     kubectl exec ${POSTGRESQL}-0 -n ${NAMESPACE} -c postgres -- patronictl list
@@ -928,7 +983,7 @@ If a Postgres cluster no longer has a leader, the database will need to be recov
     It sometimes happen that the above check reports a leader, but other checks report no leader, or report conflicting
     leader information. The following steps show the status reported by each member of the cluster.
 
-    1. Make a list of the Kubernetes pods of the cluster members.
+    1. (`ncn-mw#`) Make a list of the Kubernetes pods of the cluster members.
 
         ```bash
         PODS=$(kubectl get pods -n ${NAMESPACE} --no-headers -o custom-columns=:.metadata.name | grep "^${POSTGRESQL}-[0-9]$") ; echo ${PODS}
@@ -940,15 +995,15 @@ If a Postgres cluster no longer has a leader, the database will need to be recov
         cray-smd-postgres-0 cray-smd-postgres-1 cray-smd-postgres-2
         ```
 
-    1. Query each pod about the status of the cluster.
+    1. (`ncn-mw#`) Query each pod about the status of the cluster.
 
         This script reports the cluster status as perceived by each member of the cluster.
 
         ```bash
         for POD in ${PODS} ; do
-                    echo "Checking ${POD}..."
-                    kubectl exec ${POD} -n ${NAMESPACE} -c postgres -- curl -s http://localhost:8008/cluster |  jq ; echo
-                done
+            echo "Checking ${POD}..."
+            kubectl exec ${POD} -n ${NAMESPACE} -c postgres -- curl -s http://localhost:8008/cluster |  jq ; echo
+        done
         ```
 
         Example output:

--- a/operations/kubernetes/Troubleshoot_Postgres_Database.md
+++ b/operations/kubernetes/Troubleshoot_Postgres_Database.md
@@ -182,8 +182,6 @@ The following is an example where replication is broken:
 +-------------------+---------------------+--------------+--------+----------+----+-----------+
 ```
 
-
-
 ### Recover replication
 
 In the event that a state of broken Postgres replication persists and the space allocated for the WAL files fills up, the affected database will likely shut down and create a
@@ -199,7 +197,7 @@ For example:
 1. Reinitialize the first lagging replica member.
 
     ```bash
-    kubectl exec keycloak-postgres-1 -n services -it -- bash
+    kubectl exec keycloak-postgres-1 -c postgres -n services -it -- bash
     root@keycloak-postgres-1:/home/patronictl reinit keycloak-postgres keycloak-postgres-0
     ```
 
@@ -252,7 +250,7 @@ For example:
     For example:
 
     ```bash
-    kubectl exec cray-console-data-postgres-0 -n services -- bash
+    kubectl exec cray-console-data-postgres-0 -c postgres -n services -- bash
     root@cray-console-data-postgres-0:~# patronictl reinit cray-console-data-postgres cray-console-data-postgres-1
     ```
 
@@ -370,7 +368,7 @@ For example:
         `kubectl exec` into that pod that is `stopped` and check the most recent Postgres log for any `invalid segment number 0` errors relating to `pg_internal.init.*` files.
 
         ```bash
-        kubectl exec keycloak-postgres-2 -n services -it -- bash
+        kubectl exec keycloak-postgres-2 -c postgres -n services -it -- bash
         postgres@keycloak-postgres-2:~$ export LOG=`ls -t /home/postgres/pgdata/pgroot/pg_log/*.csv | head -1`
         postgres@keycloak-postgres-2:~$ grep pg_internal.init $LOG | grep "invalid segment number 0" | tail -1
         ```
@@ -1048,8 +1046,6 @@ If a Postgres cluster no longer has a leader, the database will need to be recov
 
         If any of the above are not true, this indicates that the cluster members are no longer properly synchronized.
         In this case, attempt the [Recover replication](#recover-replication) remediation procedures.
-
-
 
 ### Recover from a missing Postgres leader
 

--- a/operations/kubernetes/View_Postgres_Information_for_System_Databases.md
+++ b/operations/kubernetes/View_Postgres_Information_for_System_Databases.md
@@ -2,21 +2,21 @@
 
 Postgres uses SQL language to store and manage databases on the system. This procedure describes how to view and obtain helpful information about system databases, as well as the types of data being stored.
 
-### Prerequisites
+## Prerequisites
 
 This procedure requires administrative privileges.
 
-### Procedure
+## Procedure
 
-1.  Log in to the Postgres container.
+1. Log in to the Postgres container.
 
     ```bash
-    kubectl -n services exec -it cray-smd-postgres-0 -- bash
+    kubectl -n services exec -it cray-smd-postgres-0 -c postgres -- bash
     ```
 
     Example output:
 
-    ```
+    ```text
     Defaulting container name to postgres.
     Use 'kubectl describe pod/cray-smd-postgres-0 -n services' to see all of the containers in this pod.
 
@@ -41,7 +41,7 @@ This procedure requires administrative privileges.
     run: /etc/service/pgqd: (pid 25) 487273s
     ```
 
-2.  Log in as the postgres user.
+2. Log in as the `postgres` user.
 
     ```bash
     root@cray-smd-postgres-0:/home/psql -U postgres
@@ -49,14 +49,14 @@ This procedure requires administrative privileges.
 
     Example output:
 
-    ```
+    ```text
     psql (12.2 (Ubuntu 12.2-1.pgdg18.04+1), server 11.7 (Ubuntu 11.7-1.pgdg18.04+1))
     Type "help" for help.
 
     postgres=#
     ```
 
-3.  List the existing databases.
+3. List the existing databases.
 
     ```bash
     postgres=# \l
@@ -64,7 +64,7 @@ This procedure requires administrative privileges.
 
     Example output:
 
-    ```
+    ```text
                                           List of databases
         Name    |      Owner      | Encoding |   Collate   |    Ctype    |   Access privileges
     ------------+-----------------+----------+-------------+-------------+-----------------------
@@ -78,7 +78,7 @@ This procedure requires administrative privileges.
     (5 rows)
     ```
 
-4.  Establish a connection to the desired database.
+4. Establish a connection to the desired database.
 
     In the example below, the `hmsds` database is used.
 
@@ -88,13 +88,13 @@ This procedure requires administrative privileges.
 
     Example output:
 
-    ```
+    ```text
     psql (12.2 (Ubuntu 12.2-1.pgdg18.04+1), server 11.7 (Ubuntu 11.7-1.pgdg18.04+1))
     You are now connected to database "hmsds" as user "postgres".
     hmsds=#
     ```
 
-5.  List the data types that are in the database being viewed.
+5. List the data types that are in the database being viewed.
 
     ```bash
     \dt
@@ -102,7 +102,7 @@ This procedure requires administrative privileges.
 
     Example output:
 
-    ```
+    ```text
                       List of relations
      Schema |          Name           | Type  |   Owner
     --------+-------------------------+-------+-----------
@@ -128,4 +128,3 @@ This procedure requires administrative privileges.
      public | system                  | table | hmsdsuser
     (20 rows)
     ```
-

--- a/operations/kubernetes/View_Postgres_Information_for_System_Databases.md
+++ b/operations/kubernetes/View_Postgres_Information_for_System_Databases.md
@@ -8,7 +8,7 @@ This procedure requires administrative privileges.
 
 ## Procedure
 
-1. Log in to the Postgres container.
+1. (`ncn-mw#`) Log in to the Postgres container.
 
     ```bash
     kubectl -n services exec -it cray-smd-postgres-0 -c postgres -- bash
@@ -41,10 +41,10 @@ This procedure requires administrative privileges.
     run: /etc/service/pgqd: (pid 25) 487273s
     ```
 
-2. Log in as the `postgres` user.
+1. (`postgres-container#`) Log in as the `postgres` user.
 
     ```bash
-    root@cray-smd-postgres-0:/home/psql -U postgres
+    psql -U postgres
     ```
 
     Example output:
@@ -56,10 +56,10 @@ This procedure requires administrative privileges.
     postgres=#
     ```
 
-3. List the existing databases.
+1. (`postgres#`) List the existing databases.
 
-    ```bash
-    postgres=# \l
+    ```text
+    \l
     ```
 
     Example output:
@@ -78,12 +78,12 @@ This procedure requires administrative privileges.
     (5 rows)
     ```
 
-4. Establish a connection to the desired database.
+1. (`postgres#`) Establish a connection to the desired database.
 
     In the example below, the `hmsds` database is used.
 
-    ```bash
-    postgres=# \c hmsds
+    ```text
+    \c hmsds
     ```
 
     Example output:
@@ -94,9 +94,9 @@ This procedure requires administrative privileges.
     hmsds=#
     ```
 
-5. List the data types that are in the database being viewed.
+1. (`postgres#`) List the data types that are in the database being viewed.
 
-    ```bash
+    ```text
     \dt
     ```
 


### PR DESCRIPTION
# Description

Update docs to include postgres container as needed. 
Reviewed all the docs on the main branch and found a few places that also needed updates.
This is a follow on from CASMTRIAGE-3727

# Checklist Before Merging

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
