### PR TITLE
CASMINST-5180 fixed ssh_keygen_keyscan function when removing old keys

### DIFF
--- a/upgrade/scripts/common/ncn-common.sh
+++ b/upgrade/scripts/common/ncn-common.sh
@@ -165,8 +165,8 @@ function ssh_keygen_keyscan() {
     {
         NCNS=$(grep -oP 'ncn-w\w\d+|ncn-s\w\d+' /etc/hosts | sort -u)
         HOSTS=$(echo $NCNS | tr -t ' ' ',')
-        pdsh -w $HOSTS ssk-keygen -R ${target-ncn}
-        pdsh -w $HOSTS ssk-keygen -R ${ncn_ip}
+        pdsh -w $HOSTS ssh-keygen -R ${target-ncn}
+        pdsh -w $HOSTS ssh-keygen -R ${ncn_ip}
     } >& /dev/null
 
     set -e


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->

Bug fix: fixed ssh_keygen_keyscan function when removing old keys

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
