### PR TITLE
CASMPET-5914: Add in steps to recover from a failed export

### DIFF
--- a/operations/package_repository_management/Nexus_Export_and_Restore.md
+++ b/operations/package_repository_management/Nexus_Export_and_Restore.md
@@ -88,10 +88,10 @@ kubectl delete pvc -n nexus nexus-bak
 
 ### Cleanup failed or stopped export
 
-If an export is stopped prematurely or fails to complete there is a few steps that need to be taken to bring Nexus back into a working state.
+If an export is stopped prematurely or fails to complete, there are a few steps that need to be taken to bring Nexus back into a working state.
 
 1. Delete the failed or stopped job, see [Cleanup export job](#cleanup-export-job)
-1. If the export was stopped or failed delete the partially filled export PVC, see [Cleanup previous export](#cleanup-previous-export)
+1. Delete the partially filled export PVC, see [Cleanup previous export](#cleanup-previous-export)
 1. Restart Nexus if it is still stopped, depending on where the job failed the Nexus pods may still be down
     1. (`ncn-m#`) Check if the Nexus pods are down by:
 

--- a/operations/package_repository_management/Nexus_Export_and_Restore.md
+++ b/operations/package_repository_management/Nexus_Export_and_Restore.md
@@ -85,3 +85,22 @@ If the old export is not deleted, then the new job will overwrite the old export
 ```bash
 kubectl delete pvc -n nexus nexus-bak
 ```
+
+### Cleanup failed or stopped export
+
+If an export is stopped prematurely or fails to complete there is a few steps that need to be taken to bring Nexus back into a working state.
+
+1. Delete the failed or stopped job, see [Cleanup export job](#cleanup-export-job)
+1. If the export was stopped or failed delete the partially filled export PVC, see [Cleanup previous export](#cleanup-previous-export)
+1. Restart Nexus if it is still stopped, depending on where the job failed the Nexus pods may still be down
+    1. (`ncn-m#`) Check if the Nexus pods are down by:
+
+        ```bash
+        kubectl get pods -n nexus | grep nexus
+        ```
+
+    1. (`ncn-m#`) If the Nexus pod is not found scale up on any master NCN:
+
+        ```bash
+        kubectl -n nexus scale deployment nexus --replicas=1
+        ```

--- a/operations/package_repository_management/Nexus_Export_and_Restore.md
+++ b/operations/package_repository_management/Nexus_Export_and_Restore.md
@@ -90,16 +90,25 @@ kubectl delete pvc -n nexus nexus-bak
 
 If an export is stopped prematurely or fails to complete, there are a few steps that need to be taken to bring Nexus back into a working state.
 
-1. Delete the failed or stopped job, see [Cleanup export job](#cleanup-export-job)
-1. Delete the partially filled export PVC, see [Cleanup previous export](#cleanup-previous-export)
-1. Restart Nexus if it is still stopped, depending on where the job failed the Nexus pods may still be down
-    1. (`ncn-m#`) Check if the Nexus pods are down by:
+1. Delete the failed or stopped job.
+
+    See [Cleanup export job](#cleanup-export-job).
+
+1. Delete the partially filled export PVC.
+
+    See [Cleanup previous export](#cleanup-previous-export).
+
+1. Restart Nexus if it is still stopped.
+
+    Depending on where the job failed the Nexus pods may still be down.
+
+    1. (`ncn-mw#`) Check if the Nexus pods are down.
 
         ```bash
         kubectl get pods -n nexus | grep nexus
         ```
 
-    1. (`ncn-m#`) If the Nexus pod is not found scale up on any master NCN:
+    1. (`ncn-mw#`) If the Nexus pod is not found, then scale it back up.
 
         ```bash
         kubectl -n nexus scale deployment nexus --replicas=1


### PR DESCRIPTION
# Description

This adds in missing steps to recover nexus if the export procedure was ended early or stopped for any reason. This allows for simpler steps to recover from stopping the export due to time constraints.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
