### PR TITLE
CASMINST-5205: Fixes, enhancements, and linting to install/upgrade docs

### DIFF
--- a/install/install_csm_services.md
+++ b/install/install_csm_services.md
@@ -84,7 +84,7 @@ This procedure will install CSM applications and services into the CSM Kubernete
 
    ```bash
    SPIRE_JOB=$(kubectl -n spire get jobs -l app.kubernetes.io/name=spire-update-bss -o name)
-   kubectl -n spire get $SPIRE_JOB -o json | jq 'del(.spec.selector)' \
+   kubectl -n spire get "${SPIRE_JOB}" -o json | jq 'del(.spec.selector)' \
        | jq 'del(.spec.template.metadata.labels."controller-uid")' \
        | kubectl replace --force -f -
    ```
@@ -92,7 +92,7 @@ This procedure will install CSM applications and services into the CSM Kubernete
 1. (`pit#`) Wait for the `spire-update-bss` job to complete.
 
    ```bash
-   kubectl -n spire wait  $SPIRE_JOB --for=condition=complete --timeout=5m
+   kubectl -n spire wait "${SPIRE_JOB}" --for=condition=complete --timeout=5m
    ```
 
 ## 3. Wait for everything to settle

--- a/install/pre-installation.md
+++ b/install/pre-installation.md
@@ -416,16 +416,16 @@ in `/etc/environment` from the [Download CSM tarball](#21-download-csm-tarball) 
            update -y cray-site-init
        ```
 
-   1. Install `csm-testing` and `goss-servers`.
+   1. Install `csm-testing` RPM.
 
-       > ***NOTE*** These packages provide the necessary tests and their dependencies for validating the pre-installation, installation, and more.
+       > ***NOTE*** This package provides the necessary tests and their dependencies for validating the pre-installation, installation, and more.
 
        ```bash
        zypper \
            --plus-repo "${CSM_PATH}/rpm/cray/csm/sle-15sp2/" \
            --plus-repo "${CSM_PATH}/rpm/cray/csm/sle-15sp3/" \
            --no-gpg-checks \
-           install -y csm-testing goss-servers
+           install -y csm-testing
       ```
 
 1. (`pit#`) Get the artifact versions.

--- a/operations/hardware_state_manager/Set_BMC_Management_Role.md
+++ b/operations/hardware_state_manager/Set_BMC_Management_Role.md
@@ -79,6 +79,8 @@ Use the `cray hsm state components bulkRole update` command to perform setting r
    cray hsm state components bulkRole update --role Management --component-ids "${BMCList}"
    ```
 
+   This command gives no output when it completes successfully.
+
 ### How to set BMC management roles on specific BMCs of management nodes
 
 1. (`ncn-mw#`) Set the `Management` role for specific BMCs.
@@ -86,3 +88,5 @@ Use the `cray hsm state components bulkRole update` command to perform setting r
    ```bash
    cray hsm state components bulkRole update --role Management --component-ids x3000c0s8b0
    ```
+
+   This command gives no output when it completes successfully.

--- a/upgrade/README.md
+++ b/upgrade/README.md
@@ -26,21 +26,19 @@ The upgrade is a guided process starting with [Upgrade Management Nodes and CSM 
 
 ## 3. Validate CSM health
 
- **`NOTE`**
-
 - Before performing the health validation, be sure that at least 15 minutes have elapsed
   since the CSM services were upgraded. This allows the various Kubernetes resources to
   initialize and start.
-- If the site does not use UAIs, skip UAS and UAI validation. If UAIs are used, there are
-  products that configure UAS like Cray Analytics and Cray Programming Environment that
-  must be working correctly with UAIs, and should be validated (the procedures for this are
-  beyond the scope of this document) prior to validating UAS and UAI. Failures in UAI creation that result
+- If the site does not use UAIs, then skip UAS and UAI validation. If UAIs are used, then
+  before validating UAS and UAI, first validate any products that configure UAS (such as
+  Cray Analytics and Cray Programming Environment); the procedures for this are
+  beyond the scope of this document. Failures in UAI creation that result
   from incorrect or incomplete installation of these products will generally take the form of UAIs stuck in
-  waiting state trying to set up volume mounts.
-- Performing the [Booting CSM `barebones` image](../operations/validate_csm_health.md#5-booting-csm-barebones-image) test may be skipped if no
-  compute nodes are available (but only if all compute nodes are active running application workloads).
+  `waiting` state, trying to set up volume mounts.
+- Although it is not recommended, the [Booting CSM `barebones` image](../operations/validate_csm_health.md#5-booting-csm-barebones-image)
+  test may be skipped if all compute nodes are active running application workloads.
 
- See [Validate CSM Health](../operations/validate_csm_health.md)
+See [Validate CSM Health](../operations/validate_csm_health.md).
 
 ## 4. Next topic
 
@@ -50,6 +48,6 @@ on the [HPE Customer Support Center](https://www.hpe.com/support/ex-gsg)
 for more information on other product streams to be upgraded and configured after CSM.
 
 > **`NOTE`** If a newer version of the HPE Cray EX HPC Firmware Pack (HFP) is available, then the next step
-would be to install HFP which will inform the Firmware Action Services (FAS) of the newest firmware
+is to install HFP. This will inform the Firmware Action Services (FAS) of the newest firmware
 available. Once FAS is aware that new firmware is available, then see
 [Update Firmware with FAS](../operations/firmware/Update_Firmware_with_FAS.md).

--- a/upgrade/Stage_0_Prerequisites.md
+++ b/upgrade/Stage_0_Prerequisites.md
@@ -6,10 +6,7 @@
 > - If any problems are encountered and the procedure or command output does not provide relevant guidance, see
 >   [Relevant troubleshooting links for upgrade-related issues](README.md#relevant-troubleshooting-links-for-upgrade-related-issues).
 
-Stage 0 has several critical procedures which prepares and verify if the environment is ready for upgrade. First, the latest documentation RPM is installed; it includes
-critical install scripts used in the upgrade procedure.
-The management network configuration is also upgraded. Towards the end, prerequisite checks are performed to ensure that the upgrade is ready to proceed. Finally, a
-backup of Workload Manager configuration data and files is created. Once complete, the upgrade proceeds to Stage 1.
+Stage 0 has several critical procedures which prepare the environment and verify if the environment is ready for the upgrade.
 
 - [Stage 0.1 - Prepare assets](#stage-01---prepare-assets)
   - [Direct download](#direct-download)
@@ -31,8 +28,11 @@ backup of Workload Manager configuration data and files is created. Once complet
 
 1. If there are space concerns on the node, then add an `rbd` device on the node for the CSM tarball.
 
-    See [Create a storage pool](../operations/utility_storage/Alternate_Storage_Pools.md#create-a-storage-pool)
-    and [Create and map an `rbd` device](../operations/utility_storage/Alternate_Storage_Pools.md#create-and-map-an-rbd-device).
+    1. [Create a storage pool](../operations/utility_storage/Alternate_Storage_Pools.md#create-a-storage-pool).
+
+    1. [Create and map an `rbd` device](../operations/utility_storage/Alternate_Storage_Pools.md#create-and-map-an-rbd-device).
+
+    1. [Mount an `rbd` device](../operations/utility_storage/Alternate_Storage_Pools.md#mount-an-rbd-device).
 
     **Note:** This same `rbd` device can be remapped to `ncn-m002` later in the upgrade procedure, when the CSM tarball is needed on that node.
     However, the `prepare-assets.sh` script will delete the CSM tarball in order to free space on the node.

--- a/upgrade/Stage_2.md
+++ b/upgrade/Stage_2.md
@@ -1,4 +1,4 @@
-# Stage 2 - Kubernetes Upgrade from 1.19.9 to 1.20.13
+# Stage 2 - Kubernetes Upgrade
 
 **Reminder:** If any problems are encountered and the procedure or command output does not provide relevant guidance, see
 [Relevant troubleshooting links for upgrade-related issues](README.md#relevant-troubleshooting-links-for-upgrade-related-issues).
@@ -13,7 +13,7 @@
    /usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-master-nodes.sh ncn-m002
    ```
 
-   > **`NOTE`** The root password for the node may need to be reset after it is rebooted.
+   > **`NOTE`** The `root` user password for the node may need to be reset after it is rebooted.
 
 1. Repeat the previous step for each other master node **excluding `ncn-m001`**, one at a time.
 
@@ -29,24 +29,32 @@
    /usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-worker-nodes.sh ncn-w001
    ```
 
-   > **`NOTE`** The root password for the node may need to be reset after it is rebooted.
+   > **`NOTE`** The `root` user password for the node may need to be reset after it is rebooted.
 
 1. Repeat the previous steps for each other worker node, one at a time.
 
-### Option 2
+### Option 2 (Tech preview)
 
-> **`Tech Preview`**
->>
->> You can also upgrade multiple workers at the same time with comma separated list. Note that in some cases, you can't rebuild all workers in one request. It is system admin's responsibility to make sure a multiple workers request meets following conditions:
->>
->> 1. If your system has more than 5 workers, you can't rebuild `ncn-w001,ncn-w002 and ncn-w003` together in one request. You will need at least two requests (example: rebuild `ncn-w001,ncn-w003,ncn-w004,...` first and then rebuild `ncn-w002,ncn-w003,...`)
->> 2. If your system has more that 5 workers, you can't rebuild all workers that has DVS running in one request.
->
-> ```bash
-> /usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-worker-nodes.sh ncn-w001,ncn-w002,ncn-w003
->```
->
->>
+Multiple workers can be upgraded simultaneously by passing them as a comma-separated list into the upgrade script.
+
+#### Restrictions
+
+In some cases, it is not possible to upgrade all workers in one request. It is system administrator's responsibility to
+make sure that the following conditions are met:
+
+* If the system has more than five workers, then they cannot all be upgraded with a single request.
+
+    In this case, the upgrade should be split into multiple requests, with each request specifying no more than five workers.
+
+* No single upgrade request should include all of the worker nodes that have DVS running on them.
+
+#### Example
+
+(`ncn-m001#`) An example of a single request to upgrade multiple worker nodes simultaneously:
+
+```bash
+/usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-worker-nodes.sh ncn-w002,ncn-w003,ncn-w004
+```
 
 ## Stage 2.3
 

--- a/upgrade/Stage_4.md
+++ b/upgrade/Stage_4.md
@@ -1,9 +1,9 @@
 # Stage 4 - Ceph Upgrade
 
-**Reminder:** If any problems are encountered and the procedure or command output does not provide relevant guidance, see
+**Reminder:** If any problems are encountered and the procedure or command output does not provide relevant guidance, then see
 [Relevant troubleshooting links for upgrade-related issues](README.md#relevant-troubleshooting-links-for-upgrade-related-issues).
 
-## Addresses Bugs and CVEs
+## Ceph upgrade contents
 
 The upgrade includes all fixes from `v15.2.15` through `v16.2.9`. See the [Ceph version index](https://docs.ceph.com/en/latest/releases/pacific/) for details.
 
@@ -11,13 +11,14 @@ The upgrade includes all fixes from `v15.2.15` through `v16.2.9`. See the [Ceph 
 
 * This upgrade is performed using the `cubs_tool`.
 * The `cubs_tool.py` can be found on `ncn-s00[1-3]` in `/srv/cray/script/common/`
-* Unless otherwise noted, all `ceph` commands that may need to be used in this stage may be run on any master node or any of the first three storage nodes (`ncn-s00[1-3]`).
+* Unless otherwise noted, all `ceph` commands that may need to be used in this stage may be run on any master node or any of the first three storage
+  nodes (`ncn-s001`, `ncn-s002`, or `ncn-s003`).
 
 ### Initiate upgrade
 
-1. Check to ensure that the upgrade is possible.
+1. (`ncn-s001#`) Check to ensure that the upgrade is possible.
 
-   On `ncn-s001`:
+   On :
 
    ```bash
    /srv/cray/scripts/common/cubs_tool.py --version 16.2.9 --registry localhost
@@ -29,15 +30,10 @@ The upgrade includes all fixes from `v15.2.15` through `v16.2.9`. See the [Ceph 
    Upgrade Available!!  The specified version v16.2.9 has been found in the registry
    ```
 
-   **Notes:**
+   **Note:** If the output does not match what is expected, then this can indicate that a previous step has failed.
+   Review the output from [Stage 1](Stage_1.md) for errors or contact support.
 
-   * This upgrade is targeting the Ceph processes running `15.2.15` only.
-   * The monitoring services may be listed but those are patched internally and may not be upgraded with this upgrade.
-     * This includes `alertmanager`, `prometheus`, `node-exporter`, and `grafana`.
-   * If the output does not match what is expected, then this can indicate that a previous step has failed.
-     Review output from [Stage 1](Stage_1.md) for errors or contact support.
-
-1. Start the upgrade.
+1. (`ncn-s001#`) Start the upgrade.
 
    ```bash
    /srv/cray/scripts/common/cubs_tool.py --version v16.2.9 --registry localhost --upgrade
@@ -50,9 +46,12 @@ The upgrade includes all fixes from `v15.2.15` through `v16.2.9`. See the [Ceph 
    Initiating Ceph upgrade from v16.2.7 to v16.2.9
    ```
 
+   The source version in the output may vary, but the target version should match what is shown above.
+
 1. Monitor the upgrade.
 
-   The `cubs_tool` will automatically watch the upgrade.  As services are upgraded they will move from the ***Current*** column to the ***Upgraded*** column.
+   The `cubs_tool` will automatically watch the upgrade.
+   As services are upgraded, they will move from the `Total Current` column to the `Total Upgraded` column.
 
    ```text
    +---------+---------------+----------------+
@@ -67,7 +66,7 @@ The upgrade includes all fixes from `v15.2.15` through `v16.2.9`. See the [Ceph 
    +---------+---------------+----------------+
    ```
 
-   This will progress to the end result of:
+   The final result should have `0` for every service in the `Total Current` column.
 
    ```text
    +---------+---------------+----------------+
@@ -82,9 +81,7 @@ The upgrade includes all fixes from `v15.2.15` through `v16.2.9`. See the [Ceph 
    +---------+---------------+----------------+
    ```
 
-1. Verify completed upgrade
-
-   On `ncn-s001`:
+1. (`ncn-s001#`) Verify that the upgrade completed successfully.
 
    ```bash
    /srv/cray/scripts/common/cubs_tool.py --report
@@ -92,7 +89,7 @@ The upgrade includes all fixes from `v15.2.15` through `v16.2.9`. See the [Ceph 
 
    Expected output:
 
-   ```bash
+   ```text
    +----------+-------------+-----------------+---------+---------+
    |   Host   | Daemon Type |        ID       | Version |  Status |
    +----------+-------------+-----------------+---------+---------+
@@ -143,12 +140,12 @@ The upgrade includes all fixes from `v15.2.15` through `v16.2.9`. See the [Ceph 
    +----------+-------------+-----------------------+---------+---------+
    ```
 
-   **NOTE:** This is an example only and is showing only the core Ceph components.  
+   **NOTE:** This is an example only and is showing only the core Ceph components.
 
 ### Diagnose a stalled upgrade
 
-The processes running the Ceph container image will go through the upgrade process. This involves stopping the old process running the version `15.2.15`
-container and restarting the process with the new version `16.2.9` container image.
+The processes running the Ceph container image will go through the upgrade process. This involves stopping the old process
+and restarting the process with the new version `16.2.9` container image.
 
 **IMPORTANT:** Only processes running the `15.2.15` image will be upgraded. This includes `crash`, `mds`, `mgr`, `mon`, `osd`, and `rgw` processes only.
 
@@ -157,7 +154,7 @@ container and restarting the process with the new version `16.2.9` container ima
 If `ceph -s` shows a warning with `UPGRADE_FAILED_PULL: Upgrade: failed to pull target image` as the description, then perform the following procedure
 on any of the first three storage nodes (`ncn-s001`, `ncn-s002`, or `ncn-s003`).
 
-1. Check the upgrade status.
+1. (`ncn-s#`) Check the upgrade status.
 
     ```bash
     ceph orch upgrade status
@@ -174,22 +171,22 @@ on any of the first three storage nodes (`ncn-s001`, `ncn-s002`, or `ncn-s003`).
      }
      ```
 
-1. Pause and resume the upgrade.
+1. (`ncn-s#`) Pause and resume the upgrade.
 
     ```bash
     ceph orch upgrade pause
     ceph orch upgrade resume
     ```
 
-1. Watch `cephadm`.
+1. (`ncn-s#`) Watch `cephadm`.
 
-    This command watches the `cephadm` logs. If the issue occurs again, it will give more details about which node may be having an issue.
+    This command watches the `cephadm` logs. If the issue occurs again, then it will give more details about which node may be having an issue.
 
     ```bash
     ceph -W cephadm
     ```
 
-1. If the issue occurs again, then log into each of the storage nodes and perform a `podman` pull of the image.
+1. (`ncn-s#`) If the issue occurs again, then log into each of the storage nodes and perform a `podman` pull of the image.
 
     ```bash
     podman pull localhost/quay.io/ceph/ceph:v16.2.9
@@ -197,40 +194,12 @@ on any of the first three storage nodes (`ncn-s001`, `ncn-s002`, or `ncn-s003`).
 
 If these steps do not resolve the issue, then contact support for further assistance.
 
-   1. Troubleshoot the failed upgrade.
+### Troubleshoot a failed upgrade
 
-      The upgrade is not complete. See
-      See [Ceph Orchestrator Usage](../operations/utility_storage/Ceph_Orchestrator_Usage.md) for additional usage and troubleshooting.
-
-   1. Verify that no processes are running the old version `15.2.15`.
-
-   The following command will count the number of processes which are running version `15.2.15`.
-
-   ```bash
-   ceph orch ps -f json-pretty|jq -r '[.[]|select(.version=="15.2.15")] | length'
-   ```
-
-   If the command outputs any number other than zero, then this means there are processes still running `15.2.15`. In that case, do the following:
-
-   1. List the processes which are not at the expected version.
-
-      ```bash
-      ceph orch ps -f json-pretty|jq -r '[.[]|select(.version=="15.2.15")]'
-      ```
-
-   2. Make sure the upgrade has stopped.
-
-      ```bash
-      ceph orch upgrade stop
-      ```
-
-   3. Troubleshoot the failed upgrade.
-
-      The upgrade is not complete. See
-      [Ceph Orchestrator Usage](../operations/utility_storage/Ceph_Orchestrator_Usage.md) for additional usage and troubleshooting.
-
-**DO NOT** proceed past this point if the upgrade has not completed and been verified. Contact support for in-depth troubleshooting.
+See [Ceph Orchestrator Usage](../operations/utility_storage/Ceph_Orchestrator_Usage.md) for additional usage and troubleshooting.
 
 ## Stage completed
+
+**DO NOT** proceed past this point if the upgrade has not completed and been verified. Contact support for in-depth troubleshooting.
 
 This stage is completed. Continue to [Stage 5](Stage_5.md).

--- a/upgrade/Stage_5.md
+++ b/upgrade/Stage_5.md
@@ -5,18 +5,13 @@
 
 ## Procedure
 
-1. Set the `root` user password and SSH keys before running NCN personalization.
-   The location where the password is stored in Vault has changed since previous
-   CSM versions. See
-   [Configure the `root` Password and `root` SSH Keys in Vault](../operations/CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md#2-configure-the-root-password-and-ssh-keys-in-vault).
-
 1. If custom configuration content was merged with content from a previous CSM
    installation, then merge the new CSM configuration in with it in the `csm-config-management`
    Git repository. This is not necessary if the NCN personalization configuration
    was using a commit on a `cray/csm/VERSION` branch (that is, using the default
    configuration).
 
-   The new CSM configuration content is found in the `cray-product-catalog`
+   (`ncn-m002#`) The new CSM configuration content is found in the `cray-product-catalog`
    Kubernetes `ConfigMap`. If using the default CSM configuration, simply note the value in
    the `commit` field.
 
@@ -38,18 +33,18 @@
 
    The specific dates, commits, and other values may not be the same as the output above.
 
-1. View the current `ncn-personalization` configuration and write it to a JSON file.
+1. (`ncn-m002#`) View the current `ncn-personalization` configuration and write it to a JSON file.
 
    ```bash
    cray cfs configurations describe ncn-personalization --format json | tee ncn-personalization.json
    ```
 
-1. Run the `apply_csm_configuration.sh` script. This script will update the CSM
+1. (`ncn-m002#`) Run the `apply_csm_configuration.sh` script. This script will update the CSM
    layer in the `ncn-personalization` configuration, enable configuration of
    the NCNs, and monitor the progress of the NCN personalization process.
 
-   **IMPORTANT:**
-
+   > **IMPORTANT:**
+   >
    > * If using a different branch than the default to include custom
        changes, use the `--git-commit` argument to specify the desired commit on
        the branch including the customizations. Otherwise this argument is not needed.
@@ -70,7 +65,7 @@
 
    For more information on this script, see [Automatically Apply CSM Configuration to NCNs](../operations/CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md#option-1-automatically-apply-csm-configuration).
 
-1. Review the new `ncn-personalization` configuration and write it to a JSON file.
+1. (`ncn-m002#`) Review the new `ncn-personalization` configuration and write it to a JSON file.
 
    ```bash
    cray cfs configurations describe ncn-personalization --format json | tee ncn-personalization.json.new
@@ -78,4 +73,4 @@
 
 ## Stage completed
 
-This stage is completed. Proceed to [Validate CSM health](../README.md#3-validate-csm-health) on the main upgrade page.
+This stage is completed. Proceed to [Validate CSM health](README.md#3-validate-csm-health) on the main upgrade page.

--- a/upgrade/prepare_for_upgrade.md
+++ b/upgrade/prepare_for_upgrade.md
@@ -18,8 +18,7 @@ Before beginning an upgrade to a new version of CSM, there are a few things to d
         **Important:** SDU takes about 15 minutes to run on a small system \(longer for large systems\).
 
         ```bash
-        sdu --scenario triage --start_time '-4 hours' \
-        --reason "saving state before powerdown/up"
+        sdu --scenario triage --start_time '-4 hours' --reason "saving state before powerdown/up"
         ```
 
         Refer to the HPE Cray EX System Diagnostic Utility (SDU) Administration Guide for more information and troubleshooting steps.
@@ -44,125 +43,49 @@ Before beginning an upgrade to a new version of CSM, there are a few things to d
         egrep -v "Run|Completed" k8s.pods | tee k8s.pods.errors
         ```
 
-1. (`ncn-m001#`) Check for running sessions.
+1. Check for BOS, CFS, CRUS, FAS, or NMD sessions.
 
-    Ensure that these services do not have any sessions in progress: BOS, CFS, CRUS, FAS, or NMD.
-    > This SAT command has `shutdown` as one of the command line options, but it will not start a shutdown process on the system.
+    1. (`ncn-m001#`) Ensure that these services do not have any sessions in progress.
 
-    ```bash
-    sat bootsys shutdown --stage session-checks
-    ```
+        > This SAT command has `shutdown` as one of the command line options, but it will not start a shutdown process on the system.
 
-    Example output:
+        ```bash
+        sat bootsys shutdown --stage session-checks
+        ```
 
-    ```text
-    Checking for active BOS sessions.
-    Found no active BOS sessions.
-    Checking for active CFS sessions.
-    Found no active CFS sessions.
-    Checking for active CRUS upgrades.
-    Found no active CRUS upgrades.
-    Checking for active FAS actions.
-    Found no active FAS actions.
-    Checking for active NMD dumps.
-    Found no active NMD dumps.
-    No active sessions exist. It is safe to proceed with the shutdown procedure.
-    ```
+        Example output:
 
-    If active sessions are running, either wait for them to complete or shut down/cancel/delete the session.
+        ```text
+        Checking for active BOS sessions.
+        Found no active BOS sessions.
+        Checking for active CFS sessions.
+        Found no active CFS sessions.
+        Checking for active CRUS upgrades.
+        Found no active CRUS upgrades.
+        Checking for active FAS actions.
+        Found no active FAS actions.
+        Checking for active NMD dumps.
+        Found no active NMD dumps.
+        No active sessions exist. It is safe to proceed with the shutdown procedure.
+        ```
 
-1. Coordinate with the site to prevent new sessions from starting in the services listed (BOS, CFS, CRUS, FAS, NMD).
+        If active sessions are running, then either wait for them to complete or shut down, cancel, or delete them.
 
-    In version Shasta v1.5, there is no method to prevent new sessions from being created as long as the service APIs are accessible on the API gateway.
+    1. Coordinate with the site to prevent new sessions from starting in these services.
+
+        There is currently no method to prevent new sessions from being created as long as the service APIs are accessible on the API gateway.
 
 1. Validate CSM Health
 
-   Run the CSM health checks to ensure that everything is working properly before the upgrade starts.
+    Run the CSM health checks to ensure that everything is working properly before the upgrade starts.
 
-   **`IMPORTANT`**: See the `CSM Install Validation and Health Checks` procedures in the documentation for your **`CURRENT`** CSM version. The validation procedures in the CSM 1.2 documentation are not all intended to work on previous versions of CSM.
+    **`IMPORTANT`**: See the `CSM Install Validation and Health Checks` procedures in the documentation for the **`CURRENT`** CSM version on
+    the system. The validation procedures in the CSM documentation are not all intended to work on previous versions of CSM.
 
 1. Validate Lustre Health
 
-   If a Lustre file system is being used, see the ClusterStor documentation for details on how to check
-   for Lustre health. Here are a few commands which could be used to validate Lustre health. This example
-   is for a ClusterStor providing the `cls01234` filesystem.
+   If a Lustre file system is being used, then see the ClusterStor documentation for details on how to check
+   for Lustre health.
 
-   1. SSH to the primary management node.
-      For example, on system `cls01234`.
-
-      ```bash
-      remote$ ssh -l admin cls01234n000.systemname.com
-      ```
-
-   1. Check that the shared storage targets are available for the management nodes.
-
-      ```bash
-      [n000]$ pdsh -g mgmt cat /proc/mdstat | dshbak -c
-      ```
-
-      Example output:
-
-      ```text
-      ----------------
-      cls01234n000
-      ----------------
-      Personalities : [raid1] [raid6] [raid5] [raid4] [raid10]
-      md64 : active raid10 sda[0] sdc[3] sdw[2] sdl[1]
-      1152343680 blocks super 1.2 64K chunks 2 near-copies [4/4] [UUUU]
-      bitmap: 2/9 pages [8KB], 65536KB chunk
-      md127 : active raid1 sdy[0] sdz[1]
-      439548848 blocks super 1.0 [2/2] [UU]
-      unused devices: <none>
-      ----------------
-      cls01234n001
-      ----------------
-      Personalities : [raid1] [raid6] [raid5] [raid4] [raid10]
-      md67 : active raid1 sdi[0] sdt[1]
-      576171875 blocks super 1.2 [2/2] [UU]
-      bitmap: 0/5 pages [0KB], 65536KB chunk
-      md127 : active raid1 sdy[0] sdz[1]
-      439548848 blocks super 1.0 [2/2] [UU]
-      unused devices: <none>
-      ```
-
-   1. Check HA status.
-
-      ```bash
-      [n000]$ sudo crm_mon -1r
-      ```
-
-      The output indicates whether all resources are started and balanced between two nodes.
-
-   1. Check the status of the nodes.
-
-      ```bash
-      [n000]# pdsh -a date
-      ```
-
-      Example output:
-
-      ```text
-      cls01234n000: Thu Aug 7 01:29:28 PDT 2014
-      cls01234n003: Thu Aug 7 01:29:28 PDT 2014
-      cls01234n002: Thu Aug 7 01:29:28 PDT 2014
-      cls01234n001: Thu Aug 7 01:29:28 PDT 2014
-      cls01234n007: Thu Aug 7 01:29:28 PDT 2014
-      cls01234n006: Thu Aug 7 01:29:28 PDT 2014
-      cls01234n004: Thu Aug 7 01:29:28 PDT 2014
-      cls01234n005: Thu Aug 7 01:29:28 PDT 2014
-      ```
-
-   1. Check the health of the Lustre file system.
-
-      ```bash
-      [n000]# cscli csinfo
-      [n000]# cscli show_nodes
-      [n000]# cscli fs_info
-      ```
-
-1. Optional - Create `rbd` device to provide space for the CSM release tarball.
-
-    See [Create a storage pool](../operations/utility_storage/Alternate_Storage_Pools.md#create-a-storage-pool)
-    and [Create and map an `rbd` device](../operations/utility_storage/Alternate_Storage_Pools.md#create-and-map-an-rbd-device).
-
-After completing the above steps, proceed to [Upgrade Management Nodes and CSM Services](README.md#2-upgrade-management-nodes-and-csm-services).
+After completing the above steps, proceed to
+[Upgrade Management Nodes and CSM Services](README.md#2-upgrade-management-nodes-and-csm-services).

--- a/upgrade/upgrade_ncn_nodes.md
+++ b/upgrade/upgrade_ncn_nodes.md
@@ -10,7 +10,7 @@ mentioned explicitly on this page, see [resource material](resource_material/REA
 
 ### Service request adjustments are needed for small systems
 
-- For systems with only three worker nodes (typically Testing and  Development Systems (TDS)), prior to proceeding with this upgrade, CPU limits **MUST** be
+- For systems with only three worker nodes (typically Testing and Development Systems (TDS)), prior to proceeding with this upgrade, CPU limits **MUST** be
   lowered on several services in order for this upgrade to succeed. This step is
   executed automatically as part of [Stage 0.4](Stage_0_Prerequisites.md#stage-04---prerequisites-check) of the upgrade.
   See [TDS Lower CPU Requests](../operations/kubernetes/TDS_Lower_CPU_Requests.md) for more information.

--- a/upgrade/upgrade_ncn_nodes.md
+++ b/upgrade/upgrade_ncn_nodes.md
@@ -8,34 +8,19 @@ mentioned explicitly on this page, see [resource material](resource_material/REA
 
 ## Important Notes
 
-### Bifurcated CAN
+### Service request adjustments are needed for small systems
 
-A major feature of CSM 1.2 is the Bifurcated CAN (BICAN). The BICAN is designed to separate administrative network traffic from user network traffic. For more information, see the [BICAN Summary](../operations/network/management_network/bican_technical_summary.md). Review the BICAN Summary before continuing with the CSM 1.2 upgrade.
+- For systems with only three worker nodes (typically Testing and  Development Systems (TDS)), prior to proceeding with this upgrade, CPU limits **MUST** be
+  lowered on several services in order for this upgrade to succeed. This step is
+  executed automatically as part of [Stage 0.4](Stage_0_Prerequisites.md#stage-04---prerequisites-check) of the upgrade.
+  See [TDS Lower CPU Requests](../operations/kubernetes/TDS_Lower_CPU_Requests.md) for more information.
 
-For detailed BICAN documentation, see the [BICAN Technical Details](../operations/network/management_network/bican_technical_details.md) page.
+- Independently, for three-worker systems the `customizations.yaml` file is edited automatically during the upgrade, prior to deploying new CSM services. These
+  settings are contained in `/usr/share/doc/csm/upgrade/scripts/upgrade/tds_cpu_requests.yaml`. This file can be modified (prior to proceeding with this
+  upgrade), if other settings are desired in the `customizations.yaml` file for this system.
 
-### The SMA Grafana service is temporarily inaccessible during the upgrade.
-
-  During stage 3 of the CSM 1.2 upgrade, the SMA Grafana service will become inaccessible at its previous DNS location. It will
-  remain inaccessible until the upgrade to SMA 1.6.x is applied. This is because of a change in DNS names for the service.
-
-### Service request adjustments are needed for small systems.
-
-  - For systems with only three worker nodes (typically Testing and  Development Systems (TDS)), prior to proceeding with this upgrade, CPU limits **MUST** be
-    lowered on several services in order for this upgrade to succeed. This step is
-    executed automatically as part of [Stage 0.4](Stage_0_Prerequisites.md#stage-04---prerequisites-check) of the upgrade.
-    See [TDS Lower CPU Requests](../operations/kubernetes/TDS_Lower_CPU_Requests.md) for more information.
-
-  - Independently, for three-worker systems the `customizations.yaml` file is edited automatically during the upgrade, prior to deploying new CSM services. These
-    settings are contained in `/usr/share/doc/csm/upgrade/scripts/upgrade/tds_cpu_requests.yaml`. This file can be modified (prior to proceeding with this
-    upgrade), if other settings are desired in the `customizations.yaml` file for this system.
-
-    For more information about modifying `customizations.yaml` and tuning for specific systems, see
-    [Post Install Customizations](../operations/CSM_product_management/Post_Install_Customizations.md).
-
-## Known issues
-
-- `kdump` (kernel dump) may hang and fail on NCNs in CSM 1.2 (HPE Cray EX System Software 22.07 release).
+  For more information about modifying `customizations.yaml` and tuning for specific systems, see
+  [Post Install Customizations](../operations/CSM_product_management/Post_Install_Customizations.md).
 
 ## Upgrade stages
 


### PR DESCRIPTION
# Description

Fixes, enhancements, and linting based on my recent installs and upgrades.

A lot of the changes to the 1.3 docs were removing things from 1.2 that no longer applied.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
