### PR TITLE
CASMINST-4996 Fix undefined variable

### DIFF
--- a/install/re-installation.md
+++ b/install/re-installation.md
@@ -115,10 +115,10 @@ BMCs to be set back to DHCP before proceeding.
       for bmc in ${BMCS[@]}; do
          # by default the LAN for the BMC is lan channel 1, except on Intel systems.
          if ipmitool -I lanplus -U $username -E -H $bmc lan print 3 2>/dev/null; then
-            LAN=3
+            lan=3
          fi
          printf "Setting %s to DHCP ... " "$bmc"
-         if ipmitool -I lanplus -U $username -E -H $bmc lan set $LAN ipsrc dhcp; then
+         if ipmitool -I lanplus -U $username -E -H $bmc lan set $lan ipsrc dhcp; then
             echo "Done"
          else
             echo "Failed!"


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
The `lan` variable is not used, it should be capitalized or the others lower cased.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
