### PR TITLE
CASMINST-5050 - read version from kubeadm on m002 to detect what to upgrade to

### DIFF
--- a/upgrade/scripts/k8s/upgrade_control_plane.sh
+++ b/upgrade/scripts/k8s/upgrade_control_plane.sh
@@ -40,11 +40,17 @@ kubectl -n kube-system apply -f /tmp/kubeadm-config.yaml
 
 export PDSH_SSH_ARGS_APPEND="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
 masters=$(grep -oP 'ncn-m\d+' /etc/hosts | sort -u)
+
+# get version of new k8s
+# note: this is running on m002 which should have newer version already
+#       so we can query "next" version here
+k8sVersionUpgradeTo=$(kubeadm version -o json | jq -r '.clientVersion.gitVersion')
+
 for master in $masters
 do
   echo "Upgrading kube-system pods for $master:"
   echo ""
-  pdsh -b -S -w $master 'kubeadm upgrade apply v1.20.13 -y'
+  pdsh -b -S -w $master "kubeadm upgrade apply ${k8sVersionUpgradeTo} -y"
   rc=$?
   if [ "$rc" -ne 0 ]; then
     echo ""

--- a/upgrade/scripts/upgrade/util/verify-k8s-nodes-upgraded.sh
+++ b/upgrade/scripts/upgrade/util/verify-k8s-nodes-upgraded.sh
@@ -23,7 +23,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-EXPECTED_VERSION="v1.20.13"
+EXPECTED_VERSION=$(kubeadm version -o json | jq -r '.clientVersion.gitVersion')
 display_output=$(kubectl get nodes)
 versions=$(kubectl get nodes -o json | jq -r '.items[].status.nodeInfo.kubeletVersion')
 #shellcheck disable=SC3030


### PR DESCRIPTION
# Description

read version from kubeadm on m002 to detect what to upgrade to

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
