### PR TITLE
CASMPET-5811: Adding allowed-issuers and api/auth names to hmnlb gateway

### DIFF
--- a/upgrade/scripts/upgrade/util/update-customizations.sh
+++ b/upgrade/scripts/upgrade/util/update-customizations.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+set -e
+basedirLoc=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+. ${basedirLoc}/../../common/upgrade-state.sh
+trap 'err_report' ERR
+set -o pipefail
+
+usage() {
+    echo >&2 "usage: ${0##*/} [-i] [CUSTOMIZATIONS-YAML]"
+    exit 1
+}
+
+args=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h)
+            usage
+            ;;
+        -i)
+            inplace="yes"
+            ;;
+        *)
+            args+=("$1")
+            ;;
+    esac
+    shift
+done
+
+set -- "${args[@]}"
+
+[[ $# -eq 1 ]] || usage
+
+
+customizations="$1"
+
+if [[ ! -f "$customizations" ]]; then
+    echo >&2 "error: no such file: $customizations"
+    usage
+fi
+
+if ! command -v yq &> /dev/null
+then
+    echo >&2 "error: yq could not be found"
+    exit 1
+fi
+
+c="$(mktemp)"
+trap 'rm -f $c' EXIT
+
+cp "$customizations" "$c"
+
+# argo/cray-nls
+yq w -i --style=single "$c" spec.kubernetes.services.cray-nls.externalHostname 'cmn.{{ network.dns.external }}'
+
+if [[ -z "$(yq r "$c" 'spec.proxiedWebAppExternalHostnames.customerManagement(.==argo.cmn.{{ network.dns.external }})')" ]];then
+   yq w -i --style=single "$c" spec.proxiedWebAppExternalHostnames.customerManagement[+] 'argo.cmn.{{ network.dns.external }}'
+fi
+
+# cray-opa
+yq w -i "$c" 'spec.kubernetes.services.cray-opa.ingresses.ingressgateway-hmn.issuers.shasta-hmn' 'https://api.hmnlb.{{ network.dns.external }}/keycloak/realms/shasta'
+yq w -i "$c" 'spec.kubernetes.services.cray-opa.ingresses.ingressgateway-hmn.issuers.keycloak-hmn' 'https://auth.hmnlb.{{ network.dns.external }}/keycloak/realms/shasta'
+
+# cray-istio
+yq w -i "$c" 'spec.kubernetes.services.cray-istio.services.istio-ingressgateway-hmn.serviceAnnotations.[external-dns.alpha.kubernetes.io/hostname]' 'api.hmnlb.{{ network.dns.external }},auth.hmnlb.{{ network.dns.external }},hmcollector.hmnlb.{{ network.dns.external }}'
+
+if [[ "$inplace" == "yes" ]]; then
+    cp "$c" "$customizations"
+else
+    cat "$c"
+fi
+


### PR DESCRIPTION
# Description

CASMPET-5795 Added the `api` name to the hmn-gateway.   CASMPET-5817 added the `auth` name and added allowed-issuers to the hmn-gateway.   This is doing those additions to customizations.yaml for an upgrade.  

I also put back the update-customizations.sh script since we do not yet have a suitable replacement for 1.3.   I moved the two items (for argo and cray-nls) that were added directly to prerequisites.sh to the update-customizations.sh.   While testing, I found that the argo item was not idempotent so I added a fix for that as well.

# Testing
Tested on mug.

Ran the update-customizations.sh by itself multiple times to check idempotency.  Ran just the "UPDATE_CUSTOMIZATIONS" stage of prerequisites.sh on mug (without writing it back to the site-init secret) to test the changes to that stage.

# Checklist Before Merging

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

