### PR TITLE
CASMNET-1725 Clarify CANU architectures overview

### DIFF
--- a/operations/network/management_network/validate_shcd.md
+++ b/operations/network/management_network/validate_shcd.md
@@ -37,7 +37,7 @@ Use the CSM Automated Network Utility (CANU) to validate the SHCD. SHCD validati
    > `-a` defines the architecture, this will be:
    >
    > - `v1` if the HPE Cray EX system is composed of Mellanox and Dell switches, typically with Gigabyte or Intel server hardware.
-   > - `tds` if the Cray system has Aruba switches with HPE servers **and NCNs are connected to the Aruba Spine switches**.
+   > - `tds` if the HPE Cray EX system has Aruba switches with HPE servers **and NCNs are connected to the Aruba Spine switches**.
    > - `full` if the Cray system has Aruba switches with HPE servers **and NCNs are connected to the Aruba Leaf switches**.
 
    ```bash

--- a/operations/network/management_network/validate_shcd.md
+++ b/operations/network/management_network/validate_shcd.md
@@ -36,7 +36,7 @@ Use the CSM Automated Network Utility (CANU) to validate the SHCD. SHCD validati
    > **`NOTE`**
    > `-a` defines the architecture, this will be:
    >
-   > - `v1` if the Cray system is composed of Mellanox and Dell switches, typically with Gigabyte or Intel server hardware.
+   > - `v1` if the HPE Cray EX system is composed of Mellanox and Dell switches, typically with Gigabyte or Intel server hardware.
    > - `tds` if the Cray system has Aruba switches with HPE servers **and NCNs are connected to the Aruba Spine switches**.
    > - `full` if the Cray system has Aruba switches with HPE servers **and NCNs are connected to the Aruba Leaf switches**.
 

--- a/operations/network/management_network/validate_shcd.md
+++ b/operations/network/management_network/validate_shcd.md
@@ -38,7 +38,7 @@ Use the CSM Automated Network Utility (CANU) to validate the SHCD. SHCD validati
    >
    > - `v1` if the HPE Cray EX system is composed of Mellanox and Dell switches, typically with Gigabyte or Intel server hardware.
    > - `tds` if the HPE Cray EX system has Aruba switches with HPE servers **and NCNs are connected to the Aruba Spine switches**.
-   > - `full` if the Cray system has Aruba switches with HPE servers **and NCNs are connected to the Aruba Leaf switches**.
+   > - `full` if the HPE Cray EX system has Aruba switches with HPE servers **and NCNs are connected to the Aruba Leaf switches**.
 
    ```bash
    ARCH=v1

--- a/operations/network/management_network/validate_shcd.md
+++ b/operations/network/management_network/validate_shcd.md
@@ -4,12 +4,14 @@ Use the CSM Automated Network Utility (CANU) to validate the SHCD. SHCD validati
 
 ## Topics
 
-- [Prerequisites](#prerequisites)
-- [Validation steps](#validation-steps)
-- [Under the hood](#under-the-hood)
-  - [Check warnings](#check-warnings)
-  - [Check SHCD port usage](#check-shcd-port-usage)
-- [Logging and updates](#logging-and-updates)
+- [Validate the SHCD](#validate-the-shcd)
+  - [Topics](#topics)
+  - [Prerequisites](#prerequisites)
+  - [Validation steps](#validation-steps)
+  - [Under the hood](#under-the-hood)
+    - [Check warnings](#check-warnings)
+    - [Check SHCD port usage](#check-shcd-port-usage)
+  - [Logging and updates](#logging-and-updates)
 
 ## Prerequisites
 
@@ -34,9 +36,9 @@ Use the CSM Automated Network Utility (CANU) to validate the SHCD. SHCD validati
    > **`NOTE`**
    > `-a` defines the architecture, this will be:
    >
-   > - `v1` if the Cray system is composed only of River cabinets
-   > - `TDS` if the Cray system has an attached Hill cabinet
-   > - `FULL` if the Cray system has an attached Mountain cabinet (or a Mountain and a Hill cabinet)
+   > - `v1` if the Cray system is composed of Mellanox and Dell switches, typically with Gigabyte or Intel server hardware.
+   > - `tds` if the Cray system has Aruba switches with HPE servers **and NCNs are connected to the Aruba Spine switches**.
+   > - `full` if the Cray system has Aruba switches with HPE servers **and NCNs are connected to the Aruba Leaf switches**.
 
    ```bash
    ARCH=v1


### PR DESCRIPTION
# Description

Previously when validating SHCDs the meaning of CANU `-a` architecture was unclear.  This change directly states the vendors and configuration involved in the three architectures available.

# Checklist Before Merging

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
