### PR TITLE
CAST-30583: Kafka restart bugfixes

### DIFF
--- a/upgrade/1.2/scripts/strimzi/kafka-restart.sh
+++ b/upgrade/1.2/scripts/strimzi/kafka-restart.sh
@@ -38,7 +38,7 @@ set -eu
 # cray-shared-kafka-kafka-2   2/2     Running   0          3h55m
 podsready() {
     [ "1/1" = "$(kubectl get pods --no-headers=true --namespace services --selector strimzi.io/name=cray-shared-kafka-kafka --field-selector=status.phase=Running | awk '!/READY/ {print $2}' | sort -u)" ] &&
-	[ "Running" = "$(kubectl get pods --no-headers=true --namespace services --selector strimzi.io/name=cray-shared-kafka-kafka --field-selector="status.phase=Running" | awk '{print $3}' | sort -u)" ]
+	[ "Running" = "$(kubectl get pods --no-headers=true --namespace services --selector strimzi.io/name=cray-shared-kafka-kafka | awk '{print $3}' | sort -u)" ]
 }
 
 kafkaok() {
@@ -54,7 +54,14 @@ fi
 
 # Logic loop is loop/retrying things in order until ok, tries for 300 seconds
 # total and after that gives up, can be re-run.
+start=$(date +%s)
 until kafkaok && podsready; do
+    now=$(date +%s)
+    if [ $((now - start)) -ge 300 ]; then
+	printf "Giving up trying to restart kafka pods after 5 minutes\n" >&2
+	exit 1
+    fi
+
     if ! kafkaok; then
 	printf "Patching kafka cluster resource to include listeners\n" >&2
 	kubectl patch kafka cluster --namespace sma --type merge --patch-file "${cwd}/patch-listeners.yaml"
@@ -63,9 +70,9 @@ until kafkaok && podsready; do
 
     if ! podsready; then
 	printf "Found pods not at Ready = 1/1, deleting to force an update\n" >&2
-	for pod in $(kubectl get pods --no-headers=true --namespaces services --selector strimzi.io/name=cray-shared-kafka-kafka --field-selector="status.phase=Running" | grep -Ev '1/1'); do
+	for pod in $(kubectl get pods --no-headers=true --namespace services --selector strimzi.io/name=cray-shared-kafka-kafka --field-selector="status.phase=Running" | grep -Ev '1/1'); do
 	    printf "Deleting %s\n" "${pod}" >&2
-	    kubectl delete -n services "$pod"
+	    kubectl delete --namespace services pod "$pod"
 	    sleep 10
 	done
     fi


### PR DESCRIPTION
# Description

Fixes for issues encountered upgrading CSCS as well as a couple other issues I noticed while re-reading through the script and validating all the code piecemeal on a running 1.2 system.

Noticed there was a missing, stop trying to restart logic missing from a comment. Added that logic in. As well as noticed a bit of a no-op in a conditional that shouldn't impact things but technically resulted in a check of [ "Running" = "Running" ] which isn't too useful where the intent was to see if there were other states as well in the kafka pods.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
