### PR TITLE
CASMISNT-4942 automate stage 1 using argo workflows

### DIFF
--- a/upgrade/Stage_1.md
+++ b/upgrade/Stage_1.md
@@ -5,107 +5,18 @@
 
 ## Procedure
 
-1. (`ncn-m001#`) Run `ncn-upgrade-ceph-nodes.sh` for `ncn-s001`. Follow output of the script carefully. The script will pause for manual interaction.
+1. (`ncn-m001#`) Run `ncn-upgrade-worker-storage-nodes.sh` for all storage nodes to be upgraded. Provide the storage nodes in a comma-separated list, such as `ncn-s001,ncn-s002,ncn-s003`. This upgrades the storage nodes sequentially.
 
     ```bash
-    /usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-ceph-nodes.sh ncn-s001
+    /usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh ncn-s001,ncn-s002,ncn-s003
     ```
 
-    > **NOTE:** The `root` password for the node may need to be reset after it is rebooted.
-
-    **Known Issues:**
-
-    * If the below error is observed, then re-run the same command for the node upgrade. It will pick up at that point and continue.
-
-        ```text
-        ====> REDEPLOY_CEPH ...
-        /usr/bin/ssh-copy-id: INFO: Source of key(s) to be installed: "/root/ceph.pub"Number of key(s) added: 1Now try logging into the machine, with:   "ssh 'root@ncn-s003'"
-        and check to make sure that only the key(s) you wanted were added.Error EINVAL: Traceback (most recent call last):
-        ```
-
-    * During the storage node rebuild, Ceph health may report `HEALTH_WARN 1 daemons have recently crashed`. This occurs occasionally as part of the shutdown process of the node
-      being rebuilt. See [Dump Ceph Crash Data](../operations/utility_storage/Dump_Ceph_Crash_Data.md).
-
-1. **IMPORTANT:** Ensure that the Ceph cluster is healthy prior to continuing.
-
-    If there are processes not running, then see [Utility Storage Operations](../operations/utility_storage/Utility_Storage.md) for operational and troubleshooting procedures.
-
-1. Repeat the previous steps for each other storage node, one at a time.
-
-1. (`ncn-m001#`) After `ncn-upgrade-ceph-nodes.sh` has successfully run for all storage nodes, then rescan the SSH keys on all storage nodes.
-
-    ```bash
-    grep -oP "(ncn-s\w+)" /etc/hosts | sort -u | xargs -t -i ssh {} 'truncate --size=0 ~/.ssh/known_hosts'
-    grep -oP "(ncn-s\w+)" /etc/hosts | sort -u | xargs -t -i ssh {} 'grep -oP "(ncn-s\w+|ncn-m\w+|ncn-w\w+)" /etc/hosts | sort -u | xargs -t -i ssh-keyscan -H \{\} >> /root/.ssh/known_hosts'
-    ```
-
-1. Deploy `node-exporter` and `alertmanager`.
-
-    **`NOTE`** This procedure must run on a node running `ceph-mon`, which in most cases will be `ncn-s001`, `ncn-s002`, and `ncn-s003`. It only needs to be run once, not on every one of these nodes.
-
-    1. (`ncn-s#`) Deploy `node-exporter` and `alertmanager`.
-
-        ```bash
-        ceph orch apply node-exporter && ceph orch apply alertmanager
-        ```
-
-        Expected output looks similar to the following:
-
-        ```text
-        Scheduled node-exporter update...
-        Scheduled alertmanager update...
-        ```
-
-    1. (`ncn-s#`) Verify that `node-exporter` is running.
-
-        > **IMPORTANT:** There should be one `node-exporter` container per Ceph node.
-
-        ```bash
-        ceph orch ps --daemon_type node-exporter
-        ```
-
-        Expected output on a system with three Ceph nodes should look similar to the following:
-
-        ```text
-        NAME                    HOST      STATUS         REFRESHED  AGE  VERSION  IMAGE NAME                                              IMAGE ID      CONTAINER ID
-        node-exporter.ncn-s001  ncn-s001  running (57m)  3m ago     67m  0.18.1   registry.local/quay.io/prometheus/node-exporter:v1.2.2  53b6486665ad  8455ee5bfcd2
-        node-exporter.ncn-s002  ncn-s002  running (57m)  3m ago     67m  0.18.1   registry.local/quay.io/prometheus/node-exporter:v1.2.2  53b6486665ad  d37aece375e1
-        node-exporter.ncn-s003  ncn-s003  running (57m)  3m ago     67m  0.18.1   registry.local/quay.io/prometheus/node-exporter:v1.2.2  53b6486665ad  cb3ce40c10c0
-        ```
-
-        The `VERSION` may be reported as `<unknown>`. This is not an error. The three things to verify in the output are:
-
-        * The number of `node-exporter` pods matches the number of Ceph nodes.
-        * The `STATUS` for each pod is `running`.
-        * The `REFRESHED` time for each pod is low enough that it indicates the refresh did not happen **before** the `ceph orch apply` commands issued earlier in this procedure.
-
-    1. (`ncn-s#`) Verify that `alertmanager` is running.
-
-        > **IMPORTANT:** There should be a single `alertmanager` container for the cluster.
-
-        ```bash
-        ceph orch ps --daemon_type alertmanager
-        ```
-
-        Expected output looks similar to the following:
-
-        ```text
-        NAME                   HOST      STATUS         REFRESHED  AGE  VERSION  IMAGE NAME                                              IMAGE ID      CONTAINER ID
-        alertmanager.ncn-s001  ncn-s001  running (66m)  3m ago     68m  0.21.0   registry.local/quay.io/prometheus/alertmanager:v0.21.0  926ce25ce099  58bceaf8577b
-        ```
-
-        The `VERSION` may be reported as `<unknown>`. This is not an error. The three things to verify in the output are:
-
-        * There is exactly one `alertmanager` pod.
-        * The `STATUS` for each pod is `running`.
-        * The `REFRESHED` time for each pod is low enough that it indicates the refresh did not happen **before** the `ceph orch apply` commands issued earlier in this procedure.
-
-1. (`ncn-m001#`) Update BSS to ensure that the Ceph images are loaded if a node is rebuilt.
-
-    ```bash
-    . /usr/share/doc/csm/upgrade/scripts/ceph/lib/update_bss_metadata.sh
-    update_bss_storage
-    ```
+> **`NOTE`**
+>> It is possible to upgrade a single storage node at a time using the following command. 
+>
+>```bash
+> /usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh ncn-s001
+>```
 
 ## Stage completed
 

--- a/upgrade/Stage_1.md
+++ b/upgrade/Stage_1.md
@@ -12,7 +12,7 @@
     ```
 
 > **`NOTE`**
->> It is possible to upgrade a single storage node at a time using the following command. 
+> It is possible to upgrade a single storage node at a time using the following command.
 >
 >```bash
 > /usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh ncn-s001

--- a/upgrade/Stage_2.md
+++ b/upgrade/Stage_2.md
@@ -21,12 +21,12 @@
 
 ### Option 1
 
-1. (`ncn-m001#`) Run `ncn-upgrade-worker-nodes.sh` for `ncn-w001`.
+1. (`ncn-m001#`) Run `ncn-upgrade-worker-storage-nodes.sh` for `ncn-w001`.
 
    Follow output of the script carefully. The script will pause for manual interaction.
 
    ```bash
-   /usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-worker-nodes.sh ncn-w001
+   /usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh ncn-w001
    ```
 
    > **`NOTE`** The `root` user password for the node may need to be reset after it is rebooted.
@@ -53,7 +53,7 @@ make sure that the following conditions are met:
 (`ncn-m001#`) An example of a single request to upgrade multiple worker nodes simultaneously:
 
 ```bash
-/usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-worker-nodes.sh ncn-w002,ncn-w003,ncn-w004
+/usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh ncn-w002,ncn-w003,ncn-w004
 ```
 
 ## Stage 2.3

--- a/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh
+++ b/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh
@@ -40,7 +40,7 @@ function usage() {
     echo "Syntax: /usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh [COMMA_SEPARATED_NCN_HOSTNAMES] [-f|--force|--retry|--base-url|--dry-run]"
     echo "options:"
     echo "--no-retry     Do not automatically retry  (default: false)"
-    echo "-f|--force     Remove failed worker rebuild/upgrade workflow and create a new one  (default: ${force})"
+    echo "-f|--force     Remove failed worker or storage rebuild/upgrade workflow and create a new one  (default: ${force})"
     echo "--base-url     Specify base url (default: ${baseUrl})"
     echo "--dry-run      Print out steps of workflow instead of running steps (default: ${dryRun})"
     echo
@@ -203,7 +203,7 @@ unsucceededWorkflows=($(getUnsucceededRebuildWorkflows))
 numOfUnsucceededWorkflows="${#unsucceededWorkflows[*]}"
 
 if [[ ${numOfUnsucceededWorkflows} -gt 1 ]]; then
-    echo "ERROR: There are multiple unsucceeded worker rebuild workflows"
+    echo "ERROR: There are multiple unsucceeded ${nodeType} rebuild workflows"
     exit 1
 fi
 

--- a/workflows/ncn/worker/storage.rebuild.yaml
+++ b/workflows/ncn/worker/storage.rebuild.yaml
@@ -1,0 +1,174 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: ncn-lifecycle-rebuild-
+  labels:
+    target-ncns: "{{$length := len .TargetNcns }}{{range $index,$value := .TargetNcns }}{{$myvar := add $index 1}}{{if lt $myvar $length}}{{$value}}.{{else}}{{$value}}{{end}}{{ end }}"
+    type: rebuild
+    node-type: storage
+spec:
+  podMetadata:
+    annotations:
+      sidecar.istio.io/inject: "false"    
+  volumes:
+    - name: ssh
+      hostPath:
+        path: /root/.ssh
+        type: Directory
+    - name: host-usr-bin
+      hostPath:
+        path: /usr/bin
+        type: Directory
+    - name: podinfo
+      downwardAPI:
+        items:
+          - path: "labels"
+            fieldRef:
+              fieldPath: metadata.labels
+          - path: "annotations"
+            fieldRef:
+              fieldPath: metadata.annotations
+  # schedule workflow jobs asap
+  priorityCLassName: system-node-critical
+  # Pod GC strategy must be one of the following:
+  # * OnPodCompletion - delete pods immediately when pod is completed (including errors/failures)
+  # * OnPodSuccess - delete pods immediately when pod is successful
+  # * OnWorkflowCompletion - delete pods when workflow is completed
+  # * OnWorkflowSuccess - delete pods when workflow is successful
+  podGC:
+    strategy: OnPodCompletion
+  # allow workflow jobs running on master node
+  #   we may have a situation that all worker nodes
+  #   are marked as "being rebuilt" (cray.nls=ncn-w001)
+  tolerations:
+    - key: "node-role.kubernetes.io/master"
+      operator: "Exists"
+      effect: "NoSchedule"
+  affinity:
+    nodeAffinity:
+      # avoid putting workflow jobs onto workers that will be rebuilt
+      # this label is set onto each workers at beginning of workflow
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: cray.nls
+            operator: NotIn
+            values:
+            {{- range $index,$value := .TargetNcns }}
+            - {{$value -}}
+            {{- end }}
+      # try to use master nodes as much as possible
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 50
+          preference:
+            matchExpressions:
+            - key: node-role.kubernetes.io/master
+              operator: Exists
+  entrypoint: main
+  templates:
+    - name: main
+      dag:
+        tasks:
+          {{- range $index,$value := .TargetNcns}}
+          - name: upgrade-{{$value}}
+            templateRef:
+              name: ssh-template
+              template: shell-script
+            dependencies: 
+              # each upgrade depends on previous upgrade action and success
+              # so we make sure only one node is drained at a time
+              {{ if ne $index 0 }}
+              - check-ceph-health-{{ index $.TargetNcns (add $index -1) }}
+              {{ end }}
+            arguments:
+              parameters:
+                - name: dryRun
+                  value: "{{$.DryRun}}"  
+                - name: scriptContent
+                  value: |
+                    /usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-ceph-nodes.sh {{$value}}
+          - name: check-ceph-health-{{$value}}
+            templateRef:
+              name: ssh-template
+              template: shell-script
+            dependencies:
+              # check health once node upgrade is complete
+              - upgrade-{{$value}}
+            arguments:
+              parameters:
+                - name: dryRun
+                  value: "{{$.DryRun}}"  
+                - name: scriptContent
+                  value: |
+                    RESULT=$(/opt/cray/platform-utils/ceph-service-status.sh)
+                    if [[ $RESULT -ne 0 ]]
+                    then
+                      echo "ceph serice status check failed"
+                      exit 1
+                    fi
+                    RESULT=$(/opt/cray/platform-utils/ceph-service-status.sh -n {{$value}} -a true)
+                    if [[ $RESULT -ne 0 ]]
+                    then
+                      echo "ceph serice status check failed for node {{$value}}"
+                      exit 1
+                    fi
+          {{- end }}
+          - name: rescan-ssh-keys
+            templateRef:
+              name: ssh-template
+              template: shell-script
+            dependencies:
+              # wait for health check of last storage node complete
+              - check-ceph-health-{{ with $length := len $.TargetNcns }}{{ index $.TargetNcns (add $length -1) }}{{end}}
+            arguments:
+              parameters:
+                - name: dryRun
+                  value: "{{$.DryRun}}"  
+                - name: scriptContent
+                  value: |
+                    grep -oP "(ncn-s\w+)" /etc/hosts | sort -u | xargs -t -i ssh {} 'truncate --size=0 ~/.ssh/known_hosts'
+                    grep -oP "(ncn-s\w+)" /etc/hosts | sort -u | xargs -t -i ssh {} 'grep -oP "(ncn-s\w+|ncn-m\w+|ncn-w\w+)" /etc/hosts | sort -u | xargs -t -i ssh-keyscan -H \{\} >> /root/.ssh/known_hosts'
+          - name: update-bss
+            templateRef:
+              name: ssh-template
+              template: shell-script
+            dependencies:
+              - rescan-ssh-keys
+            arguments:
+              parameters:
+                - name: dryRun
+                  value: "{{$.DryRun}}"  
+                - name: scriptContent
+                  value: |
+                    . /usr/share/doc/csm/upgrade/scripts/ceph/lib/update_bss_metadata.sh
+                    RESULT=$(update_bss_storage)
+                    # check that result contains success!
+                    if [[ $RESULT != *"Success!"* ]]
+                    then
+                      echo "BSS metadata was not successfully updated. Output:"
+                      echo "$RESULT"
+                      exit 7
+                    fi

--- a/workflows/ncn/worker/storage.rebuild.yaml
+++ b/workflows/ncn/worker/storage.rebuild.yaml
@@ -92,12 +92,33 @@ spec:
     - name: main
       dag:
         tasks:
+          - name: check-ceph-ro-key
+            templateRef:
+              name: ssh-template
+              template: shell-script
+            arguments:
+              parameters:
+                - name: dryRun
+                  value: "{{$.DryRun}}"  
+                - name: scriptContent
+                  value: |
+                    for node in $(ceph orch host ls --format=json|jq -r '.[].hostname'); do
+                      ceph_ro_key_exists=$(ssh $node [[ -f /etc/ceph/ceph.client.ro.keyring ]] && echo 0 || echo 1)
+                      if [[ $ceph_ro_key_exists -ne 0 ]]; then
+                        # ceph ro key does not exist so create it
+                        ceph-authtool -C /etc/ceph/ceph.client.ro.keyring -n client.ro --cap mon 'allow r' --cap mds 'allow r' --cap osd 'allow r' --cap mgr 'allow r' --gen-key
+                        ceph auth import -i /etc/ceph/ceph.client.ro.keyring
+                        for node in $(ceph orch host ls --format=json|jq -r '.[].hostname'); do scp /etc/ceph/ceph.client.ro.keyring $node:/etc/ceph/ceph.client.ro.keyring; done
+                        break;
+                      fi
+                    done
           {{- range $index,$value := .TargetNcns}}
           - name: upgrade-{{$value}}
             templateRef:
               name: ssh-template
               template: shell-script
             dependencies: 
+              - check-ceph-ro-key
               # each upgrade depends on previous upgrade action and success
               # so we make sure only one node is drained at a time
               {{ if ne $index 0 }}

--- a/workflows/ncn/worker/storage.rebuild.yaml
+++ b/workflows/ncn/worker/storage.rebuild.yaml
@@ -102,16 +102,12 @@ spec:
                   value: "{{$.DryRun}}"  
                 - name: scriptContent
                   value: |
-                    for node in $(ceph orch host ls --format=json|jq -r '.[].hostname'); do
-                      ceph_ro_key_exists=$(ssh $node [[ -f /etc/ceph/ceph.client.ro.keyring ]] && echo 0 || echo 1)
-                      if [[ $ceph_ro_key_exists -ne 0 ]]; then
-                        # ceph ro key does not exist so create it
-                        ceph-authtool -C /etc/ceph/ceph.client.ro.keyring -n client.ro --cap mon 'allow r' --cap mds 'allow r' --cap osd 'allow r' --cap mgr 'allow r' --gen-key
-                        ceph auth import -i /etc/ceph/ceph.client.ro.keyring
-                        for node in $(ceph orch host ls --format=json|jq -r '.[].hostname'); do scp /etc/ceph/ceph.client.ro.keyring $node:/etc/ceph/ceph.client.ro.keyring; done
-                        break;
-                      fi
-                    done
+                    ceph auth get client.ro >/dev/null 2>/dev/null && result=$? || result=$?
+                    if [[  $result -ne 0 ]]; then
+                      ceph-authtool -C /etc/ceph/ceph.client.ro.keyring -n client.ro --cap mon 'allow r' --cap mds 'allow r' --cap osd 'allow r' --cap mgr 'allow r' --gen-key
+                    fi
+                    ceph auth import -i /etc/ceph/ceph.client.ro.keyring
+                    for node in $(ceph orch host ls --format=json|jq -r '.[].hostname'); do scp /etc/ceph/ceph.client.ro.keyring $node:/etc/ceph/ceph.client.ro.keyring; done
           {{- range $index,$value := .TargetNcns}}
           - name: upgrade-{{$value}}
             templateRef:

--- a/workflows/ncn/worker/storage.rebuild.yaml
+++ b/workflows/ncn/worker/storage.rebuild.yaml
@@ -102,10 +102,7 @@ spec:
                   value: "{{$.DryRun}}"  
                 - name: scriptContent
                   value: |
-                    ceph auth get client.ro >/dev/null 2>/dev/null && result=$? || result=$?
-                    if [[  $result -ne 0 ]]; then
-                      ceph-authtool -C /etc/ceph/ceph.client.ro.keyring -n client.ro --cap mon 'allow r' --cap mds 'allow r' --cap osd 'allow r' --cap mgr 'allow r' --gen-key
-                    fi
+                    ceph auth get client.ro >/dev/null 2>/dev/null || ceph-authtool -C /etc/ceph/ceph.client.ro.keyring -n client.ro --cap mon 'allow r' --cap mds 'allow r' --cap osd 'allow r' --cap mgr 'allow r' --gen-key
                     ceph auth import -i /etc/ceph/ceph.client.ro.keyring
                     for node in $(ceph orch host ls --format=json|jq -r '.[].hostname'); do scp /etc/ceph/ceph.client.ro.keyring $node:/etc/ceph/ceph.client.ro.keyring; done
           {{- range $index,$value := .TargetNcns}}


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
Automate stage 1 of upgrade using argo workflows. Also, adds automation for checking valid ceph ro key which implements CASMINST-4949. 

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
