### PR TITLE
CASMNET-1741:  Adding hmnlb network to the gateway tests

### DIFF
--- a/scripts/operations/gateway-test/gateway-test-defn.yaml
+++ b/scripts/operations/gateway-test/gateway-test-defn.yaml
@@ -23,8 +23,10 @@
 #
 
 
-use-api-gw-override: true
+use-api-gw-override: false
 test-networks:
+- name: hmnlb
+  gateway: hmn-gateway
 - name: nmnlb
   gateway: services-gateway
 - name: cmn
@@ -37,6 +39,13 @@ test-networks:
 reachable-networks: [ "can", "chn" ]
 
 ingress_api_services:
+- name: cray-argo
+  path: apis/nls/v1/readiness
+  port: 443
+  expected-result: 204
+  namespace: argo
+  gateways: ["services-gateway","customer-admin-gateway"]
+  project: CSM
 - name: cray-bos
   path: apis/bos/v1/session 
   port: 443
@@ -182,7 +191,7 @@ ingress_api_services:
   port: 443
   expected-result: 200
   namespace: services
-  gateways: ["services-gateway"]
+  gateways: ["services-gateway", "customer-admin-gateway", "hmn-gateway"]
   project: HSN
 - name: sma-telemetry
   path: apis/sma-telemetry-api/v1/ping


### PR DESCRIPTION
# Description

Adding HMNLB network to the gateway tests now that the hmn-gateway has authN and authZ.

Currently, the behavior for services that are not on the gateway (e.g. cray-bos) is different for HMNLB (returns 403) than it is for CAN/CHN (returns 404).    This is being investigated in CASMPET-5853.   In the meantime, the gateway tests have been modified to handle this difference.

I added the cray-nls (argo) service to the set of tested services since that was added in 1.3.

I also changed the use-api-gw-override to false so the test is no longer using api-gw-service-nmn.local.   We are starting to move away from that name.

# Testing

Ran the gateway tests on both NCN and UAI on surtur.   All UAI tests passed.  The only NCN tests that failed were valid issues with the argo service.   The endpoint was returning 503 because the service was not healthy.   Those same tests
did not fail in the UAI tests because the argo service is not accessible on the UAIs.

These same test changes are getting added to the uai-images repo.

# Checklist Before Merging

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

