### PR TITLE
CASMINST-4608 / CASMINST-4838 / CASMHMS-5598

### DIFF
--- a/operations/firmware/FAS_Admin_Procedures.md
+++ b/operations/firmware/FAS_Admin_Procedures.md
@@ -19,6 +19,10 @@ NCNs and their BMCs should be locked with the HSM locking API to ensure they are
 Research [Lock and Unlock Management Nodes](../hardware_state_manager/Lock_and_Unlock_Management_Nodes.md) for more information.
 Failure to lock the NCNs could result in unintentional update of the NCNs if FAS is not used correctly; this will lead to system instability problems.
 
+**NOTE**: Any node which is locked will remain in the state `inProgress` with the `stateHelper` message of `"failed to lock"` until the action times out, or the lock is released.
+These nodes will report as `failed` with the `stateHelper` message of `"time expired; could not complete update"` if action times out.
+This includes NCNs which are manually locked to prevent accidental rebooting and firmware updates.
+
 ---
 
 ## Ignore Nodes within FAS

--- a/operations/firmware/FAS_CLI.md
+++ b/operations/firmware/FAS_CLI.md
@@ -132,6 +132,10 @@ For the steps below, the following returned messages will help determine if a fi
   - If `dryrun`: There is something that FAS could do, but it likely would fail; most likely because the file is missing.
   - If `live update`: The operation failed; the identified version could not be put on the component name (xname) + target.
 
+**NOTE**: Any node which is locked will remain in the state `inProgress` with the `stateHelper` message of `"failed to lock"` until the action times out, or the lock is released.
+These nodes will report as `failed` with the `stateHelper` message of `"time expired; could not complete update"` if action times out.
+This includes NCNs which are manually locked to prevent accidental rebooting and firmware updates.
+
 Data can be viewed at several levels of information:
 
 #### Describe an action: Procedure
@@ -280,7 +284,7 @@ Example output:
     "blocked": {
       "OperationsKeys": []
     }
-  } 
+  }
 }
 ```
 

--- a/operations/firmware/FAS_Recipes.md
+++ b/operations/firmware/FAS_Recipes.md
@@ -8,6 +8,10 @@ The following example JSON files are useful to reference when updating specific 
 When updating an entire system, walk down the device hierarchy component type by component type, starting first with routers (switches), proceeding to chassis, and then finally to nodes.
 While this is not strictly necessary, it does help eliminate confusion.
 
+**NOTE**: Any node which is locked will remain in the state `inProgress` with the `stateHelper` message of `"failed to lock"` until the action times out, or the lock is released.
+These nodes will report as `failed` with the `stateHelper` message of `"time expired; could not complete update"` if action times out.
+This includes NCNs which are manually locked to prevent accidental rebooting and firmware updates.
+
 Refer to [FAS Filters](FAS_Filters.md) for more information on the content used in the example JSON files.
 
 ## Manufacturer : Cray

--- a/operations/firmware/FAS_Use_Cases.md
+++ b/operations/firmware/FAS_Use_Cases.md
@@ -10,6 +10,11 @@ This includes NCNs which are manually locked to prevent accidental rebooting and
 
 Refer to [FAS Filters](FAS_Filters.md) for more information on the content used in the example JSON files.
 
+## Prerequisites
+
+* The Cray command line interface \(CLI\) tool is initialized and configured on the system.
+See [Configure the Cray CLI](../configure_cray_cli.md).
+
 The following procedures are included in this section:
 
 1. [Update Liquid-Cooled Compute Node BMC, FPGA, and BIOS](#liquid-cooled-nodes-update-procedures)
@@ -28,10 +33,6 @@ This section includes templates for JSON files that can be used and the procedur
 All of the example JSON files below are set to run a dry-run. Update the `overrideDryrun` value to `true` to update the firmware.
 
 This procedure updates node controller \(nC\) firmware.
-
-**Prerequisites**
-
-* The Cray command line interface \(CLI\) tool is initialized and configured on the system.
 
 ### Liquid-Cooled Nodes Update Procedures
 
@@ -104,14 +105,14 @@ There are two nodes that must be updated on each BMC; these have the targets `No
 The targets can be run in the same action (as shown in the example) or run separately by only including one target in the action.
 On larger systems, it is recommended to run as two actions one after each other as the output will be shorter.
 
-**Prerequisites**
 
-* The Cray `nodeBMC` device needs to be updated before the `nodeBIOS` because the `nodeBMC` adds a new Redfish field \(`softwareId`\) that the `NodeX.BIOS` update will require. See [Update Liquid-Cooled Node Firmware](#liquidcooled) for more information.
-* Compute node BIOS updates require the nodes to be off. If nodes are not off when the update command is issued, it will report as a failed update.
-
-> **IMPORTANT:** The nodes themselves must be powered **off** in order to update the BIOS on the nodes. The BMC will still have power and will perform the update.
+> **IMPORTANT:** The Cray `nodeBMC` device needs to be updated before the `nodeBIOS` because the `nodeBMC` adds a new Redfish field \(`softwareId`\) that the `NodeX.BIOS` update will require. See [Update Liquid-Cooled Node Firmware](#liquidcooled) for more information.
+> **IMPORTANT:** The nodes themselves must be powered **off** in order to update the BIOS on the nodes.
+The BMC will still have power and will perform the update.
+If nodes are not off when the update command is issued, it will report as a failed update.
 > **IMPORTANT:** When the BMC is updated or rebooted after updating the `Node0.BIOS` and/or `Node1.BIOS` liquid-cooled nodes, the node BIOS version will not report the new version string until the nodes are powered back on.
-It is recommended that the `Node0/1` BIOS be updated in a separate action, either before or after a BMC update. It is also recommended that the nodes be powered back on after the updates are completed.
+It is recommended that the `Node0/1` BIOS be updated in a separate action, after a BMC update.
+It is also recommended that the nodes be powered back on after the updates are completed.
 
 ```json
 {
@@ -140,7 +141,7 @@ It is recommended that the `Node0/1` BIOS be updated in a separate action, eithe
 }
 ```
 
-**Procedure**
+##### Cray Node BOIS Update Procedure
 
 1. Create a JSON file using one of the example recipes with the command parameters required for updating the firmware or node BIOS.
 
@@ -284,10 +285,6 @@ Update the Chassis Management Module \(CMM\) controller \(cC\) firmware using FA
 
 The CMM firmware update process also checks and updates the Cabinet Environmental Controller \(CEC\) firmware.
 
-**Prerequisites**
-
-* The Cray command line interface \(CLI\) tool is initialized and configured on the system.
-
 ### Example Recipes
 
 **Manufacturer: Cray | Device Type: `ChassisBMC` | Target: BMC**
@@ -320,7 +317,7 @@ The CMM firmware update process also checks and updates the Cabinet Environmenta
 }
 ```
 
-**Procedure**
+##### Cray Chassis BMC Update Procedure
 
 1. Power off the liquid-cooled chassis slots and chassis rectifiers.
 
@@ -465,10 +462,6 @@ All of the example JSON files below are set to run a dry-run. Update the `overri
 After updating the BIOS or System ROM, the compute node will need to be rebooted before the new version will be displayed in the Redfish output.
 
 This procedure updates node controller \(nC\) firmware.
-
-**Prerequisites**
-
-* The Cray command line interface \(CLI\) tool is initialized and configured on the system.
 
 ### Gigabyte
 
@@ -626,7 +619,7 @@ Make sure to wait for the current firmware to be updated before starting a new F
 }
 ```
 
-**Procedure**
+##### HPE Node System ROM (BIOS) Update Procedure
 
 1. Create a JSON file using one of the example recipes with the command parameters required for updating the firmware or node BIOS.
 
@@ -947,7 +940,7 @@ Make sure you have waited for the current firmware to be updated before starting
 
 The NCN must be rebooted after updating the BIOS firmware. Follow the [Reboot NCNs](../node_management/Reboot_NCNs.md) procedure.
 
-**Procedure**
+##### HPE Node System ROM (BIOS) Procedure for NCN
 
 1. For `HPE` NCNs, check the DNS servers by running the script `/opt/cray/csm/scripts/node_management/set-bmc-ntp-dns.sh ilo -H XNAME -s`. Replace `XNAME` with the xname of the NCN BMC.
    See [Configure DNS and NTP on Each BMC](../../install/deploy_final_non-compute_node.md#configure-dns-and-ntp-on-each-bmc) for more information.
@@ -975,9 +968,7 @@ The NCN must be rebooted after updating the BIOS firmware. Follow the [Reboot NC
 Correct an issue where the model of the liquid-cooled compute node BIOS is the incorrect name. The name has changed from `WNC-ROME` to `HPE CRAY EX425` or `HPE CRAY EX425 (ROME)`.
 
 **Prerequisites**
-
 * The system is running HPE Cray EX release v1.4 or higher.
-* The system has completed the Cray System Management \(CSM\) installation.
 * A firmware upgrade has been done following [Update Liquid-Cooled Compute Node BIOS Firmware](#cn-bios).
   * The result of the upgrade is that the `NodeX.BIOS` has failed as `noSolution` and the `stateHelper` field for the operation states is `"No Image Available"`.
   * The BIOS in question is running a version less than or equal to `1.2.5` as reported by Redfish or described by the `noSolution` operation in FAS.
@@ -1023,7 +1014,7 @@ Correct an issue where the model of the liquid-cooled compute node BIOS is the i
 
   The model in this example is `WNC-Rome` and the firmware version currently running is `wnc.bios-1.2.5`.
 
-**Procedure**
+##### Compute Node BIOS Workaround for HPE CRAY EX425 Procedure
 
 1. Search for a FAS image record with `cray` as the manufacturer, `Node1.BIOS` as the target, and `HPE CRAY EX425` as the model.
 

--- a/operations/firmware/FAS_Use_Cases.md
+++ b/operations/firmware/FAS_Use_Cases.md
@@ -383,25 +383,25 @@ The CMM firmware update process also checks and updates the Cabinet Environmenta
 
         * Lists the nodes that have a valid image for updating:
 
-            ```
+            ```text
             [operationSummary.succeeded]
             ```
 
         * Lists the nodes that will not be updated because they are already at the correct version:
 
-            ```
+            ```text
             [operationSummary.noOperation]
             ```
 
         * Lists the nodes that had an error when attempting to update:
 
-            ```
+            ```text
             [operationSummary.failed]
             ```
 
         * Lists the nodes that do not have a valid image for updating:
 
-            ```
+            ```text
             [operationSummary.noSolution]
             ```
 
@@ -411,7 +411,7 @@ The CMM firmware update process also checks and updates the Cabinet Environmenta
 
         The following example is for the `chassisBMC.json` file. Update the following values:
 
-        ```
+        ```text
         "overrideDryrun":true,
         "description":"Update Cray Chassis Management Module controllers"
         ```
@@ -453,7 +453,7 @@ The CMM firmware update process also checks and updates the Cabinet Environmenta
     * The *HPE Slingshot Operations Guide* PDF for HPE Cray EX systems.
     * The *HPE Slingshot Troubleshooting Guide* PDF.
 
-2. After the components have powered on, boot the nodes using the Boot Orchestration Services \(BOS\).
+1. After the components have powered on, boot the nodes using the Boot Orchestration Services \(BOS\).
 
 ## Update Air-Cooled Compute Node BMC, BIOS, iLO 5, and System ROM
 

--- a/operations/firmware/FAS_Use_Cases.md
+++ b/operations/firmware/FAS_Use_Cases.md
@@ -35,7 +35,7 @@ This procedure updates node controller \(nC\) firmware.
 
 ### Liquid-Cooled Nodes Update Procedures
 
-**Manufacturer: Cray | Device Type: NodeBMC | Target: BMC**
+#### Manufacturer: Cray | Device Type: `NodeBMC` | Target: BMC
 
 BMC firmware with FPGA updates require the nodes to be off.
 If the nodes are not off when the update command is issued, the update will get deferred until the next power cycle of the BMC, which may be a long period of time.
@@ -67,7 +67,7 @@ If the nodes are not off when the update command is issued, the update will get 
 }
 ```
 
-**Manufacturer: Cray | Device Type: NodeBMC | Target: Redstone FPGA**
+#### Manufacturer: Cray | Device Type: `NodeBMC` | Target: Redstone FPGA
 
 > **IMPORTANT:** The Nodes themselves must be powered **on** in order to update the firmware of the Redstone FPGA on the nodes.
 
@@ -98,21 +98,20 @@ If the nodes are not off when the update command is issued, the update will get 
 }
 ```
 
-**Manufacturer: Cray | Device Type : NodeBMC | Target : NodeBIOS**
+#### Manufacturer: Cray | Device Type : `NodeBMC` | Target : `NodeBIOS`
 
 There are two nodes that must be updated on each BMC; these have the targets `Node0.BIOS` and `Node1.BIOS`.
 The targets can be run in the same action (as shown in the example) or run separately by only including one target in the action.
 On larger systems, it is recommended to run as two actions one after each other as the output will be shorter.
 
-### Prerequisites
+##### Prerequisites
 
-* The Cray nodeBMC device needs to be updated before the nodeBIOS because the nodeBMC adds a new Redfish field \(`softwareId`\) that the `NodeX.BIOS` update will require. See [Update Liquid-Cooled Node Firmware](#liquidcooled) for more information.
+* The Cray `nodeBMC` device needs to be updated before the nodeBIOS because the `nodeBMC` adds a new Redfish field \(`softwareId`\) that the `NodeX.BIOS` update will require. See [Update Liquid-Cooled Node Firmware](#liquidcooled) for more information.
 * Compute node BIOS updates require the nodes to be off. If nodes are not off when the update command is issued, it will report as a failed update.
 
 > **IMPORTANT:** The nodes themselves must be powered **off** in order to update the BIOS on the nodes. The BMC will still have power and will perform the update.
-
 > **IMPORTANT:** When the BMC is updated or rebooted after updating the `Node0.BIOS` and/or `Node1.BIOS` liquid-cooled nodes, the node BIOS version will not report the new version string until the nodes are powered back on.
-It is recommended that the Node0/1 BIOS be updated in a separate action, either before or after a BMC update. It is also recommended that the nodes be powered back on after the updates are completed.
+It is recommended that the `Node0/1` BIOS be updated in a separate action, either before or after a BMC update. It is also recommended that the nodes be powered back on after the updates are completed.
 
 ```json
 {
@@ -143,11 +142,11 @@ It is recommended that the Node0/1 BIOS be updated in a separate action, either 
 
 ### Procedure
 
-1.  Create a JSON file using one of the example recipes with the command parameters required for updating the firmware or node BIOS.
+1. Create a JSON file using one of the example recipes with the command parameters required for updating the firmware or node BIOS.
 
-1.  Initiate a dry-run to verify that the firmware can be updated.
+1. Initiate a dry-run to verify that the firmware can be updated.
 
-    1.  Create the dry-run session.
+    1. Create the dry-run session.
 
         The `overrideDryrun = false` value indicates that the command will do a dry run.
 
@@ -157,7 +156,7 @@ It is recommended that the Node0/1 BIOS be updated in a separate action, either 
         actionID = "fddd0025-f5ff-4f59-9e73-1ca2ef2a432d"
         ```
 
-    1.  Describe the `actionID` for firmware update dry-run job.
+    1. Describe the `actionID` for firmware update dry-run job.
 
         Replace the `actionID` value with the string returned in the previous step. In this example, `"fddd0025-f5ff-4f59-9e73-1ca2ef2a432d"` is used.
 
@@ -181,33 +180,33 @@ It is recommended that the Node0/1 BIOS be updated in a separate action, either 
 
         If `state = "completed"`, the dry-run has found and checked all the nodes. Check the following sections for more information:
 
-        *   Lists the nodes that have a valid image for updating:
+        * Lists the nodes that have a valid image for updating:
 
             ```
             [operationSummary.succeeded]
             ```
 
-        *   Lists the nodes that will not be updated because they are already at the correct version:
+        * Lists the nodes that will not be updated because they are already at the correct version:
 
             ```
             [operationSummary.noOperation]
             ```
 
-        *   Lists the nodes that had an error when attempting to update:
+        * Lists the nodes that had an error when attempting to update:
 
             ```
             [operationSummary.failed]
             ```
 
-        *   Lists the nodes that do not have a valid image for updating:
+        * Lists the nodes that do not have a valid image for updating:
 
             ```
             [operationSummary.noSolution]
             ```
 
-1.  Update the firmware after verifying that the dry-run worked as expected.
+1. Update the firmware after verifying that the dry-run worked as expected.
 
-    1.  Edit the JSON file and update the values so an actual firmware update can be run.
+    1. Edit the JSON file and update the values so an actual firmware update can be run.
 
         The following example is for the `nodeBMC.json` file. Update the following values:
 
@@ -216,7 +215,7 @@ It is recommended that the Node0/1 BIOS be updated in a separate action, either 
         "description":"Update Cray Node BMCs"
         ```
 
-    1.  Run the firmware update.
+    1. Run the firmware update.
 
         The output `overrideDryrun = true` indicates that an actual firmware update job was created. A new `actionID` will also be displayed.
 
@@ -230,7 +229,7 @@ It is recommended that the Node0/1 BIOS be updated in a separate action, either 
 
         The liquid-cooled node BMC automatically reboots after the BMC firmware has been loaded.
 
-1.  Retrieve the `operationID` and verify that the update is complete.
+1. Retrieve the `operationID` and verify that the update is complete.
 
     ```bash
     cray fas actions describe {actionID}
@@ -243,7 +242,7 @@ It is recommended that the Node0/1 BIOS be updated in a separate action, either 
     operationID = "e910c6ad-db98-44fc-bdc5-90477b23386f"
     ```
 
-1.  View more details for an operation using the `operationID` from the previous step.
+1. View more details for an operation using the `operationID` from the previous step.
 
     Check the list of nodes for the `failed` or `completed` state.
 
@@ -291,7 +290,7 @@ The CMM firmware update process also checks and updates the Cabinet Environmenta
 
 ### Example Recipes
 
-**Manufacturer: Cray | Device Type: ChassisBMC | Target: BMC**
+**Manufacturer: Cray | Device Type: `ChassisBMC` | Target: BMC**
 
 > **IMPORTANT:** Before updating a CMM, make sure all slot and rectifier power is off and the discovery job is stopped (see procedure below).
 
@@ -323,15 +322,15 @@ The CMM firmware update process also checks and updates the Cabinet Environmenta
 
 ### Procedure
 
-1.  Power off the liquid-cooled chassis slots and chassis rectifiers.
+1. Power off the liquid-cooled chassis slots and chassis rectifiers.
 
-    1.  Disable the `hms-discovery` Kubernetes cronjob:
+    1. Disable the `hms-discovery` Kubernetes cronjob:
 
         ```bash
         kubectl -n services patch cronjobs hms-discovery -p '{"spec" : {"suspend" : true }}'
         ```
 
-    1.  Power off all the components. For example, in chassis 0-7, cabinets 1000-1003:
+    1. Power off all the components. For example, in chassis 0-7, cabinets 1000-1003:
 
         ```bash
         cray capmc xname_off create --xnames x[1000-1003]c[0-7] --recursive true --continue true
@@ -341,11 +340,11 @@ The CMM firmware update process also checks and updates the Cabinet Environmenta
 
         When power is removed from a chassis, the high-voltage DC rectifiers that support the chassis are powered off. If a component is not populated, the `--continue` option enables the command to continue instead of returning error messages.
 
-1.  Create a JSON file using the example recipe above with the command parameters required for updating the CMM firmware.
+1. Create a JSON file using the example recipe above with the command parameters required for updating the CMM firmware.
 
-1.  Initiate a dry-run to verify that the firmware can be updated.
+1. Initiate a dry-run to verify that the firmware can be updated.
 
-    1.  Create the dry-run session.
+    1. Create the dry-run session.
 
         The `overrideDryrun = false` value indicates that the command will do a dry-run.
 
@@ -355,7 +354,7 @@ The CMM firmware update process also checks and updates the Cabinet Environmenta
         actionID = "fddd0025-f5ff-4f59-9e73-1ca2ef2a432d"
         ```
 
-    1.  Describe the `actionID` to see the firmware update dry-run job status.
+    1. Describe the `actionID` to see the firmware update dry-run job status.
 
         Replace the `actionID` value with the string returned in the previous step. In this example, `"fddd0025-f5ff-4f59-9e73-1ca2ef2a432d"` is used.
 
@@ -406,9 +405,9 @@ The CMM firmware update process also checks and updates the Cabinet Environmenta
             [operationSummary.noSolution]
             ```
 
-1.  Update the firmware after verifying that the dry-run worked as expected.
+1. Update the firmware after verifying that the dry-run worked as expected.
 
-    1.  Edit the JSON file and update the values so an actual firmware update can be run.
+    1. Edit the JSON file and update the values so an actual firmware update can be run.
 
         The following example is for the `chassisBMC.json` file. Update the following values:
 
@@ -417,7 +416,7 @@ The CMM firmware update process also checks and updates the Cabinet Environmenta
         "description":"Update Cray Chassis Management Module controllers"
         ```
 
-    1.  Run the firmware update.
+    1. Run the firmware update.
 
         The output `overrideDryrun = true` indicates that an actual firmware update job was created. A new `actionID` will also be displayed.
 
@@ -432,7 +431,7 @@ The CMM firmware update process also checks and updates the Cabinet Environmenta
 
         The time it takes for a firmware update varies. It can be a few minutes or over 20 minutes depending on response time.
 
-1.  Restart the `hms-discovery` cronjob.
+1. Restart the `hms-discovery` cronjob.
 
     ```bash
     kubectl -n services patch cronjobs hms-discovery -p '{"spec" : {"suspend" : false }}'
@@ -446,7 +445,7 @@ The CMM firmware update process also checks and updates the Cabinet Environmenta
 
     The `--prereq` option ensures all required components are powered on first. The `--continue` option allows the command to complete in systems without fully populated hardware.
 
-1.  Bring up the Slingshot Fabric.
+1. Bring up the Slingshot Fabric.
 
     Refer to the following documentation on the HPE Customer Support Center
     for more information on how to bring up the Slingshot Fabric:
@@ -454,7 +453,7 @@ The CMM firmware update process also checks and updates the Cabinet Environmenta
     * The *HPE Slingshot Operations Guide* PDF for HPE Cray EX systems.
     * The *HPE Slingshot Troubleshooting Guide* PDF.
 
-2.  After the components have powered on, boot the nodes using the Boot Orchestration Services \(BOS\).
+2. After the components have powered on, boot the nodes using the Boot Orchestration Services \(BOS\).
 
 ## Update Air-Cooled Compute Node BMC, BIOS, iLO 5, and System ROM
 
@@ -473,7 +472,7 @@ This procedure updates node controller \(nC\) firmware.
 
 ### Gigabyte
 
-**Device Type: NodeBMC | Target: BMC**
+**Device Type: `NodeBMC` | Target: BMC**
 
 ```json
 {
@@ -504,7 +503,7 @@ This procedure updates node controller \(nC\) firmware.
 }
 ```
 
-> **IMPORTANT:** The *timeLimit* is `4000` because the Gigabytes can take a lot longer to update.
+> **IMPORTANT:** The *`timeLimit`* is `4000` because the Gigabytes can take a lot longer to update.
 
 **Troubleshooting:**
 
@@ -523,7 +522,7 @@ To resolve this issue, do either of the following actions:
 
 Make sure to wait for the current firmware to be updated before starting a new FAS action on the same node.
 
-**Device Type: NodeBMC | Target: BIOS**
+**Device Type: `NodeBMC` | Target: BIOS**
 
 ```json
 {
@@ -559,7 +558,7 @@ Make sure to wait for the current firmware to be updated before starting a new F
 
 ### HPE
 
-**Device Type: NodeBMC | Target: `iLO 5` aka BMC**
+**Device Type: `NodeBMC` | Target: `iLO 5` aka BMC**
 
 ```json
 {
@@ -590,7 +589,7 @@ Make sure to wait for the current firmware to be updated before starting a new F
 }
 ```
 
-**Device Type: NodeBMC | Target: `System ROM` aka BIOS**
+**Device Type: `NodeBMC` | Target: `System ROM` aka BIOS**
 
 > **IMPORTANT:** If updating the System ROM of an NCN, the NTP and DNS server values will be lost and must be restored. For NCNs **other than `ncn-m001`** this can be done using the `/opt/cray/csm/scripts/node_management/set-bmc-ntp-dns.sh` script. Use the `-h` option to get a list of command line options required to restore the NTP and DNS values. See [Configure DNS and NTP on Each BMC](../../install/deploy_final_non-compute_node.md#configure-dns-and-ntp-on-each-bmc).
 
@@ -625,11 +624,11 @@ Make sure to wait for the current firmware to be updated before starting a new F
 
 ### Procedure
 
-1.  Create a JSON file using one of the example recipes with the command parameters required for updating the firmware or node BIOS.
+1. Create a JSON file using one of the example recipes with the command parameters required for updating the firmware or node BIOS.
 
-1.  Initiate a dry-run to verify that the firmware can be updated.
+1. Initiate a dry-run to verify that the firmware can be updated.
 
-    1.  Create the dry-run session.
+    1. Create the dry-run session.
 
         The `overrideDryrun = false` value indicates that the command will do a dry run.
 
@@ -642,7 +641,7 @@ Make sure to wait for the current firmware to be updated before starting a new F
         actionID = "fddd0025-f5ff-4f59-9e73-1ca2ef2a432d"
         ```
 
-    1.  Describe the `actionID` for firmware update dry-run job.
+    1. Describe the `actionID` for firmware update dry-run job.
 
         Replace the `actionID` value with the string returned in the previous step. In this example, `"fddd0025-f5ff-4f59-9e73-1ca2ef2a432d"` is used.
 
@@ -693,9 +692,9 @@ Make sure to wait for the current firmware to be updated before starting a new F
             [operationSummary.noSolution]
             ```
 
-1.  Update the firmware after verifying that the dry-run worked as expected.
+1. Update the firmware after verifying that the dry-run worked as expected.
 
-    1.  Edit the JSON file and update the values so an actual firmware update can be run.
+    1. Edit the JSON file and update the values so an actual firmware update can be run.
 
         The following example is for the `nodeBMC.json` file. Update the following values:
 
@@ -704,7 +703,7 @@ Make sure to wait for the current firmware to be updated before starting a new F
         "description":"Update of HPE node iLO 5"
         ```
 
-    1.  Run the firmware update.
+    1. Run the firmware update.
 
         The returned `overrideDryrun = true` indicates that an actual firmware update job was created. A new `actionID` will also be returned.
 
@@ -721,7 +720,7 @@ Make sure to wait for the current firmware to be updated before starting a new F
 
         The air-cooled node BMC automatically reboots after the BMC or iLO 5 firmware has been loaded.
 
-1.  Retrieve the `operationID` and verify that the update is complete.
+1. Retrieve the `operationID` and verify that the update is complete.
 
     ```bash
     cray fas actions describe {actionID}
@@ -737,7 +736,7 @@ Make sure to wait for the current firmware to be updated before starting a new F
     operationID = "e910c6ad-db98-44fc-bdc5-90477b23386f"
     ```
 
-1.  View more details for an operation using the `operationID` from the previous step.
+1. View more details for an operation using the `operationID` from the previous step.
 
     Check the list of nodes for the `failed` or `completed` state.
 
@@ -794,7 +793,7 @@ Due to networking, FAS cannot update `ncn-m001`. See [Updating Firmware on `ncn-
 
 ### Gigabyte
 
-**Device Type: NodeBMC | Target: BMC**
+**Device Type: `NodeBMC` | Target: BMC**
 
 ```json
 {
@@ -837,7 +836,7 @@ To resolve this issue, do either of the following actions:
 * Rerun FAS to verify that the BMC firmware was updated.
 Make sure you have waited for the current firmware to be updated before starting a new FAS action on the same node.
 
-**Device Type: NodeBMC | Target: BIOS**
+**Device Type: `NodeBMC` | Target: BIOS**
 
 ```json
 {
@@ -873,7 +872,7 @@ Make sure you have waited for the current firmware to be updated before starting
 
 ### HPE
 
-**Device Type: NodeBMC | Target: `iLO 5` aka BMC**
+**Device Type: `NodeBMC` | Target: `iLO 5` aka BMC**
 
 ```json
 {
@@ -904,7 +903,7 @@ Make sure you have waited for the current firmware to be updated before starting
 }
 ```
 
-**Device Type: NodeBMC | Target: `System ROM` aka BIOS**
+**Device Type: `NodeBMC` | Target: `System ROM` aka BIOS**
 
 > **IMPORTANT:** If updating the System ROM of an NCN, the NTP and DNS server values will be lost and must be restored. For NCNs **other than `ncn-m001`** this can be done using the `/opt/cray/csm/scripts/node_management/set-bmc-ntp-dns.sh` script. Use the `-h` option to get a list of command line options required to restore the NTP and DNS values. See [Configure DNS and NTP on Each BMC](../../install/deploy_final_non-compute_node.md#configure-dns-and-ntp-on-each-bmc).
 
@@ -1092,7 +1091,7 @@ Correct an issue where the model of the liquid-cooled compute node BIOS is the i
 
 1. Get a high-level summary of the job to verify the changes corrected the issue.
 
-   Use the returned actionID from the `cray fas actions create` command.
+   Use the returned `actionID` from the `cray fas actions create` command.
 
    ```bash
    cray fas actions create UPDATED_COMMAND.json

--- a/operations/firmware/FAS_Use_Cases.md
+++ b/operations/firmware/FAS_Use_Cases.md
@@ -592,7 +592,10 @@ Make sure to wait for the current firmware to be updated before starting a new F
 
 **Device Type: `NodeBMC` | Target: `System ROM` aka BIOS**
 
-> **IMPORTANT:** If updating the System ROM of an NCN, the NTP and DNS server values will be lost and must be restored. For NCNs **other than `ncn-m001`** this can be done using the `/opt/cray/csm/scripts/node_management/set-bmc-ntp-dns.sh` script. Use the `-h` option to get a list of command line options required to restore the NTP and DNS values. See [Configure DNS and NTP on Each BMC](../../install/deploy_final_non-compute_node.md#configure-dns-and-ntp-on-each-bmc).
+> **IMPORTANT:** If updating the System ROM of an NCN, the NTP and DNS server values will be lost and must be restored.
+> For NCNs **other than `ncn-m001`** this can be done using the `/opt/cray/csm/scripts/node_management/set-bmc-ntp-dns.sh` script.
+> Use the `-h` option to get a list of command line options required to restore the NTP and DNS values.
+> See [Configure DNS and NTP on Each BMC](../../install/deploy_final_non-compute_node.md#configure-dns-and-ntp-on-each-bmc).
 
 ```json
 {

--- a/operations/firmware/FAS_Use_Cases.md
+++ b/operations/firmware/FAS_Use_Cases.md
@@ -29,7 +29,7 @@ All of the example JSON files below are set to run a dry-run. Update the `overri
 
 This procedure updates node controller \(nC\) firmware.
 
-### Prerequisites
+**Prerequisites**
 
 * The Cray command line interface \(CLI\) tool is initialized and configured on the system.
 
@@ -104,7 +104,7 @@ There are two nodes that must be updated on each BMC; these have the targets `No
 The targets can be run in the same action (as shown in the example) or run separately by only including one target in the action.
 On larger systems, it is recommended to run as two actions one after each other as the output will be shorter.
 
-##### Prerequisites
+**Prerequisites**
 
 * The Cray `nodeBMC` device needs to be updated before the `nodeBIOS` because the `nodeBMC` adds a new Redfish field \(`softwareId`\) that the `NodeX.BIOS` update will require. See [Update Liquid-Cooled Node Firmware](#liquidcooled) for more information.
 * Compute node BIOS updates require the nodes to be off. If nodes are not off when the update command is issued, it will report as a failed update.
@@ -140,7 +140,7 @@ It is recommended that the `Node0/1` BIOS be updated in a separate action, eithe
 }
 ```
 
-### Procedure
+**Procedure**
 
 1. Create a JSON file using one of the example recipes with the command parameters required for updating the firmware or node BIOS.
 
@@ -284,7 +284,7 @@ Update the Chassis Management Module \(CMM\) controller \(cC\) firmware using FA
 
 The CMM firmware update process also checks and updates the Cabinet Environmental Controller \(CEC\) firmware.
 
-### Prerequisites
+**Prerequisites**
 
 * The Cray command line interface \(CLI\) tool is initialized and configured on the system.
 
@@ -320,7 +320,7 @@ The CMM firmware update process also checks and updates the Cabinet Environmenta
 }
 ```
 
-### Procedure
+**Procedure**
 
 1. Power off the liquid-cooled chassis slots and chassis rectifiers.
 
@@ -466,7 +466,7 @@ After updating the BIOS or System ROM, the compute node will need to be rebooted
 
 This procedure updates node controller \(nC\) firmware.
 
-### Prerequisites
+**Prerequisites**
 
 * The Cray command line interface \(CLI\) tool is initialized and configured on the system.
 
@@ -623,7 +623,7 @@ Make sure to wait for the current firmware to be updated before starting a new F
 }
 ```
 
-### Procedure
+**Procedure**
 
 1. Create a JSON file using one of the example recipes with the command parameters required for updating the firmware or node BIOS.
 
@@ -792,7 +792,7 @@ After updating the BIOS, the NCN will need to be rebooted. Follow the [Reboot NC
 
 Due to networking, FAS cannot update `ncn-m001`. See [Updating Firmware on `ncn-m001`](Updating_Firmware_m001.md)
 
-### Gigabyte
+### Gigabyte NCNs
 
 **Device Type: `NodeBMC` | Target: BMC**
 
@@ -873,7 +873,7 @@ Make sure you have waited for the current firmware to be updated before starting
 
 > **IMPORTANT:** The `timeLimit` is `4000` because the Gigabytes can take a lot longer to update.
 
-### HPE
+### HPE NCNs
 
 **Device Type: `NodeBMC` | Target: `iLO 5` aka BMC**
 
@@ -908,7 +908,10 @@ Make sure you have waited for the current firmware to be updated before starting
 
 **Device Type: `NodeBMC` | Target: `System ROM` aka BIOS**
 
-> **IMPORTANT:** If updating the System ROM of an NCN, the NTP and DNS server values will be lost and must be restored. For NCNs **other than `ncn-m001`** this can be done using the `/opt/cray/csm/scripts/node_management/set-bmc-ntp-dns.sh` script. Use the `-h` option to get a list of command line options required to restore the NTP and DNS values. See [Configure DNS and NTP on Each BMC](../../install/deploy_final_non-compute_node.md#configure-dns-and-ntp-on-each-bmc).
+> **IMPORTANT:** If updating the System ROM of an NCN, the NTP and DNS server values will be lost and must be restored.
+> For NCNs **other than `ncn-m001`** this can be done using the `/opt/cray/csm/scripts/node_management/set-bmc-ntp-dns.sh` script.
+> Use the `-h` option to get a list of command line options required to restore the NTP and DNS values.
+> See [Configure DNS and NTP on Each BMC](../../install/deploy_final_non-compute_node.md#configure-dns-and-ntp-on-each-bmc).
 
 ```json
 {
@@ -941,7 +944,7 @@ Make sure you have waited for the current firmware to be updated before starting
 
 The NCN must be rebooted after updating the BIOS firmware. Follow the [Reboot NCNs](../node_management/Reboot_NCNs.md) procedure.
 
-### Procedure
+**Procedure**
 
 1. For `HPE` NCNs, check the DNS servers by running the script `/opt/cray/csm/scripts/node_management/set-bmc-ntp-dns.sh ilo -H XNAME -s`. Replace `XNAME` with the xname of the NCN BMC.
    See [Configure DNS and NTP on Each BMC](../../install/deploy_final_non-compute_node.md#configure-dns-and-ntp-on-each-bmc) for more information.
@@ -968,7 +971,7 @@ The NCN must be rebooted after updating the BIOS firmware. Follow the [Reboot NC
 
 Correct an issue where the model of the liquid-cooled compute node BIOS is the incorrect name. The name has changed from `WNC-ROME` to `HPE CRAY EX425` or `HPE CRAY EX425 (ROME)`.
 
-### Prerequisites
+**Prerequisites**
 
 * The system is running HPE Cray EX release v1.4 or higher.
 * The system has completed the Cray System Management \(CSM\) installation.
@@ -1017,7 +1020,7 @@ Correct an issue where the model of the liquid-cooled compute node BIOS is the i
 
   The model in this example is `WNC-Rome` and the firmware version currently running is `wnc.bios-1.2.5`.
 
-### Procedure
+**Procedure**
 
 1. Search for a FAS image record with `cray` as the manufacturer, `Node1.BIOS` as the target, and `HPE CRAY EX425` as the model.
 

--- a/operations/firmware/FAS_Use_Cases.md
+++ b/operations/firmware/FAS_Use_Cases.md
@@ -18,7 +18,7 @@ The following procedures are included in this section:
 1. [Update NCN BIOS and BMC Firmware with FAS](#update-non-compute-node-ncn-bios-and-bmc-firmware)
 1. [Compute Node BIOS Workaround for HPE CRAY EX425](#compute-node-bios-workaround-for-hpe-cray-ex425)
 
-> **`NOTE`** To update Switch Controllers \(sC\) or RouterBMC, refer to the Rosetta Documentation.
+> **`NOTE`** To update Switch Controllers \(sC\) or `RouterBMC`, refer to the Rosetta Documentation.
 
 ## Update Liquid-Cooled Nodes BMC, FPGA, and Node BIOS
 
@@ -106,7 +106,7 @@ On larger systems, it is recommended to run as two actions one after each other 
 
 ##### Prerequisites
 
-* The Cray `nodeBMC` device needs to be updated before the nodeBIOS because the `nodeBMC` adds a new Redfish field \(`softwareId`\) that the `NodeX.BIOS` update will require. See [Update Liquid-Cooled Node Firmware](#liquidcooled) for more information.
+* The Cray `nodeBMC` device needs to be updated before the `nodeBIOS` because the `nodeBMC` adds a new Redfish field \(`softwareId`\) that the `NodeX.BIOS` update will require. See [Update Liquid-Cooled Node Firmware](#liquidcooled) for more information.
 * Compute node BIOS updates require the nodes to be off. If nodes are not off when the update command is issued, it will report as a failed update.
 
 > **IMPORTANT:** The nodes themselves must be powered **off** in order to update the BIOS on the nodes. The BMC will still have power and will perform the update.
@@ -182,25 +182,25 @@ It is recommended that the `Node0/1` BIOS be updated in a separate action, eithe
 
         * Lists the nodes that have a valid image for updating:
 
-            ```
+            ```text
             [operationSummary.succeeded]
             ```
 
         * Lists the nodes that will not be updated because they are already at the correct version:
 
-            ```
+            ```text
             [operationSummary.noOperation]
             ```
 
         * Lists the nodes that had an error when attempting to update:
 
-            ```
+            ```text
             [operationSummary.failed]
             ```
 
         * Lists the nodes that do not have a valid image for updating:
 
-            ```
+            ```text
             [operationSummary.noSolution]
             ```
 
@@ -381,25 +381,25 @@ The CMM firmware update process also checks and updates the Cabinet Environmenta
 
         If `state = "completed"`, the dry-run has found and checked all the nodes. Check the following sections for more information:
 
-        *   Lists the nodes that have a valid image for updating:
+        * Lists the nodes that have a valid image for updating:
 
             ```
             [operationSummary.succeeded]
             ```
 
-        *   Lists the nodes that will not be updated because they are already at the correct version:
+        * Lists the nodes that will not be updated because they are already at the correct version:
 
             ```
             [operationSummary.noOperation]
             ```
 
-        *   Lists the nodes that had an error when attempting to update:
+        * Lists the nodes that had an error when attempting to update:
 
             ```
             [operationSummary.failed]
             ```
 
-        *   Lists the nodes that do not have a valid image for updating:
+        * Lists the nodes that do not have a valid image for updating:
 
             ```
             [operationSummary.noSolution]
@@ -517,6 +517,7 @@ FAS has incorrectly marked this node as failed.
 It most likely will complete the update successfully.
 
 To resolve this issue, do either of the following actions:
+
 * Check the update status by looking at the Redfish `FirmwareInventory` (`/redfish/v1/UpdateService/FirmwareInventory/BMC`).
 * Rerun FAS to verify that the BMC firmware was updated.
 
@@ -668,27 +669,27 @@ Make sure to wait for the current firmware to be updated before starting a new F
 
         If `state = "completed"`, the dry-run has found and checked all the nodes. Check the following sections for more information:
 
-        *   Lists the nodes that have a valid image for updating:
+        * Lists the nodes that have a valid image for updating:
 
-            ```
+            ```text
             [operationSummary.succeeded]
             ```
 
-        *   Lists the nodes that will not be updated because they are already at the correct version:
+        * Lists the nodes that will not be updated because they are already at the correct version:
 
-            ```
+            ```text
             [operationSummary.noOperation]
             ```
 
-        *   Lists the nodes that had an error when attempting to update:
+        * Lists the nodes that had an error when attempting to update:
 
-            ```
+            ```text
             [operationSummary.failed]
             ```
 
-        *   Lists the nodes that do not have a valid image for updating:
+        * Lists the nodes that do not have a valid image for updating:
 
-            ```
+            ```text
             [operationSummary.noSolution]
             ```
 
@@ -698,7 +699,7 @@ Make sure to wait for the current firmware to be updated before starting a new F
 
         The following example is for the `nodeBMC.json` file. Update the following values:
 
-        ```
+        ```text
         "overrideDryrun":true,
         "description":"Update of HPE node iLO 5"
         ```
@@ -832,8 +833,10 @@ It may report that a node failed to update with the output:
 FAS has incorrectly marked this node as failed.
 It most likely will complete the update successfully.
 To resolve this issue, do either of the following actions:
+
 * Check the update status by looking at the Redfish `FirmwareInventory` (`/redfish/v1/UpdateService/FirmwareInventory/BMC`)
 * Rerun FAS to verify that the BMC firmware was updated.
+
 Make sure you have waited for the current firmware to be updated before starting a new FAS action on the same node.
 
 **Device Type: `NodeBMC` | Target: BIOS**
@@ -1048,7 +1051,7 @@ Correct an issue where the model of the liquid-cooled compute node BIOS is the i
 
    Take note of the returned `imageID` value to use in the next step.
 
-2. Create a JSON file to override the existing image with the corrected values.
+1. Create a JSON file to override the existing image with the corrected values.
 
    > **IMPORTANT:** The `imageID` must be changed to match the identified `imageID` in the previous step.
 

--- a/operations/firmware/FAS_Use_Cases.md
+++ b/operations/firmware/FAS_Use_Cases.md
@@ -105,8 +105,8 @@ There are two nodes that must be updated on each BMC; these have the targets `No
 The targets can be run in the same action (as shown in the example) or run separately by only including one target in the action.
 On larger systems, it is recommended to run as two actions one after each other as the output will be shorter.
 
-
-> **IMPORTANT:** The Cray `nodeBMC` device needs to be updated before the `nodeBIOS` because the `nodeBMC` adds a new Redfish field \(`softwareId`\) that the `NodeX.BIOS` update will require. See [Update Liquid-Cooled Node Firmware](#liquidcooled) for more information.
+> **IMPORTANT:** The Cray `nodeBMC` device needs to be updated before the `nodeBIOS` because the `nodeBMC` adds a new Redfish field \(`softwareId`\) that the `NodeX.BIOS` update will require.
+See [Update Liquid-Cooled Node Firmware](#liquidcooled) for more information.
 > **IMPORTANT:** The nodes themselves must be powered **off** in order to update the BIOS on the nodes.
 The BMC will still have power and will perform the update.
 If nodes are not off when the update command is issued, it will report as a failed update.
@@ -317,7 +317,7 @@ The CMM firmware update process also checks and updates the Cabinet Environmenta
 }
 ```
 
-##### Cray Chassis BMC Update Procedure
+#### Cray Chassis BMC Update Procedure
 
 1. Power off the liquid-cooled chassis slots and chassis rectifiers.
 
@@ -619,7 +619,7 @@ Make sure to wait for the current firmware to be updated before starting a new F
 }
 ```
 
-##### HPE Node System ROM (BIOS) Update Procedure
+#### HPE Node System ROM (BIOS) Update Procedure
 
 1. Create a JSON file using one of the example recipes with the command parameters required for updating the firmware or node BIOS.
 
@@ -940,7 +940,7 @@ Make sure you have waited for the current firmware to be updated before starting
 
 The NCN must be rebooted after updating the BIOS firmware. Follow the [Reboot NCNs](../node_management/Reboot_NCNs.md) procedure.
 
-##### HPE Node System ROM (BIOS) Procedure for NCN
+#### HPE Node System ROM (BIOS) Procedure for NCN
 
 1. For `HPE` NCNs, check the DNS servers by running the script `/opt/cray/csm/scripts/node_management/set-bmc-ntp-dns.sh ilo -H XNAME -s`. Replace `XNAME` with the xname of the NCN BMC.
    See [Configure DNS and NTP on Each BMC](../../install/deploy_final_non-compute_node.md#configure-dns-and-ntp-on-each-bmc) for more information.
@@ -967,7 +967,7 @@ The NCN must be rebooted after updating the BIOS firmware. Follow the [Reboot NC
 
 Correct an issue where the model of the liquid-cooled compute node BIOS is the incorrect name. The name has changed from `WNC-ROME` to `HPE CRAY EX425` or `HPE CRAY EX425 (ROME)`.
 
-**Prerequisites**
+Prerequisites:
 * The system is running HPE Cray EX release v1.4 or higher.
 * A firmware upgrade has been done following [Update Liquid-Cooled Compute Node BIOS Firmware](#cn-bios).
   * The result of the upgrade is that the `NodeX.BIOS` has failed as `noSolution` and the `stateHelper` field for the operation states is `"No Image Available"`.
@@ -1014,7 +1014,7 @@ Correct an issue where the model of the liquid-cooled compute node BIOS is the i
 
   The model in this example is `WNC-Rome` and the firmware version currently running is `wnc.bios-1.2.5`.
 
-##### Compute Node BIOS Workaround for HPE CRAY EX425 Procedure
+### Compute Node BIOS Workaround for HPE CRAY EX425 Procedure
 
 1. Search for a FAS image record with `cray` as the manufacturer, `Node1.BIOS` as the target, and `HPE CRAY EX425` as the model.
 

--- a/operations/firmware/FAS_Use_Cases.md
+++ b/operations/firmware/FAS_Use_Cases.md
@@ -968,6 +968,7 @@ The NCN must be rebooted after updating the BIOS firmware. Follow the [Reboot NC
 Correct an issue where the model of the liquid-cooled compute node BIOS is the incorrect name. The name has changed from `WNC-ROME` to `HPE CRAY EX425` or `HPE CRAY EX425 (ROME)`.
 
 Prerequisites:
+
 * The system is running HPE Cray EX release v1.4 or higher.
 * A firmware upgrade has been done following [Update Liquid-Cooled Compute Node BIOS Firmware](#cn-bios).
   * The result of the upgrade is that the `NodeX.BIOS` has failed as `noSolution` and the `stateHelper` field for the operation states is `"No Image Available"`.

--- a/operations/firmware/FAS_Use_Cases.md
+++ b/operations/firmware/FAS_Use_Cases.md
@@ -4,6 +4,10 @@ Use the Firmware Action Service (FAS) to update the firmware on supported hardwa
 
 When updating an entire system, walk down the device hierarchy component type by component type, starting first with Routers (switches), proceeding to Chassis, and then finally to Nodes. While this is not strictly necessary, it does help eliminate confusion.
 
+**NOTE**: Any node which is locked will remain in the state `inProgress` with the `stateHelper` message of `"failed to lock"` until the action times out, or the lock is released.
+These nodes will report as `failed` with the `stateHelper` message of `"time expired; could not complete update"` if action times out.
+This includes NCNs which are manually locked to prevent accidental rebooting and firmware updates.
+
 Refer to [FAS Filters](FAS_Filters.md) for more information on the content used in the example JSON files.
 
 The following procedures are included in this section:
@@ -645,7 +649,7 @@ Make sure to wait for the current firmware to be updated before starting a new F
         ```bash
         cray fas actions describe {actionID}
         ```
-        
+
         ```text
         blockedBy = []
         state = "completed"
@@ -976,7 +980,7 @@ Correct an issue where the model of the liquid-cooled compute node BIOS is the i
   ```bash
   cray fas operations describe {operationID} --format json
   ```
-  
+
   ```json
   {
     "operationID":"102c949f-e662-4019-bc04-9e4b433ab45e",
@@ -1019,7 +1023,7 @@ Correct an issue where the model of the liquid-cooled compute node BIOS is the i
    cray fas images list --format json | jq '.images[] | select(.manufacturer=="cray") \
    | select(.target=="Node1.BIOS") | select(any(.models[]; contains("EX425")))'
    ```
-   
+
    ```json
    {
        "imageID": "e23f5465-ed29-4b18-9389-f8cf0580ca60",

--- a/operations/firmware/Update_Firmware_with_FAS.md
+++ b/operations/firmware/Update_Firmware_with_FAS.md
@@ -37,6 +37,10 @@ Non-compute nodes (NCNs) and their BMCs should be locked with the HSM locking AP
 See [Lock and Unlock Management Nodes](../hardware_state_manager/Lock_and_Unlock_Management_Nodes.md) for more information.
 Failure to lock the NCNs could result in unintentional update of the NCNs if FAS is not used correctly; this will lead to system instability problems.
 
+**NOTE**: Any node which is locked will remain in the state `inProgress` with the `stateHelper` message of `"failed to lock"` until the action times out, or the lock is released.
+These nodes will report as `failed` with the `stateHelper` message of `"time expired; could not complete update"` if action times out.
+This includes NCNs which are manually locked to prevent accidental rebooting and firmware updates.
+
 Follow the process outlined in [FAS CLI](FAS_CLI.md) to update the system. Use the recipes listed in [FAS Recipes](FAS_Recipes.md) to update each supported type.
 
 > **`NOTE`** Each system is different and may not have all hardware options.
@@ -173,7 +177,7 @@ The following is an example of an image:
   "manufacturer": "intel",
   "model": ["s2600","s2600_REV_a"],
   "target": "BIOS",
-  "tag": ["recovery", default"],
+  "tag": ["recovery", "default"],
   "firmwareVersion": "f1.123.24xz",
   "semanticFirmwareVersion": "v1.2.252",
   "updateURI": "/redfish/v1/Systems/UpdateService/BIOS",

--- a/operations/kubernetes/Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md
+++ b/operations/kubernetes/Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md
@@ -172,7 +172,7 @@ Data is repopulated in BSS when the REDS `init` job is run.
         ```bash
         TMPFILE=$(mktemp)
         sat status --no-borders --no-headings | grep Ready | grep Compute | awk '{printf("nid%06d-nmn\n",$3);}' > $TMPFILE
-        pdsh -w ^${TMPFILE} "systemctl restart cray-dvs-orca"
+        pdsh -w ^${TMPFILE} "systemctl restart cray-orca"
         rm -rf $TMPFILE
         ```
 
@@ -181,6 +181,6 @@ Data is repopulated in BSS when the REDS `init` job is run.
         **`NOTE`** Modify the `-w` arguments in the following commands to reflect the number of worker and storage nodes in the system.
 
         ```bash
-        pdsh -w ncn-w00[0-4]-can.local "systemctl restart cray-dvs-orca"
-        pdsh -w ncn-s00[0-4]-can.local "systemctl restart cray-dvs-orca"
+        pdsh -w ncn-w00[0-4]-can.local "systemctl restart cray-orca"
+        pdsh -w ncn-s00[0-4]-can.local "systemctl restart cray-orca"
         ```

--- a/operations/kubernetes/Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md
+++ b/operations/kubernetes/Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md
@@ -167,20 +167,20 @@ Data is repopulated in BSS when the REDS `init` job is run.
 
 1. Resubscribe the compute nodes and any NCNs that use the ORCA daemon for their State Change Notifications \(SCN\).
 
-    1. Resubscribe all compute nodes.
+    1. (`ncn-m#`) Resubscribe all compute nodes.
 
         ```bash
         TMPFILE=$(mktemp)
-        sat status --no-borders --no-headings | grep Ready | grep Compute | awk '{printf("nid%06d-nmn\n",$3);}' > $TMPFILE
+        sat status --no-borders --no-headings | grep Ready | grep Compute | awk '{printf("nid%06d-nmn\n",$4);}' > $TMPFILE
         pdsh -w ^${TMPFILE} "systemctl restart cray-orca"
         rm -rf $TMPFILE
         ```
 
-    1. Resubscribe the NCNs.
+    1. (`ncn-m#`) Resubscribe the NCNs.
 
         **`NOTE`** Modify the `-w` arguments in the following commands to reflect the number of worker and storage nodes in the system.
 
         ```bash
-        pdsh -w ncn-w00[0-4]-can.local "systemctl restart cray-orca"
-        pdsh -w ncn-s00[0-4]-can.local "systemctl restart cray-orca"
+        pdsh -w ncn-w00[1-4]-can.local "systemctl restart cray-orca"
+        pdsh -w ncn-s00[1-4]-can.local "systemctl restart cray-orca"
         ```

--- a/operations/security_and_authentication/Change_Credentials_on_ServerTech_PDUs.md
+++ b/operations/security_and_authentication/Change_Credentials_on_ServerTech_PDUs.md
@@ -8,6 +8,7 @@ all ServerTech PDUs in the system can be updated to the same global credentials.
 - This procedure does not update the default credentials that RTS uses for new ServerTech PDUs added to a system. To change the default credentials, see
   [Update default ServerTech PDU Credentials used by the Redfish Translation Service](Update_Default_ServerTech_PDU_Credentials_used_by_the_Redfish_Translation_Service.md).
 - ServerTech PDUs running firmware version `8.0q` or greater must have the password of the `admn` user changed before the JAWS REST API will function as expected.
+- The default user/password for ServerTech PDUs is `admn`/`admn`
 
 ## Prerequisites
 
@@ -19,7 +20,7 @@ all ServerTech PDUs in the system can be updated to the same global credentials.
 
     ```bash
     PDU=x3000m0
-    curl -k https://$PDU -i | grep Server
+    curl -k -s --compressed  https://$PDU -i | grep Server:
     ```
 
     Expected output for a ServerTech PDU:
@@ -27,6 +28,8 @@ all ServerTech PDUs in the system can be updated to the same global credentials.
     ```text
     Server: ServerTech-AWS/v8.0v
     ```
+
+    *NOTE*: The firmware version is listed after the '/' in the output in this case the firmware version is `8.0v`
 
 ## Procedure
 
@@ -42,6 +45,8 @@ all ServerTech PDUs in the system can be updated to the same global credentials.
     ```text
     x3000m0
     ```
+
+    If some or all of the PDUs have NOT been discovered by HSM, you will need to obtain the xname for each of the ServerTech PDUs on the system.
 
 1. (`ncn-mw#`) Set up Vault password variable and command alias.
 
@@ -88,8 +93,6 @@ all ServerTech PDUs in the system can be updated to the same global credentials.
 
     - Update the password on a single ServerTech PDU
 
-        **NOTE**: To change the password on a single PDU, that PDU must be successfully discovered by HSM.
-
         1. (`ncn-mw#`) Set the PDU hostname to change the `admn` credentials:
 
             ```bash
@@ -130,6 +133,8 @@ all ServerTech PDUs in the system can be updated to the same global credentials.
             ```
 
     - Update all ServerTech PDUs in the system to the same password.
+
+        **NOTE**: To change the password on all PDUs, that PDUs must be successfully discovered by HSM.
 
         1. (`ncn-mw#`) Change password for the `admn` user on the ServerTech PDUs currently discovered in the system.
 
@@ -175,7 +180,7 @@ all ServerTech PDUs in the system can be updated to the same global credentials.
             done
             ```
 
-    **NOTE**: After five minutes, the previous credential should stop working as the existing sessions time out.
+            **NOTE**: After five minutes, the previous credential should stop working as the existing sessions time out.
 
 1. (`ncn-mw#`) Restart the Redfish Translation Service (RTS) to pickup the new PDU credentials.
 

--- a/operations/security_and_authentication/Change_Credentials_on_ServerTech_PDUs.md
+++ b/operations/security_and_authentication/Change_Credentials_on_ServerTech_PDUs.md
@@ -8,7 +8,7 @@ all ServerTech PDUs in the system can be updated to the same global credentials.
 - This procedure does not update the default credentials that RTS uses for new ServerTech PDUs added to a system. To change the default credentials, see
   [Update default ServerTech PDU Credentials used by the Redfish Translation Service](Update_Default_ServerTech_PDU_Credentials_used_by_the_Redfish_Translation_Service.md).
 - ServerTech PDUs running firmware version `8.0q` or greater must have the password of the `admn` user changed before the JAWS REST API will function as expected.
-- The default user/password for ServerTech PDUs is `admn`/`admn`
+- The default user/password for ServerTech PDUs is `admn`/`admn`.
 
 ## Prerequisites
 
@@ -29,7 +29,7 @@ all ServerTech PDUs in the system can be updated to the same global credentials.
     Server: ServerTech-AWS/v8.0v
     ```
 
-    *NOTE*: The firmware version is listed after the '/' in the output in this case the firmware version is `8.0v`
+    *NOTE*: The firmware version is listed after the '/'. In this case, the firmware version is `8.0v`.
 
 ## Procedure
 
@@ -46,7 +46,7 @@ all ServerTech PDUs in the system can be updated to the same global credentials.
     x3000m0
     ```
 
-    If some or all of the PDUs have NOT been discovered by HSM, you will need to obtain the xname for each of the ServerTech PDUs on the system.
+    If some or all of the PDUs have NOT been discovered by HSM, you must obtain the component name (xname) for each of the ServerTech PDUs on the system.
 
 1. (`ncn-mw#`) Set up Vault password variable and command alias.
 


### PR DESCRIPTION
# Description

CASMINST-4608 - cray-hmnfd-etcd instructions reference nonexistent service
CASMINST-4838 - ServerTech PDU documentation incomplete
CASMHMS-5598 - Clarify failures of firmware updates related to locking

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
