### PR TITLE
CASMINST-5016:  Update the gateway test definition to use HSM v2 API

### DIFF
--- a/scripts/operations/gateway-test/gateway-test-defn.yaml
+++ b/scripts/operations/gateway-test/gateway-test-defn.yaml
@@ -150,7 +150,7 @@ ingress_api_services:
   gateways: ["services-gateway","customer-admin-gateway"]
   project: CSM
 - name: cray-smd
-  path: apis/smd/hsm/v1/service/ready
+  path: apis/smd/hsm/v2/service/ready
   port: 443
   expected-result: 200
   namespace: services


### PR DESCRIPTION
# Description

The HSM v1 APIs are being removed in 1.3.  This updates the gateway test definition to use HSM v2 API.

# Checklist Before Merging

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams

# Testing

Tested by running the NCN gateway tests on mug.   The UAN and Computes don't have access to the admin interfaces so those scripts will not hit this issue.

```
------------- api-gw-service-nmn.local -------------------
api-gw-service-nmn.local is reachable
PASS - [cray-bos]: https://api-gw-service-nmn.local/apis/bos/v1/session - 200
PASS - [cray-bss]: https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters - 200
PASS - [cray-capmc]: https://api-gw-service-nmn.local/apis/capmc/capmc/get_node_rules - 200
PASS - [cray-cfs-api]: https://api-gw-service-nmn.local/apis/cfs/v2/sessions - 200
PASS - [cray-console-data]: https://api-gw-service-nmn.local/apis/consoledata/liveness - 204
PASS - [cray-console-node]: https://api-gw-service-nmn.local/apis/console-node/console-node/liveness - 204
FAIL - [cray-console-operator]: https://api-gw-service-nmn.local/apis/console-operator/console-operator/liveness - 503
SKIP - [cray-cps]: https://api-gw-service-nmn.local/apis/v2/cps/contents - virtual service not found
PASS - [cray-fas]: https://api-gw-service-nmn.local/apis/fas/v1/snapshots - 200
PASS - [cray-hbtd]: https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/health - 200
PASS - [cray-hmnfd]: https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/health - 200
PASS - [cray-ims]: https://api-gw-service-nmn.local/apis/ims/images - 200
PASS - [cray-powerdns-manager]: https://api-gw-service-nmn.local/apis/powerdns-manager/v1/liveness - 204
PASS - [cray-reds]: https://api-gw-service-nmn.local/apis/reds/v1/liveness - 204
PASS - [cray-scsd]: https://api-gw-service-nmn.local/apis/scsd/v1/health - 200
PASS - [cray-sls]: https://api-gw-service-nmn.local/apis/sls/v1/health - 200
PASS - [cray-smd]: https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/ready - 200
PASS - [cray-sts]: https://api-gw-service-nmn.local/apis/sts/healthz - 200
PASS - [cray-uas-mgr]: https://api-gw-service-nmn.local/apis/uas-mgr/v1/images - 200
SKIP - [nmdv2-service]: https://api-gw-service-nmn.local/apis/v2/nmd/dumps - virtual service not found
SKIP - [slingshot-fabric-manager]: https://api-gw-service-nmn.local/apis/fabric-manager/fabric/port-policies - virtual service not found
SKIP - [sma-telemetry]: https://api-gw-service-nmn.local/apis/sma-telemetry-api/v1/ping - virtual service not found

------------- api.cmn.drax.dev.cray.com -------------------
api.cmn.drax.dev.cray.com is reachable
PASS - [cray-bos]: https://api.cmn.drax.dev.cray.com/apis/bos/v1/session - 200
PASS - [cray-bss]: https://api.cmn.drax.dev.cray.com/apis/bss/boot/v1/bootparameters - 200
PASS - [cray-capmc]: https://api.cmn.drax.dev.cray.com/apis/capmc/capmc/get_node_rules - 200
PASS - [cray-cfs-api]: https://api.cmn.drax.dev.cray.com/apis/cfs/v2/sessions - 200
PASS - [cray-console-data]: https://api.cmn.drax.dev.cray.com/apis/consoledata/liveness - 204
PASS - [cray-console-node]: https://api.cmn.drax.dev.cray.com/apis/console-node/console-node/liveness - 204
FAIL - [cray-console-operator]: https://api.cmn.drax.dev.cray.com/apis/console-operator/console-operator/liveness - 503
SKIP - [cray-cps]: https://api.cmn.drax.dev.cray.com/apis/v2/cps/contents - virtual service not found
PASS - [cray-fas]: https://api.cmn.drax.dev.cray.com/apis/fas/v1/snapshots - 200
PASS - [cray-hbtd]: https://api.cmn.drax.dev.cray.com/apis/hbtd/hmi/v1/health - 200
PASS - [cray-hmnfd]: https://api.cmn.drax.dev.cray.com/apis/hmnfd/hmi/v2/health - 200
PASS - [cray-ims]: https://api.cmn.drax.dev.cray.com/apis/ims/images - 200
PASS - [cray-powerdns-manager]: https://api.cmn.drax.dev.cray.com/apis/powerdns-manager/v1/liveness - 204
PASS - [cray-reds]: https://api.cmn.drax.dev.cray.com/apis/reds/v1/liveness - 204
PASS - [cray-scsd]: https://api.cmn.drax.dev.cray.com/apis/scsd/v1/health - 200
PASS - [cray-sls]: https://api.cmn.drax.dev.cray.com/apis/sls/v1/health - 200
PASS - [cray-smd]: https://api.cmn.drax.dev.cray.com/apis/smd/hsm/v2/service/ready - 200
PASS - [cray-sts]: https://api.cmn.drax.dev.cray.com/apis/sts/healthz - 200
PASS - [cray-uas-mgr]: https://api.cmn.drax.dev.cray.com/apis/uas-mgr/v1/images - 200
SKIP - [nmdv2-service]: https://api.cmn.drax.dev.cray.com/apis/v2/nmd/dumps - virtual service not found
SKIP - [slingshot-fabric-manager]: https://api.cmn.drax.dev.cray.com/apis/fabric-manager/fabric/port-policies - virtual service not found
SKIP - [sma-telemetry]: https://api.cmn.drax.dev.cray.com/apis/sma-telemetry-api/v1/ping - virtual service not found

------------- api.can.drax.dev.cray.com -------------------
api.can.drax.dev.cray.com is reachable
PASS - [cray-bos]: https://api.can.drax.dev.cray.com/apis/bos/v1/session - 404
PASS - [cray-bss]: https://api.can.drax.dev.cray.com/apis/bss/boot/v1/bootparameters - 404
PASS - [cray-capmc]: https://api.can.drax.dev.cray.com/apis/capmc/capmc/get_node_rules - 404
PASS - [cray-cfs-api]: https://api.can.drax.dev.cray.com/apis/cfs/v2/sessions - 404
PASS - [cray-console-data]: https://api.can.drax.dev.cray.com/apis/consoledata/liveness - 404
PASS - [cray-console-node]: https://api.can.drax.dev.cray.com/apis/console-node/console-node/liveness - 404
PASS - [cray-console-operator]: https://api.can.drax.dev.cray.com/apis/console-operator/console-operator/liveness - 404
SKIP - [cray-cps]: https://api.can.drax.dev.cray.com/apis/v2/cps/contents - virtual service not found
PASS - [cray-fas]: https://api.can.drax.dev.cray.com/apis/fas/v1/snapshots - 404
PASS - [cray-hbtd]: https://api.can.drax.dev.cray.com/apis/hbtd/hmi/v1/health - 404
PASS - [cray-hmnfd]: https://api.can.drax.dev.cray.com/apis/hmnfd/hmi/v2/health - 404
PASS - [cray-ims]: https://api.can.drax.dev.cray.com/apis/ims/images - 404
PASS - [cray-powerdns-manager]: https://api.can.drax.dev.cray.com/apis/powerdns-manager/v1/liveness - 404
PASS - [cray-reds]: https://api.can.drax.dev.cray.com/apis/reds/v1/liveness - 404
PASS - [cray-scsd]: https://api.can.drax.dev.cray.com/apis/scsd/v1/health - 404
PASS - [cray-sls]: https://api.can.drax.dev.cray.com/apis/sls/v1/health - 404
PASS - [cray-smd]: https://api.can.drax.dev.cray.com/apis/smd/hsm/v2/service/ready - 404
PASS - [cray-sts]: https://api.can.drax.dev.cray.com/apis/sts/healthz - 404
PASS - [cray-uas-mgr]: https://api.can.drax.dev.cray.com/apis/uas-mgr/v1/images - 404
SKIP - [nmdv2-service]: https://api.can.drax.dev.cray.com/apis/v2/nmd/dumps - virtual service not found
SKIP - [slingshot-fabric-manager]: https://api.can.drax.dev.cray.com/apis/fabric-manager/fabric/port-policies - virtual service not found
SKIP - [sma-telemetry]: https://api.can.drax.dev.cray.com/apis/sma-telemetry-api/v1/ping - virtual service not found

```
