### PR TITLE
(CSM 1.2) CASMTRIAGE-3777: Add missing step to rediscover a ChassisBMC after blade removal.

### DIFF
--- a/operations/node_management/Removing_a_Liquid-cooled_blade_from_a_System.md
+++ b/operations/node_management/Removing_a_Liquid-cooled_blade_from_a_System.md
@@ -119,7 +119,7 @@ The `NodeBMC` MAC and IP addresses are assigned algorithmically and *must not be
 
     ```json
     [
-        {
+      {
         "ID": "0040a6836339",
         "Description": "Node Maintenance Network",
         "MACAddress": "00:40:a6:83:63:39",
@@ -127,11 +127,11 @@ The `NodeBMC` MAC and IP addresses are assigned algorithmically and *must not be
         "ComponentID": "x9000c3s0b0n0",
         "Type": "Node",
         "IPAddresses": [
-            {
+          {
             "IPAddress": "10.100.0.10"
-            }
+          }
         ]
-        }
+      }
     ]
     ```
 
@@ -168,7 +168,7 @@ The `NodeBMC` MAC and IP addresses are assigned algorithmically and *must not be
 1. Remove entries from the state components.
 
     ```bash
-    ncn# for xname in $(cray hsm state components list --class Mountain --format json |
+    ncn# for xname in $(cray hsm state components list --format json |
                           jq -r --arg CHASSIS_SLOT "${CHASSIS_SLOT}" \
                             '.Components[] | select((.ID | startswith($CHASSIS_SLOT)) and (.ID != $CHASSIS_SLOT)) | .ID' )
          do
@@ -208,6 +208,29 @@ The `NodeBMC` MAC and IP addresses are assigned algorithmically and *must not be
     - Review *HPE Cray EX Coolant Service Procedures H-6199*. If using the hand pump, then review procedures in the *HPE Cray EX Hand Pump User Guide H-6200*. These procedures can be found on the [HPE Support Center](https://support.hpe.com/).
 
 1. Install the blade from the source system in a storage rack or leave it on the cart.
+
+### Step 9: Rediscover the Chassis BMC of the chassis the blade was removed from
+
+1. Determine the name of the Chassis BMC.
+
+    ```bash
+    ncn-mw# CHASSIS_BMC="$(echo $CHASSIS_SLOT | egrep -o 'x[0-9]+c[0-9]+')b0"
+    ncn-mw# echo $CHASSIS_BMC
+    ```
+
+    Example output:
+
+    ```text
+    x9000c3b0
+    ```
+
+1. Rediscover the Chassis BMC.
+
+    ```bash
+    ncn-mw# cray hsm inventory discover create --xnames $CHASSIS_BMC
+    ```
+
+### Step 10: Re-enable the `hms-discovery` cronjob
 
 1. Un-suspend the `hms-discovery` cron job if no more liquid-cooled blades are planned to be removed from the system.
 


### PR DESCRIPTION
# Description

Add missing step to rediscover a ChassisBMC after blade removal. 

Removed class filter to allow more than mountain, which allows this procedure to also remove Hill hardware. This is due a change in HSM made in CSM 1.2 that causes Hill liquid-cooled blades to have the Hill class. 

These changes were tested on Loki.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
