### PR TITLE
CASMPET-5686: mvp script for known 503 detection

### DIFF
--- a/operations/kubernetes/Troubleshoot_Intermittent_503s.md
+++ b/operations/kubernetes/Troubleshoot_Intermittent_503s.md
@@ -62,6 +62,14 @@ are being created.
 
 Once the roll out is complete, or the new pod is running, then the HTTP 503 message should clear.
 
+To ensure there are no further pods in this state you may run this script:
+
+```bash
+/usr/share/doc/csm/scripts/operations/known-issues.sh
+```
+
+If any pods are still affected by this specific issue the script will provide a list of `kubectl` delete commands that will need to be run.
+
 ## `UAEX`
 
 ### Symptom (`UAEX`)

--- a/scripts/operations/known-issues.sh
+++ b/scripts/operations/known-issues.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env sh
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+printf "Looking for known istio issues"
+istioissues=""
+remediation=""
+
+rc=0
+
+for ns in $(kubectl get ns -A --no-headers=true 2> /dev/null | awk '/Active/ {print $1}'); do
+  for pod in $(kubectl get pods -n "${ns}" --no-headers=true 2> /dev/null | awk '/Running/ {print $1}'); do
+    for cont in $(kubectl get pods -n "${ns}" "${pod}" -o jsonpath='{.spec.containers[*].name}' 2> /dev/null | grep istio); do
+      if kubectl logs -n "${ns}" "${pod}" -c "${cont}" 2> /dev/null | grep '[[:space:]]503[[:space:]]' | grep SDS > /dev/null 2>&1; then
+        istioissues="${istioissues}\nistio http 503 issues found in namespace: ${ns} pod: ${pod} container: ${cont}"
+        remediation="${remediation}\nkubectl delete pod --namespace ${ns} ${pod}"
+      fi
+    done
+  done
+done
+
+if [ "${istioissues}" = "" ]; then
+  printf " done, and none found\n"
+else
+  # This usage is fine in this instance with the newlines in the variable as
+  # they're intentional.
+  printf " done, and found known issues:"
+  #shellcheck disable=SC2059
+  printf "${istioissues}\n"
+
+  if [ "" != "${remediation}" ]; then
+    printf "To remediate run the following commands:\n"
+    #shellcheck disable=SC2059
+    printf "${remediation}\n"
+  fi
+  rc=$((rc + 1))
+fi
+
+exit ${rc}


### PR DESCRIPTION
While there is more it could and should still do, I'll leave other 503 istio issues for
future me to add in evolutionarily.

Note while for right now this is only finding a specific itio 503 I want to expand this beyond only istio to be more of a generic "if you find a thing and can fix it report what needs to happen" script. Hence why its not named say find-istio-503 errors. Simpler to have one script to rule them all that you run than N scripts that all could be run.

# Description

Add a script to find pods with envoy proxy issues and if so report back what kubectl delete commands need to be run to clear them.

I don't have any output at the moment to document them, but once we find another broken system I can update these docs with examples. Or I could contrive what it will output.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
