### PR TITLE
CASMINST-5134/CASMTRIAGE-3817: Corrections to password setting/changing procedures

### DIFF
--- a/operations/image_management/Create_UAN_Boot_Images.md
+++ b/operations/image_management/Create_UAN_Boot_Images.md
@@ -59,10 +59,13 @@ and the HPE Cray Programming Environment\) that must be configured on the UANs.
           id: cbd5cdf6-eac3-47e6-ace4-aa1aecb1359a                         # <--- IMS recipe id
     ```
 
-1. Generate the password hash for the `root` user. Replace `PASSWORD` with the desired `root` password.
+1. Generate the password hash for the `root` user.
+
+    > Replace `PASSWORD` with the desired `root` password.
+    > Do not omit the `-n` from the echo command. It is necessary to generate a valid hash.
 
     ```bash
-    openssl passwd -6 -salt $(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c4) PASSWORD
+    echo -n PASSWORD | openssl passwd -6 -salt $(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c4) --stdin
     ```
 
 1. Obtain the HashiCorp Vault `root` token.

--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
@@ -138,10 +138,10 @@ mkdir -pv /run/initramfs/overlayfs/workingarea && cd /run/initramfs/overlayfs/wo
 ### 3. (`ncn#`) Customize the images
 
 Add SSH keys and the `root` password to the NCN SquashFS images. Optionally set their timezone, if a timezone other than UTC
-(the default) is desired. This is all done by running the `ncn-image-modification.sh` script, which is located in the `scripts/operations/node_management` directory of the CSM documentation. Set the path to the script:
+(the default) is desired. This is all done by running the `ncn-image-modification.sh` script. Set the path to the script:
 
 ```bash
-NCN_MOD_SCRIPT=$(rpm -ql docs-csm | grep ncn-image-modification.sh)
+NCN_MOD_SCRIPT=$(rpm -ql docs-csm | grep ncn-image-modification[.]sh)
 ```
 
 This document provides common ways of using the script to accomplish this. However, specific environments may require
@@ -203,22 +203,21 @@ export SQUASHFS_ROOT_PW_HASH=$(awk -F':' /^root:/'{print $2}' < /etc/shadow)
 
 The following script can be used to manually enter a new password, and then generate its hash.
 
-> The script uses `read -s` to prevent the password from being echoed to the screen or saved
+> This script uses `read -s` to prevent the password from being echoed to the screen or saved
 > in the shell history. It unsets the plaintext password variables at the end, so that only
 > the hash is preserved.
 
 ```bash
-echo -n "Enter root password for NCN images: " ; read -s PW1 ; echo ; if [[ -z $PW1 ]]; then
+read -r -s -p "Enter root password for NCN images: " PW1 ; echo ; if [[ -z ${PW1} ]]; then
     echo "ERROR: Password cannot be blank"
 else
-    echo -n "Enter again: "
-    read -s PW2
+    read -r -s -p "Enter again: " PW2
     echo
-    if [[ $PW1 != $PW2 ]]; then
+    if [[ ${PW1} != ${PW2} ]]; then
         echo "ERROR: Passwords do not match"
     else
-        export SQUASHFS_ROOT_PW_HASH=$(echo "$PW1" | openssl passwd -6 -salt $(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c4) --stdin)
-        [[ -n $SQUASHFS_ROOT_PW_HASH ]] && echo "Password hash set and exported" || echo "ERROR: Problem generating hash"
+        export SQUASHFS_ROOT_PW_HASH=$(echo -n "${PW1}" | openssl passwd -6 -salt $(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c4) --stdin)
+        [[ -n ${SQUASHFS_ROOT_PW_HASH} ]] && echo "Password hash set and exported" || echo "ERROR: Problem generating hash"
     fi
 fi ; unset PW1 PW2
 ```

--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md
@@ -30,7 +30,7 @@ Add SSH keys and the `root` password to the NCN SquashFS images. Optionally set 
 (the default) is desired. This is all done by running the `ncn-image-modification.sh` script, which is located in the `scripts/operations/node_management` directory of the CSM documentation. Set the path to the script:
 
 ```bash
-NCN_MOD_SCRIPT=$(rpm -ql docs-csm | grep ncn-image-modificaiton.sh)
+NCN_MOD_SCRIPT=$(rpm -ql docs-csm | grep ncn-image-modification[.]sh)
 ```
 
 This document provides common ways of using the script to accomplish this. However, specific environments may require
@@ -93,22 +93,21 @@ export SQUASHFS_ROOT_PW_HASH=$(awk -F':' /^root:/'{print $2}' < /etc/shadow)
 
 The following script can be used to manually enter a new password, and then generate its hash.
 
-> The script uses `read -s` to prevent the password from being echoed to the screen or saved
+> This script uses `read -s` to prevent the password from being echoed to the screen or saved
 > in the shell history. It unsets the plaintext password variables at the end, so that only
 > the hash is preserved.
 
 ```bash
-echo -n "Enter root password for NCN images: " ; read -s PW1 ; echo ; if [[ -z $PW1 ]]; then
+read -r -s -p "Enter root password for NCN images: " PW1 ; echo ; if [[ -z ${PW1} ]]; then
     echo "ERROR: Password cannot be blank"
 else
-    echo -n "Enter again: "
-    read -s PW2
+    read -r -s -p "Enter again: " PW2
     echo
-    if [[ $PW1 != $PW2 ]]; then
-        echo "ERROR: Passwords do not match"        
+    if [[ ${PW1} != ${PW2} ]]; then
+        echo "ERROR: Passwords do not match"
     else
-        export SQUASHFS_ROOT_PW_HASH=$(echo "$PW1" | openssl passwd -6 -salt $(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c4) --stdin)
-        [[ -n $SQUASHFS_ROOT_PW_HASH ]] && echo "Password hash set and exported" || echo "ERROR: Problem generating hash"
+        export SQUASHFS_ROOT_PW_HASH=$(echo -n "${PW1}" | openssl passwd -6 -salt $(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c4) --stdin)
+        [[ -n ${SQUASHFS_ROOT_PW_HASH} ]] && echo "Password hash set and exported" || echo "ERROR: Problem generating hash"
     fi
 fi ; unset PW1 PW2
 ```


### PR DESCRIPTION
# Description

This PR corrects two main problems with the procedure used for customizing NCN passwords (and for generating password hashes in general).

1. [CASMINST-5134](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5134): Fixes a typo on the NCN image modification procedures that prevents the script from being found.
2. [CASMTRIAGE-3817](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3817) - Uses "echo -n" instead of "echo" when piping the password into the openssl command. The addition of the newline was generating incorrect hashes. However, using the echo option is better than specifying the password on the command line to openssl, since that can be seen by anyone on the system in ps -ef output.

I tested the updated commands on surtur and validated that they generate the correct hash.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
