### PR TITLE
CASMINST-5204 Remove `CSM_PATH` from USB

### DIFF
--- a/install/livecd/Boot_LiveCD_USB.md
+++ b/install/livecd/Boot_LiveCD_USB.md
@@ -40,7 +40,7 @@ which device will be used for it.
 
    In the above example, internal disks are the `ATA` devices and USB drives are the final two devices.
 
-   Set a variable with the USB device:
+   Set a variable with the USB device and for the `CSM_PATH`:
 
    ```bash
    USB=/dev/sd<disk_letter>
@@ -51,7 +51,7 @@ which device will be used for it.
     - Use the CSI application to do this:
 
         ```bash
-        csi pit format "${USB}" "${CSM_PATH}/"cray-pre-install-toolkit-*.iso 50000
+        csi pit format "${USB}" cray-pre-install-toolkit-*.iso 50000
         ```
 
     - If CSI is unavailable, then fetch and use the `write-livecd.sh` script:
@@ -76,7 +76,7 @@ which device will be used for it.
         >
 
         ```bash
-        write-livecd.sh "${USB}" "${CSM_PATH}/"cray-pre-install-toolkit-*.iso 50000
+        write-livecd.sh "${USB}" cray-pre-install-toolkit-*.iso 50000
         ```
 
 ## Boot the LiveCD


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
USB path does not need `CSM_PATH` set, the LiveCD should be available at the present working directory.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
