### PR TITLE
CASMINST-5031: Change CAPMC URL to target for test

### DIFF
--- a/scripts/operations/gateway-test/gateway-test-defn.yaml
+++ b/scripts/operations/gateway-test/gateway-test-defn.yaml
@@ -52,7 +52,7 @@ ingress_api_services:
   gateways: ["services-gateway","customer-admin-gateway"]
   project: CSM
 - name: cray-capmc
-  path: apis/capmc/capmc/get_node_rules
+  path: apis/capmc/capmc/v1/health
   port: 443
   expected-result: 200
   namespace: services


### PR DESCRIPTION
# Description

The URL being used to test communication with CAPMC was removed. Changed it to the health CAPMC health URL.

Validated new CAPMC health URL on surtur.

PASS - [cray-capmc]: https://api.cmn.surtur.hpc.amslabs.hpecorp.net/apis/capmc/capmc/v1/health - 200

Overall Gateway Test Status:  PASS

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
