### PR TITLE
CASMINST-4970: Be consistent in how CSM_RELEASE is used in 1.3

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -635,6 +635,10 @@ lockout-tagout
 # To allow System Admin Toolkit
 Admin
 
+- operations/security_and_authentication/Manage_Sealed_Secrets.md
+# To allow Site Init
+Init
+
 - operations/security_and_authentication/Updating_the_Liquid-Cooled_EX_Cabinet_Default_Credentials_after_a_CEC_Password_Change.md
 # To allow Site Init
 Init

--- a/operations/security_and_authentication/Add_LDAP_User_Federation.md
+++ b/operations/security_and_authentication/Add_LDAP_User_Federation.md
@@ -19,11 +19,11 @@ LDAP user federation is not currently configured in Keycloak. For example, if it
 
    If there is not a backup of `site-init`, perform the following steps to create a new one using the values stored in the Kubernetes cluster.
 
+   1. Set the `CSM_DISTDIR` variable to the path to the unpacked CSM release tarball.
+
+      See [Download and extract CSM product release](../../update_product_stream/README.md#download-and-extract-csm-product-release).
+
    1. Create a new `site-init` directory using the CSM tarball.
-
-      Determine the location of the initial unpacked install tarball and set `${CSM_DISTDIR}` accordingly.
-
-      > **`NOTE`** If the unpacked set of CSM directories was copied, no untar action is required. If the tarball `.tgz` file was copied, the command to unpack it is `tar -zxvf CSM_RELEASE.tar.gz`. Replace the `CSM_RELEASE` value before running the command to unpack the tarball.
 
       ```bash
       cp -r ${CSM_DISTDIR}/shasta-cfg/* /root/site-init

--- a/operations/security_and_authentication/Add_LDAP_User_Federation.md
+++ b/operations/security_and_authentication/Add_LDAP_User_Federation.md
@@ -90,7 +90,8 @@ LDAP user federation is not currently configured in Keycloak. For example, if it
    Other LDAP configuration settings are set in the `spec.kubernetes.services.cray-keycloak-users-localize` field in the `customizations.yaml` file.
 
    A list of the fields follows. The format of the entries in this list is:
-   ```
+
+   ```yaml
      * <cray-keycloak-users-localize chart option name> : <description>
        - default: <the default value if not overridden in customizations.yaml
        - type: <type that the value in customizations.yaml has to be. e.g., if type is string and a number is entered then you need to quote it>
@@ -98,6 +99,7 @@ LDAP user federation is not currently configured in Keycloak. For example, if it
    ```
 
    The fields are:
+
    ```yaml
      * ldapProviderId : The Keycloak provider ID for the component. This must be "ldap"
        - default: ldap
@@ -276,19 +278,19 @@ LDAP user federation is not currently configured in Keycloak. For example, if it
 
       **Troubleshooting:**
 
-      * If the output shows the `skopeo.tar` file cannot be found, then ensure that the `$CSM_DISTDIR` directory looks contains the `dtr.dev.cray.com` directory which includes the originally installed docker images.
+      - If the output shows the `skopeo.tar` file cannot be found, then ensure that the `$CSM_DISTDIR` directory looks contains the `dtr.dev.cray.com` directory which includes the originally installed docker images.
 
          The following is an example of the skopeo.tar file not being found:
 
-         ```bash
+         ```text
          ++ podman load -q -i ./hack/../vendor/skopeo.tar
          ++ sed -e 's/^.*: //'
          + SKOPEO_IMAGE=
          ```
 
-      * If the following overlay error is returned, it could be caused by an earlier podman invocation using a different configuration:
+      - If the following overlay error is returned, it could be caused by an earlier podman invocation using a different configuration:
 
-         ```
+         ```text
          "ERRO[0000] [graphdriver] prior storage driver overlay failed: 'overlay' is not supported over overlayfs, a mount_program is required: backing file system is unsupported for this graph driver"
          ```
 
@@ -307,8 +309,8 @@ LDAP user federation is not currently configured in Keycloak. For example, if it
 
       ```bash
       podman run --rm -v "$(pwd):/data" dtr.dev.cray.com/library/openjdk:11-jre-slim keytool \
-                -importcert -trustcacerts -file /data/<ca-cert.pem> -alias <alias> -keystore /data/certs.jks \
-                -storepass password -noprompt
+         -importcert -trustcacerts -file /data/<ca-cert.pem> -alias <alias> -keystore /data/certs.jks \
+         -storepass password -noprompt
       ```
 
    1. Set variables for the LDAP server.
@@ -316,12 +318,13 @@ LDAP user federation is not currently configured in Keycloak. For example, if it
       In the following example, the LDAP server has the hostname `dcldap2.us.cray.com` and is using the port `636`.
 
       ```bash
-      export LDAP=dcldap2.us.cray.com
-      export PORT=636
+      LDAP=dcldap2.us.cray.com
+      PORT=636
       ```
 
-   1. Get the issuer certificate for the LDAP server at port `636`. Use `openssl s_client` to connect
-      and show the certificate chain returned by the LDAP host.
+   1. Get the issuer certificate for the LDAP server at port `636`.
+
+      Use `openssl s_client` to connect and show the certificate chain returned by the LDAP host.
 
       ```bash
       openssl s_client -showcerts -connect $LDAP:${PORT} </dev/null
@@ -334,14 +337,13 @@ LDAP user federation is not currently configured in Keycloak. For example, if it
       create it automatically.
 
       > **`NOTE`** The following commands were verified using OpenSSL
-      > version 1.1.1d and use the `-nameopt RFC2253` option to ensure
-      > consistent formatting of distinguished names (DNs).
-      > Unfortunately, older versions of OpenSSL may not support
+      > version `1.1.1d` and use the `-nameopt RFC2253` option to ensure
+      > consistent formatting of distinguished names.
+      > Older versions of OpenSSL may not support
       > `-nameopt` on the `s_client` command or may use a different
-      > default format. As a result, mileage may vary; however,
-      > administrators should be able to extract the issuer certificate manually
-      > from the output of the above `openssl s_client` example if the
-      > following commands are unsuccessful.
+      > default format. However, administrators should be able to extract
+      > the issuer certificate manually from the output of the above
+      > `openssl s_client` example, if necessary.
 
       1. Observe the issuer's DN.
 
@@ -349,7 +351,11 @@ LDAP user federation is not currently configured in Keycloak. For example, if it
 
          ```bash
          openssl s_client -showcerts -nameopt RFC2253 -connect $LDAP:${PORT} </dev/null 2>/dev/null | grep issuer= | sed -e 's/^issuer=//'
+         ```
 
+         Example output:
+
+         ```text
          emailAddress=dcops@hpe.com,CN=Data Center,OU=HPC/MCS,O=HPE,ST=WI,C=US
          ```
 
@@ -357,12 +363,12 @@ LDAP user federation is not currently configured in Keycloak. For example, if it
 
          > **`NOTE`** The issuer DN is properly escaped as part of the
          > `awk` pattern below. If the value being used is
-         > different, be sure to escape it properly!
+         > different, then be sure to escape it properly!
 
          ```bash
          openssl s_client -showcerts -nameopt RFC2253 -connect $LDAP:${PORT} </dev/null 2>/dev/null |
-                    awk '/s:emailAddress=dcops@hpe.com,CN=Data Center,OU=HPC\/MCS,O=HPE,ST=WI,C=US/,/END CERTIFICATE/' |
-                    awk '/BEGIN CERTIFICATE/,/END CERTIFICATE/' > cacert.pem
+            awk '/s:emailAddress=dcops@hpe.com,CN=Data Center,OU=HPC\/MCS,O=HPE,ST=WI,C=US/,/END CERTIFICATE/' |
+            awk '/BEGIN CERTIFICATE/,/END CERTIFICATE/' > cacert.pem
          ```
 
    1. Verify the issuer's certificate was properly extracted and saved in `cacert.pem`.
@@ -373,7 +379,7 @@ LDAP user federation is not currently configured in Keycloak. For example, if it
 
       Expected output looks similar to the following:
 
-      ```
+      ```text
       -----BEGIN CERTIFICATE-----
       MIIDvTCCAqWgAwIBAgIUYxrG/PrMcmIzDuJ+U1Gh8hpsU8cwDQYJKoZIhvcNAQEL
       BQAwbjELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAldJMQwwCgYDVQQKDANIUEUxEDAO
@@ -403,8 +409,8 @@ LDAP user federation is not currently configured in Keycloak. For example, if it
 
       ```bash
       podman run --rm -v "$(pwd):/data" dtr.dev.cray.com/library/openjdk:11-jre-slim keytool -importcert \
-                    -trustcacerts -file /data/cacert.pem -alias cray-data-center-ca -keystore /data/certs.jks \
-                    -storepass password -noprompt
+        -trustcacerts -file /data/cacert.pem -alias cray-data-center-ca -keystore /data/certs.jks \
+        -storepass password -noprompt
       ```
 
    1. Create `certs.jks.b64` by base-64 encoding `certs.jks`.
@@ -415,9 +421,9 @@ LDAP user federation is not currently configured in Keycloak. For example, if it
 
    1. Inject and encrypt `certs.jks.b64` into `customizations.yaml`.
 
-      ```bash
-      cat <<EOF | yq w - 'data."certs.jks"' "$(<certs.jks.b64)" |
-                    yq r -j - | /root/site-init/utils/secrets-encrypt.sh |
+      ```console
+      cat <<EOF | yq w - 'data."certs.jks"' "$(<certs.jks.b64)" | \
+                    yq r -j - | /root/site-init/utils/secrets-encrypt.sh | \
                     yq w -f - -i /root/site-init/customizations.yaml \
                     spec.kubernetes.sealed_secrets.cray-keycloak
       {
@@ -461,7 +467,7 @@ LDAP user federation is not currently configured in Keycloak. For example, if it
 
    Expected output looks similar to:
 
-   ```
+   ```text
    Creating Sealed Secret keycloak-certs
    Generating type static_b64...
    Creating Sealed Secret keycloak-master-admin-auth
@@ -503,7 +509,8 @@ LDAP user federation is not currently configured in Keycloak. For example, if it
    ```
 
    Expected output looks similar to the following:
-   ```
+
+   ```text
    ldaps://my_ldap.my_org.test
    ```
 
@@ -558,19 +565,20 @@ LDAP user federation is not currently configured in Keycloak. For example, if it
       kubectl rollout status statefulset -n services cray-keycloak
       ```
 
-1.  Re-apply the `cray-keycloak-users-localize` Helm chart with the updated `customizations.yaml` file.
+1. Re-apply the `cray-keycloak-users-localize` Helm chart with the updated `customizations.yaml` file.
 
-   1.  Determine the `cray-keycloak-users-localize` chart version that is currently deployed.
+   1. Determine the `cray-keycloak-users-localize` chart version that is currently deployed.
 
       ```bash
       helm ls -A -a | grep cray-keycloak-users-localize | awk '{print $(NF-1)}'
       cray-keycloak-users-localize-1.5.6
       ```
 
-   1.  Create a manifest file that will be used to reapply the same chart version.
+   1. Create a manifest file that will be used to reapply the same chart version.
 
-      ```bash
-      cat << EOF > ./cray-keycloak-users-localize-manifest.yaml
+      Create the file `./cray-keycloak-users-localize-manifest.yaml` with the following contents:
+
+      ```yaml
       apiVersion: manifests/v1beta1
       metadata:
         name: reapply-cray-keycloak-users-localize
@@ -579,7 +587,6 @@ LDAP user federation is not currently configured in Keycloak. For example, if it
           - name: cray-keycloak-users-localize
             namespace: services
             version: 1.5.6
-      EOF
       ```
 
    1. Uninstall the current `cray-keycloak-users-localize` chart.
@@ -598,7 +605,7 @@ LDAP user federation is not currently configured in Keycloak. For example, if it
 
       ```bash
       loftsman ship --manifest-path ./deploy.yaml \
-                --charts-repo https://packages.local/repository/charts
+        --charts-repo https://packages.local/repository/charts
       ```
 
    1. Watch the pod to check the status of the job.
@@ -607,16 +614,25 @@ LDAP user federation is not currently configured in Keycloak. For example, if it
 
       ```bash
       kubectl get pods -n services | grep keycloak-users-localize
+      ```
+
+      Example output:
+
+      ```text
       keycloak-users-localize-1-sk2hn                                0/2     Completed   0          2m35s
       ```
 
-   1.  Check the pod's logs.
+   1. Check the pod's logs.
 
       Replace the `KEYCLOAK_POD_NAME` value with the pod name from the previous step.
 
       ```bash
       kubectl logs -n services KEYCLOAK_POD_NAME keycloak-localize
-      <logs showing it has updated the "s3" objects and ConfigMaps>
+      ```
+
+      Example log entry showing that it has updated the "s3" objects and `ConfigMaps`:
+
+      ```text
       2020-07-20 18:26:15,774 - INFO    - keycloak_localize - keycloak-localize complete
       ```
 
@@ -626,10 +642,10 @@ LDAP user federation is not currently configured in Keycloak. For example, if it
 
       ```bash
       kubectl get secret -n services vcs-user-credentials \
-                    --template={{.data.vcs_password}} | base64 --decode
+        --template={{.data.vcs_password}} | base64 --decode
       ```
 
-   1. Checkout content from the `cos-config-management` VCS repository.
+   1. Check out content from the `cos-config-management` VCS repository.
 
       ```bash
       git clone https://api-gw-service-nmn.local/vcs/cray/cos-config-management.git
@@ -639,9 +655,9 @@ LDAP user federation is not currently configured in Keycloak. For example, if it
 
    1. Create the `group_vars/Compute/keycloak.yaml` file.
 
-      The file should contain the following values:
+      The file contents should be:
 
-      ```bash
+      ```yaml
       ---
       keycloak_config_computes: True
       ```
@@ -657,8 +673,12 @@ LDAP user federation is not currently configured in Keycloak. For example, if it
    1. Update the Configuration Framework Service (CFS) configuration.
 
       ```bash
-      cray cfs configurations update configurations-example \
-        --file ./configurations-example.json --format json
+      cray cfs configurations update configurations-example --file ./configurations-example.json --format json
+      ```
+
+      Example output:
+
+      ```json
       {
         "lastUpdated": "2021-07-28T03:26:30:37Z",
         "layers": [
@@ -687,7 +707,7 @@ LDAP user federation is not currently configured in Keycloak. For example, if it
       kubectl get secrets -n services keycloak-master-admin-auth -ojsonpath='{.data.password}' | base64 -d
       ```
 
-   1. Login to the Keycloak UI using the `admin` user and the password obtained in the previous step.
+   1. Log in to the Keycloak UI using the `admin` user and the password obtained in the previous step.
 
       The Keycloak UI URL is typically similar to the following: `https://auth.cmn.<system_name>/keycloak`
 
@@ -698,9 +718,9 @@ LDAP user federation is not currently configured in Keycloak. For example, if it
    1. Verify that a token can be retrieved from Keycloak using an LDAP user/password.
 
       In the example below, replace `myuser`, `mypass`, and `shasta` in the cURL command with
-      site-specific values. The shasta client is created during the SMS install process.
+      site-specific values. The `shasta` client is created during the SMS install process.
 
-      In the following example, the `python -mjson.tool` is not required; it is simply used to
+      In the following example, the `jq` command is not required; it is simply used to
       format the output for readability.
 
       ```bash
@@ -710,7 +730,7 @@ LDAP user federation is not currently configured in Keycloak. For example, if it
          -d username=myuser \
          -d password=mypass \
          https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token |
-         python -mjson.tool
+      jq
       ```
 
       Expected output:
@@ -731,7 +751,7 @@ LDAP user federation is not currently configured in Keycloak. For example, if it
    1. Validate that the `access_token` looks correct.
 
       Copy the `access_token` from the previous step and open a browser window.
-      Navigate to http://jwt.io and paste the token in the `Encoded` field.
+      Navigate to `http://jwt.io` and paste the token in the `Encoded` field.
 
       Verify that the `preferred_username` is the expected LDAP user, and that the
       role is `admin` (or other role appropriate for the user).

--- a/operations/security_and_authentication/Manage_Sealed_Secrets.md
+++ b/operations/security_and_authentication/Manage_Sealed_Secrets.md
@@ -50,13 +50,11 @@ If LDAP user federation is required, then refer to
    If there is not a backup of `site-init`, perform the following steps to create a new one using the
    values stored in the Kubernetes cluster.
 
+   1. Set the `CSM_DISTDIR` variable to the path to the unpacked CSM release tarball.
+
+      See [Download and extract CSM product release](../../update_product_stream/README.md#download-and-extract-csm-product-release).
+
    1. Create a new `site-init` directory using the CSM tarball.
-
-      Determine the location of the initial unpacked install tarball and set `${CSM_DISTDIR}` accordingly.
-
-      > **`NOTE`** If the unpacked set of CSM directories was copied, no action is required to expand the tarball.
-      If the tarball tgz file was copied, the command to unpack it is `tar -zxvf CSM_RELEASE.tar.gz`.
-      Replace the `CSM_RELEASE` value before running the command to unpack the tarball.
 
       ```bash
       cp -r ${CSM_DISTDIR}/shasta-cfg/* /root/site-init
@@ -166,7 +164,7 @@ use of `utils/secrets-seed-customizations.sh` above).
 To view currently tracked sealed secrets:
 
 ```bash
-yq read /mnt/pitdata/${CSM_RELEASE}/shasta-cfg/customizations.yaml spec.kubernetes.tracked_sealed_secrets
+yq read ${CSM_PATH}/shasta-cfg/customizations.yaml spec.kubernetes.tracked_sealed_secrets
 ```
 
 Expected output looks similar to the following:
@@ -206,7 +204,8 @@ in the `cray_reds_credentials` secret, resulting in hardware not being discovere
 
 The general process outlined in the following steps can be followed if a different value is incorrect.
 
-```bash./utils/secrets-decrypt.sh cray_reds_credentials | jq -r '.data.vault_switch_defaults' | base64 --decode
+```bash
+./utils/secrets-decrypt.sh cray_reds_credentials | jq -r '.data.vault_switch_defaults' | base64 --decode
 ```
 
 Output looks similar to the following:

--- a/update_product_stream/README.md
+++ b/update_product_stream/README.md
@@ -24,14 +24,14 @@ be downloaded and extracted.
 
    ```bash
    ENDPOINT=URL_SERVER_Hosting_tarball
-   CSM_RELEASE=csm-x.y.z
-   wget "${ENDPOINT}/${CSM_RELEASE}.tar.gz"
+   CSM_RELEASE=x.y.z
+   wget "${ENDPOINT}/csm-${CSM_RELEASE}.tar.gz"
    ```
 
 1. Extract the release distribution.
 
    ```bash
-   tar -xzvf "${CSM_RELEASE}.tar.gz"
+   tar -xzvf "csm-${CSM_RELEASE}.tar.gz"
    ```
 
 1. Before using this software release, check for any patches available for it.
@@ -76,41 +76,41 @@ The following requirements must be met on the system where the procedure is bein
 
    ```bash
    ENDPOINT=URL_SERVER_Hosting_tarball
-   CSM_RELEASE=csm-x.y.z
+   CSM_RELEASE=x.y.z
    PATCH_RELEASE=x.z.a
-   wget "${ENDPOINT}/${CSM_RELEASE}-${PATCH_RELEASE}.patch.gz"
+   wget "${ENDPOINT}/csm-${CSM_RELEASE}-${PATCH_RELEASE}.patch.gz"
    ```
 
 1. Uncompress the patch.
 
    ```bash
-   gunzip -v "${CSM_RELEASE}-${PATCH_RELEASE}.patch.gz"
+   gunzip -v "csm-${CSM_RELEASE}-${PATCH_RELEASE}.patch.gz"
    ```
 
 1. Apply the patch.
 
    ```bash
    git apply -p2 --whitespace=nowarn \
-                        --directory="${CSM_RELEASE}" \
-                        "${CSM_RELEASE}-${PATCH_RELEASE}.patch"
+                        --directory="csm-${CSM_RELEASE}" \
+                        "csm-${CSM_RELEASE}-${PATCH_RELEASE}.patch"
    ```
 
 1. Set a variable to reflect the new version.
 
    ```bash
-   NEW_CSM_RELEASE="$(./${CSM_RELEASE}/lib/version.sh)"
+   NEW_CSM_RELEASE="$(./csm-${CSM_RELEASE}/lib/version.sh)"
    ```
 
 1. Update the name of the CSM release distribution directory.
 
    ```bash
-   mv -v "${CSM_RELEASE}" "${NEW_CSM_RELEASE}"
+   mv -v "csm-${CSM_RELEASE}" "csm-${NEW_CSM_RELEASE}"
    ```
 
 1. Create a tarball from the patched release distribution.
 
    ```bash
-   tar -cvzf "${NEW_CSM_RELEASE}.tar.gz" "${NEW_CSM_RELEASE}/"
+   tar -cvzf "csm-${NEW_CSM_RELEASE}.tar.gz" "csm-${NEW_CSM_RELEASE}/"
    ```
 
 This tarball can now be used in place of the original CSM software release tarball.
@@ -128,13 +128,13 @@ Acquire the latest documentation RPM. This may include updates, corrections, and
 1. Download and upgrade the latest documentation RPM.
 
    ```bash
-   rpm -Uvh --force https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/docs-csm/1.2/noarch/docs-csm-latest.noarch.rpm
+   rpm -Uvh --force https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/docs-csm/1.3/noarch/docs-csm-latest.noarch.rpm
    ```
 
    If this machine does not have direct internet access, then this RPM will need to be externally downloaded and copied to the system. This example copies it to `ncn-m001`.
 
    ```bash
-   wget https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/docs-csm/1.2/noarch/docs-csm-latest.noarch.rpm -O docs-csm-latest.noarch.rpm
+   wget https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/docs-csm/1.3/noarch/docs-csm-latest.noarch.rpm -O docs-csm-latest.noarch.rpm
    scp docs-csm-latest.noarch.rpm ncn-m001:/root
    ssh ncn-m001
    rpm -Uvh --force /root/docs-csm-latest.noarch.rpm

--- a/update_product_stream/README.md
+++ b/update_product_stream/README.md
@@ -98,7 +98,7 @@ The following requirements must be met on the system where the procedure is bein
 1. Set a variable to reflect the new version.
 
    ```bash
-   NEW_CSM_RELEASE="$(./${CSM_RELEASE/lib/version.sh)"
+   NEW_CSM_RELEASE="$(./${CSM_RELEASE}/lib/version.sh)"
    ```
 
 1. Update the name of the CSM release distribution directory.

--- a/upgrade/Stage_0_Prerequisites.md
+++ b/upgrade/Stage_0_Prerequisites.md
@@ -27,7 +27,8 @@ backup of Workload Manager configuration data and files is created. Once complet
 1. (`ncn-m001#`) Set the `CSM_RELEASE` variable to the **target** CSM version of this upgrade.
 
    ```bash
-   CSM_RELEASE=csm-1.3.0
+   CSM_RELEASE=1.3.0
+   CSM_REL_NAME=csm-${CSM_RELEASE}
    ```
 
 1. If there are space concerns on the node, then add an `rbd` device on the node for the CSM tarball.
@@ -60,7 +61,7 @@ backup of Workload Manager configuration data and files is created. Once complet
 
 1. (`ncn-m001#`) Set the `ENDPOINT` variable to the URL of the directory containing the CSM release `tar` file.
 
-   In other words, the full URL to the CSM release `tar` file must be `${ENDPOINT}${CSM_RELEASE}.tar.gz`
+   In other words, the full URL to the CSM release `tar` file must be `${ENDPOINT}${CSM_REL_NAME}.tar.gz`
 
    **NOTE** This step is optional for Cray/HPE internal installs, if `ncn-m001` can reach the internet.
 
@@ -103,7 +104,7 @@ backup of Workload Manager configuration data and files is created. Once complet
    > copy the tarball file to a different location, and set the `CSM_TAR_PATH` to point to this new location.
 
    ```bash
-   CSM_TAR_PATH=/path/to/${CSM_RELEASE}.tar.gz
+   CSM_TAR_PATH=/path/to/${CSM_REL_NAME}.tar.gz
    ```
 
 1. (`ncn-m001#`) Run the script.

--- a/upgrade/Stage_2.md
+++ b/upgrade/Stage_2.md
@@ -89,7 +89,8 @@ upgrade procedure pivots to use `ncn-m002` as the new "stable node", in order to
 1. (`ncn-m002#`) Set the `CSM_RELEASE` variable to the **target** CSM version of this upgrade.
 
    ```bash
-   CSM_RELEASE=1.2.0
+   CSM_RELEASE=1.3.0
+   CSM_REL_NAME=csm-${CSM_RELEASE}
    ```
 
 1. (`ncn-m002#`) Copy artifacts from `ncn-m001`.
@@ -97,11 +98,11 @@ upgrade procedure pivots to use `ncn-m002` as the new "stable node", in order to
    A later stage of the upgrade expects the `docs-csm` RPM to be located at `/root/docs-csm-latest.noarch.rpm` on `ncn-m002`; that is why this command copies it there.
 
    ```bash
-   mkdir -pv /etc/cray/upgrade/csm/csm-${CSM_RELEASE} &&
+   mkdir -pv /etc/cray/upgrade/csm/${CSM_REL_NAME} &&
              scp ncn-m001:/etc/cray/upgrade/csm/myenv /etc/cray/upgrade/csm/myenv &&
              scp ncn-m001:/root/output.log /root/pre-m001-reboot-upgrade.log &&
              cray artifacts create config-data pre-m001-reboot-upgrade.log /root/pre-m001-reboot-upgrade.log
-   csi_rpm=$(ssh ncn-m001 "find /etc/cray/upgrade/csm/csm-${CSM_RELEASE}/tarball/${CSM_RELEASE}/rpm/cray/csm/ -name 'cray-site-init*.rpm'") &&
+   csi_rpm=$(ssh ncn-m001 "find /etc/cray/upgrade/csm/${CSM_REL_NAME}/tarball/${CSM_REL_NAME}/rpm/cray/csm/ -name 'cray-site-init*.rpm'") &&
              scp ncn-m001:${csi_rpm} /tmp/cray-site-init.rpm &&
              scp ncn-m001:/root/docs-csm-*.noarch.rpm /root/docs-csm-latest.noarch.rpm &&
              rpm -Uvh --force /tmp/cray-site-init.rpm /root/docs-csm-latest.noarch.rpm

--- a/upgrade/Stage_3.md
+++ b/upgrade/Stage_3.md
@@ -8,7 +8,8 @@
 1. Set the `CSM_RELEASE` variable to the **target** CSM version of this upgrade.
 
    ```bash
-   CSM_RELEASE=1.2.0
+   CSM_RELEASE=1.3.0
+   CSM_REL_NAME=csm-${CSM_RELEASE}
    ```
 
 1. Follow either the [Direct download](#direct-download) or [Manual copy](#manual-copy) procedure.
@@ -20,7 +21,7 @@
 
 1. Set the `ENDPOINT` variable to the URL of the directory containing the CSM release `tar` file.
 
-   In other words, the full URL to the CSM release `tar` file must be `${ENDPOINT}${CSM_RELEASE}.tar.gz`
+   In other words, the full URL to the CSM release `tar` file must be `${ENDPOINT}${CSM_REL_NAME}.tar.gz`
 
    > **`NOTE`** This step is optional for Cray/HPE internal installs, if `ncn-m002` can reach the internet.
 
@@ -33,7 +34,7 @@
    > **`NOTE`** For Cray/HPE internal installs, if `ncn-m002` can reach the internet, then the `--endpoint` argument may be omitted.
 
    ```bash
-   /usr/share/doc/csm/upgrade/scripts/upgrade/prepare-assets.sh --csm-version csm-${CSM_RELEASE} --endpoint "${ENDPOINT}"
+   /usr/share/doc/csm/upgrade/scripts/upgrade/prepare-assets.sh --csm-version ${CSM_RELEASE} --endpoint "${ENDPOINT}"
    ```
 
 1. Skip the `Manual copy` subsection and proceed to [Perform upgrade](#perform-upgrade).
@@ -47,7 +48,7 @@
 1. Set the `CSM_TAR_PATH` variable to the full path to the CSM `tar` file on `ncn-m002`.
 
    ```bash
-   CSM_TAR_PATH=/path/to/csm-${CSM_RELEASE}.tar.gz
+   CSM_TAR_PATH=/path/to/${CSM_REL_NAME}.tar.gz
    ```
 
 1. Run the script.
@@ -56,7 +57,7 @@
    > append the `--no-delete-tarball-file` argument when running the script.
 
    ```bash
-   /usr/share/doc/csm/upgrade/scripts/upgrade/prepare-assets.sh --csm-version csm-${CSM_RELEASE} --tarball-file "${CSM_TAR_PATH}"
+   /usr/share/doc/csm/upgrade/scripts/upgrade/prepare-assets.sh --csm-version ${CSM_RELEASE} --tarball-file "${CSM_TAR_PATH}"
    ```
 
 ## Perform upgrade

--- a/upgrade/scripts/common/upgrade-state.sh
+++ b/upgrade/scripts/common/upgrade-state.sh
@@ -23,13 +23,15 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-mkdir -p /etc/cray/upgrade/csm/$CSM_RELEASE
+CSM_REL_NAME=${CSM_REL_NAME-"csm-${CSM_RELEASE}"}
+mkdir -p "/etc/cray/upgrade/csm/${CSM_REL_NAME}"
 
 function record_state () {
     state_name=$1
     local target_ncn=$2
+    local state_dir="/etc/cray/upgrade/csm/${CSM_REL_NAME}/${target_ncn}"
 
-    mkdir -p /etc/cray/upgrade/csm/$CSM_RELEASE/$target_ncn
+    mkdir -p "${state_dir}"
 
     if [[ -z ${state_name} ]]; then
         echo "state name is not specified"
@@ -41,7 +43,7 @@ function record_state () {
     fi
     state_recorded=$(is_state_recorded $state_name $target_ncn)
     if [[ $state_recorded == "0" ]]; then
-        printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "${state_name}" >> /etc/cray/upgrade/csm/$CSM_RELEASE/$target_ncn/state
+        printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "${state_name}" >> "${state_dir}/state"
     fi
     echo "====> ${state_name} has been completed"
 }
@@ -49,7 +51,10 @@ function record_state () {
 function is_state_recorded () {
     state_name=$1
     local target_ncn=$2
-    mkdir -p /etc/cray/upgrade/csm/$CSM_RELEASE/$target_ncn
+    local state_dir="/etc/cray/upgrade/csm/${CSM_REL_NAME}/${target_ncn}"
+
+    mkdir -p "${state_dir}"
+
     if [[ -z ${state_name} ]]; then
         echo "state name is not specified"
         exit 1
@@ -58,7 +63,7 @@ function is_state_recorded () {
         echo "upgrade ncn is not specified"
         exit 1
     fi
-    state_recorded=$(cat /etc/cray/upgrade/csm/$CSM_RELEASE/$target_ncn/state 2>/dev/null | grep "${state_name}" | wc -l)
+    state_recorded=$(grep "${state_name}" "${state_dir}/state" 2>/dev/null | wc -l)
     if [[ ${state_recorded} != 0 ]]; then
         echo "1"
     else
@@ -71,7 +76,9 @@ function move_state_file () {
     # this will not block another upgrade/rebuild/reboot
     # it also leaves a trace of what happened before
     local target_ncn=$1
-    mv /etc/cray/upgrade/csm/$CSM_RELEASE/$target_ncn/state /etc/cray/upgrade/csm/$CSM_RELEASE/$target_ncn/state.bak
+    local state_dir="/etc/cray/upgrade/csm/${CSM_REL_NAME}/${target_ncn}"
+    
+    mv "${state_dir}/state" "${state_dir}/state.bak"
 }
 
 function err_report() {

--- a/upgrade/scripts/cps/snapshot-cps-deployment.sh
+++ b/upgrade/scripts/cps/snapshot-cps-deployment.sh
@@ -23,13 +23,16 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # Take cps deployment snapshot (if cps installed)
+
+CSM_REL_NAME=${CSM_REL_NAME-"csm-${CSM_RELEASE}"}
+
 set +e
 trap - ERR
 kubectl get pod -n services | grep -q cray-cps
 if [ "$?" -eq 0 ]; then
   cps_deployment_snapshot=$(cray cps deployment list --format json | jq -r \
     '.[] | select(."podname" != "NA" and ."podname" != "") | .node' || true)
-  echo $cps_deployment_snapshot > /etc/cray/upgrade/csm/${CSM_RELEASE}/cp.deployment.snapshot
+  echo $cps_deployment_snapshot > /etc/cray/upgrade/csm/${CSM_REL_NAME}/cp.deployment.snapshot
 fi
 trap 'err_report' ERR
 set -e

--- a/upgrade/scripts/rebuild/ncn-rebuild-worker-nodes.sh
+++ b/upgrade/scripts/rebuild/ncn-rebuild-worker-nodes.sh
@@ -32,6 +32,8 @@ target_ncn=$1
 
 . ${basedir}/../common/ncn-common.sh ${target_ncn}
 
+CSM_REL_NAME=${CSM_REL_NAME-"csm-${CSM_RELEASE}"}
+
 ssh_keygen_keyscan $1 || true # or true to unblock rerun
 
 ${basedir}/../cfs/wait_for_configuration.sh --xnames $TARGET_XNAME
@@ -113,7 +115,7 @@ ${basedir}/../common/ncn-rebuild-common.sh $target_ncn --rebuild
 ${basedir}/../cfs/wait_for_configuration.sh --xnames $TARGET_XNAME
 
 ### redeploy CPS if required
-redeploy=$(cat /etc/cray/upgrade/csm/${CSM_RELEASE}/cp.deployment.snapshot | grep $target_ncn | wc -l)
+redeploy=$(cat /etc/cray/upgrade/csm/${CSM_REL_NAME}/cp.deployment.snapshot | grep $target_ncn | wc -l)
 if [[ $redeploy == "1" ]];then
     cray cps deployment update --nodes $target_ncn
     # We will retry for a few minutes before giving up

--- a/upgrade/scripts/upgrade/ncn-upgrade-worker-nodes.sh
+++ b/upgrade/scripts/upgrade/ncn-upgrade-worker-nodes.sh
@@ -32,6 +32,8 @@ target_ncn=$1
 
 . ${basedir}/../common/ncn-common.sh ${target_ncn}
 
+CSM_REL_NAME=${CSM_REL_NAME-"csm-${CSM_RELEASE}"}
+
 ssh_keygen_keyscan $1 || true # or true to unblock rerun
 
 ${basedir}/../cfs/wait_for_configuration.sh --xnames $TARGET_XNAME
@@ -116,7 +118,7 @@ ${basedir}/../common/ncn-rebuild-common.sh $target_ncn
 ${basedir}/../cfs/wait_for_configuration.sh --xnames $TARGET_XNAME
 
 ### redeploy CPS if required
-redeploy=$(cat /etc/cray/upgrade/csm/${CSM_RELEASE}/cp.deployment.snapshot | grep $target_ncn | wc -l)
+redeploy=$(cat /etc/cray/upgrade/csm/${CSM_REL_NAME}/cp.deployment.snapshot | grep $target_ncn | wc -l)
 if [[ $redeploy == "1" ]];then
     cray cps deployment update --nodes $target_ncn
 fi

--- a/upgrade/scripts/upgrade/prepare-assets.sh
+++ b/upgrade/scripts/upgrade/prepare-assets.sh
@@ -41,6 +41,7 @@ do
     case $key in
         --csm-version)
         CSM_RELEASE="$2"
+        CSM_REL_NAME="csm-${CSM_RELEASE}"
         shift # past argument
         shift # past value
         ;;
@@ -114,9 +115,9 @@ if [[ -z ${TARBALL_FILE} ]]; then
         touch /etc/cray/upgrade/csm/myenv
         echo "====> ${state_name} ..."
         {
-        wget --progress=dot:giga ${ENDPOINT}/${CSM_RELEASE}.tar.gz
+        wget --progress=dot:giga ${ENDPOINT}/${CSM_REL_NAME}.tar.gz
         # set TARBALL_FILE to newly downloaded file
-        TARBALL_FILE=${CSM_RELEASE}.tar.gz
+        TARBALL_FILE=${CSM_REL_NAME}.tar.gz
         } >> ${LOG_FILE} 2>&1
         #shellcheck disable=SC2046
         record_state ${state_name} $(hostname)
@@ -133,9 +134,9 @@ state_recorded=$(is_state_recorded "${state_name}" $(hostname))
 if [[ $state_recorded == "0" ]]; then
     echo "====> ${state_name} ..."
     {
-    mkdir -p /etc/cray/upgrade/csm/${CSM_RELEASE}/tarball
-    tar -xzf ${TARBALL_FILE} -C /etc/cray/upgrade/csm/${CSM_RELEASE}/tarball
-    CSM_ARTI_DIR=/etc/cray/upgrade/csm/${CSM_RELEASE}/tarball/${CSM_RELEASE}
+    mkdir -p /etc/cray/upgrade/csm/${CSM_REL_NAME}/tarball
+    tar -xzf ${TARBALL_FILE} -C /etc/cray/upgrade/csm/${CSM_REL_NAME}/tarball
+    CSM_ARTI_DIR=/etc/cray/upgrade/csm/${CSM_REL_NAME}/tarball/${CSM_REL_NAME}
     if [[ "${DELETE_TARBALL_FILE}" != N ]]; then
         rm -rf "${TARBALL_FILE}"
     fi
@@ -143,8 +144,9 @@ if [[ $state_recorded == "0" ]]; then
     # if we have to untar a file, we assume this is a new upgrade
     # remove existing myenv file just in case
     rm -rf /etc/cray/upgrade/csm/myenv
-    echo "export CSM_ARTI_DIR=/etc/cray/upgrade/csm/${CSM_RELEASE}/tarball/${CSM_RELEASE}" >> /etc/cray/upgrade/csm/myenv
+    echo "export CSM_ARTI_DIR=/etc/cray/upgrade/csm/${CSM_REL_NAME}/tarball/${CSM_REL_NAME}" >> /etc/cray/upgrade/csm/myenv
     echo "export CSM_RELEASE=${CSM_RELEASE}" >> /etc/cray/upgrade/csm/myenv
+    echo "export CSM_REL_NAME=${CSM_REL_NAME}" >> /etc/cray/upgrade/csm/myenv
     } >> ${LOG_FILE} 2>&1
     #shellcheck disable=SC2046
     record_state ${state_name} $(hostname)

--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -40,6 +40,7 @@ key="$1"
 case $key in
     --csm-version)
     CSM_RELEASE="$2"
+    CSM_REL_NAME="csm-${CSM_RELEASE}"
     shift # past argument
     shift # past value
     ;;
@@ -269,7 +270,7 @@ if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     echo "====> ${state_name} ..."
     {
     # get existing customization.yaml file
-    SITE_INIT_DIR=/etc/cray/upgrade/csm/${CSM_RELEASE_VERSION}/site-init
+    SITE_INIT_DIR=/etc/cray/upgrade/csm/${CSM_REL_NAME}/site-init
     mkdir -p "${SITE_INIT_DIR}"
     DATETIME=$(date +%Y-%m-%d_%H-%M-%S)
     CUSTOMIZATIONS_YAML=$(mktemp -p "${SITE_INIT_DIR}" "customizations-${DATETIME}-XXX.yaml")


### PR DESCRIPTION
# Description

I checked through the doc repo for everywhere that CSM_RELEASE was used (both docs and scripts), and made sure that in 1.3 we always use it in its new form (a.b.c). For cases where the old format was useful, I set the CSM_REL_NAME variable to be equal to csm-${CSM_RELEASE}.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
