### PR TITLE
CASMINST-4980 Fix Broken Command

### DIFF
--- a/install/pre-installation.md
+++ b/install/pre-installation.md
@@ -462,10 +462,10 @@ in `/etc/environment` from the [Download CSM tarball](#21-download-csm-tarball) 
    1. Run `ncn-image-modification.sh` from the CSM tarball:
 
        ```bash
-       "${PITDATA}/csm-${CSM_RELEASE}/ncn-image-modification.sh -p \
+       "${PITDATA}/csm-${CSM_RELEASE}/ncn-image-modification.sh" -p \
           -d /root/.ssh \
-          -k /var/www/ephemeral/data/k8s/${kubernetes_version}/kubernetes-${kubernetes_version}.squashfs \
-          -s /var/www/ephemeral/data/ceph/${kubernetes_version}/storage-ceph-${ceph_version}.squashfs"
+          -k "/var/www/ephemeral/data/k8s/${kubernetes_version}/kubernetes-${kubernetes_version}.squashfs" \
+          -s "/var/www/ephemeral/data/ceph/${kubernetes_version}/storage-ceph-${ceph_version}.squashfs"
        ```
 
 1. (`pit#`) Log the currently installed PIT packages.


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
The double-quotes surround the command break running it if it is copy and pasted verbatium.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
