### PR TITLE
CASMINST-5041 Remove Dupe Steps and Fix Password

### DIFF
--- a/install/deploy_non-compute_nodes.md
+++ b/install/deploy_non-compute_nodes.md
@@ -124,28 +124,7 @@ After the operating system boots on each node, there are some configuration acti
 console or the console log for certain nodes can help to understand what happens and when. When the process is complete
 for all nodes, the Ceph storage will have been initialized and the Kubernetes cluster will be created ready for a workload.
 
-1. (`pit#`) Set the default `root` password and SSH keys and optionally change the timezone.
-
-   > **NOTE:** The management nodes images do not contain a default `root` password or SSH keys.
-   > If this step is skipped and the nodes are booted, then they will be inaccessible via console or SSH.
-   > In that case, the nodes would have to be rebooted with the secure images built from this step, have their disks wiped,
-   > and then redeployed.
-
-   It is **required** to set the default `root` password and SSH keys in the images used to boot the management nodes.
-   Follow the NCN image customization steps in [Change NCN Image Root Password and SSH Keys on PIT Node](../operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md)
-
-1. (`pit#`) Create boot directories for any NCN in DNS.
-
-    > **NOTE:** This script also sets the BMCs to DHCP. This script only sets up boot directories
-    > for nodes that appear in `/var/lib/misc/dnsmasq.leases`. Since nodes may take a few seconds
-    > to DHCP after switching from their old, static IP addresses, it is advised to run this twice when
-    > reinstalling a system.
-
-    ```bash
-    /root/bin/set-sqfs-links.sh
-    ```
-
-1. (`pit#`) Customize boot scripts for any out-of-baseline NCNs.
+1. (`pit#`) Customize boot scripts for any out-of-baseline NCNs if needed (see below).
 
     - See the [Plan of Record](../background/ncn_plan_of_record.md) and compare against the server's hardware.
     - If modifications are needed for the PCIe hardware, then see [Customize PCIe Hardware](../operations/node_management/Customize_PCIe_Hardware.md).

--- a/install/pre-installation.md
+++ b/install/pre-installation.md
@@ -429,8 +429,8 @@ in `/etc/environment` from the [Download CSM tarball](#21-download-csm-tarball) 
 1. (`pit#`) Get the artifact versions.
 
    ```bash
-   kubernetes_version="$(find ${CSM_PATH}/images/kubernetes -name '*.squashfs' -exec basename {} .squashfs \; | awk -F '-' '{print $NF}')"
-   ceph_version="$(find ${CSM_PATH}/images/storage-ceph -name '*.squashfs' -exec basename {} .squashfs \; | awk -F '-' '{print $NF}')"
+   KUBERNETES_VERSION="$(find ${CSM_PATH}/images/kubernetes -name '*.squashfs' -exec basename {} .squashfs \; | awk -F '-' '{print $NF}')"
+   CEPH_VERSION="$(find ${CSM_PATH}/images/storage-ceph -name '*.squashfs' -exec basename {} .squashfs \; | awk -F '-' '{print $NF}')"
    ```
 
 1. (`pit#`) Copy the NCN images from the expanded tarball.
@@ -439,8 +439,8 @@ in `/etc/environment` from the [Download CSM tarball](#21-download-csm-tarball) 
 
    ```bash
    mkdir -pv "${PITDATA}/data/k8s/" "${PITDATA}/data/ceph/"
-   rsync -rltDP --delete "${CSM_PATH}/images/kubernetes/" --link-dest="${CSM_PATH}/images/kubernetes/" "${PITDATA}/data/k8s/${kubernetes_version}"
-   rsync -rltDP --delete "${CSM_PATH}/images/storage-ceph/" --link-dest="${CSM_PATH}/images/storage-ceph/" "${PITDATA}/data/ceph/${ceph_version}"
+   rsync -rltDP --delete "${CSM_PATH}/images/kubernetes/" --link-dest="${CSM_PATH}/images/kubernetes/" "${PITDATA}/data/k8s/${KUBERNETES_VERSION}"
+   rsync -rltDP --delete "${CSM_PATH}/images/storage-ceph/" --link-dest="${CSM_PATH}/images/storage-ceph/" "${PITDATA}/data/ceph/${CEPH_VERSION}"
    ```
 
 1. (`pit#`) Generate SSH keys and invoke `ncn-image-modification.sh`:
@@ -464,8 +464,8 @@ in `/etc/environment` from the [Download CSM tarball](#21-download-csm-tarball) 
        ```bash
        "${PITDATA}/csm-${CSM_RELEASE}/ncn-image-modification.sh" -p \
           -d /root/.ssh \
-          -k "/var/www/ephemeral/data/k8s/${kubernetes_version}/kubernetes-${kubernetes_version}.squashfs" \
-          -s "/var/www/ephemeral/data/ceph/${kubernetes_version}/storage-ceph-${ceph_version}.squashfs"
+          -k "/var/www/ephemeral/data/k8s/${KUBERNETES_VERSION}/kubernetes-${KUBERNETES_VERSION}.squashfs" \
+          -s "/var/www/ephemeral/data/ceph/${CEPH_VERSION}/storage-ceph-${CEPH_VERSION}.squashfs"
        ```
 
 1. (`pit#`) Log the currently installed PIT packages.
@@ -621,7 +621,7 @@ Follow the [Prepare Site Init](prepare_site_init.md) procedure.
 
 1. (`pit#`) Setup boot links to the artifacts extracted from the CSM tarball.
 
-   > **NOTES:**
+   > ***NOTES***
    >
    > - This will also set all the BMCs to DHCP.
    > - Changing into the `$HOME` directory ensures the proper operation of the script.

--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md
@@ -124,10 +124,13 @@ copies the `root` user password from the PIT node. It does not change the timezo
 
 ```bash
 export SQUASHFS_ROOT_PW_HASH=$(awk -F':' /^root:/'{print $2}' < /etc/shadow)
+KUBERNETES_VERSION="$(find ${CSM_PATH}/images/kubernetes -name '*.squashfs' -exec basename {} .squashfs \; | awk -F '-' '{print $NF}')"
+CEPH_VERSION="$(find ${CSM_PATH}/images/storage-ceph -name '*.squashfs' -exec basename {} .squashfs \; | awk -F '-' '{print $NF}')"
+   
 ${CSM_PATH}/ncn-image-modification.sh -p \
                                       -t rsa \
-                                      -k "${PITDATA}"/data/k8s/kubernetes-*.squashfs \
-                                      -s "${PITDATA}"/data/ceph/storage-ceph-*.squashfs
+                                      -k "${PITDATA}/data/k8s/${KUBERNETES_VERSION}/kubernetes-${KUBERNETES_VERSION}.squashfs" \
+                                      -s "${PITDATA}/data/ceph/${CEPH_VERSION}/storage-ceph-${CEPH_VERSION}.squashfs"
 ```
 
 ### Example 2: Provide keys, prompt for password, change timezone
@@ -139,8 +142,8 @@ administrator for the `root` user password during execution. It changes the time
 ${CSM_PATH}/ncn-image-modification.sh -p \
                                       -d /my/pre-existing/keys \
                                       -z America/Chicago \
-                                      -k "${PITDATA}"/data/k8s/kubernetes-*.squashfs \
-                                      -s "${PITDATA}"/data/ceph/storage-ceph-*.squashfs
+                                      -k "${PITDATA}/data/k8s/${KUBERNETES_VERSION}/kubernetes-${KUBERNETES_VERSION}.squashfs" \
+                                      -s "${PITDATA}/data/ceph/${CEPH_VERSION}/storage-ceph-${CEPH_VERSION}.squashfs"
 ```
 
 ### Example 3: New keys, copy PIT password, keep UTC, no prompting
@@ -154,8 +157,8 @@ export SQUASHFS_ROOT_PW_HASH=$(awk -F':' /^root:/'{print $2}' < /etc/shadow)
 ${CSM_PATH}/ncn-image-modification.sh -p \
                                       -t rsa \
                                       -N "" \
-                                      -k "${PITDATA}"/data/k8s/kubernetes-*.squashfs \
-                                      -s "${PITDATA}"/data/ceph/storage-ceph-*.squashfs
+                                      -k "${PITDATA}/data/k8s/${KUBERNETES_VERSION}/kubernetes-${KUBERNETES_VERSION}.squashfs" \
+                                      -s "${PITDATA}/data/ceph/${CEPH_VERSION}/storage-ceph-${CEPH_VERSION}.squashfs"
 ```
 
 ## Cleanup


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
This fixes the Change NCN Password and SSH Keys on PIT Node page to use the correct paths to the images.

This also removes the duplicate steps for invoking `ncn-image-modification.sh` and `set-sqfs-links.sh`, which were invoked in both the `pre-installation.md` and `deploy_non-compute_nodes.md` pages. The steps in `deploy_non-compute_nodes.md` were redundant, since
`pre-installation.md` is _required_ before starting the `deploy_non-compute_nodes.md` page.

This also fixes a typo that went unnoticed, the storage-ceph image path was using the `kubernetes_version` variable. This wasn't causing problems because the two versions are _usually_ the same, but since they potentially can differ this ensures that either case is handled.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
