### PR TITLE
CASMINST-5194 CASMINST-5192 fix syntax isisue

### DIFF
--- a/workflows/ncn/worker/worker.wipe-and-reboot.yaml
+++ b/workflows/ncn/worker/worker.wipe-and-reboot.yaml
@@ -51,7 +51,7 @@ tasks:
           value: |
             {{- include "common.envar" . | indent 12 }}
 
-            SSH_OPT="-i /myssh/id_rsa -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+            SSH_OPT="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
 
             ssh $SSH_OPT "$TARGET_NCN" "TOKEN=$TOKEN /srv/cray/scripts/common/chrony/csm_ntp.py"
             loop_idx=0
@@ -66,7 +66,7 @@ tasks:
                     in_sync=$(ssh $SSH_OPT "${TARGET_NCN}" timedatectl | awk /synchronized:/'{print $NF}')
                     loop_idx=$(( loop_idx+1 ))
                 done
-                if [[ "$in_sync" == "no" ]]; then
+                if [[ "$in_sync" != "yes" ]]; then
                     exit 1
                 fi
             fi

--- a/workflows/ncn/worker/worker.wipe-and-reboot.yaml
+++ b/workflows/ncn/worker/worker.wipe-and-reboot.yaml
@@ -39,9 +39,41 @@ tasks:
               echo "${TARGET_NCN} is missing NTP data in BSS. Please see the procedure which can be found in the 'Known Issues and Bugs' section titled 'Fix BSS Metadata' on the 'Configure NTP on NCNs' page of the CSM documentation."
               exit 1
             fi
+  - name: "force-time-sync"
+    templateRef:
+      name: ssh-template
+      template: shell-script
+    arguments:
+      parameters:
+        - name: dryRun
+          value: "{{ `{{inputs.parameters.dryRun}}` }}"
+        - name: scriptContent
+          value: |
+            {{- include "common.envar" . | indent 12 }}
+
+            SSH_OPT="-i /myssh/id_rsa -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+
+            ssh $SSH_OPT "$TARGET_NCN" "TOKEN=$TOKEN /srv/cray/scripts/common/chrony/csm_ntp.py"
+            loop_idx=0
+            in_sync=$(ssh $SSH_OPT "${TARGET_NCN}" timedatectl | awk /synchronized:/'{print $NF}')
+            if [[ "$in_sync" == "no" ]]; then
+                ssh $SSH_OPT "$TARGET_NCN" chronyc makestep
+                sleep 5
+                in_sync=$(ssh $SSH_OPT "${TARGET_NCN}" timedatectl | awk /synchronized:/'{print $NF}')
+                # wait up to 90s for the node to be in sync
+                while [[ $loop_idx -lt 18 && "$in_sync" == "no" ]]; do
+                    sleep 5
+                    in_sync=$(ssh $SSH_OPT "${TARGET_NCN}" timedatectl | awk /synchronized:/'{print $NF}')
+                    loop_idx=$(( loop_idx+1 ))
+                done
+                if [[ "$in_sync" == "no" ]]; then
+                    exit 1
+                fi
+            fi
   - name: "get-bootscript-last-access-timestamp"
     dependencies:
       - validate-bss-ntp
+      - force-time-sync
     templateRef:
       name: kubectl-and-curl-template
       template: shell-script

--- a/workflows/ncn/worker/worker.wipe-and-reboot.yaml
+++ b/workflows/ncn/worker/worker.wipe-and-reboot.yaml
@@ -68,7 +68,7 @@ tasks:
               # because a node might never pxe booted in the past
               # we set it to zero as default value
               bootscript_last_epoch=0
-              echo bootscript_last_epoch
+              echo $bootscript_last_epoch
             fi
   - name: set-next-boot-to-pxe
     templateRef:


### PR DESCRIPTION
# Description

- CASMINST-5192 fix syntax isisue
- CASMINST-5194 add missing force-ntp-setup step

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
