### PR TITLE
MTL-1926: add a step to set the next boot device

### DIFF
--- a/background/ncn_boot_workflow.md
+++ b/background/ncn_boot_workflow.md
@@ -170,6 +170,12 @@ The commands are the same for all hardware vendors, except where noted.
     ncn/pit# efibootmgr -o $(cat /tmp/bbs* | awk '!x[$0]++' | sed 's/^Boot//g' | tr -d '*' | awk '{print $1}' | tr -t '\n' ',' | sed 's/,$//') | grep -i bootorder
     ```
 
+1. Set next boot entry.
+
+    ```bash
+    ncn/pit# efibootmgr -n <desired_next_boot_device>
+    ```
+
 1. Set all of the desired boot options to be active.
 
     ```bash


### PR DESCRIPTION
# Description

This is mentioned in the "Locating USB device" section, but not in
the "setting boot order" section.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
