### PR TITLE
CASMTRIAGE-3803 Add artifactory.algol60.net to containerd for air-gapped systems on upgrade

### DIFF
--- a/scripts/reconfigure_containerd.sh
+++ b/scripts/reconfigure_containerd.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+if ! grep -q "plugins.*artifactory.algol60.net" /etc/containerd/config.toml; then
+  echo "Adding artifactory.algol60.net to containerd config"
+tee -a /etc/containerd/config.toml 1>/dev/null << END
+      [plugins."io.containerd.grpc.v1.cri".registry.mirrors."artifactory.algol60.net"]
+        endpoint = ["http://pit.nmn:5000/v2/artifactory.algol60.net", "http://pit.nmn:5000","https://registry.local/v2/artifactory.algol60.net", "https://registry.local", "dummy://artifactory.algol60.net"]
+END
+  echo "Restarting containerd"
+  systemctl restart containerd
+else
+  echo "artifactory.algol60.net already in config.toml -- no reconfig needed"
+fi


### PR DESCRIPTION
# Description

Change for https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3803 -- add containerd config for artifactory.algol60.net to support upgrading unbound before NCNs are upgraded.

# Testing

```
ncn-m001-48d9c509:/home/bklein # ./foo.sh
Reconfiguring containerd on ncn-w001:
reconfigure_containerd.sh                                                                                                  100%  653     1.6MB/s   00:00
ncn-w001: Warning: Permanently added 'ncn-w001,10.1.0.7' (ECDSA) to the list of known hosts.
ncn-w001: Adding artifactory.algol60.net to containerd config
ncn-w001: Restarting containerd
Reconfiguring containerd on ncn-w002:
reconfigure_containerd.sh                                                                                                  100%  653     1.3MB/s   00:00
ncn-w002: Warning: Permanently added 'ncn-w002,10.1.0.6' (ECDSA) to the list of known hosts.
ncn-w002: artifactory.algol60.net already in config.toml -- no reconfig needed
Reconfiguring containerd on ncn-w003:
reconfigure_containerd.sh                                                                                                  100%  653     1.2MB/s   00:00
ncn-w003: Warning: Permanently added 'ncn-w003,10.1.0.3' (ECDSA) to the list of known hosts.
ncn-w003: artifactory.algol60.net already in config.toml -- no reconfig needed
Reconfiguring containerd on ncn-w004:
reconfigure_containerd.sh                                                                                                  100%  653     1.3MB/s   00:00
ncn-w004: Warning: Permanently added 'ncn-w004,10.1.0.9' (ECDSA) to the list of known hosts.
ncn-w004: artifactory.algol60.net already in config.toml -- no reconfig needed
Reconfiguring containerd on ncn-w005:
reconfigure_containerd.sh                                                                                                  100%  653     1.3MB/s   00:00
ncn-w005: Warning: Permanently added 'ncn-w005,10.1.0.5' (ECDSA) to the list of known hosts.
ncn-w005: artifactory.algol60.net already in config.toml -- no reconfig needed
Reconfiguring containerd on ncn-w006:
reconfigure_containerd.sh                                                                                                  100%  653     1.6MB/s   00:00
ncn-w006: Warning: Permanently added 'ncn-w006,10.1.0.8' (ECDSA) to the list of known hosts.
ncn-w006: artifactory.algol60.net already in config.toml -- no reconfig needed
Restarting sonar-jobs-watcher pods
daemonset.apps/sonar-jobs-watcher restarted
Waiting for daemon set "sonar-jobs-watcher" rollout to finish: 0 out of 6 new pods have been updated...
Waiting for daemon set "sonar-jobs-watcher" rollout to finish: 1 out of 6 new pods have been updated...
Waiting for daemon set "sonar-jobs-watcher" rollout to finish: 1 out of 6 new pods have been updated...
Waiting for daemon set "sonar-jobs-watcher" rollout to finish: 2 out of 6 new pods have been updated...
Waiting for daemon set "sonar-jobs-watcher" rollout to finish: 2 out of 6 new pods have been updated...
Waiting for daemon set "sonar-jobs-watcher" rollout to finish: 3 out of 6 new pods have been updated...
Waiting for daemon set "sonar-jobs-watcher" rollout to finish: 3 out of 6 new pods have been updated...
Waiting for daemon set "sonar-jobs-watcher" rollout to finish: 4 out of 6 new pods have been updated...
Waiting for daemon set "sonar-jobs-watcher" rollout to finish: 4 out of 6 new pods have been updated...
Waiting for daemon set "sonar-jobs-watcher" rollout to finish: 5 out of 6 new pods have been updated...
Waiting for daemon set "sonar-jobs-watcher" rollout to finish: 5 out of 6 new pods have been updated...
Waiting for daemon set "sonar-jobs-watcher" rollout to finish: 5 of 6 updated pods are available...
daemon set "sonar-jobs-watcher" successfully rolled out
```

# Checklist Before Merging

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.
