### PR TITLE
CASMINST-5184: Add language making it clear default keys should be purged

### DIFF
--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
@@ -1,5 +1,6 @@
 # Change NCN Image Root Password and SSH Keys
 
+The default SSH keys in the NCN image must be removed. The default password for the root user must be change
 Customize the NCN images by changing the root password or adding different SSH keys for the root account.
 This procedure shows this process being done any time after the first time installation of the CSM
 software has been completed and the PIT node is booted as a regular master node. To change the NCN image
@@ -72,11 +73,20 @@ The Kubernetes image `k8s-image` is used by the master and worker nodes.
    ncn-m# unsquashfs -d k8s/${K8SVERSION}/filesystem.squashfs k8s/${K8SVERSION}/filesystem.squashfs.orig
    ```
 
+1. If the image being modififed contains the default SSH keys for the root user and/or the default
+   SSH host keys, remove them now.
+
+   ```bash
+   ncn-m# rm -rf k8s/${K8SVERSION}/filesystem.squashfs/root/.ssh
+   ncn-m# rm -f k8s/${K8SVERSION}/filesystem.squashfs/etc/ssh/*key*
+   ```
+
 1. Copy the generated public and private SSH keys for the root account into the image.
 
    This example assumes that an RSA key was generated.
 
    ```bash
+   ncn-m# mkdir -m 0700 k8s/${K8SVERSION}/filesystem.squashfs/root/.ssh
    ncn-m# cp -p /root/.ssh/id_rsa /root/.ssh/id_rsa.pub k8s/${K8SVERSION}/filesystem.squashfs/root/.ssh
    ```
 

--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md
@@ -1,6 +1,7 @@
 # Change NCN Image Root Password and SSH Keys on PIT Node
 
-Customize the NCN images by changing the root password or adding different SSH keys for the root account.
+The default SSH keys in the NCN image must be removed. The default password for the root user must be changed.
+Customize the NCN images by changing the root password and adding different SSH keys for the root account.
 This procedure shows this process being done on the PIT node during a first time installation of the CSM
 software.
 
@@ -39,11 +40,19 @@ The Kubernetes image is used by the master and worker nodes.
    pit# unsquashfs kubernetes-0.1.69.squashfs
    ```
 
+1. Remove default SSH keys
+
+   ```bash
+   pit# rm -rf squashfs-root/root/.ssh
+   pit# rm -f /etc/ssh/*key*
+   ```
+
 1. Copy the generated public and private SSH keys for the root account into the image.
 
    This example assumes that an RSA key was generated.
 
    ```bash
+   pit# mkdir -m 0700 squashfs-root/root/.ssh
    pit# cp -p /root/.ssh/id_rsa /root/.ssh/id_rsa.pub squashfs-root/root/.ssh
    ```
 


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
