### PR TITLE
CASMNET-1777: Fix the canu generate commands

### DIFF
--- a/operations/network/Gateway_Testing.md
+++ b/operations/network/Gateway_Testing.md
@@ -9,10 +9,6 @@ will obtain an API token from Keycloak and then use that token to attempt to acc
 more networks, as defined in the gateway test definition file (`gateway-test-defn.yaml`). The test will check the
 return code to make sure it gets the expected response.
 
-When the `nmnlb` network is tested, the test will use `api-gw-service-nmn.local` as an override for
-`nmnlb.<system-domain>` in CSM v1.2. Optionally, setting `use-api-gw-override: false` in `gateway-test-defn.yaml`
-disables that override, and the test will use `nmnlb.<system-domain>`.
-
 ## Topics
 
 - [Running Gateway Tests on an NCN Management Node](#running-gateway-tests-on-an-ncn-management-node)

--- a/operations/network/management_network/generate_switch_configs.md
+++ b/operations/network/management_network/generate_switch_configs.md
@@ -31,7 +31,7 @@ Generating a configuration file can be done for a single switch, or for the full
 
 **Important:** Modify the following items in your command:
 
-* `--csm` : Which CSM version configuration do you want to use? For example, `1.2` or `1.0`
+* `--csm` : Which CSM version configuration do you want to use? For example, `1.3`, `1.2` or `1.0`
 * `--a`   : What is the system architecture? (See above)
 * `--ccj` : Match the `ccj.json` file to the one you created for your system.
 * `--sls` : Match the `sls_file.json` to the one you created for your system.
@@ -40,11 +40,11 @@ Generating a configuration file can be done for a single switch, or for the full
 * Generate a configuration file for single switch:
 
     ```console
-    canu generate switch configuration--csm 1.2 -a full --ccj system-ccj.json  --sls-file sls_file.json --name sw-spine-001
+    canu generate switch config --csm 1.3 -a full --ccj system-ccj.json  --sls-file sls_file.json --name sw-spine-001
     ```
 
 * Generate configuration files for full system:
 
     ```console
-    canu generate network configuration--csm 1.2 -a full --ccj system-ccj.json  --sls-file sls_file.json --folder generated
+    canu generate network config --csm 1.3 -a full --ccj system-ccj.json  --sls-file sls_file.json --folder generated
     ```

--- a/operations/network/management_network/validate_switch_configs.md
+++ b/operations/network/management_network/validate_switch_configs.md
@@ -9,7 +9,7 @@
   * Run `canu --version` to see version.
   * If doing a CSM install or upgrade, a CANU RPM is located in the release tarball. For more information, see this procedure: [Update CANU From CSM Tarball](canu/update_canu_from_csm_tarball.md)
 
-## Compare CSM 1.2 switch configurations with running configurations
+## Compare CSM 1.3 switch configurations with running configurations
 
 Compare the current running configuration with the generated configuration.
 
@@ -19,6 +19,7 @@ can also pull the configuration from the switch by using the `--ip`, `--username
 Example of CANU pulling configuration.
 
 (`ncn#` or `pit#`)
+
 ```bash
 canu validate switch config --ip 192.168.1.1 --username USERNAME --password PASSWORD --generated ./generated/sw-spine-001.cfg
 ```
@@ -28,6 +29,7 @@ Doing file comparisons on your local machine:
 * Comparing configuration file for single switch:
 
 (`ncn#` or `pit#`)
+
 ```bash
 canu validate switch config --running ./running/sw-spine-001.cfg --generated sw-spine-001.cfg
 ```
@@ -37,8 +39,9 @@ Please enter the vendor (Aruba, Dell, Mellanox): Aruba
 * Comparing configuration files for full system:
 
 (`ncn#` or `pit#`)
+
 ```bash
-canu validate network config --csm 1.2 --running ./running/ --generated ./generated/
+canu validate network config --csm 1.3 --running ./running/ --generated ./generated/
 ```
 
 CANU-generated switch configurations will not include any ports or devices not defined in the model. These were previously discussed in the
@@ -59,7 +62,7 @@ custom to every site and must be distributed with the analysis and configuration
 
 Note: A roadmap item for CANU is the ability to "inject" customer configurations into CANU and provide solid, repeatable configuration customization.
 
-## Analyze CSM 1.2 configuration upgrade
+## Analyze CSM 1.3 configuration upgrade
 
 Configuration updates depending on the current version of network configuration may be as easy as adding few lines or be a complete "rip and replace"
 operation which may lead you to choosing to wipe the existing configuration or just simply adding few lines in the configuration.


### PR DESCRIPTION
# Description
 
While validating some switch configs on jolt1, I found that the `canu generate` commands in the main branch were not correct.   While fixing that I also changed the 1.2 references to 1.3.  

I also found a 1.2 specific line in Gateway_Testing.md that needed to be removed since it is no longer true.

# Checklist Before Merging

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
