### PR TITLE
CASMINST-5206 Upgrade spire during prereq steps

### DIFF
--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -338,6 +338,20 @@ else
     echo "====> ${state_name} has been completed"
 fi
 
+state_name="UPGRADE_SPIRE"
+#shellcheck disable=SC2046
+state_recorded=$(is_state_recorded "${state_name}" $(hostname))
+if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
+    echo "====> ${state_name} ..."
+    {
+        "${locOfScript}"/util/upgrade-spire.sh
+    } >> ${LOG_FILE} 2>&1
+    #shellcheck disable=SC2046
+    record_state ${state_name} $(hostname)
+else
+    echo "====> ${state_name} has been completed"
+fi
+
 state_name="UPGRADE_KYVERNO"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
 if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then

--- a/upgrade/scripts/upgrade/util/upgrade-spire.sh
+++ b/upgrade/scripts/upgrade/util/upgrade-spire.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+set -eu
+
+function deploySpire() {
+    BUILDDIR="/tmp/build"
+    mkdir -p "$BUILDDIR"
+    kubectl get secrets -n loftsman site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d > "${BUILDDIR}/customizations.yaml"
+    manifestgen -i "${CSM_ARTI_DIR}/manifests/sysmgmt.yaml" -c "${BUILDDIR}/customizations.yaml" -o "${BUILDDIR}/spireupgrade.yaml"
+    charts="$(yq r $BUILDDIR/spireupgrade.yaml 'spec.charts[*].name')"
+    for chart in $charts; do
+        if [[ $chart != "spire" ]]; then 
+            yq d -i $BUILDDIR/spireupgrade.yaml "spec.charts.(name==$chart)"
+        fi
+    done
+
+    yq w -i $BUILDDIR/spireupgrade.yaml "metadata.name" "spireupgrade"
+    yq d -i $BUILDDIR/spireupgrade.yaml "spec.sources"
+
+    loftsman ship --charts-path "${CSM_ARTI_DIR}/helm/" --manifest-path $BUILDDIR/spireupgrade.yaml
+}
+
+deploySpire


### PR DESCRIPTION
# Description

CSM 1.3 changes the location of the spire files from `/root/spire` to `/var/lib/spire`. The spire chart needs to be updated prior to NCNs being upgraded so that they can rejoin spire properly.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
