### PR TITLE
CASMINST-5188 - Should not be checking for can0 interfaces if CHN is configured

### DIFF
--- a/install/deploy_final_non-compute_node.md
+++ b/install/deploy_final_non-compute_node.md
@@ -332,22 +332,6 @@ The steps in this section load hand-off data before a later procedure reboots th
        addr:     ipv4 172.30.53.88/20 [static]
     ```
 
-1. (`ncn-m001#`) Verify that the site link (`lan0`) and the VLANs have IP addresses.
-
-    > Examine the output to ensure that each interface has been assigned an IPv4 address.
-
-    ```bash
-    for INT in lan0 bond0.nmn0 bond0.hmn0 bond0.can0 bond0.cmn0 ; do
-        ip a show "${INT}" || echo "ERROR: Command failed: ip a show ${INT}"
-    done
-    ```
-
-1. (`ncn-m001#`) Verify that the default route is via the CMN.
-
-    ```bash
-    ip r show default
-    ```
-
 1. (`ncn-m001#`) Verify that there **is not** a metal bootstrap IP address.
 
     ```bash


### PR DESCRIPTION
# Description

Remove manual checks that are covered by Goss tests.

# Checklist Before Merging

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.