### PR TITLE
CASMINST-5110 fix automation of setting ssh keys

### DIFF
--- a/upgrade/scripts/common/ncn-common.sh
+++ b/upgrade/scripts/common/ncn-common.sh
@@ -158,14 +158,14 @@ function ssh_keygen_keyscan() {
     [ $? -ne 0 ] && return 1
     ssh-keygen -R "${ncn_ip}" -f "${known_hosts}" > /dev/null 2>&1
     [ $? -ne 0 ] && return 1
-    ssh-keyscan -H "${target_ncn},${ncn_ip}" >> "${known_hosts}"  > /dev/null 2>&1
+    ssh-keyscan -H "${target_ncn},${ncn_ip}" > /dev/null 2>&1 >> "${known_hosts}"
     res=$?
 
     # remove the old authorized_hosts entry for the target NCN cluster-wide
     {
         NCNS=$(grep -oP 'ncn-w\w\d+|ncn-s\w\d+' /etc/hosts | sort -u)
         HOSTS=$(echo $NCNS | tr -t ' ' ',')
-        pdsh -w $HOSTS ssh-keygen -R ${target-ncn}
+        pdsh -w $HOSTS ssh-keygen -R ${target_ncn}
         pdsh -w $HOSTS ssh-keygen -R ${ncn_ip}
     } >& /dev/null
 

--- a/upgrade/scripts/common/ncn-rebuild-common.sh
+++ b/upgrade/scripts/common/ncn-rebuild-common.sh
@@ -442,6 +442,8 @@ export TOKEN
 if [[ $state_recorded == "0" ]]; then
     echo "====> ${state_name} ..."
     {
+    ssh_keygen_keyscan "${target_ncn}"
+    ssh_keys_done=1
     ssh "$target_ncn" "TOKEN=$TOKEN /srv/cray/scripts/common/chrony/csm_ntp.py"
     loop_idx=0
     in_sync=$(ssh "${target_ncn}" timedatectl | awk /synchronized:/'{print $NF}')

--- a/upgrade/scripts/upgrade/ncn-upgrade-ceph-nodes.sh
+++ b/upgrade/scripts/upgrade/ncn-upgrade-ceph-nodes.sh
@@ -106,10 +106,8 @@ state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
 if [[ $state_recorded == "0" ]]; then
     echo "====> ${state_name} ..."
     {
-    if [[ $ssh_keys_done == "0" ]]; then
-        ssh_keygen_keyscan "${target_ncn}"
-        ssh_keys_done=1
-    fi
+    ssh_keygen_keyscan "${target_ncn}"
+    ssh_keys_done=1
     scp ./${target_ncn}-ceph.tgz $target_ncn:/
     ssh ${target_ncn} 'cd /; tar -xvf ./$(hostname)-ceph.tgz; rm /$(hostname)-ceph.tgz'
     ssh ${target_ncn} '/srv/cray/scripts/common/pre-load-images.sh'


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
Fix automation of setting ssh keys. ncn_upgrade_ceph_nodes.sh script will no longer need manual input to verify hostnames before ssh-ing to a node.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
