### PR TITLE
CRAYSAT-1495: Document limitations to `sat swap` blade replacement procedure

### DIFF
--- a/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System_Using_SAT.md
+++ b/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System_Using_SAT.md
@@ -35,6 +35,7 @@ This procedure will add a liquid-cooled blade to an HPE Cray EX system.
    `--dst-mapping` argument should be a mappings file of the MAC addresses, IP addresses, and component xnames from the new blade. If the new
    blade was removed from another system, the mappings file was saved while performing the
    [Removing a Liquid-cooled Blade from a System Using SAT](Removing_a_Liquid-cooled_blade_from_a_System_Using_SAT.md) procedure on the other system.
+   If the new blade is a brand new blade, (i.e. not from another running system,) then neither `--src-mapping` or `--dst-mapping` should be used.
 
    ```bash
    sat swap blade --src-mapping <SRC_MAPPING> --dst-mapping <DST_MAPPING> --action enable <SLOT_XNAME>

--- a/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System_Using_SAT.md
+++ b/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System_Using_SAT.md
@@ -35,7 +35,7 @@ This procedure will add a liquid-cooled blade to an HPE Cray EX system.
    `--dst-mapping` argument should be a mappings file of the MAC addresses, IP addresses, and component xnames from the new blade. If the new
    blade was removed from another system, the mappings file was saved while performing the
    [Removing a Liquid-cooled Blade from a System Using SAT](Removing_a_Liquid-cooled_blade_from_a_System_Using_SAT.md) procedure on the other system.
-   If the new blade is a brand new blade, (i.e. not from another running system,) then neither `--src-mapping` or `--dst-mapping` should be used.
+   If the blade is a new blade, (that is, not from another running system), do not use either `--src-mapping` or `--dst-mapping`.
 
    ```bash
    sat swap blade --src-mapping <SRC_MAPPING> --dst-mapping <DST_MAPPING> --action enable <SLOT_XNAME>

--- a/operations/node_management/Replace_a_Compute_Blade.md
+++ b/operations/node_management/Replace_a_Compute_Blade.md
@@ -5,15 +5,15 @@ Replace an HPE Cray EX liquid-cooled compute blade.
 ## Shutdown software and power off the blade
 
 1. Temporarily disable endpoint discovery service (MEDS) for the compute nodes(s) being replaced.
-   This example disables MEDS for the compute node in cabinet 1000, chassis 3, slot 0 (x1000c3s0b0). If there is more than 1 node card, in the blade specify each node card (x1000c3s0b0,x1000c3s0b1).
+   This example disables MEDS for the compute node in cabinet 1000, chassis 3, slot 0 (`x1000c3s0b0`). If there is more than 1 node card, in the blade specify each node card (`x1000c3s0b0`, `x1000c3s0b1`).
 
    ```bash
    cray hsm inventory redfishEndpoints update --enabled false x1000c3s0b0
    ```
 
-2. Verify that the workload manager (WLM) is not using the affected nodes.
+1. Verify that the workload manager (WLM) is not using the affected nodes.
 
-3. Use Boot Orchestration Services (BOS) to shut down the affected nodes. Specify the appropriate BOS template for the node type.
+1. Use Boot Orchestration Services (BOS) to shut down the affected nodes. Specify the appropriate BOS template for the node type.
 
    ```bash
    cray bos session create --template-uuid BOS_TEMPLATE \
@@ -22,25 +22,25 @@ Replace an HPE Cray EX liquid-cooled compute blade.
 
    Specify all the nodes in the blade using a comma-separated list. This example shows the command to shut down an EX425 compute blade (Windom) in cabinet 1000, chassis 3, slot 5. This blade type includes two node cards, each with two logical nodes (4 processors).
 
-4. Disable the chassis slot in the Hardware State Manager (HSM).
+1. Disable the chassis slot in the Hardware State Manager (HSM).
 
-   This example shows cabinet 1000, chassis 3, slot 0 (x1000c3s0).
+   This example shows cabinet 1000, chassis 3, slot 0 (`x1000c3s0`).
 
    ```bash
    cray hsm state components enabled update --enabled false x1000c3s0
    ```
 
-   Disabling the slot prevents hms-discovery from attempting to automatically power on slots. If the slot
-   automatically powers on after using CAPMC to power the slot off, then temporarily suspend the hms-discovery cron job in k8s:
+   Disabling the slot prevents `hms-discovery` from attempting to automatically power on slots. If the slot
+   automatically powers on after using CAPMC to power the slot off, then temporarily suspend the `hms-discovery` cron job in Kubernetes:
 
-   1. Suspend the hms-discovery cron job to prevent slot power on.
+   1. Suspend the `hms-discovery` cron job to prevent slot power on.
 
       ```bash
       kubectl -n services patch cronjobs hms-discovery \
       -p '{"spec" : {"suspend" : true }}'
       ```
 
-   2. Verify that the hms-discovery cron job has stopped (ACTIVE column = 0).
+   1. Verify that the `hms-discovery` cron job has stopped (ACTIVE column = 0).
 
       ```bash
       kubectl get cronjobs -n services hms-discovery
@@ -48,12 +48,12 @@ Replace an HPE Cray EX liquid-cooled compute blade.
 
       Example output:
 
-      ```
+      ```text
       NAME SCHEDULE SUSPEND ACTIVE LAST SCHEDULE AGE^M
       hms-discovery */3 * * * * True 0 117s 15d
       ```
 
-5. Use CAPMC to power off slot 0 in chassis 3.
+1. Use CAPMC to power off slot 0 in chassis 3.
 
    ```bash
    cray capmc xname_off create --xnames x1000c3s0 \
@@ -62,7 +62,7 @@ Replace an HPE Cray EX liquid-cooled compute blade.
 
 ## Delete the HSM entries
 
-6. Delete the node Ethernet interface MAC addresses and the Redfish endpoint from the Hardware State
+1. Delete the node Ethernet interface MAC addresses and the Redfish endpoint from the Hardware State
    Manager (HSM).
 
    **IMPORTANT**: The HSM stores the node's BMC NIC MAC addresses for the hardware management
@@ -82,45 +82,45 @@ Replace an HPE Cray EX liquid-cooled compute blade.
 
       Example output:
 
-      ```
-      	[
-      		{
-      			"ID": "b42e99be1a2b",
-      			"Description": "Ethernet Interface Lan1",
-      			"MACAddress": "b4:2e:99:be:1a:2b",
-      			"LastUpdate": "2021-01-27T00:07:08.658927Z",
-      			"ComponentID": "x1000c3s0b0n0",
-      			"Type": "Node",
-      			"IPAddresses": [
-      			{
-      				"IPAddress": "10.252.1.26"
-      			}
-      			]
-      		},
-      		{
-      			"ID": "b42e99be1a2c",
-      			"Description": "Ethernet Interface Lan2",
-      			"MACAddress": "b4:2e:99:be:1a:2c",
-      			"LastUpdate": "2021-01-26T22:43:10.593193Z",
-      			"ComponentID": "x1000c3s0b0n0",
-      			"Type": "Node",
-      			"IPAddresses": []
-      		}
-      	]
+      ```json
+      [
+          {
+              "ID": "b42e99be1a2b",
+              "Description": "Ethernet Interface Lan1",
+              "MACAddress": "b4:2e:99:be:1a:2b",
+              "LastUpdate": "2021-01-27T00:07:08.658927Z",
+              "ComponentID": "x1000c3s0b0n0",
+              "Type": "Node",
+              "IPAddresses": [
+              {
+                  "IPAddress": "10.252.1.26"
+              }
+              ]
+          },
+          {
+              "ID": "b42e99be1a2c",
+              "Description": "Ethernet Interface Lan2",
+              "MACAddress": "b4:2e:99:be:1a:2c",
+              "LastUpdate": "2021-01-26T22:43:10.593193Z",
+              "ComponentID": "x1000c3s0b0n0",
+              "Type": "Node",
+              "IPAddresses": []
+          }
+      ]
       ```
 
-      2. Delete each Node NIC MAC address the Hardware State Manager (HSM) Ethernet interfaces table.
+      1. Delete each Node NIC MAC address the Hardware State Manager (HSM) Ethernet interfaces table.
 
          ```bash
          cray hsm inventory ethernetInterfaces delete b42e99be1a2b
          cray hsm inventory ethernetInterfaces delete b42e99be1a2c
          ```
 
-      3. Delete the Redfish endpoint for the removed node.
+      1. Delete the Redfish endpoint for the removed node.
 
-7. Replace the blade hardware.
+1. Replace the blade hardware.
 
-   Review the *Remove a Compute Blade Using the Lift* procedure in *HPE Cray EX Hardware Replacement Procedures H-6173* for detailed instructions (https://internal.support.hpe.com/).
+   Review the *Remove a Compute Blade Using the Lift* procedure in *HPE Cray EX Hardware Replacement Procedures H-6173* for detailed instructions.
 
    **CAUTION**: Always power off the chassis slot or device before removal. The best practice is to unlatch
    and unseat the device while the coolant hoses are still connected, then disconnect the coolant hoses.
@@ -129,7 +129,7 @@ Replace an HPE Cray EX liquid-cooled compute blade.
 
 ## Power on and boot the compute nodes
 
-8. Un-suspend the hms-discovery cronjob in k8s.
+1. Un-suspend the `hms-discovery` cronjob in Kubernetes.
 
    ```bash
    kubectl -n services patch cronjobs hms-discovery -p '{"spec" : {"suspend" : false }}'
@@ -144,7 +144,7 @@ Replace an HPE Cray EX liquid-cooled compute blade.
    ]
    ```
 
-9. Enable MEDS for the compute node(s) in the blade.
+1. Enable MEDS for the compute node(s) in the blade.
 
    ```bash
    cray hsm inventory redfishEndpoints update --enabled true --rediscover-on-update true
@@ -152,9 +152,9 @@ Replace an HPE Cray EX liquid-cooled compute blade.
 
    The updated component name(s) (xnames) will be returned.
 
-10. Wait for 3-5 minutes for the blade to power on and the node BMCs to be discovered.
+1. Wait for 3-5 minutes for the blade to power on and the node BMCs to be discovered.
 
-11. Verify that the affected nodes are enabled in the HSM.
+1. Verify that the affected nodes are enabled in the HSM.
 
     ```bash
     cray hsm state components describe x1000c3s0b0n0
@@ -162,14 +162,14 @@ Replace an HPE Cray EX liquid-cooled compute blade.
 
     Example output:
 
-    ```
+    ```text
     Type = "Node"
     Enabled = true
     State = "Off"
     . . .
     ```
 
-12. To verify the BMC(s) has been discovered by the HSM.
+1. To verify the BMC(s) has been discovered by the HSM.
 
     ```bash
     cray hsm inventory redfishEndpoints describe x1000c3s0b0 --format json
@@ -177,25 +177,25 @@ Replace an HPE Cray EX liquid-cooled compute blade.
 
     Example output:
 
-    ```
-    	{
-    		"ID": "x1000c3s0b0",
-    		"Type": "NodeBMC",
-    		"Hostname": "x1000c3s0b0",
-    		"Domain": "",
-    		"FQDN": "x1000c3s0b0",
-    		"Enabled": true,
-    		"UUID": "e005dd6e-debf-0010-e803-b42e99be1a2d",
-    		"User": "root",
-    		"Password": "",
-    		"MACAddr": "b42e99be1a2d",
-    		"RediscoverOnUpdate": true,
-    		"DiscoveryInfo": {
-    			"LastDiscoveryAttempt": "2021-01-29T16:15:37.643327Z",
-    			"LastDiscoveryStatus": "DiscoverOK",
-    			"RedfishVersion": "1.7.0"
-    		}
-    	}
+    ```json
+        {
+            "ID": "x1000c3s0b0",
+            "Type": "NodeBMC",
+            "Hostname": "x1000c3s0b0",
+            "Domain": "",
+            "FQDN": "x1000c3s0b0",
+            "Enabled": true,
+            "UUID": "e005dd6e-debf-0010-e803-b42e99be1a2d",
+            "User": "root",
+            "Password": "",
+            "MACAddr": "b42e99be1a2d",
+            "RediscoverOnUpdate": true,
+            "DiscoveryInfo": {
+                "LastDiscoveryAttempt": "2021-01-29T16:15:37.643327Z",
+                "LastDiscoveryStatus": "DiscoverOK",
+                "RedfishVersion": "1.7.0"
+            }
+        }
     ```
 
     - When `LastDiscoveryStatus` displays as `DiscoverOK`, the node BMC has been successfully discovered.
@@ -203,15 +203,15 @@ Replace an HPE Cray EX liquid-cooled compute blade.
     - If the last discovery state is `HTTPsGetFailed` or `ChildVerificationFailed`, then an error has
       occurred during the discovery process.
 
-13. Enable each node individually in the HSM database (in this example, the nodes are `x1000c3s0b0n0-n3`).
+1. Enable each node individually in the HSM database (in this example, the nodes are `x1000c3s0b0n0-n3`).
 
-14. Optional: To force rediscovery of the components in the chassis (the example shows cabinet 1000, chassis 3).
+1. Optional: To force rediscovery of the components in the chassis (the example shows cabinet 1000, chassis 3).
 
     ```bash
     cray hsm inventory discover create --xnames x1000c3
     ```
 
-15. Optional: Verify that discovery has completed (`LastDiscoveryStatus` = "`DiscoverOK`").
+1. Optional: Verify that discovery has completed (`LastDiscoveryStatus` = "`DiscoverOK`").
 
     ```bash
     cray hsm inventory redfishEndpoints describe x1000c3
@@ -219,7 +219,7 @@ Replace an HPE Cray EX liquid-cooled compute blade.
 
     Example output:
 
-    ```
+    ```text
     Type = "ChassisBMC"
     Domain = ""
     MACAddr = "02:13:88:03:00:00"
@@ -237,15 +237,15 @@ Replace an HPE Cray EX liquid-cooled compute blade.
     LastDiscoveryStatus = "DiscoverOK"
     ```
 
-16. Verify that the correct firmware versions for node BIOS, node controller (nC), NIC mezzanine card (NMC), GPUs, and so on.
+1. Verify that the correct firmware versions for node BIOS, node controller (nC), NIC mezzanine card (NMC), GPUs, and so on.
 
-17. Optional: If necessary, update the firmware. Review the [Firmware Action Service (FAS)](../firmware/FAS_Admin_Procedures.md) documentation.
+1. Optional: If necessary, update the firmware. Review the [Firmware Action Service (FAS)](../firmware/FAS_Admin_Procedures.md) documentation.
 
     ```bash
     cray fas actions create CUSTOM_DEVICE_PARAMETERS.json
     ```
 
-18. Update the System Layout Service (SLS).
+1. Update the System Layout Service (SLS).
 
     1. Dump the existing SLS configuration.
 
@@ -253,20 +253,20 @@ Replace an HPE Cray EX liquid-cooled compute blade.
        cray sls networks describe HSN --format=json > existingHSN.json
        ```
 
-    2. Copy `existingHSN.json` to a `newHSN.json`, edit `newHSN.json` with the changes, then run
+    1. Copy `existingHSN.json` to a `newHSN.json`, edit `newHSN.json` with the changes, then run
 
        ```bash
        curl -s -k -H "Authorization: Bearer ${TOKEN}" https://API_SYSTEM/apis/sls/v1/networks/HSN \
        -X PUT -d @newHSN.json
        ```
 
-19. Optional: If necessary, reload DVS on NCNs.
+1. Optional: If necessary, reload DVS on NCNs.
 
     Reload DVS if it is running over the NMN. The recommendation is to run DVS over the HSN for simplified management and significant performance benefits.
 
     For more information, see *HPE Cray Operating System Administration Guide: CSM on HPE Cray EX Systems (S-8024)*.
 
-20. Use boot orchestration to power on and boot the nodes.
+1. Use boot orchestration to power on and boot the nodes.
 
     Specify the appropriate BOS template for the node type.
 
@@ -274,4 +274,3 @@ Replace an HPE Cray EX liquid-cooled compute blade.
     cray bos session create --template-uuid BOS_TEMPLATE --operation reboot \
     --limit x1000c3s0b0n0,x1000c3s0b0n1,x1000c3s0b1n0,x1000c3s0b1n1
     ```
-

--- a/operations/node_management/Replace_a_Compute_Blade.md
+++ b/operations/node_management/Replace_a_Compute_Blade.md
@@ -262,9 +262,9 @@ Replace an HPE Cray EX liquid-cooled compute blade.
 
 19. Optional: If necessary, reload DVS on NCNs.
 
-    DVS should be reloaded if it is running over the NMN. It is recommended that DVS be run over the HSN for simplified management and significant performance benefits.
+    Reload DVS if it is running over the NMN. The recommendation is to run DVS over the HSN for simplified management and significant performance benefits.
 
-    See *HPE Cray Operating System Administration Guide: CSM on HPE Cray EX Systems (S-8024)* for more information.
+    For more information, see *HPE Cray Operating System Administration Guide: CSM on HPE Cray EX Systems (S-8024)*.
 
 20. Use boot orchestration to power on and boot the nodes.
 

--- a/operations/node_management/Replace_a_Compute_Blade.md
+++ b/operations/node_management/Replace_a_Compute_Blade.md
@@ -2,7 +2,7 @@
 
 Replace an HPE Cray EX liquid-cooled compute blade.
 
-### Shutdown software and power off the blade
+## Shutdown software and power off the blade
 
 1. Temporarily disable endpoint discovery service (MEDS) for the compute nodes(s) being replaced.
    This example disables MEDS for the compute node in cabinet 1000, chassis 3, slot 0 (x1000c3s0b0). If there is more than 1 node card, in the blade specify each node card (x1000c3s0b0,x1000c3s0b1).
@@ -60,7 +60,7 @@ Replace an HPE Cray EX liquid-cooled compute blade.
    --recursive true --format json
    ```
 
-### Delete the HSM entries
+## Delete the HSM entries
 
 6. Delete the node Ethernet interface MAC addresses and the Redfish endpoint from the Hardware State
    Manager (HSM).
@@ -127,7 +127,7 @@ Replace an HPE Cray EX liquid-cooled compute blade.
    If this is not possible, disconnect the coolant hoses, then quickly unlatch/unseat the device (within 10
    seconds). Failure to do so may damage the equipment.
 
-### Power on and boot the compute nodes
+## Power on and boot the compute nodes
 
 8. Un-suspend the hms-discovery cronjob in k8s.
 
@@ -260,7 +260,11 @@ Replace an HPE Cray EX liquid-cooled compute blade.
        -X PUT -d @newHSN.json
        ```
 
-19. Reload DVS on NCNs.
+19. Optional: If necessary, reload DVS on NCNs.
+
+    DVS should be reloaded if it is running over the NMN. It is recommended that DVS be run over the HSN for simplified management and significant performance benefits.
+
+    See *HPE Cray Operating System Administration Guide: CSM on HPE Cray EX Systems (S-8024)* for more information.
 
 20. Use boot orchestration to power on and boot the nodes.
 

--- a/operations/node_management/Replace_a_Compute_Blade_Using_SAT.md
+++ b/operations/node_management/Replace_a_Compute_Blade_Using_SAT.md
@@ -19,6 +19,8 @@ Replace an HPE Cray EX liquid-cooled compute blade.
 
 - The System Admin Toolkit \(SAT\) is installed and configured on the system.
 
+- DVS must be running over the HSN.
+
 ## Shutdown nodes on the compute blade
 
 1. Verify that the workload manager (WLM) is not using the affected nodes.
@@ -151,10 +153,6 @@ Replace an HPE Cray EX liquid-cooled compute blade.
       curl -s -k -H "Authorization: Bearer ${TOKEN}" https://API_SYSTEM/apis/sls/v1/networks/HSN \
                 -X PUT -d @newHSN.json
       ```
-
-1. Reload DVS on NCNs.
-
-   See *HPE Cray Operating System Administration Guide: CSM on HPE Cray EX Systems (S-8024)* for more information.
 
 1. Power on and boot the nodes.
 


### PR DESCRIPTION
* Make DVS reload optional on manual replacement procedure

* Add note making DVS over HSN prereq for SAT blade swap

# Description

The blade swap procedure using `sat` currently only supports DVS over HSN when swapping in a new replacement blade. This change documents that limitation and adds detail on when DVS should be reloaded when using the manual procedure, and also notes when the `--src-mapping` and `--dst-mapping` flags may be omitted

# Checklist Before Merging

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
