### PR TITLE
CASMISNT-5128: fix BMC hostname array

### DIFF
--- a/install/deploy_final_non-compute_node.md
+++ b/install/deploy_final_non-compute_node.md
@@ -457,7 +457,7 @@ However, the commands in this section are all run **on** `ncn-m001`.
    except `ncn-m001-mgmt`:
 
     ```bash
-    readarray BMCS < <(grep mgmt /etc/hosts | awk '{print $NF}' | grep -v m001 | sort -u)
+    readarray BMCS < <(grep mgmt /etc/hosts | awk '{print $NF}' | grep -v m001 | sort -u | tr '\n' ' ')
     for BMC in "${BMCS[@]}"; do echo ${BMC}; done
     ```
 


### PR DESCRIPTION
# Description

Each host in the BMC array had a trailing newline character, causing
problems for DNS resolution during execution of the bmc/dns script.

Tested on surtur.

<!--- Describe what this change is and what it is for. -->

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
