### PR TITLE
CASMINST-5112 User reported `logout` fails

### DIFF
--- a/install/pre-installation.md
+++ b/install/pre-installation.md
@@ -288,7 +288,7 @@ These variables will need to be set for many procedures within the CSM installat
    ls -l "$(lsblk -o MOUNTPOINT -nr /dev/disk/by-label/PITDATA)/admin"
    ```
 
-1. (`pit#`) Exit the typescript and logout.
+1. (`pit#`) Exit the typescript and log out.
 
    ```bash
    exit

--- a/install/pre-installation.md
+++ b/install/pre-installation.md
@@ -281,16 +281,17 @@ These variables will need to be set for many procedures within the CSM installat
 
 ### 1.6 Exit the console and log in with SSH
 
-1. (`pit#`) Create the `admin` directory and logout.
+1. (`pit#`) Create the `admin` directory for the typescripts and administrative scratch work.
 
    ```bash
    mkdir -pv "$(lsblk -o MOUNTPOINT -nr /dev/disk/by-label/PITDATA)/admin"
-   logout
+   ls -l "$(lsblk -o MOUNTPOINT -nr /dev/disk/by-label/PITDATA)/admin"
    ```
 
-1. (`pit#`) Exit the typescript
+1. (`pit#`) Exit the typescript and logout.
 
    ```bash
+   exit
    exit
    ```
 


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
Use `exit` instead, and ensure the `admin/` directory exists by listing it and moving `exit` into a separate step.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
