### PR TITLE
CASMPET-5884 Remove unneeded anti-affinity patch

### DIFF
--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -524,43 +524,6 @@ else
     echo "====> ${state_name} has been completed"
 fi
 
-state_name="POD_ANTI_AFFINITY"
-#shellcheck disable=SC2046
-state_recorded=$(is_state_recorded "${state_name}" $(hostname))
-if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
-    echo "====> ${state_name} ..."
-    {
-
-    kubectl patch deployment -n spire spire-jwks -p '{
-        "spec": {
-        "strategy": {"rollingUpdate": {"maxSurge": 0}},
-        "template": {
-            "spec": {
-                "affinity": {
-                    "podAntiAffinity": {
-                        "requiredDuringSchedulingIgnoredDuringExecution": [
-                            {
-                            "labelSelector": {
-                                "matchLabels": {
-                                    "app.kubernetes.io/name":"spire-jwks"
-                                }
-                            },
-                            "topologyKey": "kubernetes.io/hostname"
-                            }
-                        ]
-                    }
-                }
-            }
-        }
-    }}'
-
-    } >> ${LOG_FILE} 2>&1
-    #shellcheck disable=SC2046
-    record_state ${state_name} $(hostname)
-else
-    echo "====> ${state_name} has been completed"
-fi
-
 state_name="CREATE_CEPH_RO_KEY"
 #shellcheck disable=SC2046
 state_recorded=$(is_state_recorded "${state_name}" $(hostname))


### PR DESCRIPTION
# Description

This removes the spire-jwks anti-affinity prereq patch. This has been fixed in the helm chart and is no longer needed.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
