### PR TITLE
CASMPET-5784: Add Nexus export to Prerequisites.sh

### DIFF
--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -298,6 +298,21 @@ else
     echo "====> ${state_name} has been completed"
 fi
 
+state_name="EXPORT_NEXUS"
+#shellcheck disable=SC2046
+state_recorded=$(is_state_recorded "${state_name}" $(hostname))
+if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
+    echo "====> ${state_name} ..."
+    {
+    ${locOfScript}/../../../scripts/nexus-export.sh
+
+    } >> ${LOG_FILE} 2>&1
+    #shellcheck disable=SC2046
+    record_state ${state_name} $(hostname)
+else
+    echo "====> ${state_name} has been completed"
+fi
+
 state_name="SETUP_NEXUS"
 #shellcheck disable=SC2046
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))


### PR DESCRIPTION
# Description

This adds the Nexus export to prerequisites.sh. A concern with this is the export will add significant time to the running time of the script. It takes around one hour for every 60 Gigabytes in Nexus.

# Checklist Before Merging

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
