### PR TITLE
CASMINST-5245: Change download location of csm tarball

### DIFF
--- a/upgrade/scripts/upgrade/prepare-assets.sh
+++ b/upgrade/scripts/upgrade/prepare-assets.sh
@@ -93,7 +93,7 @@ if [[ -z ${TARBALL_FILE} ]]; then
 
     # Ensure we have enough disk space
     reqSpace=80000000 # ~80GB
-    availSpace=$(df "$HOME" | awk 'NR==2 { print $4 }')
+    availSpace=$(df "/etc/cray/upgrade/" | awk 'NR==2 { print $4 }')
     # Validate that we received a nonnegative integer for the amount of available space
     if ! [[ $availSpace =~ ^(0|[1-9][0-9]*)$ ]]; then
         echo "ERROR: Invalid free space reported by df command: $availSpace"
@@ -115,9 +115,9 @@ if [[ -z ${TARBALL_FILE} ]]; then
         touch /etc/cray/upgrade/csm/myenv
         echo "====> ${state_name} ..."
         {
-        wget --progress=dot:giga ${ENDPOINT}/${CSM_REL_NAME}.tar.gz
+        wget --progress=dot:giga ${ENDPOINT}/${CSM_REL_NAME}.tar.gz -P /etc/cray/upgrade/
         # set TARBALL_FILE to newly downloaded file
-        TARBALL_FILE=${CSM_REL_NAME}.tar.gz
+        TARBALL_FILE=/etc/cray/upgrade/${CSM_REL_NAME}.tar.gz
         } >> ${LOG_FILE} 2>&1
         #shellcheck disable=SC2046
         record_state ${state_name} $(hostname)

--- a/upgrade/scripts/upgrade/prepare-assets.sh
+++ b/upgrade/scripts/upgrade/prepare-assets.sh
@@ -93,7 +93,7 @@ if [[ -z ${TARBALL_FILE} ]]; then
 
     # Ensure we have enough disk space
     reqSpace=80000000 # ~80GB
-    availSpace=$(df "/etc/cray/upgrade/" | awk 'NR==2 { print $4 }')
+    availSpace=$(df "/etc/cray/upgrade/csm" | awk 'NR==2 { print $4 }')
     # Validate that we received a nonnegative integer for the amount of available space
     if ! [[ $availSpace =~ ^(0|[1-9][0-9]*)$ ]]; then
         echo "ERROR: Invalid free space reported by df command: $availSpace"
@@ -115,9 +115,9 @@ if [[ -z ${TARBALL_FILE} ]]; then
         touch /etc/cray/upgrade/csm/myenv
         echo "====> ${state_name} ..."
         {
-        wget --progress=dot:giga ${ENDPOINT}/${CSM_REL_NAME}.tar.gz -P /etc/cray/upgrade/
+        wget --progress=dot:giga ${ENDPOINT}/${CSM_REL_NAME}.tar.gz -P /etc/cray/upgrade/csm/
         # set TARBALL_FILE to newly downloaded file
-        TARBALL_FILE=/etc/cray/upgrade/${CSM_REL_NAME}.tar.gz
+        TARBALL_FILE=/etc/cray/upgrade/csm/${CSM_REL_NAME}.tar.gz
         } >> ${LOG_FILE} 2>&1
         #shellcheck disable=SC2046
         record_state ${state_name} $(hostname)


### PR DESCRIPTION
Also remove un-needed steps in stage 2

# Description

This solves an extra space check for getting the csm tarball before moving it to the rbd mount. This also removes a step to move the rbd mount that is no longer needed in stage 2. 

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
