### PR TITLE
CASMINST-4608 / CASMINST-4838 / CASMHMS-5598 / CASMHMS-5556 for v1.2

### DIFF
--- a/operations/firmware/FAS_Admin_Procedures.md
+++ b/operations/firmware/FAS_Admin_Procedures.md
@@ -276,6 +276,8 @@ as well as how to target specific manufacturers, component names (xnames), and t
       ncn# cray fas actions status list {actionID} --format toml
       ```
 
+      Example output:
+
       ```toml
       actionID = "e6dc14cd-5e12-4d36-a97b-0dd372b0930f"
       snapshotID = "00000000-0000-0000-0000-000000000000"
@@ -319,6 +321,8 @@ as well as how to target specific manufacturers, component names (xnames), and t
        ```bash
        ncn# cray fas actions describe {actionID} --format json
        ```
+
+      Example output:
 
        ```json
        {
@@ -419,6 +423,8 @@ as well as how to target specific manufacturers, component names (xnames), and t
    ncn# cray fas operations describe {operationID} --format json
    ```
 
+   Example output:
+
    ```json
    {
       "fromFirmwareVersion": "", "fromTag": "",
@@ -487,6 +493,8 @@ This procedure will read all RPMs in the Nexus repository and upload firmware im
 
     > **`NOTE`** `{loadRunID}` is the ID from step #2 above -- in that case `7b0ce40f-cd6d-4ff0-9b71-0f3c9686f5ce`.
     Use the `--format json` to make it easier to read.
+
+    Example output:
 
     ```json
     {
@@ -567,6 +575,8 @@ This procedure will read a single local RPM (or ZIP) file and upload firmware im
 
     > **`NOTE`** `{loadRunID}` is the ID from step #2 above -- in that case `7b0ce40f-cd6d-4ff0-9b71-0f3c9686f5ce`.
     Use the `--format json` to make it easier to read.
+
+    Example output:
 
     ```json
     {

--- a/operations/firmware/FAS_Admin_Procedures.md
+++ b/operations/firmware/FAS_Admin_Procedures.md
@@ -66,12 +66,12 @@ Refer to [Lock and Unlock Management Nodes](../hardware_state_manager/Lock_and_U
 
 ## Override an Image for an Update
 
-If you wish to update to a firmeare image other than the latest image found by FAS, you can override the image for the update.
-This procedure would also be useful if an update fails because of `"No Image available"`, whcih is caused by FAS unable to match the data on the node to find an image in the image list.
+If you wish to update to a firmware image other than the latest image found by FAS, you can override the image for the update.
+This procedure would also be useful if an update fails because of `"No Image available"`, which is caused by FAS unable to match the data on the node to find an image in the image list.
 
 > **WARNING:** Make sure to select the correct image as FAS will force a flash of the device -- using incorrect firmware may make it inoperable.
 
-It is strongly recomended to do a dryrun first and check the output.
+It is strongly recommended to do a dryrun first and check the output.
 
 ### Procedure to Override an Image
 

--- a/operations/firmware/FAS_Admin_Procedures.md
+++ b/operations/firmware/FAS_Admin_Procedures.md
@@ -67,7 +67,7 @@ Refer to [Lock and Unlock Management Nodes](../hardware_state_manager/Lock_and_U
 ## Override an Image for an Update
 
 In order to update to a firmware image other than the latest image found by FAS, the image for the update can be overridden.
-This procedure would also be useful if an update fails because of `"No Image available"`, which is caused by FAS unable to match the data on the node to find an image in the image list.
+This is also useful if an update fails because of `"No Image available"`, which happens when FAS is unable to match the data on the node to an image in the image list.
 
 > **WARNING:** Make sure to select the correct image as FAS will force a flash of the device -- using incorrect firmware may make it inoperable.
 

--- a/operations/firmware/FAS_Admin_Procedures.md
+++ b/operations/firmware/FAS_Admin_Procedures.md
@@ -20,7 +20,7 @@ NCNs and their BMCs must be locked with the HSM locking API to ensure they are n
 Research [Lock and Unlock Management Nodes](../hardware_state_manager/Lock_and_Unlock_Management_Nodes.md) for more information.
 Failure to lock the NCNs could result in unintentional update of the NCNs if FAS is not used correctly; this will lead to system instability problems.
 
-**NOTE**: Any node which is locked will remain in the state `inProgress` with the `stateHelper` message of `"failed to lock"` until the action times out, or the lock is released.
+**NOTE**: Any node that is locked remains in the state `inProgress` with the `stateHelper` message of `"failed to lock"` until the action times out, or the lock is released.
 These nodes will report as `failed` with the `stateHelper` message of `"time expired; could not complete update"` if action times out.
 This includes NCNs which are manually locked to prevent accidental rebooting and firmware updates.
 

--- a/operations/firmware/FAS_Admin_Procedures.md
+++ b/operations/firmware/FAS_Admin_Procedures.md
@@ -272,7 +272,7 @@ as well as how to target specific manufacturers, component names (xnames), and t
       ncn# cray fas actions status list {actionID}
       ```
 
-      ```text
+      ```toml
       actionID = "e6dc14cd-5e12-4d36-a97b-0dd372b0930f"
       snapshotID = "00000000-0000-0000-0000-000000000000"
       startTime = "2021-09-07 16:43:04.294233199 +0000 UTC"
@@ -313,7 +313,7 @@ as well as how to target specific manufacturers, component names (xnames), and t
        A common cause for an operation failing is due to a missing firmware image file.
 
        ```bash
-       cray fas actions describe {actionID} --format json
+       ncn# cray fas actions describe {actionID} --format json
        ```
 
        ```json

--- a/operations/firmware/FAS_Admin_Procedures.md
+++ b/operations/firmware/FAS_Admin_Procedures.md
@@ -455,7 +455,7 @@ This procedure will read all RPMs in the Nexus repository and upload firmware im
 
     This will return a `ready` or `busy` status.
 
-    ```bash
+    ```toml
     loaderStatus = "ready"
     ```
 
@@ -469,7 +469,7 @@ This procedure will read all RPMs in the Nexus repository and upload firmware im
 
     This will return an ID which will be used to check the status of the run.
 
-    ```bash
+    ```toml
     loaderRunID = "7b0ce40f-cd6d-4ff0-9b71-0f3c9686f5ce"
     ```
 
@@ -535,7 +535,7 @@ This procedure will read a single local RPM (or ZIP) file and upload firmware im
 
     This will return a `ready` or `busy` status.
 
-    ```bash
+    ```toml
     loaderStatus = "ready"
     ```
 
@@ -551,7 +551,7 @@ This procedure will read a single local RPM (or ZIP) file and upload firmware im
 
     This will return an ID which will be used to check the status of the run.
 
-    ```bash
+    ```toml
     loaderRunID = "7b0ce40f-cd6d-4ff0-9b71-0f3c9686f5ce"
     ```
 

--- a/operations/firmware/FAS_Admin_Procedures.md
+++ b/operations/firmware/FAS_Admin_Procedures.md
@@ -16,7 +16,7 @@ Procedures for leveraging the Firmware Action Service (FAS) CLI to manage firmwa
 
 ## Warning for Non-Compute Nodes (NCNs)
 
-NCNs and their BMCs should be locked with the HSM locking API to ensure they are not unintentionally updated by FAS.
+NCNs and their BMCs must be locked with the HSM locking API to ensure they are not unintentionally updated by FAS.
 Research [Lock and Unlock Management Nodes](../hardware_state_manager/Lock_and_Unlock_Management_Nodes.md) for more information.
 Failure to lock the NCNs could result in unintentional update of the NCNs if FAS is not used correctly; this will lead to system instability problems.
 

--- a/operations/firmware/FAS_Admin_Procedures.md
+++ b/operations/firmware/FAS_Admin_Procedures.md
@@ -66,8 +66,12 @@ Refer to [Lock and Unlock Management Nodes](../hardware_state_manager/Lock_and_U
 
 ## Override an Image for an Update
 
-If an update fails because of `"No Image available"`, it may be caused by FAS unable to
-match the data on the node to find an image in the image list.
+If you wish to update to a firmeare image other than the latest image found by FAS, you can override the image for the update.
+This procedure would also be useful if an update fails because of `"No Image available"`, whcih is caused by FAS unable to match the data on the node to find an image in the image list.
+
+> **WARNING:** Make sure to select the correct image as FAS will force a flash of the device -- using incorrect firmware may make it inoperable.
+
+It is strongly recomended to do a dryrun first and check the output.
 
 ### Procedure to Override an Image
 

--- a/operations/firmware/FAS_Admin_Procedures.md
+++ b/operations/firmware/FAS_Admin_Procedures.md
@@ -5,6 +5,7 @@ Procedures for leveraging the Firmware Action Service (FAS) CLI to manage firmwa
 ## Topics
 
 * [Warning for Non-Compute Nodes (NCNs)](#warning-for-non-compute-nodes-ncns)
+* [Declarative vs Imperative FAS Updates](#declarative-vs-imperative-fas-updates)
 * [Ignore Nodes within FAS](#ignore-nodes-within-fas)
 * [Override an Image for an Update](#override-an-image-for-an-update)
 * [Check for New Firmware Versions with a Dry-Run](#check-for-new-firmware-versions-with-a-dry-run)
@@ -22,6 +23,16 @@ Failure to lock the NCNs could result in unintentional update of the NCNs if FAS
 **NOTE**: Any node which is locked will remain in the state `inProgress` with the `stateHelper` message of `"failed to lock"` until the action times out, or the lock is released.
 These nodes will report as `failed` with the `stateHelper` message of `"time expired; could not complete update"` if action times out.
 This includes NCNs which are manually locked to prevent accidental rebooting and firmware updates.
+
+---
+
+## Declarative vs Imperative FAS Updates
+
+In most cases, FAS will update firmware on each node to the required version.
+This version is determined by comparing the `semantic versions` for all valid images for each node and selecting the highest value.
+Sometimes however, a different version is required for updating a node.
+FAS can update a node to any uploaded version using the [Override an Image for an Update](#override-an-image-for-an-update) procedure.
+If the required image is not installed, obtain the RPM or ZIP file and use the [Load Firmware from RPM or ZIP file](#load-firmware-from-rpm-or-zip-file) procedure.
 
 ---
 

--- a/operations/firmware/FAS_Admin_Procedures.md
+++ b/operations/firmware/FAS_Admin_Procedures.md
@@ -273,7 +273,7 @@ as well as how to target specific manufacturers, component names (xnames), and t
       In the example below, there are two operations in the `succeeded` state, indicating there is an available firmware version that FAS can use to update firmware.
 
       ```bash
-      ncn# cray fas actions status list {actionID}
+      ncn# cray fas actions status list {actionID} --format toml
       ```
 
       ```toml

--- a/operations/firmware/FAS_Admin_Procedures.md
+++ b/operations/firmware/FAS_Admin_Procedures.md
@@ -49,13 +49,13 @@ Refer to [Lock and Unlock Management Nodes](../hardware_state_manager/Lock_and_U
 1. Check that there are no FAS actions running.
 
     ```bash
-    cray fas actions list
+    ncn# cray fas actions list
     ```
 
 2. Edit the `cray-fas` deployment.
 
     ```bash
-    kubectl -n services edit deployment cray-fas
+    ncn# kubectl -n services edit deployment cray-fas
     ```
 
 3. Change the `NODE_BLACKLIST` value from `ignore_ignore_ignore` to `management`.
@@ -76,13 +76,13 @@ match the data on the node to find an image in the image list.
    Change *TARGETNAME* to the actual target being searched.
 
    ```bash
-   cray fas images list --format json | jq '.[] | .[] | select(.target=="TARGETNAME")'
+   ncn# cray fas images list --format json | jq '.[] | .[] | select(.target=="TARGETNAME")'
    ```
 
    To narrow down the selection, update the select field to match multiple items. For example:
 
    ```bash
-   cray fas images list --format json | jq '.[] | .[] | select(.target=="BMC" and .manufacturer=="cray" and .deviceType=="NodeBMC")'
+   ncn# cray fas images list --format json | jq '.[] | .[] | select(.target=="BMC" and .manufacturer=="cray" and .deviceType=="NodeBMC")'
    ```
 
    The example command displays one or more images available for updates.
@@ -152,7 +152,7 @@ match the data on the node to find an image in the image list.
 3. Verify the correct image ID was found.
 
    ```bash
-   cray fas images describe {imageID}
+   ncn# cray fas images describe {imageID}
    ```
 
    > **WARNING:** FAS will force a flash of the device -- using incorrect firmware may make it inoperable.
@@ -209,7 +209,7 @@ as well as how to target specific manufacturers, component names (xnames), and t
     2. Run the dry-run for the full system.
 
         ```bash
-        cray fas actions create COMMAND.json
+        ncn# cray fas actions create COMMAND.json
         ```
 
         Proceed to the next step to determine if any firmware needs to be updated.
@@ -248,7 +248,7 @@ as well as how to target specific manufacturers, component names (xnames), and t
     2. Run a dry-run on the targeted devices.
 
        ```bash
-       cray fas actions create CUSTOM_DEVICE_PARAMETERS.json
+       ncn# cray fas actions create CUSTOM_DEVICE_PARAMETERS.json
        ```
 
        Proceed to the next step to determine if any firmware needs to be updated.
@@ -269,7 +269,7 @@ as well as how to target specific manufacturers, component names (xnames), and t
       In the example below, there are two operations in the `succeeded` state, indicating there is an available firmware version that FAS can use to update firmware.
 
       ```bash
-      cray fas actions status list {actionID}
+      ncn# cray fas actions status list {actionID}
       ```
 
       ```text
@@ -412,7 +412,7 @@ as well as how to target specific manufacturers, component names (xnames), and t
    In this example, there is a device that is available for a firmware upgrade because the operation being viewed is a succeeded operation.
 
    ```bash
-   cray fas operations describe {operationID} --format json
+   ncn# cray fas operations describe {operationID} --format json
    ```
 
    ```json
@@ -450,7 +450,7 @@ This procedure will read all RPMs in the Nexus repository and upload firmware im
 1. Check the loader status.
 
     ```bash
-    cray fas loader list | grep loaderStatus
+    ncn# cray fas loader list | grep loaderStatus
     ```
 
     This will return a `ready` or `busy` status.
@@ -464,7 +464,7 @@ This procedure will read all RPMs in the Nexus repository and upload firmware im
 2. Run the loader Nexus command.
 
     ```bash
-    cray fas loader nexus create
+    ncn# cray fas loader nexus create
     ```
 
     This will return an ID which will be used to check the status of the run.
@@ -478,7 +478,7 @@ This procedure will read all RPMs in the Nexus repository and upload firmware im
 3. Check the results of the loader run.
 
     ```bash
-    cray fas loader describe ${loaderRunID} --format json
+    ncn# cray fas loader describe ${loaderRunID} --format json
     ```
 
     > **`NOTE`** `{loadRunID}` is the ID from step #2 above -- in that case `7b0ce40f-cd6d-4ff0-9b71-0f3c9686f5ce`.
@@ -530,7 +530,7 @@ This procedure will read a single local RPM (or ZIP) file and upload firmware im
 2. Check the loader status:
 
     ```bash
-    cray fas loader list | grep loaderStatus
+    ncn# cray fas loader list | grep loaderStatus
     ```
 
     This will return a `ready` or `busy` status.
@@ -546,7 +546,7 @@ This procedure will read a single local RPM (or ZIP) file and upload firmware im
     `firmware.rpm` is the name of the RPM. If the file is not in the current directory, add the path to the filename.
 
     ```bash
-    cray fas loader create --file firmware.RPM
+    ncn# cray fas loader create --file firmware.RPM
     ```
 
     This will return an ID which will be used to check the status of the run.
@@ -558,7 +558,7 @@ This procedure will read a single local RPM (or ZIP) file and upload firmware im
 4. Check the results of the loader run.
 
     ```bash
-    cray fas loader describe {loaderRunID} --format json
+    ncn# cray fas loader describe {loaderRunID} --format json
     ```
 
     > **`NOTE`** `{loadRunID}` is the ID from step #2 above -- in that case `7b0ce40f-cd6d-4ff0-9b71-0f3c9686f5ce`.

--- a/operations/firmware/FAS_Admin_Procedures.md
+++ b/operations/firmware/FAS_Admin_Procedures.md
@@ -478,7 +478,7 @@ This procedure will read all RPMs in the Nexus repository and upload firmware im
 3. Check the results of the loader run.
 
     ```bash
-    ncn# cray fas loader describe ${loaderRunID} --format json
+    ncn# cray fas loader describe {loaderRunID} --format json
     ```
 
     > **`NOTE`** `{loadRunID}` is the ID from step #2 above -- in that case `7b0ce40f-cd6d-4ff0-9b71-0f3c9686f5ce`.

--- a/operations/firmware/FAS_Admin_Procedures.md
+++ b/operations/firmware/FAS_Admin_Procedures.md
@@ -66,7 +66,7 @@ Refer to [Lock and Unlock Management Nodes](../hardware_state_manager/Lock_and_U
 
 ## Override an Image for an Update
 
-If you wish to update to a firmware image other than the latest image found by FAS, you can override the image for the update.
+In order to update to a firmware image other than the latest image found by FAS, the image for the update can be overridden.
 This procedure would also be useful if an update fails because of `"No Image available"`, which is caused by FAS unable to match the data on the node to find an image in the image list.
 
 > **WARNING:** Make sure to select the correct image as FAS will force a flash of the device -- using incorrect firmware may make it inoperable.

--- a/operations/firmware/FAS_Admin_Procedures.md
+++ b/operations/firmware/FAS_Admin_Procedures.md
@@ -69,7 +69,7 @@ Refer to [Lock and Unlock Management Nodes](../hardware_state_manager/Lock_and_U
 In order to update to a firmware image other than the latest image found by FAS, the image for the update can be overridden.
 This is also useful if an update fails because of `"No Image available"`, which happens when FAS is unable to match the data on the node to an image in the image list.
 
-> **WARNING:** Make sure to select the correct image as FAS will force a flash of the device -- using incorrect firmware may make it inoperable.
+> **WARNING:** Make sure to select the correct image because FAS will force a flash of the device -- using incorrect firmware may make it inoperable.
 
 It is strongly recommended to do a dryrun first and check the output.
 

--- a/operations/firmware/FAS_Admin_Procedures.md
+++ b/operations/firmware/FAS_Admin_Procedures.md
@@ -21,7 +21,7 @@ Research [Lock and Unlock Management Nodes](../hardware_state_manager/Lock_and_U
 Failure to lock the NCNs could result in unintentional update of the NCNs if FAS is not used correctly; this will lead to system instability problems.
 
 **NOTE**: Any node that is locked remains in the state `inProgress` with the `stateHelper` message of `"failed to lock"` until the action times out, or the lock is released.
-These nodes will report as `failed` with the `stateHelper` message of `"time expired; could not complete update"` if action times out.
+If the action is timed out, these nodes report as `failed` with the `stateHelper` message of `"time expired; could not complete update"`.
 This includes NCNs which are manually locked to prevent accidental rebooting and firmware updates.
 
 ---

--- a/operations/firmware/FAS_CLI.md
+++ b/operations/firmware/FAS_CLI.md
@@ -58,7 +58,7 @@ This covers the generic process for executing an action. For more specific examp
 
    Filters narrow the scope of FAS to target specific component names (xnames), manufacturers, targets, and so on. For this example, FAS will run with no selection filters applied.
 
-1. Create a JSON file.
+1. (`ncn-mw#`) Create a JSON file.
 
     To make this a `live update` set `"overrideDryrun": true`.
 
@@ -73,12 +73,12 @@ This covers the generic process for executing an action. For more specific examp
     }
     ```
 
-1. Execute the dry-run.
+1. (`ncn-mw#`) Execute the dry-run.
 
     Modify the example command to specify the JSON file created in the previous step.
 
     ```bash
-    ncn-mw# cray fas actions create filename.json --format json
+    cray fas actions create filename.json --format json
     ```
 
     Example output:
@@ -104,12 +104,12 @@ Firmware updates can be stopped if required. This is useful because only one act
 
 #### Abort an action: Procedure
 
-Issue the abort command to the action.
+(`ncn-mw#`) Issue the abort command to the action.
 
 Modify the example command to specify the `actionID` of the action being aborted.
 
 ```bash
-ncn-mw# cray fas actions instance delete {actionID}
+cray fas actions instance delete {actionID}
 ```
 
 The action could take up to a minute to fully abort.
@@ -132,18 +132,22 @@ For the steps below, the following returned messages will help determine if a fi
   - If `dryrun`: There is something that FAS could do, but it likely would fail; most likely because the file is missing.
   - If `live update`: The operation failed; the identified version could not be put on the component name (xname) + target.
 
+**NOTE**: Any node which is locked will remain in the state `inProgress` with the `stateHelper` message of `"failed to lock"` until the action times out, or the lock is released.
+These nodes will report as `failed` with the `stateHelper` message of `"time expired; could not complete update"` if action times out.
+This includes NCNs which are manually locked to prevent accidental rebooting and firmware updates.
+
 Data can be viewed at several levels of information:
 
 #### Describe an action: Procedure
 
 ##### Get high level summary
 
-To view counts of operations, what state they are in, the overall state of the action, and what parameters were used to create the action:
+(`ncn-mw#`) To view counts of operations, what state they are in, the overall state of the action, and what parameters were used to create the action:
 
 Modify the following command to specify the actual `actionID` of the action to be examined.
 
 ```bash
-ncn-mw# cray fas actions status list {actionID} --format toml
+cray fas actions status list {actionID} --format toml
 ```
 
 Example output:
@@ -185,10 +189,10 @@ unknown = 0
 
 ##### Get details of action
 
-Modify the following command to specify the actual `actionID` of the action to be examined.
+(`ncn-mw#`) Modify the following command to specify the actual `actionID` of the action to be examined.
 
 ```bash
-ncn-mw# cray fas actions describe {actionID} --format json
+cray fas actions describe {actionID} --format json
 ```
 
 Example output:
@@ -280,18 +284,18 @@ Example output:
     "blocked": {
       "OperationsKeys": []
     }
-  } 
+  }
 }
 ```
 
 ##### Get details of operation
 
-Using the `operationID` listed in the actions array, see the full detail of the operation.
+(`ncn-mw#`) Using the `operationID` listed in the actions array, see the full detail of the operation.
 
 Modify the following command to specify the actual `operationID` of the operation to be examined.
 
 ```bash
-ncn-mw# cray fas operations describe {operationID} --format json
+cray fas operations describe {operationID} --format json
 ```
 
 Example output:
@@ -332,7 +336,7 @@ A snapshot of the system captures the firmware version for every device that is 
 
 #### Create a snapshot: Procedure
 
-1. Determine the desired snapshot level.
+1. (`ncn-mw#`) Determine the desired snapshot level.
 
    Create a JSON file based on the desired level.
 
@@ -369,12 +373,12 @@ A snapshot of the system captures the firmware version for every device that is 
       }
       ```
 
-1. Create the snapshot.
+1. (`ncn-mw#`) Create the snapshot.
 
     Modify the example command to specify the JSON file created in the previous step.
 
     ```bash
-    ncn-mw# cray fas snapshots create {file.json}
+    cray fas snapshots create {file.json}
     ```
 
 1. Use the snapshot name to query the snapshot. This is a long-running operation, so monitor the `state` field to determine if the snapshot is complete.
@@ -385,10 +389,10 @@ A list of all snapshots can be viewed on the system. Any of the snapshots listed
 
 #### List snapshots: Procedure
 
-1. List the snapshots.
+1. (`ncn-mw#`) List the snapshots.
 
     ```bash
-    ncn-mw# cray fas snapshots list --format json
+    cray fas snapshots list --format json
     ```
 
     Example output:
@@ -427,12 +431,12 @@ View a snapshot to see which versions of firmware are set for each target.
 
 #### View snapshots: Procedure
 
-1. View a snapshot.
+1. (`ncn-mw#`) View a snapshot.
 
     Modify the following command to specify the actual name of the snapshot to be examined.
 
     ```bash
-    ncn-mw# cray fas snapshots describe {snapshot_name} --format json
+    cray fas snapshots describe {snapshot_name} --format json
     ```
 
     Example output:
@@ -503,18 +507,18 @@ Given the nature of the `model` field and its likelihood to not be standardized,
 
 ### Update a firmware image: Procedure
 
-1. List the existing firmware images to find the `imageID` of the desired firmware image.
+1. (`ncn-mw#`) List the existing firmware images to find the `imageID` of the desired firmware image.
 
     ```bash
-    ncn-mw# cray fas images list
+    cray fas images list
     ```
 
-1. Describe the image using the `imageID`.
+1. (`ncn-mw#`) Describe the image using the `imageID`.
 
     Modify the following command to specify the actual `imageID` of the image to be examined.
 
     ```bash
-    ncn-mw# cray fas images describe {imageID} --format json
+    cray fas images describe {imageID} --format json
     ```
 
     Example output:
@@ -543,7 +547,7 @@ Given the nature of the `model` field and its likelihood to not be standardized,
     }
     ```
 
-1. Describe the FAS action and compare it to the image from the previous step.
+1. (`ncn-mw#`) Describe the FAS action and compare it to the image from the previous step.
 
     Look at the hardware models to see if some of the population is in a `noSolution` state, while others are in a `succeeded` state.
     If that is the case, then view the operation data and examine the models.
@@ -551,7 +555,7 @@ Given the nature of the `model` field and its likelihood to not be standardized,
     Modify the following command to specify the actual `actionID` of the action to be examined.
 
     ```bash
-    ncn-mw# cray fas actions describe {actionID} --format json
+    cray fas actions describe {actionID} --format json
     ```
 
     Example output:
@@ -695,14 +699,14 @@ Given the nature of the `model` field and its likelihood to not be standardized,
     }
     ```
 
-1. View the operation data.
+1. (`ncn-mw#`) View the operation data.
 
     If the model name is different between identical hardware, it may be appropriate to update the image model with the model of the `noSolution` hardware.
 
     Modify the following command to specify the actual `operationID` of the operation to be examined.
 
     ```bash
-    ncn-mw# cray fas operations describe {operationID} --format json
+    cray fas operations describe {operationID} --format json
     ```
 
     Example output:
@@ -736,7 +740,7 @@ Given the nature of the `model` field and its likelihood to not be standardized,
     }
     ```
 
-1. Update the firmware image file.
+1. (`ncn-mw#`) Update the firmware image file.
 
    This step should be skipped if there is no clear evidence of a missing image or incorrect model name.
 
@@ -747,7 +751,7 @@ Given the nature of the `model` field and its likelihood to not be standardized,
       Modify the following command to specify the actual `imageID` of the image to be updated.
 
       ```bash
-      ncn-mw# cray fas images describe {imageID} --format json > imagedata.json
+      cray fas images describe {imageID} --format json > imagedata.json
       ```
 
    1. Edit the new `imagedata.json` file.
@@ -760,17 +764,17 @@ Given the nature of the `model` field and its likelihood to not be standardized,
       and be sure that the filename matches the edited file from the previous step.
 
       ```bash
-      ncn-mw# cray fas images update imagedata.json {imageID}
+      cray fas images update imagedata.json {imageID}
       ```
 
 ## FAS loader commands
 
 ### Loader status
 
-To check if the loader is currently busy and receive a list of loader run IDs:
+(`ncn-mw#`) To check if the loader is currently busy and receive a list of loader run IDs:
 
 ```bash
-ncn-mw# cray fas loader list --format toml
+cray fas loader list --format toml
 ```
 
 Example output:
@@ -790,10 +794,10 @@ The loader can only run one job at a time. If the loader is busy, then it will r
 
 Firmware may be released and placed into the Nexus repository.
 
-To load the firmware from Nexus into FAS, use the following command:
+(`ncn-mw#`) To load the firmware from Nexus into FAS, use the following command:
 
 ```bash
-ncn-mw# cray fas loader nexus create --format toml
+cray fas loader nexus create --format toml
 ```
 
 Example output:
@@ -810,12 +814,12 @@ See [Load Firmware from Nexus](FAS_Admin_Procedures.md#load-firmware-from-nexus)
 
 1. Copy the RPM or ZIP file to one of the master or worker NCNs.
 
-1. Load the firmware into FAS.
+1. (`ncn-mw#`) Load the firmware into FAS.
 
    Be sure to update the example command with the actual path and filename of the RPM or ZIP file to be loaded.
 
    ```bash
-   ncn-mw# cray fas loader create --file firmware.rpm --format toml
+   cray fas loader create --file firmware.rpm --format toml
    ```
 
    Example output:
@@ -830,12 +834,12 @@ See [Load Firmware from RPM or ZIP file](FAS_Admin_Procedures.md#load-firmware-f
 
 ### Display results of loader run
 
-Using the `loaderRunID` returned from the loader upload command, run the following command to get the output from the upload.
+(`ncn-mw#`) Using the `loaderRunID` returned from the loader upload command, run the following command to get the output from the upload.
 
 Be sure to update the example command with the actual `loaderRunID` whose output is to be checked.
 
 ```bash
-ncn-mw# cray fas loader describe dd37dd45-84ec-4bd6-b3c9-7af480048966 --format json
+cray fas loader describe dd37dd45-84ec-4bd6-b3c9-7af480048966 --format json
 ```
 
 Example output:
@@ -875,12 +879,12 @@ A successful run will end with `*** Number of Updates: x ***`.
 
 ### Delete loader run data
 
-To delete the output from a loader run and remove it from the loader run list:
+(`ncn-mw#`) To delete the output from a loader run and remove it from the loader run list:
 
 Be sure to update the example command with the actual `loaderRunID` whose output should be deleted.
 
 ```bash
-ncn-mw# cray fas loader delete dd37dd45-84ec-4bd6-b3c9-7af480048966
+cray fas loader delete dd37dd45-84ec-4bd6-b3c9-7af480048966
 ```
 
 The delete command does not return anything if successful.

--- a/operations/firmware/FAS_CLI.md
+++ b/operations/firmware/FAS_CLI.md
@@ -58,7 +58,7 @@ This covers the generic process for executing an action. For more specific examp
 
    Filters narrow the scope of FAS to target specific component names (xnames), manufacturers, targets, and so on. For this example, FAS will run with no selection filters applied.
 
-1. (`ncn-mw#`) Create a JSON file.
+1. Create a JSON file.
 
     To make this a `live update` set `"overrideDryrun": true`.
 
@@ -73,12 +73,12 @@ This covers the generic process for executing an action. For more specific examp
     }
     ```
 
-1. (`ncn-mw#`) Execute the dry-run.
+1. Execute the dry-run.
 
     Modify the example command to specify the JSON file created in the previous step.
 
     ```bash
-    cray fas actions create filename.json --format json
+    ncn-mw# cray fas actions create filename.json --format json
     ```
 
     Example output:
@@ -104,12 +104,12 @@ Firmware updates can be stopped if required. This is useful because only one act
 
 #### Abort an action: Procedure
 
-(`ncn-mw#`) Issue the abort command to the action.
+Issue the abort command to the action.
 
 Modify the example command to specify the `actionID` of the action being aborted.
 
 ```bash
-cray fas actions instance delete {actionID}
+ncn-mw# cray fas actions instance delete {actionID}
 ```
 
 The action could take up to a minute to fully abort.
@@ -142,12 +142,12 @@ Data can be viewed at several levels of information:
 
 ##### Get high level summary
 
-(`ncn-mw#`) To view counts of operations, what state they are in, the overall state of the action, and what parameters were used to create the action:
+To view counts of operations, what state they are in, the overall state of the action, and what parameters were used to create the action:
 
 Modify the following command to specify the actual `actionID` of the action to be examined.
 
 ```bash
-cray fas actions status list {actionID} --format toml
+ncn-mw# cray fas actions status list {actionID} --format toml
 ```
 
 Example output:
@@ -189,10 +189,10 @@ unknown = 0
 
 ##### Get details of action
 
-(`ncn-mw#`) Modify the following command to specify the actual `actionID` of the action to be examined.
+Modify the following command to specify the actual `actionID` of the action to be examined.
 
 ```bash
-cray fas actions describe {actionID} --format json
+ncn-mw# cray fas actions describe {actionID} --format json
 ```
 
 Example output:
@@ -290,12 +290,12 @@ Example output:
 
 ##### Get details of operation
 
-(`ncn-mw#`) Using the `operationID` listed in the actions array, see the full detail of the operation.
+Using the `operationID` listed in the actions array, see the full detail of the operation.
 
 Modify the following command to specify the actual `operationID` of the operation to be examined.
 
 ```bash
-cray fas operations describe {operationID} --format json
+ncn-mw# cray fas operations describe {operationID} --format json
 ```
 
 Example output:
@@ -336,7 +336,7 @@ A snapshot of the system captures the firmware version for every device that is 
 
 #### Create a snapshot: Procedure
 
-1. (`ncn-mw#`) Determine the desired snapshot level.
+1. Determine the desired snapshot level.
 
    Create a JSON file based on the desired level.
 
@@ -373,12 +373,12 @@ A snapshot of the system captures the firmware version for every device that is 
       }
       ```
 
-1. (`ncn-mw#`) Create the snapshot.
+1. Create the snapshot.
 
     Modify the example command to specify the JSON file created in the previous step.
 
     ```bash
-    cray fas snapshots create {file.json}
+    ncn-mw# cray fas snapshots create {file.json}
     ```
 
 1. Use the snapshot name to query the snapshot. This is a long-running operation, so monitor the `state` field to determine if the snapshot is complete.
@@ -389,10 +389,10 @@ A list of all snapshots can be viewed on the system. Any of the snapshots listed
 
 #### List snapshots: Procedure
 
-1. (`ncn-mw#`) List the snapshots.
+1. List the snapshots.
 
     ```bash
-    cray fas snapshots list --format json
+    ncn-mw# cray fas snapshots list --format json
     ```
 
     Example output:
@@ -431,12 +431,12 @@ View a snapshot to see which versions of firmware are set for each target.
 
 #### View snapshots: Procedure
 
-1. (`ncn-mw#`) View a snapshot.
+1. View a snapshot.
 
     Modify the following command to specify the actual name of the snapshot to be examined.
 
     ```bash
-    cray fas snapshots describe {snapshot_name} --format json
+    ncn-mw# cray fas snapshots describe {snapshot_name} --format json
     ```
 
     Example output:
@@ -507,18 +507,18 @@ Given the nature of the `model` field and its likelihood to not be standardized,
 
 ### Update a firmware image: Procedure
 
-1. (`ncn-mw#`) List the existing firmware images to find the `imageID` of the desired firmware image.
+1. List the existing firmware images to find the `imageID` of the desired firmware image.
 
     ```bash
-    cray fas images list
+    ncn-mw# cray fas images list
     ```
 
-1. (`ncn-mw#`) Describe the image using the `imageID`.
+1. Describe the image using the `imageID`.
 
     Modify the following command to specify the actual `imageID` of the image to be examined.
 
     ```bash
-    cray fas images describe {imageID} --format json
+    ncn-mw# cray fas images describe {imageID} --format json
     ```
 
     Example output:
@@ -547,7 +547,7 @@ Given the nature of the `model` field and its likelihood to not be standardized,
     }
     ```
 
-1. (`ncn-mw#`) Describe the FAS action and compare it to the image from the previous step.
+1. Describe the FAS action and compare it to the image from the previous step.
 
     Look at the hardware models to see if some of the population is in a `noSolution` state, while others are in a `succeeded` state.
     If that is the case, then view the operation data and examine the models.
@@ -555,7 +555,7 @@ Given the nature of the `model` field and its likelihood to not be standardized,
     Modify the following command to specify the actual `actionID` of the action to be examined.
 
     ```bash
-    cray fas actions describe {actionID} --format json
+    ncn-mw# cray fas actions describe {actionID} --format json
     ```
 
     Example output:
@@ -699,14 +699,14 @@ Given the nature of the `model` field and its likelihood to not be standardized,
     }
     ```
 
-1. (`ncn-mw#`) View the operation data.
+1. View the operation data.
 
     If the model name is different between identical hardware, it may be appropriate to update the image model with the model of the `noSolution` hardware.
 
     Modify the following command to specify the actual `operationID` of the operation to be examined.
 
     ```bash
-    cray fas operations describe {operationID} --format json
+    ncn-mw# cray fas operations describe {operationID} --format json
     ```
 
     Example output:
@@ -740,7 +740,7 @@ Given the nature of the `model` field and its likelihood to not be standardized,
     }
     ```
 
-1. (`ncn-mw#`) Update the firmware image file.
+1. Update the firmware image file.
 
    This step should be skipped if there is no clear evidence of a missing image or incorrect model name.
 
@@ -751,7 +751,7 @@ Given the nature of the `model` field and its likelihood to not be standardized,
       Modify the following command to specify the actual `imageID` of the image to be updated.
 
       ```bash
-      cray fas images describe {imageID} --format json > imagedata.json
+      ncn-mw# cray fas images describe {imageID} --format json > imagedata.json
       ```
 
    1. Edit the new `imagedata.json` file.
@@ -764,17 +764,17 @@ Given the nature of the `model` field and its likelihood to not be standardized,
       and be sure that the filename matches the edited file from the previous step.
 
       ```bash
-      cray fas images update imagedata.json {imageID}
+      ncn-mw# cray fas images update imagedata.json {imageID}
       ```
 
 ## FAS loader commands
 
 ### Loader status
 
-(`ncn-mw#`) To check if the loader is currently busy and receive a list of loader run IDs:
+To check if the loader is currently busy and receive a list of loader run IDs:
 
 ```bash
-cray fas loader list --format toml
+ncn-mw# cray fas loader list --format toml
 ```
 
 Example output:
@@ -794,10 +794,10 @@ The loader can only run one job at a time. If the loader is busy, then it will r
 
 Firmware may be released and placed into the Nexus repository.
 
-(`ncn-mw#`) To load the firmware from Nexus into FAS, use the following command:
+To load the firmware from Nexus into FAS, use the following command:
 
 ```bash
-cray fas loader nexus create --format toml
+ncn-mw# cray fas loader nexus create --format toml
 ```
 
 Example output:
@@ -814,12 +814,12 @@ See [Load Firmware from Nexus](FAS_Admin_Procedures.md#load-firmware-from-nexus)
 
 1. Copy the RPM or ZIP file to one of the master or worker NCNs.
 
-1. (`ncn-mw#`) Load the firmware into FAS.
+1. Load the firmware into FAS.
 
    Be sure to update the example command with the actual path and filename of the RPM or ZIP file to be loaded.
 
    ```bash
-   cray fas loader create --file firmware.rpm --format toml
+   ncn-mw# cray fas loader create --file firmware.rpm --format toml
    ```
 
    Example output:
@@ -834,12 +834,12 @@ See [Load Firmware from RPM or ZIP file](FAS_Admin_Procedures.md#load-firmware-f
 
 ### Display results of loader run
 
-(`ncn-mw#`) Using the `loaderRunID` returned from the loader upload command, run the following command to get the output from the upload.
+Using the `loaderRunID` returned from the loader upload command, run the following command to get the output from the upload.
 
 Be sure to update the example command with the actual `loaderRunID` whose output is to be checked.
 
 ```bash
-cray fas loader describe dd37dd45-84ec-4bd6-b3c9-7af480048966 --format json
+ncn-mw# cray fas loader describe dd37dd45-84ec-4bd6-b3c9-7af480048966 --format json
 ```
 
 Example output:
@@ -879,12 +879,12 @@ A successful run will end with `*** Number of Updates: x ***`.
 
 ### Delete loader run data
 
-(`ncn-mw#`) To delete the output from a loader run and remove it from the loader run list:
+To delete the output from a loader run and remove it from the loader run list:
 
 Be sure to update the example command with the actual `loaderRunID` whose output should be deleted.
 
 ```bash
-cray fas loader delete dd37dd45-84ec-4bd6-b3c9-7af480048966
+ncn-mw# cray fas loader delete dd37dd45-84ec-4bd6-b3c9-7af480048966
 ```
 
 The delete command does not return anything if successful.

--- a/operations/firmware/FAS_Recipes.md
+++ b/operations/firmware/FAS_Recipes.md
@@ -1,12 +1,16 @@
 # FAS Recipes
 
-> **NOTE:** This is a collection of various FAS recipes for performing updates.
+> **`NOTE`** This is a collection of various FAS recipes for performing updates.
 > For step by step directions and commands, see [FAS Use Cases](FAS_Use_Cases.md).
 
 The following example JSON files are useful to reference when updating specific hardware components. In all of these examples, the `overrideDryrun` field will be set to `false`; set them to `true` to perform a live update.
 
 When updating an entire system, walk down the device hierarchy component type by component type, starting first with routers (switches), proceeding to chassis, and then finally to nodes.
 While this is not strictly necessary, it does help eliminate confusion.
+
+**NOTE**: Any node which is locked will remain in the state `inProgress` with the `stateHelper` message of `"failed to lock"` until the action times out, or the lock is released.
+These nodes will report as `failed` with the `stateHelper` message of `"time expired; could not complete update"` if action times out.
+This includes NCNs which are manually locked to prevent accidental rebooting and firmware updates.
 
 Refer to [FAS Filters](FAS_Filters.md) for more information on the content used in the example JSON files.
 
@@ -18,8 +22,8 @@ Refer to [FAS Filters](FAS_Filters.md) for more information on the content used 
 >
 > - Make sure all slot and rectifier power is off.
 > - The `hms-discovery` job must also be stopped before updates and restarted after updates are complete.
->   - Stop `hms-discovery` job: `ncn-mw# kubectl -n services patch cronjobs hms-discovery -p '{"spec":{"suspend":true}}'`
->   - Start `hms-discovery` job: `ncn-mw# kubectl -n services patch cronjobs hms-discovery -p '{"spec":{"suspend":false}}'`
+>   - (`ncn-mw#`) Stop `hms-discovery` job: `kubectl -n services patch cronjobs hms-discovery -p '{"spec":{"suspend":true}}'`
+>   - (`ncn-mw#`) Start `hms-discovery` job: `kubectl -n services patch cronjobs hms-discovery -p '{"spec":{"suspend":false}}'`
 
 ```json
 {
@@ -112,7 +116,7 @@ Refer to [FAS Filters](FAS_Filters.md) for more information on the content used 
 }
 ```
 
-> **NOTE:** If this update does not work as expected, follow the [Compute Node BIOS Workaround for HPE CRAY EX425](FAS_Use_Cases.md#cn-workaround) procedure.
+> **`NOTE`** If this update does not work as expected, follow the [Compute Node BIOS Workaround for HPE CRAY EX425](FAS_Use_Cases.md#compute-node-bios-workaround-for-hpe-cray-ex425) procedure.
 
 ### (Cray) Device Type: `NodeBMC` | Target: Redstone FPGA
 
@@ -185,7 +189,7 @@ Refer to [FAS Filters](FAS_Filters.md) for more information on the content used 
 >
 > - If updating the System ROM of an NCN, the NTP and DNS server values will be lost and must be restored. For NCNs **other than `ncn-m001`**, this can be done using the
 >   `/opt/cray/csm/scripts/node_management/set-bmc-ntp-dns.sh` script. Use the `-h` option to get a list of command line options required to restore the NTP and DNS values.
->   See [Configure DNS and NTP on Each BMC](../../install/deploy_final_ncn.md#7-configure-dns-and-ntp-on-each-bmc).
+>   See [Configure DNS and NTP on Each BMC](../../install/deploy_final_non-compute_node.md#7-configure-dns-and-ntp-on-each-bmc).
 > - Node should be powered on for System ROM update and will need to be rebooted to use the updated BIOS.
 
 ```json
@@ -214,7 +218,7 @@ Refer to [FAS Filters](FAS_Filters.md) for more information on the content used 
 }
 ```
 
-> **NOTE:** Update of System ROM may report as an error when it actually succeeded because of an incorrect string in the image metadata in FAS. Manually check the update version to get around this error.
+> **`NOTE`** Update of System ROM may report as an error when it actually succeeded because of an incorrect string in the image metadata in FAS. Manually check the update version to get around this error.
 
 ## Manufacturer: Gigabyte
 
@@ -247,7 +251,7 @@ Refer to [FAS Filters](FAS_Filters.md) for more information on the content used 
 }
 ```
 
-> **NOTE:** The `timeLimit` is `4000` because the Gigabytes can take a lot longer to update.
+> **`NOTE`** The `timeLimit` is `4000` because the Gigabytes can take a lot longer to update.
 
 #### Troubleshooting
 
@@ -298,4 +302,4 @@ Make sure to wait for the current firmware to be updated before starting a new F
 
 ## Update Non-Compute Nodes (NCNs)
 
-See [Uploading BIOS and BMC Firmware for NCNs in FAS Use Cases](FAS_Use_Cases.md#ncn-bios-bmc).
+See [Uploading BIOS and BMC Firmware for NCNs in FAS Use Cases](FAS_Use_Cases.md#update-non-compute-node-ncn-bios-and-bmc-firmware).

--- a/operations/firmware/FAS_Recipes.md
+++ b/operations/firmware/FAS_Recipes.md
@@ -189,7 +189,7 @@ Refer to [FAS Filters](FAS_Filters.md) for more information on the content used 
 >
 > - If updating the System ROM of an NCN, the NTP and DNS server values will be lost and must be restored. For NCNs **other than `ncn-m001`**, this can be done using the
 >   `/opt/cray/csm/scripts/node_management/set-bmc-ntp-dns.sh` script. Use the `-h` option to get a list of command line options required to restore the NTP and DNS values.
->   See [Configure DNS and NTP on Each BMC](../../install/deploy_final_non-compute_node.md#7-configure-dns-and-ntp-on-each-bmc).
+>   See [Configure DNS and NTP on Each BMC](../../install/deploy_final_ncn.md#7-configure-dns-and-ntp-on-each-bmc).
 > - Node should be powered on for System ROM update and will need to be rebooted to use the updated BIOS.
 
 ```json

--- a/operations/firmware/FAS_Recipes.md
+++ b/operations/firmware/FAS_Recipes.md
@@ -22,8 +22,8 @@ Refer to [FAS Filters](FAS_Filters.md) for more information on the content used 
 >
 > - Make sure all slot and rectifier power is off.
 > - The `hms-discovery` job must also be stopped before updates and restarted after updates are complete.
->   - (`ncn-mw#`) Stop `hms-discovery` job: `kubectl -n services patch cronjobs hms-discovery -p '{"spec":{"suspend":true}}'`
->   - (`ncn-mw#`) Start `hms-discovery` job: `kubectl -n services patch cronjobs hms-discovery -p '{"spec":{"suspend":false}}'`
+>   - Stop `hms-discovery` job: `ncn-mw# kubectl -n services patch cronjobs hms-discovery -p '{"spec":{"suspend":true}}'`
+>   - Start `hms-discovery` job: ncn-mw# `kubectl -n services patch cronjobs hms-discovery -p '{"spec":{"suspend":false}}'`
 
 ```json
 {

--- a/operations/firmware/FAS_Recipes.md
+++ b/operations/firmware/FAS_Recipes.md
@@ -8,7 +8,7 @@ The following example JSON files are useful to reference when updating specific 
 When updating an entire system, walk down the device hierarchy component type by component type, starting first with routers (switches), proceeding to chassis, and then finally to nodes.
 While this is not strictly necessary, it does help eliminate confusion.
 
-**NOTE**: Any node which is locked will remain in the state `inProgress` with the `stateHelper` message of `"failed to lock"` until the action times out, or the lock is released.
+**NOTE**: Any node that is locked remains in the state `inProgress` with the `stateHelper` message of `"failed to lock"` until the action times out, or the lock is released.
 These nodes will report as `failed` with the `stateHelper` message of `"time expired; could not complete update"` if action times out.
 This includes NCNs which are manually locked to prevent accidental rebooting and firmware updates.
 

--- a/operations/firmware/FAS_Recipes.md
+++ b/operations/firmware/FAS_Recipes.md
@@ -9,7 +9,7 @@ When updating an entire system, walk down the device hierarchy component type by
 While this is not strictly necessary, it does help eliminate confusion.
 
 **NOTE**: Any node that is locked remains in the state `inProgress` with the `stateHelper` message of `"failed to lock"` until the action times out, or the lock is released.
-These nodes will report as `failed` with the `stateHelper` message of `"time expired; could not complete update"` if action times out.
+If the action is timed out, these nodes report as `failed` with the `stateHelper` message of `"time expired; could not complete update"`.
 This includes NCNs which are manually locked to prevent accidental rebooting and firmware updates.
 
 Refer to [FAS Filters](FAS_Filters.md) for more information on the content used in the example JSON files.

--- a/operations/firmware/FAS_Recipes.md
+++ b/operations/firmware/FAS_Recipes.md
@@ -23,7 +23,7 @@ Refer to [FAS Filters](FAS_Filters.md) for more information on the content used 
 > - Make sure all slot and rectifier power is off.
 > - The `hms-discovery` job must also be stopped before updates and restarted after updates are complete.
 >   - Stop `hms-discovery` job: `ncn-mw# kubectl -n services patch cronjobs hms-discovery -p '{"spec":{"suspend":true}}'`
->   - Start `hms-discovery` job: ncn-mw# `kubectl -n services patch cronjobs hms-discovery -p '{"spec":{"suspend":false}}'`
+>   - Start `hms-discovery` job: `ncn-mw# kubectl -n services patch cronjobs hms-discovery -p '{"spec":{"suspend":false}}'`
 
 ```json
 {

--- a/operations/firmware/FAS_Use_Cases.md
+++ b/operations/firmware/FAS_Use_Cases.md
@@ -588,7 +588,7 @@ Make sure to wait for the current firmware to be updated before starting a new F
 > **IMPORTANT:** If updating the System ROM of an NCN, the NTP and DNS server values will be lost and must be restored.
 > For NCNs **other than `ncn-m001`** this can be done using the `/opt/cray/csm/scripts/node_management/set-bmc-ntp-dns.sh` script.
 > Use the `-h` option to get a list of command line options required to restore the NTP and DNS values.
-> See [Configure DNS and NTP on Each BMC](../../install/deploy_final_non-compute_node.md#configure-dns-and-ntp-on-each-bmc).
+> See [Configure DNS and NTP on Each BMC](../../install/deploy_final_non.md#configure-dns-and-ntp-on-each-bmc).
 
 ```json
 {

--- a/operations/firmware/FAS_Use_Cases.md
+++ b/operations/firmware/FAS_Use_Cases.md
@@ -588,7 +588,7 @@ Make sure to wait for the current firmware to be updated before starting a new F
 > **IMPORTANT:** If updating the System ROM of an NCN, the NTP and DNS server values will be lost and must be restored.
 > For NCNs **other than `ncn-m001`** this can be done using the `/opt/cray/csm/scripts/node_management/set-bmc-ntp-dns.sh` script.
 > Use the `-h` option to get a list of command line options required to restore the NTP and DNS values.
-> See [Configure DNS and NTP on Each BMC](../../install/deploy_final_non.md#configure-dns-and-ntp-on-each-bmc).
+> See [Configure DNS and NTP on Each BMC](../../install/deploy_final_ncn.md#configure-dns-and-ntp-on-each-bmc).
 
 ```json
 {
@@ -907,7 +907,7 @@ Make sure you have waited for the current firmware to be updated before starting
 > **IMPORTANT:** If updating the System ROM of an NCN, the NTP and DNS server values will be lost and must be restored.
 > For NCNs **other than `ncn-m001`** this can be done using the `/opt/cray/csm/scripts/node_management/set-bmc-ntp-dns.sh` script.
 > Use the `-h` option to get a list of command line options required to restore the NTP and DNS values.
-> See [Configure DNS and NTP on Each BMC](../../install/deploy_final_non-compute_node.md#configure-dns-and-ntp-on-each-bmc).
+> See [Configure DNS and NTP on Each BMC](../../install/deploy_final_ncn.md#configure-dns-and-ntp-on-each-bmc).
 
 ```json
 {
@@ -943,7 +943,7 @@ The NCN must be rebooted after updating the BIOS firmware. Follow the [Reboot NC
 #### HPE Node System ROM (BIOS) Procedure for NCN
 
 1. For `HPE` NCNs, check the DNS servers by running the script `/opt/cray/csm/scripts/node_management/set-bmc-ntp-dns.sh ilo -H XNAME -s`. Replace `XNAME` with the xname of the NCN BMC.
-   See [Configure DNS and NTP on Each BMC](../../install/deploy_final_non-compute_node.md#configure-dns-and-ntp-on-each-bmc) for more information.
+   See [Configure DNS and NTP on Each BMC](../../install/deploy_final_ncn.md#configure-dns-and-ntp-on-each-bmc) for more information.
 1. Run a `dryrun` for all NCNs first to determine which NCNs and targets need updating.
 1. For each NCN requiring updates to target `BMC` or `iLO 5`:
    > **`NOTE`** Update of `BMC` and `iLO 5` will not affect the nodes.
@@ -959,7 +959,7 @@ The NCN must be rebooted after updating the BIOS firmware. Follow the [Reboot NC
    1. Reboot the Node.
       See [Reboot NCNs](../node_management/Reboot_NCNs.md).
    1. For `HPE` NCNs, run the script `/opt/cray/csm/scripts/node_management/set-bmc-ntp-dns.sh`.
-      See [Configure DNS and NTP on Each BMC](../../install/deploy_final_non-compute_node.md#configure-dns-and-ntp-on-each-bmc).
+      See [Configure DNS and NTP on Each BMC](../../install/deploy_final_ncn.md#configure-dns-and-ntp-on-each-bmc).
    1. Relock the NCN BMC.
       See [Lock and Unlock Management Nodes](../hardware_state_manager/Lock_and_Unlock_Management_Nodes.md).
 

--- a/operations/firmware/FAS_Use_Cases.md
+++ b/operations/firmware/FAS_Use_Cases.md
@@ -4,19 +4,26 @@ Use the Firmware Action Service (FAS) to update the firmware on supported hardwa
 
 When updating an entire system, walk down the device hierarchy component type by component type, starting first with Routers (switches), proceeding to Chassis, and then finally to Nodes. While this is not strictly necessary, it does help eliminate confusion.
 
+**NOTE**: Any node which is locked will remain in the state `inProgress` with the `stateHelper` message of `"failed to lock"` until the action times out, or the lock is released.
+These nodes will report as `failed` with the `stateHelper` message of `"time expired; could not complete update"` if action times out.
+This includes NCNs which are manually locked to prevent accidental rebooting and firmware updates.
+
 Refer to [FAS Filters](FAS_Filters.md) for more information on the content used in the example JSON files.
+
+## Prerequisites
+
+* The Cray command line interface \(CLI\) tool is initialized and configured on the system.
+See [Configure the Cray CLI](../configure_cray_cli.md).
 
 The following procedures are included in this section:
 
-1. [Update Liquid-Cooled Compute Node BMC, FPGA, and BIOS](#liquidcooled)
-1. [Update Air-Cooled Compute Node BMC, BIOS, iLO 5, and System ROM](#aircooled)
-1. [Update Chassis Management Module (CMM) Firmware](#cmm)
-1. [Update NCN BIOS and BMC Firmware with FAS](#ncn-bios-bmc)
-1. [Compute Node BIOS Workaround for HPE CRAY EX425](#cn-workaround)
+1. [Update Liquid-Cooled Compute Node BMC, FPGA, and BIOS](#liquid-cooled-nodes-update-procedures)
+1. [Update Air-Cooled Compute Node BMC, BIOS, iLO 5, and System ROM](#update-air-cooled-compute-node-bmc-bios-ilo-5-and-system-rom)
+1. [Update Chassis Management Module (CMM) Firmware](#update-chassis-management-module-firmware)
+1. [Update NCN BIOS and BMC Firmware with FAS](#update-non-compute-node-ncn-bios-and-bmc-firmware)
+1. [Compute Node BIOS Workaround for HPE CRAY EX425](#compute-node-bios-workaround-for-hpe-cray-ex425)
 
-> **NOTE:** To update Switch Controllers \(sC\) or RouterBMC, refer to the Rosetta Documentation.
-
-<a name="liquidcooled"></a>
+> **`NOTE`** To update Switch Controllers \(sC\) or `RouterBMC`, refer to the Rosetta Documentation.
 
 ## Update Liquid-Cooled Nodes BMC, FPGA, and Node BIOS
 
@@ -27,13 +34,9 @@ All of the example JSON files below are set to run a dry-run. Update the `overri
 
 This procedure updates node controller \(nC\) firmware.
 
-### Prerequisites
-
-* The Cray command line interface \(CLI\) tool is initialized and configured on the system.
-
 ### Liquid-Cooled Nodes Update Procedures
 
-**Manufacturer: Cray | Device Type: NodeBMC | Target: BMC**
+#### Manufacturer: Cray | Device Type: `NodeBMC` | Target: BMC
 
 BMC firmware with FPGA updates require the nodes to be off.
 If the nodes are not off when the update command is issued, the update will get deferred until the next power cycle of the BMC, which may be a long period of time.
@@ -65,7 +68,7 @@ If the nodes are not off when the update command is issued, the update will get 
 }
 ```
 
-**Manufacturer: Cray | Device Type: NodeBMC | Target: Redstone FPGA**
+#### Manufacturer: Cray | Device Type: `NodeBMC` | Target: Redstone FPGA
 
 > **IMPORTANT:** The Nodes themselves must be powered **on** in order to update the firmware of the Redstone FPGA on the nodes.
 
@@ -96,21 +99,20 @@ If the nodes are not off when the update command is issued, the update will get 
 }
 ```
 
-**Manufacturer: Cray | Device Type : NodeBMC | Target : NodeBIOS**
+#### Manufacturer: Cray | Device Type : `NodeBMC` | Target : `NodeBIOS`
 
 There are two nodes that must be updated on each BMC; these have the targets `Node0.BIOS` and `Node1.BIOS`.
 The targets can be run in the same action (as shown in the example) or run separately by only including one target in the action.
 On larger systems, it is recommended to run as two actions one after each other as the output will be shorter.
 
-### Prerequisites
-
-* The Cray nodeBMC device needs to be updated before the nodeBIOS because the nodeBMC adds a new Redfish field \(`softwareId`\) that the `NodeX.BIOS` update will require. See [Update Liquid-Cooled Node Firmware](#liquidcooled) for more information.
-* Compute node BIOS updates require the nodes to be off. If nodes are not off when the update command is issued, it will report as a failed update.
-
-> **IMPORTANT:** The nodes themselves must be powered **off** in order to update the BIOS on the nodes. The BMC will still have power and will perform the update.
-
+> **IMPORTANT:** The Cray `nodeBMC` device needs to be updated before the `nodeBIOS` because the `nodeBMC` adds a new Redfish field \(`softwareId`\) that the `NodeX.BIOS` update will require.
+See [Update Liquid-Cooled Node Firmware](#liquidcooled) for more information.
+> **IMPORTANT:** The nodes themselves must be powered **off** in order to update the BIOS on the nodes.
+The BMC will still have power and will perform the update.
+If nodes are not off when the update command is issued, it will report as a failed update.
 > **IMPORTANT:** When the BMC is updated or rebooted after updating the `Node0.BIOS` and/or `Node1.BIOS` liquid-cooled nodes, the node BIOS version will not report the new version string until the nodes are powered back on.
-It is recommended that the Node0/1 BIOS be updated in a separate action, either before or after a BMC update. It is also recommended that the nodes be powered back on after the updates are completed.
+It is recommended that the `Node0/1` BIOS be updated in a separate action, after a BMC update.
+It is also recommended that the nodes be powered back on after the updates are completed.
 
 ```json
 {
@@ -139,28 +141,28 @@ It is recommended that the Node0/1 BIOS be updated in a separate action, either 
 }
 ```
 
-### Procedure
+##### Cray Node BOIS Update Procedure
 
-1.  Create a JSON file using one of the example recipes with the command parameters required for updating the firmware or node BIOS.
+1. Create a JSON file using one of the example recipes with the command parameters required for updating the firmware or node BIOS.
 
-1.  Initiate a dry-run to verify that the firmware can be updated.
+1. Initiate a dry-run to verify that the firmware can be updated.
 
-    1.  Create the dry-run session.
+    1. Create the dry-run session.
 
         The `overrideDryrun = false` value indicates that the command will do a dry run.
 
         ```bash
-        ncn# cray fas actions create nodeBMC.json
+        cray fas actions create nodeBMC.json
         overrideDryrun = false
         actionID = "fddd0025-f5ff-4f59-9e73-1ca2ef2a432d"
         ```
 
-    1.  Describe the `actionID` for firmware update dry-run job.
+    1. Describe the `actionID` for firmware update dry-run job.
 
         Replace the `actionID` value with the string returned in the previous step. In this example, `"fddd0025-f5ff-4f59-9e73-1ca2ef2a432d"` is used.
 
         ```bash
-        ncn# cray fas actions describe {actionID}
+        cray fas actions describe {actionID}
         blockedBy = []
         state = "completed"
         actionID = "fddd0025-f5ff-4f59-9e73-1ca2ef2a432d"
@@ -179,33 +181,33 @@ It is recommended that the Node0/1 BIOS be updated in a separate action, either 
 
         If `state = "completed"`, the dry-run has found and checked all the nodes. Check the following sections for more information:
 
-        *   Lists the nodes that have a valid image for updating:
+        * Lists the nodes that have a valid image for updating:
 
-            ```
+            ```text
             [operationSummary.succeeded]
             ```
 
-        *   Lists the nodes that will not be updated because they are already at the correct version:
+        * Lists the nodes that will not be updated because they are already at the correct version:
 
-            ```
+            ```text
             [operationSummary.noOperation]
             ```
 
-        *   Lists the nodes that had an error when attempting to update:
+        * Lists the nodes that had an error when attempting to update:
 
-            ```
+            ```text
             [operationSummary.failed]
             ```
 
-        *   Lists the nodes that do not have a valid image for updating:
+        * Lists the nodes that do not have a valid image for updating:
 
-            ```
+            ```text
             [operationSummary.noSolution]
             ```
 
-1.  Update the firmware after verifying that the dry-run worked as expected.
+1. Update the firmware after verifying that the dry-run worked as expected.
 
-    1.  Edit the JSON file and update the values so an actual firmware update can be run.
+    1. Edit the JSON file and update the values so an actual firmware update can be run.
 
         The following example is for the `nodeBMC.json` file. Update the following values:
 
@@ -214,12 +216,12 @@ It is recommended that the Node0/1 BIOS be updated in a separate action, either 
         "description":"Update Cray Node BMCs"
         ```
 
-    1.  Run the firmware update.
+    1. Run the firmware update.
 
         The output `overrideDryrun = true` indicates that an actual firmware update job was created. A new `actionID` will also be displayed.
 
         ```bash
-        ncn# cray fas actions create nodeBMC.json
+        cray fas actions create nodeBMC.json
         overrideDryrun = true
         actionID = "bc40f10a-e50c-4178-9288-8234b336077b"
         ```
@@ -228,10 +230,10 @@ It is recommended that the Node0/1 BIOS be updated in a separate action, either 
 
         The liquid-cooled node BMC automatically reboots after the BMC firmware has been loaded.
 
-1.  Retrieve the `operationID` and verify that the update is complete.
+1. Retrieve the `operationID` and verify that the update is complete.
 
     ```bash
-    ncn# cray fas actions describe {actionID}
+    cray fas actions describe {actionID}
     [operationSummary.failed]
     [[operationSummary.failed.operationKeys]]
     stateHelper = "unexpected change detected in firmware version. Expected nc.1.3.10-shasta-release.arm.2020-07-21T23:58:22+00:00.d479f59 got: nc.cronomatic-dev.arm.2019-09-24T13:20:24+00:00.9d0f8280"
@@ -241,18 +243,18 @@ It is recommended that the Node0/1 BIOS be updated in a separate action, either 
     operationID = "e910c6ad-db98-44fc-bdc5-90477b23386f"
     ```
 
-1.  View more details for an operation using the `operationID` from the previous step.
+1. View more details for an operation using the `operationID` from the previous step.
 
     Check the list of nodes for the `failed` or `completed` state.
 
     ```bash
-    ncn# cray fas operations describe {operationID}
+    cray fas operations describe {operationID}
     ```
 
     For example:
 
     ```bash
-    ncn# cray fas operations describe "e910c6ad-db98-44fc-bdc5-90477b23386f"
+    cray fas operations describe "e910c6ad-db98-44fc-bdc5-90477b23386f"
     fromFirmwareVersion = "nc.cronomatic-dev.arm.2019-09-24T13:20:24+00:00.9d0f8280"
     fromTag = ""
     fromImageURL = ""
@@ -277,21 +279,15 @@ It is recommended that the Node0/1 BIOS be updated in a separate action, either 
 
     Once firmware and BIOS are updated, the compute nodes can be turned back on.
 
-<a name="cmm"></a>
-
 ## Update Chassis Management Module Firmware
 
 Update the Chassis Management Module \(CMM\) controller \(cC\) firmware using FAS. This procedure uses the dry-run feature to verify that the update will be successful.
 
 The CMM firmware update process also checks and updates the Cabinet Environmental Controller \(CEC\) firmware.
 
-### Prerequisites
-
-* The Cray command line interface \(CLI\) tool is initialized and configured on the system.
-
 ### Example Recipes
 
-**Manufacturer: Cray | Device Type: ChassisBMC | Target: BMC**
+**Manufacturer: Cray | Device Type: `ChassisBMC` | Target: BMC**
 
 > **IMPORTANT:** Before updating a CMM, make sure all slot and rectifier power is off and the discovery job is stopped (see procedure below).
 
@@ -321,46 +317,49 @@ The CMM firmware update process also checks and updates the Cabinet Environmenta
 }
 ```
 
-### Procedure
+#### Cray Chassis BMC Update Procedure
 
-1.  Power off the liquid-cooled chassis slots and chassis rectifiers.
+1. Power off the liquid-cooled chassis slots and chassis rectifiers.
 
-    1.  Disable the `hms-discovery` Kubernetes cronjob:
+    1. Disable the `hms-discovery` Kubernetes cronjob:
 
         ```bash
-        ncn# kubectl -n services patch cronjobs hms-discovery -p '{"spec" : {"suspend" : true }}'
+        kubectl -n services patch cronjobs hms-discovery -p '{"spec" : {"suspend" : true }}'
         ```
 
-    1.  Power off all the components. For example, in chassis 0-7, cabinets 1000-1003:
+    1. Power off all the components. For example, in chassis 0-7, cabinets 1000-1003:
 
         ```bash
-        ncn# cray capmc xname_off create --xnames x[1000-1003]c[0-7] --recursive true --continue true
+        cray capmc xname_off create --xnames x[1000-1003]c[0-7] --recursive true --continue true
         ```
 
         This command powers off all the node cards, then all the compute blades, then all the Slingshot switch ASICS, then all the Slingshot switch enclosures, and finally all the chassis enclosures in cabinets 1000-1003.
 
         When power is removed from a chassis, the high-voltage DC rectifiers that support the chassis are powered off. If a component is not populated, the `--continue` option enables the command to continue instead of returning error messages.
 
-1.  Create a JSON file using the example recipe above with the command parameters required for updating the CMM firmware.
+1. Create a JSON file using the example recipe above with the command parameters required for updating the CMM firmware.
 
-1.  Initiate a dry-run to verify that the firmware can be updated.
+1. Initiate a dry-run to verify that the firmware can be updated.
 
-    1.  Create the dry-run session.
+    1. Create the dry-run session.
 
         The `overrideDryrun = false` value indicates that the command will do a dry-run.
 
         ```bash
-        ncn# cray fas actions create chassisBMC.json
+        cray fas actions create chassisBMC.json
         overrideDryrun = false
         actionID = "fddd0025-f5ff-4f59-9e73-1ca2ef2a432d"
         ```
 
-    1.  Describe the `actionID` to see the firmware update dry-run job status.
+    1. Describe the `actionID` to see the firmware update dry-run job status.
 
         Replace the `actionID` value with the string returned in the previous step. In this example, `"fddd0025-f5ff-4f59-9e73-1ca2ef2a432d"` is used.
 
         ```bash
-        ncn# cray fas actions describe {actionID}
+        cray fas actions describe {actionID}
+        ```
+
+        ```text
         blockedBy = []
         state = "completed"
         actionID = "fddd0025-f5ff-4f59-9e73-1ca2ef2a432d"
@@ -379,78 +378,79 @@ The CMM firmware update process also checks and updates the Cabinet Environmenta
 
         If `state = "completed"`, the dry-run has found and checked all the nodes. Check the following sections for more information:
 
-        *   Lists the nodes that have a valid image for updating:
+        * Lists the nodes that have a valid image for updating:
 
-            ```
+            ```text
             [operationSummary.succeeded]
             ```
 
-        *   Lists the nodes that will not be updated because they are already at the correct version:
+        * Lists the nodes that will not be updated because they are already at the correct version:
 
-            ```
+            ```text
             [operationSummary.noOperation]
             ```
 
-        *   Lists the nodes that had an error when attempting to update:
+        * Lists the nodes that had an error when attempting to update:
 
-            ```
+            ```text
             [operationSummary.failed]
             ```
 
-        *   Lists the nodes that do not have a valid image for updating:
+        * Lists the nodes that do not have a valid image for updating:
 
-            ```
+            ```text
             [operationSummary.noSolution]
             ```
 
-1.  Update the firmware after verifying that the dry-run worked as expected.
+1. Update the firmware after verifying that the dry-run worked as expected.
 
-    1.  Edit the JSON file and update the values so an actual firmware update can be run.
+    1. Edit the JSON file and update the values so an actual firmware update can be run.
 
         The following example is for the `chassisBMC.json` file. Update the following values:
 
-        ```
+        ```text
         "overrideDryrun":true,
         "description":"Update Cray Chassis Management Module controllers"
         ```
 
-    1.  Run the firmware update.
+    1. Run the firmware update.
 
         The output `overrideDryrun = true` indicates that an actual firmware update job was created. A new `actionID` will also be displayed.
 
         ```bash
-        ncn# cray fas actions create chassisBMC.json
+        cray fas actions create chassisBMC.json
+        ```
+
+        ```text
         overrideDryrun = true
         actionID = "bc40f10a-e50c-4178-9288-8234b336077b"
         ```
 
         The time it takes for a firmware update varies. It can be a few minutes or over 20 minutes depending on response time.
 
-1.  Restart the `hms-discovery` cronjob.
+1. Restart the `hms-discovery` cronjob.
 
     ```bash
-    ncn# kubectl -n services patch cronjobs hms-discovery -p '{"spec" : {"suspend" : false }}'
+    kubectl -n services patch cronjobs hms-discovery -p '{"spec" : {"suspend" : false }}'
     ```
 
     The `hms-discovery` cronjob will run within 5 minutes of being unsuspended and start powering on the chassis enclosures, switches, and compute blades. If components are not being powered back on, then power them on manually:
 
     ```bash
-    ncn# cray capmc xname_on create --xnames x[1000-1003]c[0-7]r[0-7],x[1000-1003]c[0-7]s[0-7] --prereq true --continue true
+    cray capmc xname_on create --xnames x[1000-1003]c[0-7]r[0-7],x[1000-1003]c[0-7]s[0-7] --prereq true --continue true
     ```
 
     The `--prereq` option ensures all required components are powered on first. The `--continue` option allows the command to complete in systems without fully populated hardware.
 
-1.  Bring up the Slingshot Fabric.
-    
+1. Bring up the Slingshot Fabric.
+
     Refer to the following documentation on the HPE Customer Support Center
     for more information on how to bring up the Slingshot Fabric:
-    
+
     * The *HPE Slingshot Operations Guide* PDF for HPE Cray EX systems.
     * The *HPE Slingshot Troubleshooting Guide* PDF.
 
-2.  After the components have powered on, boot the nodes using the Boot Orchestration Services \(BOS\).
-
-<a name="aircooled"></a>
+1. After the components have powered on, boot the nodes using the Boot Orchestration Services \(BOS\).
 
 ## Update Air-Cooled Compute Node BMC, BIOS, iLO 5, and System ROM
 
@@ -463,13 +463,9 @@ After updating the BIOS or System ROM, the compute node will need to be rebooted
 
 This procedure updates node controller \(nC\) firmware.
 
-### Prerequisites
-
-* The Cray command line interface \(CLI\) tool is initialized and configured on the system.
-
 ### Gigabyte
 
-**Device Type: NodeBMC | Target: BMC**
+**Device Type: `NodeBMC` | Target: BMC**
 
 ```json
 {
@@ -500,13 +496,13 @@ This procedure updates node controller \(nC\) firmware.
 }
 ```
 
-> **IMPORTANT:** The *timeLimit* is `4000` because the Gigabytes can take a lot longer to update.
+> **IMPORTANT:** The *`timeLimit`* is `4000` because the Gigabytes can take a lot longer to update.
 
 **Troubleshooting:**
 
 A node may fail to update with the output:
 
-```
+```text
 stateHelper = "Firmware Update Information Returned Downloading – See /redfish/v1/UpdateService"
 ```
 
@@ -514,12 +510,13 @@ FAS has incorrectly marked this node as failed.
 It most likely will complete the update successfully.
 
 To resolve this issue, do either of the following actions:
+
 * Check the update status by looking at the Redfish `FirmwareInventory` (`/redfish/v1/UpdateService/FirmwareInventory/BMC`).
 * Rerun FAS to verify that the BMC firmware was updated.
-  
+
 Make sure to wait for the current firmware to be updated before starting a new FAS action on the same node.
 
-**Device Type: NodeBMC | Target: BIOS**
+**Device Type: `NodeBMC` | Target: BIOS**
 
 ```json
 {
@@ -555,7 +552,7 @@ Make sure to wait for the current firmware to be updated before starting a new F
 
 ### HPE
 
-**Device Type: NodeBMC | Target: `iLO 5` aka BMC**
+**Device Type: `NodeBMC` | Target: `iLO 5` aka BMC**
 
 ```json
 {
@@ -586,9 +583,12 @@ Make sure to wait for the current firmware to be updated before starting a new F
 }
 ```
 
-**Device Type: NodeBMC | Target: `System ROM` aka BIOS**
+**Device Type: `NodeBMC` | Target: `System ROM` aka BIOS**
 
-> **IMPORTANT:** If updating the System ROM of an NCN, the NTP and DNS server values will be lost and must be restored. For NCNs **other than `ncn-m001`** this can be done using the `/opt/cray/csm/scripts/node_management/set-bmc-ntp-dns.sh` script. Use the `-h` option to get a list of command line options required to restore the NTP and DNS values. See [Configure DNS and NTP on Each BMC](../../install/deploy_final_ncn.md#configure-dns-and-ntp-on-each-bmc).
+> **IMPORTANT:** If updating the System ROM of an NCN, the NTP and DNS server values will be lost and must be restored.
+> For NCNs **other than `ncn-m001`** this can be done using the `/opt/cray/csm/scripts/node_management/set-bmc-ntp-dns.sh` script.
+> Use the `-h` option to get a list of command line options required to restore the NTP and DNS values.
+> See [Configure DNS and NTP on Each BMC](../../install/deploy_final_non-compute_node.md#configure-dns-and-ntp-on-each-bmc).
 
 ```json
 {
@@ -619,28 +619,34 @@ Make sure to wait for the current firmware to be updated before starting a new F
 }
 ```
 
-### Procedure
+#### HPE Node System ROM (BIOS) Update Procedure
 
-1.  Create a JSON file using one of the example recipes with the command parameters required for updating the firmware or node BIOS.
+1. Create a JSON file using one of the example recipes with the command parameters required for updating the firmware or node BIOS.
 
-1.  Initiate a dry-run to verify that the firmware can be updated.
+1. Initiate a dry-run to verify that the firmware can be updated.
 
-    1.  Create the dry-run session.
+    1. Create the dry-run session.
 
         The `overrideDryrun = false` value indicates that the command will do a dry run.
 
         ```bash
-        ncn# cray fas actions create nodeBMC.json
+        cray fas actions create nodeBMC.json
+        ```
+
+        ```text
         overrideDryrun = false
         actionID = "fddd0025-f5ff-4f59-9e73-1ca2ef2a432d"
         ```
 
-    1.  Describe the `actionID` for firmware update dry-run job.
+    1. Describe the `actionID` for firmware update dry-run job.
 
         Replace the `actionID` value with the string returned in the previous step. In this example, `"fddd0025-f5ff-4f59-9e73-1ca2ef2a432d"` is used.
 
         ```bash
-        ncn# cray fas actions describe {actionID}
+        cray fas actions describe {actionID}
+        ```
+
+        ```text
         blockedBy = []
         state = "completed"
         actionID = "fddd0025-f5ff-4f59-9e73-1ca2ef2a432d"
@@ -659,47 +665,50 @@ Make sure to wait for the current firmware to be updated before starting a new F
 
         If `state = "completed"`, the dry-run has found and checked all the nodes. Check the following sections for more information:
 
-        *   Lists the nodes that have a valid image for updating:
+        * Lists the nodes that have a valid image for updating:
 
-            ```
+            ```text
             [operationSummary.succeeded]
             ```
 
-        *   Lists the nodes that will not be updated because they are already at the correct version:
+        * Lists the nodes that will not be updated because they are already at the correct version:
 
-            ```
+            ```text
             [operationSummary.noOperation]
             ```
 
-        *   Lists the nodes that had an error when attempting to update:
+        * Lists the nodes that had an error when attempting to update:
 
-            ```
+            ```text
             [operationSummary.failed]
             ```
 
-        *   Lists the nodes that do not have a valid image for updating:
+        * Lists the nodes that do not have a valid image for updating:
 
-            ```
+            ```text
             [operationSummary.noSolution]
             ```
 
-1.  Update the firmware after verifying that the dry-run worked as expected.
+1. Update the firmware after verifying that the dry-run worked as expected.
 
-    1.  Edit the JSON file and update the values so an actual firmware update can be run.
+    1. Edit the JSON file and update the values so an actual firmware update can be run.
 
         The following example is for the `nodeBMC.json` file. Update the following values:
 
-        ```
+        ```text
         "overrideDryrun":true,
         "description":"Update of HPE node iLO 5"
         ```
 
-    1.  Run the firmware update.
+    1. Run the firmware update.
 
         The returned `overrideDryrun = true` indicates that an actual firmware update job was created. A new `actionID` will also be returned.
 
         ```bash
-        ncn# cray fas actions create nodeBMC.json
+        cray fas actions create nodeBMC.json
+        ```
+
+        ```json
         overrideDryrun = true
         actionID = "bc40f10a-e50c-4178-9288-8234b336077b"
         ```
@@ -708,10 +717,13 @@ Make sure to wait for the current firmware to be updated before starting a new F
 
         The air-cooled node BMC automatically reboots after the BMC or iLO 5 firmware has been loaded.
 
-1.  Retrieve the `operationID` and verify that the update is complete.
+1. Retrieve the `operationID` and verify that the update is complete.
 
     ```bash
-    ncn# cray fas actions describe {actionID}
+    cray fas actions describe {actionID}
+    ```
+
+    ```json
     [operationSummary.failed]
     [[operationSummary.failed.operationKeys]]
     stateHelper = "unexpected change detected in firmware version. Expected 2.46 May 11 2021 got: 2.32 Apr 27 2020"
@@ -721,18 +733,21 @@ Make sure to wait for the current firmware to be updated before starting a new F
     operationID = "e910c6ad-db98-44fc-bdc5-90477b23386f"
     ```
 
-1.  View more details for an operation using the `operationID` from the previous step.
+1. View more details for an operation using the `operationID` from the previous step.
 
     Check the list of nodes for the `failed` or `completed` state.
 
     ```bash
-    ncn# cray fas operations describe {operationID}
+    cray fas operations describe {operationID}
     ```
 
     For example:
 
     ```bash
-    ncn# cray fas operations describe "e910c6ad-db98-44fc-bdc5-90477b23386f"
+    cray fas operations describe "e910c6ad-db98-44fc-bdc5-90477b23386f"
+    ```
+
+    ```json
     fromFirmwareVersion = "2.32 Apr 27 2020"
     fromTag = ""
     fromImageURL = ""
@@ -755,8 +770,6 @@ Make sure to wait for the current firmware to be updated before starting a new F
     deviceType = "NodeBMC"
     ```
 
-<a name="ncn-bios-bmc"></a>
-
 ## Update Non-Compute Node (NCN) BIOS and BMC Firmware
 
 Gigabyte and HPE non-compute nodes \(NCNs\) firmware can be updated with FAS. This section includes templates for JSON files that can be used to update firmware with the `cray fas actions create` command.
@@ -764,7 +777,7 @@ Gigabyte and HPE non-compute nodes \(NCNs\) firmware can be updated with FAS. Th
 After creating the JSON file for the device being upgraded, use the following command to run the FAS job:
 
 ```bash
-ncn# cray fas actions create CUSTOM_DEVICE_PARAMETERS.json
+cray fas actions create CUSTOM_DEVICE_PARAMETERS.json
 ```
 
 All of the example JSON files below are set to run a dry-run. Update the `overrideDryrun` value to `True` to update the firmware.
@@ -775,9 +788,9 @@ After updating the BIOS, the NCN will need to be rebooted. Follow the [Reboot NC
 
 Due to networking, FAS cannot update `ncn-m001`. See [Updating Firmware on `ncn-m001`](Updating_Firmware_m001.md)
 
-### Gigabyte
+### Gigabyte NCNs
 
-**Device Type: NodeBMC | Target: BMC**
+**Device Type: `NodeBMC` | Target: BMC**
 
 ```json
 {
@@ -816,11 +829,13 @@ It may report that a node failed to update with the output:
 FAS has incorrectly marked this node as failed.
 It most likely will complete the update successfully.
 To resolve this issue, do either of the following actions:
+
 * Check the update status by looking at the Redfish `FirmwareInventory` (`/redfish/v1/UpdateService/FirmwareInventory/BMC`)
 * Rerun FAS to verify that the BMC firmware was updated.
+
 Make sure you have waited for the current firmware to be updated before starting a new FAS action on the same node.
 
-**Device Type: NodeBMC | Target: BIOS**
+**Device Type: `NodeBMC` | Target: BIOS**
 
 ```json
 {
@@ -854,9 +869,9 @@ Make sure you have waited for the current firmware to be updated before starting
 
 > **IMPORTANT:** The `timeLimit` is `4000` because the Gigabytes can take a lot longer to update.
 
-### HPE
+### HPE NCNs
 
-**Device Type: NodeBMC | Target: `iLO 5` aka BMC**
+**Device Type: `NodeBMC` | Target: `iLO 5` aka BMC**
 
 ```json
 {
@@ -887,9 +902,12 @@ Make sure you have waited for the current firmware to be updated before starting
 }
 ```
 
-**Device Type: NodeBMC | Target: `System ROM` aka BIOS**
+**Device Type: `NodeBMC` | Target: `System ROM` aka BIOS**
 
-> **IMPORTANT:** If updating the System ROM of an NCN, the NTP and DNS server values will be lost and must be restored. For NCNs **other than `ncn-m001`** this can be done using the `/opt/cray/csm/scripts/node_management/set-bmc-ntp-dns.sh` script. Use the `-h` option to get a list of command line options required to restore the NTP and DNS values. See [Configure DNS and NTP on Each BMC](../../install/deploy_final_ncn.md#configure-dns-and-ntp-on-each-bmc).
+> **IMPORTANT:** If updating the System ROM of an NCN, the NTP and DNS server values will be lost and must be restored.
+> For NCNs **other than `ncn-m001`** this can be done using the `/opt/cray/csm/scripts/node_management/set-bmc-ntp-dns.sh` script.
+> Use the `-h` option to get a list of command line options required to restore the NTP and DNS values.
+> See [Configure DNS and NTP on Each BMC](../../install/deploy_final_non-compute_node.md#configure-dns-and-ntp-on-each-bmc).
 
 ```json
 {
@@ -922,13 +940,13 @@ Make sure you have waited for the current firmware to be updated before starting
 
 The NCN must be rebooted after updating the BIOS firmware. Follow the [Reboot NCNs](../node_management/Reboot_NCNs.md) procedure.
 
-### Procedure
+#### HPE Node System ROM (BIOS) Procedure for NCN
 
 1. For `HPE` NCNs, check the DNS servers by running the script `/opt/cray/csm/scripts/node_management/set-bmc-ntp-dns.sh ilo -H XNAME -s`. Replace `XNAME` with the xname of the NCN BMC.
-   See [Configure DNS and NTP on Each BMC](../../install/deploy_final_ncn.md#configure-dns-and-ntp-on-each-bmc) for more information.
+   See [Configure DNS and NTP on Each BMC](../../install/deploy_final_non-compute_node.md#configure-dns-and-ntp-on-each-bmc) for more information.
 1. Run a `dryrun` for all NCNs first to determine which NCNs and targets need updating.
 1. For each NCN requiring updates to target `BMC` or `iLO 5`:
-   > **NOTE:** Update of `BMC` and `iLO 5` will not affect the nodes.
+   > **`NOTE`** Update of `BMC` and `iLO 5` will not affect the nodes.
    1. Unlock the NCN BMC.
       See [Lock and Unlock Management Nodes](../hardware_state_manager/Lock_and_Unlock_Management_Nodes.md).
    1. Run the FAS action on the NCN.
@@ -941,20 +959,17 @@ The NCN must be rebooted after updating the BIOS firmware. Follow the [Reboot NC
    1. Reboot the Node.
       See [Reboot NCNs](../node_management/Reboot_NCNs.md).
    1. For `HPE` NCNs, run the script `/opt/cray/csm/scripts/node_management/set-bmc-ntp-dns.sh`.
-      See [Configure DNS and NTP on Each BMC](../../install/deploy_final_ncn.md#configure-dns-and-ntp-on-each-bmc).
+      See [Configure DNS and NTP on Each BMC](../../install/deploy_final_non-compute_node.md#configure-dns-and-ntp-on-each-bmc).
    1. Relock the NCN BMC.
       See [Lock and Unlock Management Nodes](../hardware_state_manager/Lock_and_Unlock_Management_Nodes.md).
-
-<a name="cn-workaround"></a>
 
 ## Compute Node BIOS Workaround for HPE CRAY EX425
 
 Correct an issue where the model of the liquid-cooled compute node BIOS is the incorrect name. The name has changed from `WNC-ROME` to `HPE CRAY EX425` or `HPE CRAY EX425 (ROME)`.
 
-### Prerequisites
+Prerequisites:
 
 * The system is running HPE Cray EX release v1.4 or higher.
-* The system has completed the Cray System Management \(CSM\) installation.
 * A firmware upgrade has been done following [Update Liquid-Cooled Compute Node BIOS Firmware](#cn-bios).
   * The result of the upgrade is that the `NodeX.BIOS` has failed as `noSolution` and the `stateHelper` field for the operation states is `"No Image Available"`.
   * The BIOS in question is running a version less than or equal to `1.2.5` as reported by Redfish or described by the `noSolution` operation in FAS.
@@ -963,7 +978,10 @@ Correct an issue where the model of the liquid-cooled compute node BIOS is the i
   If the Redfish model is different \(ignoring casing\) and the blades in question are not `Windom`, contact customer support. To find the model reported by Redfish, run the following:
 
   ```bash
-  ncn# cray fas operations describe {operationID} --format json
+  cray fas operations describe {operationID} --format json
+  ```
+
+  ```json
   {
     "operationID":"102c949f-e662-4019-bc04-9e4b433ab45e",
     "actionID":"9088f9a2-953a-498d-8266-e2013ba2d15d",
@@ -997,13 +1015,16 @@ Correct an issue where the model of the liquid-cooled compute node BIOS is the i
 
   The model in this example is `WNC-Rome` and the firmware version currently running is `wnc.bios-1.2.5`.
 
-### Procedure
+### Compute Node BIOS Workaround for HPE CRAY EX425 Procedure
 
 1. Search for a FAS image record with `cray` as the manufacturer, `Node1.BIOS` as the target, and `HPE CRAY EX425` as the model.
 
    ```bash
-   ncn# cray fas images list --format json | jq '.images[] | select(.manufacturer=="cray") \
+   cray fas images list --format json | jq '.images[] | select(.manufacturer=="cray") \
    | select(.target=="Node1.BIOS") | select(any(.models[]; contains("EX425")))'
+   ```
+
+   ```json
    {
        "imageID": "e23f5465-ed29-4b18-9389-f8cf0580ca60",
        "createTime": "2021-03-04T00:04:05Z",
@@ -1028,7 +1049,7 @@ Correct an issue where the model of the liquid-cooled compute node BIOS is the i
 
    Take note of the returned `imageID` value to use in the next step.
 
-2. Create a JSON file to override the existing image with the corrected values.
+1. Create a JSON file to override the existing image with the corrected values.
 
    > **IMPORTANT:** The `imageID` must be changed to match the identified `imageID` in the previous step.
 
@@ -1066,13 +1087,13 @@ Correct an issue where the model of the liquid-cooled compute node BIOS is the i
 1. Run a firmware upgrade using the updated parameters defined in the new JSON file.
 
    ```bash
-   ncn# cray fas actions create UPDATED_COMMAND.json
+   cray fas actions create UPDATED_COMMAND.json
    ```
 
 1. Get a high-level summary of the job to verify the changes corrected the issue.
 
-   Use the returned actionID from the `cray fas actions create` command.
-   
+   Use the returned `actionID` from the `cray fas actions create` command.
+
    ```bash
-   ncn# cray fas actions create UPDATED_COMMAND.json
+   cray fas actions create UPDATED_COMMAND.json
    ```

--- a/operations/firmware/FAS_Use_Cases.md
+++ b/operations/firmware/FAS_Use_Cases.md
@@ -227,7 +227,7 @@ It is also recommended that the nodes be powered back on after the updates are c
         The output `overrideDryrun = true` indicates that an actual firmware update job was created. A new `actionID` will also be displayed.
 
         ```bash
-        ncn# cray fas actions create nodeBMC.json
+        ncn# cray fas actions create nodeBMC.json --format toml
         ```
 
         ```toml

--- a/operations/firmware/FAS_Use_Cases.md
+++ b/operations/firmware/FAS_Use_Cases.md
@@ -165,7 +165,7 @@ It is also recommended that the nodes be powered back on after the updates are c
         Replace the `actionID` value with the string returned in the previous step. In this example, `"fddd0025-f5ff-4f59-9e73-1ca2ef2a432d"` is used.
 
         ```bash
-        ncn# cray fas actions describe {actionID}
+        ncn# cray fas actions describe {actionID} --format toml
         ```
 
         ```toml

--- a/operations/firmware/FAS_Use_Cases.md
+++ b/operations/firmware/FAS_Use_Cases.md
@@ -153,6 +153,9 @@ It is also recommended that the nodes be powered back on after the updates are c
 
         ```bash
         ncn# cray fas actions create nodeBMC.json
+        ```
+
+        ```toml
         overrideDryrun = false
         actionID = "fddd0025-f5ff-4f59-9e73-1ca2ef2a432d"
         ```
@@ -163,6 +166,9 @@ It is also recommended that the nodes be powered back on after the updates are c
 
         ```bash
         ncn# cray fas actions describe {actionID}
+        ```
+
+        ```toml
         blockedBy = []
         state = "completed"
         actionID = "fddd0025-f5ff-4f59-9e73-1ca2ef2a432d"
@@ -211,7 +217,7 @@ It is also recommended that the nodes be powered back on after the updates are c
 
         The following example is for the `nodeBMC.json` file. Update the following values:
 
-        ```bash
+        ```json
         "overrideDryrun":true,
         "description":"Update Cray Node BMCs"
         ```
@@ -222,6 +228,9 @@ It is also recommended that the nodes be powered back on after the updates are c
 
         ```bash
         ncn# cray fas actions create nodeBMC.json
+        ```
+
+        ```toml
         overrideDryrun = true
         actionID = "bc40f10a-e50c-4178-9288-8234b336077b"
         ```
@@ -234,6 +243,9 @@ It is also recommended that the nodes be powered back on after the updates are c
 
     ```bash
     ncn# cray fas actions describe {actionID}
+    ```
+
+    ```toml
     [operationSummary.failed]
     [[operationSummary.failed.operationKeys]]
     stateHelper = "unexpected change detected in firmware version. Expected nc.1.3.10-shasta-release.arm.2020-07-21T23:58:22+00:00.d479f59 got: nc.cronomatic-dev.arm.2019-09-24T13:20:24+00:00.9d0f8280"
@@ -255,6 +267,9 @@ It is also recommended that the nodes be powered back on after the updates are c
 
     ```bash
     ncn# cray fas operations describe "e910c6ad-db98-44fc-bdc5-90477b23386f"
+    ```
+
+    ```toml
     fromFirmwareVersion = "nc.cronomatic-dev.arm.2019-09-24T13:20:24+00:00.9d0f8280"
     fromTag = ""
     fromImageURL = ""
@@ -347,6 +362,9 @@ The CMM firmware update process also checks and updates the Cabinet Environmenta
 
         ```bash
         ncn# cray fas actions create chassisBMC.json
+        ```
+
+        ```toml
         overrideDryrun = false
         actionID = "fddd0025-f5ff-4f59-9e73-1ca2ef2a432d"
         ```
@@ -408,7 +426,7 @@ The CMM firmware update process also checks and updates the Cabinet Environmenta
 
         The following example is for the `chassisBMC.json` file. Update the following values:
 
-        ```toml
+        ```json
         "overrideDryrun":true,
         "description":"Update Cray Chassis Management Module controllers"
         ```
@@ -695,7 +713,7 @@ Make sure to wait for the current firmware to be updated before starting a new F
 
         The following example is for the `nodeBMC.json` file. Update the following values:
 
-        ```toml
+        ```json
         "overrideDryrun":true,
         "description":"Update of HPE node iLO 5"
         ```

--- a/operations/firmware/FAS_Use_Cases.md
+++ b/operations/firmware/FAS_Use_Cases.md
@@ -155,6 +155,8 @@ It is also recommended that the nodes be powered back on after the updates are c
         ncn# cray fas actions create nodeBMC.json --format toml
         ```
 
+        Example output:
+
         ```toml
         overrideDryrun = false
         actionID = "fddd0025-f5ff-4f59-9e73-1ca2ef2a432d"

--- a/operations/firmware/FAS_Use_Cases.md
+++ b/operations/firmware/FAS_Use_Cases.md
@@ -273,6 +273,8 @@ It is also recommended that the nodes be powered back on after the updates are c
     ncn# cray fas operations describe "e910c6ad-db98-44fc-bdc5-90477b23386f"
     ```
 
+    Example output:
+
     ```toml
     fromFirmwareVersion = "nc.cronomatic-dev.arm.2019-09-24T13:20:24+00:00.9d0f8280"
     fromTag = ""

--- a/operations/firmware/FAS_Use_Cases.md
+++ b/operations/firmware/FAS_Use_Cases.md
@@ -251,6 +251,8 @@ It is also recommended that the nodes be powered back on after the updates are c
     ncn# cray fas actions describe {actionID}
     ```
 
+    Example output:
+
     ```toml
     [operationSummary.failed]
     [[operationSummary.failed.operationKeys]]

--- a/operations/firmware/FAS_Use_Cases.md
+++ b/operations/firmware/FAS_Use_Cases.md
@@ -4,8 +4,8 @@ Use the Firmware Action Service (FAS) to update the firmware on supported hardwa
 
 When updating an entire system, walk down the device hierarchy component type by component type, starting first with Routers (switches), proceeding to Chassis, and then finally to Nodes. While this is not strictly necessary, it does help eliminate confusion.
 
-**NOTE**: Any node which is locked will remain in the state `inProgress` with the `stateHelper` message of `"failed to lock"` until the action times out, or the lock is released.
-These nodes will report as `failed` with the `stateHelper` message of `"time expired; could not complete update"` if action times out.
+**NOTE**: Any node that is locked remains in the state `inProgress` with the `stateHelper` message of `"failed to lock"` until the action times out, or the lock is released.
+If the action is timed out, these nodes report as `failed` with the `stateHelper` message of `"time expired; could not complete update"`.
 This includes NCNs which are manually locked to prevent accidental rebooting and firmware updates.
 
 Refer to [FAS Filters](FAS_Filters.md) for more information on the content used in the example JSON files.
@@ -152,7 +152,7 @@ It is also recommended that the nodes be powered back on after the updates are c
         The `overrideDryrun = false` value indicates that the command will do a dry run.
 
         ```bash
-        cray fas actions create nodeBMC.json
+        ncn# cray fas actions create nodeBMC.json
         overrideDryrun = false
         actionID = "fddd0025-f5ff-4f59-9e73-1ca2ef2a432d"
         ```
@@ -162,7 +162,7 @@ It is also recommended that the nodes be powered back on after the updates are c
         Replace the `actionID` value with the string returned in the previous step. In this example, `"fddd0025-f5ff-4f59-9e73-1ca2ef2a432d"` is used.
 
         ```bash
-        cray fas actions describe {actionID}
+        ncn# cray fas actions describe {actionID}
         blockedBy = []
         state = "completed"
         actionID = "fddd0025-f5ff-4f59-9e73-1ca2ef2a432d"
@@ -183,25 +183,25 @@ It is also recommended that the nodes be powered back on after the updates are c
 
         * Lists the nodes that have a valid image for updating:
 
-            ```text
+            ```toml
             [operationSummary.succeeded]
             ```
 
         * Lists the nodes that will not be updated because they are already at the correct version:
 
-            ```text
+            ```toml
             [operationSummary.noOperation]
             ```
 
         * Lists the nodes that had an error when attempting to update:
 
-            ```text
+            ```toml
             [operationSummary.failed]
             ```
 
         * Lists the nodes that do not have a valid image for updating:
 
-            ```text
+            ```toml
             [operationSummary.noSolution]
             ```
 
@@ -221,7 +221,7 @@ It is also recommended that the nodes be powered back on after the updates are c
         The output `overrideDryrun = true` indicates that an actual firmware update job was created. A new `actionID` will also be displayed.
 
         ```bash
-        cray fas actions create nodeBMC.json
+        ncn# cray fas actions create nodeBMC.json
         overrideDryrun = true
         actionID = "bc40f10a-e50c-4178-9288-8234b336077b"
         ```
@@ -233,7 +233,7 @@ It is also recommended that the nodes be powered back on after the updates are c
 1. Retrieve the `operationID` and verify that the update is complete.
 
     ```bash
-    cray fas actions describe {actionID}
+    ncn# cray fas actions describe {actionID}
     [operationSummary.failed]
     [[operationSummary.failed.operationKeys]]
     stateHelper = "unexpected change detected in firmware version. Expected nc.1.3.10-shasta-release.arm.2020-07-21T23:58:22+00:00.d479f59 got: nc.cronomatic-dev.arm.2019-09-24T13:20:24+00:00.9d0f8280"
@@ -248,13 +248,13 @@ It is also recommended that the nodes be powered back on after the updates are c
     Check the list of nodes for the `failed` or `completed` state.
 
     ```bash
-    cray fas operations describe {operationID}
+    ncn# cray fas operations describe {operationID}
     ```
 
     For example:
 
     ```bash
-    cray fas operations describe "e910c6ad-db98-44fc-bdc5-90477b23386f"
+    ncn# cray fas operations describe "e910c6ad-db98-44fc-bdc5-90477b23386f"
     fromFirmwareVersion = "nc.cronomatic-dev.arm.2019-09-24T13:20:24+00:00.9d0f8280"
     fromTag = ""
     fromImageURL = ""
@@ -324,13 +324,13 @@ The CMM firmware update process also checks and updates the Cabinet Environmenta
     1. Disable the `hms-discovery` Kubernetes cronjob:
 
         ```bash
-        kubectl -n services patch cronjobs hms-discovery -p '{"spec" : {"suspend" : true }}'
+        ncn# kubectl -n services patch cronjobs hms-discovery -p '{"spec" : {"suspend" : true }}'
         ```
 
     1. Power off all the components. For example, in chassis 0-7, cabinets 1000-1003:
 
         ```bash
-        cray capmc xname_off create --xnames x[1000-1003]c[0-7] --recursive true --continue true
+        ncn# cray capmc xname_off create --xnames x[1000-1003]c[0-7] --recursive true --continue true
         ```
 
         This command powers off all the node cards, then all the compute blades, then all the Slingshot switch ASICS, then all the Slingshot switch enclosures, and finally all the chassis enclosures in cabinets 1000-1003.
@@ -346,7 +346,7 @@ The CMM firmware update process also checks and updates the Cabinet Environmenta
         The `overrideDryrun = false` value indicates that the command will do a dry-run.
 
         ```bash
-        cray fas actions create chassisBMC.json
+        ncn# cray fas actions create chassisBMC.json
         overrideDryrun = false
         actionID = "fddd0025-f5ff-4f59-9e73-1ca2ef2a432d"
         ```
@@ -356,10 +356,10 @@ The CMM firmware update process also checks and updates the Cabinet Environmenta
         Replace the `actionID` value with the string returned in the previous step. In this example, `"fddd0025-f5ff-4f59-9e73-1ca2ef2a432d"` is used.
 
         ```bash
-        cray fas actions describe {actionID}
+        ncn# cray fas actions describe {actionID}
         ```
 
-        ```text
+        ```toml
         blockedBy = []
         state = "completed"
         actionID = "fddd0025-f5ff-4f59-9e73-1ca2ef2a432d"
@@ -380,25 +380,25 @@ The CMM firmware update process also checks and updates the Cabinet Environmenta
 
         * Lists the nodes that have a valid image for updating:
 
-            ```text
+            ```toml
             [operationSummary.succeeded]
             ```
 
         * Lists the nodes that will not be updated because they are already at the correct version:
 
-            ```text
+            ```toml
             [operationSummary.noOperation]
             ```
 
         * Lists the nodes that had an error when attempting to update:
 
-            ```text
+            ```toml
             [operationSummary.failed]
             ```
 
         * Lists the nodes that do not have a valid image for updating:
 
-            ```text
+            ```toml
             [operationSummary.noSolution]
             ```
 
@@ -408,7 +408,7 @@ The CMM firmware update process also checks and updates the Cabinet Environmenta
 
         The following example is for the `chassisBMC.json` file. Update the following values:
 
-        ```text
+        ```toml
         "overrideDryrun":true,
         "description":"Update Cray Chassis Management Module controllers"
         ```
@@ -418,10 +418,10 @@ The CMM firmware update process also checks and updates the Cabinet Environmenta
         The output `overrideDryrun = true` indicates that an actual firmware update job was created. A new `actionID` will also be displayed.
 
         ```bash
-        cray fas actions create chassisBMC.json
+        ncn# cray fas actions create chassisBMC.json
         ```
 
-        ```text
+        ```toml
         overrideDryrun = true
         actionID = "bc40f10a-e50c-4178-9288-8234b336077b"
         ```
@@ -431,13 +431,13 @@ The CMM firmware update process also checks and updates the Cabinet Environmenta
 1. Restart the `hms-discovery` cronjob.
 
     ```bash
-    kubectl -n services patch cronjobs hms-discovery -p '{"spec" : {"suspend" : false }}'
+    ncn# kubectl -n services patch cronjobs hms-discovery -p '{"spec" : {"suspend" : false }}'
     ```
 
     The `hms-discovery` cronjob will run within 5 minutes of being unsuspended and start powering on the chassis enclosures, switches, and compute blades. If components are not being powered back on, then power them on manually:
 
     ```bash
-    cray capmc xname_on create --xnames x[1000-1003]c[0-7]r[0-7],x[1000-1003]c[0-7]s[0-7] --prereq true --continue true
+    ncn# cray capmc xname_on create --xnames x[1000-1003]c[0-7]r[0-7],x[1000-1003]c[0-7]s[0-7] --prereq true --continue true
     ```
 
     The `--prereq` option ensures all required components are powered on first. The `--continue` option allows the command to complete in systems without fully populated hardware.
@@ -502,7 +502,7 @@ This procedure updates node controller \(nC\) firmware.
 
 A node may fail to update with the output:
 
-```text
+```toml
 stateHelper = "Firmware Update Information Returned Downloading – See /redfish/v1/UpdateService"
 ```
 
@@ -630,10 +630,10 @@ Make sure to wait for the current firmware to be updated before starting a new F
         The `overrideDryrun = false` value indicates that the command will do a dry run.
 
         ```bash
-        cray fas actions create nodeBMC.json
+        ncn# cray fas actions create nodeBMC.json
         ```
 
-        ```text
+        ```toml
         overrideDryrun = false
         actionID = "fddd0025-f5ff-4f59-9e73-1ca2ef2a432d"
         ```
@@ -643,10 +643,10 @@ Make sure to wait for the current firmware to be updated before starting a new F
         Replace the `actionID` value with the string returned in the previous step. In this example, `"fddd0025-f5ff-4f59-9e73-1ca2ef2a432d"` is used.
 
         ```bash
-        cray fas actions describe {actionID}
+        ncn# cray fas actions describe {actionID}
         ```
 
-        ```text
+        ```toml
         blockedBy = []
         state = "completed"
         actionID = "fddd0025-f5ff-4f59-9e73-1ca2ef2a432d"
@@ -667,25 +667,25 @@ Make sure to wait for the current firmware to be updated before starting a new F
 
         * Lists the nodes that have a valid image for updating:
 
-            ```text
+            ```toml
             [operationSummary.succeeded]
             ```
 
         * Lists the nodes that will not be updated because they are already at the correct version:
 
-            ```text
+            ```toml
             [operationSummary.noOperation]
             ```
 
         * Lists the nodes that had an error when attempting to update:
 
-            ```text
+            ```toml
             [operationSummary.failed]
             ```
 
         * Lists the nodes that do not have a valid image for updating:
 
-            ```text
+            ```toml
             [operationSummary.noSolution]
             ```
 
@@ -695,7 +695,7 @@ Make sure to wait for the current firmware to be updated before starting a new F
 
         The following example is for the `nodeBMC.json` file. Update the following values:
 
-        ```text
+        ```toml
         "overrideDryrun":true,
         "description":"Update of HPE node iLO 5"
         ```
@@ -705,10 +705,10 @@ Make sure to wait for the current firmware to be updated before starting a new F
         The returned `overrideDryrun = true` indicates that an actual firmware update job was created. A new `actionID` will also be returned.
 
         ```bash
-        cray fas actions create nodeBMC.json
+        ncn# cray fas actions create nodeBMC.json
         ```
 
-        ```json
+        ```toml
         overrideDryrun = true
         actionID = "bc40f10a-e50c-4178-9288-8234b336077b"
         ```
@@ -723,7 +723,7 @@ Make sure to wait for the current firmware to be updated before starting a new F
     cray fas actions describe {actionID}
     ```
 
-    ```json
+    ```toml
     [operationSummary.failed]
     [[operationSummary.failed.operationKeys]]
     stateHelper = "unexpected change detected in firmware version. Expected 2.46 May 11 2021 got: 2.32 Apr 27 2020"
@@ -738,16 +738,16 @@ Make sure to wait for the current firmware to be updated before starting a new F
     Check the list of nodes for the `failed` or `completed` state.
 
     ```bash
-    cray fas operations describe {operationID}
+    ncn# cray fas operations describe {operationID}
     ```
 
     For example:
 
     ```bash
-    cray fas operations describe "e910c6ad-db98-44fc-bdc5-90477b23386f"
+    ncn# cray fas operations describe "e910c6ad-db98-44fc-bdc5-90477b23386f"
     ```
 
-    ```json
+    ```toml
     fromFirmwareVersion = "2.32 Apr 27 2020"
     fromTag = ""
     fromImageURL = ""
@@ -777,7 +777,7 @@ Gigabyte and HPE non-compute nodes \(NCNs\) firmware can be updated with FAS. Th
 After creating the JSON file for the device being upgraded, use the following command to run the FAS job:
 
 ```bash
-cray fas actions create CUSTOM_DEVICE_PARAMETERS.json
+ncn# cray fas actions create CUSTOM_DEVICE_PARAMETERS.json
 ```
 
 All of the example JSON files below are set to run a dry-run. Update the `overrideDryrun` value to `True` to update the firmware.
@@ -978,7 +978,7 @@ Prerequisites:
   If the Redfish model is different \(ignoring casing\) and the blades in question are not `Windom`, contact customer support. To find the model reported by Redfish, run the following:
 
   ```bash
-  cray fas operations describe {operationID} --format json
+  ncn# cray fas operations describe {operationID} --format json
   ```
 
   ```json
@@ -1020,7 +1020,7 @@ Prerequisites:
 1. Search for a FAS image record with `cray` as the manufacturer, `Node1.BIOS` as the target, and `HPE CRAY EX425` as the model.
 
    ```bash
-   cray fas images list --format json | jq '.images[] | select(.manufacturer=="cray") \
+   ncn# cray fas images list --format json | jq '.images[] | select(.manufacturer=="cray") \
    | select(.target=="Node1.BIOS") | select(any(.models[]; contains("EX425")))'
    ```
 
@@ -1087,7 +1087,7 @@ Prerequisites:
 1. Run a firmware upgrade using the updated parameters defined in the new JSON file.
 
    ```bash
-   cray fas actions create UPDATED_COMMAND.json
+   ncn# cray fas actions create UPDATED_COMMAND.json
    ```
 
 1. Get a high-level summary of the job to verify the changes corrected the issue.
@@ -1095,5 +1095,5 @@ Prerequisites:
    Use the returned `actionID` from the `cray fas actions create` command.
 
    ```bash
-   cray fas actions create UPDATED_COMMAND.json
+   ncn# cray fas actions create UPDATED_COMMAND.json
    ```

--- a/operations/firmware/FAS_Use_Cases.md
+++ b/operations/firmware/FAS_Use_Cases.md
@@ -170,6 +170,8 @@ It is also recommended that the nodes be powered back on after the updates are c
         ncn# cray fas actions describe {actionID} --format toml
         ```
 
+        Example output:
+
         ```toml
         blockedBy = []
         state = "completed"

--- a/operations/firmware/FAS_Use_Cases.md
+++ b/operations/firmware/FAS_Use_Cases.md
@@ -248,7 +248,7 @@ It is also recommended that the nodes be powered back on after the updates are c
 1. Retrieve the `operationID` and verify that the update is complete.
 
     ```bash
-    ncn# cray fas actions describe {actionID}
+    ncn# cray fas actions describe {actionID} --format toml
     ```
 
     Example output:

--- a/operations/firmware/FAS_Use_Cases.md
+++ b/operations/firmware/FAS_Use_Cases.md
@@ -349,7 +349,7 @@ The CMM firmware update process also checks and updates the Cabinet Environmenta
     1. Disable the `hms-discovery` Kubernetes cronjob:
 
         ```bash
-        ncn# kubectl -n services patch cronjobs hms-discovery -p '{"spec" : {"suspend" : true }}'
+        ncn-mw# kubectl -n services patch cronjobs hms-discovery -p '{"spec" : {"suspend" : true }}'
         ```
 
     1. Power off all the components. For example, in chassis 0-7, cabinets 1000-1003:

--- a/operations/firmware/FAS_Use_Cases.md
+++ b/operations/firmware/FAS_Use_Cases.md
@@ -232,6 +232,8 @@ It is also recommended that the nodes be powered back on after the updates are c
         ncn# cray fas actions create nodeBMC.json --format toml
         ```
 
+        Example output:
+
         ```toml
         overrideDryrun = true
         actionID = "bc40f10a-e50c-4178-9288-8234b336077b"

--- a/operations/firmware/FAS_Use_Cases.md
+++ b/operations/firmware/FAS_Use_Cases.md
@@ -374,6 +374,8 @@ The CMM firmware update process also checks and updates the Cabinet Environmenta
         ncn# cray fas actions create chassisBMC.json --format toml
         ```
 
+        Example output:
+
         ```toml
         overrideDryrun = false
         actionID = "fddd0025-f5ff-4f59-9e73-1ca2ef2a432d"
@@ -384,8 +386,10 @@ The CMM firmware update process also checks and updates the Cabinet Environmenta
         Replace the `actionID` value with the string returned in the previous step. In this example, `"fddd0025-f5ff-4f59-9e73-1ca2ef2a432d"` is used.
 
         ```bash
-        ncn# cray fas actions describe {actionID}
+        ncn# cray fas actions describe {actionID} --format toml
         ```
+
+        Example output:
 
         ```toml
         blockedBy = []
@@ -446,8 +450,10 @@ The CMM firmware update process also checks and updates the Cabinet Environmenta
         The output `overrideDryrun = true` indicates that an actual firmware update job was created. A new `actionID` will also be displayed.
 
         ```bash
-        ncn# cray fas actions create chassisBMC.json
+        ncn# cray fas actions create chassisBMC.json --format toml
         ```
+
+        Example output:
 
         ```toml
         overrideDryrun = true
@@ -459,7 +465,7 @@ The CMM firmware update process also checks and updates the Cabinet Environmenta
 1. Restart the `hms-discovery` cronjob.
 
     ```bash
-    ncn# kubectl -n services patch cronjobs hms-discovery -p '{"spec" : {"suspend" : false }}'
+    ncn-mw# kubectl -n services patch cronjobs hms-discovery -p '{"spec" : {"suspend" : false }}'
     ```
 
     The `hms-discovery` cronjob will run within 5 minutes of being unsuspended and start powering on the chassis enclosures, switches, and compute blades. If components are not being powered back on, then power them on manually:
@@ -658,8 +664,10 @@ Make sure to wait for the current firmware to be updated before starting a new F
         The `overrideDryrun = false` value indicates that the command will do a dry run.
 
         ```bash
-        ncn# cray fas actions create nodeBMC.json
+        ncn# cray fas actions create nodeBMC.json --format toml
         ```
+
+        Example output:
 
         ```toml
         overrideDryrun = false
@@ -671,8 +679,10 @@ Make sure to wait for the current firmware to be updated before starting a new F
         Replace the `actionID` value with the string returned in the previous step. In this example, `"fddd0025-f5ff-4f59-9e73-1ca2ef2a432d"` is used.
 
         ```bash
-        ncn# cray fas actions describe {actionID}
+        ncn# cray fas actions describe {actionID} --format toml
         ```
+
+        Example output:
 
         ```toml
         blockedBy = []
@@ -733,8 +743,10 @@ Make sure to wait for the current firmware to be updated before starting a new F
         The returned `overrideDryrun = true` indicates that an actual firmware update job was created. A new `actionID` will also be returned.
 
         ```bash
-        ncn# cray fas actions create nodeBMC.json
+        ncn# cray fas actions create nodeBMC.json --format toml
         ```
+
+        Example output:
 
         ```toml
         overrideDryrun = true
@@ -748,8 +760,10 @@ Make sure to wait for the current firmware to be updated before starting a new F
 1. Retrieve the `operationID` and verify that the update is complete.
 
     ```bash
-    cray fas actions describe {actionID}
+    ncn# cray fas actions describe {actionID} --format toml
     ```
+
+    Example output:
 
     ```toml
     [operationSummary.failed]
@@ -772,8 +786,10 @@ Make sure to wait for the current firmware to be updated before starting a new F
     For example:
 
     ```bash
-    ncn# cray fas operations describe "e910c6ad-db98-44fc-bdc5-90477b23386f"
+    ncn# cray fas operations describe "e910c6ad-db98-44fc-bdc5-90477b23386f" --format toml
     ```
+
+    Example output:
 
     ```toml
     fromFirmwareVersion = "2.32 Apr 27 2020"
@@ -1009,6 +1025,8 @@ Prerequisites:
   ncn# cray fas operations describe {operationID} --format json
   ```
 
+  Example output:
+
   ```json
   {
     "operationID":"102c949f-e662-4019-bc04-9e4b433ab45e",
@@ -1051,6 +1069,8 @@ Prerequisites:
    ncn# cray fas images list --format json | jq '.images[] | select(.manufacturer=="cray") \
    | select(.target=="Node1.BIOS") | select(any(.models[]; contains("EX425")))'
    ```
+
+   Example output:
 
    ```json
    {

--- a/operations/firmware/FAS_Use_Cases.md
+++ b/operations/firmware/FAS_Use_Cases.md
@@ -274,7 +274,7 @@ It is also recommended that the nodes be powered back on after the updates are c
     For example:
 
     ```bash
-    ncn# cray fas operations describe "e910c6ad-db98-44fc-bdc5-90477b23386f"
+    ncn# cray fas operations describe "e910c6ad-db98-44fc-bdc5-90477b23386f" --format toml
     ```
 
     Example output:

--- a/operations/firmware/FAS_Use_Cases.md
+++ b/operations/firmware/FAS_Use_Cases.md
@@ -371,7 +371,7 @@ The CMM firmware update process also checks and updates the Cabinet Environmenta
         The `overrideDryrun = false` value indicates that the command will do a dry-run.
 
         ```bash
-        ncn# cray fas actions create chassisBMC.json
+        ncn# cray fas actions create chassisBMC.json --format toml
         ```
 
         ```toml

--- a/operations/firmware/FAS_Use_Cases.md
+++ b/operations/firmware/FAS_Use_Cases.md
@@ -152,7 +152,7 @@ It is also recommended that the nodes be powered back on after the updates are c
         The `overrideDryrun = false` value indicates that the command will do a dry run.
 
         ```bash
-        ncn# cray fas actions create nodeBMC.json
+        ncn# cray fas actions create nodeBMC.json --format toml
         ```
 
         ```toml

--- a/operations/firmware/Update_Firmware_with_FAS.md
+++ b/operations/firmware/Update_Firmware_with_FAS.md
@@ -5,7 +5,7 @@ If FAS has not yet been installed, firmware for NCNs can be updated manually wit
 The Firmware Action Service (FAS) provides an interface for managing firmware versions of Redfish-enabled hardware in the system. FAS interacts with the Hardware State Managers (HSM), device data, and image data in order to update firmware.
 
 Reset Gigabyte node BMC to factory defaults if having problems with `ipmitool`, problems using Redfish, or when flashing procedures fail.
-See [Set Gigabyte Node BMC to Factory Defaults](../../operations/node_management/Set_Gigabyte_Node_BMC_to_Factory_Defaults.md).
+See [Set Gigabyte Node BMC to Factory Defaults](../../install/set_gigabyte_node_bmc_to_factory_defaults.md).
 
 FAS images contain the following information that is needed for a hardware device to update firmware versions:
 

--- a/operations/firmware/Update_Firmware_with_FAS.md
+++ b/operations/firmware/Update_Firmware_with_FAS.md
@@ -5,7 +5,7 @@ If FAS has not yet been installed, firmware for NCNs can be updated manually wit
 The Firmware Action Service (FAS) provides an interface for managing firmware versions of Redfish-enabled hardware in the system. FAS interacts with the Hardware State Managers (HSM), device data, and image data in order to update firmware.
 
 Reset Gigabyte node BMC to factory defaults if having problems with `ipmitool`, problems using Redfish, or when flashing procedures fail.
-See [Set Gigabyte Node BMC to Factory Defaults](../../install/set_gigabyte_node_bmc_to_factory_defaults.md).
+See [Set Gigabyte Node BMC to Factory Defaults](../../operations/node_management/Set_Gigabyte_Node_BMC_to_Factory_Defaults.md).
 
 FAS images contain the following information that is needed for a hardware device to update firmware versions:
 
@@ -20,12 +20,10 @@ FAS images contain the following information that is needed for a hardware devic
 * [Current capabilities](#current-capabilities)
 * [Order of operations](#order-of-operations)
 * [Hardware precedence order](#hardware-precedence-order)
-* [FAS administrative procedures](#fas-admin-procedures)
+* [FAS administrative procedures](#fas-administrative-procedures)
 * [Firmware actions](#firmware-actions)
 * [Firmware operations](#firmware-operations)
 * [Firmware images](#firmware-images)
-
-<a name="prerequisites"></a>
 
 ## Prerequisites
 
@@ -33,19 +31,19 @@ FAS images contain the following information that is needed for a hardware devic
 1. All management nodes have been locked.
 1. Identify the type and manufacturers of hardware in the system. If Gigabyte nodes are not in use on the system, do not update them!
 
-<a name="warning"></a>
-
 ## Warning
 
 Non-compute nodes (NCNs) and their BMCs should be locked with the HSM locking API to ensure they are not unintentionally updated by FAS.
 See [Lock and Unlock Management Nodes](../hardware_state_manager/Lock_and_Unlock_Management_Nodes.md) for more information.
 Failure to lock the NCNs could result in unintentional update of the NCNs if FAS is not used correctly; this will lead to system instability problems.
 
+**NOTE**: Any node which is locked will remain in the state `inProgress` with the `stateHelper` message of `"failed to lock"` until the action times out, or the lock is released.
+These nodes will report as `failed` with the `stateHelper` message of `"time expired; could not complete update"` if action times out.
+This includes NCNs which are manually locked to prevent accidental rebooting and firmware updates.
+
 Follow the process outlined in [FAS CLI](FAS_CLI.md) to update the system. Use the recipes listed in [FAS Recipes](FAS_Recipes.md) to update each supported type.
 
-> **NOTE:** Each system is different and may not have all hardware options.
-
-<a name="current-capabilities"></a>
+> **`NOTE`** Each system is different and may not have all hardware options.
 
 ## Current capabilities
 
@@ -60,8 +58,6 @@ Table 1. Upgradable Firmware Items
 | Cray             | `routerBMC`  | `BMC`, `Recovery`                                                                   |
 | Gigabyte         | `nodeBMC`    | `BMC`, `BIOS`                                                                       |
 | HPE              | `nodeBMC`    | `iLO 5` (`BMC` or `1` ), `System ROM` ,`Redundant System ROM` (`BIOS` or `2`)       |
-
-<a name="order-of-operations"></a>
 
 ## Order of operations
 
@@ -100,8 +96,6 @@ For each item in the `Hardware Precedence Order`:
 
 1. Interpret the outcome of the live update; proceed to next type of hardware.
 
-<a name="hardware-precedence-order"></a>
-
 ## Hardware precedence order
 
 After identifying which hardware is in the system, start with the top item on this list to update. If any of the following hardware is not in the system, then skip it.
@@ -109,22 +103,20 @@ After identifying which hardware is in the system, start with the top item on th
 > **IMPORTANT:**
 > This process does not communicate the SAFE way to update NCNs. If the NCNs and their BMCs have not been locked, or if FAS is blindly used to update NCNs without following the correct process, then **THE STABILITY OF THE SYSTEM WILL BE JEOPARDIZED**.
 > Read the corresponding recipes before updating. There are sometimes ancillary actions that must be completed in order to ensure update integrity.
-> **NOTE:** To update Switch Controllers \(sC\) or `RouterBMC`, refer to the Rosetta Documentation.
+> **`NOTE`** To update Switch Controllers \(sC\) or `RouterBMC`, refer to the Rosetta Documentation.
 
-1. [Cray](FAS_Recipes.md#manufacturer-cray)
-   1. [`ChassisBMC`](FAS_Recipes.md#cray-device-type-chassisbmc-target-bmc)
+1. [Cray](FAS_Recipes.md#manufacturer--cray)
+   1. [`ChassisBMC`](FAS_Recipes.md#device-type-chassisbmc--target-bmc)
    1. `NodeBMC`
-      1. [BMC](FAS_Recipes.md#cray-device-type-nodebmc-target-bmc)
-      1. [`NodeBIOS`](FAS_Recipes.md#cray-device-type-nodebmc-target-nodebios)
-      1. [Redstone FPGA](FAS_Recipes.md#cray-device-type-nodebmc-target-redstone-fpga)
+      1. [BMC](FAS_Recipes.md#device-type-nodebmc--target-bmc)
+      1. [`NodeBIOS`](FAS_Recipes.md#device-type-nodebmc--target-nodebios)
+      1. [Redstone FPGA](FAS_Recipes.md#device-type-nodebmc--target-redstone-fpga)
 1. [Gigabyte](FAS_Recipes.md#manufacturer-gigabyte)
-   1. [BMC](FAS_Recipes.md#gb-device-type-nodebmc-target-bmc)
-   1. [BIOS](FAS_Recipes.md#gb-device-type-nodebmc-target-bios)
+   1. [BMC](FAS_Recipes.md#device-type-nodebmc--target-bmc)
+   1. [BIOS](FAS_Recipes.md#device-type-nodebmc--target-bios)
 1. [HPE](FAS_Recipes.md#manufacturer-hpe)
-   1. [BMC (`iLO5`)](FAS_Recipes.md#hpe-device-type-nodebmc-target--aka-bmc)
-   1. [BIOS (System ROM)](FAS_Recipes.md#hpe-device-type-nodebmc-target--aka-bios)
-
-<a name="fas-admin-procedures"></a>
+   1. [BMC (`iLO5`)](FAS_Recipes.md#device-type-nodebmc--target-ilo-5-aka-bmc)
+   1. [BIOS (System ROM)](FAS_Recipes.md#device-type-nodebmc--target-system-rom-aka-bios)
 
 ## FAS administrative procedures
 
@@ -137,8 +129,6 @@ Under no circumstances should non-administrator users attempt to use FAS or perf
 * Take a snapshot of the system: Record the firmware versions present on each target for the identified component names (xnames). If the firmware version corresponds to an image available in the images repository, link the `imageID` to the record.
 * Restore the snapshot of the system: Take the previously recorded snapshot and use the related `imageIDs` to put the component name (xname)/targets back to the firmware version they were at, at the time of the snapshot.
 * Provide firmware for updating: FAS can only update a component name (xname)/target if it has an image record that is applicable. Most administrators will not encounter this use case.
-
-<a name="firmware-actions"></a>
 
 ## Firmware actions
 
@@ -157,8 +147,6 @@ The static portion of the life cycle is where the action is created and configur
 
 The dynamic portion of the life cycle is where the action is executed to completion. It begins when the actions is transitioned from the `new` to `configured` state. The action will then be ultimately transitioned to an end state of `aborted` or `completed`.
 
-<a name="firmware-operations"></a>
-
 ## Firmware operations
 
 Operations are individual tasks in a FAS action.
@@ -175,8 +163,6 @@ FAS operations will have one of the following states:
 * `noSolution` - FAS does not have a suitable image for an update.
 * `aborted` - The operation was aborted before it could determine if it was successful. If aborted after the update command was sent to the node, then the node may still have updated.
 
-<a name="firmware-images"></a>
-
 ## Firmware images
 
 FAS requires images in order to update firmware for any device on the system. An image contains the data that allows FAS to establish a link between an administrative command, available devices \(xname/targets\), and available firmware.
@@ -191,7 +177,7 @@ The following is an example of an image:
   "manufacturer": "intel",
   "model": ["s2600","s2600_REV_a"],
   "target": "BIOS",
-  "tag": ["recovery", default"],
+  "tag": ["recovery", "default"],
   "firmwareVersion": "f1.123.24xz",
   "semanticFirmwareVersion": "v1.2.252",
   "updateURI": "/redfish/v1/Systems/UpdateService/BIOS",

--- a/operations/firmware/Update_Firmware_with_FAS.md
+++ b/operations/firmware/Update_Firmware_with_FAS.md
@@ -38,7 +38,7 @@ See [Lock and Unlock Management Nodes](../hardware_state_manager/Lock_and_Unlock
 Failure to lock the NCNs could result in unintentional update of the NCNs if FAS is not used correctly; this will lead to system instability problems.
 
 **NOTE**: Any node that is locked remains in the state `inProgress` with the `stateHelper` message of `"failed to lock"` until the action times out, or the lock is released.
-These nodes will report as `failed` with the `stateHelper` message of `"time expired; could not complete update"` if action times out.
+If the action is timed out, these nodes report as `failed` with the `stateHelper` message of `"time expired; could not complete update"`.
 This includes NCNs which are manually locked to prevent accidental rebooting and firmware updates.
 
 Follow the process outlined in [FAS CLI](FAS_CLI.md) to update the system. Use the recipes listed in [FAS Recipes](FAS_Recipes.md) to update each supported type.

--- a/operations/firmware/Update_Firmware_with_FAS.md
+++ b/operations/firmware/Update_Firmware_with_FAS.md
@@ -37,7 +37,7 @@ Non-compute nodes (NCNs) and their BMCs should be locked with the HSM locking AP
 See [Lock and Unlock Management Nodes](../hardware_state_manager/Lock_and_Unlock_Management_Nodes.md) for more information.
 Failure to lock the NCNs could result in unintentional update of the NCNs if FAS is not used correctly; this will lead to system instability problems.
 
-**NOTE**: Any node which is locked will remain in the state `inProgress` with the `stateHelper` message of `"failed to lock"` until the action times out, or the lock is released.
+**NOTE**: Any node that is locked remains in the state `inProgress` with the `stateHelper` message of `"failed to lock"` until the action times out, or the lock is released.
 These nodes will report as `failed` with the `stateHelper` message of `"time expired; could not complete update"` if action times out.
 This includes NCNs which are manually locked to prevent accidental rebooting and firmware updates.
 

--- a/operations/firmware/Update_Firmware_with_FAS.md
+++ b/operations/firmware/Update_Firmware_with_FAS.md
@@ -41,7 +41,7 @@ Failure to lock the NCNs could result in unintentional update of the NCNs if FAS
 If the action is timed out, these nodes report as `failed` with the `stateHelper` message of `"time expired; could not complete update"`.
 This includes NCNs which are manually locked to prevent accidental rebooting and firmware updates.
 
-Follow the process outlined in [FAS CLI](FAS_CLI.md) to update the system. Use the recipes listed in [FAS Recipes](FAS_Recipes.md) to update each supported type.
+Follow the process outlined in [FAS CLI](/operations/firmware/FAS_CLI.md) to update the system. Use the recipes listed in [FAS Recipes](/operations/firmware/FAS_Recipes.md) to update each supported type.
 
 > **`NOTE`** Each system is different and may not have all hardware options.
 

--- a/operations/firmware/Update_Firmware_with_FAS.md
+++ b/operations/firmware/Update_Firmware_with_FAS.md
@@ -41,7 +41,7 @@ Failure to lock the NCNs could result in unintentional update of the NCNs if FAS
 If the action is timed out, these nodes report as `failed` with the `stateHelper` message of `"time expired; could not complete update"`.
 This includes NCNs which are manually locked to prevent accidental rebooting and firmware updates.
 
-Follow the process outlined in [FAS CLI](/operations/firmware/FAS_CLI.md) to update the system. Use the recipes listed in [FAS Recipes](/operations/firmware/FAS_Recipes.md) to update each supported type.
+Follow the process outlined in [FAS CLI](FAS_CLI.md) to update the system. Use the recipes listed in [FAS Recipes](FAS_Recipes.md) to update each supported type.
 
 > **`NOTE`** Each system is different and may not have all hardware options.
 

--- a/operations/kubernetes/Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md
+++ b/operations/kubernetes/Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md
@@ -39,7 +39,7 @@ Repopulate clusters for CPS.
 
 ## CRUS
 
-> **`NOTE`** CRUS was deprecated in CSM 1.2.0. It will be removed in a future CSM release and replaced with BOS V2, which will provide similar functionality. See
+**Note:** CRUS is deprecated in CSM 1.2.0. It will be removed in a future CSM release and replaced with BOS V2, which will provide similar functionality. See
 [Deprecated features](../../introduction/differences.md#deprecated_features).
 
 1. View the progress of existing CRUS sessions.
@@ -171,14 +171,14 @@ Data is repopulated in BSS when the REDS `init` job is run.
 
         ```bash
         ncn-m# TMPFILE=$(mktemp)
-        ncn-m# sat status --no-borders --no-headings | grep Ready | grep Compute | awk '{printf("nid%06d-nmn\n",$4);}' > $TMPFILE
-        ncn-m# pdsh -w ^${TMPFILE} "systemctl restart cray-orca"
-        ncn-m# rm -rf $TMPFILE
+        ncn-m# sat status --no-borders --no-headings | grep Ready | grep Compute | awk '{printf("nid%06d-nmn\n",$4);}' > "${TMPFILE}"
+        ncn-m# pdsh -w ^"${TMPFILE}" "systemctl restart cray-orca"
+        ncn-m# rm -rf "${TMPFILE}"
         ```
 
     1. Resubscribe the NCNs.
 
-        **`NOTE`** Modify the `-w` arguments in the following commands to reflect the number of worker and storage nodes in the system.
+        **NOTE:** Modify the `-w` arguments in the following commands to reflect the number of worker and storage nodes in the system.
 
         ```bash
         ncn-m# pdsh -w ncn-w00[1-4]-can.local "systemctl restart cray-orca"

--- a/operations/kubernetes/Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md
+++ b/operations/kubernetes/Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md
@@ -47,7 +47,7 @@ Repopulate clusters for CPS.
     1. List the existing CRUS sessions to find the `upgrade_id` for the desired session.
 
         ```bash
-        cray crus session list
+        ncn# cray crus session list
         ```
 
         Example output:
@@ -73,7 +73,7 @@ Repopulate clusters for CPS.
         If the session continued and appears to be in a healthy state, proceed to the [BSS](#bss) section.
 
         ```bash
-        cray crus session describe CRUS_UPGRADE_ID
+        ncn# cray crus session describe CRUS_UPGRADE_ID
         ```
 
         Example output:
@@ -110,7 +110,7 @@ Repopulate clusters for CPS.
     Deleting the pod will restart CRUS and start the discovery process for any data recovered in etcd.
 
     ```bash
-    kubectl delete pods -n services POD_NAME
+    ncn# kubectl delete pods -n services POD_NAME
     ```
 
 ## BSS
@@ -120,20 +120,20 @@ Data is repopulated in BSS when the REDS `init` job is run.
 1. Get the current REDS job.
 
     ```bash
-    kubectl get -o json -n services job/cray-reds-init |
+    ncn# kubectl get -o json -n services job/cray-reds-init |
             jq 'del(.spec.template.metadata.labels["controller-uid"], .spec.selector)' > cray-reds-init.json
     ```
 
 1. Delete the `reds-client-init` job.
 
     ```bash
-    kubectl delete -n services -f cray-reds-init.json
+    ncn# kubectl delete -n services -f cray-reds-init.json
     ```
 
 1. Restart the `reds-client-init` job.
 
     ```bash
-    kubectl apply -n services -f cray-reds-init.json
+    ncn# kubectl apply -n services -f cray-reds-init.json
     ```
 
 ## REDS
@@ -141,7 +141,7 @@ Data is repopulated in BSS when the REDS `init` job is run.
 1. Restart REDS.
 
     ```bash
-    kubectl -n services delete pods --selector='app.kubernetes.io/name=cray-reds'
+    ncn# kubectl -n services delete pods --selector='app.kubernetes.io/name=cray-reds'
     ```
 
 ## MEDS
@@ -149,7 +149,7 @@ Data is repopulated in BSS when the REDS `init` job is run.
 1. Restart MEDS.
 
     ```bash
-    kubectl -n services delete pods --selector='app.kubernetes.io/name=cray-meds'
+    ncn# kubectl -n services delete pods --selector='app.kubernetes.io/name=cray-meds'
     ```
 
 ## FAS
@@ -167,20 +167,20 @@ Data is repopulated in BSS when the REDS `init` job is run.
 
 1. Resubscribe the compute nodes and any NCNs that use the ORCA daemon for their State Change Notifications \(SCN\).
 
-    1. (`ncn-m#`) Resubscribe all compute nodes.
+    1. Resubscribe all compute nodes.
 
         ```bash
-        TMPFILE=$(mktemp)
-        sat status --no-borders --no-headings | grep Ready | grep Compute | awk '{printf("nid%06d-nmn\n",$4);}' > $TMPFILE
-        pdsh -w ^${TMPFILE} "systemctl restart cray-orca"
-        rm -rf $TMPFILE
+        ncn-m# TMPFILE=$(mktemp)
+        ncn-m# sat status --no-borders --no-headings | grep Ready | grep Compute | awk '{printf("nid%06d-nmn\n",$4);}' > $TMPFILE
+        ncn-m# pdsh -w ^${TMPFILE} "systemctl restart cray-orca"
+        ncn-m# rm -rf $TMPFILE
         ```
 
-    1. (`ncn-m#`) Resubscribe the NCNs.
+    1. Resubscribe the NCNs.
 
         **`NOTE`** Modify the `-w` arguments in the following commands to reflect the number of worker and storage nodes in the system.
 
         ```bash
-        pdsh -w ncn-w00[1-4]-can.local "systemctl restart cray-orca"
-        pdsh -w ncn-s00[1-4]-can.local "systemctl restart cray-orca"
+        ncn-m# pdsh -w ncn-w00[1-4]-can.local "systemctl restart cray-orca"
+        ncn-m# pdsh -w ncn-s00[1-4]-can.local "systemctl restart cray-orca"
         ```

--- a/operations/kubernetes/Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md
+++ b/operations/kubernetes/Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md
@@ -96,7 +96,7 @@ Repopulate clusters for CPS.
 1. Find the name of the running CRUS pod.
 
     ```bash
-    kubectl get pods -n services | grep cray-crus
+    ncn# kubectl get pods -n services | grep cray-crus
     ```
 
     Example output:

--- a/operations/security_and_authentication/Change_Credentials_on_ServerTech_PDUs.md
+++ b/operations/security_and_authentication/Change_Credentials_on_ServerTech_PDUs.md
@@ -8,18 +8,19 @@ all ServerTech PDUs in the system can be updated to the same global credentials.
 - This procedure does not update the default credentials that RTS uses for new ServerTech PDUs added to a system. To change the default credentials, see
   [Update default ServerTech PDU Credentials used by the Redfish Translation Service](Update_Default_ServerTech_PDU_Credentials_used_by_the_Redfish_Translation_Service.md).
 - ServerTech PDUs running firmware version `8.0q` or greater must have the password of the `admn` user changed before the JAWS REST API will function as expected.
+- The default user/password for ServerTech PDUs is `admn`/`admn`.
 
 ## Prerequisites
 
-- All of the commands in these procedures should be run from a master or worker node, unless otherwise indicated.
 - The Cray command line interface (CLI) is initialized and configured on the system. See [Configure the Cray CLI](../configure_cray_cli.md).
 - The PDU is accessible over the network. A PDU can be reachable by its component name (xname) hostname, but may not yet be discovered by HSM.
 - PDUs are manufactured by ServerTech.
-    This can be verified by the following command
+
+    (`ncn-mw#`) This can be verified by the following command
 
     ```bash
-    ncn-mw# PDU=x3000m0
-    ncn-mw# curl -k https://$PDU -i | grep Server
+    PDU=x3000m0
+    curl -k -s --compressed  https://$PDU -i | grep Server:
     ```
 
     Expected output for a ServerTech PDU:
@@ -28,12 +29,14 @@ all ServerTech PDUs in the system can be updated to the same global credentials.
     Server: ServerTech-AWS/v8.0v
     ```
 
+    *NOTE*: The firmware version is listed after the '/'. In this case, the firmware version is `8.0v`.
+
 ## Procedure
 
-1. List the ServerTech PDUs currently discovered in the system.
+1. (`ncn-mw#`) List the ServerTech PDUs currently discovered in the system.
 
     ```bash
-    ncn-mw# cray hsm inventory redfishEndpoints list --type CabinetPDUController --format json |
+    cray hsm inventory redfishEndpoints list --type CabinetPDUController --format json |
         jq -r '.RedfishEndpoints[] | select(.FQDN | contains("rts")).ID'
     ```
 
@@ -43,32 +46,34 @@ all ServerTech PDUs in the system can be updated to the same global credentials.
     x3000m0
     ```
 
-1. Set up Vault password variable and command alias.
+    If some or all of the PDUs have NOT been discovered by HSM, you must obtain the component name (xname) for each of the ServerTech PDUs on the system.
+
+1. (`ncn-mw#`) Set up Vault password variable and command alias.
 
     ```bash
-    ncn-mw# VAULT_PASSWD=$(kubectl -n vault get secrets cray-vault-unseal-keys -o json | jq -r '.data["vault-root"]' |  base64 -d)
-    ncn-mw# alias vault='kubectl -n vault exec -i cray-vault-0 -c vault -- env VAULT_TOKEN=$VAULT_PASSWD VAULT_ADDR=http://127.0.0.1:8200 VAULT_FORMAT=json vault'
+    VAULT_PASSWD=$(kubectl -n vault get secrets cray-vault-unseal-keys -o json | jq -r '.data["vault-root"]' |  base64 -d)
+    alias vault='kubectl -n vault exec -i cray-vault-0 -c vault -- env VAULT_TOKEN=$VAULT_PASSWD VAULT_ADDR=http://127.0.0.1:8200 VAULT_FORMAT=json vault'
     ```
 
-1. Look up the existing password for the `admn` user.
+1. (`ncn-mw#`) Look up the existing password for the `admn` user.
 
     - To extract the global credentials from Vault for the PDUs:
 
         ```bash
-        ncn-mw# vault kv get secret/pdu-creds/global/pdu
+        vault kv get secret/pdu-creds/global/pdu
         ```
 
     - To extract the credentials from Vault for a single PDU:
 
         ```bash
-        ncn-mw# PDU=x3000m0
-        ncn-mw# vault kv get secret/pdu-creds/$PDU
+        PDU=x3000m0
+        vault kv get secret/pdu-creds/$PDU
         ```
 
-1. Store the existing password for the `admn` user.
+1. (`ncn-mw#`) Store the existing password for the `admn` user.
 
     ```bash
-    ncn-mw# read -s OLD_PDU_PASSWORD
+    read -s OLD_PDU_PASSWORD
     ```
 
 1. Specify the new desired password for the `admn` user. The new password must follow the following criteria:
@@ -79,7 +84,7 @@ all ServerTech PDUs in the system can be updated to the same global credentials.
     - At least 1 number character
 
     ```bash
-    ncn-mw# read -s NEW_PDU_PASSWORD
+    read -s NEW_PDU_PASSWORD
     ```
 
 1. Change and update the password for ServerTech PDUs.
@@ -88,25 +93,23 @@ all ServerTech PDUs in the system can be updated to the same global credentials.
 
     - Update the password on a single ServerTech PDU
 
-        **NOTE**: To change the password on a single PDU, that PDU must be successfully discovered by HSM.
-
-        1. Set the PDU hostname to change the `admn` credentials:
+        1. (`ncn-mw#`) Set the PDU hostname to change the `admn` credentials:
 
             ```bash
-            ncn-mw# PDU=x3000m0
+            PDU=x3000m0
             ```
 
-        1. Verify that the PDU is reachable:
+        1. (`ncn-mw#`) Verify that the PDU is reachable:
 
             ```bash
-            ncn-mw# ping $PDU
+            ping $PDU
             ```
 
-        1. Change password for the `admn` user on the ServerTech PDU.
+        1. (`ncn-mw#`) Change password for the `admn` user on the ServerTech PDU.
 
             ```bash
-            ncn-mw# curl -i -k -u "admn:$OLD_PDU_PASSWORD" -X PATCH https://$PDU/jaws/config/users/local/admn \
-                -d $(jq --arg PASSWORD "$NEW_PDU_PASSWORD" -nc '{password: $PASSWORD}')
+            curl -i -k -u "admn:$OLD_PDU_PASSWORD" -X PATCH https://$PDU/jaws/config/users/local/admn \
+                 -d $(jq --arg PASSWORD "$NEW_PDU_PASSWORD" -nc '{password: $PASSWORD}')
             ```
 
             Expected output upon a successful password change:
@@ -121,25 +124,27 @@ all ServerTech PDUs in the system can be updated to the same global credentials.
             Pragma: JAWS v1.01
             ```
 
-        1. Update the PDU credentials stored in Vault.
+        1. (`ncn-mw#`) Update the PDU credentials stored in Vault.
 
             ```bash
-            ncn-mw# vault kv get secret/pdu-creds/$PDU |
+            vault kv get secret/pdu-creds/$PDU |
                     jq --arg PASSWORD "$NEW_PDU_PASSWORD" '.data | .Password=$PASSWORD' |
                     vault kv put secret/pdu-creds/$PDU -
             ```
 
     - Update all ServerTech PDUs in the system to the same password.
 
-        1. Change password for the `admn` user on the ServerTech PDUs currently discovered in the system.
+        **NOTE**: To change the password on all PDUs, that PDUs must be successfully discovered by HSM.
+
+        1. (`ncn-mw#`) Change password for the `admn` user on the ServerTech PDUs currently discovered in the system.
 
             ```bash
-            ncn-mw# for PDU in $(cray hsm inventory redfishEndpoints list --type CabinetPDUController --format json |
-                      jq -r '.RedfishEndpoints[] | select(.FQDN | contains("rts")).ID'); do
-                          echo "Updating password on $PDU"
-                          curl -i -k -u "admn:$OLD_PDU_PASSWORD" -X PATCH https://$PDU/jaws/config/users/local/admn \
-                                -d $(jq --arg PASSWORD "$NEW_PDU_PASSWORD" -nc '{password: $PASSWORD}')
-                    done
+            for PDU in $(cray hsm inventory redfishEndpoints list --type CabinetPDUController --format json |
+            jq -r '.RedfishEndpoints[] | select(.FQDN | contains("rts")).ID'); do
+                echo "Updating password on $PDU"
+                curl -i -k -u "admn:$OLD_PDU_PASSWORD" -X PATCH https://$PDU/jaws/config/users/local/admn \
+                    -d $(jq --arg PASSWORD "$NEW_PDU_PASSWORD" -nc '{password: $PASSWORD}')
+            done
             ```
 
             Expected output upon a successful password change:
@@ -163,37 +168,37 @@ all ServerTech PDUs in the system can be updated to the same global credentials.
             Pragma: JAWS v1.01
             ```
 
-        1. Update Vault for all ServerTech PDUs in the system to the same password:
+        1. (`ncn-mw#`) Update Vault for all ServerTech PDUs in the system to the same password:
 
             ```bash
-            ncn-mw# for PDU in $(cray hsm inventory redfishEndpoints list --type CabinetPDUController --format json |
-                      jq -r '.RedfishEndpoints[] | select(.FQDN | contains("rts")).ID'); do
-                          echo "Updating password on $PDU"
-                          vault kv get secret/pdu-creds/$PDU |
-                            jq --arg PASSWORD "$NEW_PDU_PASSWORD" '.data | .Password=$PASSWORD' |
-                            vault kv put secret/pdu-creds/$PDU -
-                    done
+            for PDU in $(cray hsm inventory redfishEndpoints list --type CabinetPDUController --format json |
+              jq -r '.RedfishEndpoints[] | select(.FQDN | contains("rts")).ID'); do
+                echo "Updating password on $PDU"
+                vault kv get secret/pdu-creds/$PDU |
+                    jq --arg PASSWORD "$NEW_PDU_PASSWORD" '.data | .Password=$PASSWORD' |
+                    vault kv put secret/pdu-creds/$PDU -
+            done
             ```
 
-    **NOTE**: After five minutes, the previous credential should stop working as the existing sessions time out.
+            **NOTE**: After five minutes, the previous credential should stop working as the existing sessions time out.
 
-1. Restart the Redfish Translation Service (RTS) to pickup the new PDU credentials.
+1. (`ncn-mw#`) Restart the Redfish Translation Service (RTS) to pickup the new PDU credentials.
 
     ```bash
-    ncn-mw# kubectl -n services rollout restart deployment cray-hms-rts
-    ncn-mw# kubectl -n services rollout status deployment cray-hms-rts
+    kubectl -n services rollout restart deployment cray-hms-rts
+    kubectl -n services rollout status deployment cray-hms-rts
     ```
 
-1. Wait for RTS to initialize itself.
+1. (`ncn-mw#`) Wait for RTS to initialize itself.
 
     ```bash
-    ncn-mw# sleep 3m
+    sleep 3m
     ```
 
-1. Verify that RTS was able to communicate with the PDUs with the updated credentials.
+1. (`ncn-mw#`) Verify that RTS was able to communicate with the PDUs with the updated credentials.
 
     ```bash
-    ncn-mw# kubectl -n services exec -it deployment/cray-hms-rts -c cray-hms-rts-redis -- redis-cli keys '*/redfish/v1/Managers'
+    kubectl -n services exec -it deployment/cray-hms-rts -c cray-hms-rts-redis -- redis-cli keys '*/redfish/v1/Managers'
     ```
 
     Expected output for a system with two PDUs.

--- a/operations/security_and_authentication/Change_Credentials_on_ServerTech_PDUs.md
+++ b/operations/security_and_authentication/Change_Credentials_on_ServerTech_PDUs.md
@@ -180,7 +180,7 @@ all ServerTech PDUs in the system can be updated to the same global credentials.
             done
             ```
 
-            **NOTE**: After five minutes, the previous credential should stop working as the existing sessions time out.
+            **`NOTE`**: After five minutes, the previous credential should stop working as the existing sessions time out.
 
 1. (`ncn-mw#`) Restart the Redfish Translation Service (RTS) to pickup the new PDU credentials.
 

--- a/operations/security_and_authentication/Change_Credentials_on_ServerTech_PDUs.md
+++ b/operations/security_and_authentication/Change_Credentials_on_ServerTech_PDUs.md
@@ -134,7 +134,7 @@ all ServerTech PDUs in the system can be updated to the same global credentials.
 
     - Update all ServerTech PDUs in the system to the same password.
 
-        **NOTE**: To change the password on all PDUs, that PDUs must be successfully discovered by HSM.
+        **`NOTE`**: To change the password on all PDUs, PDUs must be successfully discovered by HSM.
 
         1. (`ncn-mw#`) Change password for the `admn` user on the ServerTech PDUs currently discovered in the system.
 

--- a/operations/security_and_authentication/Change_Credentials_on_ServerTech_PDUs.md
+++ b/operations/security_and_authentication/Change_Credentials_on_ServerTech_PDUs.md
@@ -66,8 +66,8 @@ all ServerTech PDUs in the system can be updated to the same global credentials.
     - To extract the credentials from Vault for a single PDU:
 
         ```bash
-        PDU=x3000m0
-        vault kv get secret/pdu-creds/$PDU
+        ncn-mw# PDU=x3000m0
+        ncn-mw# vault kv get secret/pdu-creds/$PDU
         ```
 
 1. Store the existing password for the `admn` user.
@@ -84,7 +84,7 @@ all ServerTech PDUs in the system can be updated to the same global credentials.
     - At least 1 number character
 
     ```bash
-    read -s NEW_PDU_PASSWORD
+    ncn-mw# read -s NEW_PDU_PASSWORD
     ```
 
 1. Change and update the password for ServerTech PDUs.

--- a/operations/security_and_authentication/Change_Credentials_on_ServerTech_PDUs.md
+++ b/operations/security_and_authentication/Change_Credentials_on_ServerTech_PDUs.md
@@ -29,7 +29,7 @@ all ServerTech PDUs in the system can be updated to the same global credentials.
     Server: ServerTech-AWS/v8.0v
     ```
 
-    *NOTE*: The firmware version is listed after the '/'. In this case, the firmware version is `8.0v`.
+    **`NOTE`**: The firmware version is listed after the '/'. In this case, the firmware version is `8.0v`.
 
 ## Procedure
 

--- a/operations/security_and_authentication/Change_Credentials_on_ServerTech_PDUs.md
+++ b/operations/security_and_authentication/Change_Credentials_on_ServerTech_PDUs.md
@@ -46,7 +46,7 @@ all ServerTech PDUs in the system can be updated to the same global credentials.
     x3000m0
     ```
 
-    If some or all of the PDUs have NOT been discovered by HSM, you must obtain the component name (xname) for each of the ServerTech PDUs on the system.
+    If some or all of the PDUs are not discovered by HSM, you must obtain the component name (`xname`) for each of the ServerTech PDUs on the system.
 
 1. (`ncn-mw#`) Set up Vault password variable and command alias.
 

--- a/operations/security_and_authentication/Change_Credentials_on_ServerTech_PDUs.md
+++ b/operations/security_and_authentication/Change_Credentials_on_ServerTech_PDUs.md
@@ -20,7 +20,7 @@ all ServerTech PDUs in the system can be updated to the same global credentials.
 
     ```bash
     ncn-mw# PDU=x3000m0
-    ncn-mw# curl -k -s --compressed  https://$PDU -i | grep Server:
+    ncn-mw# curl -k -s --compressed  https://${PDU} -i | grep Server:
     ```
 
     Expected output for a ServerTech PDU:
@@ -46,7 +46,7 @@ all ServerTech PDUs in the system can be updated to the same global credentials.
     x3000m0
     ```
 
-    If some or all of the PDUs are not discovered by HSM, you must obtain the component name (`xname`) for each of the ServerTech PDUs on the system.
+    If any of the PDUs are not discovered by HSM, then the component name (`xname`) for each of the ServerTech PDUs on the system must be obtained.
 
 1. Set up Vault password variable and command alias.
 
@@ -108,8 +108,8 @@ all ServerTech PDUs in the system can be updated to the same global credentials.
         1. Change password for the `admn` user on the ServerTech PDU.
 
             ```bash
-            ncn-mw# curl -i -k -u "admn:$OLD_PDU_PASSWORD" -X PATCH https://$PDU/jaws/config/users/local/admn \
-                 -d $(jq --arg PASSWORD "$NEW_PDU_PASSWORD" -nc '{password: $PASSWORD}')
+            ncn-mw# curl -i -k -u "admn:${OLD_PDU_PASSWORD}" -X PATCH https://${PDU}/jaws/config/users/local/admn \
+                 -d $(jq --arg PASSWORD "${NEW_PDU_PASSWORD}" -nc '{password: $PASSWORD}')
             ```
 
             Expected output upon a successful password change:
@@ -134,16 +134,16 @@ all ServerTech PDUs in the system can be updated to the same global credentials.
 
     - Update all ServerTech PDUs in the system to the same password.
 
-        **`NOTE`**: To change the password on all PDUs, PDUs must be successfully discovered by HSM.
+        **`NOTE`**: In order to change the password on all PDUs, the PDUs must be successfully discovered by HSM.
 
         1. Change password for the `admn` user on the ServerTech PDUs currently discovered in the system.
 
             ```bash
             ncn-mw# for PDU in $(cray hsm inventory redfishEndpoints list --type CabinetPDUController --format json |
             jq -r '.RedfishEndpoints[] | select(.FQDN | contains("rts")).ID'); do
-                echo "Updating password on $PDU"
-                curl -i -k -u "admn:$OLD_PDU_PASSWORD" -X PATCH https://$PDU/jaws/config/users/local/admn \
-                    -d $(jq --arg PASSWORD "$NEW_PDU_PASSWORD" -nc '{password: $PASSWORD}')
+                echo "Updating password on ${PDU}"
+                curl -i -k -u "admn:${OLD_PDU_PASSWORD}" -X PATCH https://${PDU}/jaws/config/users/local/admn \
+                    -d $(jq --arg PASSWORD "${NEW_PDU_PASSWORD}" -nc '{password: $PASSWORD}')
             done
             ```
 
@@ -173,14 +173,14 @@ all ServerTech PDUs in the system can be updated to the same global credentials.
             ```bash
             ncn-mw# for PDU in $(cray hsm inventory redfishEndpoints list --type CabinetPDUController --format json |
               jq -r '.RedfishEndpoints[] | select(.FQDN | contains("rts")).ID'); do
-                echo "Updating password on $PDU"
-                vault kv get secret/pdu-creds/$PDU |
-                    jq --arg PASSWORD "$NEW_PDU_PASSWORD" '.data | .Password=$PASSWORD' |
-                    vault kv put secret/pdu-creds/$PDU -
+                echo "Updating password on ${PDU}"
+                vault kv get secret/pdu-creds/${PDU} |
+                    jq --arg PASSWORD "${NEW_PDU_PASSWORD}" '.data | .Password=$PASSWORD' |
+                    vault kv put secret/pdu-creds/${PDU} -
             done
             ```
 
-            **`NOTE`**: After five minutes, the previous credential should stop working as the existing sessions time out.
+            **NOTE**: After five minutes, the previous credential should stop working as the existing sessions time out.
 
 1. Restart the Redfish Translation Service (RTS) to pickup the new PDU credentials.
 

--- a/operations/security_and_authentication/Change_Credentials_on_ServerTech_PDUs.md
+++ b/operations/security_and_authentication/Change_Credentials_on_ServerTech_PDUs.md
@@ -8,7 +8,7 @@ all ServerTech PDUs in the system can be updated to the same global credentials.
 - This procedure does not update the default credentials that RTS uses for new ServerTech PDUs added to a system. To change the default credentials, see
   [Update default ServerTech PDU Credentials used by the Redfish Translation Service](Update_Default_ServerTech_PDU_Credentials_used_by_the_Redfish_Translation_Service.md).
 - ServerTech PDUs running firmware version `8.0q` or greater must have the password of the `admn` user changed before the JAWS REST API will function as expected.
-- The default user/password for ServerTech PDUs is `admn`/`admn`.
+- The default username and password for ServerTech PDUs is `admn` and `admn`.
 
 ## Prerequisites
 


### PR DESCRIPTION
# Description

[CASMINST-4608](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4608) - cray-hmnfd-etcd instructions reference nonexistent service
[CASMINST-4838](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4838) - ServerTech PDU documentation incomplete
[CASMHMS-5598](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5598) - Clarify failures of firmware updates related to locking
[CASMHMS-5556](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5556)  - Explain Declarative vs Imperative FAS updates

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
