### PR TITLE
CASMPET-5887: Update Nexus password check in prereqs

### DIFF
--- a/upgrade/Stage_0_Prerequisites.md
+++ b/upgrade/Stage_0_Prerequisites.md
@@ -149,9 +149,9 @@ Stage 0 has several critical procedures which prepare the environment and verify
 
 1. (`ncn-m001#`) Set the `NEXUS_PASSWORD` variable **only if needed**.
 
-   > **IMPORTANT:** If the password for the local Nexus `admin` account has
-   > been changed from the default `admin123` (not typical), then set the
-   > `NEXUS_PASSWORD` environment variable to the correct `admin` password
+   > **IMPORTANT:** If the password for the local Nexus `admin` account has been
+   > changed from the password set in the `nexus-admin-credential` secret (not typical),
+   > then set the `NEXUS_PASSWORD` environment variable to the correct `admin` password
    > and export it, before running `prerequisites.sh`.
    >
    > For example:
@@ -163,8 +163,8 @@ Stage 0 has several critical procedures which prepare the environment and verify
    > export NEXUS_PASSWORD
    > ```
    >
-   > Otherwise, a random 32-character base-64-encoded string will be generated
-   > and updated as the default `admin` password when Nexus is upgraded.
+   > Otherwise, the upgrade will try to use the password in the `nexus-admin-credential`
+   > secret and fail to upgrade Nexus.
 
 1. (`ncn-m001#`) Run the script.
 


### PR DESCRIPTION
# Description

This adds in a check to the prerequisites.sh script to ensure the Nexus admin credentials are correct so the upgrade does not fail further down the line. This also update stage 0 to more accurately describe how the password is used in the upgrade.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
