### PR TITLE
CASMTRIAGE-3889: Add upgrade step for csm-config

### DIFF
--- a/upgrade/Stage_0_Prerequisites.md
+++ b/upgrade/Stage_0_Prerequisites.md
@@ -186,6 +186,10 @@ Stage 0 has several critical procedures which prepare the environment and verify
    If the script does not end with this output, then try rerunning it. If it still fails, see
    [Upgrade Troubleshooting](README.md#relevant-troubleshooting-links-for-upgrade-related-issues).
    If the failure persists, then open a support ticket for guidance before proceeding.
+   
+1. (`ncn-m001#`) Assign a new CFS configuration to the worker node.
+
+The content of the new CFS configuration is described in HPE Cray EX System Software Getting Started Guide S-8000, section "HPE Cray EX Software Upgrade Workflow" subsection "Cray System Management (CSM)". Replace ${NEW_NCN_CONFIGURATION} with the name of the new CFS configuration and ${XNAME} with the component name (xname) of the worker node that was upgraded.
 
 1. (`ncn-m001#`) Unset the `NEXUS_PASSWORD` variable, if it was set in the earlier step.
 


### PR DESCRIPTION
# Description

This adds a step to the upgrade process for upgrading csm-config in order to work around a problem where old versions of csm-config were being applied during configuration of ncns

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.