### PR TITLE
CASMINST-4795 - Add procedure to limit Kubernetes API Audit Log Retention

### DIFF
--- a/operations/CSM_product_management/Apply_Security_Hardening.md
+++ b/operations/CSM_product_management/Apply_Security_Hardening.md
@@ -20,8 +20,8 @@ None.
 
 3. Limit Kubernetes Audit Log Retention.
 
-   If Kubernetes API Auditing was enabled at install, perform procedure(s) in [Limit Kubernetes API Audit Log Maximum Backups](../kubernetes/Limit_Kubernetes_API_Audit_Log_Maxbackups.md). 
-   
+   If Kubernetes API Auditing was enabled at install, perform procedure(s) in [Limit Kubernetes API Audit Log Maximum Backups](../kubernetes/Limit_Kubernetes_API_Audit_Log_Maxbackups.md).
+
    Failure to apply the referenced configuration could result in NCN disk space exhaustion on Kubernetes Master Nodes.
 
 4. (Optional) Change Keycloak OAuth token lifetime.

--- a/operations/CSM_product_management/Apply_Security_Hardening.md
+++ b/operations/CSM_product_management/Apply_Security_Hardening.md
@@ -18,9 +18,11 @@ None.
 
    Perform procedure(s) in [Restrict Access to `ncn-images` S3 Bucket](../security_and_authentication/Restrict_Access_to_NCN_Images_S3_Bucket.md).
 
-3. Limit Kubernetes Audit Log Retention. 
+3. Limit Kubernetes Audit Log Retention.
 
-   If Kubernetes API Auditing was enabled at install, perform procedure(s) in [Limit Kubernetes API Audit Log Maximum Backups](../kubernetes/Limit_Kubernetes_API_Audit_Log_Maxbackups.md). Failure to do so could result in NCN disk space exhaustion on Kubernetes Master Nodes.
+   If Kubernetes API Auditing was enabled at install, perform procedure(s) in [Limit Kubernetes API Audit Log Maximum Backups](../kubernetes/Limit_Kubernetes_API_Audit_Log_Maxbackups.md). 
+   
+   Failure to apply the referenced configuration could result in NCN disk space exhaustion on Kubernetes Master Nodes.
 
 4. (Optional) Change Keycloak OAuth token lifetime.
 

--- a/operations/CSM_product_management/Apply_Security_Hardening.md
+++ b/operations/CSM_product_management/Apply_Security_Hardening.md
@@ -18,10 +18,14 @@ None.
 
    Perform procedure(s) in [Restrict Access to `ncn-images` S3 Bucket](../security_and_authentication/Restrict_Access_to_NCN_Images_S3_Bucket.md).
 
-3. (Optional) Change Keycloak OAuth token lifetime.
+3. Limit Kubernetes Audit Log Retention. 
+
+   If Kubernetes API Auditing was enabled at install, perform procedure(s) in [Limit Kubernetes API Audit Log Maximum Backups](../kubernetes/Limit_Kubernetes_API_Audit_Log_Maxbackups.md). Failure to do so could result in NCN disk space exhaustion on Kubernetes Master Nodes.
+
+4. (Optional) Change Keycloak OAuth token lifetime.
 
    Perform procedure(s) in [Change Keycloak token lifetime](../security_and_authentication/Change_Keycloak_Token_Lifetime.md).
 
-4. (Optional) Remove Kiali.
+5. (Optional) Remove Kiali.
 
    Perform procedure(s) in [Remove Kiali](../system_management_health/Remove_Kiali.md).

--- a/operations/index.md
+++ b/operations/index.md
@@ -260,6 +260,7 @@ As a result, the system's micro-services are modular, resilient, and can be upda
   - [Disaster Recovery for Postgres](kubernetes/Disaster_Recovery_Postgres.md)
   - [View Postgres Information for System Databases](kubernetes/View_Postgres_Information_for_System_Databases.md)
 - [Troubleshoot Intermittent HTTP 503 Code Failures](kubernetes/Troubleshoot_Intermittent_503s.md)
+- [Configure API Audit Log Retention](kubernetes/Limit_Kubernetes_API_Audit_Log_Maxbackups.md)
 
 ## Package repository management
 

--- a/operations/kubernetes/Limit_Kubernetes_API_Audit_Log_Maxbackups.md
+++ b/operations/kubernetes/Limit_Kubernetes_API_Audit_Log_Maxbackups.md
@@ -1,65 +1,65 @@
 # Configure Kubernetes API Audit Log Maximum Backups
 
-If Kubernetes API Auditing was enabled at install or upgrade, via the `CSI` option `--k8s-api-auditing-enabled true` or the `system_config.yaml` option `k8s-api-auditing-enabled: true`, apply this procedure to running Kubernetes Master Nodes. 
+If Kubernetes API Auditing was enabled at install or upgrade, via the `CSI` option `--k8s-api-auditing-enabled true` or the `system_config.yaml` option `k8s-api-auditing-enabled: true`, apply this procedure to running Kubernetes Master Nodes.
 
-### Prerequisites
+## Prerequisites
 
 This procedure requires administrative privileges and assumes that the device being used has:
 
 - `kubectl` is installed
 - Access to the site admin network
 
-### Procedure
+## Procedure
 
-1.  SSH as root to the first Kubernetes Master Node, canonically ncn-m001. 
+1. SSH as root to the first Kubernetes Master Node, canonically `ncn-m001`.
 
-2.  Verify Kubernetes API Auditing is enabled.
+2. Verify Kubernetes API Auditing is enabled.
 
-    You should see both of the following settings in `kube-apiserver.yaml`. 
+   You should see both of the following settings in `kube-apiserver.yaml`.
 
-    ```bash
-    ncn-m# egrep 'audit-log-path|audit-policy-file' /etc/kubernetes/manifests/kube-apiserver.yaml 
-        - --audit-log-path=/var/log/audit/kl8s/apiserver/audit.log
-        - --audit-policy-file=/etc/kubernetes/audit/audit-policy.yaml
-    ```
+   ```bash
+   ncn-m# egrep 'audit-log-path|audit-policy-file' /etc/kubernetes/manifests/kube-apiserver.yaml 
+       - --audit-log-path=/var/log/audit/kl8s/apiserver/audit.log
+       - --audit-policy-file=/etc/kubernetes/audit/audit-policy.yaml
+   ```
 
-3.  Verify all Kubernetes API Server Pods are Running. You should have one for each master node.  
+3. Verify all Kubernetes API Server Pods are Running. You should have one for each master node.  
 
-    ```bash
-    ncn-m# kubectl get pod -n kube-system -l component=kube-apiserver -o wide
-    NAME                      READY   STATUS    RESTARTS   AGE     IP           NODE       NOMINATED NODE   READINESS GATES
-    kube-apiserver-ncn-m001   1/1     Running   0          44m     10.252.1.4   ncn-m001   <none>           <none>
-    kube-apiserver-ncn-m002   1/1     Running   0          2m1s    10.252.1.5   ncn-m002   <none>           <none>
-    kube-apiserver-ncn-m003   1/1     Running   0          3d20h   10.252.1.6   ncn-m003   <none>           <none>
-    ```
+   ```bash
+   ncn-m# kubectl get pod -n kube-system -l component=kube-apiserver -o wide
+   NAME                      READY   STATUS    RESTARTS   AGE     IP           NODE       NOMINATED NODE   READINESS GATES
+   kube-apiserver-ncn-m001   1/1     Running   0          44m     10.252.1.4   ncn-m001   <none>           <none>
+   kube-apiserver-ncn-m002   1/1     Running   0          2m1s    10.252.1.5   ncn-m002   <none>           <none>
+   kube-apiserver-ncn-m003   1/1     Running   0          3d20h   10.252.1.6   ncn-m003   <none>           <none>
+   ```
 
-4.  If Kubernetes API Auditing is enabled, add `--audit-log-maxbackup=100` command line option to the Kubernetes API Server.
+4. If Kubernetes API Auditing is enabled, add `--audit-log-maxbackup=100` command line option to the Kubernetes API Server.
 
-    Make a backup of the `/etc/kubernetes/manifests/kube-apiserver.yaml`. Ensure the backup is to a directory other than `/etc/kubernetes/manifests/`. 
+   Make a backup of the `/etc/kubernetes/manifests/kube-apiserver.yaml`. Ensure the backup is to a directory other than `/etc/kubernetes/manifests/`.
 
-    ```bash
-    ncn-m# cp -a /etc/kubernetes/manifests/kube-apiserver.yaml /tmp/
-    ```
+   ```bash
+   ncn-m# cp -a /etc/kubernetes/manifests/kube-apiserver.yaml /tmp/
+   ```
 
-    Edit the `/etc/kubernetes/manifests/kube-apiserver.yaml` file, adding `--audit-log-maxbackup=100` as an option after `--audit-policy-file`. 
+   Edit the `/etc/kubernetes/manifests/kube-apiserver.yaml` file, adding `--audit-log-maxbackup=100` as an option after `--audit-policy-file`.
 
-    ```bash
-    ncn-m# grep -n "\-\-audit" /etc/kubernetes/manifests/kube-apiserver.yaml 
-    46:    - --audit-log-path=/var/log/audit/kl8s/apiserver/audit.log
-    47:    - --audit-policy-file=/etc/kubernetes/audit/audit-policy.yaml
-    48:    - --audit-log-maxbackup=100
-    ```
+   ```bash
+   ncn-m# grep -n "\-\-audit" /etc/kubernetes/manifests/kube-apiserver.yaml 
+   46:    - --audit-log-path=/var/log/audit/kl8s/apiserver/audit.log
+   47:    - --audit-policy-file=/etc/kubernetes/audit/audit-policy.yaml
+   48:    - --audit-log-maxbackup=100
+   ```
 
-5.  Wait for the Kubernetes API Server Pod on the node to restart. Do not proceed until the pod is in a running state and is ready. 
+5. Wait for the Kubernetes API Server Pod on the node to restart. Do not proceed until the pod is in a running state and is ready.
 
-    You can monitor the node and pod age using:
+   Monitor the node and pod age using:
 
-    ```bash
-    ncn-m# kubectl get pod -n kube-system -l component=kube-apiserver -o wide
-    NAME                      READY   STATUS    RESTARTS   AGE     IP           NODE       NOMINATED NODE   READINESS GATES
-    kube-apiserver-ncn-m001   1/1     Running   0          44m     10.252.1.4   ncn-m001   <none>           <none>
-    kube-apiserver-ncn-m002   1/1     Running   0          2m1s    10.252.1.5   ncn-m002   <none>           <none>
-    kube-apiserver-ncn-m003   1/1     Running   0          3d20h   10.252.1.6   ncn-m003   <none>           <none>
-    ```
+   ```bash
+   ncn-m# kubectl get pod -n kube-system -l component=kube-apiserver -o wide
+   NAME                      READY   STATUS    RESTARTS   AGE     IP           NODE       NOMINATED NODE   READINESS GATES
+   kube-apiserver-ncn-m001   1/1     Running   0          44m     10.252.1.4   ncn-m001   <none>           <none>
+   kube-apiserver-ncn-m002   1/1     Running   0          2m1s    10.252.1.5   ncn-m002   <none>           <none>
+   kube-apiserver-ncn-m003   1/1     Running   0          3d20h   10.252.1.6   ncn-m003   <none>           <none>
+   ```
 
-6.  Repeat steps 2-5 for all other master nodes. 
+6. Repeat steps 2-5 for all other master nodes.

--- a/operations/kubernetes/Limit_Kubernetes_API_Audit_Log_Maxbackups.md
+++ b/operations/kubernetes/Limit_Kubernetes_API_Audit_Log_Maxbackups.md
@@ -1,0 +1,65 @@
+# Configure Kubernetes API Audit Log Maximum Backups
+
+If Kubernetes API Auditing was enabled at install or upgrade, via the `CSI` option `--k8s-api-auditing-enabled true` or the `system_config.yaml` option `k8s-api-auditing-enabled: true`, apply this procedure to running Kubernetes Master Nodes. 
+
+### Prerequisites
+
+This procedure requires administrative privileges and assumes that the device being used has:
+
+- `kubectl` is installed
+- Access to the site admin network
+
+### Procedure
+
+1.  SSH as root to the first Kubernetes Master Node, canonically ncn-m001. 
+
+2.  Verify Kubernetes API Auditing is enabled.
+
+    You should see both of the following settings in `kube-apiserver.yaml`. 
+
+    ```bash
+    ncn-m# egrep 'audit-log-path|audit-policy-file' /etc/kubernetes/manifests/kube-apiserver.yaml 
+        - --audit-log-path=/var/log/audit/kl8s/apiserver/audit.log
+        - --audit-policy-file=/etc/kubernetes/audit/audit-policy.yaml
+    ```
+
+3.  Verify all Kubernetes API Server Pods are Running. You should have one for each master node.  
+
+    ```bash
+    ncn-m# kubectl get pod -n kube-system -l component=kube-apiserver -o wide
+    NAME                      READY   STATUS    RESTARTS   AGE     IP           NODE       NOMINATED NODE   READINESS GATES
+    kube-apiserver-ncn-m001   1/1     Running   0          44m     10.252.1.4   ncn-m001   <none>           <none>
+    kube-apiserver-ncn-m002   1/1     Running   0          2m1s    10.252.1.5   ncn-m002   <none>           <none>
+    kube-apiserver-ncn-m003   1/1     Running   0          3d20h   10.252.1.6   ncn-m003   <none>           <none>
+    ```
+
+4.  If Kubernetes API Auditing is enabled, add `--audit-log-maxbackup=100` command line option to the Kubernetes API Server.
+
+    Make a backup of the `/etc/kubernetes/manifests/kube-apiserver.yaml`. Ensure the backup is to a directory other than `/etc/kubernetes/manifests/`. 
+
+    ```bash
+    ncn-m# cp -a /etc/kubernetes/manifests/kube-apiserver.yaml /tmp/
+    ```
+
+    Edit the `/etc/kubernetes/manifests/kube-apiserver.yaml` file, adding `--audit-log-maxbackup=100` as an option after `--audit-policy-file`. 
+
+    ```bash
+    ncn-m# grep -n "\-\-audit" /etc/kubernetes/manifests/kube-apiserver.yaml 
+    46:    - --audit-log-path=/var/log/audit/kl8s/apiserver/audit.log
+    47:    - --audit-policy-file=/etc/kubernetes/audit/audit-policy.yaml
+    48:    - --audit-log-maxbackup=100
+    ```
+
+5.  Wait for the Kubernetes API Server Pod on the node to restart. Do not proceed until the pod is in a running state and is ready. 
+
+    You can monitor the node and pod age using:
+
+    ```bash
+    ncn-m# kubectl get pod -n kube-system -l component=kube-apiserver -o wide
+    NAME                      READY   STATUS    RESTARTS   AGE     IP           NODE       NOMINATED NODE   READINESS GATES
+    kube-apiserver-ncn-m001   1/1     Running   0          44m     10.252.1.4   ncn-m001   <none>           <none>
+    kube-apiserver-ncn-m002   1/1     Running   0          2m1s    10.252.1.5   ncn-m002   <none>           <none>
+    kube-apiserver-ncn-m003   1/1     Running   0          3d20h   10.252.1.6   ncn-m003   <none>           <none>
+    ```
+
+6.  Repeat steps 2-5 for all other master nodes. 


### PR DESCRIPTION
# Description

NCN Master disk space is being exhausted when customers enable K8S API Auditing, this as settings re: historical retention are not populated by our installer. This PR adds a procedure to correct this on running NCN K8S Master nodes as a stop gap measure. 

Due to potential conflict between kubeadm and the cloud-init scripts that establish K8S API auditing logging configuration, currently, will split the work out to make these settings persist. 

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
