### PR TITLE
CASMPET-5558 Add missing spire metadata fix

### DIFF
--- a/operations/README.md
+++ b/operations/README.md
@@ -177,7 +177,7 @@ Upgrade sets of compute nodes with the Compute Rolling Upgrade Service \(CRUS\) 
 administrators to limit the impact on production caused from upgrading compute nodes by working through one step of the upgrade process at a time.
 
 > **NOTE** CRUS was deprecated in CSM 1.2.0. It will be removed in a future CSM release and replaced with BOS V2, which will provide similar functionality.
-See [Deprecated features](../introduction/differences.md#deprecated-features).
+> See [Deprecated features](../introduction/differences.md#deprecated-features).
 
 - [Compute Rolling Upgrade Service (CRUS)](compute_rolling_upgrades/Compute_Rolling_Upgrades.md)
 - [CRUS Workflow](compute_rolling_upgrades/CRUS_Workflow.md)
@@ -615,6 +615,7 @@ Spire provides the ability to authenticate nodes and workloads, and to securely 
 - [Troubleshoot Spire Failing to Start on NCNs](spire/Troubleshoot_Spire_Failing_to_Start_on_NCNs.md)
 - [Update Spire Intermediate CA Certificate](spire/Update_Spire_Intermediate_CA_Certificate.md)
 - [Xname Validation](spire/xname_validation.md)
+- [Restore Missing Spire Meta-Data](spire/Restore_Missing_Spire_Metadata.md)
 
 ## Update firmware with FAS
 

--- a/operations/README.md
+++ b/operations/README.md
@@ -177,7 +177,7 @@ Upgrade sets of compute nodes with the Compute Rolling Upgrade Service \(CRUS\) 
 administrators to limit the impact on production caused from upgrading compute nodes by working through one step of the upgrade process at a time.
 
 > **NOTE** CRUS was deprecated in CSM 1.2.0. It will be removed in a future CSM release and replaced with BOS V2, which will provide similar functionality.
-> See [Deprecated features](../introduction/differences.md#deprecated-features).
+See [Deprecated features](../introduction/differences.md#deprecated-features).
 
 - [Compute Rolling Upgrade Service (CRUS)](compute_rolling_upgrades/Compute_Rolling_Upgrades.md)
 - [CRUS Workflow](compute_rolling_upgrades/CRUS_Workflow.md)

--- a/operations/spire/Restore_Missing_Spire_Metadata.md
+++ b/operations/spire/Restore_Missing_Spire_Metadata.md
@@ -1,8 +1,8 @@
-# Restore missing spire metadata
+# Restore missing Spire metadata
 
-If the BSS meta-data server does contain the proper spire meta-data then
+If the Boot Script Service (BSS) metadata server does contain the proper Spire metadata, then the
 computes will fail to boot. This is due to `dracut` pulling server data from the
-meta-data during startup. To fix this issue, the `spire-update-bss` job needs
+metadata during startup. To fix this issue, the `spire-update-bss` job needs
 to be rerun.
 
 ## Error
@@ -15,7 +15,7 @@ to be rerun.
 
 ## Check
 
-(`ncn-m#`) Run `goss-spire-bss-metadata-exist` test
+(`ncn-m#`) Run the `goss-spire-bss-metadata-exist` test.
 
 ```bash
 goss -g /opt/cray/tests/install/ncn/tests/goss-spire-bss-metadata-exist.yaml v
@@ -43,9 +43,9 @@ Count: 1, Failed: 1, Skipped: 0
 ## Solution
 
 Run the following command on a master node to restart the job that populates
-the meta-data server with the correct spire information
+the metadata server with the correct Spire information.
 
-(`ncn-m#`) Re-run the `spire-update-bss` job
+(`ncn-m#`) Re-run the `spire-update-bss` job.
 
 ```bash
 JOB=$(kubectl get jobs -n spire -l app.kubernetes.io/name=spire-update-bss --no-headers -oname |sort -u | tail -n1); kubectl get -n spire $JOB -o json  | jq 'del(.spec.selector,.spec.template.metadata.labels)' | kubectl replace --force -f -

--- a/operations/spire/Restore_Missing_Spire_Metadata.md
+++ b/operations/spire/Restore_Missing_Spire_Metadata.md
@@ -15,7 +15,7 @@ to be rerun.
 
 ## Check
 
-(`ncn-m#`) Run `goss-spire-bss-metadata-exist` goss test
+(`ncn-m#`) Run `goss-spire-bss-metadata-exist` test
 
 ```bash
 goss -g /opt/cray/tests/install/ncn/tests/goss-spire-bss-metadata-exist.yaml v
@@ -45,7 +45,7 @@ Count: 1, Failed: 1, Skipped: 0
 Run the following command on a master node to restart the job that populates
 the meta-data server with the correct spire information
 
-(`ncn-m#`) Re-run the spire-update-bss job
+(`ncn-m#`) Re-run the `spire-update-bss` job
 
 ```bash
 JOB=$(kubectl get jobs -n spire -l app.kubernetes.io/name=spire-update-bss --no-headers -oname |sort -u | tail -n1); kubectl get -n spire $JOB -o json  | jq 'del(.spec.selector,.spec.template.metadata.labels)' | kubectl replace --force -f -

--- a/operations/spire/Restore_Missing_Spire_Metadata.md
+++ b/operations/spire/Restore_Missing_Spire_Metadata.md
@@ -1,0 +1,50 @@
+# Restore missing spire metadata
+
+If the BSS meta-data server does contain the proper spire meta-data then
+computes will fail to boot. This is due to `dracut` pulling server data from the
+meta-data during startup. To fix this issue, the `spire-update-bss` job needs
+to be rerun.
+
+## Error
+
+```text
+[  557.513984] Apr 22 18:02:02 nid000004 dracut-initqueue[4177]: time="2022-04-22T18:02:02Z" level=info msg="SVID is not found. Starting node attestation" subsystem_name=attestor trust_domain_id="spiffe://null"
+[  557.514000] Apr 22 18:02:07 nid000004 dracut-initqueue[4194]: Agent is unavailable.
+[  557.514017] Apr 22 18:02:07 nid000004 dracut-initqueue[4174]: Warning: Spire-agent healthcheck failed, return code 1
+```
+
+## Check
+
+Command:
+
+```bash
+goss -g /opt/cray/tests/install/ncn/tests/goss-spire-bss-metadata-exist.yaml v
+```
+
+Example output:
+
+```text
+Failures/Skipped:
+
+Title: Kubernetes Query BSS Cloud-init for spire meta data
+Meta:
+    desc: Kubernetes Query BSS Cloud-init for spire meta data
+    sev: 0
+Command: spire_in_bss_cloudinit: exit-status:
+Expected
+    <int>: 1
+to equal
+    <int>: 0
+
+Total Duration: 0.387s
+Count: 1, Failed: 1, Skipped: 0
+```
+
+## Solution
+
+Run the following command on a master node to restart the job that populates
+the meta-data server with the correct spire information
+
+```bash
+JOB=$(kubectl get jobs -n spire -l app.kubernetes.io/name=spire-update-bss --no-headers -oname |sort -u | tail -n1); kubectl get -n spire $JOB -o json  | jq 'del(.spec.selector,.spec.template.metadata.labels)' | kubectl replace --force -f -
+```

--- a/operations/spire/Restore_Missing_Spire_Metadata.md
+++ b/operations/spire/Restore_Missing_Spire_Metadata.md
@@ -15,7 +15,7 @@ to be rerun.
 
 ## Check
 
-Command:
+(`ncn-m#`) Run `goss-spire-bss-metadata-exist` goss test
 
 ```bash
 goss -g /opt/cray/tests/install/ncn/tests/goss-spire-bss-metadata-exist.yaml v
@@ -44,6 +44,8 @@ Count: 1, Failed: 1, Skipped: 0
 
 Run the following command on a master node to restart the job that populates
 the meta-data server with the correct spire information
+
+(`ncn-m#`) Re-run the spire-update-bss job
 
 ```bash
 JOB=$(kubectl get jobs -n spire -l app.kubernetes.io/name=spire-update-bss --no-headers -oname |sort -u | tail -n1); kubectl get -n spire $JOB -o json  | jq 'del(.spec.selector,.spec.template.metadata.labels)' | kubectl replace --force -f -


### PR DESCRIPTION
# Description

This adds a troubleshooting document on how to add the spire metadata to BSS if its not there.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
