### PR TITLE
CASMTRIAGE-3767: Update kubeadm.cfg source file location

### DIFF
--- a/operations/node_management/Add_Remove_Replace_NCNs/Remove_NCN_from_Role.md
+++ b/operations/node_management/Add_Remove_Replace_NCNs/Remove_NCN_from_Role.md
@@ -88,7 +88,7 @@ Determine if the master node being removed is the first master node.
    export MAX_PODS_PER_NODE=$(craysys metadata get kubernetes-max-pods-per-node)
    export PODS_CIDR=$(craysys metadata get kubernetes-pods-cidr)
    export SERVICES_CIDR=$(craysys metadata get kubernetes-services-cidr)
-   envsubst < /srv/cray/resources/common/kubeadm.yaml > /etc/cray/kubernetes/kubeadm.yaml
+   envsubst < /srv/cray/resources/common/kubeadm.cfg > /etc/cray/kubernetes/kubeadm.yaml
    kubeadm token create --print-join-command > /etc/cray/kubernetes/join-command 2>/dev/null
    echo "$(cat /etc/cray/kubernetes/join-command) --control-plane --certificate-key $(cat /etc/cray/kubernetes/certificate-key)" > /etc/cray/kubernetes/join-command-control-plane
    mkdir -p /srv/cray/scripts/kubernetes

--- a/upgrade/scripts/k8s/promote-initial-master.sh
+++ b/upgrade/scripts/k8s/promote-initial-master.sh
@@ -44,7 +44,7 @@ export MAX_PODS_PER_NODE=$(craysys metadata get kubernetes-max-pods-per-node)
 export PODS_CIDR=$(craysys metadata get kubernetes-pods-cidr)
 #shellcheck disable=SC2155
 export SERVICES_CIDR=$(craysys metadata get kubernetes-services-cidr)
-envsubst < /srv/cray/resources/common/kubeadm.yaml > /etc/cray/kubernetes/kubeadm.yaml
+envsubst < /srv/cray/resources/common/kubeadm.cfg > /etc/cray/kubernetes/kubeadm.yaml
 
 kubeadm token create --print-join-command > /etc/cray/kubernetes/join-command 2>/dev/null
 echo "$(cat /etc/cray/kubernetes/join-command) --control-plane --certificate-key $(cat /etc/cray/kubernetes/certificate-key)" > /etc/cray/kubernetes/join-command-control-plane


### PR DESCRIPTION
This has recently changed, use the new filename.

# Description

<!--- Describe what this change is and what it is for. -->

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
