### PR TITLE
CASMINST-5219: Corrections and improvements to install and upgrade documents

### DIFF
--- a/install/bootstrap_livecd_usb.md
+++ b/install/bootstrap_livecd_usb.md
@@ -49,9 +49,9 @@ Fetch the base installation CSM tarball, extract it, and install the contained C
    > and exported.
 
    ```bash
-   pit# export CSM_RELEASE=csm-x.y.z
-   pit# export SYSTEM_NAME=eniac
-   pit# export PITDATA=/mnt/pitdata
+   linux# export CSM_RELEASE=csm-x.y.z
+   linux# export SYSTEM_NAME=eniac
+   linux# export PITDATA=/mnt/pitdata
    ```
 
 1. Download and expand the CSM software release.
@@ -150,16 +150,26 @@ Fetch the base installation CSM tarball, extract it, and install the contained C
 
     If reinstalling the system and **using `ncn-m001` to prepare the USB image**, then remove the prior CNI configuration.
 
-    ```bash
-    ncn-m001# rm -rf /etc/cni/net.d/00-multus.conf /etc/cni/net.d/10-*.conflist /etc/cni/net.d/multus.d
-    ```
 
-    This should leave the following two files in `/etc/cni/net.d`.
+    1. Remove the configuration files.
 
-    ```bash
-    ncn-m001# ls /etc/cni/net.d
-    87-podman-bridge.conflist  99-loopback.conf.sample
-    ```
+        ```bash
+        ncn-m001# rm -rf /etc/cni/net.d/00-multus.conf /etc/cni/net.d/10-*.conflist /etc/cni/net.d/multus.d
+        ```
+
+    1. List the remaining contents of the `/etc/cni/net.d` directory.
+
+        ```bash
+        ncn-m001# ls /etc/cni/net.d
+        ```
+
+        Example output:
+
+        ```text
+        87-podman-bridge.conflist  99-loopback.conf.sample
+        ```
+
+        The exact directory contents may vary depending on the CSM version previously installed on `ncn-m001`.
 
 <a name="create-the-bootable-media"></a>
 
@@ -252,8 +262,8 @@ The `SHASTA-CFG` structure and other configuration files will be prepared, then 
 This payload will be used for the rest of the CSM installation on the USB device.
 
 1. [Generate Installation Files](#generate-installation-files)
-2. [Verify and Backup `system_config.yaml`](#verify-csi-versions-match)
-3. [Prepare `Site Init`](#prepare-site-init)
+1. [Verify and Backup `system_config.yaml`](#verify-csi-versions-match)
+1. [Prepare `Site Init`](#prepare-site-init)
 
 <a name="generate-installation-files"></a>
 
@@ -447,7 +457,7 @@ information for this system has not yet been prepared.
       > **`NOTE`** This step is needed only for fresh installs where `system_config.yaml` is missing from the `prep/` directory.
 
       ```bash
-      pit# cd ${PITDATA}/prep && ln ${SYSTEM_NAME}/system_config.yaml
+      linux# cd ${PITDATA}/prep && ln ${SYSTEM_NAME}/system_config.yaml
       ```
 
    1. Continue to the next step to [verify and backup `system_config.yaml`](#verify-csi-versions-match).
@@ -820,13 +830,7 @@ On first log in (over SSH or at local console), the LiveCD will prompt the admin
    pit# /root/bin/pit-init.sh
    ```
 
-1. Start and configure NTP on the LiveCD for a fallback/recovery server.
-
-   ```bash
-   pit# /root/bin/configure-ntp.sh
-   ```
-
-1. Install Goss Tests and Server
+1. Install Goss tests.
 
    The following assumes the `CSM_PATH` environment variable is set to the absolute path of the unpacked CSM release.
 

--- a/install/bootstrap_livecd_usb.md
+++ b/install/bootstrap_livecd_usb.md
@@ -150,7 +150,6 @@ Fetch the base installation CSM tarball, extract it, and install the contained C
 
     If reinstalling the system and **using `ncn-m001` to prepare the USB image**, then remove the prior CNI configuration.
 
-
     1. Remove the configuration files.
 
         ```bash

--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md
@@ -29,7 +29,7 @@ Add SSH keys and the `root` password to the NCN SquashFS images. Optionally set 
 (the default) is desired. This is all done by running the `ncn-image-modification.sh` script, which is located in the `scripts/operations/node_management` directory of the CSM documentation. Set the path to the script:
 
 ```bash
-pit# NCN_MOD_SCRIPT=$(rpm -ql docs-csm | grep ncn-image-modification[.]sh)
+pit# NCN_MOD_SCRIPT=$(rpm -ql docs-csm | grep ncn-image-modification[.]sh) ; echo "${NCN_MOD_SCRIPT}"
 ```
 
 This document provides common ways of using the script to accomplish this. However, specific environments may require

--- a/upgrade/1.2/README.md
+++ b/upgrade/1.2/README.md
@@ -21,7 +21,7 @@ For detailed BICAN documentation, see the [BICAN Technical Details](../../operat
 
 - Service request adjustments are needed for small systems.
 
-  - For systems with only three worker nodes (typically Testing and  Development Systems (TDS)), prior to proceeding with this upgrade, CPU limits **MUST** be
+  - For systems with only three worker nodes (typically Testing and Development Systems (TDS)), prior to proceeding with this upgrade, CPU limits **MUST** be
     lowered on several services in order for this upgrade to succeed. This step is
     executed automatically as part of [Stage 0.4](Stage_0_Prerequisites.md#prerequisites-check) of the upgrade.
     See [TDS Lower CPU Requests](../../operations/kubernetes/TDS_Lower_CPU_Requests.md) for more information.


### PR DESCRIPTION
Primarily a backport of the applicable parts of https://github.com/Cray-HPE/docs-csm/pull/2233, plus some 1.2-specific fixes.