### PR TITLE
CASMTRIAGE-3993 Remove invalid `csi` call

### DIFF
--- a/upgrade/scripts/upgrade/prepare-assets.sh
+++ b/upgrade/scripts/upgrade/prepare-assets.sh
@@ -163,8 +163,6 @@ if [[ $state_recorded == "0" ]]; then
     #shellcheck disable=SC2046
     rpm --force -Uvh $(find ${CSM_ARTI_DIR}/rpm/cray/csm/ -name "cray-site-init*.rpm") 
 
-    # upload csi to s3
-    csi handoff upload-utils --kubeconfig /etc/kubernetes/admin.conf
     } >> ${LOG_FILE} 2>&1
     #shellcheck disable=SC2046
     record_state ${state_name} $(hostname)


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
`csi handoff upload-utils` no longer exists, and the call itself was no longer necessary. Now that the function no longer exists this call fails, but since it is no longer necessary this call can be removed.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
