### PR TITLE
MTL-1926: add a step to set the next boot device

### DIFF
--- a/background/ncn_boot_workflow.md
+++ b/background/ncn_boot_workflow.md
@@ -170,6 +170,12 @@ The commands are the same for all hardware vendors, except where noted.
     cat /tmp/bbs* | awk '!x[$0]++' | sed 's/^Boot//g' | tr -d '*' | awk '{print $1}' | xargs -r -t -i efibootmgr -b {} -a
     ```
 
+1. Set next boot entry.
+
+    ```bash
+    efibootmgr -n <desired_next_boot_device>
+    ```
+
 After following the steps above on a given NCN, that NCN will use the desired Shasta boot order.
 
 This is the end of the `Setting boot order` procedure.


### PR DESCRIPTION
# Description

This is mentioned in the "Locating USB device" section, but not in
the "setting boot order" section.



<!--- Describe what this change is and what it is for. -->

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
