### PR TITLE
CASMPET-5905: Update docs for recent changes to improve/fix etcd_restore_rebuild.sh script

### DIFF
--- a/operations/kubernetes/Rebuild_Unhealthy_etcd_Clusters.md
+++ b/operations/kubernetes/Rebuild_Unhealthy_etcd_Clusters.md
@@ -1,8 +1,8 @@
 # Rebuild Unhealthy etcd Clusters
 
-Rebuild any cluster that does not have healthy pods by deleting and redeploying unhealthy pods.
-This procedure includes examples for rebuilding etcd clusters in the services namespace.
-This procedure must be used for each unhealthy cluster, not just the services used in the following examples.
+In order to rebuild a healthy cluster, delete and redeploy the unhealthy pods.
+This procedure includes examples for rebuilding etcd clusters in the `services` namespace.
+This procedure must be used for each unhealthy cluster, and not just the services used in the following examples.
 
 This process also applies when etcd is not visible when running the `kubectl get pods` command.
 
@@ -11,11 +11,9 @@ A special use case is also included for the Content Projection Service \(CPS\) a
 ---
 > **`NOTE`**
 
-Etcd Clusters other than the Content Projection Service \(CPS\) can be rebuilt using the automation script or the manual procedure below.
+Etcd clusters other than the Content Projection Service \(CPS\) are rebuilt using the following manual procedure or automation script.
 The automation script follows the same steps as the manual procedure.
-If the automation script fails at any step, continue rebuilding the cluster using the manual procedure.
-
----
+If the automation script fails at any step, then continue rebuilding the cluster using the manual procedure.
 
 ## Prerequisites
 

--- a/operations/kubernetes/Rebuild_Unhealthy_etcd_Clusters.md
+++ b/operations/kubernetes/Rebuild_Unhealthy_etcd_Clusters.md
@@ -21,7 +21,7 @@ An etcd cluster has pods that are not healthy, or the etcd cluster has no pods. 
 
 The automated script will restore the cluster from a backup if it finds a backup created within the last 7 days. If it does not discover a backup within the last 7 days, it will ask the user if they would like to rebuild the cluster.
 
-```
+```text
 ncn-w001 # cd /opt/cray/platform-utils/etcd_restore_rebuild_util
 
 # rebuild/restore a single cluster
@@ -43,7 +43,7 @@ ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util # ./etcd_restore_reb
 
 Example output:
 
-```bash
+```text
 The following etcd clusters will be restored/rebuilt:
 cray-bss-etcd
 You will be accepting responsibility for any missing data if there is a restore/rebuild over a running etcd k/v. HPE assumes no responsibility.
@@ -81,7 +81,7 @@ etcdbackup.etcd.database.coreos.com "cray-bss-etcd-cluster-periodic-backup" dele
 
 ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util #
 ```
-Check if restored cluster's data needs to be repopulated [Repopulate Data in etcd Clusters When Rebuilding Them](Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md)
+Check if rebuilt cluster's data needs to be repopulated [Repopulate Data in etcd Clusters When Rebuilding Them](Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md)
 Rerun the etcd cluster health check \(see [Check the Health and Balance of etcd Clusters](Check_the_Health_and_Balance_of_etcd_Clusters.md)\) after recovering one or more clusters. Ensure that the clusters are healthy and have the correct number of pods.
 
 ### Manual Procedure for Clusters in the Services Namespace
@@ -107,7 +107,7 @@ The following examples use the `cray-bos` etcd cluster, but these steps must be 
 
     For example:
 
-    ```
+    ```text
     creationTimestamp: "2019-11-26T16:54:23Z"
     generation: 1
 
@@ -166,7 +166,7 @@ The following examples use the `cray-bos` etcd cluster, but these steps must be 
 
     Example output:
 
-    ```
+    ```text
     cray-bos-etcd-hwcw4429b9                  1/1     Running         1          7d18h
     cray-bos-etcd-mdnl28vq9c                  1/1     Running         0          36h
     cray-bos-etcd-w5vv7j4ghh                  1/1     Running         0          18h
@@ -211,6 +211,6 @@ The following examples use the `cray-bos` etcd cluster, but these steps must be 
         kubectl delete etcdbackup -n services \
         cray-bos-etcd-cluster-periodic-backup
         ```
-Check if restored cluster's data needs to be repopulated [Repopulate Data in etcd Clusters When Rebuilding Them](Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md)
+Check if rebuilt cluster's data needs to be repopulated [Repopulate Data in etcd Clusters When Rebuilding Them](Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md)
 Rerun the etcd cluster health check \(see [Check the Health and Balance of etcd Clusters](Check_the_Health_and_Balance_of_etcd_Clusters.md)\) after recovering one or more clusters. Ensure that the clusters are healthy and have the correct number of pods.
 

--- a/operations/kubernetes/Rebuild_Unhealthy_etcd_Clusters.md
+++ b/operations/kubernetes/Rebuild_Unhealthy_etcd_Clusters.md
@@ -35,11 +35,10 @@ Regardless of which method is chosen, after completing the rebuild, the last ste
 
 ### Automated script for clusters in the `services` namespace
 
-> The automated script follows the same steps as the manual procedure.
-> If the automated script fails at any step, then continue rebuilding the cluster using the manual procedure.
-
-
 The automated script will restore the cluster from a backup if it finds a backup created within the last 7 days. If it does not discover a backup within the last 7 days, it will ask the user if they would like to rebuild the cluster.
+
+The automated script follows the same steps as the manual procedure.
+If the automated script fails at any step, then continue rebuilding the cluster using the manual procedure.
 
 * (`ncn-mw#`) Rebuild/restore a single cluster
 
@@ -102,8 +101,6 @@ deployment.apps/cray-bss created
 SUCCESSFUL REBUILD of the cray-bss-etcd cluster completed.
 
 etcdbackup.etcd.database.coreos.com "cray-bss-etcd-cluster-periodic-backup" deleted
-
-ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util #
 ```
 
 #### Next step

--- a/operations/kubernetes/Rebuild_Unhealthy_etcd_Clusters.md
+++ b/operations/kubernetes/Rebuild_Unhealthy_etcd_Clusters.md
@@ -211,6 +211,6 @@ The following examples use the `cray-bos` etcd cluster, but these steps must be 
         kubectl delete etcdbackup -n services \
         cray-bos-etcd-cluster-periodic-backup
         ```
-Check if rebuilt cluster's data needs to be repopulated [Repopulate Data in etcd Clusters When Rebuilding Them](Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md)
+Check if rebuilt cluster's data needs to be repopulated [Repopulate Data in etcd Clusters When Rebuilding Them](Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md).
 Rerun the etcd cluster health check \(see [Check the Health and Balance of etcd Clusters](Check_the_Health_and_Balance_of_etcd_Clusters.md)\) after recovering one or more clusters. Ensure that the clusters are healthy and have the correct number of pods.
 

--- a/operations/kubernetes/Rebuild_Unhealthy_etcd_Clusters.md
+++ b/operations/kubernetes/Rebuild_Unhealthy_etcd_Clusters.md
@@ -94,24 +94,24 @@ Rerun the etcd cluster health check \(see [Check the Health and Balance of etcd 
 The following examples use the `cray-bos` etcd cluster, but these steps must be repeated for every unhealthy service.
 
 1.  Retrieve the `.yaml` file for the deployment and the etcd cluster objects.
-    
+
     ```bash
     kubectl -n services get deployment cray-bos -o yaml > /root/etcd/cray-bos.yaml
     kubectl -n services get etcd cray-bos-etcd -o yaml > /root/etcd/cray-bos-etcd.yaml
     ```
-    
+
     Only two files must be retrieved in most cases. There is a third file needed if rebuilding clusters for the CPS. CPS must be unmounted before running the commands to rebuild the etcd cluster.
-    
+
     ```bash
     kubectl -n services get deployment cray-cps -o yaml > /root/etcd/cray-cps.yaml
     kubectl -n services get daemonset cray-cps-cm-pm -o yaml > /root/etcd/cray-cps-cm-pm.yaml
     kubectl -n services get etcd cray-cps-etcd -o yaml > /root/etcd/cray-cps-etcd.yaml
     ```
-    
+
 2.  Edit each `.yaml` file to remove the entire line for `creationTimestamp`, generation, `resourceVersion`, `uid`, and everything after status \(including status\).
-    
+
     For example:
-    
+
     ```text
     creationTimestamp: "2019-11-26T16:54:23Z"
     generation: 1
@@ -139,83 +139,83 @@ The following examples use the `cray-bos` etcd cluster, but these steps must be 
       replicas: 1
       updatedReplicas: 1
     ```
-     
+
 3.  Delete the deployment and the etcd cluster objects.
-    
+
     Wait for the pods to terminate before proceeding to the next step.
-    
+
     ```bash
     kubectl delete -f /root/etcd/cray-bos.yaml
     kubectl delete -f /root/etcd/cray-bos-etcd.yaml
     ```
-    
+
     In the use case of CPS clusters being rebuilt, the following files must be deleted:
-    
+
     ```bash
     kubectl delete -f /root/etcd/cray-cps.yaml
     kubectl delete -f /root/etcd/cray-cps-cm-pm.yaml
     kubectl delete -f /root/etcd/cray-cps-etcd.yaml
     ```
-    
+
 4.  Apply the etcd cluster file.
-    
+
     ```bash
     kubectl apply -f /root/etcd/cray-bos-etcd.yaml
     ```
-    
+
     Wait for all three pods to go into the Running state before proceeding to the next step. Use the following command to monitor the status of the pods:
-    
+
     ```bash
     kubectl get pods -n services | grep bos-etcd
     ```
-    
+
     Example output:
-    
+
     ```text
     cray-bos-etcd-hwcw4429b9                  1/1     Running         1          7d18h
     cray-bos-etcd-mdnl28vq9c                  1/1     Running         0          36h
     cray-bos-etcd-w5vv7j4ghh                  1/1     Running         0          18h
     ```
-    
+
 5.  Apply the deployment file.
-    
+
     ```bash
     kubectl apply -f /root/etcd/cray-bos.yaml
     ```
-    
+
     If using CPS, the etcd cluster file, deployment file, and daemonset file must be reapplied:
-    
+
     ```bash
     kubectl apply -f /root/etcd/cray-cps.yaml
     kubectl apply -f /root/etcd/cray-cps-cm-pm.yaml
     kubectl apply -f /root/etcd/cray-cps-etcd.yaml
     ```
-    
+
     Proceed to the next step to finish rebuilding the cluster.
-    
+
 ## Post-Rebuild
 
 1.  Update the IP address needed to interact with the rebuilt cluster.
-     
+
     After recreating the etcd cluster, the IP address needed to interact with the cluster changes, which requires recreating the etcd backup. The IP address is created automatically via a cronjob that runs at the top of each hour.
-    
+
     1.  Determine the periodic backup name for the cluster.
-        
+
         The following example is for the `bos` cluster:
-        
+
         ```bash
         kubectl get etcdbackup -n services | grep bos.*periodic
         cray-bos-etcd-cluster-periodic-backup
         ```
-                
+
     2.  Delete the etcd backup definition.
-        
+
         A new backup will be created that points to the new IP address. Use the value returned in the previous substep.
         
         ```bash
         kubectl delete etcdbackup -n services \
         cray-bos-etcd-cluster-periodic-backup
         ```
-        
+
 Check if rebuilt cluster's data needs to be repopulated [Repopulate Data in etcd Clusters When Rebuilding Them](Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md).
 Rerun the etcd cluster health check \(see [Check the Health and Balance of etcd Clusters](Check_the_Health_and_Balance_of_etcd_Clusters.md)\) after recovering one or more clusters. Ensure that the clusters are healthy and have the correct number of pods.

--- a/operations/kubernetes/Rebuild_Unhealthy_etcd_Clusters.md
+++ b/operations/kubernetes/Rebuild_Unhealthy_etcd_Clusters.md
@@ -1,6 +1,8 @@
 # Rebuild Unhealthy etcd Clusters
 
-Rebuild any cluster that does not have healthy pods by deleting and redeploying unhealthy pods. This procedure includes examples for rebuilding etcd clusters in the services namespace. This procedure must be used for each unhealthy cluster, not just the services used in the following examples.
+Rebuild any cluster that does not have healthy pods by deleting and redeploying unhealthy pods.
+This procedure includes examples for rebuilding etcd clusters in the services namespace.
+This procedure must be used for each unhealthy cluster, not just the services used in the following examples.
 
 This process also applies when etcd is not visible when running the `kubectl get pods` command.
 
@@ -9,15 +11,17 @@ A special use case is also included for the Content Projection Service \(CPS\) a
 ---
 > **`NOTE`**
 
-Etcd Clusters other than the Content Projection Service \(CPS\) can be rebuilt using the automation script or the manual procedure below. The automation script follows the same steps as the manual procedure. If the automation script fails at any step, continue rebuilding the cluster using the manual procedure.
+Etcd Clusters other than the Content Projection Service \(CPS\) can be rebuilt using the automation script or the manual procedure below.
+The automation script follows the same steps as the manual procedure.
+If the automation script fails at any step, continue rebuilding the cluster using the manual procedure.
 
 ---
 
-### Prerequisites
+## Prerequisites
 
 An etcd cluster has pods that are not healthy, or the etcd cluster has no pods. See [Check the Health and Balance of etcd Clusters](Check_the_Health_and_Balance_of_etcd_Clusters.md) for more information.
 
-### Automation Script for Clusters in the Services Namespace
+## Automation Script for Clusters in the Services Namespace
 
 The automated script will restore the cluster from a backup if it finds a backup created within the last 7 days. If it does not discover a backup within the last 7 days, it will ask the user if they would like to rebuild the cluster.
 
@@ -34,7 +38,7 @@ ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util # ./etcd_restore_reb
 ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util # ./etcd_restore_rebuild.sh -a
 ```
 
-An example using the automation script is below for ncn-w001. Can also
+An example using the automation script is below for `ncn-w001`. Can also
 be executed on any master NCN.
 
 ```bash
@@ -81,32 +85,33 @@ etcdbackup.etcd.database.coreos.com "cray-bss-etcd-cluster-periodic-backup" dele
 
 ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util #
 ```
+
 Check if rebuilt cluster's data needs to be repopulated [Repopulate Data in etcd Clusters When Rebuilding Them](Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md).
 Rerun the etcd cluster health check \(see [Check the Health and Balance of etcd Clusters](Check_the_Health_and_Balance_of_etcd_Clusters.md)\) after recovering one or more clusters. Ensure that the clusters are healthy and have the correct number of pods.
 
-### Manual Procedure for Clusters in the Services Namespace
+## Manual Procedure for Clusters in the Services Namespace
 
 The following examples use the `cray-bos` etcd cluster, but these steps must be repeated for every unhealthy service.
 
-1.  Retrieve the .yaml file for the deployment and the etcd cluster objects.
-
+1.  Retrieve the `.yaml` file for the deployment and the etcd cluster objects.
+    
     ```bash
     kubectl -n services get deployment cray-bos -o yaml > /root/etcd/cray-bos.yaml
     kubectl -n services get etcd cray-bos-etcd -o yaml > /root/etcd/cray-bos-etcd.yaml
     ```
-
+    
     Only two files must be retrieved in most cases. There is a third file needed if rebuilding clusters for the CPS. CPS must be unmounted before running the commands to rebuild the etcd cluster.
-
+    
     ```bash
     kubectl -n services get deployment cray-cps -o yaml > /root/etcd/cray-cps.yaml
     kubectl -n services get daemonset cray-cps-cm-pm -o yaml > /root/etcd/cray-cps-cm-pm.yaml
     kubectl -n services get etcd cray-cps-etcd -o yaml > /root/etcd/cray-cps-etcd.yaml
     ```
-
-2.  Edit each .yaml file to remove the entire line for creationTimestamp, generation, resourceVersion, uid, and everything after status \(including status\).
-
+    
+2.  Edit each `.yaml` file to remove the entire line for `creationTimestamp`, generation, `resourceVersion`, `uid`, and everything after status \(including status\).
+    
     For example:
-
+    
     ```text
     creationTimestamp: "2019-11-26T16:54:23Z"
     generation: 1
@@ -134,83 +139,83 @@ The following examples use the `cray-bos` etcd cluster, but these steps must be 
       replicas: 1
       updatedReplicas: 1
     ```
-
+     
 3.  Delete the deployment and the etcd cluster objects.
-
+    
     Wait for the pods to terminate before proceeding to the next step.
-
+    
     ```bash
     kubectl delete -f /root/etcd/cray-bos.yaml
     kubectl delete -f /root/etcd/cray-bos-etcd.yaml
     ```
-
+    
     In the use case of CPS clusters being rebuilt, the following files must be deleted:
-
+    
     ```bash
     kubectl delete -f /root/etcd/cray-cps.yaml
     kubectl delete -f /root/etcd/cray-cps-cm-pm.yaml
     kubectl delete -f /root/etcd/cray-cps-etcd.yaml
     ```
-
+    
 4.  Apply the etcd cluster file.
-
+    
     ```bash
     kubectl apply -f /root/etcd/cray-bos-etcd.yaml
     ```
-
+    
     Wait for all three pods to go into the Running state before proceeding to the next step. Use the following command to monitor the status of the pods:
-
+    
     ```bash
     kubectl get pods -n services | grep bos-etcd
     ```
-
+    
     Example output:
-
+    
     ```text
     cray-bos-etcd-hwcw4429b9                  1/1     Running         1          7d18h
     cray-bos-etcd-mdnl28vq9c                  1/1     Running         0          36h
     cray-bos-etcd-w5vv7j4ghh                  1/1     Running         0          18h
     ```
-
+    
 5.  Apply the deployment file.
-
+    
     ```bash
     kubectl apply -f /root/etcd/cray-bos.yaml
     ```
-
+    
     If using CPS, the etcd cluster file, deployment file, and daemonset file must be reapplied:
-
+    
     ```bash
     kubectl apply -f /root/etcd/cray-cps.yaml
     kubectl apply -f /root/etcd/cray-cps-cm-pm.yaml
     kubectl apply -f /root/etcd/cray-cps-etcd.yaml
     ```
-
+    
     Proceed to the next step to finish rebuilding the cluster.
-
-### Post-Rebuild
+    
+## Post-Rebuild
 
 1.  Update the IP address needed to interact with the rebuilt cluster.
-
+     
     After recreating the etcd cluster, the IP address needed to interact with the cluster changes, which requires recreating the etcd backup. The IP address is created automatically via a cronjob that runs at the top of each hour.
-
+    
     1.  Determine the periodic backup name for the cluster.
-
+        
         The following example is for the `bos` cluster:
-
+        
         ```bash
         kubectl get etcdbackup -n services | grep bos.*periodic
         cray-bos-etcd-cluster-periodic-backup
         ```
-
+                
     2.  Delete the etcd backup definition.
-
+        
         A new backup will be created that points to the new IP address. Use the value returned in the previous substep.
-
+        
         ```bash
         kubectl delete etcdbackup -n services \
         cray-bos-etcd-cluster-periodic-backup
         ```
+        
 Check if rebuilt cluster's data needs to be repopulated [Repopulate Data in etcd Clusters When Rebuilding Them](Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md).
 Rerun the etcd cluster health check \(see [Check the Health and Balance of etcd Clusters](Check_the_Health_and_Balance_of_etcd_Clusters.md)\) after recovering one or more clusters. Ensure that the clusters are healthy and have the correct number of pods.
-

--- a/operations/kubernetes/Rebuild_Unhealthy_etcd_Clusters.md
+++ b/operations/kubernetes/Rebuild_Unhealthy_etcd_Clusters.md
@@ -9,7 +9,7 @@ A special use case is also included for the Content Projection Service \(CPS\) a
 ---
 > **`NOTE`**
 
-Etcd Clusters can be rebuilt using the automation script or the manual procedure below. The automation script follows the same steps as the manual procedure. If the automation script fails at any step, continue rebuilding the cluster using the manual procedure.
+Etcd Clusters other than the Content Projection Service \(CPS\) can be rebuilt using the automation script or the manual procedure below. The automation script follows the same steps as the manual procedure. If the automation script fails at any step, continue rebuilding the cluster using the manual procedure.
 
 ---
 
@@ -81,7 +81,7 @@ etcdbackup.etcd.database.coreos.com "cray-bss-etcd-cluster-periodic-backup" dele
 
 ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util #
 ```
-Check if rebuilt cluster's data needs to be repopulated [Repopulate Data in etcd Clusters When Rebuilding Them](Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md)
+Check if rebuilt cluster's data needs to be repopulated [Repopulate Data in etcd Clusters When Rebuilding Them](Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md).
 Rerun the etcd cluster health check \(see [Check the Health and Balance of etcd Clusters](Check_the_Health_and_Balance_of_etcd_Clusters.md)\) after recovering one or more clusters. Ensure that the clusters are healthy and have the correct number of pods.
 
 ### Manual Procedure for Clusters in the Services Namespace

--- a/operations/kubernetes/Rebuild_Unhealthy_etcd_Clusters.md
+++ b/operations/kubernetes/Rebuild_Unhealthy_etcd_Clusters.md
@@ -94,7 +94,6 @@ Rerun the etcd cluster health check \(see [Check the Health and Balance of etcd 
 The following examples use the `cray-bos` etcd cluster, but these steps must be repeated for every unhealthy service.
 
 1.  Retrieve the `.yaml` file for the deployment and the etcd cluster objects.
-
     ```bash
     kubectl -n services get deployment cray-bos -o yaml > /root/etcd/cray-bos.yaml
     kubectl -n services get etcd cray-bos-etcd -o yaml > /root/etcd/cray-bos-etcd.yaml
@@ -109,7 +108,6 @@ The following examples use the `cray-bos` etcd cluster, but these steps must be 
     ```
 
 2.  Edit each `.yaml` file to remove the entire line for `creationTimestamp`, generation, `resourceVersion`, `uid`, and everything after status \(including status\).
-
     For example:
 
     ```text
@@ -141,7 +139,6 @@ The following examples use the `cray-bos` etcd cluster, but these steps must be 
     ```
 
 3.  Delete the deployment and the etcd cluster objects.
-
     Wait for the pods to terminate before proceeding to the next step.
 
     ```bash
@@ -158,7 +155,6 @@ The following examples use the `cray-bos` etcd cluster, but these steps must be 
     ```
 
 4.  Apply the etcd cluster file.
-
     ```bash
     kubectl apply -f /root/etcd/cray-bos-etcd.yaml
     ```
@@ -178,7 +174,6 @@ The following examples use the `cray-bos` etcd cluster, but these steps must be 
     ```
 
 5.  Apply the deployment file.
-
     ```bash
     kubectl apply -f /root/etcd/cray-bos.yaml
     ```
@@ -196,11 +191,9 @@ The following examples use the `cray-bos` etcd cluster, but these steps must be 
 ## Post-Rebuild
 
 1.  Update the IP address needed to interact with the rebuilt cluster.
-
     After recreating the etcd cluster, the IP address needed to interact with the cluster changes, which requires recreating the etcd backup. The IP address is created automatically via a cronjob that runs at the top of each hour.
 
     1.  Determine the periodic backup name for the cluster.
-
         The following example is for the `bos` cluster:
 
         ```bash
@@ -209,9 +202,7 @@ The following examples use the `cray-bos` etcd cluster, but these steps must be 
         ```
 
     2.  Delete the etcd backup definition.
-
         A new backup will be created that points to the new IP address. Use the value returned in the previous substep.
-        
         ```bash
         kubectl delete etcdbackup -n services \
         cray-bos-etcd-cluster-periodic-backup

--- a/operations/kubernetes/Rebuild_Unhealthy_etcd_Clusters.md
+++ b/operations/kubernetes/Rebuild_Unhealthy_etcd_Clusters.md
@@ -34,53 +34,54 @@ ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util # ./etcd_restore_reb
 ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util # ./etcd_restore_rebuild.sh -a
 ```
 
-An example using the automation script is below.
+An example using the automation script is below for ncn-w001. Can also
+be executed on any master NCN.
 
-```
-ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util # ./etcd_restore_rebuild.sh -s cray-uas-mgr-etcd
+```bash
+ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util # ./etcd_restore_rebuild.sh -s cray-bss-etcd
 ```
 
 Example output:
 
-```
+```bash
 The following etcd clusters will be restored/rebuilt:
-cray-uas-mgr-etcd
+cray-bss-etcd
 You will be accepting responsibility for any missing data if there is a restore/rebuild over a running etcd k/v. HPE assumes no responsibility.
 Proceed restoring/rebuilding? (yes/no)
 yes
 Proceeding: restoring/rebuilding etcd clusters.
 The following etcd clusters did not have backups so they will need to be rebuilt:
-cray-uas-mgr-etcd
+cray-bss-etcd
 Would you like to proceed rebuilding all of these etcd clusters? (yes/no)
 yes
 
- ----- Rebuilding cray-uas-mgr-etcd -----
+ ----- Rebuilding cray-bss-etcd -----
 Deployment and etcd cluster objects captured in yaml file
 yaml files edited
-deployment.apps "cray-uas-mgr" deleted
-etcdcluster.etcd.database.coreos.com "cray-uas-mgr-etcd" deleted
+deployment.apps "cray-bss" deleted
+etcdcluster.etcd.database.coreos.com "cray-bss-etcd" deleted
 Waiting for pods to terminate.
-etcdcluster.etcd.database.coreos.com/cray-uas-mgr-etcd created
+etcdcluster.etcd.database.coreos.com/cray-bss-etcd created
 Waiting for pods to be 'Running'.
+- Waiting for 3 cray-bss-etcd pods to be running:
+No resources found in services namespace.
 - 0/3  Running
 - 1/3  Running
 - 2/3  Running
 - 3/3  Running
-error: unable to upgrade connection: container not found ("etcd")
-cray-uas-mgr-etcd-42qj56htp5 - Could not reach endpoint. 1/5 Attempts.   Will try again in 15 seconds.
-error: unable to upgrade connection: container not found ("etcd")
-cray-uas-mgr-etcd-42qj56htp5 - Could not reach endpoint. 2/5 Attempts.   Will try again in 15 seconds.
-cray-uas-mgr-etcd-42qj56htp5 - Endpoint reached successfully
-cray-uas-mgr-etcd-6rpprkwbpp - Endpoint reached successfully
-cray-uas-mgr-etcd-nzbzl7k6gm - Endpoint reached successfully
-deployment.apps/cray-uas-mgr created
+Checking endpoint health.
+cray-bss-etcd-qj4ds8j9k6 - Endpoint reached successfully
+cray-bss-etcd-s8ck74hf96 - Endpoint reached successfully
+cray-bss-etcd-vc2xznnbpj - Endpoint reached successfully
+deployment.apps/cray-bss created
+2022-07-31-05:04:27
+SUCCESSFUL REBUILD of the cray-bss-etcd cluster completed.
 
-SUCCESSFUL REBUILD cray-uas-mgr-etcd.
+etcdbackup.etcd.database.coreos.com "cray-bss-etcd-cluster-periodic-backup" deleted
 
-Could not find existing backup definition. If one exists, it should be deleted so a new one can be created that points to the new cluster IP.
-Example delete command: groot-ncn-w001:~ # kubectl delete etcdbackup -n services cray-bos-etcd-cluster-periodic-backup
+ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util #
 ```
-
+Check if restored cluster's data needs to be repopulated [Repopulate Data in etcd Clusters When Rebuilding Them](Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md)
 Rerun the etcd cluster health check \(see [Check the Health and Balance of etcd Clusters](Check_the_Health_and_Balance_of_etcd_Clusters.md)\) after recovering one or more clusters. Ensure that the clusters are healthy and have the correct number of pods.
 
 ### Manual Procedure for Clusters in the Services Namespace
@@ -210,6 +211,6 @@ The following examples use the `cray-bos` etcd cluster, but these steps must be 
         kubectl delete etcdbackup -n services \
         cray-bos-etcd-cluster-periodic-backup
         ```
-
+Check if restored cluster's data needs to be repopulated [Repopulate Data in etcd Clusters When Rebuilding Them](Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md)
 Rerun the etcd cluster health check \(see [Check the Health and Balance of etcd Clusters](Check_the_Health_and_Balance_of_etcd_Clusters.md)\) after recovering one or more clusters. Ensure that the clusters are healthy and have the correct number of pods.
 

--- a/operations/kubernetes/Rebuild_Unhealthy_etcd_Clusters.md
+++ b/operations/kubernetes/Rebuild_Unhealthy_etcd_Clusters.md
@@ -93,7 +93,7 @@ Rerun the etcd cluster health check \(see [Check the Health and Balance of etcd 
 
 The following examples use the `cray-bos` etcd cluster, but these steps must be repeated for every unhealthy service.
 
-1.  Retrieve the `.yaml` file for the deployment and the etcd cluster objects.
+1. Retrieve the `.yaml` file for the deployment and the etcd cluster objects.
 
     ```bash
     kubectl -n services get deployment cray-bos -o yaml > /root/etcd/cray-bos.yaml
@@ -108,7 +108,7 @@ The following examples use the `cray-bos` etcd cluster, but these steps must be 
     kubectl -n services get etcd cray-cps-etcd -o yaml > /root/etcd/cray-cps-etcd.yaml
     ```
 
-2.  Edit each `.yaml` file to remove the entire line for `creationTimestamp`, generation, `resourceVersion`, `uid`, and everything after status \(including status\).
+2. Edit each `.yaml` file to remove the entire line for `creationTimestamp`, generation, `resourceVersion`, `uid`, and everything after status \(including status\).
 
     For example:
 
@@ -140,7 +140,7 @@ The following examples use the `cray-bos` etcd cluster, but these steps must be 
       updatedReplicas: 1
     ```
 
-3.  Delete the deployment and the etcd cluster objects.
+3. Delete the deployment and the etcd cluster objects.
 
     Wait for the pods to terminate before proceeding to the next step.
 
@@ -157,7 +157,7 @@ The following examples use the `cray-bos` etcd cluster, but these steps must be 
     kubectl delete -f /root/etcd/cray-cps-etcd.yaml
     ```
 
-4.  Apply the etcd cluster file.
+4. Apply the etcd cluster file.
 
     ```bash
     kubectl apply -f /root/etcd/cray-bos-etcd.yaml
@@ -177,7 +177,7 @@ The following examples use the `cray-bos` etcd cluster, but these steps must be 
     cray-bos-etcd-w5vv7j4ghh                  1/1     Running         0          18h
     ```
 
-5.  Apply the deployment file.
+5. Apply the deployment file.
 
     ```bash
     kubectl apply -f /root/etcd/cray-bos.yaml
@@ -195,27 +195,27 @@ The following examples use the `cray-bos` etcd cluster, but these steps must be 
 
 ## Post-Rebuild
 
-1.  Update the IP address needed to interact with the rebuilt cluster.
+1. Update the IP address needed to interact with the rebuilt cluster.
 
     After recreating the etcd cluster, the IP address needed to interact with the cluster changes, which requires recreating the etcd backup. The IP address is created automatically via a cronjob that runs at the top of each hour.
 
-1.  Determine the periodic backup name for the cluster.
+1. Determine the periodic backup name for the cluster.
 
-        The following example is for the `bos` cluster:
+    The following example is for the `bos` cluster:
 
-        ```bash
-        kubectl get etcdbackup -n services | grep bos.*periodic
-        cray-bos-etcd-cluster-periodic-backup
-        ```
+    ```bash
+    kubectl get etcdbackup -n services | grep bos.*periodic
+    cray-bos-etcd-cluster-periodic-backup
+    ```
 
-2.  Delete the etcd backup definition.
+2. Delete the etcd backup definition.
 
-        A new backup will be created that points to the new IP address. Use the value returned in the previous substep.
+    A new backup will be created that points to the new IP address. Use the value returned in the previous substep.
 
-        ```bash
-        kubectl delete etcdbackup -n services \
-        cray-bos-etcd-cluster-periodic-backup
-        ```
+    ```bash
+    kubectl delete etcdbackup -n services \
+    cray-bos-etcd-cluster-periodic-backup
+    ```
 
 Check if rebuilt cluster's data needs to be repopulated [Repopulate Data in etcd Clusters When Rebuilding Them](Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md).
 Rerun the etcd cluster health check \(see [Check the Health and Balance of etcd Clusters](Check_the_Health_and_Balance_of_etcd_Clusters.md)\) after recovering one or more clusters. Ensure that the clusters are healthy and have the correct number of pods.

--- a/operations/kubernetes/Rebuild_Unhealthy_etcd_Clusters.md
+++ b/operations/kubernetes/Rebuild_Unhealthy_etcd_Clusters.md
@@ -208,7 +208,7 @@ The following examples use the `cray-bos` etcd cluster, but these steps must be 
     cray-bos-etcd-cluster-periodic-backup
     ```
 
-2. Delete the etcd backup definition.
+1. Delete the etcd backup definition.
 
     A new backup will be created that points to the new IP address. Use the value returned in the previous substep.
 

--- a/operations/kubernetes/Rebuild_Unhealthy_etcd_Clusters.md
+++ b/operations/kubernetes/Rebuild_Unhealthy_etcd_Clusters.md
@@ -1,8 +1,8 @@
 # Rebuild Unhealthy etcd Clusters
 
-In order to rebuild a healthy cluster, delete and redeploy the unhealthy pods.
+Rebuild any cluster that does not have healthy pods by deleting and redeploying unhealthy pods.
 This procedure includes examples for rebuilding etcd clusters in the `services` namespace.
-This procedure must be used for each unhealthy cluster, and not just the services used in the following examples.
+This procedure must be used for each unhealthy cluster, not just those in the `services` namespace used in the following examples.
 
 This process also applies when etcd is not visible when running the `kubectl get pods` command.
 
@@ -11,9 +11,10 @@ A special use case is also included for the Content Projection Service \(CPS\) a
 ---
 > **`NOTE`**
 
-Etcd clusters other than the Content Projection Service \(CPS\) are rebuilt using the following manual procedure or automation script.
+Etcd Clusters can be rebuilt using the automation script or the manual procedure below.
 The automation script follows the same steps as the manual procedure.
 If the automation script fails at any step, then continue rebuilding the cluster using the manual procedure.
+Note that the Content Projection Service \(CPS\) cluster can only be rebuilt using the manual procedure.
 
 ## Prerequisites
 
@@ -193,7 +194,7 @@ The following examples use the `cray-bos` etcd cluster, but these steps must be 
 
 ## Post-Rebuild
 
-1. Update the IP address needed to interact with the rebuilt cluster.
+1. Update the IP address that interacts with the rebuilt cluster.
 
     After recreating the etcd cluster, the IP address needed to interact with the cluster changes, which requires recreating the etcd backup. The IP address is created automatically via a cronjob that runs at the top of each hour.
 

--- a/operations/kubernetes/Rebuild_Unhealthy_etcd_Clusters.md
+++ b/operations/kubernetes/Rebuild_Unhealthy_etcd_Clusters.md
@@ -94,6 +94,7 @@ Rerun the etcd cluster health check \(see [Check the Health and Balance of etcd 
 The following examples use the `cray-bos` etcd cluster, but these steps must be repeated for every unhealthy service.
 
 1.  Retrieve the `.yaml` file for the deployment and the etcd cluster objects.
+
     ```bash
     kubectl -n services get deployment cray-bos -o yaml > /root/etcd/cray-bos.yaml
     kubectl -n services get etcd cray-bos-etcd -o yaml > /root/etcd/cray-bos-etcd.yaml
@@ -108,6 +109,7 @@ The following examples use the `cray-bos` etcd cluster, but these steps must be 
     ```
 
 2.  Edit each `.yaml` file to remove the entire line for `creationTimestamp`, generation, `resourceVersion`, `uid`, and everything after status \(including status\).
+
     For example:
 
     ```text
@@ -139,6 +141,7 @@ The following examples use the `cray-bos` etcd cluster, but these steps must be 
     ```
 
 3.  Delete the deployment and the etcd cluster objects.
+
     Wait for the pods to terminate before proceeding to the next step.
 
     ```bash
@@ -155,6 +158,7 @@ The following examples use the `cray-bos` etcd cluster, but these steps must be 
     ```
 
 4.  Apply the etcd cluster file.
+
     ```bash
     kubectl apply -f /root/etcd/cray-bos-etcd.yaml
     ```
@@ -174,6 +178,7 @@ The following examples use the `cray-bos` etcd cluster, but these steps must be 
     ```
 
 5.  Apply the deployment file.
+
     ```bash
     kubectl apply -f /root/etcd/cray-bos.yaml
     ```
@@ -191,9 +196,11 @@ The following examples use the `cray-bos` etcd cluster, but these steps must be 
 ## Post-Rebuild
 
 1.  Update the IP address needed to interact with the rebuilt cluster.
+
     After recreating the etcd cluster, the IP address needed to interact with the cluster changes, which requires recreating the etcd backup. The IP address is created automatically via a cronjob that runs at the top of each hour.
 
-    1.  Determine the periodic backup name for the cluster.
+1.  Determine the periodic backup name for the cluster.
+
         The following example is for the `bos` cluster:
 
         ```bash
@@ -201,8 +208,10 @@ The following examples use the `cray-bos` etcd cluster, but these steps must be 
         cray-bos-etcd-cluster-periodic-backup
         ```
 
-    2.  Delete the etcd backup definition.
+2.  Delete the etcd backup definition.
+
         A new backup will be created that points to the new IP address. Use the value returned in the previous substep.
+
         ```bash
         kubectl delete etcdbackup -n services \
         cray-bos-etcd-cluster-periodic-backup

--- a/operations/kubernetes/Rebuild_Unhealthy_etcd_Clusters.md
+++ b/operations/kubernetes/Rebuild_Unhealthy_etcd_Clusters.md
@@ -6,7 +6,9 @@ This procedure must be used for each unhealthy cluster, and not just those used 
 
 This process also applies when etcd is not visible when running the `kubectl get pods` command.
 
-A special use case is also included for the Content Projection Service \(CPS\) as the process for rebuilding the cluster is slightly different.
+The commands in this procedure can be run on any Kubernetes master or worker node on the system.
+
+A special procedure is also included for the Content Projection Service \(CPS\), because the process for rebuilding its cluster is slightly different.
 
 1. [Prerequisites](#prerequisites)
 1. [Rebuild procedure](#rebuild-procedure)

--- a/operations/kubernetes/Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md
+++ b/operations/kubernetes/Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md
@@ -9,7 +9,6 @@ The following services need their data repopulated in the etcd cluster:
 - Boot Script Service \(BSS\)
 - Content Projection Service \(CPS\)
 - Compute Rolling Upgrade Service \(CRUS\)
-- External DNS
 - Firmware Action Service \(FAS\)
 - HMS Notification Fanout Daemon \(HMNFD\)
 - Mountain Endpoint Discovery Service \(MEDS\)

--- a/operations/kubernetes/Restore_an_etcd_Cluster_from_a_Backup.md
+++ b/operations/kubernetes/Restore_an_etcd_Cluster_from_a_Backup.md
@@ -69,6 +69,7 @@ ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util #
 ## Restore with Manual Procedure
 
 1.  List the backups for the desired etcd cluster.
+
     The example below uses the Boot Orchestration Service \(BOS\).
 
     ```bash
@@ -90,6 +91,7 @@ ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util #
     ```
 
 2.  Restore the cluster using a backup.
+
     Replace `etcd.backup\_v277935\_2020-03-30-23:52:54` in the command below with the name of the backup being used.
 
     ```bash
@@ -105,6 +107,7 @@ ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util #
     ```
 
 3.  Restart the pods for the etcd cluster.
+
     1.  Watch the pods come back online.
 
         This may take a couple minutes.
@@ -122,6 +125,7 @@ ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util #
         ```
 
     2.  Delete the EtcdRestore custom resource.
+
         This step will make it possible for future restores to occur. Replace the etcdrestore.etcd.database.coreos.com/cray-bos-etcd value with the name returned in step 2.
 
         ```bash

--- a/operations/kubernetes/Restore_an_etcd_Cluster_from_a_Backup.md
+++ b/operations/kubernetes/Restore_an_etcd_Cluster_from_a_Backup.md
@@ -2,43 +2,54 @@
 
 Use an existing backup of a healthy etcd cluster to restore an unhealthy cluster to a healthy state.
 
-The commands in this procedure can be run on any master node \(`ncn-mXXX`\) or worker node \(`ncn-wXXX`\) on the system.
+The commands in this procedure can be run on any Kubernetes master or worker node on the system.
 
----
-> **`NOTE`**
-
-Etcd Clusters can be restored using the automation script or the manual procedure below. The automation script follows the same steps as the manual procedure.
-If the automation script fails to get the date from backups, follow the manual procedure.
-
----
+* [Prerequisites](#prerequisites)
+* [Restore procedure](#restore-procedure)
+  * [Automated script](#restore-with-automated-script)
+  * [Manual procedure](#restore-with-manual-procedure)
 
 ## Prerequisites
 
 A backup of a healthy etcd cluster has been created.
 
-## Restore with Automation Script
+## Restore procedure
+
+Etcd clusters can be restored using an automated script or a manual procedure.
+
+* [Restore with automated script](#restore-with-automated-script)
+* [Restore with manual procedure](#restore-with-manual-procedure)
+
+### Restore with automated script
 
 The automated script will restore the cluster from the most recent backup if it finds a backup created within the last 7 days.
 If it does not discover a backup within the last 7 days, it will ask the user if they would like to rebuild the cluster.
 
-```text
-cd /opt/cray/platform-utils/etcd_restore_rebuild_util
+The automated script follows the same steps as the manual procedure.
+If the automated script fails to get the date from backups, then follow the manual procedure.
 
-# rebuild/restore a single cluster
-ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util # ./etcd_restore_rebuild.sh -s cray-bos-etcd
+* (`ncn-mw#`) Rebuild/restore a single cluster
 
-# rebuild/restore multiple clusters
-ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util # ./etcd_restore_rebuild.sh -m cray-bos-etcd,cray-uas-mgr-etcd
+    ```bash
+    /opt/cray/platform-utils/etcd_restore_rebuild_util/etcd_restore_rebuild.sh -s cray-bos-etcd
+    ```
 
-# rebuild/restore all clusters
-ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util # ./etcd_restore_rebuild.sh -a
-```
+* (`ncn-mw#`) Rebuild/restore multiple clusters
 
-An example using the automation script is below for `ncn-w001`. Can also
-be executed on any master NCN.
+    ```bash
+    /opt/cray/platform-utils/etcd_restore_rebuild_util/etcd_restore_rebuild.sh -m cray-bos-etcd,cray-uas-mgr-etcd
+    ```
+
+* (`ncn-mw#`) Rebuild/restore all clusters
+
+   ```bash
+   /opt/cray/platform-utils/etcd_restore_rebuild_util/etcd_restore_rebuild.sh -a
+   ```
+
+#### Example command and output
 
 ```bash
-ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util # ./etcd_restore_rebuild.sh -s cray-bss-etcd
+/opt/cray/platform-utils/etcd_restore_rebuild_util/etcd_restore_rebuild.sh -s cray-bss-etcd
 ```
 
 Example output:
@@ -62,20 +73,18 @@ etcdrestore.etcd.database.coreos.com/cray-bss-etcd created
 etcdrestore.etcd.database.coreos.com "cray-bss-etcd" deleted
 2022-07-31-04:23:23
 The cray-bss-etcd cluster has successfully been restored from cray-bss/etcd.backup_v5702_2022-07-30-19:00:02.
-
-ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util #
 ```
 
-## Restore with Manual Procedure
+### Restore with manual procedure
 
-1. List the backups for the desired etcd cluster.
+1. (`ncn-mw#`) List the backups for the desired etcd cluster.
 
     The example below uses the Boot Orchestration Service \(BOS\).
 
     ```bash
     kubectl exec -it -n operators \
-    $(kubectl get pod -n operators | grep etcd-backup-restore | head -1 | awk '{print $1}') \
-    -c boto3 -- list_backups cray-bos
+        $(kubectl get pod -n operators | grep etcd-backup-restore | head -1 | awk '{print $1}') \
+        -c boto3 -- list_backups cray-bos
     ```
 
     Example output:
@@ -90,14 +99,14 @@ ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util #
     cray-bos/etcd.backup_v86767_2020-03-19-18:00:05
     ```
 
-2. Restore the cluster using a backup.
+1. (`ncn-mw#`) Restore the cluster using a backup.
 
-    Replace `etcd.backup\_v277935\_2020-03-30-23:52:54` in the command below with the name of the backup being used.
+    Replace `etcd.backup\_v277935\_2020-03-30-23:52:54` in the command below with the name of the chosen backup from the previous step.
 
     ```bash
     kubectl exec -it -n operators \
-    $(kubectl get pod -n operators | grep etcd-backup-restore | head -1 | awk '{print $1}') \
-    -c util -- restore_from_backup cray-bos etcd.backup_v277935_2020-03-30-23:52:54
+        $(kubectl get pod -n operators | grep etcd-backup-restore | head -1 | awk '{print $1}') \
+        -c util -- restore_from_backup cray-bos etcd.backup_v277935_2020-03-30-23:52:54
     ```
 
     Example output:
@@ -106,34 +115,34 @@ ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util #
     etcdrestore.etcd.database.coreos.com/cray-bos-etcd created
     ```
 
-3. Restart the pods for the etcd cluster.
+1. (`ncn-mw#`) Wait for the pods to restart and watch the pods come back online.
 
-    1. Watch the pods come back online.
+    This may take a few minutes.
 
-        This may take a couple minutes.
+    ```bash
+    kubectl -n services get pod | grep SERVICE_NAME
+    ```
 
-        ```bash
-        kubectl -n services get pod | grep SERVICE_NAME
-        ```
+    Example output:
 
-        Example output:
+    ```text
+    cray-bos-etcd-498jn7th6p             1/1     Running              0          4h1m
+    cray-bos-etcd-dj7d894227             1/1     Running              0          3h59m
+    cray-bos-etcd-tk4pr4kgqk             1/1     Running              0          4
+    ```
 
-        ```text
-        cray-bos-etcd-498jn7th6p             1/1     Running              0          4h1m
-        cray-bos-etcd-dj7d894227             1/1     Running              0          3h59m
-        cray-bos-etcd-tk4pr4kgqk             1/1     Running              0          4
-        ```
+1. (`ncn-mw#`) Delete the `EtcdRestore` custom resource.
 
-    2. Delete the EtcdRestore custom resource.
+    This step will make it possible for future restores to occur. In the following command, replace
+    `etcdrestore.etcd.database.coreos.com/cray-bos-etcd` value with the output of the earlier command used to
+    initiate the restore.
 
-        This step will make it possible for future restores to occur. Replace the etcdrestore.etcd.database.coreos.com/cray-bos-etcd value with the name returned in step 2.
+    ```bash
+    kubectl -n services delete etcdrestore.etcd.database.coreos.com/cray-bos-etcd
+    ```
 
-        ```bash
-        kubectl -n services delete etcdrestore.etcd.database.coreos.com/cray-bos-etcd
-        ```
+    Example output:
 
-        Example output:
-
-        ```text
-        etcdrestore.etcd.database.coreos.com "cray-bos-etcd" deleted
-        ```
+    ```text
+    etcdrestore.etcd.database.coreos.com "cray-bos-etcd" deleted
+    ```

--- a/operations/kubernetes/Restore_an_etcd_Cluster_from_a_Backup.md
+++ b/operations/kubernetes/Restore_an_etcd_Cluster_from_a_Backup.md
@@ -21,7 +21,7 @@ A backup of a healthy etcd cluster has been created.
 The automated script will restore the cluster from the most recent backup if it finds a backup created within the last 7 days.
 If it does not discover a backup within the last 7 days, it will ask the user if they would like to rebuild the cluster.
 
-```
+```text
 cd /opt/cray/platform-utils/etcd_restore_rebuild_util
 
 # rebuild/restore a single cluster
@@ -43,7 +43,7 @@ ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util # ./etcd_restore_reb
 
 Example output:
 
-```bash
+```text
 The following etcd clusters will be restored/rebuilt:
 cray-bss-etcd
 You will be accepting responsibility for any missing data if there is a restore/rebuild over a running etcd k/v. HPE assumes no responsibility.
@@ -80,7 +80,7 @@ ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util #
 
     Example output:
 
-    ```
+    ```text
     cray-bos/etcd.backup_v108497_2020-03-20-23:42:37
     cray-bos/etcd.backup_v125815_2020-03-21-23:42:37
     cray-bos/etcd.backup_v143095_2020-03-22-23:42:38
@@ -102,7 +102,7 @@ ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util #
 
     Example output:
 
-    ```
+    ```text
     etcdrestore.etcd.database.coreos.com/cray-bos-etcd created
     ```
 
@@ -118,7 +118,7 @@ ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util #
 
         Example output:
 
-        ```
+        ```text
         cray-bos-etcd-498jn7th6p             1/1     Running              0          4h1m
         cray-bos-etcd-dj7d894227             1/1     Running              0          3h59m
         cray-bos-etcd-tk4pr4kgqk             1/1     Running              0          4
@@ -134,7 +134,7 @@ ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util #
 
         Example output:
 
-        ```
+        ```text
         etcdrestore.etcd.database.coreos.com "cray-bos-etcd" deleted
         ```
 

--- a/operations/kubernetes/Restore_an_etcd_Cluster_from_a_Backup.md
+++ b/operations/kubernetes/Restore_an_etcd_Cluster_from_a_Backup.md
@@ -68,7 +68,7 @@ ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util #
 
 ## Restore with Manual Procedure
 
-1.  List the backups for the desired etcd cluster.
+1. List the backups for the desired etcd cluster.
 
     The example below uses the Boot Orchestration Service \(BOS\).
 
@@ -90,7 +90,7 @@ ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util #
     cray-bos/etcd.backup_v86767_2020-03-19-18:00:05
     ```
 
-2.  Restore the cluster using a backup.
+2. Restore the cluster using a backup.
 
     Replace `etcd.backup\_v277935\_2020-03-30-23:52:54` in the command below with the name of the backup being used.
 
@@ -106,9 +106,9 @@ ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util #
     etcdrestore.etcd.database.coreos.com/cray-bos-etcd created
     ```
 
-3.  Restart the pods for the etcd cluster.
+3. Restart the pods for the etcd cluster.
 
-    1.  Watch the pods come back online.
+    1. Watch the pods come back online.
 
         This may take a couple minutes.
 
@@ -117,14 +117,14 @@ ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util #
         ```
 
         Example output:
-        
+
         ```text
         cray-bos-etcd-498jn7th6p             1/1     Running              0          4h1m
         cray-bos-etcd-dj7d894227             1/1     Running              0          3h59m
         cray-bos-etcd-tk4pr4kgqk             1/1     Running              0          4
         ```
 
-    2.  Delete the EtcdRestore custom resource.
+    2. Delete the EtcdRestore custom resource.
 
         This step will make it possible for future restores to occur. Replace the etcdrestore.etcd.database.coreos.com/cray-bos-etcd value with the name returned in step 2.
 

--- a/operations/kubernetes/Restore_an_etcd_Cluster_from_a_Backup.md
+++ b/operations/kubernetes/Restore_an_etcd_Cluster_from_a_Backup.md
@@ -101,7 +101,7 @@ The cray-bss-etcd cluster has successfully been restored from cray-bss/etcd.back
 
 1. (`ncn-mw#`) Restore the cluster using a backup.
 
-    Replace `etcd.backup\_v277935\_2020-03-30-23:52:54` in the command below with the name of the chosen backup from the previous step.
+    Replace `etcd.backup_v277935_2020-03-30-23:52:54` in the command below with the name of the chosen backup from the previous step.
 
     ```bash
     kubectl exec -it -n operators \

--- a/operations/kubernetes/Restore_an_etcd_Cluster_from_a_Backup.md
+++ b/operations/kubernetes/Restore_an_etcd_Cluster_from_a_Backup.md
@@ -69,17 +69,17 @@ ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util #
 ## Restore with Manual Procedure
 
 1.  List the backups for the desired etcd cluster.
-     
+
     The example below uses the Boot Orchestration Service \(BOS\).
-    
+
     ```bash
     kubectl exec -it -n operators \
     $(kubectl get pod -n operators | grep etcd-backup-restore | head -1 | awk '{print $1}') \
     -c boto3 -- list_backups cray-bos
     ```
-    
+
     Example output:
-    
+
     ```text
     cray-bos/etcd.backup_v108497_2020-03-20-23:42:37
     cray-bos/etcd.backup_v125815_2020-03-21-23:42:37
@@ -89,33 +89,33 @@ ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util #
     cray-bos/etcd.backup_v277935_2020-03-30-23:52:54
     cray-bos/etcd.backup_v86767_2020-03-19-18:00:05
     ```
-    
+
 2.  Restore the cluster using a backup.
-    
+
     Replace `etcd.backup\_v277935\_2020-03-30-23:52:54` in the command below with the name of the backup being used.
-    
+
     ```bash
     kubectl exec -it -n operators \
     $(kubectl get pod -n operators | grep etcd-backup-restore | head -1 | awk '{print $1}') \
     -c util -- restore_from_backup cray-bos etcd.backup_v277935_2020-03-30-23:52:54
     ```
-    
+
     Example output:
-    
+
     ```text
     etcdrestore.etcd.database.coreos.com/cray-bos-etcd created
     ```
-    
+
 3.  Restart the pods for the etcd cluster.
-    
+
     1.  Watch the pods come back online.
-        
+
         This may take a couple minutes.
-        
+
         ```bash
         kubectl -n services get pod | grep SERVICE_NAME
         ```
-        
+
         Example output:
         
         ```text
@@ -123,17 +123,17 @@ ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util #
         cray-bos-etcd-dj7d894227             1/1     Running              0          3h59m
         cray-bos-etcd-tk4pr4kgqk             1/1     Running              0          4
         ```
-        
+
     2.  Delete the EtcdRestore custom resource.
-        
+
         This step will make it possible for future restores to occur. Replace the etcdrestore.etcd.database.coreos.com/cray-bos-etcd value with the name returned in step 2.
-        
+
         ```bash
         kubectl -n services delete etcdrestore.etcd.database.coreos.com/cray-bos-etcd
         ```
-        
+
         Example output:
-        
+
         ```text
         etcdrestore.etcd.database.coreos.com "cray-bos-etcd" deleted
         ```

--- a/operations/kubernetes/Restore_an_etcd_Cluster_from_a_Backup.md
+++ b/operations/kubernetes/Restore_an_etcd_Cluster_from_a_Backup.md
@@ -34,21 +34,36 @@ ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util # ./etcd_restore_reb
 ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util # ./etcd_restore_rebuild.sh -a
 ```
 
-An example using the automation script is below.
+An example using the automation script is below for ncn-w001. Can also
+be executed on any master NCN.
+
+```bash
+ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util # ./etcd_restore_rebuild.sh -s cray-bss-etcd
 ```
-ncn-m001:/opt/cray/platform-utils/etcd_restore_rebuild_util # ./etcd_restore_rebuild.sh -s cray-externaldns-etcd
+
+Example output:
+
+```bash
 The following etcd clusters will be restored/rebuilt:
-cray-externaldns-etcd
+cray-bss-etcd
 You will be accepting responsibility for any missing data if there is a restore/rebuild over a running etcd k/v. HPE assumes no responsibility.
 Proceed restoring/rebuilding? (yes/no)
 yes
 Proceeding: restoring/rebuilding etcd clusters.
 
- ----- Restoring from cray-externaldns/etcd.backup_v8362_2021-08-18-20:00:09
-etcdrestore.etcd.database.coreos.com/cray-externaldns-etcd created
+ ----- Restoring from cray-bss/etcd.backup_v5702_2022-07-30-19:00:02 -----
+etcdrestore.etcd.database.coreos.com/cray-bss-etcd created
+- Any existing cray-bss-etcd pods no longer in "Running" state.
+- Waiting for 3 cray-bss-etcd pods to be running:
+- 0/3  Running
+- 1/3  Running
+- 2/3  Running
 - 3/3  Running
-Successfully restored cray-externaldns-etcd
-etcdrestore.etcd.database.coreos.com "cray-externaldns-etcd" deleted
+etcdrestore.etcd.database.coreos.com "cray-bss-etcd" deleted
+2022-07-31-04:23:23
+The cray-bss-etcd cluster has successfully been restored from cray-bss/etcd.backup_v5702_2022-07-30-19:00:02.
+
+ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util #
 ```
 
 ### Restore with Manual Procedure

--- a/operations/kubernetes/Restore_an_etcd_Cluster_from_a_Backup.md
+++ b/operations/kubernetes/Restore_an_etcd_Cluster_from_a_Backup.md
@@ -12,11 +12,11 @@ If the automation script fails to get the date from backups, follow the manual p
 
 ---
 
-### Prerequisites
+## Prerequisites
 
 A backup of a healthy etcd cluster has been created.
 
-### Restore with Automation Script
+## Restore with Automation Script
 
 The automated script will restore the cluster from the most recent backup if it finds a backup created within the last 7 days.
 If it does not discover a backup within the last 7 days, it will ask the user if they would like to rebuild the cluster.
@@ -34,7 +34,7 @@ ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util # ./etcd_restore_reb
 ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util # ./etcd_restore_rebuild.sh -a
 ```
 
-An example using the automation script is below for ncn-w001. Can also
+An example using the automation script is below for `ncn-w001`. Can also
 be executed on any master NCN.
 
 ```bash
@@ -66,20 +66,20 @@ The cray-bss-etcd cluster has successfully been restored from cray-bss/etcd.back
 ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util #
 ```
 
-### Restore with Manual Procedure
+## Restore with Manual Procedure
 
 1.  List the backups for the desired etcd cluster.
-
+     
     The example below uses the Boot Orchestration Service \(BOS\).
-
+    
     ```bash
     kubectl exec -it -n operators \
     $(kubectl get pod -n operators | grep etcd-backup-restore | head -1 | awk '{print $1}') \
     -c boto3 -- list_backups cray-bos
     ```
-
+    
     Example output:
-
+    
     ```text
     cray-bos/etcd.backup_v108497_2020-03-20-23:42:37
     cray-bos/etcd.backup_v125815_2020-03-21-23:42:37
@@ -89,52 +89,51 @@ ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util #
     cray-bos/etcd.backup_v277935_2020-03-30-23:52:54
     cray-bos/etcd.backup_v86767_2020-03-19-18:00:05
     ```
-
+    
 2.  Restore the cluster using a backup.
-
-    Replace etcd.backup\_v277935\_2020-03-30-23:52:54 in the command below with the name of the backup being used.
-
+    
+    Replace `etcd.backup\_v277935\_2020-03-30-23:52:54` in the command below with the name of the backup being used.
+    
     ```bash
     kubectl exec -it -n operators \
     $(kubectl get pod -n operators | grep etcd-backup-restore | head -1 | awk '{print $1}') \
     -c util -- restore_from_backup cray-bos etcd.backup_v277935_2020-03-30-23:52:54
     ```
-
+    
     Example output:
-
+    
     ```text
     etcdrestore.etcd.database.coreos.com/cray-bos-etcd created
     ```
-
+    
 3.  Restart the pods for the etcd cluster.
-
+    
     1.  Watch the pods come back online.
-
+        
         This may take a couple minutes.
-
+        
         ```bash
         kubectl -n services get pod | grep SERVICE_NAME
         ```
-
+        
         Example output:
-
+        
         ```text
         cray-bos-etcd-498jn7th6p             1/1     Running              0          4h1m
         cray-bos-etcd-dj7d894227             1/1     Running              0          3h59m
         cray-bos-etcd-tk4pr4kgqk             1/1     Running              0          4
         ```
-
+        
     2.  Delete the EtcdRestore custom resource.
-
+        
         This step will make it possible for future restores to occur. Replace the etcdrestore.etcd.database.coreos.com/cray-bos-etcd value with the name returned in step 2.
-
+        
         ```bash
         kubectl -n services delete etcdrestore.etcd.database.coreos.com/cray-bos-etcd
         ```
-
+        
         Example output:
-
+        
         ```text
         etcdrestore.etcd.database.coreos.com "cray-bos-etcd" deleted
         ```
-

--- a/operations/kubernetes/Restore_an_etcd_Cluster_from_a_Backup.md
+++ b/operations/kubernetes/Restore_an_etcd_Cluster_from_a_Backup.md
@@ -69,7 +69,6 @@ ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util #
 ## Restore with Manual Procedure
 
 1.  List the backups for the desired etcd cluster.
-
     The example below uses the Boot Orchestration Service \(BOS\).
 
     ```bash
@@ -91,7 +90,6 @@ ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util #
     ```
 
 2.  Restore the cluster using a backup.
-
     Replace `etcd.backup\_v277935\_2020-03-30-23:52:54` in the command below with the name of the backup being used.
 
     ```bash
@@ -107,7 +105,6 @@ ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util #
     ```
 
 3.  Restart the pods for the etcd cluster.
-
     1.  Watch the pods come back online.
 
         This may take a couple minutes.
@@ -125,7 +122,6 @@ ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util #
         ```
 
     2.  Delete the EtcdRestore custom resource.
-
         This step will make it possible for future restores to occur. Replace the etcdrestore.etcd.database.coreos.com/cray-bos-etcd value with the name returned in step 2.
 
         ```bash


### PR DESCRIPTION
### Summary and Scope
Main - CASMPET-5905: Docs: Update docs for recent CASMPET-5531 changes to improve/fix etcd_restore_rebuild.sh script.

Update docs with etcd_restore_rebuild.sh script output changes.
Remove no longer supported "External DNS" cluster reference.

### Issues and Related PRs
CASMPET-5905

### Testing
Viewed changes.

Was a fresh Install tested? N - N/A
Was an Upgrade tested? N - N/A
Was a Downgrade tested? N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations
Low

### Requires:
N/A