### PR TITLE
CASMHMS-5469 Add Known Issue for custom component roles and subroles in HSM, linting for CSM-1.0

### DIFF
--- a/troubleshooting/interpreting_hms_health_check_results.md
+++ b/troubleshooting/interpreting_hms_health_check_results.md
@@ -1,25 +1,39 @@
 # Interpreting HMS Health Check Results
 
-### Table of contents:
-1. [Introduction](#introduction)
-2. [HMS Smoke Tests](#hms-smoke-tests)
-3. [HMS Functional Tests](#hms-functional-tests)
-4. [Additional Troubleshooting](#additional-troubleshooting)
-5. [Install Blocking vs. Non-Blocking Failures](#blocking-vs-nonblocking-failures)
-6. [Known Issues](#known-issues)
+## Table of contents
 
-<a name="introduction"></a>
-### Introduction
+- [Introduction](#introduction)
+- [HMS smoke tests](#hms-smoke-tests)
+- [HMS functional tests](#hms-functional-tests)
+- [Additional troubleshooting](#additional-troubleshooting)
+  - [`smd_discovery_status_test_ncn-smoke.sh`](#smd_discovery_status_test_ncn-smokesh)
+    - [`HTTPsGetFailed`](#httpsgetfailed)
+    - [`ChildVerificationFailed`](#childverificationfailed)
+    - [`DiscoveryStarted`](#discoverystarted)
+- [Install blocking vs. Non-blocking failures](#install-blocking-vs-non-blocking-failures)
+- [Known issues](#known-issues)
+  - [Warning flags incorrectly set in HSM for Mountain BMCs](#warning-flags-incorrectly-set-in-hsm-for-mountain-bmcs)
+  - [BMCs set to `On` state in HSM](#bmcs-set-to-on-state-in-hsm)
+  - [`ComponentEndpoints` of Redfish subtype `AuxiliaryController` in HSM](#componentendpoints-of-redfish-subtype-auxiliarycontroller-in-hsm)
+  - [Custom Roles and SubRoles for Components in HSM](#custom-roles-and-subroles-for-components-in-hsm)
 
-This document describes how to interpret the results of the HMS Health Check scripts and techniques for troubleshooting when failures occur.
+## Introduction
 
-<a name="hms-smoke-tests"></a>
-### HMS Smoke Tests
+This document describes how to interpret the results of the HMS health check scripts and techniques for troubleshooting when failures occur.
 
-The HMS smoke tests consist of bash scripts that check the status of HMS service pods and jobs in Kubernetes and verify HTTP status codes returned by the HMS service APIs. Additionally, there is one test called `smd_discovery_status_test_ncn-smoke.sh` which verifies that the system hardware has been discovered successfully. The `hms_run_ct_smoke_tests_ncn-resources.sh` wrapper script checks for executable files in the HMS smoke test directory on the NCN and runs all tests found in succession.
+## HMS smoke tests
+
+The HMS smoke tests consist of bash scripts that check the status of HMS service pods and jobs in Kubernetes and verify HTTP status codes returned by the HMS service APIs. Additionally, there is one
+test called `smd_discovery_status_test_ncn-smoke.sh` which verifies that the system hardware has been discovered successfully. The `hms_run_ct_smoke_tests_ncn-resources.sh` wrapper script checks for
+executable files in the HMS smoke test directory on the NCN and runs all tests found in succession.
 
 ```bash
-ncn# /opt/cray/tests/ncn-resources/hms/hms-test/hms_run_ct_smoke_tests_ncn-resources.sh
+ncn-mw# /opt/cray/tests/ncn-resources/hms/hms-test/hms_run_ct_smoke_tests_ncn-resources.sh
+```
+
+Example output:
+
+```text
 searching for HMS CT smoke tests...
 found 11 HMS CT smoke tests...
 running HMS CT smoke tests...
@@ -67,13 +81,19 @@ cleaning up...
 '/opt/cray/tests/ncn-smoke/hms/hms-capmc/capmc_smoke_test_ncn-smoke.sh' exited with status code: 1
 ```
 
-<a name="hms-functional-tests"></a>
-### HMS Functional Tests
+## HMS functional tests
 
-The HMS functional tests consist of Tavern-based API tests for HMS services that are written in yaml and execute within `hms-pytest` containers on the NCNs that are spun up using podman. The functional tests are more rigorous than the smoke tests and verify the behavior of HMS service APIs in greater detail. The `hms_run_ct_functional_tests_ncn-resources.sh` wrapper script checks for executable files in the HMS functional test directory on the NCN and runs all tests found in succession.
+The HMS functional tests consist of Tavern-based API tests for HMS services that are written in YAML and execute within `hms-pytest` containers on the NCNs that are spun up using `podman`. The
+functional tests are more rigorous than the smoke tests and verify the behavior of HMS service APIs in greater detail. The `hms_run_ct_functional_tests_ncn-resources.sh` wrapper script checks for
+executable files in the HMS functional test directory on the NCN and runs all tests found in succession.
 
 ```bash
-ncn# /opt/cray/tests/ncn-resources/hms/hms-test/hms_run_ct_functional_tests_ncn-resources.sh
+ncn-mw# /opt/cray/tests/ncn-resources/hms/hms-test/hms_run_ct_functional_tests_ncn-resources.sh
+```
+
+Initial output will resemble the following:
+
+```text
 searching for HMS CT functional tests...
 found 4 HMS CT functional tests...
 running HMS CT functional tests...
@@ -129,13 +149,14 @@ test_smd_state_change_notifications_ncn-functional_remote-functional.tavern.yaml
 
 When API test failures occur, output from Tavern is printed by `pytest` indicating the following:
 
-* The `Source test stage` that was executing when the failure occurred which is a portion of the source code for the failed test case.
-* The `Formatted stage` that was executing when the failure occurred which is a portion of the source code for the failed test case with its variables filled in with the values that were set at the time of the failure. This includes the request header, method, url, and other options of the failed test case which is useful for attempting to reproduce the failure using the `curl` command.
-* The specific *Errors* encountered when processing the API response that caused the failure. **This is the first place to look when debugging API test failures.**
+- The `Source test stage` that was executing when the failure occurred which is a portion of the source code for the failed test case.
+- The `Formatted stage` that was executing when the failure occurred which is a portion of the source code for the failed test case with its variables filled in with the values that were set at the
+  time of the failure. This includes the request header, method, URL, and other options of the failed test case which is useful for attempting to reproduce the failure using the `curl` command.
+- The specific `Errors` encountered when processing the API response that caused the failure. **This is the first place to look when debugging API test failures.**
 
 The following is an example `Source test stage`:
 
-```text
+```yaml
 Source test stage (line 179):
   - name: Ensure the boot script service can provide the bootscript for a given node
     request:
@@ -155,7 +176,7 @@ Formatted stage:
   name: Ensure the boot script service can provide the bootscript for a given node
   request:
     headers:
-      Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJXcXFhelBLNnNVSnpUV250bThmYWh3cGVLOGRjeTB4SjFpSmRWRGZaLV8wIn0.eyJqdGkiOiI4ZGZkNTQ0YS1jNTY5LTQyNmUtYThiYy02NDg4MzgxOWUyOTAiLCJleHAiOjE2NDQ0MzczODEsIm5iZiI6MCwiaWF0IjoxNjEyOTAxMzgxLCJpc3MiOiJodHRwczovL2FwaS1ndy1zZXJ2aWNlLW5tbi5sb2NhbC9rZXljbG9hay9yZWFsbXMvc2hhc3RhIiwiYXVkIjpbImdhdGVrZWVwZXIiLCJzaGFzdGEiLCJhY2NvdW50Il0sInN1YiI6IjJjNDFiYjgwLTM2NGEtNGNkOS1hMGZkLTQyYzQ5ODRmMTM2ZSIsInR5cCI6IkJlYXJlciIsImF6cCI6ImFkbWluLWNsaWVudCIsImF1dGhfdGltZSI6MCwic2Vzc2lvbl9zdGF0ZSI6IjEzZGQ1YmY2LWQxNGMtNDcwZC05ZWI0LTQ5MDFmYzc3YWYwOSIsImFjciI6IjEiLCJyZWFsbV9hY2Nlc3MiOnsicm9sZXMiOlsib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdfSwicmVzb3VyY2VfYWNjZXNzIjp7InNoYXN0YSI6eyJyb2xlcyI6WyJhZG1pbiJdfSwiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJwcm9maWxlIGVtYWlsIiwiY2xpZW50SG9zdCI6IjEwLjMyLjAuMSIsImNsaWVudElkIjoiYWRtaW4tY2xpZW50IiwiZW1haWxfdmVyaWZpZWQiOmZhbHNlLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJzZXJ2aWNlLWFjY291bnQtYWRtaW4tY2xpZW50IiwiY2xpZW50QWRkcmVzcyI6IjEwLjMyLjAuMSJ9.c37RtSOzcM_-6poyPecS7HP_t1hnqURkgjRcXTQj2S0IEZAkMyfeOVYRFr1gDlAFP-BnRPkf_X2_B7d63j9gI15M1gksYcv8PP0bZFX3PAOaBu-hHGfIw2pDsNsJEA-L72Pb9nmcaPR1CnnVijwRFV-jAmGBJ_vv612mjR5nbI_YJUHDkgdzDfWbpWKQzuCxiJ8USxPD-ASqx_pLecUzcihorb6PNngMaeisc2TqLTV8YRhSZYeL3cssEcXyTxRBe3zjPDawlPArjY2FUkEdzbtl-Tq3D2Ulii44esOf4_ooGmUsOc9vrvYvM_JNPAVamv0-0709PRwwNjFl9nEd5g
+      Authorization: Bearer <REDACTED>
     method: GET
     url: 'https://api-gw-service-nmn.local/apis/bss/boot/v1/bootscript?nid=None'
     verify: !bool 'False'
@@ -165,19 +186,18 @@ Formatted stage:
 
 The following is an example `Errors` section:
 
-```text
+```yaml
 Errors:
 E   tavern.util.exceptions.TestFailError: Test 'Ensure the boot script service can provide the bootscript for a given node' failed:
     - Status code was 400, expected 200:
         {"type": "about:blank", "title": "Bad Request", "detail": "Need a mac=, name=, or nid= parameter", "status": 400}
 ```
 
-<a name="additional-troubleshooting"></a>
-### Additional Troubleshooting
+## Additional troubleshooting
 
-This section provides guidance for handling specific HMS Health Check failures that may occur.
+This section provides guidance for handling specific HMS health check failures that may occur.
 
-#### smd_discovery_status_test_ncn-smoke.sh
+### `smd_discovery_status_test_ncn-smoke.sh`
 
 This test verifies that the system hardware has been discovered successfully.
 
@@ -186,8 +206,8 @@ The following is an example of a failed test execution:
 ```text
 Running smd_discovery_status_test...
 (22:19:34) Running 'kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}''...
-(22:19:34) Running 'curl -k -i -s -S -d grant_type=client_credentials -d client_id=admin-client -d client_secret=4c591ddc-b770-41c8-a4de-465ec034c7cf https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token'...
-(22:19:35) Testing 'curl -s -k -H "Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJEdDZ3ZGNMSzNvT196LWFKaGNkYzBMTkpNSVY5cXRiX25GSXhlRUxCaWFRIn0.eyJqdGkiOiI2NGI0OWE0Zi03YzFiLTRkMjQtYmI2Zi1lYzRhYjczYTI0MDIiLCJleHAiOjE2NTk2NTE1NzQsIm5iZiI6MCwiaWF0IjoxNjI4MTE1NTc0LCJpc3MiOiJodHRwczovL2FwaS1ndy1zZXJ2aWNlLW5tbi5sb2NhbC9rZXljbG9hay9yZWFsbXMvc2hhc3RhIiwiYXVkIjpbImdhdGVrZWVwZXIiLCJzaGFzdGEiLCJhY2NvdW50Il0sInN1YiI6IjdhNGM3YWI5LTMyY2EtNGE5Ny04NGJiLWIzNjc3NmUyZTUwZSIsInR5cCI6IkJlYXJlciIsImF6cCI6ImFkbWluLWNsaWVudCIsImF1dGhfdGltZSI6MCwic2Vzc2lvbl9zdGF0ZSI6ImZjOTdiMzVlLWVjMmUtNGZmYy05NjEzLTg2MDZhY2RiODUxMyIsImFjciI6IjEiLCJyZWFsbV9hY2Nlc3MiOnsicm9sZXMiOlsib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiJdfSwicmVzb3VyY2VfYWNjZXNzIjp7InNoYXN0YSI6eyJyb2xlcyI6WyJhZG1pbiJdfSwiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJlbWFpbCBwcm9maWxlIiwiZW1haWxfdmVyaWZpZWQiOmZhbHNlLCJjbGllbnRIb3N0IjoiMTAuNDYuMC4wIiwiY2xpZW50SWQiOiJhZG1pbi1jbGllbnQiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJzZXJ2aWNlLWFjY291bnQtYWRtaW4tY2xpZW50IiwiY2xpZW50QWRkcmVzcyI6IjEwLjQ2LjAuMCJ9.Moecw0ygc_G5whueojAwT3V6Tqtyp7pmqJlvMS5fMz0NxLhb6-3FYK60N5XIqK4RgXeP8TY004hxMyfel9ZqHwI1e5jC8ZHx0y4N41-1t3dgPZnmxvKiaIE14WfovYFDJGU3xcugZcFAnpylVFIABrPQG4Sk66MVaiOubsqW-i855Z0GZurSJOJMAl6LceJ_ek6OWhVlEsEh3S2phCmUA4C-lxRNviDcXhHThPZ0ruOb9bhtQV5uVD7BviIA_VBBN1BSrNJIfIyps5ZwpYr0KwbnntwbYap8zf56UC5MVz0kOyGk1n6qMlVNKn2W0tB4oTJynBdGgehNIqv93rXZyA" https://api-gw-service-nmn.local/apis/smd/hsm/v1/Inventory/RedfishEndpoints'...
+(22:19:34) Running 'curl -k -i -s -S -d grant_type=client_credentials -d client_id=admin-client -d client_secret=<REDACTED> https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token'...
+(22:19:35) Testing 'curl -s -k -H "Authorization: Bearer <REDACTED>" https://api-gw-service-nmn.local/apis/smd/hsm/v1/Inventory/RedfishEndpoints'...
 (22:19:35) Processing response with: 'jq '.RedfishEndpoints[] | { ID: .ID, LastDiscoveryStatus: .DiscoveryInfo.LastDiscoveryStatus}' -c | sort -V | jq -c'...
 (19:06:02) Verifying endpoint discovery statuses...
 {"ID":"x3000c0s1b0","LastDiscoveryStatus":"HTTPsGetFailed"}
@@ -198,88 +218,109 @@ FAIL: smd_discovery_status_test found 4 endpoints that failed discovery, maximum
 '/opt/cray/tests/ncn-smoke/hms/hms-smd/smd_discovery_status_test_ncn-smoke.sh' exited with status code: 1
 ```
 
-The expected state of LastDiscoveryStatus is `DiscoverOK` for all endpoints with the exception of the BMC for `ncn-m001`, which is not normally connected to the site network and expected to be `HTTPsGetFailed`. If the test fails because of two or more endpoints not having been discovered successfully, the following additional steps can be taken to determine the cause of the failure:
+The expected state of `LastDiscoveryStatus` is `DiscoverOK` for all endpoints with the exception of the BMC for `ncn-m001`, which is not normally connected to the site network and expected to be
+`HTTPsGetFailed`. If the test fails because of two or more endpoints not having been discovered successfully, then take the following additional steps in order to determine the cause of the failure:
 
-##### HTTPsGetFailed
+#### `HTTPsGetFailed`
 
-1. Check to see if the failed component name (xname) resolves using the `nslookup` command. If not, then the problem may be a DNS issue.
-```bash
-ncn# nslookup <xname>
-```
-2. Check to see if the failed component name (xname) responds to the `ping` command. If not, then the problem may be a network or hardware issue.
-```bash
-ncn# ping -c 1 <xname>
-```
-3. Check to see if the failed component name (xname) responds to a Redfish query. If not, then the problem may be a credentials issue. Use the password set in the REDS sealed secret when creating site init.
-```bash
-ncn# curl -s -k -u root:<password> https://<xname>/redfish/v1/Managers | jq
-```
+1. Check to see if the failed component name (xname) resolves using the `nslookup` command.
 
-##### ChildVerificationFailed
+    If not, then the problem may be a DNS issue.
+
+    ```bash
+    ncn-mw# nslookup <xname>
+    ```
+
+1. Check to see if the failed component name (xname) responds to the `ping` command.
+
+    If not, then the problem may be a network or hardware issue.
+
+    ```bash
+    ncn-mw# ping -c 1 <xname>
+    ```
+
+1. Check to see if the failed component name (xname) responds to a Redfish query.
+
+    If not, then the problem may be a credentials issue. Use the password set in the REDS sealed secret.
+
+    ```bash
+    ncn-mw# curl -s -k -u root:<password> https://<xname>/redfish/v1/Managers | jq
+    ```
+
+#### `ChildVerificationFailed`
 
 Check the SMD logs to determine the cause of the bad Redfish path encountered during discovery.
 
-```bash
-# get the SMD pod names
-ncn # kubectl -n services get pods -l app.kubernetes.io/name=cray-smd
-NAME                        READY   STATUS    RESTARTS   AGE
-cray-smd-5b9d574756-9b2lj   2/2     Running   0          24d
-cray-smd-5b9d574756-bnztf   2/2     Running   0          24d
-cray-smd-5b9d574756-hhc5p   2/2     Running   0          24d
+1. Get the SMD pod names.
 
-# get the logs from each of the SMD pods
-ncn# kubectl -n services logs <cray-smd-pod1> cray-smd > smd_pod1_logs
-ncn# kubectl -n services logs <cray-smd-pod2> cray-smd > smd_pod2_logs
-ncn# kubectl -n services logs <cray-smd-pod3> cray-smd > smd_pod3_logs
-```
+    ```bash
+    ncn-mw# kubectl -n services get pods -l app.kubernetes.io/name=cray-smd
+    ```
 
-##### DiscoveryStarted
+    Example output:
 
-The endpoint is in the process of being inventoried by Hardware State Manager (HSM). Wait for the current discovery operation to end which should result in a new LastDiscoveryStatus state being set for the endpoint.
+    ```text
+    NAME                        READY   STATUS    RESTARTS   AGE
+    cray-smd-5b9d574756-9b2lj   2/2     Running   0          24d
+    cray-smd-5b9d574756-bnztf   2/2     Running   0          24d
+    cray-smd-5b9d574756-hhc5p   2/2     Running   0          24d
+    ```
+
+1. Get the logs from each of the SMD pods.
+
+    ```bash
+    ncn-mw# kubectl -n services logs <cray-smd-pod1> cray-smd > smd_pod1_logs
+    ncn-mw# kubectl -n services logs <cray-smd-pod2> cray-smd > smd_pod2_logs
+    ncn-mw# kubectl -n services logs <cray-smd-pod3> cray-smd > smd_pod3_logs
+    ```
+
+#### `DiscoveryStarted`
+
+The endpoint is in the process of being inventoried by Hardware State Manager (HSM). Wait for the current discovery operation to end which should result in a new `LastDiscoveryStatus` state being set for the endpoint.
 
 Use the following command to check the current discovery status of the endpoint:
 
 ```bash
-ncn# cray hsm inventory redfishEndpoints describe <xname>
+ncn-mw# cray hsm inventory redfishEndpoints describe <xname>
 ```
 
-<a name="blocking-vs-nonblocking-failures"></a>
-### Install Blocking vs. Non-Blocking Failures
+## Install blocking vs. Non-blocking failures
 
-The HMS Health Checks include tests for multiple types of system components, some of which are critical for the installation of the system, while others are not.
+The HMS health checks include tests for multiple types of system components, some of which are critical for the installation of the system, while others are not.
 
 The following types of HMS test failures should be considered blocking for system installations:
 
-* HMS service pods not running
-* HMS service APIs unreachable through the API Gateway or Cray CLI
-* Failures related to HMS discovery (unreachable BMCs, unresponsive controller hardware, no Redfish connectivity)
+- HMS service pods not running
+- HMS service APIs unreachable through the API Gateway or Cray CLI
+- Failures related to HMS discovery (for example: unreachable BMCs, unresponsive controller hardware, or no Redfish connectivity)
 
 The following types of HMS test failures should **not** be considered blocking for system installations:
 
-* Failures due to hardware issues on individual compute nodes
+- Failures due to hardware issues on individual compute nodes (alerts or warning flags set in HSM)
 
-It is typically safe to postpone the investigation and resolution of non-blocking failures until after the CSM installation has completed.
+It is typically safe to postpone the investigation and resolution of non-blocking failures until after the CSM installation or upgrade has completed.
 
-<a name="known-issues"></a>
-### Known Issues
+## Known issues
 
-This section outlines known issues that cause HMS Health Check failures.
+This section outlines known issues that cause HMS health check failures.
 
-* [Warning flags incorrectly set in HSM for Mountain BMCs](#hms-known-issue-mountain-bmcs-warning-flags)
-* [BMCs set to "On" state in HSM](#hms-bmcs-set-to-on-state-in-hsm)
-* [ComponentEndpoints of Redfish subtype "AuxiliaryController" in HSM](#hms-component-endpoints-auxiliary-controller-redfish-subtype-hsm)
+- [Warning flags incorrectly set in HSM for Mountain BMCs](#warning-flags-incorrectly-set-in-hsm-for-mountain-bmcs)
+- [BMCs set to `On` state in HSM](#bmcs-set-to-on-state-in-hsm)
+- [`ComponentEndpoints` of Redfish subtype `AuxiliaryController` in HSM](#componentendpoints-of-redfish-subtype-auxiliarycontroller-in-hsm)
+- [Custom Roles and SubRoles for Components in HSM](#custom-roles-and-subroles-for-components-in-hsm)
 
-<a name="hms-known-issue-mountain-bmcs-warning-flags"></a>
-#### Warning flags incorrectly set in HSM for Mountain BMCs
+### Warning flags incorrectly set in HSM for Mountain BMCs
 
-The HMS functional tests include a check for unexpected flags that may be set in Hardware State Manager (HSM) for the BMCs on the system. There is a known issue that can cause Warning flags to be incorrectly set in HSM for Mountain BMCs and result in test failures.
+The HMS functional tests include a check for unexpected flags that may be set in Hardware State Manager (HSM) for the BMCs on the system. There is a known issue that can cause Warning flags to be
+incorrectly set in HSM for Mountain BMCs and result in test failures.
 
 The following HMS functional test may fail due to this issue:
-* `test_smd_components_ncn-functional_remote-functional.tavern.yaml`
+
+- `test_smd_components_ncn-functional_remote-functional.tavern.yaml`
 
 The symptom of this issue is the test fails with error messages about Warning flags being set on one or more BMCs. It may look similar to the following in the test output:
 
-```
+```text
 =================================== FAILURES ===================================
 _ /opt/cray/tests/ncn-functional/hms/hms-smd/test_smd_components_ncn-functional_remote-functional.tavern.yaml::Ensure that we can conduct a query for all Node BMCs in the Component collection _
 
@@ -300,12 +341,18 @@ E   tavern.util.exceptions.TestFailError: Test 'Verify the expected response fie
          - Enum 'Warning' does not exist. Path: '/Components/14/Flag'.: Path: '/'>
 ```
 
-If you see this, perform the following steps:
+If this failure is encountered, then perform the following steps:
 
-1. Retrieve the xnames of all Mountain BMCs with Warning flags set in HSM:
+1. Retrieve the component names (xnames) of all Mountain BMCs with Warning flags set in HSM.
 
+    ```bash
+    ncn-mw# curl -s -k -H "Authorization: Bearer ${TOKEN}" https://api-gw-service-nmn.local/apis/smd/hsm/v1/State/Components?Type=NodeBMC\&Class=Mountain\&Flag=Warning | 
+                jq '.Components[] | { ID: .ID, Flag: .Flag, Class: .Class }' -c | sort -V | jq -c
     ```
-    ncn-mw# curl -s -k -H "Authorization: Bearer ${TOKEN}" https://api-gw-service-nmn.local/apis/smd/hsm/v1/State/Components?Type=NodeBMC\&Class=Mountain\&Flag=Warning | jq '.Components[] | { ID: .ID, Flag: .Flag, Class: .Class }' -c | sort -V | jq -c
+
+    Example output:
+
+    ```json
     {"ID":"x5000c1s0b0","Flag":"Warning","Class":"Mountain"}
     {"ID":"x5000c1s0b1","Flag":"Warning","Class":"Mountain"}
     {"ID":"x5000c1s1b0","Flag":"Warning","Class":"Mountain"}
@@ -316,8 +363,13 @@ If you see this, perform the following steps:
 
 1. For each Mountain BMC xname, check its Redfish BMC Manager status:
 
-    ```
+    ```bash
     ncn-mw# curl -s -k -u root:${BMC_PASSWORD} https://x5000c1s0b0/redfish/v1/Managers/BMC | jq '.Status'
+    ```
+
+    Example output:
+
+    ```json
     {
       "Health": "OK",
       "State": "Online"
@@ -326,15 +378,15 @@ If you see this, perform the following steps:
 
 Test failures and HSM Warning flags for Mountain BMCs with the Redfish BMC Manager status shown above can be safely ignored.
 
-<a name="hms-bmcs-set-to-on-state-in-hsm"></a>
-#### BMCs set to "On" state in HSM
+### BMCs set to `On` state in HSM
 
-The following HMS functional test may fail due to a known issue because of CMMs setting BMC states to "On" instead of "Ready" in HSM:
-* `test_smd_components_ncn-functional_remote-functional.tavern.yaml`
+The following HMS functional test may fail due to a known issue because of CMMs setting BMC states to `On` instead of `Ready` in HSM:
+
+- `test_smd_components_ncn-functional_remote-functional.tavern.yaml`
 
 This issue looks similar to the following in the test output:
 
-```
+```text
       Traceback (most recent call last):
             verifier.validate()
          File "/usr/lib/python3.8/site-packages/pykwalify/core.py", line 166, in validate
@@ -344,17 +396,17 @@ This issue looks similar to the following in the test output:
          - Enum 'On' does not exist. Path: '/Components/10/State'.: Path: '/'>
 ```
 
-Failures of this test caused by BMCs in the "On" state can be safely ignored.
+Failures of this test caused by BMCs in the `On` state can be safely ignored.
 
-<a name="hms-component-endpoints-auxiliary-controller-redfish-subtype-hsm"></a>
-#### ComponentEndpoints of Redfish subtype "AuxiliaryController" in HSM
+### `ComponentEndpoints` of Redfish subtype `AuxiliaryController` in HSM
 
-The following HMS functional test may fail due to a known issue because of ComponentEndpoints of Redfish subtype "AuxiliaryController" in HSM:
-* `test_smd_component_endpoints_ncn-functional_remote-functional.tavern.yaml`
+The following HMS functional test may fail due to a known issue because of `ComponentEndpoints` of Redfish subtype `AuxiliaryController` in HSM:
+
+- `test_smd_component_endpoints_ncn-functional_remote-functional.tavern.yaml`
 
 This issue looks similar to the following in the test output:
 
-```
+```text
         Traceback (most recent call last):
           File "/usr/lib/python3.8/site-packages/tavern/schemas/files.py", line 106, in verify_generic
             verifier.validate()
@@ -368,4 +420,29 @@ This issue looks similar to the following in the test output:
          - Enum 'AuxiliaryController' does not exist. Path: '/ComponentEndpoints/126/RedfishSubtype'.: Path: '/'>
 ```
 
-Failures of this test caused by AuxiliaryController endpoints for Cassini mezzanine cards can be safely ignored.
+Failures of this test caused by `AuxiliaryController` endpoints for Cassini mezzanine cards can be safely ignored.
+
+### Custom Roles and SubRoles for Components in HSM
+
+The following HMS functional test may fail due to a known issue because of Components with custom Roles or SubRoles set in HSM:
+
+- `test_smd_components_ncn-functional_remote-functional.tavern.yaml`
+
+This issue looks similar to the following in the test output:
+
+```text
+        Traceback (most recent call last):
+          File "/usr/lib/python3.8/site-packages/tavern/schemas/files.py", line 106, in verify_generic
+            verifier.validate()
+          File "/usr/lib/python3.8/site-packages/pykwalify/core.py", line 166, in validate
+            raise SchemaError(u"Schema validation failed:\n - {error_msg}.".format(
+        pykwalify.errors.SchemaError: <SchemaError: error code 2: Schema validation failed:
+         - Enum 'DVS' does not exist. Path: '/Components/7/SubRole'.
+         - Enum 'VizNode' does not exist. Path: '/Components/20/SubRole'.
+         - Enum 'CrayDataServices' does not exist. Path: '/Components/147/SubRole'.
+         - Enum 'MI' does not exist. Path: '/Components/165/SubRole'.
+         - Enum 'NearNodeTier0' does not exist. Path: '/Components/198/SubRole'.
+         - Enum 'DataMovers' does not exist. Path: '/Components/1499/SubRole'.: Path: '/'>
+```
+
+Failures of this test caused by custom Component Roles or SubRoles can be safely ignored.


### PR DESCRIPTION
### Summary and Scope

This PR updates the HMS Health Check troubleshooting documentation with an additional Known Issues section about failures related to custom component roles and subroles in HSM. It also includes many formatting and linting updates.

### Issues and Related PRs

* Resolves CASMHMS-5469.

### Testing

Was a fresh Install tested? N/A
Was an Upgrade tested? N/A
Was a Downgrade tested? N/A

### Risks and Mitigations

Low risk, test documentation update.