### PR TITLE
CASMPET-5629: DOCS: Update 1.2 & 1.3 Restore Bare-Metal etcd Clusters…

### DIFF
--- a/operations/kubernetes/Restore_Bare-Metal_etcd_Clusters_from_an_S3_Snapshot.md
+++ b/operations/kubernetes/Restore_Bare-Metal_etcd_Clusters_from_an_S3_Snapshot.md
@@ -2,7 +2,8 @@
 
 The etcd cluster that serves Kubernetes on master nodes is backed up every 10 minutes. These backups are pushed to `Ceph Rados Gateway` \(S3\).
 
-Restoring the etcd cluster from backup is only meant to be used in a catastrophic scenario, whereby the Kubernetes cluster and master nodes are being rebuilt. This procedure shows how to restore the bare-metal etcd cluster from a `Simple Storage Service` \(S3\) snapshot.
+Restoring the etcd cluster from backup is only meant to be used in a catastrophic scenario, whereby the Kubernetes cluster and master nodes are being rebuilt.
+This procedure shows how to restore the bare-metal etcd cluster from a `Simple Storage Service` \(S3\) snapshot.
 
 The etcd cluster needs to be restored from a backup when the Kubernetes cluster and master nodes are being rebuilt.
 
@@ -50,7 +51,7 @@ The Kubernetes cluster on master nodes is being rebuilt.
         mv etcd-backup-2020-02-04-18-50-03/etcd-dump.bin /tmp
         ```
 
-    2. Push the file to the other NCN master nodes. 
+    2. Push the file to the other NCN master nodes.
 
         ```bash
         scp /tmp/etcd-dump.bin ncn-m002:/tmp
@@ -67,7 +68,7 @@ The Kubernetes cluster on master nodes is being rebuilt.
         mkdir /tmp/etcd_restore
         ```
 
-    3. Change to the /tmp/etcd_restore directory.
+    3. Change to the `/tmp/etcd_restore` directory.
 
         ```bash
         cd /tmp/etcd_restore
@@ -106,7 +107,7 @@ The Kubernetes cluster on master nodes is being rebuilt.
 
     1. Log in as root to `ncn-m002`.
 
-    2. Create a new temporary /tmp/etcd\_restore directory.
+    2. Create a new temporary `/tmp/etcd_restore` directory.
 
         ```bash
         mkdir /tmp/etcd_restore
@@ -151,7 +152,7 @@ The Kubernetes cluster on master nodes is being rebuilt.
 
     1. Log in as root to `ncn-m003`.
 
-    2. Create a new temporary /tmp/etcd\_restore directory.
+    2. Create a new temporary `/tmp/etcd_restore` directory.
 
         ```bash
         mkdir /tmp/etcd_restore
@@ -260,4 +261,3 @@ The Kubernetes cluster on master nodes is being rebuilt.
     986f6ff2a30b01cb, started, ncn-m002, https://10.252.1.8:2380, https://10.252.1.8:2379,https://127.0.0.1:2379, false
     d5a8e497e2788510, started, ncn-m003, https://10.252.1.9:2380, https://10.252.1.9:2379,https://127.0.0.1:2379, false
     ```
-

--- a/operations/kubernetes/Restore_Bare-Metal_etcd_Clusters_from_an_S3_Snapshot.md
+++ b/operations/kubernetes/Restore_Bare-Metal_etcd_Clusters_from_an_S3_Snapshot.md
@@ -1,20 +1,21 @@
 # Restore Bare-Metal etcd Clusters from an S3 Snapshot
 
-The etcd cluster that serves Kubernetes on master nodes is backed up every 10 minutes. These backups are pushed to Ceph Rados Gateway \(S3\).
+The etcd cluster that serves Kubernetes on master nodes is backed up every 10 minutes. These backups are pushed to `Ceph Rados Gateway` \(S3\).
 
-Restoring the etcd cluster from backup is only meant to be used in a catastrophic scenario, whereby the Kubernetes cluster and master nodes are being rebuilt. This procedure shows how to restore the bare-metal etcd cluster from an Simple Storage Service \(S3\) snapshot.
+Restoring the etcd cluster from backup is only meant to be used in a catastrophic scenario, whereby the Kubernetes cluster and master nodes are being rebuilt. This procedure shows how to restore the bare-metal etcd cluster from a `Simple Storage Service` \(S3\) snapshot.
 
 The etcd cluster needs to be restored from a backup when the Kubernetes cluster and master nodes are being rebuilt.
 
-### Prerequisites
+## Prerequisites
 
 The Kubernetes cluster on master nodes is being rebuilt.
 
-### Procedure
+## Procedure
 
-1.  Select a snapshot to restore a backup.
+1. Select a snapshot to restore a backup.
 
-    The following command lists the available backups. It must be run from the /opt/cray/platform-utils/s3 directory.
+    The following command lists the available backups. It must be run from the `/opt/cray/platform-utils/s3` directory on a master NCN.
+    Shown here for `ncn-m001`, but could be executed on any of the master nodes.
 
     ```bash
     ./list-objects.py --bucket-name etcd-backup
@@ -22,7 +23,7 @@ The Kubernetes cluster on master nodes is being rebuilt.
 
     Example output:
 
-    ```
+    ```text
     bare-metal/etcd-backup-2020-02-04-18-00-10.tar.gz
     bare-metal/etcd-backup-2020-02-04-18-10-06.tar.gz
     bare-metal/etcd-backup-2020-02-04-18-20-02.tar.gz
@@ -33,9 +34,9 @@ The Kubernetes cluster on master nodes is being rebuilt.
 
     Note the file name for the desired snapshot/backup.
 
-1.  Download the snapshot and copy it to all NCN master nodes.
+1. Download the snapshot and copy it to all NCN master nodes.
 
-    1.  Retrieve the backup from S3 and uncompress it.
+    1. Retrieve the backup from S3 and uncompress it.
 
         ```bash
         mkdir /tmp/etcd_restore
@@ -49,30 +50,30 @@ The Kubernetes cluster on master nodes is being rebuilt.
         mv etcd-backup-2020-02-04-18-50-03/etcd-dump.bin /tmp
         ```
 
-    2.  Push the file to the other NCN master nodes.
+    2. Push the file to the other NCN master nodes. 
 
         ```bash
         scp /tmp/etcd-dump.bin ncn-m002:/tmp
         scp /tmp/etcd-dump.bin ncn-m003:/tmp
         ```
 
-1.  Prepare to restore the member directory for `ncn-m001`.
+1. Prepare to restore the member directory for `ncn-m001`.
 
-    1.  Log in as root to `ncn-m001`.
+    1. Log in as root to `ncn-m001`.
 
-    2.  Create a new temporary /tmp/etcd\_restore directory.
+    2. Create a new temporary `/tmp/etcd_restore` directory. If step 2.1 was executed on `ncn-m001`, the `/tmp/etcd_restore` directory already exists.
 
-        ```screen
+        ```bash
         mkdir /tmp/etcd_restore
         ```
 
-    3.  Change to the /tmp/etcd_restore directory.
+    3. Change to the /tmp/etcd_restore directory.
 
-        ```screen
+        ```bash
         cd /tmp/etcd_restore
         ```
 
-    4.  Retrieve the 'initial-cluster' and 'initial-advertise-peer-urls' values from the `kubeadmcfg.yaml` file.
+    4. Retrieve the `initial-cluster` and `initial-advertise-peer-urls` values from the `kubeadmcfg.yaml` file.
 
         The returned values will be used in the next step.
 
@@ -83,12 +84,12 @@ The Kubernetes cluster on master nodes is being rebuilt.
 
         Example output:
 
-        ```
+        ```text
         initial-cluster: ncn-m001=https://10.252.1.7:2380,ncn-m002=https://10.252.1.8:2380,ncn-m003=https://10.252.1.9:2380
         initial-advertise-peer-urls: https://10.252.1.7:2380
         ```
 
-    5.  Restore the member directory.
+    5. Restore the member directory.
 
         ```bash
         ETCDCTL_API=3 etcdctl --cacert /etc/kubernetes/pki/etcd/ca.crt \
@@ -101,23 +102,23 @@ The Kubernetes cluster on master nodes is being rebuilt.
           snapshot restore /tmp/etcd-dump.bin
         ```
 
-1.  Prepare to restore the member directory for `ncn-m002`.
+1. Prepare to restore the member directory for `ncn-m002`.
 
-    1.  Log in as root to `ncn-m002`.
+    1. Log in as root to `ncn-m002`.
 
-    2.  Create a new temporary /tmp/etcd\_restore directory.
+    2. Create a new temporary /tmp/etcd\_restore directory.
 
         ```bash
         mkdir /tmp/etcd_restore
         ```
 
-    3.  Change to the `/tmp/etcd_restore` directory.
+    3. Change to the `/tmp/etcd_restore` directory.
 
         ```bash
         cd /tmp/etcd_restore
         ```
 
-    4.  Retrieve the 'initial-cluster' and 'initial-advertise-peer-urls' values from the `kubeadmcfg.yaml` file.
+    4. Retrieve the `initial-cluster` and `initial-advertise-peer-urls` values from the `kubeadmcfg.yaml` file.
 
         The returned values will be used in the next step.
 
@@ -128,12 +129,12 @@ The Kubernetes cluster on master nodes is being rebuilt.
 
         Example output:
 
-        ```
+        ```text
         initial-cluster: ncn-m001=https://10.252.1.7:2380,ncn-m002=https://10.252.1.8:2380,ncn-m003=https://10.252.1.9:2380
         initial-advertise-peer-urls: https://10.252.1.8:2380
         ```
 
-    5.  Restore the member directory.
+    5. Restore the member directory.
 
         ```bash
         ETCDCTL_API=3 etcdctl --cacert /etc/kubernetes/pki/etcd/ca.crt \
@@ -146,23 +147,23 @@ The Kubernetes cluster on master nodes is being rebuilt.
         snapshot restore /tmp/etcd-dump.bin
         ```
 
-1.  Prepare to restore the member directory for `ncn-m003`.
+1. Prepare to restore the member directory for `ncn-m003`.
 
-    1.  Log in as root to `ncn-m003`.
+    1. Log in as root to `ncn-m003`.
 
-    2.  Create a new temporary /tmp/etcd\_restore directory.
+    2. Create a new temporary /tmp/etcd\_restore directory.
 
         ```bash
         mkdir /tmp/etcd_restore
         ```
 
-    3.  Change to the `/tmp/etcd_restore` directory.
+    3. Change to the `/tmp/etcd_restore` directory.
 
         ```bash
         cd /tmp/etcd_restore
         ```
 
-    4.  Retrieve the 'initial-cluster' and 'initial-advertise-peer-urls' values from the `kubeadmcfg.yaml` file.
+    4. Retrieve the `initial-cluster` and `initial-advertise-peer-urls` values from the `kubeadmcfg.yaml` file.
 
         The returned values will be used in the next step.
 
@@ -173,12 +174,12 @@ The Kubernetes cluster on master nodes is being rebuilt.
 
         Example output:
 
-        ```
+        ```text
         initial-cluster: ncn-m001=https://10.252.1.7:2380,ncn-m002=https://10.252.1.8:2380,ncn-m003=https://10.252.1.9:2380
         initial-advertise-peer-urls: https://10.252.1.9:2380
         ```
 
-    5.  Restore the member directory.
+    5. Restore the member directory.
 
         ```bash
         ETCDCTL_API=3 etcdctl --cacert /etc/kubernetes/pki/etcd/ca.crt \
@@ -191,52 +192,55 @@ The Kubernetes cluster on master nodes is being rebuilt.
         snapshot restore /tmp/etcd-dump.bin
         ```
 
-1.  Stop the current running cluster.
+1. Stop the current running cluster.
 
     If the cluster is currently running, run the following command on all three master nodes \(`ncn-m001`, `ncn-m002`, `ncn-m003`\).
 
-    1.  Stop the cluster on `ncn-m001`.
+    1. Stop the cluster on `ncn-m001`.
 
         ```bash
         systemctl stop etcd
         ```
 
-    2.  Stop the cluster on `ncn-m002`.
+    2. Stop the cluster on `ncn-m002`.
 
         ```bash
         systemctl stop etcd
         ```
 
-    3.  Stop the cluster on `ncn-m003`.
+    3. Stop the cluster on `ncn-m003`.
 
         ```bash
         systemctl stop etcd
         ```
 
-1.  Start the restored cluster on each master node.
+1. Start the restored cluster on each master node.
 
     Run the following commands on all three master nodes \(`ncn-m001`, `ncn-m002`, `ncn-m003`\) to start the restored cluster.
 
-    1.  Start the cluster on `ncn-m001`.
+    1. Start the cluster on `ncn-m001`.
 
         ```bash
         rm -rf /var/lib/etcd/member
+        cd /tmp/etcd_restore
         mv ncn-m001.etcd/member/ /var/lib/etcd/
         systemctl start etcd
         ```
 
-    2.  Start the cluster on `ncn-m002`.
+    2. Start the cluster on `ncn-m002`.
 
         ```bash
         rm -rf /var/lib/etcd/member
+        cd /tmp/etcd_restore
         mv ncn-m002.etcd/member/ /var/lib/etcd/
         systemctl start etcd
         ```
 
-    3.  Start the cluster on `ncn-m003`.
+    3. Start the cluster on `ncn-m003`.
 
         ```bash
         rm -rf /var/lib/etcd/member
+        cd /tmp/etcd_restore
         mv ncn-m003.etcd/member/ /var/lib/etcd/
         systemctl start etcd
         ```
@@ -251,9 +255,9 @@ The Kubernetes cluster on master nodes is being rebuilt.
 
     Example output:
 
-    ```
-    448a8d056377359a, started, ncn-m001, https://10.252.1.7:2380, https://10.252.1.7:2379,https://127.0.0.1:2379
-    986f6ff2a30b01cb, started, ncn-m002, https://10.252.1.8:2380, https://10.252.1.8:2379,https://127.0.0.1:2379
-    d5a8e497e2788510, started, ncn-m003, https://10.252.1.9:2380, https://10.252.1.9:2379,https://127.0.0.1:2379
+    ```text
+    448a8d056377359a, started, ncn-m001, https://10.252.1.7:2380, https://10.252.1.7:2379,https://127.0.0.1:2379, false
+    986f6ff2a30b01cb, started, ncn-m002, https://10.252.1.8:2380, https://10.252.1.8:2379,https://127.0.0.1:2379, false
+    d5a8e497e2788510, started, ncn-m003, https://10.252.1.9:2380, https://10.252.1.9:2379,https://127.0.0.1:2379, false
     ```
 

--- a/operations/kubernetes/Restore_Bare-Metal_etcd_Clusters_from_an_S3_Snapshot.md
+++ b/operations/kubernetes/Restore_Bare-Metal_etcd_Clusters_from_an_S3_Snapshot.md
@@ -24,7 +24,7 @@ This procedure can be run on any master NCN.
 1. (`ncn-m#`) Select a snapshot to restore a backup.
 
     1. List the available backups.
-    
+
         ```bash
         cd /opt/cray/platform-utils/s3 && ./list-objects.py --bucket-name etcd-backup
         ```
@@ -102,7 +102,6 @@ The following procedure must be performed on all master nodes, one at a time. Th
         ```bash
         NODE_NAME=$(yq r /etc/kubernetes/kubeadmcfg.yaml 'etcd.local.extraArgs.name') ; echo "${NODE_NAME}"
         ```
-
 
     1. Retrieve the initial cluster.
 

--- a/operations/kubernetes/Restore_Bare-Metal_etcd_Clusters_from_an_S3_Snapshot.md
+++ b/operations/kubernetes/Restore_Bare-Metal_etcd_Clusters_from_an_S3_Snapshot.md
@@ -2,7 +2,7 @@
 
 The etcd cluster that serves Kubernetes on master nodes is backed up every 10 minutes. These backups are pushed to `Ceph Rados Gateway` \(S3\).
 
-Restoring the etcd cluster from backup is only meant to be used in a catastrophic scenario, whereby the Kubernetes cluster and master nodes are being rebuilt.
+Restoring the etcd cluster from backup is only meant to be used in a catastrophic scenario, in which the Kubernetes cluster and master nodes are being rebuilt.
 This procedure shows how to restore the bare-metal etcd cluster from a `Simple Storage Service` \(S3\) snapshot.
 
 The etcd cluster needs to be restored from a backup when the Kubernetes cluster and master nodes are being rebuilt.

--- a/operations/kubernetes/Restore_Bare-Metal_etcd_Clusters_from_an_S3_Snapshot.md
+++ b/operations/kubernetes/Restore_Bare-Metal_etcd_Clusters_from_an_S3_Snapshot.md
@@ -13,29 +13,44 @@ The Kubernetes cluster on master nodes is being rebuilt.
 
 ## Procedure
 
-1. Select a snapshot to restore a backup.
+1. [Preparation](#1-preparation)
+1. [Restore member directory](#2-restore-member-directory)
+1. [Restart the cluster](#3-restart-the-cluster)
 
-    The following command lists the available backups. It must be run from the `/opt/cray/platform-utils/s3` directory on a master NCN.
-    Shown here for `ncn-m001`, but could be executed on any of the master nodes.
+### 1. Preparation
 
-    ```bash
-    ./list-objects.py --bucket-name etcd-backup
-    ```
+This procedure can be run on any master NCN.
 
-    Example output:
+1. (`ncn-m#`) Select a snapshot to restore a backup.
 
-    ```text
-    bare-metal/etcd-backup-2020-02-04-18-00-10.tar.gz
-    bare-metal/etcd-backup-2020-02-04-18-10-06.tar.gz
-    bare-metal/etcd-backup-2020-02-04-18-20-02.tar.gz
-    bare-metal/etcd-backup-2020-02-04-18-30-10.tar.gz
-    bare-metal/etcd-backup-2020-02-04-18-40-06.tar.gz
-    bare-metal/etcd-backup-2020-02-04-18-50-03.tar.gz
-    ```
+    1. List the available backups.
+    
+        ```bash
+        cd /opt/cray/platform-utils/s3 && ./list-objects.py --bucket-name etcd-backup
+        ```
 
-    Note the file name for the desired snapshot/backup.
+        Example output:
 
-1. Download the snapshot and copy it to all NCN master nodes.
+        ```text
+        bare-metal/etcd-backup-2020-02-04-18-00-10.tar.gz
+        bare-metal/etcd-backup-2020-02-04-18-10-06.tar.gz
+        bare-metal/etcd-backup-2020-02-04-18-20-02.tar.gz
+        bare-metal/etcd-backup-2020-02-04-18-30-10.tar.gz
+        bare-metal/etcd-backup-2020-02-04-18-40-06.tar.gz
+        bare-metal/etcd-backup-2020-02-04-18-50-03.tar.gz
+        ```
+
+    1. Set the `BACKUP_NAME` variable to the file name of the desired backup from the list.
+
+        Omit the `bare-metal/` prefix shown in the output of the previous command, as well as the `.tar.gz` suffix.
+
+        For example:
+
+        ```bash
+        BACKUP_NAME=etcd-backup-2020-02-04-18-50-03
+        ```
+
+1. (`ncn-m#`) Download the snapshot and copy it to all NCN master nodes.
 
     1. Retrieve the backup from S3 and uncompress it.
 
@@ -43,215 +58,130 @@ The Kubernetes cluster on master nodes is being rebuilt.
         mkdir /tmp/etcd_restore
         cd /opt/cray/platform-utils/s3
         ./download-file.py --bucket-name etcd-backup \
-        --key-name bare-metal/etcd-backup-2020-02-04-18-50-03.tar.gz \
-        --file-name /tmp/etcd_restore/etcd-backup-2020-02-04-18-50-03.tar.gz
+            --key-name "bare-metal/${BACKUP_NAME}.tar.gz" \
+            --file-name "/tmp/etcd_restore/${BACKUP_NAME}.tar.gz"
         cd /tmp/etcd_restore
-        gunzip etcd-backup-2020-02-04-18-50-03.tar.gz
-        tar -xvf etcd-backup-2020-02-04-18-50-03.tar
-        mv etcd-backup-2020-02-04-18-50-03/etcd-dump.bin /tmp
+        gunzip "${BACKUP_NAME}.tar.gz"
+        tar -xvf "${BACKUP_NAME}.tar"
+        mv -v "${BACKUP_NAME}/etcd-dump.bin" /tmp
         ```
 
-    2. Push the file to the other NCN master nodes.
+    1. Push the file to the other NCN master nodes.
+
+        If not running these steps on `ncn-m001`, adjust the NCN names in the following command accordingly.
 
         ```bash
         scp /tmp/etcd-dump.bin ncn-m002:/tmp
         scp /tmp/etcd-dump.bin ncn-m003:/tmp
         ```
 
-1. Prepare to restore the member directory for `ncn-m001`.
+### 2. Restore member directory
 
-    1. Log in as root to `ncn-m001`.
+The following procedure must be performed on all master nodes, one at a time. The order does not matter.
 
-    2. Create a new temporary `/tmp/etcd_restore` directory. If step 2.1 was executed on `ncn-m001`, the `/tmp/etcd_restore` directory already exists.
+1. (`ncn-m#`) Create a new temporary `/tmp/etcd_restore` directory, if it does not already exist.
+
+    ```bash
+    mkdir -pv /tmp/etcd_restore
+    ```
+
+1. (`ncn-m#`) Change to the `/tmp/etcd_restore` directory.
+
+    ```bash
+    cd /tmp/etcd_restore
+    ```
+
+1. (`ncn-m#`) Retrieve values from the `kubeadmcfg.yaml` file.
+
+    These values will be saved in variables and used in the following step.
+
+    1. Retrieve the node name.
+
+        The value should be the name of the master node where this command is being run (for example, `ncn-m002`).
 
         ```bash
-        mkdir /tmp/etcd_restore
+        NODE_NAME=$(yq r /etc/kubernetes/kubeadmcfg.yaml 'etcd.local.extraArgs.name') ; echo "${NODE_NAME}"
         ```
 
-    3. Change to the `/tmp/etcd_restore` directory.
+
+    1. Retrieve the initial cluster.
 
         ```bash
-        cd /tmp/etcd_restore
-        ```
-
-    4. Retrieve the `initial-cluster` and `initial-advertise-peer-urls` values from the `kubeadmcfg.yaml` file.
-
-        The returned values will be used in the next step.
-
-        ```bash
-        grep -e initial-cluster: -e initial-advertise-peer-urls: \
-        /etc/kubernetes/kubeadmcfg.yaml
+        INIT_CLUSTER=$(yq r /etc/kubernetes/kubeadmcfg.yaml 'etcd.local.extraArgs.initial-cluster'); echo "${INIT_CLUSTER}"
         ```
 
         Example output:
 
         ```text
-        initial-cluster: ncn-m001=https://10.252.1.7:2380,ncn-m002=https://10.252.1.8:2380,ncn-m003=https://10.252.1.9:2380
-        initial-advertise-peer-urls: https://10.252.1.7:2380
+        ncn-m001=https://10.252.1.10:2380,ncn-m002=https://10.252.1.9:2380,ncn-m003=https://10.252.1.8:2380
         ```
 
-    5. Restore the member directory.
+    1. Retrieve the initial advertise peer URLs.
 
         ```bash
-        ETCDCTL_API=3 etcdctl --cacert /etc/kubernetes/pki/etcd/ca.crt \
-          --cert /etc/kubernetes/pki/etcd/server.crt \
-          --key /etc/kubernetes/pki/etcd/server.key \
-          --name ncn-m001 \
-          --initial-cluster ncn-m001=https://10.252.1.7:2380,ncn-m002=https://10.252.1.8:2380,ncn-m003=https://10.252.1.9:2380 \
-          --initial-cluster-token tkn \
-          --initial-advertise-peer-urls https://10.252.1.7:2380 \
-          snapshot restore /tmp/etcd-dump.bin
-        ```
-
-1. Prepare to restore the member directory for `ncn-m002`.
-
-    1. Log in as root to `ncn-m002`.
-
-    2. Create a new temporary `/tmp/etcd_restore` directory.
-
-        ```bash
-        mkdir /tmp/etcd_restore
-        ```
-
-    3. Change to the `/tmp/etcd_restore` directory.
-
-        ```bash
-        cd /tmp/etcd_restore
-        ```
-
-    4. Retrieve the `initial-cluster` and `initial-advertise-peer-urls` values from the `kubeadmcfg.yaml` file.
-
-        The returned values will be used in the next step.
-
-        ```bash
-        grep -e initial-cluster: -e initial-advertise-peer-urls: \
-        /etc/kubernetes/kubeadmcfg.yaml
+        INIT_URLS=$(yq r /etc/kubernetes/kubeadmcfg.yaml 'etcd.local.extraArgs.initial-advertise-peer-urls'); echo "${INIT_URLS}"
         ```
 
         Example output:
 
         ```text
-        initial-cluster: ncn-m001=https://10.252.1.7:2380,ncn-m002=https://10.252.1.8:2380,ncn-m003=https://10.252.1.9:2380
-        initial-advertise-peer-urls: https://10.252.1.8:2380
+        https://10.252.1.10:2380
         ```
 
-    5. Restore the member directory.
-
-        ```bash
-        ETCDCTL_API=3 etcdctl --cacert /etc/kubernetes/pki/etcd/ca.crt \
-        --cert /etc/kubernetes/pki/etcd/server.crt \
-        --key /etc/kubernetes/pki/etcd/server.key \
-        --name ncn-m002 \
-        --initial-cluster ncn-m001=https://10.252.1.7:2380,ncn-m002=https://10.252.1.8:2380,ncn-m003=https://10.252.1.9:2380 \
-        --initial-cluster-token tkn \
-        --initial-advertise-peer-urls https://10.252.1.8:2380 \
-        snapshot restore /tmp/etcd-dump.bin
-        ```
-
-1. Prepare to restore the member directory for `ncn-m003`.
-
-    1. Log in as root to `ncn-m003`.
-
-    2. Create a new temporary `/tmp/etcd_restore` directory.
-
-        ```bash
-        mkdir /tmp/etcd_restore
-        ```
-
-    3. Change to the `/tmp/etcd_restore` directory.
-
-        ```bash
-        cd /tmp/etcd_restore
-        ```
-
-    4. Retrieve the `initial-cluster` and `initial-advertise-peer-urls` values from the `kubeadmcfg.yaml` file.
-
-        The returned values will be used in the next step.
-
-        ```bash
-        grep -e initial-cluster: -e initial-advertise-peer-urls: \
-        /etc/kubernetes/kubeadmcfg.yaml
-        ```
-
-        Example output:
-
-        ```text
-        initial-cluster: ncn-m001=https://10.252.1.7:2380,ncn-m002=https://10.252.1.8:2380,ncn-m003=https://10.252.1.9:2380
-        initial-advertise-peer-urls: https://10.252.1.9:2380
-        ```
-
-    5. Restore the member directory.
-
-        ```bash
-        ETCDCTL_API=3 etcdctl --cacert /etc/kubernetes/pki/etcd/ca.crt \
-        --cert /etc/kubernetes/pki/etcd/server.crt \
-        --key /etc/kubernetes/pki/etcd/server.key \
-        --name ncn-m003 \
-        --initial-cluster ncn-m001=https://10.252.1.7:2380,ncn-m002=https://10.252.1.8:2380,ncn-m003=https://10.252.1.9:2380 \
-        --initial-cluster-token tkn \
-        --initial-advertise-peer-urls https://10.252.1.9:2380 \
-        snapshot restore /tmp/etcd-dump.bin
-        ```
-
-1. Stop the current running cluster.
-
-    If the cluster is currently running, run the following command on all three master nodes \(`ncn-m001`, `ncn-m002`, `ncn-m003`\).
-
-    1. Stop the cluster on `ncn-m001`.
-
-        ```bash
-        systemctl stop etcd
-        ```
-
-    2. Stop the cluster on `ncn-m002`.
-
-        ```bash
-        systemctl stop etcd
-        ```
-
-    3. Stop the cluster on `ncn-m003`.
-
-        ```bash
-        systemctl stop etcd
-        ```
-
-1. Start the restored cluster on each master node.
-
-    Run the following commands on all three master nodes \(`ncn-m001`, `ncn-m002`, `ncn-m003`\) to start the restored cluster.
-
-    1. Start the cluster on `ncn-m001`.
-
-        ```bash
-        rm -rf /var/lib/etcd/member
-        cd /tmp/etcd_restore
-        mv ncn-m001.etcd/member/ /var/lib/etcd/
-        systemctl start etcd
-        ```
-
-    2. Start the cluster on `ncn-m002`.
-
-        ```bash
-        rm -rf /var/lib/etcd/member
-        cd /tmp/etcd_restore
-        mv ncn-m002.etcd/member/ /var/lib/etcd/
-        systemctl start etcd
-        ```
-
-    3. Start the cluster on `ncn-m003`.
-
-        ```bash
-        rm -rf /var/lib/etcd/member
-        cd /tmp/etcd_restore
-        mv ncn-m003.etcd/member/ /var/lib/etcd/
-        systemctl start etcd
-        ```
-
-1. Confirm the membership of the cluster.
+1. (`ncn-m#`) Restore the member directory.
 
     ```bash
     ETCDCTL_API=3 etcdctl --cacert /etc/kubernetes/pki/etcd/ca.crt \
-    --cert /etc/kubernetes/pki/etcd/server.crt \
-    --key /etc/kubernetes/pki/etcd/server.key member list
+      --cert /etc/kubernetes/pki/etcd/server.crt \
+      --key /etc/kubernetes/pki/etcd/server.key \
+      --name "${NODE_NAME}" \
+      --initial-cluster "${INIT_CLUSTER}" \
+      --initial-cluster-token tkn \
+      --initial-advertise-peer-urls "${INIT_URLS}" \
+      snapshot restore /tmp/etcd-dump.bin
+    ```
+
+Repeat the steps in this section on the next master node, until they have been performed on every master node.
+
+### 3. Restart the cluster
+
+1. (`ncn-m#`) Stop the cluster.
+
+    Run the following command on **each master node**.
+
+    > If the etcd cluster is not currently running, this step can be skipped.
+
+    ```bash
+    systemctl stop etcd
+    ```
+
+1. (`ncn-m#`) Start the restored etcd cluster on **every** master node.
+
+    Do the following steps on **each master node**.
+
+    1. Set a variable with the node name of the current master node.
+
+        ```bash
+        NODE_NAME=ncn-mxxx
+        ```
+
+    1. Run the following commands.
+
+        ```bash
+        rm -rvf /var/lib/etcd/member &&
+        cd /tmp/etcd_restore &&
+        mv -v ${NODE_NAME}.etcd/member/ /var/lib/etcd/ &&
+        systemctl start etcd
+        ```
+
+1. (`ncn-m#`) Confirm the membership of the cluster.
+
+    This command can be run on any master node.
+
+    ```bash
+    ETCDCTL_API=3 etcdctl --cacert /etc/kubernetes/pki/etcd/ca.crt \
+        --cert /etc/kubernetes/pki/etcd/server.crt \
+        --key /etc/kubernetes/pki/etcd/server.key member list
     ```
 
     Example output:


### PR DESCRIPTION
### Summary and Scope
Main - CASMPET-5629: DOCS: Update 1.2 & 1.3 Restore Bare-Metal etcd Clusters from an S3 Snapshot document.

Update/Clarify Restore Bare-Metal etcd Clusters from an S3 Snapshot document. 

### Issues and Related PRs
CASMPET-5629

### Testing
Viewed changes.

Was a fresh Install tested? N - N/A
Was an Upgrade tested? N - N/A
Was a Downgrade tested? N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations
Low

### Requires:
N/A