### PR TITLE
MTL-1876 NCN Images and Private S3 Buckets

### DIFF
--- a/background/README.md
+++ b/background/README.md
@@ -280,8 +280,8 @@ This parameter's value tells the initramFS where to download the kernel, initrd,
 | NCN Type | Default Value(s) |
 | :------: | :------------ |
 | All | `http://pit/<hostname>` |
-| All | `http://rgw-vip.nmn/ncn-images/k8s/<version>` |
-| All | `http://rgw-vip.nmn/ncn-images/ceph/<version>` |
+| All | `http://rgw-vip.nmn/boot-images/k8s/<version>` |
+| All | `http://rgw-vip.nmn/boot-images/ceph/<version>` |
 
 For more information, see [`dracut-metal-mdsquash`'s usage on `metal.server`][2].
 

--- a/background/ncn_images.md
+++ b/background/ncn_images.md
@@ -25,13 +25,13 @@ To boot an NCN, you need three artifacts for each node-type (`kubernetes-master/
 
 1. The Kubernetes SquashFS ([stable][4] or [unstable][5])
 
-   * `initrd-img-[RELEASE].xz`
+   * `initrd.img-[RELEASE].xz`
    * `$version-[RELEASE].kernel`
    * `kubernetes-[RELEASE].squashfs`
 
 1. The CEPH SquashFS ([stable][6] or [unstable][7])
 
-   * `initrd-img-[RELEASE].xz`
+   * `initrd.img-[RELEASE].xz`
    * `$version-[RELEASE].kernel`
    * `storage-ceph-[RELEASE].squashfs`
 

--- a/install/troubleshooting_pxe_boot.md
+++ b/install/troubleshooting_pxe_boot.md
@@ -342,16 +342,12 @@ In that case, then use the following recovery procedure.
 
 1. (`pit#`) Set variables for the system name, the CAN IP address for `ncn-m002`, the Kubernetes version, and the Ceph version.
 
-    The Kubernetes and Ceph versions are from the output of the [`csi handoff ncn-images` command in the Deploy Final NCN procedure](deploy_final_non-compute_node.md#31-handoff-data).
-
     If needed, the typescript file from that procedure should be on `ncn-m002` and `ncn-m003` in the `/metal/bootstrap/prep/admin` directory.
 
     Substitute the correct values for the system in use in the following commands:
 
     ```bash
     CAN_IP_NCN_M002=$(ssh ncn-m002 ip -4 a show bond0.can0 | grep inet | awk '{print $2}' | cut -d / -f1)
-    export KUBERNETES_VERSION=m.n.o
-    export CEPH_VERSION=x.y.z
     ```
 
 1. (`pit#`) **If using a remote ISO PIT**, then run the following commands to finish configuring the network and copy files.


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
This changes various pieces to support private S3 buckets. Namely replacing all usages of ncn-images with boot-images, and replacing `csi handoff` with `cray artifacts`.

This following pages, these are coming later via MTL-1874:
- `Change_NCN_Image_Root_Password_and_SSH_Keys.md`
- `Pre_Boot_NCN_Image_Configuration.md`
- `ceph-upload-file-public-read.py`

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
