### PR TITLE
CASMINST-4948: Update CSM version in NCN Personalization Steps

### DIFF
--- a/upgrade/README.md
+++ b/upgrade/README.md
@@ -22,7 +22,7 @@ See [Prepare for Upgrade](prepare_for_upgrade.md).
 
 The upgrade of CSM software will do a controlled, rolling reboot of all management nodes before updating the CSM services.
 
-The upgrade is a guided process starting with [Upgrade Management Nodes and CSM Services](1.2/README.md).
+The upgrade is a guided process starting with [Upgrade Management Nodes and CSM Services](upgrade_ncn_nodes.md).
 
 ## 3. Validate CSM health
 

--- a/upgrade/Stage_5.md
+++ b/upgrade/Stage_5.md
@@ -27,11 +27,11 @@
    The output will contain a section resembling the following:
 
    ```yaml
-   1.2.0:
+   1.3.0:
      configuration:
        clone_url: https://vcs.cmn.SYSTEM_DOMAIN_NAME/vcs/cray/csm-config-management.git
        commit: 43ecfa8236bed625b54325ebb70916f55884b3a4
-       import_branch: cray/csm/1.9.24
+       import_branch: cray/csm/1.10.0
        import_date: 2022-07-28 03:26:01.869501
        ssh_url: git@vcs.cmn.SYSTEM_DOMAIN_NAME:cray/csm-config-management.git
    ```
@@ -65,7 +65,7 @@
 
    ```bash
    /usr/share/doc/csm/scripts/operations/configuration/apply_csm_configuration.sh \
-            [--csm-release 1.2.0] [--git-commit COMMIT] [--ncn-config-file  /path/to/ncn-personalization.json]
+            [--csm-release 1.3.0] [--git-commit COMMIT] [--ncn-config-file  /path/to/ncn-personalization.json]
    ```
 
    For more information on this script, see [Automatically Apply CSM Configuration to NCNs](../operations/CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md#option-1-automatically-apply-csm-configuration).


### PR DESCRIPTION
# Description

Update the version of CSM shown in example output from querying the
product catalog from 1.2.0 to 1.3.0. Also update the import_branch in
that example to show the current 1.10.0 version. This may change before
the release of CSM 1.3.0, but it's okay because it's noted that the
output is an example.

Update the value of the `--csm-release` option for CSM 1.3.0 in the call
to `apply_csm_configuration.sh`. This will default to the latest
version, but if the user specifies it here, they would want to specify
CSM 1.3.0.

Fix broken link in `upgrade/README.md`

The file `upgrade/1.2/README.md` moved to `upgrade/upgrade_ncn_nodes.md`
in CASMINST-4943, but the link in `upgrade/README.md` was not updated,
so the link was broken. Update the link. Note that the contents of that
file still needs to be updated for CSM 1.3. That is not done here.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
