### PR TITLE
CASMTRIAGE-3699: Add in missing EthernetInterface delete command to the removing a liquid-cooled blade procedure.

### DIFF
--- a/operations/node_management/Removing_a_Liquid-cooled_blade_from_a_System.md
+++ b/operations/node_management/Removing_a_Liquid-cooled_blade_from_a_System.md
@@ -6,7 +6,7 @@ This procedure will remove a liquid-cooled blades from an HPE Cray EX system.
 
 - The Cray command line interface \(CLI\) tool is initialized and configured on the system. See [Configure the Cray CLI](../configure_cray_cli.md).
 
-- Knowledge of whether DVS is operating over the Node Management Network (NMN) or the High Speed Network (HSN).
+- Knowledge of whether Data Virtualization Service (DVS) is operating over the Node Management Network (NMN) or the High Speed Network (HSN).
 
 - The Slingshot fabric must be configured with the desired topology for desired state of the blades in the system.
 
@@ -20,7 +20,7 @@ This procedure will remove a liquid-cooled blades from an HPE Cray EX system.
 
 ## Procedure
 
-### 1. Prepare the source system blade for removal
+### Step 1: Prepare the source system blade for removal
 
 1. Use the workload manager (WLM) to drain running jobs from the affected nodes on the blade.
 
@@ -36,7 +36,7 @@ This procedure will remove a liquid-cooled blades from an HPE Cray EX system.
     cray bos session create --template-uuid $BOS_TEMPLATE --operation shutdown --limit x9000c3s0b0n0,x9000c3s0b0n1,x9000c3s0b1n0,x9000c3s0b1n1
     ```
 
-### 2. Disable the Redfish endpoints for the nodes
+### Step 2: Disable the Redfish endpoints for the nodes
 
 1. (`ncn#`) Temporarily disable the Redfish endpoints for `NodeBMCs` present in the blade.
 
@@ -45,7 +45,7 @@ This procedure will remove a liquid-cooled blades from an HPE Cray EX system.
     cray hsm inventory redfishEndpoints update --enabled false x9000c3s0b1
     ```
 
-### 3. Clear the node controller settings
+### Step 3: Clear the node controller settings
 
 1. (`ncn#`) Remove the system-specific settings from each node controller on the blade.
 
@@ -61,7 +61,7 @@ This procedure will remove a liquid-cooled blades from an HPE Cray EX system.
 
    Use Ctrl-C to return to the prompt if command does not return.
 
-### 4. Power off the chassis slot
+### Step 4: Power off the chassis slot
 
 1. (`ncn-mw#`) Suspend the `hms-discovery` cron job.
 
@@ -90,7 +90,7 @@ This procedure will remove a liquid-cooled blades from an HPE Cray EX system.
     cray capmc xname_off create --xnames x9000c3s0 --recursive true
     ```
 
-### 5. Disable the chassis slot
+### Step 5: Disable the chassis slot
 
 1. (`ncn#`) Disable the chassis slot.
 
@@ -100,9 +100,9 @@ This procedure will remove a liquid-cooled blades from an HPE Cray EX system.
     cray hsm state components enabled update --enabled false x9000c3s0
     ```
 
-### 6. Record MAC and IP addresses for nodes
+### Step 6: Record MAC and IP addresses for nodes
 
-**IMPORTANT**: Record the node management network (NMN) MAC and IP addresses for each node in the blade (labeled `Node Maintenance Network`). To prevent disruption in the data virtualization service (DVS) when over operating the NMN, these addresses must
+**IMPORTANT**: Record the NMN MAC and IP addresses for each node in the blade (labeled `Node Maintenance Network`). To prevent disruption in DVS when over operating the NMN, these addresses must
 be maintained in the HSM when the blade is swapped and discovered.
 
 The `NodeBMC` MAC and IP addresses are assigned algorithmically and *must not be deleted* from the HSM.
@@ -145,9 +145,9 @@ The `NodeBMC` MAC and IP addresses are assigned algorithmically and *must not be
 
 1. Repeat the command to record the `ComponentID`, MAC addresses, and IP addresses for the `Node Maintenance Network` for the other nodes in the blade.
 
-### 7. Cleanup Hardware State Manager
+### Step 7: Cleanup Hardware State Manager
 
-1. (`ncn#`) Set environment corresponding the chassis slot of the blade.
+1. (`ncn#`) Set an environment variable that corresponds to the chassis slot of the blade.
 
     ```bash
     CHASSIS_SLOT=x9000c3s0
@@ -165,7 +165,7 @@ The `NodeBMC` MAC and IP addresses are assigned algorithmically and *must not be
     done
     ```
 
-1. (`ncn#`) Remove entries from state components.
+1. (`ncn#`) Remove entries from the state components.
 
     ```bash
     for xname in $(cray hsm state components list --class Mountain --format json |
@@ -197,7 +197,7 @@ The `NodeBMC` MAC and IP addresses are assigned algorithmically and *must not be
     ncn-mw# kubectl delete pods -n services -l app.kubernetes.io/name=cray-dhcp-kea
     ```
 
-### 8. Remove the blade
+### Step 8: Remove the blade
 
 1. Remove the blade from the source location.
 

--- a/operations/node_management/Removing_a_Liquid-cooled_blade_from_a_System.md
+++ b/operations/node_management/Removing_a_Liquid-cooled_blade_from_a_System.md
@@ -3,42 +3,46 @@
 This procedure will remove a liquid-cooled blades from an HPE Cray EX system.
 
 ## Perquisites
--   The Cray command line interface \(CLI\) tool is initialized and configured on the system.
 
--   Knowledge of whether DVS is operating over the Node Management Network (NMN) or the High Speed Network (HSN).
+- The Cray command line interface \(CLI\) tool is initialized and configured on the system.
 
--   The Slingshot fabric must be configured with the desired topology for desired state of the blades in the system.
+- Knowledge of whether DVS is operating over the Node Management Network (NMN) or the High Speed Network (HSN).
 
--   The System Layout Service (SLS) must have the desired HSN configuration.
+- The Slingshot fabric must be configured with the desired topology for desired state of the blades in the system.
 
--   Check the status of the high-speed network (HSN) and record link status before the procedure.
+- The System Layout Service (SLS) must have the desired HSN configuration.
 
--   The blades must have the coolant drained and filled during the swap to minimize cross-contamination of cooling systems.
-    - Review procedures in *HPE Cray EX Coolant Service Procedures H-6199*
-    - Review the *HPE Cray EX Hand Pump User Guide H-6200*
+- Check the status of the high-speed network (HSN) and record link status before the procedure.
+
+- The blades must have the coolant drained and filled during the swap to minimize cross-contamination of cooling systems.
+  - Review procedures in *HPE Cray EX Coolant Service Procedures H-6199*
+  - Review the *HPE Cray EX Hand Pump User Guide H-6200*
 
 ## Procedure
 
-### Prepare the source system blade for removal
-1.  Using the work load manager (WLM), drain running jobs from the affected nodes on the blade. Refer to the vendor documentation for the WLM for more information.
+### 1. Prepare the source system blade for removal
 
-2.  Use Boot Orchestration Services (BOS) to shut down the affected nodes in the source blade (in this example, `x9000c3s0`). Specify the appropriate component name (xname) and BOS template for the node type in the following command.
+1. Using the work load manager (WLM), drain running jobs from the affected nodes on the blade. Refer to the vendor documentation for the WLM for more information.
+
+1. (`ncn#`) Use Boot Orchestration Services (BOS) to shut down the affected nodes in the source blade (in this example, `x9000c3s0`). Specify the appropriate component name (xname) and BOS template for the node type in the following command.
 
     ```bash
     BOS_TEMPLATE=cos-2.0.30-slurm-healthy-compute
     cray bos session create --template-uuid $BOS_TEMPLATE --operation shutdown --limit x9000c3s0b0n0,x9000c3s0b0n1,x9000c3s0b1n0,x9000c3s0b1n1
     ```
 
-#### Disable the Redfish endpoints for the nodes
-3.  Temporarily disable the Redfish endpoints for NodeBMCs present in the blade.
+### 2. Disable the Redfish endpoints for the nodes
+
+1. (`ncn#`) Temporarily disable the Redfish endpoints for `NodeBMCs` present in the blade.
 
     ```bash
     cray hsm inventory redfishEndpoints update --enabled false x9000c3s0b0
     cray hsm inventory redfishEndpoints update --enabled false x9000c3s0b1
     ```
 
-#### Clear the node controller settings
-4. Remove the system specific settings from each node controller on the blade.
+### 3. Clear the node controller settings
+
+1. (`ncn#`) Remove the system specific settings from each node controller on the blade.
 
    ```bash
    curl -k -u root:PASSWORD -X POST -H \
@@ -49,16 +53,18 @@ This procedure will remove a liquid-cooled blades from an HPE Cray EX system.
      'Content-Type: application/json' -d '{"ResetType":"StatefulReset"}' \
      https://x9000c3s0b1/redfish/v1/Managers/BMC/Actions/Manager.Reset
    ```
+
    Use Ctrl-C to return to the prompt if command does not return.
 
-#### Power off the chassis slot
-5.  Suspend the hms-discovery cron job.
+### 4. Power off the chassis slot
+
+1. (`ncn#`) Suspend the `hms-discovery` cron job.
 
     ```bash
     kubectl -n services patch cronjobs hms-discovery -p '{"spec" : {"suspend" : true }}'
     ```
 
-    1.  Verify that the hms-discovery cron job has stopped (`ACTIVE` = `0` and `SUSPEND` = `True`).
+    1. (`ncn#`) Verify that the hms-discovery cron job has stopped (`ACTIVE` = `0` and `SUSPEND` = `True`).
 
         ```bash
         kubectl get cronjobs -n services hms-discovery
@@ -66,25 +72,28 @@ This procedure will remove a liquid-cooled blades from an HPE Cray EX system.
         hms-discovery    */3 * * * *     True         0       117s             15d
         ```
 
-    2.  Power off the chassis slot. This examples powers off slot 0, chassis 3, in cabinet 9000.
+    1. (`ncn#`)Power off the chassis slot. This examples powers off slot 0, chassis 3, in cabinet 9000.
 
         ```bash
         cray capmc xname_off create --xnames x9000c3s0 --recursive true
         ```
 
-#### Disable the chassis slot
-6.  Disable the chassis slot. Disabling the slot prevents hms-discovery from automatically powering on the slot. This example disables slot 0, chassis 3, in cabinet 9000.
+### 5. Disable the chassis slot
+
+1. (`ncn#`) Disable the chassis slot. Disabling the slot prevents `hms-discovery` from automatically powering on the slot. This example disables slot 0, chassis 3, in cabinet 9000.
 
     ```bash
     cray hsm state components enabled update --enabled false x9000c3s0
     ```
 
-#### Record MAC and IP addresses for nodes
-**IMPORTANT**: Record the node management network (NMN) MAC and IP addresses for each node in the blade (labeled `Node Maintenance Network`). To prevent disruption in the data virtualization service (DVS) when over operating the NMN, these addresses must be maintained in the HSM when the blade is swapped and discovered.
+### 6. Record MAC and IP addresses for nodes
 
-The NodeBMC MAC and IP addresses are assigned algorithmically and *must not be deleted* from the HSM.
+**IMPORTANT**: Record the node management network (NMN) MAC and IP addresses for each node in the blade (labeled `Node Maintenance Network`). To prevent disruption in the data virtualization service (DVS) when over operating the NMN, these addresses must
+be maintained in the HSM when the blade is swapped and discovered.
 
-7.  **Skip this step if DVS is operating over the HSN, otherwise proceed with this step.** Query HSM to determine the ComponentID, MAC, and IP addresses for each node in the blade.
+The `NodeBMC` MAC and IP addresses are assigned algorithmically and *must not be deleted* from the HSM.
+
+1. (`ncn#`) **Skip this step if DVS is operating over the HSN, otherwise proceed with this step.** Query HSM to determine the `ComponentID`, MAC, and IP addresses for each node in the blade.
    The prerequisites show an example of how to gather HSM values and store them to a file.
 
     ```bash
@@ -106,7 +115,7 @@ The NodeBMC MAC and IP addresses are assigned algorithmically and *must not be d
     ]
     ```
 
-    1.  Record the following values for the blade:
+    1. Record the following values for the blade:
 
         ```bash
         `ComponentID: "x9000c3s0b0n0"`
@@ -114,16 +123,17 @@ The NodeBMC MAC and IP addresses are assigned algorithmically and *must not be d
         `IPAddress: "10.100.0.10"`
         ```
 
-    2.  Repeat the command to record the ComponentID, MAC, and IP addresses for the `Node Maintenance Network` the other nodes in the blade.
+    2. Repeat the command to record the ComponentID, MAC, and IP addresses for the `Node Maintenance Network` the other nodes in the blade.
 
-#### Cleanup Hardware State Manager
-8.  Set environment corresponding the chassis slot of the blade.
+### 7. Cleanup Hardware State Manager
+
+1. (`ncn#`) Set environment corresponding the chassis slot of the blade.
 
     ```bash
     export CHASSIS_SLOT=x9000c3s0
     ```
 
-9.  Delete the Redfish endpoints for each node.
+1. (`ncn#`) Delete the Redfish endpoints for each node.
 
     ```bash
     for xname in $(cray hsm inventory redfishEndpoints list --format json | jq -r --arg CHASSIS_SLOT $CHASSIS_SLOT '.RedfishEndpoints[] | select(.ID | startswith($CHASSIS_SLOT)) | .ID'); do
@@ -132,7 +142,8 @@ The NodeBMC MAC and IP addresses are assigned algorithmically and *must not be d
     done
     ```
 
-10. Remove entries from state components.
+1. (`ncn#`) Remove entries from state components.
+
     ```bash
     for xname in $(cray hsm state components list --class Mountain --format json |  jq -r --arg CHASSIS_SLOT $CHASSIS_SLOT '.Components[] | select((.ID | startswith($CHASSIS_SLOT)) and (.ID != $CHASSIS_SLOT)) | .ID' ); do
         echo "Removing $xname from HSM State components"
@@ -140,29 +151,32 @@ The NodeBMC MAC and IP addresses are assigned algorithmically and *must not be d
     done
     ```
 
-11. Delete the NMN MAC and IP addresses each node in the blade from the HSM. *Do not delete the MAC and IP addresses for the node BMC*.
+1. (`ncn#`) Delete the NMN MAC and IP addresses each node in the blade from the HSM. *Do not delete the MAC and IP addresses for the node BMC*.
+
     ```bash
     for mac in $(cray hsm inventory ethernetInterfaces list --type Node --format json | jq -r --arg CHASSIS_SLOT $CHASSIS_SLOT '.[] | select(.ComponentID | startswith($CHASSIS_SLOT)) | .ID'); do
         echo "Removing $mac from HSM Inventory EthernetInterfaces"
+        cray hsm inventory ethernetInterfaces delete $mac
     done
     ```
 
-12. Restart KEA.
+1. (`ncn#`) Restart KEA.
 
     ```bash
     kubectl delete pods -n services -l app.kubernetes.io/name=cray-dhcp-kea
     ```
 
-#### Remove the blade
-13.  Remove the blade from the source location.
-    - Review the *Remove a Compute Blade Using the Lift* procedure in *HPE Cray EX Hardware Replacement Procedures H-6173* for detailed instructions for replacing liquid-cooled blades (https://internal.support.hpe.com/).
+### 8. Remove the blade
 
-14.  Drain the coolant from the blade and fill with fresh coolant to minimize cross-contamination of cooling systems.
-    - Review *HPE Cray EX Coolant Service Procedures H-6199*. If using the hand pump, review procedures in the *HPE Cray EX Hand Pump User Guide H-6200* (https://internal.support.hpe.com/).
+1. Remove the blade from the source location.
+    - Review the *Remove a Compute Blade Using the Lift* procedure in *HPE Cray EX Hardware Replacement Procedures H-6173* for detailed instructions for replacing liquid-cooled blades. These procedures can be found on the [HPE Support Center](https://internal.support.hpe.com/).
 
-15. Install the blade from the source system in a storage rack or leave it on the cart.
+1. Drain the coolant from the blade and fill with fresh coolant to minimize cross-contamination of cooling systems.
+    - Review *HPE Cray EX Coolant Service Procedures H-6199*. If using the hand pump, review procedures in the *HPE Cray EX Hand Pump User Guide H-6200*. These procedures can be found on the [HPE Support Center](https://internal.support.hpe.com/).
 
-16. Un-suspend the hms-discovery cron job if no more liquid-cooled blades are planned to be removed from the system.
+1. Install the blade from the source system in a storage rack or leave it on the cart.
+
+1. (`ncn#`) Un-suspend the `hms-discovery` cron job if no more liquid-cooled blades are planned to be removed from the system.
 
     ```bash
     kubectl -n services patch cronjobs hms-discovery -p '{"spec" : {"suspend" : false }}'

--- a/operations/node_management/Removing_a_Liquid-cooled_blade_from_a_System.md
+++ b/operations/node_management/Removing_a_Liquid-cooled_blade_from_a_System.md
@@ -4,7 +4,7 @@ This procedure will remove a liquid-cooled blades from an HPE Cray EX system.
 
 ## Perquisites
 
-- The Cray command line interface \(CLI\) tool is initialized and configured on the system.
+- The Cray command line interface \(CLI\) tool is initialized and configured on the system. See [Configure the Cray CLI](../configure_cray_cli.md).
 
 - Knowledge of whether DVS is operating over the Node Management Network (NMN) or the High Speed Network (HSN).
 
@@ -12,7 +12,7 @@ This procedure will remove a liquid-cooled blades from an HPE Cray EX system.
 
 - The System Layout Service (SLS) must have the desired HSN configuration.
 
-- Check the status of the high-speed network (HSN) and record link status before the procedure.
+- Check the status of the HSN and record link status before the procedure.
 
 - The blades must have the coolant drained and filled during the swap to minimize cross-contamination of cooling systems.
   - Review procedures in *HPE Cray EX Coolant Service Procedures H-6199*
@@ -22,9 +22,14 @@ This procedure will remove a liquid-cooled blades from an HPE Cray EX system.
 
 ### 1. Prepare the source system blade for removal
 
-1. Using the work load manager (WLM), drain running jobs from the affected nodes on the blade. Refer to the vendor documentation for the WLM for more information.
+1. Use the workload manager (WLM) to drain running jobs from the affected nodes on the blade.
 
-1. (`ncn#`) Use Boot Orchestration Services (BOS) to shut down the affected nodes in the source blade (in this example, `x9000c3s0`). Specify the appropriate component name (xname) and BOS template for the node type in the following command.
+    Refer to the vendor documentation for the WLM for more information.
+
+1. (`ncn#`) Use Boot Orchestration Services (BOS) to shut down the affected nodes in the source blade.
+
+    In this example, `x9000c3s0` is the source blade. Specify the appropriate component name (xname) and BOS
+    template for the node type in the following command.
 
     ```bash
     BOS_TEMPLATE=cos-2.0.30-slurm-healthy-compute
@@ -42,7 +47,7 @@ This procedure will remove a liquid-cooled blades from an HPE Cray EX system.
 
 ### 3. Clear the node controller settings
 
-1. (`ncn#`) Remove the system specific settings from each node controller on the blade.
+1. (`ncn#`) Remove the system-specific settings from each node controller on the blade.
 
    ```bash
    curl -k -u root:PASSWORD -X POST -H \
@@ -58,29 +63,38 @@ This procedure will remove a liquid-cooled blades from an HPE Cray EX system.
 
 ### 4. Power off the chassis slot
 
-1. (`ncn#`) Suspend the `hms-discovery` cron job.
+1. (`ncn-mw#`) Suspend the `hms-discovery` cron job.
 
     ```bash
     kubectl -n services patch cronjobs hms-discovery -p '{"spec" : {"suspend" : true }}'
     ```
 
-    1. (`ncn#`) Verify that the hms-discovery cron job has stopped (`ACTIVE` = `0` and `SUSPEND` = `True`).
+1. (`ncn-mw#`) Verify that the `hms-discovery` cron job has stopped (`ACTIVE` = `0` and `SUSPEND` = `True`).
 
-        ```bash
-        kubectl get cronjobs -n services hms-discovery
-        NAME             SCHEDULE        SUSPEND     ACTIVE   LAST   SCHEDULE  AGE
-        hms-discovery    */3 * * * *     True         0       117s             15d
-        ```
+    ```bash
+    kubectl get cronjobs -n services hms-discovery
+    ```
 
-    1. (`ncn#`)Power off the chassis slot. This examples powers off slot 0, chassis 3, in cabinet 9000.
+    Example output:
 
-        ```bash
-        cray capmc xname_off create --xnames x9000c3s0 --recursive true
-        ```
+    ```text
+    NAME             SCHEDULE        SUSPEND     ACTIVE   LAST   SCHEDULE  AGE
+    hms-discovery    */3 * * * *     True         0       117s             15d
+    ```
+
+1. (`ncn#`) Power off the chassis slot.
+
+    This examples powers off slot 0, chassis 3, in cabinet 9000.
+
+    ```bash
+    cray capmc xname_off create --xnames x9000c3s0 --recursive true
+    ```
 
 ### 5. Disable the chassis slot
 
-1. (`ncn#`) Disable the chassis slot. Disabling the slot prevents `hms-discovery` from automatically powering on the slot. This example disables slot 0, chassis 3, in cabinet 9000.
+1. (`ncn#`) Disable the chassis slot.
+
+    Disabling the slot prevents `hms-discovery` from automatically powering on the slot. This example disables slot 0, chassis 3, in cabinet 9000.
 
     ```bash
     cray hsm state components enabled update --enabled false x9000c3s0
@@ -93,11 +107,17 @@ be maintained in the HSM when the blade is swapped and discovered.
 
 The `NodeBMC` MAC and IP addresses are assigned algorithmically and *must not be deleted* from the HSM.
 
-1. (`ncn#`) **Skip this step if DVS is operating over the HSN, otherwise proceed with this step.** Query HSM to determine the `ComponentID`, MAC, and IP addresses for each node in the blade.
-   The prerequisites show an example of how to gather HSM values and store them to a file.
+1. (`ncn#`) **Skip this step if DVS is operating over the HSN, otherwise proceed with this step.** Query HSM to determine the `ComponentID`, MAC addresses, and IP addresses for each node in the blade.
+
+    The prerequisites show an example of how to gather HSM values and store them to a file.
 
     ```bash
     cray hsm inventory ethernetInterfaces list --component-id x9000c3s0b0n0 --format json
+    ```
+
+    Example output:
+
+    ```json
     [
         {
         "ID": "0040a6836339",
@@ -115,28 +135,31 @@ The `NodeBMC` MAC and IP addresses are assigned algorithmically and *must not be
     ]
     ```
 
-    1. Record the following values for the blade:
+1. Record the following values for the blade:
 
-        ```bash
-        `ComponentID: "x9000c3s0b0n0"`
-        `MACAddress: "00:40:a6:83:63:39"`
-        `IPAddress: "10.100.0.10"`
-        ```
+    ```text
+    `ComponentID: "x9000c3s0b0n0"`
+    `MACAddress: "00:40:a6:83:63:39"`
+    `IPAddress: "10.100.0.10"`
+    ```
 
-    2. Repeat the command to record the ComponentID, MAC, and IP addresses for the `Node Maintenance Network` the other nodes in the blade.
+1. Repeat the command to record the `ComponentID`, MAC addresses, and IP addresses for the `Node Maintenance Network` for the other nodes in the blade.
 
 ### 7. Cleanup Hardware State Manager
 
 1. (`ncn#`) Set environment corresponding the chassis slot of the blade.
 
     ```bash
-    export CHASSIS_SLOT=x9000c3s0
+    CHASSIS_SLOT=x9000c3s0
     ```
 
 1. (`ncn#`) Delete the Redfish endpoints for each node.
 
     ```bash
-    for xname in $(cray hsm inventory redfishEndpoints list --format json | jq -r --arg CHASSIS_SLOT $CHASSIS_SLOT '.RedfishEndpoints[] | select(.ID | startswith($CHASSIS_SLOT)) | .ID'); do
+    for xname in $(cray hsm inventory redfishEndpoints list --format json |
+                     jq -r --arg CHASSIS_SLOT "${CHASSIS_SLOT}" \
+                       '.RedfishEndpoints[] | select(.ID | startswith($CHASSIS_SLOT)) | .ID')
+    do
         echo "Removing $xname from HSM Inventory RedfishEndpoints"
         cray hsm inventory redfishEndpoints delete "$xname"
     done
@@ -145,47 +168,62 @@ The `NodeBMC` MAC and IP addresses are assigned algorithmically and *must not be
 1. (`ncn#`) Remove entries from state components.
 
     ```bash
-    for xname in $(cray hsm state components list --class Mountain --format json |  jq -r --arg CHASSIS_SLOT $CHASSIS_SLOT '.Components[] | select((.ID | startswith($CHASSIS_SLOT)) and (.ID != $CHASSIS_SLOT)) | .ID' ); do
+    for xname in $(cray hsm state components list --class Mountain --format json |
+                     jq -r --arg CHASSIS_SLOT "${CHASSIS_SLOT}" \
+                       '.Components[] | select((.ID | startswith($CHASSIS_SLOT)) and (.ID != $CHASSIS_SLOT)) | .ID' )
+    do
         echo "Removing $xname from HSM State components"
         cray hsm state components delete "$xname"
     done
     ```
 
-1. (`ncn#`) Delete the NMN MAC and IP addresses each node in the blade from the HSM. *Do not delete the MAC and IP addresses for the node BMC*.
+1. (`ncn#`) Delete the NMN MAC and IP addresses each node in the blade from the HSM.
+
+    *Do not delete the MAC and IP addresses for the node BMC*.
 
     ```bash
-    for mac in $(cray hsm inventory ethernetInterfaces list --type Node --format json | jq -r --arg CHASSIS_SLOT $CHASSIS_SLOT '.[] | select(.ComponentID | startswith($CHASSIS_SLOT)) | .ID'); do
+    for mac in $(cray hsm inventory ethernetInterfaces list --type Node --format json |
+                   jq -r --arg CHASSIS_SLOT "${CHASSIS_SLOT}" \
+                     '.[] | select(.ComponentID | startswith($CHASSIS_SLOT)) | .ID')
+    do
         echo "Removing $mac from HSM Inventory EthernetInterfaces"
-        cray hsm inventory ethernetInterfaces delete $mac
+        cray hsm inventory ethernetInterfaces delete "$mac"
     done
     ```
 
-1. (`ncn#`) Restart KEA.
+1. (`ncn-mw#`) Restart Kea.
 
     ```bash
-    kubectl delete pods -n services -l app.kubernetes.io/name=cray-dhcp-kea
+    ncn-mw# kubectl delete pods -n services -l app.kubernetes.io/name=cray-dhcp-kea
     ```
 
 ### 8. Remove the blade
 
 1. Remove the blade from the source location.
-    - Review the *Remove a Compute Blade Using the Lift* procedure in *HPE Cray EX Hardware Replacement Procedures H-6173* for detailed instructions for replacing liquid-cooled blades. These procedures can be found on the [HPE Support Center](https://internal.support.hpe.com/).
+
+    - Review the *Remove a Compute Blade Using the Lift* procedure in *HPE Cray EX Hardware Replacement Procedures H-6173* for detailed instructions for replacing liquid-cooled blades. These procedures can be found on the [HPE Support Center](https://support.hpe.com/).
 
 1. Drain the coolant from the blade and fill with fresh coolant to minimize cross-contamination of cooling systems.
-    - Review *HPE Cray EX Coolant Service Procedures H-6199*. If using the hand pump, review procedures in the *HPE Cray EX Hand Pump User Guide H-6200*. These procedures can be found on the [HPE Support Center](https://internal.support.hpe.com/).
+
+    - Review *HPE Cray EX Coolant Service Procedures H-6199*. If using the hand pump, then review procedures in the *HPE Cray EX Hand Pump User Guide H-6200*. These procedures can be found on the [HPE Support Center](https://support.hpe.com/).
 
 1. Install the blade from the source system in a storage rack or leave it on the cart.
 
-1. (`ncn#`) Un-suspend the `hms-discovery` cron job if no more liquid-cooled blades are planned to be removed from the system.
+1. (`ncn-mw#`) Un-suspend the `hms-discovery` cron job if no more liquid-cooled blades are planned to be removed from the system.
 
     ```bash
     kubectl -n services patch cronjobs hms-discovery -p '{"spec" : {"suspend" : false }}'
     ```
 
-    Verify that the hms-discovery cron job has stopped (`ACTIVE` = `0` and `SUSPEND` = `False`).
+1. (`ncn-mw#`) Verify that the `hms-discovery` cron job has stopped (`ACTIVE` = `0` and `SUSPEND` = `False`).
 
     ```bash
     kubectl get cronjobs -n services hms-discovery
+    ```
+
+    Example output:
+
+    ```text
     NAME            SCHEDULE      SUSPEND   ACTIVE   LAST SCHEDULE   AGE
     hms-discovery   */3 * * * *   False     1        46s             15d
     ```


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
Add in missing EthernetInterface delete command to the removing a liquid-cooled blade procedure. The 4th step in the `Cleanup Hardware State Manager` section to include the missing command within the for loop.

Also appease the markdown linter, and conform to the new command prompt spec.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
