### PR TITLE
CASMTRIAGE-3921: Fix shebang line in scripts/csm_rbd_tool.py

### DIFF
--- a/scripts/csm_rbd_tool.py
+++ b/scripts/csm_rbd_tool.py
@@ -1,4 +1,4 @@
-#!/opt/cray/csm/scripts/csm_rbd_tool/bin/python
+#! /usr/bin/env python3
 #
 # MIT License
 #


### PR DESCRIPTION
# Description

Last week, PR #2207 merged and created `scripts/csm_rbd_tool.py`. That script had an invalid shebang line, which in turn causes the docs-csm RPM to fail to install:

```text
# rpm -Uvh --force https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/docs-csm/1.3/noarch/docs-csm-latest.noarch.rpm
Retrieving https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/docs-csm/1.3/noarch/docs-csm-latest.noarch.rpm
error: Failed dependencies:
        /opt/cray/csm/scripts/csm_rbd_tool/bin/python is needed by docs-csm-1.3.32-1.noarch
```

I have confirmed that the RPMs worked prior to that PR, and failed starting with that PR. In addition, I have verified that the RPM generated by this PR (which fixes the shebang line) installs without a problem.

We should get this merged and tagged ASAP, since without it the latest 1.3 docs-csm RPM is not able to be installed (or not without having it ignore dependencies, anyway). And even if installing with --nodeps to ignore dependencies, I assume the `csm_rbd_tool` script would still not work itself, because of its messed up shebang line.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
