### PR TITLE
CASMHMS-5595 Set TPM State when adding an NCN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 999*
 .vscode
 .idea
+*.swp

--- a/operations/node_management/Add_Remove_Replace_NCNs.md
+++ b/operations/node_management/Add_Remove_Replace_NCNs.md
@@ -295,6 +295,7 @@ The following is a high-level overview of the add NCN workflow:
 1. [Add Switch Configuration](Add_Remove_Replace_NCNs/Add_Switch_Config.md).
 1. [Add NCN data](Add_Remove_Replace_NCNs/Add_NCN_Data.md) for SLS, BSS and HSM.
 1. [Update Firmware](Add_Remove_Replace_NCNs/Update_Firmware.md) via FAS.
+1. [Update NCN BIOS TPM State](Add_Remove_Replace_NCNs/Update_NCN_BIOS_TPM_State.md)
 1. [Boot NCN and Configure](Add_Remove_Replace_NCNs/Boot_NCN.md).
 1. [Redeploy Services](Add_Remove_Replace_NCNs/Redeploy_Services.md).
 1. [Validate NCN](Add_Remove_Replace_NCNs/Validate_NCN.md).

--- a/operations/node_management/Add_Remove_Replace_NCNs/Update_Firmware.md
+++ b/operations/node_management/Add_Remove_Replace_NCNs/Update_Firmware.md
@@ -8,4 +8,4 @@ Use FAS to update the firmware and set the BMC password.
 
 See [Update Firmware](../../firmware/Update_Firmware_with_FAS.md).
 
-Proceed to the next step to [Boot NCN and Configure](Boot_NCN.md) or return to the main [Add, Remove, Replace, or Move NCNs](../Add_Remove_Replace_NCNs.md) page.
+Proceed to the next step to [Update NCN BIOS TPM State](Update_NCN_BIOS_TPM_State.md) or return to the main [Add, Remove, Replace, or Move NCNs](../Add_Remove_Replace_NCNs.md) page.

--- a/operations/node_management/Add_Remove_Replace_NCNs/Update_NCN_BIOS_TPM_State.md
+++ b/operations/node_management/Add_Remove_Replace_NCNs/Update_NCN_BIOS_TPM_State.md
@@ -1,0 +1,90 @@
+# Update NCN BIOS TPM State
+
+## Description
+
+Enable Trusted Platform Module (TPM) in the BIOS on the new NCN if TPM is being used on the other NCNs.
+**Skip this step if TPM is not being used in the system** and proceed to the next step to [Boot NCN and Configure](Boot_NCN.md).
+
+Using TPM involves both enabling the hardware and configuring TPM.
+This document only details how to enable TPM on the hardware.
+The state of the other NCNs in the system can be checked using steps [1](#step1) and [2](#step2) of this document.
+
+Disabling TPM is not required when not using it. Many types of hardware come with TPM enabled by default.
+
+## Current capabilities
+
+The following table lists the type of hardware where the TPM State can be enabled. Not all models from a given manufacturer support TPM.
+
+| **Manufacturer** | **Type**     |
+| ---------------- | ------------ |
+| Gigabyte         | `nodeBMC`    |
+| HPE              | `nodeBMC`    |
+
+SCSD does not support setting the TPM state on Intel hardware.
+With Intel hardware skip these steps and proceed to the next step to [Boot NCN and Configure](Boot_NCN.md).
+
+## Procedure
+
+1. (`ncn-mw#`) Select the component name (xname) of the BMC node. <a name="step1"></a>
+
+    ```bash
+    export XNAME_BMC=x3000c0s4b0n0
+    ```
+
+1. (`ncn-mw#`) Check the TPM state. <a name="step2"></a>
+
+    ```bash
+    cray scsd bmc bios describe tpmstate $XNAME_BMC --format json
+    ```
+
+    Example output for the `Disabled` case:
+
+    ```json
+    {
+        "Current" : "Disabled",
+        "Future" : "Disabled"
+    }
+    ```
+
+    If the response is `NotPresent`, then setting TPM is not supported.
+    The remaining steps should be skipped. Proceed to the next step to [Boot NCN and Configure](Boot_NCN.md).
+
+    ```json
+    {
+        "Current" : "NotPresent",
+        "Future" : "NotPresent"
+    }
+    ```
+
+    If the response is an error, then setting TPM is not supported by SCSD or is not supported by the hardware.
+    This includes any usage errors from the `cray` command.
+    The remaining steps should be skipped. Proceed to the next step to [Boot NCN and Configure](Boot_NCN.md).
+
+1. (`ncn-mw#`) Enable the TPM state if it is `Disabled`.
+
+    If the the previous step showed that TPM was `Disabled`, then `Enable` it with the following request.
+
+    ```bash
+    cray scsd bmc bios update tpmstate $XNAME_BMC --future Enabled
+    ```
+
+1. (`ncn-mw#`) Check that the `Future` value is set.
+
+    ```bash
+    cray scsd bmc bios describe tpmstate $XNAME_BMC --format json
+    ```
+
+    Example output:
+
+    ```json
+    {
+        "Current" : "Disabled",
+        "Future" : "Enabled"
+    }
+    ```
+
+    The new TPM state will take effect the next time the node is booted.
+
+## Next Step
+
+Proceed to the next step to [Boot NCN and Configure](Boot_NCN.md) or return to the main [Add, Remove, Replace, or Move NCNs](../Add_Remove_Replace_NCNs.md) page.


### PR DESCRIPTION
# Description

Add step to enable TPM in the BIOS when adding NCN

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
