### PR TITLE
CASMPET-5881 Fix incorrect renewncnjoin example

### DIFF
--- a/operations/spire/Troubleshoot_Spire_Failing_to_Start_on_NCNs.md
+++ b/operations/spire/Troubleshoot_Spire_Failing_to_Start_on_NCNs.md
@@ -1,17 +1,17 @@
 # Troubleshoot Spire Failing to Start on NCNs
 
-The spire-agent service may fail to start on Kubernetes non-compute nodes \(NCNs\). A key indication of this failure is when logging errors occur with the journalctl command. The following are logging errors that will indicate if the spire-agent is failing to start:
+The spire-agent service may fail to start on Kubernetes non-compute nodes \(NCNs\). A key indication of this failure is when logging errors occur with the `journalctl` command. The following are logging errors that will indicate if the spire-agent is failing to start:
 
 - The `join token does not exist or has already been used` message is returned
 - The last lines of the logs contain multiple lines of `systemd[1]: spire-agent.service: Start request repeated too quickly.`
 
-Deleting the `request-ncn-join-token` daemonset pod running on the node may clear the issue.
+Deleting the `request-ncn-join-token` `daemonset` pod running on the node may clear the issue.
 
-While the spire-agent systemctl service on the Kubernetes node should eventually restart cleanly, administrators may need to log in to the impacted nodes and restart the service. The easiest way to delete the appropriate pod is to create the following function and run it on the impacted node.
+While the spire-agent `systemctl` service on the Kubernetes node should eventually restart cleanly, administrators may need to log in to the impacted nodes and restart the service. The easiest way to delete the appropriate pod is to create the following function and run it on the impacted node.
 
 ```bash
 function renewncnjoin() {
-    if [ -z "$1" ]; then echo "usage: renewncnjoin NODE_XNAME"
+    if [ -z "$1" ]; then echo "usage: renewncnjoin NODE_HOSTNAME"
     else
         for pod in $(kubectl get pods -n spire | grep request-ncn-join-token | awk '{print $1}');
         do
@@ -23,17 +23,16 @@ function renewncnjoin() {
 }
 ```
 
-Run the renewncnjoin function on the NCN where `kubectl` is running:
+Run the `renewncnjoin` function on the NCN where `kubectl` is running:
 
 ```bash
-renewncnjoin NODE_XNAME
+renewncnjoin NODE_HOSTNAME
 ```
 
-The spire-agent service may also fail if an NCN was powered off for too long and its tokens expired. If this happens, delete /root/spire/agent\_svid.der, /root/spire/bundle.der, and /root/spire/data/svid.key off the NCN before deleting the request-ncn-join-token daemonset pod.
+The spire-agent service may also fail if an NCN was powered off for too long and its tokens expired. If this happens, delete `/root/spire/agent_svid.der`, `/root/spire/bundle.der`, and `/root/spire/data/svid.key` off the NCN before deleting the `request-ncn-join-token` `daemonset` pod.
 
 ```bash
 rm /root/spire/agent_svid.der
 rm /root/spire/bundle.der
 rm /root/spire/data/svid.key
 ```
-


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
This change switches the example from NCN_XNAME to NCN_HOSTNAME. This command takes the host name of the NCN and not the xname, causing confusion for the user.


# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
