### PR TITLE
CASMPET-5912: Remove Nexus Export Step

### DIFF
--- a/upgrade/prepare_for_upgrade.md
+++ b/upgrade/prepare_for_upgrade.md
@@ -11,11 +11,6 @@ Before beginning an upgrade to a new version of CSM, there are a few things to d
    maintained by the remaining two nodes. If one of those two nodes has a fault before the third node completes its upgrade,
    then quorum would be lost.
 
-1. Recommended backup/export of some services
-
-    1. Backup Nexus data. Refer to [Nexus Export and Restore](../operations/package_repository_management/Nexus_Export_and_Restore.md) to export Nexus data.
-       This will take around 1 hour for every 60 GiB of data in the `nexus-data` PVC. This is recommended to take prior to running any upgrade steps.
-
 1. Check for BOS, CFS, CRUS, FAS, or NMD sessions.
 
     1. (`ncn-m001#`) Ensure that these services do not have any sessions in progress.


### PR DESCRIPTION
# Description

This removed the recommended step to take an export of the nexus data. This was found to be used on the in-house systems and would take much too long for testing. Another page is being created that should hold this information for use once it has been further polished. Read [CASMPET-5912](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5912) for more information on why the step should be removed.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
