### PR TITLE
CASMPET-5838-1.3 : Break/Fix: Etcd health checks failing - need to specify etcd container

### DIFF
--- a/operations/kubernetes/Check_for_and_Clear_etcd_Cluster_Alarms.md
+++ b/operations/kubernetes/Check_for_and_Clear_etcd_Cluster_Alarms.md
@@ -4,25 +4,25 @@ Check for any etcd cluster alarms and clear them as needed. An etcd cluster alar
 
 For example, a cluster's database "NOSPACE" alarm is set when database storage space is no longer available. A subsequent defrag may free up database storage space, but writes to the database will continue to fail while the "NOSPACE" alarm is set.
 
-### Prerequisites
+## Prerequisites
 
--   This procedure requires root privileges.
--   The etcd clusters are in a healthy state.
+- This procedure requires root privileges.
+- The etcd clusters are in a healthy state.
 
-### Procedure
+## Procedure
 
-1.  Check for etcd cluster alarms.
+1. Check for etcd cluster alarms.
 
     An empty list will be returned if no alarms are set.
 
-    -   Check if any etcd alarms are set for etcd clusters in the services namespace.
+    - Check if any etcd alarms are set for etcd clusters in the services namespace.
 
         ```bash
         for pod in $(kubectl get pods -l etcd_cluster=cray-bos-etcd \
                              -n services -o jsonpath='{.items[*].metadata.name}')
         do
             echo "### ${pod} Alarms Set: ###"
-            kubectl -n services exec ${pod} -- /bin/sh \
+            kubectl -n services exec ${pod} -c etcd -- /bin/sh \
                     -c "ETCDCTL_API=3 etcdctl alarm list"
         done
         ```
@@ -30,13 +30,13 @@ For example, a cluster's database "NOSPACE" alarm is set when database storage s
         ```bash
         for pod in $(kubectl get pods -l app=etcd -n services \
         -o jsonpath='{.items[*].metadata.name}'); \
-        do echo "### ${pod} Alarms Set: ###"; kubectl -n services exec ${pod} -- /bin/sh -c \
+        do echo "### ${pod} Alarms Set: ###"; kubectl -n services exec ${pod} -c etcd -- /bin/sh -c \
         "ETCDCTL_API=3 etcdctl alarm list"; done
         ```
 
         Example output:
 
-        ```
+        ```text
         ### cray-bos-etcd-7cxq6qrhz5 Alarms Set: ###
         ### cray-bos-etcd-b9m4k5qfrd Alarms Set: ###
         ### cray-bos-etcd-tnpv8x6cxv Alarms Set: ###
@@ -55,14 +55,14 @@ For example, a cluster's database "NOSPACE" alarm is set when database storage s
         [...]
         ```
 
-    -   Check if any etcd alarms are set for a particular etcd cluster in the services namespace.
+    - Check if any etcd alarms are set for a particular etcd cluster in the services namespace.
 
         ```bash
         for pod in $(kubectl get pods -l etcd_cluster=cray-bos-etcd \
                              -n services -o jsonpath='{.items[*].metadata.name}')
         do
             echo "### ${pod} Alarms Set: ###"
-            kubectl -n services exec ${pod} -- /bin/sh \
+            kubectl -n services exec ${pod} -c etcd -- /bin/sh \
                     -c "ETCDCTL_API=3 etcdctl alarm list"
         done
         ```
@@ -70,30 +70,30 @@ For example, a cluster's database "NOSPACE" alarm is set when database storage s
         ```bash
         for pod in $(kubectl get pods -l etcd_cluster=cray-bos-etcd \
         -n services -o jsonpath='{.items[*].metadata.name}'); do echo "### \
-        ${pod} Alarms Set: ###"; kubectl -n services exec ${pod} -- /bin/sh -c \
+        ${pod} Alarms Set: ###"; kubectl -n services exec ${pod} -c etcd -- /bin/sh -c \
         "ETCDCTL_API=3 etcdctl alarm list"; done
         ```
 
         Example output:
 
-        ```
+        ```text
         ### cray-bos-etcd-7cxq6qrhz5 Alarms Set: ###
         ### cray-bos-etcd-b9m4k5qfrd Alarms Set: ###
         ### cray-bos-etcd-tnpv8x6cxv Alarms Set: ###
         ```
 
-2.  Clear any etcd cluster alarms.
+2. Clear any etcd cluster alarms.
 
     A list of disarmed alarms will be returned. An empty list is returned if no alarms were set.
 
-    -   Clear all etcd alarms set in etcd clusters.
+    - Clear all etcd alarms set in etcd clusters.
 
         ```bash
         for pod in $(kubectl get pods -l app=etcd -n services \
                              -o jsonpath='{.items[*].metadata.name}')
         do
             echo "### ${pod} Disarmed Alarms: ###"
-            kubectl -n services exec ${pod} -- /bin/sh \
+            kubectl -n services exec ${pod} -c etcd -- /bin/sh \
                     -c "ETCDCTL_API=3 etcdctl alarm disarm"
         done
         ```
@@ -101,13 +101,13 @@ For example, a cluster's database "NOSPACE" alarm is set when database storage s
         ```bash
         for pod in $(kubectl get pods -l app=etcd -n services -o \
         jsonpath='{.items[*].metadata.name}'); do echo "### ${pod} Disarmed Alarms: \
-        ###"; kubectl -n services exec ${pod} -- /bin/sh -c \
+        ###"; kubectl -n services exec ${pod} -c etcd -- /bin/sh -c \
         "ETCDCTL_API=3 etcdctl alarm disarm"; done
         ```
 
         Example output:
 
-        ```
+        ```text
         ### cray-bos-etcd-7cxq6qrhz5 Disarmed Alarms: ###
         ### cray-bos-etcd-b9m4k5qfrd Disarmed Alarms: ###
         ### cray-bos-etcd-tnpv8x6cxv Disarmed Alarms: ###
@@ -120,14 +120,14 @@ For example, a cluster's database "NOSPACE" alarm is set when database storage s
         [...]
         ```
 
-    -   Clear all alarms in one particular etcd cluster.
+    - Clear all alarms in one particular etcd cluster.
 
         ```bash
         for pod in $(kubectl get pods -l etcd_cluster=cray-bos-etcd \
                              -n services -o jsonpath='{.items[*].metadata.name}')
         do
             echo "### ${pod} Disarmed Alarms:  ###"
-            kubectl -n services exec ${pod} -- /bin/sh \
+            kubectl -n services exec ${pod} -c etcd -- /bin/sh \
                     -c "ETCDCTL_API=3 etcdctl alarm disarm"
         done
         ```
@@ -135,13 +135,13 @@ For example, a cluster's database "NOSPACE" alarm is set when database storage s
         ```bash
         for pod in $(kubectl get pods -l etcd_cluster=cray-bos-etcd \
         -n services -o jsonpath='{.items[*].metadata.name}'); do echo "### ${pod} \
-        Disarmed Alarms:  ###"; kubectl -n services exec ${pod} -- /bin/sh \
+        Disarmed Alarms:  ###"; kubectl -n services exec ${pod} -c etcd -- /bin/sh \
         -c "ETCDCTL_API=3 etcdctl alarm disarm"; done
         ```
 
         Example output:
 
-        ```
+        ```text
         ### cray-bos-etcd-7cxq6qrhz5 Disarmed Alarms:  ###
         memberID:14039380531903955557 alarm:NOSPACE
         memberID:10060051157615504224 alarm:NOSPACE
@@ -149,4 +149,3 @@ For example, a cluster's database "NOSPACE" alarm is set when database storage s
         ### cray-bos-etcd-b9m4k5qfrd Disarmed Alarms:  ###
         ### cray-bos-etcd-tnpv8x6cxv Disarmed Alarms:  ###
         ```
-

--- a/operations/kubernetes/Clear_Space_in_an_etcd_Cluster_Database.md
+++ b/operations/kubernetes/Clear_Space_in_an_etcd_Cluster_Database.md
@@ -4,34 +4,34 @@ Use this procedure to clear the etcd cluster NOSPACE alarm. Once it is set it wi
 
 Defragging the database cluster and clearing the etcd cluster NOSPACE alarm will free up database space.
 
-### Prerequisites
+## Prerequisites
 
 - This procedure requires root privileges
 - The etcd clusters are in a healthy state
 
-### Procedure
+## Procedure
 
-1.  Clear up space when the etcd database space has exceeded and has been defragged, but the NOSPACE alarm remains set.
+1. Clear up space when the etcd database space has exceeded and has been defragged, but the NOSPACE alarm remains set.
 
-    1.  Verify that the attempt to store a new key-value fails.
+    1. Verify that the attempt to store a new key-value fails.
 
-        Replace *hbtd-ETCD_CLUSTER* before running the following command.
+        Replace `hbtd-ETCD_CLUSTER` before running the following command.
         `hbtd-etcd-h59j42knjv` is an example replacement value.
 
         ```bash
-        kubectl -n services exec -it hbtd-ETCD_CLUSTER -- sh
+        kubectl -n services exec -it hbtd-ETCD_CLUSTER -c etcd -- sh
         ```
 
         Example output:
 
-        ```
+        ```text
         # export ETCDCTL_API=3
         # etcdctl put foo bar
         {"level":"warn","ts":"2020-10-23T23:56:48.408Z","caller":"clientv3/retry_interceptor.go:62","msg":"retrying of unary invoker failed","target":"endpoint://client-208534eb-2ab4-4c58-8853-58bff088c394/127.0.0.1:2379","attempt":0,"error":"rpc error: code = ResourceExhausted desc = etcdserver: mvcc: database space exceeded"}
         Error: etcdserver: mvcc: database space exceeded
         ```
 
-    2.  Check to see if the default 2G disk usage space \(unless defined different in the helm chart\) is currently exceeded.
+    2. Check to see if the default 2G disk usage space \(unless defined different in the helm chart\) is currently exceeded.
 
         In the following example, the disk usage is 375.5 M, which means the disk space has not been exceeded.
 
@@ -39,12 +39,12 @@ Defragging the database cluster and clearing the etcd cluster NOSPACE alarm will
         `hbtd-etcd-h59j42knjv` is an example replacement value.
 
         ```bash
-        kubectl -n services exec -it hbtd-ETCD_CLUSTER -- sh
+        kubectl -n services exec -it hbtd-ETCD_CLUSTER -c etcd -- sh
         ```
 
         Example output:
 
-        ```
+        ```text
         # df -h
         Filesystem                Size      Used Available Use% Mounted on
         overlay                 396.3G     59.6G    316.5G  16% /
@@ -56,14 +56,14 @@ Defragging the database cluster and clearing the etcd cluster NOSPACE alarm will
         /dev/sdc5               396.3G     59.6G    316.5G  16% /etc/resolv.conf
         ```
 
-    3.  Clear the NOSPACE alarm.
+    3. Clear the NOSPACE alarm.
 
         ```bash
         for pod in $(kubectl get pods -l etcd_cluster=hbtd-etcd \
                              -n services -o jsonpath='{.items[*].metadata.name}')
         do
             echo "### ${pod} ###"
-            kubectl -n services exec ${pod} -- /bin/sh \
+            kubectl -n services exec ${pod} -c etcd -- /bin/sh \
                     -c "ETCDCTL_API=3 etcdctl alarm disarm"
         done
         ```
@@ -73,13 +73,13 @@ Defragging the database cluster and clearing the etcd cluster NOSPACE alarm will
         ```bash
         for pod in $(kubectl get pods -l etcd_cluster=hbtd-etcd \
         -n services -o jsonpath='{.items[*].metadata.name}'); do echo "### ${pod} ###"; \
-        kubectl -n services exec ${pod} -- /bin/sh \
+        kubectl -n services exec ${pod} -c etcd -- /bin/sh \
         -c "ETCDCTL_API=3 etcdctl alarm disarm"; done
         ```
 
         Example output:
 
-        ```
+        ```text
         ### hbtd-etcd-h59j42knjv ###
         memberID:6004340417806974740 alarm:NOSPACE
         memberID:10618826089438871005 alarm:NOSPACE
@@ -88,21 +88,21 @@ Defragging the database cluster and clearing the etcd cluster NOSPACE alarm will
         ### hbtd-etcd-mhklm4n5qd ###
         ```
 
-    4.  Verify a new key-value can now be successfully stored.
+    4. Verify a new key-value can now be successfully stored.
 
         Replace *hbtd-ETCD_CLUSTER* before running the following command.
         `hbtd-etcd-h59j42knjv` is an example replacement value.
 
         ```bash
-        kubectl -n services exec -it hbtd-ETCD_CLUSTER -- sh
+        kubectl -n services exec -it hbtd-ETCD_CLUSTER -c etcd -- sh
         export ETCDCTL_API=3
         etcdctl put foo bar
         OK
         ```
 
-2.  Clear the NOSPACE alarm. If the database needs to be defragged, the alarm will be reset.
+2. Clear the NOSPACE alarm. If the database needs to be defragged, the alarm will be reset.
 
-    1.  Confirm the "database space exceeded" message is present.
+    1. Confirm the "database space exceeded" message is present.
 
         ```bash
         kubectl logs -n services --tail=-1 --prefix=true -l \
@@ -111,7 +111,7 @@ Defragging the database cluster and clearing the etcd cluster NOSPACE alarm will
 
         Example output:
 
-        ```
+        ```text
         [pod/cray-hbtd-56bc4f6fdb-92bqx/cray-hbtd] 2020/09/15 20:00:44 INTERNAL ERROR storing key  {"Component":"x3005c0s19b1n0","Last_hb_rcv_time":"5f611d6c","Last_hb_timestamp":"2020-09-15T15:00:44.878876-06:00","Last_hb_status":"OK","Had_warning":""} :  etcdserver: mvcc: database space exceeded
         [pod/cray-hbtd-56bc4f6fdb-92bqx/cray-hbtd] 2020/09/15 20:00:47 INTERNAL ERROR storing key  {"Component":"x3005c0s19b1n0","Last_hb_rcv_time":"5f611d6f","Last_hb_timestamp":"2020-09-15T15:00:47.893757-06:00","Last_hb_status":"OK","Had_warning":""} :  etcdserver: mvcc: database space exceeded
         [pod/cray-hbtd-56bc4f6fdb-92bqx/cray-hbtd] 2020/09/15 20:00:53 INTERNAL ERROR storing key  {"Component":"x3005c0s19b1n0","Last_hb_rcv_time":"5f611d75","Last_hb_timestamp":"2020-09-15T15:00:53.926195-06:00","Last_hb_status":"OK","Had_warning":""} :  etcdserver: mvcc: database space exceeded
@@ -119,18 +119,18 @@ Defragging the database cluster and clearing the etcd cluster NOSPACE alarm will
         [pod/cray-hbtd-56bc4f6fdb-92bqx/cray-hbtd] 2020/09/15 20:01:05 INTERNAL ERROR storing key  {"Component":"x3005c0s19b1n0","Last_hb_rcv_time":"5f611d81","Last_hb_timestamp":"2020-09-15T15:01:05.983828-06:00","Last_hb_status":"OK","Had_warning":""} :  etcdserver: mvcc: database space exceeded
         ```
 
-    2.  Check if the default 2G \(unless defined different in the helm chart\) disk usage has been exceeded.
+    2. Check if the default 2G \(unless defined different in the helm chart\) disk usage has been exceeded.
 
         Replace *ETCD_CLUSTER_NAME* before running the following command.
         For example, `cray-hbtd-etcd-6p4tc4jdgm` could be used.
 
         ```bash
-        kubectl exec -it -n services ETCD_CLUSTER_NAME -- sh
+        kubectl exec -it -n services ETCD_CLUSTER_NAME -c etcd -- sh
         ```
 
         Example output:
 
-        ```
+        ```text
         # df -h
         Filesystem                Size      Used Available Use% Mounted on
         overlay                 439.1G     15.2G    401.5G   4% /
@@ -139,11 +139,11 @@ Defragging the database cluster and clearing the etcd cluster NOSPACE alarm will
         /dev/rbd3                 7.8G      2.4G      5.4G  31% /var/etcd
         ```
 
-    3.  Resolve the space issue by either increasing the frequency of how often the etcd-defrag cron job is run, or by triggering it manually.
+    3. Resolve the space issue by either increasing the frequency of how often the etcd-defrag cron job is run, or by triggering it manually.
 
         Select one of the following options:
 
-        -   Increase the frequency of the kube-etcd-defrag from every 24 hours to 12 hours.
+        - Increase the frequency of the kube-etcd-defrag from every 24 hours to 12 hours.
 
             ```bash
             kubectl edit -n operators cronjob.batch/kube-etcd-defrag
@@ -151,7 +151,7 @@ Defragging the database cluster and clearing the etcd cluster NOSPACE alarm will
 
             Example output:
 
-            ```
+            ```text
             [...]
 
                           name: etcd-defrag
@@ -164,7 +164,7 @@ Defragging the database cluster and clearing the etcd cluster NOSPACE alarm will
             [...]
             ```
 
-        -   Trigger the job manually.
+        - Trigger the job manually.
 
             ```bash
             kubectl -n operators create job --from=cronjob/kube-etcd-defrag kube-etcd-defrag
@@ -175,7 +175,7 @@ Defragging the database cluster and clearing the etcd cluster NOSPACE alarm will
             --from=cronjob/kube-etcd-defrag kube-etcd-defrag
             ```
 
-    4.  Check the log messages after the defrag job is triggered.
+    4. Check the log messages after the defrag job is triggered.
 
         ```bash
         kubectl logs -f -n operators pod/kube-etcd-defrag-1600171200-fxpn7
@@ -183,7 +183,7 @@ Defragging the database cluster and clearing the etcd cluster NOSPACE alarm will
 
         Example output:
 
-        ```
+        ```text
         Defragging cray-bos-etcd-j7czpr9pbr
         Defragging cray-bos-etcd-k4qtjtgqjb
         Defragging cray-bos-etcd-wcm8cs7dvc
@@ -201,18 +201,18 @@ Defragging the database cluster and clearing the etcd cluster NOSPACE alarm will
         [...]
         ```
 
-    5.  Verify the disk space is less than the size limit.
+    5. Verify the disk space is less than the size limit.
 
         Replace *ETCD_CLUSTER_NAME* before running the following command.
         For example, `cray-hbtd-etcd-6p4tc4jdgm` could be used.
 
         ```bash
-        kubectl exec -it -n services ETCD_CLUSTER_NAME -- sh
+        kubectl exec -it -n services ETCD_CLUSTER_NAME -c etcd -- sh
         ```
 
         Example output:
 
-        ```
+        ```text
         # df -h
         Filesystem                Size      Used Available Use% Mounted on
         overlay                 439.1G     15.2G    401.5G   4% /
@@ -221,21 +221,20 @@ Defragging the database cluster and clearing the etcd cluster NOSPACE alarm will
         /dev/rbd3                 7.8G    403.0M      7.4G   5% /var/etcd.
         ```
 
-    6.  Turn off the NOSPACE alarm.
+    6. Turn off the NOSPACE alarm.
 
         Replace *ETCD_CLUSTER_NAME* before running the following command.
         For example, `cray-hbtd-etcd-6p4tc4jdgm` could be used.
 
         ```bash
-        kubectl exec -it -n services ETCD_CLUSTER_NAME -- sh
+        kubectl exec -it -n services ETCD_CLUSTER_NAME -c etcd -- sh
         ```
 
         Example output:
 
-        ```
+        ```text
         # ETCDCTL_API=3 etcdctl alarm disarm
         memberID:14039380531903955557 alarm:NOSPACE
         memberID:10060051157615504224 alarm:NOSPACE
         memberID:9418794810465807950 alarm:NOSPACE
         ```
-

--- a/operations/kubernetes/Report_the_Endpoint_Status_for_etcd_Clusters.md
+++ b/operations/kubernetes/Report_the_Endpoint_Status_for_etcd_Clusters.md
@@ -4,14 +4,14 @@ Report etcd cluster end point status. The report includes a cluster's endpoint, 
 
 This procedure provides the ability to view the etcd cluster endpoint status.
 
-### Prerequisites
+## Prerequisites
 
 - This procedure requires root privileges.
 - The etcd clusters are in a healthy state.
 
-### Procedure
+## Procedure
 
-1.  Report the endpoint status for all etcd clusters in a namespace.
+1. Report the endpoint status for all etcd clusters in a namespace.
 
     The following example is for the services namespace.
 
@@ -20,7 +20,7 @@ This procedure provides the ability to view the etcd cluster endpoint status.
                          -o jsonpath='{.items[*].metadata.name}')
     do
         echo "### ${pod} Endpoint Status: ###"
-        kubectl -n services exec ${pod} -- /bin/sh \
+        kubectl -n services exec ${pod} -c etcd -- /bin/sh \
                 -c "ETCDCTL_API=3 etcdctl endpoint status -w table"
     done
     ```
@@ -30,13 +30,13 @@ This procedure provides the ability to view the etcd cluster endpoint status.
     ```bash
     for pod in $(kubectl get pods -l app=etcd -n services -o \
     jsonpath='{.items[*].metadata.name}'); do echo "### ${pod} Endpoint Status: ###"; \
-    kubectl -n services exec ${pod} -- /bin/sh -c \
+    kubectl -n services exec ${pod} -c etcd -- /bin/sh -c \
     "ETCDCTL_API=3 etcdctl endpoint status -w table"; done;
     ```
 
     Example output:
 
-    ```
+    ```text
     ### cray-bos-etcd-7cxq6qrhz5 Endpoint Status: ###
     +----------------+------------------+---------+---------+-----------+-----------+------------+
     |    ENDPOINT    |        ID        | VERSION | DB SIZE | IS LEADER | RAFT TERM | RAFT INDEX |
@@ -77,7 +77,7 @@ This procedure provides the ability to view the etcd cluster endpoint status.
     [...]
     ```
 
-2.  Report the endpoint status for a singe etcd cluster in a namespace.
+2. Report the endpoint status for a singe etcd cluster in a namespace.
 
     The following example is for the services namespace.
 
@@ -86,7 +86,7 @@ This procedure provides the ability to view the etcd cluster endpoint status.
                          -o jsonpath='{.items[*].metadata.name}')
     do
         echo "### ${pod} Endpoint Status: ###"
-        kubectl -n services exec ${pod} -- /bin/sh \
+        kubectl -n services exec ${pod} -c etcd -- /bin/sh \
                 -c "ETCDCTL_API=3 etcdctl endpoint status -w table"
     done
     ```
@@ -96,13 +96,13 @@ This procedure provides the ability to view the etcd cluster endpoint status.
     ```bash
     for pod in $(kubectl get pods -l etcd_cluster=cray-bos-etcd -n services \
     -o jsonpath='{.items[*].metadata.name}'); do echo "### ${pod} Endpoint Status: \
-    ###"; kubectl -n services exec ${pod} -- /bin/sh -c \
+    ###"; kubectl -n services exec ${pod} -c etcd -- /bin/sh -c \
     "ETCDCTL\_API=3 etcdctl endpoint status -w table"; done
     ```
 
     Example output:
 
-    ```
+    ```text
     ### cray-bos-etcd-7cxq6qrhz5 Endpoint Status: ###
     +----------------+------------------+---------+---------+-----------+-----------+------------+
     |    ENDPOINT    |        ID        | VERSION | DB SIZE | IS LEADER | RAFT TERM | RAFT INDEX |
@@ -123,4 +123,3 @@ This procedure provides the ability to view the etcd cluster endpoint status.
     +----------------+------------------+---------+---------+-----------+-----------+------------+
 
     ```
-


### PR DESCRIPTION
# Description

Adding the container (-c etcd) when exec'ing into the etcd pods.
Not needed for csm 1.0 or 1.2.

# Checklist Before Merging

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
