### PR TITLE
CASMTRIAGE-3927: add slack alerts for build failures

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -51,10 +51,11 @@ pipeline {
     environment {
         GIT_REPO_NAME = getRepoName()
         VERSION = sh(returnStdout: true, script: "git describe --tags | tr -s '-' '~' | tr -d '^v'").trim()
+        SLACK_CHANNEL_ALERTS = "csm-release-alerts"
     }
     
     stages {
-        stage("Prepare") {
+      stage("Prepare") {
             agent {
                 docker {
                     image "artifactory.algol60.net/csm-docker/stable/csm-docker-sle:${sleVersion}"
@@ -71,8 +72,7 @@ pipeline {
                     }
                 }
             }
-        }
-
+      }
       stage("Build RPM") {
           agent {
               docker {
@@ -87,8 +87,7 @@ pipeline {
                   }
                 }
             }
-        }
-
+      }
       stage('Publish') {
           steps {
             script {
@@ -104,6 +103,18 @@ pipeline {
             }
         }
       }
+    }
+    post {
+        failure {
+            script {
+                slackSend(channel: env.SLACK_CHANNEL_ALERTS, color: "danger", message: "<${env.BUILD_URL}|DOCS-CSM ${env.VERSION}> - :x: Build did not complete successfully")
+            }
+        }
+        aborted {
+            script {
+                slackSend(channel: env.SLACK_CHANNEL_ALERTS, color: "warning", message: "<${env.BUILD_URL}|DOCS-CSM ${env.VERSION}> - :warning: Job was aborted")
+            }
+        }
     }
   }
 


### PR DESCRIPTION
# Description

Add slack notification to csm-release-alerts channel when/if build pipeline fails. Also removed some whitespace from stages section to line everything up.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
