### PR TITLE
CASMINST-5121 Remove spine_switch as the default --from-types parameter

### DIFF
--- a/scripts/operations/pyscripts/pyscripts/commands/cmd_test_bican_internal.py
+++ b/scripts/operations/pyscripts/pyscripts/commands/cmd_test_bican_internal.py
@@ -33,8 +33,8 @@ import click
     "--from-types",
     type=click.Choice(["ncn_master", "ncn_worker", "ncn_storage", "cn", "uan", "spine_switch", "leaf_switch", "leaf_BMC", "CDU"], case_sensitive=False),
     multiple=True,
-    default=["ncn_master", "spine_switch"],
-    help="What types of nodes to run the tests from. Defaults: ('ncn_master', 'spine_switch')"
+    default=["ncn_master"],
+    help="What types of nodes to run the tests from. Defaults: ('ncn_master')"
 )
 @click.option(
     "--to-types",


### PR DESCRIPTION
# Description

A lot of our internal testing yields unnecessary RemoteHostIdentificationChanged errors. These happen because:

1. NCNs are wiped for the next install/upgrade, thereby generating new keys.
2. The public keys stored in switches for these NCNs go stale because of the wipe.
3. SSH'ing from switches to NCN's therefore yields RemoteHostIdentificationChanged errors.
4. These errors are unavoidable because the SSH utility within the switch being used does not support supplying the flag ` -o StrictHostKeyChecking=no` (and there is no other way to disable strict host key checking)
5. Note that switches don't run python code, so it is the SSH binary being used on switches to conduct these tests, not some python library with which we can easily disable these tests.

Therefore, we have come to the conclusion that either:
1. We wipe stale keys on switches ourselves.
2. We disable the SSH tests from switches (switches -> NCNs and switches -> switches).

It was discussed that the use case for SSH'ing from switches was not a valid use case that customers have, and so it makes sense to disable these tests entirely by default.

The PR disables SSH'ing from switches by default, but the customer can always explicitly supply the command line parameter `--from-nodes=spine_switch` to re-enable these tests.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
