### PR TITLE
CASMTRIAGE-3786: be more careful when deleting .ssh/config

### DIFF
--- a/upgrade/1.2/scripts/common/upgrade-state.sh
+++ b/upgrade/1.2/scripts/common/upgrade-state.sh
@@ -85,8 +85,10 @@ function err_report() {
     echo "${cmd}"
 
     # restore previous ssh config if there was one, remove ours
-    rm -f /root/.ssh/config
-    test -f /root/.ssh/config.bak && mv /root/.ssh/config.bak /root/.ssh/config
+    if [[ $RESTORE_SSH_CONFIG -eq 1 ]] ; then
+        rm -f /root/.ssh/config
+        test -f /root/.ssh/config.bak && mv /root/.ssh/config.bak /root/.ssh/config
+    fi
 
     # ignore some internal expected errors
     local ignoreCmd="cray artifacts list config-data"

--- a/upgrade/1.2/scripts/upgrade/prerequisites.sh
+++ b/upgrade/1.2/scripts/upgrade/prerequisites.sh
@@ -109,7 +109,12 @@ if [[ $state_recorded == "0" ]]; then
     echo "====> ${state_name} ..."
     {
 
-    test -f /root/.ssh/config && mv /root/.ssh/config /root/.ssh/config.bak
+    if [ -f /root/.ssh/config ]; then
+        # shellcheck disable=SC2034 # it is referenced in upgrade-state.sh, which is sourced at the
+        # top of this file.
+        RESTORE_SSH_CONFIG=1
+        mv /root/.ssh/config /root/.ssh/config.bak
+    fi
     cat <<EOF> /root/.ssh/config
 Host *
     StrictHostKeyChecking no


### PR DESCRIPTION
# Description

The cleanup function referenced by `trap` in prerequisites.sh
is also used in other contexts. However, only prerequisites.sh
deals with creating a backup ssh config file.  If the trap function
is run from another context, it blindly removes the system ssh
config.


<!--- Describe what this change is and what it is for. -->

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
