### PR TITLE
CASMTRIAGE-3723: Be more careful when editing BSS boot parameters

### DIFF
--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
@@ -19,8 +19,8 @@ All of the commands in this procedure are intended to be run on a single master 
 ## Procedure
 
 1. [Preparation](#1-preparation)
-2. [Get NCN artifacts](#2-get-ncn-artifacts)
-3. [Customize the images](#3-customize-the-images)
+1. [Get NCN artifacts](#2-get-ncn-artifacts)
+1. [Customize the images](#3-customize-the-images)
 
     - [SSH keys](#ssh-keys)
       - [Script-generated keys](#script-generated-keys)
@@ -34,10 +34,10 @@ All of the commands in this procedure are intended to be run on a single master 
       - [Example 2: Provide keys, prompt for password, change timezone](#example-2-provide-keys-prompt-for-password-change-timezone)
       - [Example 3: New keys, no password change, keep UTC, no prompting](#example-3-new-keys-no-password-change-keep-utc-no-prompting)
 
-4. [Upload artifacts into S3](#4-upload-artifacts-into-s3)
-5. [Update BSS](#update-bss)
-6. [Cleanup](#6-cleanup)
-7. [Rebuild NCNs](#7-rebuild-ncns)
+1. [Upload artifacts into S3](#4-upload-artifacts-into-s3)
+1. [Update BSS](#update-bss)
+1. [Cleanup](#6-cleanup)
+1. [Rebuild NCNs](#7-rebuild-ncns)
 
 ### 1. Preparation
 
@@ -314,7 +314,7 @@ The Kubernetes and storage images now have the image changes.
 
 ### 5. Update BSS
 
-**WARNING:** If doing a CSM software upgrade, skip this section and proceed to [Cleanup](#6-cleanup).
+**WARNING:** If doing a CSM software upgrade, then skip this section and proceed to [Cleanup](#6-cleanup).
 
 This step updates the entries in BSS for the NCNs to use the new images.
 
@@ -364,6 +364,6 @@ ncn-mw# rm -rvf /run/initramfs/overlayfs/workingarea
 
 ### 7. Rebuild NCNs
 
-**WARNING:** If doing a CSM software upgrade, skip this step since the upgrade process does a rolling rebuild with some additional steps.
+**WARNING:** If doing a CSM software upgrade, then skip this step because the upgrade process does a rolling rebuild with some additional steps.
 
 Do a rolling rebuild of all NCNs. See [Rebuild NCNs](../node_management/Rebuild_NCNs/Rebuild_NCNs.md).

--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
@@ -328,7 +328,7 @@ This step updates the entries in BSS for the NCNs to use the new images.
                 xname=$(ssh $node cat /etc/cray/xname)
                 echo $xname
                 cray bss bootparameters list --name $xname --format json > bss_$xname.json
-                sed -i.old "s@k8s/${K8SVERSION}@k8s/${K8SNEW}@g" bss_$xname.json
+                sed -i.$(date +%Y%m%d_%H%M%S%N).orig "s@/k8s/${K8SVERSION}\([\"/[:space:]]\)@/k8s/${K8SNEW}\1@g" bss_$xname.json
                 kernel=$(cat bss_$xname.json | jq '.[]  .kernel')
                 initrd=$(cat bss_$xname.json | jq '.[]  .initrd')
                 params=$(cat bss_$xname.json | jq '.[]  .params')
@@ -346,7 +346,7 @@ This step updates the entries in BSS for the NCNs to use the new images.
                 xname=$(ssh $node cat /etc/cray/xname)
                 echo $xname
                 cray bss bootparameters list --name $xname --format json > bss_$xname.json
-                sed -i.old "s@ceph/${CEPHVERSION}@ceph/${CEPHNEW}@g" bss_$xname.json
+                sed -i.$(date +%Y%m%d_%H%M%S%N).orig "s@/ceph/${CEPHVERSION}\([\"/[:space:]]\)@/ceph/${CEPHNEW}\1@g" bss_$xname.json
                 kernel=$(cat bss_$xname.json | jq '.[]  .kernel')
                 initrd=$(cat bss_$xname.json | jq '.[]  .initrd')
                 params=$(cat bss_$xname.json | jq '.[]  .params')


### PR DESCRIPTION
# Description

The "Change NCN image root password and SSH keys" procedure has a step which involves updating the BSS bootparameters to point to the correct Kubernetes and Ceph image versions. This involves using a sed command to do string replacement. However, that sed command is not as precise as it ought to be. Specifically, it will replace some version strings even if they do not completely match the version being replaced (that is, if the old version is 1.2.3, then the sed command would replace all version strings that began with 1.2.3, even if they had additional characters.

The sed command does make a backup before doing the replacement, but the file names involved are hard-coded, so if the commands are run multiple times, the original backup will be lost.

This PR makes two changes two address these issues:
1. The regex in the sed command is modified so that it only matches on the desired version followed by quotation marks, white space, or a /. Therefore it will no longer match versions which merely start with the desired version string.
2. The name of the backup file from the sed command now includes a timestamp (which includes nanoseconds), so that subsequent runs of the command will not overwrite previously-created backup files. It will also be easy to identify the earlier backup file.

I tested the update sed command to verify that it behaves as expected.

```text
ncn-m001:~ # K8SVERSION=0.3.40
ncn-m001:~ # K8SNEW=0.3.40-2
ncn-m001:~ # cray bss bootparameters list --format json --name "x3000c0s9b0n0" | jq^C
ncn-m001:~ # xname="x3000c0s9b0n0"
ncn-m001:~ # cray bss bootparameters list --name $xname --format json > bss_$xname.json
ncn-m001:~ # sed -i.$(date +%Y%m%d_%H%M%S%N).orig "s@/k8s/${K8SVERSION}\([\"/[:space:]]\)@/k8s/${K8SNEW}\1@g" bss_$xname.json
ncn-m001:~ # ls -al bss*
-rw-r--r-- 1 root root 71155 Aug 23 07:21 bss-backup-2022-08-23.json
-rw-r--r-- 1 root root  5819 Aug 23 17:18 bss_x3000c0s9b0n0.json
-rw-r--r-- 1 root root  5813 Aug 23 17:18 bss_x3000c0s9b0n0.json.20220823_171830850268298.orig
ncn-m001:~ # diff bss_x3000c0s9b0n0.json bss_x3000c0s9b0n0.json.20220823_171830850268298.orig
6,8c6,8
<     "params": "biosdevname=1 ifname=hsn1:98:03:9b:aa:95:e8 ifname=hsn0:98:03:9b:aa:94:bc ifname=lan1:b4:2e:99:3a:26:05 ifname=lan0:b4:2e:99:3a:26:04 ifname=mgmt0:b8:59:9f:d9:9e:38 ifname=mgmt1:b8:59:9f:d9:9e:39 pcie_ports=native transparent_hugepage=never console=tty0 console=ttyS0,115200 iommu=pt metal.server=http://rgw-vip.nmn/ncn-images/k8s/0.3.40-2 metal.no-wipe=1 ds=nocloud-net;s=http://10.92.100.81:8888/ rootfallback=LABEL=BOOTRAID initrd=initrd.img.xz root=live:LABEL=SQFSRAID rd.live.ram=0 rd.writable.fsimg=0 rd.skipfsck rd.live.squashimg=filesystem.squashfs rd.live.overlay=LABEL=ROOTRAID rd.live.overlay.thin=1 rd.live.overlay.overlayfs=1 rd.luks=0 module_blacklist=rpcrdma rd.luks.crypttab=0 rd.lvm.conf=0 rd.lvm=1 rd.auto=1 rd.md=1 rd.dm=0 rd.neednet=0 rd.md.waitclean=1 rd.multipath=0 rd.md.conf=1 rd.bootif=0 hostname=ncn-w002 rd.net.timeout.carrier=120 rd.net.timeout.ifup=120 rd.net.timeout.iflink=120 rd.net.timeout.ipv6auto=0 rd.net.timeout.ipv6dad=0 append nosplash quiet crashkernel=360M log_buf_len=1 rd.retry=10 rd.shell ip=mgmt0:dhcp rd.peerdns=0 rd.net.dhcp.retry=5 psi=1",
<     "kernel": "s3://ncn-images/k8s/0.3.40-2/kernel",
<     "initrd": "s3://ncn-images/k8s/0.3.40-2/initrd",
---
>     "params": "biosdevname=1 ifname=hsn1:98:03:9b:aa:95:e8 ifname=hsn0:98:03:9b:aa:94:bc ifname=lan1:b4:2e:99:3a:26:05 ifname=lan0:b4:2e:99:3a:26:04 ifname=mgmt0:b8:59:9f:d9:9e:38 ifname=mgmt1:b8:59:9f:d9:9e:39 pcie_ports=native transparent_hugepage=never console=tty0 console=ttyS0,115200 iommu=pt metal.server=http://rgw-vip.nmn/ncn-images/k8s/0.3.40 metal.no-wipe=1 ds=nocloud-net;s=http://10.92.100.81:8888/ rootfallback=LABEL=BOOTRAID initrd=initrd.img.xz root=live:LABEL=SQFSRAID rd.live.ram=0 rd.writable.fsimg=0 rd.skipfsck rd.live.squashimg=filesystem.squashfs rd.live.overlay=LABEL=ROOTRAID rd.live.overlay.thin=1 rd.live.overlay.overlayfs=1 rd.luks=0 module_blacklist=rpcrdma rd.luks.crypttab=0 rd.lvm.conf=0 rd.lvm=1 rd.auto=1 rd.md=1 rd.dm=0 rd.neednet=0 rd.md.waitclean=1 rd.multipath=0 rd.md.conf=1 rd.bootif=0 hostname=ncn-w002 rd.net.timeout.carrier=120 rd.net.timeout.ifup=120 rd.net.timeout.iflink=120 rd.net.timeout.ipv6auto=0 rd.net.timeout.ipv6dad=0 append nosplash quiet crashkernel=360M log_buf_len=1 rd.retry=10 rd.shell ip=mgmt0:dhcp rd.peerdns=0 rd.net.dhcp.retry=5 psi=1",
>     "kernel": "s3://ncn-images/k8s/0.3.40/kernel",
>     "initrd": "s3://ncn-images/k8s/0.3.40/initrd",
ncn-m001:~ # sed -i.$(date +%Y%m%d_%H%M%S%N).orig "s@/k8s/${K8SVERSION}\([\"/[:space:]]\)@/k8s/${K8SNEW}\1@g" bss_$xname.json
ncn-m001:~ # ls -al bss*
-rw-r--r-- 1 root root 71155 Aug 23 07:21 bss-backup-2022-08-23.json
-rw-r--r-- 1 root root  5819 Aug 23 17:18 bss_x3000c0s9b0n0.json
-rw-r--r-- 1 root root  5813 Aug 23 17:18 bss_x3000c0s9b0n0.json.20220823_171830850268298.orig
-rw-r--r-- 1 root root  5819 Aug 23 17:18 bss_x3000c0s9b0n0.json.20220823_171852068799754.orig
ncn-m001:~ # diff bss_x3000c0s9b0n0.json bss_x3000c0s9b0n0.json.20220823_171852068799754.orig
ncn-m001:~ #
```

There are other minor issues with the script being used in this section, but since this is for 1.2, I was hesitant to make more sweeping changes. I may make more extensive changes for 1.3 or 1.4 (or, better still, may move all of that code into a separate script file).

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
