### PR TITLE
CASMINST-5087: Add logic for prmote-initial-master to work on 1.2 and 1.3

### DIFF
--- a/upgrade/scripts/k8s/promote-initial-master.sh
+++ b/upgrade/scripts/k8s/promote-initial-master.sh
@@ -44,7 +44,15 @@ export MAX_PODS_PER_NODE=$(craysys metadata get kubernetes-max-pods-per-node)
 export PODS_CIDR=$(craysys metadata get kubernetes-pods-cidr)
 #shellcheck disable=SC2155
 export SERVICES_CIDR=$(craysys metadata get kubernetes-services-cidr)
-envsubst < /srv/cray/resources/common/kubeadm.cfg > /etc/cray/kubernetes/kubeadm.yaml
+
+# Note: for pre 1.3 the kubeadm source file had a .yaml suffix for 1.3+ it is
+# .cfg if we have the .yaml file symlink .cfg to that for 1.2 upgrades.
+k8scfg="/srv/cray/resources/common/kubeadm.cfg"
+k8syaml="/srv/cray/resources/common/kubeadm.yaml"
+if [ -f "${k8syaml}" ]; then
+  ln -sf "${k8syaml}" "${k8scfg}"
+fi
+envsubst < "${k8scfg}" > /etc/cray/kubernetes/kubeadm.yaml
 
 kubeadm token create --print-join-command > /etc/cray/kubernetes/join-command 2>/dev/null
 echo "$(cat /etc/cray/kubernetes/join-command) --control-plane --certificate-key $(cat /etc/cray/kubernetes/certificate-key)" > /etc/cray/kubernetes/join-command-control-plane


### PR DESCRIPTION
Prior fix for file name would only allow for 1.3->1.3 upgrades, this should
tackle 1.2 as well by symlinking the old config file if found to the expected location.

# Description

<!--- Describe what this change is and what it is for. -->

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
