### PR TITLE
CASMPET-5881 Fix incorrect renewncnjoin example

### DIFF
--- a/operations/spire/Troubleshoot_Spire_Failing_to_Start_on_NCNs.md
+++ b/operations/spire/Troubleshoot_Spire_Failing_to_Start_on_NCNs.md
@@ -11,7 +11,7 @@ While the spire-agent systemctl service on the Kubernetes node should eventually
 
 ```bash
 function renewncnjoin() {
-    if [ -z "$1" ]; then echo "usage: renewncnjoin NODE_XNAME"
+    if [ -z "$1" ]; then echo "usage: renewncnjoin NODE_HOSTNAME"
     else
         for pod in $(kubectl get pods -n spire | grep request-ncn-join-token | awk '{print $1}');
         do
@@ -26,14 +26,13 @@ function renewncnjoin() {
 Run the renewncnjoin function on the NCN where `kubectl` is running:
 
 ```bash
-# renewncnjoin NODE_XNAME
+# renewncnjoin NODE_HOSTNAME
 ```
 
-The spire-agent service may also fail if an NCN was powered off for too long and its tokens expired. If this happens, delete /root/spire/agent\_svid.der, /root/spire/bundle.der, and /root/spire/data/svid.key off the NCN before deleting the request-ncn-join-token daemonset pod.
+The spire-agent service may also fail if an NCN was powered off for too long and its tokens expired. If this happens, delete /root/spire/agent_svid.der, /root/spire/bundle.der, and /root/spire/data/svid.key off the NCN before deleting the request-ncn-join-token daemonset pod.
 
 ```bash
 # rm /root/spire/agent_svid.der
 # rm /root/spire/bundle.der
 # rm /root/spire/data/svid.key
 ```
-


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
This change switches the example from NCN_XNAME to NCN_HOSTNAME. This command takes the host name of the NCN and not the xname, causing confusion for the user.


# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
