### PR TITLE
CASMINST-4799

### DIFF
--- a/operations/node_management/Configure_NTP_on_NCNs.md
+++ b/operations/node_management/Configure_NTP_on_NCNs.md
@@ -71,6 +71,11 @@ The following steps are structured to be executed on one node at a time. However
 
 ## Fix broken configuration
 
+Clock sync is performed in increments vs. all at once, so it may take some time for the clocks to sync.
+Before executing any commands, give the nodes some time to update. Sync typically happens within a few seconds, but on
+occasion could take up to 30+ minutes. Periodically running `chronyc tracking` will show clock statistics and can be
+used to determine if the clocks are gradually syncing.
+
 On each affected NCN run the following:
 
 1. Set a token as described in [Identify Nodes and Update Metadata](Rebuild_NCNs/Identify_Nodes_and_Update_Metadata.md).

--- a/operations/node_management/Configure_NTP_on_NCNs.md
+++ b/operations/node_management/Configure_NTP_on_NCNs.md
@@ -71,9 +71,9 @@ The following steps are structured to be executed on one node at a time. However
 
 ## Fix broken configuration
 
-Clock sync is performed in increments vs. all at once, so it may take some time for the clocks to sync.
+Clock sync is performed in increments instead of all at once, so it may take some time for the clocks to sync.
 Before executing any commands, give the nodes some time to update. Sync typically happens within a few seconds, but on
-occasion could take up to 30+ minutes. Periodically running `chronyc tracking` will show clock statistics and can be
+occasion could up to 30 or more minutes. Periodically running `chronyc tracking` will show clock statistics and can be
 used to determine if the clocks are gradually syncing.
 
 On each affected NCN run the following:


### PR DESCRIPTION
# Description

Adds verbiage indicating that clock make take some time and provides command to check clock stats.

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.
