### PR TITLE
CASMNET-1753 - Update documentation to reflect that cray-powerdns-manager now creates ExternalDNS PTR records

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -661,3 +661,6 @@ Admin
 
 - operations/system_management_health/Configure_Prometheus_Alerta_Alert_Notifications.md
 Alerta
+
+- operations/network/dns/DNS.md
+ExternalDNS

--- a/operations/network/dns/DNS.md
+++ b/operations/network/dns/DNS.md
@@ -14,7 +14,8 @@ The DNS infrastructure is comprised of a number of components.
 
 Unbound is a caching DNS resolver which is also used as the primary DNS server.
 
-The DNS records served by Unbound include system component names (xnames), node hostnames, and service names and these records are read from the `cray-dns-unbound` ConfigMap which is populated by `cray-dns-unbound-manager`.
+The DNS records served by Unbound include system component names (xnames), node hostnames, 
+and service names and these records are read from the `cray-dns-unbound` ConfigMap which is populated by `cray-dns-unbound-manager`.
 
 The DNS server functionality will be migrated to PowerDNS in a future release leaving Unbound acting purely as a caching DNS resolver.
 
@@ -22,21 +23,24 @@ Unbound also forwards queries to PowerDNS or the site DNS server if the query ca
 
 ### Unbound Manager (`cray-dns-unbound-manager`)
 
-The `cray-dns-unbound-manager` cron job runs every three minutes and queries the System Layout Service, the Hardware State Manager, and the Kea DHCP server for new or changed hardware components and creates DNS records for these components in the `cray-dns-unbound` ConfigMap.
+The `cray-dns-unbound-manager` cron job runs every three minutes and queries the System Layout Service, the Hardware State Manager, 
+and the Kea DHCP server for new or changed hardware components and creates DNS records for these components in the `cray-dns-unbound` ConfigMap.
 
 This job also initiates a rolling restart of Unbound if the `cray-dns-unbound` ConfigMap was modified.
 
-### Kubernetes DNS (coredns)
+### Kubernetes DNS (`coredns`)
 
-Kubernetes creates DNS records for services and pods. A CoreDNS server running in the` kube-system` namespace is used for this purpose.
+Kubernetes creates DNS records for services and pods. A CoreDNS server running in the `kube-system` namespace is used for this purpose.
 
-The CoreDNS service is also configured to forward DNS requests to Unbound in order to allow pods to resolve system hardware components and other services. This configuration is performed by the `cray-dns-unbound-coredns` job which is invoked whenever the `cray-dns-unbound` Helm chart is deployed or upgraded.
+The CoreDNS service is also configured to forward DNS requests to Unbound in order to allow pods to resolve system hardware components and other services. 
+This configuration is performed by the `cray-dns-unbound-coredns` job which is invoked whenever the `cray-dns-unbound` Helm chart is deployed or upgraded.
 
 See the [Kubernetes documentation](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/) for more information.
 
 ### ExternalDNS (`cray-externaldns-external-dns`)
 
-ExternalDNS creates DNS records for services that are intended to be accessible via the Customer Access Network (CAN), Customer Management Network (CMN), and Customer High-Speed Network (CHN). For example grafana.cmn.wasp.dev.cray.com.
+ExternalDNS creates DNS records for services that are intended to be accessible via the Customer Access Network (CAN), Customer Management Network (CMN), 
+and Customer High-Speed Network (CHN). For example `grafana.cmn.wasp.dev.cray.com`.
 
 Kubernetes Services annotated with `external-dns.alpha.kubernetes.io/hostname` have DNS records created.
 
@@ -46,15 +50,17 @@ Starting with CSM version 1.1 these DNS records are created in the PowerDNS serv
 
 ### PowerDNS (`cray-dns-powerdns`)
 
-PowerDNS is an authoritative DNS server which over the next few CSM releases will replace Unbound sa the primary DNS server within a CSM system.
+PowerDNS is an authoritative DNS server which over the next few CSM releases will replace Unbound as the primary DNS server within a CSM system.
 
-PowerDNS is able to respond to queries for services accessible via the CAN, CMN, or CHN. Records are externally accessible via the LoadBalancer IP address specified for the CSI `--cmn-external-dns` option.
+PowerDNS is able to respond to queries for services accessible via the CAN, CMN, or CHN. Records are externally accessible via the Kubernetes `LoadBalancer` IP address specified for the CSI `--cmn-external-dns` option.
 
 As with earlier CSM releases it is possible to delegate to PowerDNS to resolve services and it is also possible to configure zone transfer to sync the DNS records from PowerDNS to Site DNS.
 
 ### PowerDNS Manager (`cray-powerdns-manager`)
 
-The PowerDNS Manager serves a similar purpose to the Unbound Manager. It runs in the background and periodically queries the System Layout Service, the Hardware State Manager, and the Kea DHCP server for new or changed hardware components and creates DNS records for these components in PowerDNS. It also creates and removes reverse DNS PTR records that correspond to the A records that are created by ExternalDNS.
+The PowerDNS Manager serves a similar purpose to the Unbound Manager. It runs in the background and periodically queries the System Layout Service, the Hardware State Manager, 
+and the Kea DHCP server for new or changed hardware components and creates DNS records for these components in PowerDNS. It also creates and removes reverse DNS PTR records 
+that correspond to the A records that are created by ExternalDNS.
 
 The PowerDNS Manager also configures the PowerDNS server for zone transfer and DNSSEC if required.
 

--- a/operations/network/dns/DNS.md
+++ b/operations/network/dns/DNS.md
@@ -54,7 +54,7 @@ As with earlier CSM releases it is possible to delegate to PowerDNS to resolve s
 
 ### PowerDNS Manager (`cray-powerdns-manager`)
 
-The PowerDNS Manager serves a similar purpose to the Unbound Manager. It runs in the background and periodically queries the System Layout Service, the Hardware State Manager, and the Kea DHCP server for new or changed hardware components and creates DNS records for these components in PowerDNS.
+The PowerDNS Manager serves a similar purpose to the Unbound Manager. It runs in the background and periodically queries the System Layout Service, the Hardware State Manager, and the Kea DHCP server for new or changed hardware components and creates DNS records for these components in PowerDNS. It also creates and removes reverse DNS PTR records that correspond to the A records that are created by ExternalDNS.
 
 The PowerDNS Manager also configures the PowerDNS server for zone transfer and DNSSEC if required.
 

--- a/operations/network/dns/DNS.md
+++ b/operations/network/dns/DNS.md
@@ -14,7 +14,7 @@ The DNS infrastructure is comprised of a number of components.
 
 Unbound is a caching DNS resolver which is also used as the primary DNS server.
 
-The DNS records served by Unbound include system component names (xnames), node hostnames, 
+The DNS records served by Unbound include system component names (xnames), node hostnames,
 and service names and these records are read from the `cray-dns-unbound` ConfigMap which is populated by `cray-dns-unbound-manager`.
 
 The DNS server functionality will be migrated to PowerDNS in a future release leaving Unbound acting purely as a caching DNS resolver.
@@ -23,7 +23,7 @@ Unbound also forwards queries to PowerDNS or the site DNS server if the query ca
 
 ### Unbound Manager (`cray-dns-unbound-manager`)
 
-The `cray-dns-unbound-manager` cron job runs every three minutes and queries the System Layout Service, the Hardware State Manager, 
+The `cray-dns-unbound-manager` cron job runs every three minutes and queries the System Layout Service, the Hardware State Manager,
 and the Kea DHCP server for new or changed hardware components and creates DNS records for these components in the `cray-dns-unbound` ConfigMap.
 
 This job also initiates a rolling restart of Unbound if the `cray-dns-unbound` ConfigMap was modified.
@@ -32,14 +32,14 @@ This job also initiates a rolling restart of Unbound if the `cray-dns-unbound` C
 
 Kubernetes creates DNS records for services and pods. A CoreDNS server running in the `kube-system` namespace is used for this purpose.
 
-The CoreDNS service is also configured to forward DNS requests to Unbound in order to allow pods to resolve system hardware components and other services. 
+The CoreDNS service is also configured to forward DNS requests to Unbound in order to allow pods to resolve system hardware components and other services.
 This configuration is performed by the `cray-dns-unbound-coredns` job which is invoked whenever the `cray-dns-unbound` Helm chart is deployed or upgraded.
 
 See the [Kubernetes documentation](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/) for more information.
 
 ### ExternalDNS (`cray-externaldns-external-dns`)
 
-ExternalDNS creates DNS records for services that are intended to be accessible via the Customer Access Network (CAN), Customer Management Network (CMN), 
+ExternalDNS creates DNS records for services that are intended to be accessible via the Customer Access Network (CAN), Customer Management Network (CMN),
 and Customer High-Speed Network (CHN). For example `grafana.cmn.wasp.dev.cray.com`.
 
 Kubernetes Services annotated with `external-dns.alpha.kubernetes.io/hostname` have DNS records created.
@@ -58,8 +58,8 @@ As with earlier CSM releases it is possible to delegate to PowerDNS to resolve s
 
 ### PowerDNS Manager (`cray-powerdns-manager`)
 
-The PowerDNS Manager serves a similar purpose to the Unbound Manager. It runs in the background and periodically queries the System Layout Service, the Hardware State Manager, 
-and the Kea DHCP server for new or changed hardware components and creates DNS records for these components in PowerDNS. It also creates and removes reverse DNS PTR records 
+The PowerDNS Manager serves a similar purpose to the Unbound Manager. It runs in the background and periodically queries the System Layout Service, the Hardware State Manager,
+and the Kea DHCP server for new or changed hardware components and creates DNS records for these components in PowerDNS. It also creates and removes reverse DNS PTR records
 that correspond to the A records that are created by ExternalDNS.
 
 The PowerDNS Manager also configures the PowerDNS server for zone transfer and DNSSEC if required.

--- a/operations/network/dns/DNS.md
+++ b/operations/network/dns/DNS.md
@@ -15,7 +15,7 @@ The DNS infrastructure is comprised of a number of components.
 Unbound is a caching DNS resolver which is also used as the primary DNS server.
 
 The DNS records served by Unbound include system component names (xnames), node hostnames,
-and service names and these records are read from the `cray-dns-unbound` ConfigMap which is populated by `cray-dns-unbound-manager`.
+and service names. These records are read from the `cray-dns-unbound` ConfigMap which is populated by `cray-dns-unbound-manager`.
 
 The DNS server functionality will be migrated to PowerDNS in a future release leaving Unbound acting purely as a caching DNS resolver.
 
@@ -23,7 +23,7 @@ Unbound also forwards queries to PowerDNS or the site DNS server if the query ca
 
 ### Unbound Manager (`cray-dns-unbound-manager`)
 
-The `cray-dns-unbound-manager` cron job runs every three minutes and queries the System Layout Service, the Hardware State Manager,
+The `cray-dns-unbound-manager` cron job runs every three minutes and queries the System Layout Service (SLS), the Hardware State Manager (HSM),
 and the Kea DHCP server for new or changed hardware components and creates DNS records for these components in the `cray-dns-unbound` ConfigMap.
 
 This job also initiates a rolling restart of Unbound if the `cray-dns-unbound` ConfigMap was modified.
@@ -40,7 +40,7 @@ See the [Kubernetes documentation](https://kubernetes.io/docs/concepts/services-
 ### ExternalDNS (`cray-externaldns-external-dns`)
 
 ExternalDNS creates DNS records for services that are intended to be accessible via the Customer Access Network (CAN), Customer Management Network (CMN),
-and Customer High-Speed Network (CHN). For example `grafana.cmn.wasp.dev.cray.com`.
+and Customer High-Speed Network (CHN). For example, `grafana.cmn.wasp.dev.cray.com`.
 
 Kubernetes Services annotated with `external-dns.alpha.kubernetes.io/hostname` have DNS records created.
 
@@ -58,9 +58,9 @@ As with earlier CSM releases it is possible to delegate to PowerDNS to resolve s
 
 ### PowerDNS Manager (`cray-powerdns-manager`)
 
-The PowerDNS Manager serves a similar purpose to the Unbound Manager. It runs in the background and periodically queries the System Layout Service, the Hardware State Manager,
+The PowerDNS Manager serves a similar purpose to the Unbound Manager. It runs in the background and periodically queries the SLS, HSM,
 and the Kea DHCP server for new or changed hardware components and creates DNS records for these components in PowerDNS. It also creates and removes reverse DNS PTR records
-that correspond to the A records that are created by ExternalDNS.
+that correspond to the records that are created by ExternalDNS.
 
 The PowerDNS Manager also configures the PowerDNS server for zone transfer and DNSSEC if required.
 


### PR DESCRIPTION
# Description

The cray-powerdns-manager pod now creates and manages PTR records that correspond to ExternalDNS created A records.

# Checklist Before Merging

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

