### PR TITLE
CASMINST-5089 Add References to Manual Steps

### DIFF
--- a/install/pre-installation.md
+++ b/install/pre-installation.md
@@ -522,7 +522,7 @@ Run the following steps before starting any of the system configuration procedur
 
 1. (`pit#`) Download the SHCD to the `prep` directory.
 
-    This will need to be retrieved from the administrators Cray deliverable.
+    This will need to be retrieved from the administrator's Cray deliverable.
 
 1. Validate the SHCD.
 
@@ -531,43 +531,41 @@ Run the following steps before starting any of the system configuration procedur
 ### 3.2 Generate topology files
 
 The following steps use the new, automated method for generating files. The previous step for
-[validate SHCD](#31-validate-shcd) will have generated "paddle" files, these are necessary for generating
+[validate SHCD](#31-validate-shcd) generated "paddle" files; these are necessary for generating
 the rest of the seed files.
 
 > ***NOTE*** The paddle files are temporarily not used due to bugs in the seed file generation software.
 > Until these bugs are resolved, the seed files must be manually generated.
 
-If seed files from a prior installation of the same major-minor version of CSM exist, these can be used and
+If seed files from a prior installation of the same major-minor version of CSM exist, then these can be used and
 this step may be skipped.
 
-1. (`pit#`) Create each seed file unless they already exist from a previous installation:
+1. (`pit#`) Create each seed file, unless they already exist from a previous installation.
 
    - For new installations of CSM that have no prior seed files, each one must be created:
 
-      - [Create `application_node_config.yaml`](./create_application_node_config_yaml.md)
-      - [Create `cabinets.yaml`](./create_cabinets_yaml.md)
-      - [Create `hmn_connections.json`](./create_hmn_connections_json.md)
-      - [Create `ncn_metadata.csv`](./create_ncn_metadata_csv.md)
-      - [Create `switch_metadata.csv`](./create_switch_metadata_csv.md)
+      - [Create `application_node_config.yaml`](create_application_node_config_yaml.md)
+      - [Create `cabinets.yaml`](create_cabinets_yaml.md)
+      - [Create `hmn_connections.json`](create_hmn_connections_json.md)
+      - [Create `ncn_metadata.csv`](create_ncn_metadata_csv.md)
+      - [Create `switch_metadata.csv`](create_switch_metadata_csv.md)
 
    - For re-installations of CSM 1.3, the previous seed files may be used and this step can be skipped.
-   - For new installations of CSM 1.3 that have prior seed files from CSM 1.2 or older, the following files
-   need to be recreated due to changes in their content or formatting:
+   - For new installations of CSM 1.3 that have prior seed files from CSM 1.2 or older, the previous seed files
+   may be used **except that the following files must be recreated** because of content or formatting changes:
 
-      - [Create `cabinets.yaml`](./create_cabinets_yaml.md)
-      - [Create `hmn_connections.json`](./create_hmn_connections_json.md)
+      - [Create `cabinets.yaml`](create_cabinets_yaml.md)
+      - [Create `hmn_connections.json`](create_hmn_connections_json.md)
 
-   The other files can be re-used (e.g. `application_node_config.yaml`, `ncn_metadata.csv`, and `switch_metadata.csv`).
-
-1. (`pit#`) Confirm that the following files exist:
+1. (`pit#`) Confirm that the following files exist.
 
    ```bash
-   ls -l ${PITDATA}/prep/{application_node_config.yaml,cabinets.yaml,hmn_connections.json,ncn_metadata.csv,switch_metadata.csv}
+   ls -l "${PITDATA}"/prep/{application_node_config.yaml,cabinets.yaml,hmn_connections.json,ncn_metadata.csv,switch_metadata.csv}
    ```
 
    Expected output may look like:
 
-   ```bash
+   ```text
    -rw-r--r-- 1 root root  146 Jun  6 00:12 /var/www/ephemeral/prep/application_node_config.yaml
    -rw-r--r-- 1 root root  392 Jun  6 00:12 /var/www/ephemeral/prep/cabinets.yaml
    -rwxr-xr-x 1 root root 3768 Jun  6 00:12 /var/www/ephemeral/prep/hmn_connections.json

--- a/install/pre-installation.md
+++ b/install/pre-installation.md
@@ -522,38 +522,58 @@ Run the following steps before starting any of the system configuration procedur
 
 1. (`pit#`) Download the SHCD to the `prep` directory.
 
-   This will need to be retrieved from the administrators Cray deliverable.
+    This will need to be retrieved from the administrators Cray deliverable.
 
 1. Validate the SHCD.
 
-   See [Validate SHCD](../operations/network/management_network/validate_shcd.md) and then return to this page.
+    See [Validate SHCD](../operations/network/management_network/validate_shcd.md) and then return to this page.
 
 ### 3.2 Generate topology files
 
-1. (`pit#`) Generate `hmn_connections.json`.
+The following steps use the new, automated method for generating files. The previous step for
+[validate SHCD](#31-validate-shcd) will have generated "paddle" files, these are necessary for generating
+the rest of the seed files.
+
+> ***NOTE*** The paddle files are temporarily not used due to bugs in the seed file generation software.
+> Until these bugs are resolved, the seed files must be manually generated.
+
+If seed files from a prior installation of the same major-minor version of CSM exist, these can be used and
+this step may be skipped.
+
+1. (`pit#`) Create each seed file unless they already exist from a previous installation:
+
+   - For new installations of CSM that have no prior seed files, each one must be created:
+
+      - [Create `application_node_config.yaml`](./create_application_node_config_yaml.md)
+      - [Create `cabinets.yaml`](./create_cabinets_yaml.md)
+      - [Create `hmn_connections.json`](./create_hmn_connections_json.md)
+      - [Create `ncn_metadata.csv`](./create_ncn_metadata_csv.md)
+      - [Create `switch_metadata.csv`](./create_switch_metadata_csv.md)
+
+   - For re-installations of CSM 1.3, the previous seed files may be used and this step can be skipped.
+   - For new installations of CSM 1.3 that have prior seed files from CSM 1.2 or older, the following files
+   need to be recreated due to changes in their content or formatting:
+
+      - [Create `cabinets.yaml`](./create_cabinets_yaml.md)
+      - [Create `hmn_connections.json`](./create_hmn_connections_json.md)
+
+   The other files can be re-used (e.g. `application_node_config.yaml`, `ncn_metadata.csv`, and `switch_metadata.csv`).
+
+1. (`pit#`) Confirm that the following files exist:
 
    ```bash
-   csi config shcd "$SYSTEM_NAME-hmn-paddle.json" -H
+   ls -l ${PITDATA}/prep/{application_node_config.yaml,cabinets.yaml,hmn_connections.json,ncn_metadata.csv,switch_metadata.csv}
    ```
 
-1. (`pit#`) Create `application_node_config.yaml`, `ncn_metadata.csv`, and `switch_metadata.csv`.
+   Expected output may look like:
 
-    ```bash
-    csi config shcd "${SYSTEM_NAME}-full-paddle.json" -ANS
-    ```
-
-1. Create the `cabinents.yaml` file.
-
-   > If using this file, then do not forget to set the `cabinets-yaml` field in the
-   > [Customize `system_config.yaml`](#33-customize-system_configyaml) step.
-
-   See [Create `cabinets.yaml`](create_cabinets_yaml.md).
-
-1. Fill in the `ncn_metadata.csv` placeholder values with the actual values.
-
-   > **NOTE:** If a previous `ncn_metadata.csv` file is available, simply copy it into place by overriding the generated one.
-
-   See [Collect MAC Addresses for NCNs](collect_mac_addresses_for_ncns.md).
+   ```bash
+   -rw-r--r-- 1 root root  146 Jun  6 00:12 /var/www/ephemeral/prep/application_node_config.yaml
+   -rw-r--r-- 1 root root  392 Jun  6 00:12 /var/www/ephemeral/prep/cabinets.yaml
+   -rwxr-xr-x 1 root root 3768 Jun  6 00:12 /var/www/ephemeral/prep/hmn_connections.json
+   -rw-r--r-- 1 root root 1216 Jun  6 00:12 /var/www/ephemeral/prep/ncn_metadata.csv
+   -rw-r--r-- 1 root root  150 Jun  6 00:12 /var/www/ephemeral/prep/switch_metadata.csv
+   ```
 
 ### 3.3 Customize `system_config.yaml`
 


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
This adds links for each seed file on how to manually create that seed file.

Currently Admins are being directed at step 3.2 in `pre-installation.md` to _jump_ to 1.2 documentation, I think this is because some do not realize the manual steps still exist in the 1.3 branch (`main`) of this repository. These added notes ensure that an administrator will be given notice of what to do when auto-generation does not succeed and where the manual documentation lives.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
