### PR TITLE
MTL-1875: blacklisting `rpcrdma` is always required

### DIFF
--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -227,23 +227,12 @@ If the following command does not complete successfully, check if the `TOKEN` en
    ncn-m001# export SW_ADMIN_PASSWORD
    ```
 
-1. Prevent the use of the `rpcrdma` modules **only if needed**.
+1. Prevent the use of the `rpcrdma` module.
 
-   This step is required if the Kubernetes worker nodes on the system contain Mellanox ConnectX-4
-   network cards.
+   This step is required. The `rpcrdma` kernel module needs to be ignored so that it does not interfere
+   with Slingshot Host Software.
 
-   1. Determine if Mellanox ConnectX-4 network cards are in use.
-
-       ```bash
-       ncn-m001# ssh ncn-w001 lspci | grep ConnectX-4
-       ```
-
-   If no output is emitted, then skip the following sub-step and continue to the next step.
-
-   1. Run the following script to add the necessary parameters to the kernel command line on the worker nodes.
-
-       On worker nodes containing ConnectX-4 network interface cards, the `rpcrdma` kernel module needs
-       to be ignored so that it does not interfere with Slingshot Host Software.
+   Run the following script to add the necessary parameters to the kernel command line on the worker nodes.
 
    ```bash
    ncn-m001# /usr/share/doc/csm/upgrade/1.2/scripts/k8s/blacklist-kernel-modules.sh


### PR DESCRIPTION
# Description

It was discovered on `hela`, which does not have any CX-4 cards, that the blacklisting was still necessary.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
