### PR TITLE
CASMINST-5225 Remove manual redundancy

### DIFF
--- a/install/pre-installation.md
+++ b/install/pre-installation.md
@@ -176,12 +176,7 @@ On first login, the LiveCD will prompt the administrator to change the password.
       > **NOTES:**
       >
       > - All of the `/root/bin/csi-*` scripts can be run without parameters to display usage statements.
-      > - The hostname is auto-resolved based on reverse DNS, if it is unresolvable then the user can set the hostname with:
-      >
-      >    ```bash
-      >    hostname=eniac-ncn-m001
-      >    hostamectl set-hostname "${hostname}-pit" 
-      >    ```
+      > - The hostname is auto-resolved based on reverse DNS.
 
       ```bash
       /root/bin/csi-setup-lan0.sh "${site_ip}" "${site_gw}" "${site_dns}" "${site_nics}"


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
Remove manual step, force users to use the setup script.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
