### PR TITLE
CASMINST-5102 Do not use RAIDed disks

### DIFF
--- a/install/pre-installation.md
+++ b/install/pre-installation.md
@@ -209,9 +209,10 @@ On first login, the LiveCD will prompt the administrator to change the password.
       Use a local disk for `PITDATA`:
 
       ```bash
-      disk="$(lsblk -l -o SIZE,NAME,TYPE,TRAN | grep -E '(sata|nvme|sas)' | sort -h | awk '{print $2}' | head -n 1 | tr -d '\n')"
-      echo ${disk}
-      parted --wipesignatures -m --align=opt --ignore-busy -s "/dev/$disk" -- mklabel gpt mkpart primary ext4 2048s 100%
+      disk="$(lsblk -l -o SIZE,NAME,TYPE,TRAN -e7 -d -n | sort -h | awk '{print $2}' | xargs -I {} bash -c "if ! grep -Fq {} /proc/mdstat; then echo {}; fi")"
+      echo "Using ${disk}"
+      parted --wipesignatures -m --align=opt --ignore-busy -s "/dev/${disk}" -- mklabel gpt mkpart primary ext4 2048s 100%
+      partprobe "/dev/${disk}"
       mkfs.ext4 -L PITDATA "/dev/${disk}1"
       mount -vL PITDATA
       ```


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
This changes the `lsblk` command to only list block devices, while also excluding loop devices (`-e7`). The resulting disks are piped into `xargs` where they're compared aginst `/proc/mdstat`. If the disk doesn't exist in `/proc/mdstat`, then it isn't used in a RAID and it can be safely formatted and used as PITDATA.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
