### PR TITLE
fix typo and shadowed issues

### DIFF
--- a/upgrade/1.2/scripts/strimzi/kafka-restart.sh
+++ b/upgrade/1.2/scripts/strimzi/kafka-restart.sh
@@ -63,9 +63,9 @@ until kafkaok && podsready; do
 
     if ! podsready; then
 	printf "Found pods not at Ready = 1/1, deleting to force an update\n" >&2
-	for pod in $(kubectl get pods --no-headers=true --namespaces services --selector strimzi.io/name=cray-shared-kafka-kafka --field-selector="status.phase=Running" | grep -Ev '1/1'); do
+	for pod in $(kubectl get pods --no-headers=true --namespace services --selector strimzi.io/name=cray-shared-kafka-kafka --field-selector="status.phase=Running" | grep -Ev '1/1' | awk '{print $1}'); do
 	    printf "Deleting %s\n" "${pod}" >&2
-	    kubectl delete -n services "$pod"
+	    kubectl delete -n services pod "$pod"
 	    sleep 10
 	done
     fi


### PR DESCRIPTION
the `--namespaces` flag was incorrect hiding that the delete wasn't working

Signed-off-by: Douglas Jacobsen <dmjacobsen@lbl.gov>

# Description

The procedure to restart strimzi related services is non-functional in the csm 1.2 upgrade.  This is at least one part of why that is true.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
