### PR TITLE
CASMINST-5036: Fix command to get m002 site IP; Fix IPMI_PASSWORD export command

### DIFF
--- a/install/deploy_final_non-compute_node.md
+++ b/install/deploy_final_non-compute_node.md
@@ -218,7 +218,7 @@ The steps in this section load hand-off data before a later procedure reboots th
     1. (`pit#`) Get the IP address.
 
         ```bash
-        ssh ncn-m002 ip -4 a show bond0.can0 | grep inet | awk '{print $2}' | cut -d / -f1
+        ssh ncn-m002 ip -4 a show bond0.cmn0 | grep inet | awk '{print $2}' | cut -d / -f1
         ```
 
         Expected output will look similar to the following (exact values may differ):
@@ -231,7 +231,6 @@ The steps in this section load hand-off data before a later procedure reboots th
 
         ```bash
         ssh root@10.102.11.13
-        ncn-m002#
         ```
 
         > Keep this terminal active as it will enable `kubectl` commands during the bring-up of the new NCN.
@@ -265,7 +264,7 @@ The steps in this section load hand-off data before a later procedure reboots th
     ```
 
     ```bash
-    export IPMI_PASSWORD=changeme
+    export IPMI_PASSWORD
     ipmitool -I lanplus -U $USERNAME -E -H ${SYSTEM_NAME}-ncn-m001-mgmt chassis power status
     ipmitool -I lanplus -U $USERNAME -E -H ${SYSTEM_NAME}-ncn-m001-mgmt sol activate
     ```


### PR DESCRIPTION
# Description

The command to get the m002 site IP address is incorrect in the deploy final NCN procedure. It attempted to get the CAN IP instead of the CMN IP. This PR fixes that.

This PR also fixes an error in the IPMI_PASSWORD export on the same page -- it mistakenly also assigned the value to that variable, even though it had just been set in the previous command.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
