### PR TITLE
CAST-30583: Remove a now useless grep and do it all with awk instead

### DIFF
--- a/upgrade/1.2/scripts/strimzi/kafka-restart.sh
+++ b/upgrade/1.2/scripts/strimzi/kafka-restart.sh
@@ -70,7 +70,7 @@ until kafkaok && podsready; do
 
     if ! podsready; then
 	printf "Found pods not at Ready = 1/1, deleting to force an update\n" >&2
-	for pod in $(kubectl get pods --no-headers=true --namespace services --selector strimzi.io/name=cray-shared-kafka-kafka --field-selector="status.phase=Running" | grep -Ev '1/1' | awk '{print $1}'); do
+	for pod in $(kubectl get pods --no-headers=true --namespace services --selector strimzi.io/name=cray-shared-kafka-kafka --field-selector="status.phase=Running" | awk '!/1\/1/ {print $1}'); do
 	    printf "Deleting %s\n" "${pod}" >&2
 	    kubectl delete --namespace services pod "$pod"
 	    sleep 10


### PR DESCRIPTION
# Description

Nothing special just a nit removing a now useless grep in favor of just awk.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
