### PR TITLE
CASMPET-5828

### DIFF
--- a/upgrade/scripts/upgrade/ncn-upgrade-ceph-nodes.sh
+++ b/upgrade/scripts/upgrade/ncn-upgrade-ceph-nodes.sh
@@ -206,6 +206,7 @@ if [[ $ssh_keys_done == "0" ]]; then
     ssh_keygen_keyscan "${target_ncn}"
     ssh_keys_done=1
 fi
+sleep 30
 ssh $target_ncn -t 'GOSS_BASE=/opt/cray/tests/install/ncn goss -g /opt/cray/tests/install/ncn/suites/ncn-upgrade-tests-storage.yaml --vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml validate' 
 
 move_state_file ${target_ncn}


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
Add sleep before tests are run in ncn-upgrade-ceph-nodes.sh. Tests should no longer result in false negatives because storage node was not fully up

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
