### PR TITLE
CASMINST-5230 CASMINST-5229 LiveCD and CSI Path

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -634,6 +634,9 @@ Init
 - install/README.md
 Alerta
 
+- install/livecd/Boot_LiveCD_USB.md
+Init
+
 - introduction/site_survey.md
 # To allow Site Init
 Init

--- a/install/livecd/Boot_LiveCD_USB.md
+++ b/install/livecd/Boot_LiveCD_USB.md
@@ -18,6 +18,7 @@ which device will be used for it.
    SCRIPT_FILE="$(pwd)/csm-install-usb.$(date +%Y-%m-%d).txt"
    script -af "${SCRIPT_FILE}"
    export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
+   export OUT_DIR=$(pwd)/csm-temp
    ```
 
 1. (`external#`) Identify the USB device.
@@ -51,7 +52,7 @@ which device will be used for it.
     - Use the CSI application to do this:
 
         ```bash
-        csi pit format "${USB}" cray-pre-install-toolkit-*.iso 50000
+        csi pit format "${USB}" "${OUT_DIR}/"cray-pre-install-toolkit-*.iso 50000
         ```
 
     - If CSI is unavailable, then fetch and use the `write-livecd.sh` script:
@@ -62,21 +63,21 @@ which device will be used for it.
         > is also available on GitHub:
         >
         >    ```curl
-        >    curl -f -O https://raw.githubusercontent.com/Cray-HPE/cray-site-init/main/scripts/write-livecd.sh && chmod +x write-livecd.sh
+        >    curl -f -o "${OUT_DIR}/write-livecd.sh" https://raw.githubusercontent.com/Cray-HPE/cray-site-init/main/scripts/write-livecd.sh && chmod +x "${OUT_DIR}/write-livecd.sh"
         >    ```
         >
         > Alternatively if the RPM is available but the LiveCD is being created on a non-RPM based distro,
         > then the script can be extracted from the RPM file:
         >
         >    ```bash
-        >    bsdtar xvf cray-site-init-*.rpm --include *write-livecd.sh -C ./
-        >    mv -v ./usr/local/bin/write-livecd.sh ./
-        >    rmdir -pv ./usr/local/bin/
+        >    bsdtar xvf cray-site-init-*.rpm --include *write-livecd.sh -C "./${OUT_DIR}"
+        >    mv -v "${OUT_DIR}/usr/local/bin/write-livecd.sh" ./
+        >    rmdir -pv "${OUT_DIR}/usr/local/bin/"
         >    ```
         >
 
         ```bash
-        write-livecd.sh "${USB}" cray-pre-install-toolkit-*.iso 50000
+        write-livecd.sh "${USB}" "${OUT_DIR}/"cray-pre-install-toolkit-*.iso 50000
         ```
 
 ## Boot the LiveCD

--- a/install/pre-installation.md
+++ b/install/pre-installation.md
@@ -63,7 +63,9 @@ Any steps run on an `external` server require that server to have the following 
 1. (`external#`) Extract the LiveCD from the tarball.
 
    ```bash
-   tar --wildcards --no-anchored -xzvf "csm-${CSM_RELEASE}.tar.gz" 'cray-pre-install-toolkit-*.iso'
+   OUT_DIR="$(pwd)/csm-temp"
+   mkdir -pv "${OUT_DIR}"
+   tar -C "${OUT_DIR}" --wildcards --no-anchored --transform='s/.*\///' -xzvf "csm-${CSM_RELEASE}.tar.gz" 'cray-pre-install-toolkit-*.iso'
    ```
 
 ### 1.2 Boot the LiveCD
@@ -91,7 +93,9 @@ Any steps run on an `external` server require that server to have the following 
       1. (`external#`) Get `cray-site-init` from the tarball.
 
          ```bash
-         tar --wildcards --no-anchored -xzvf "csm-${CSM_RELEASE}.tar.gz" 'cray-site-init-*.rpm'
+         OUT_DIR="$(pwd)/csm-temp"
+         mkdir -pv "${OUT_DIR}"
+         tar -C "${OUT_DIR}" --wildcards --no-anchored --transform='s/.*\///' -xzvf "csm-${CSM_RELEASE}.tar.gz" 'cray-site-init-*.rpm'
          ```
 
       1. (`external#`) Install the `write-livecd.sh` script:
@@ -99,22 +103,22 @@ Any steps run on an `external` server require that server to have the following 
          - RPM-based systems:
 
             ```bash
-            rpm -Uvh --force cray-site-init*.rpm
+            rpm -Uvh --force ${OUT_DIR}/cray-site-init*.rpm
             ```
 
          - Non-RPM-based systems (requires `bsdtar`):
 
             ```bash
-            bsdtar xvf cray-site-init-*.rpm --include *write-livecd.sh -C ./
-            mv -v ./usr/local/bin/write-livecd.sh ./
-            rmdir -pv ./usr/local/bin/
+            bsdtar xvf "${OUT_DIR}"/cray-site-init-*.rpm --include *write-livecd.sh -C "${OUT_DIR}"
+            mv -v "${OUT_DIR}"/usr/local/bin/write-livecd.sh "./${OUT_DIR}"
+            rmdir -pv "${OUT_DIR}/usr/local/bin/"
             ```
 
          - Non-RPM Based Distros (requires `rpm2cpio`):
 
             ```bash
             rpm2cpio cray-site-init-*.rpm | cpio -idmv
-            mv -v ./usr/local/bin/write-livecd.sh ./
+            mv -v ./usr/local/bin/write-livecd.sh "./${OUT_DIR}"
             rm -vrf ./usr
             ```
 


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
This uses more specific `tar` and `bsdtar` arguments to get the LiveCD and PIT into a more reliable path.
    
The user is expected NOT to change directories between extracting the RPMs and using the USB path.


# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
