### PR TITLE
CASMINST-5143 does not direct output to /dev/tty if unavailable

### DIFF
--- a/upgrade/scripts/common/upgrade-state.sh
+++ b/upgrade/scripts/common/upgrade-state.sh
@@ -115,17 +115,33 @@ function err_report() {
         return 0
     fi
     
-    # force output to console regardless of redirection
-    echo >/dev/tty 
-    echo "[ERROR] - Unexpected errors, check logs: ${LOG_FILE}" >/dev/tty 
+    # check if /dev/tty is available, it is not available when using argo workflows
+    if sh -c ": >/dev/tty" >/dev/null 2>/dev/null; then
+        # /dev/tty is available and usable
+        # force output to console regardless of redirection
+        echo >/dev/tty 
+        echo "[ERROR] - Unexpected errors, check logs: ${LOG_FILE}" >/dev/tty
+    else
+        # /dev/tty is not available
+        echo
+        echo "[ERROR] - Unexpected errors, check logs: ${LOG_FILE}"
+    fi
     # avoid shell double trap
     NO_ERROR_TRAP=1
 }
 
 function ok_report() {
-    # force output to console regardless of redirection
-    echo >/dev/tty 
-    echo "[OK] - Successfully completed" >/dev/tty
+    # check if /dev/tty is available, it is not available when using argo workflows
+    if sh -c ": >/dev/tty" >/dev/null 2>/dev/null; then
+        # /dev/tty is available and usable
+        # force output to console regardless of redirection
+        echo >/dev/tty 
+        echo "[OK] - Successfully completed" >/dev/tty
+    else
+        # /dev/tty is not available
+        echo
+        echo "[OK] - Successfully completed"
+    fi
     # avoid shell double trap
     NO_ERROR_TRAP=1
 }
@@ -141,9 +157,9 @@ function argo_err_report() {
     echo "${caller}"
     echo "${cmd}"
 
-    
-    echo >/dev/tty 
-    echo "[ERROR] - Unexpected errors" >/dev/tty 
+
+    echo
+    echo "[ERROR] - Unexpected errors"
     # avoid shell double trap
     NO_ERROR_TRAP=1
 }

--- a/upgrade/scripts/upgrade/ncn-upgrade-ceph-nodes.sh
+++ b/upgrade/scripts/upgrade/ncn-upgrade-ceph-nodes.sh
@@ -164,13 +164,12 @@ fi
 wait_for_health_ok ${target_ncn}
 
 # Wait for rgw to start before executing goss tests
-target_ncn=ncn-s001
 rgw_counter=0
 until [[ $(ceph orch ps --daemon_type rgw ${target_ncn} --format json-pretty|jq -r '.[].status_desc') == "running" ]]
 do
   sleep 30
   let rgw_counter+=1
-  if rgw_counter -gt 10
+  if [[ $rgw_counter -gt 10 ]]
   then
     exit 1
   fi


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
Does not direct output to /dev/tty if unavailable. It is unavailable when using argo workflows.
Also fixes CASMINST-5133 - removes line setting target_ncn=ncn-s001


# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
