### PR TITLE
CASMINST-5146: don't quote array

### DIFF
--- a/install/deploy_final_non-compute_node.md
+++ b/install/deploy_final_non-compute_node.md
@@ -458,7 +458,7 @@ However, the commands in this section are all run **on** `ncn-m001`.
 
     ```bash
     readarray BMCS < <(grep mgmt /etc/hosts | awk '{print $NF}' | grep -v m001 | sort -u | tr '\n' ' ')
-    for BMC in "${BMCS[@]}"; do echo ${BMC}; done
+    for BMC in ${BMCS[@]}; do echo ${BMC}; done
     ```
 
     Expected output looks similar to the following:
@@ -494,7 +494,7 @@ However, the commands in this section are all run **on** `ncn-m001`.
 1. (`ncn-m001#`) Run the following to loop through all of the BMCs (except `ncn-m001-mgmt`) and apply the desired settings.
 
     ```bash
-    for BMC in "${BMCS[@]}"; do
+    for BMC in ${BMCS[@]}; do
         echo "${BMC}: Disabling DHCP and configure NTP on the BMC using data from unbound service"
         /opt/cray/csm/scripts/node_management/set-bmc-ntp-dns.sh ilo -H "${BMC}" -S -n
         echo


### PR DESCRIPTION
# Description

We don't want to quote these arrays. If quoted, bash treats them
like a single element vs a list to iterate over.

Tested on surtur
<!--- Describe what this change is and what it is for. -->

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
