### PR TITLE
CASMHMS-5693: Clear out redfish event subscriptions when add or removing blades from the system.

### DIFF
--- a/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System.md
+++ b/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System.md
@@ -376,6 +376,43 @@ This procedure will add a liquid-cooled blades from an HPE Cray EX system.
             curl -k -u root:password https://x1005c3s0b0/redfish/v1/Managers
             ```
 
+1. Clear out the existing Redfish event subscriptions from the BMCs on the blade.
+
+    1. (`ncn#`) Set the environment variable `SLOT` corresponding to the blades location:
+
+        ```bash
+        SLOT="x1005c3s0"
+        ```
+
+    1. (`ncn#`) Clear the Redfish event subscriptions:
+
+        ```bash
+        for BMC in $(cray hsm inventory  redfishEndpoints list --type NodeBMC --format json | jq .RedfishEndpoints[].ID -r | grep $SLOT); do
+            PASSWD=$(cray scsd bmc creds list --targets $BMC --format json | jq .Targets[].Password -r)
+            SUBS=$(curl -sk -u root:$PASSWD https://${BMC}/redfish/v1/EventService/Subscriptions | jq -r '.Members[]."@odata.id"')
+            for SUB in $SUBS; do
+                echo "Deleting event subscription: https://${BMC}${SUB}" 
+                curl -i -sk -u root:$PASSWD -X DELETE https://${BMC}${SUB}
+            done
+        done
+        ```
+
+        Each event subscription deleted that was deleted will have output like the following:
+
+        ```text
+        Deleting event subscription: https://x1005c3s0b0/redfish/v1/EventService/Subscriptions/1
+        HTTP/2 204
+        access-control-allow-credentials: true
+        access-control-allow-headers: X-Auth-Token
+        access-control-allow-origin: *
+        access-control-expose-headers: X-Auth-Token
+        cache-control: no-cache, must-revalidate
+        content-type: text/html; charset=UTF-8
+        date: Tue, 19 Jan 2038 03:14:07 GMT
+        odata-version: 4.0
+        server: Cray Embedded Software Redfish Service
+        ```
+
 1. (`ncn#`) Enable the nodes in the HSM database.
 
     For a blade with four nodes per blade:

--- a/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System_Using_SAT.md
+++ b/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System_Using_SAT.md
@@ -47,6 +47,43 @@ This procedure will add a liquid-cooled blade to an HPE Cray EX system.
    sat swap blade --action enable <SLOT_XNAME>
    ```
 
+1. Clear out the existing Redfish event subscriptions from the BMCs on the blade.
+
+    1. (`ncn#`) Set the environment variable `SLOT` corresponding to the blades location:
+
+        ```bash
+        SLOT=<SLOT_XNAME>
+        ```
+
+    1. (`ncn#`) Clear the Redfish event subscriptions:
+
+        ```bash
+        for BMC in $(cray hsm inventory  redfishEndpoints list --type NodeBMC --format json | jq .RedfishEndpoints[].ID -r | grep $SLOT); do
+            PASSWD=$(cray scsd bmc creds list --targets $BMC --format json | jq .Targets[].Password -r)
+            SUBS=$(curl -sk -u root:$PASSWD https://${BMC}/redfish/v1/EventService/Subscriptions | jq -r '.Members[]."@odata.id"')
+            for SUB in $SUBS; do
+                echo "Deleting event subscription: https://${BMC}${SUB}" 
+                curl -i -sk -u root:$PASSWD -X DELETE https://${BMC}${SUB}
+            done
+        done
+        ```
+
+        Each event subscription deleted that was deleted will have output like the following:
+
+        ```text
+        Deleting event subscription: https://x1005c3s0b0/redfish/v1/EventService/Subscriptions/1
+        HTTP/2 204
+        access-control-allow-credentials: true
+        access-control-allow-headers: X-Auth-Token
+        access-control-allow-origin: *
+        access-control-expose-headers: X-Auth-Token
+        cache-control: no-cache, must-revalidate
+        content-type: text/html; charset=UTF-8
+        date: Tue, 19 Jan 2038 03:14:07 GMT
+        odata-version: 4.0
+        server: Cray Embedded Software Redfish Service
+        ```
+
 ## Power on and boot the nodes
 
 1. Determine which Boot Orchestration Service \(BOS\) templates to use to shut down nodes on the target blade.

--- a/operations/node_management/Swap_a_Compute_Blade_with_a_Different_System.md
+++ b/operations/node_management/Swap_a_Compute_Blade_with_a_Different_System.md
@@ -106,6 +106,43 @@ Swap an HPE Cray EX liquid-cooled compute blade between two systems.
    cray hsm inventory redfishEndpoints update --enabled false x9000c3s0b1
    ```
 
+### Source: Clear out the existing Redfish event subscriptions from the BMCs on the blade
+
+1. (`ncn#`) Set the environment variable `SLOT` corresponding to the blades location:
+
+     ```bash
+     ncn# SLOT="x9000c3s0"
+     ```
+
+1. (`ncn#`) Clear the Redfish event subscriptions:
+
+    ```bash
+    ncn# for BMC in $(cray hsm inventory  redfishEndpoints list --type NodeBMC --format json | jq .RedfishEndpoints[].ID -r | grep $SLOT); do
+        PASSWD=$(cray scsd bmc creds list --targets $BMC --format json | jq .Targets[].Password -r)
+        SUBS=$(curl -sk -u root:$PASSWD https://${BMC}/redfish/v1/EventService/Subscriptions | jq -r '.Members[]."@odata.id"')
+        for SUB in $SUBS; do
+            echo "Deleting event subscription: https://${BMC}${SUB}" 
+            curl -i -sk -u root:$PASSWD -X DELETE https://${BMC}${SUB}
+        done
+    done
+    ```
+
+    Each event subscription deleted that was deleted will have output like the following:
+
+    ```text
+    Deleting event subscription: https://x9000c3s2b0/redfish/v1/EventService/Subscriptions/1
+    HTTP/2 204
+    access-control-allow-credentials: true
+    access-control-allow-headers: X-Auth-Token
+    access-control-allow-origin: *
+    access-control-expose-headers: X-Auth-Token
+    cache-control: no-cache, must-revalidate
+    content-type: text/html; charset=UTF-8
+    date: Tue, 19 Jan 2038 03:14:07 GMT
+    odata-version: 4.0
+    server: Cray Embedded Software Redfish Service
+    ```
+
 ### Source: Clear the node controller settings
 
 1. (`ncn#`) Remove the system specific settings from each node controller on the blade.
@@ -256,6 +293,43 @@ The hardware management network MAC and IP addresses are assigned algorithmicall
     ```bash
     cray hsm inventory redfishEndpoints update --enabled false x1005c3s0b0
     cray hsm inventory redfishEndpoints update --enabled false x1005c3s0b1
+    ```
+
+### Destination: Clear out the existing Redfish event subscriptions from the BMCs on the blade
+
+1. Set the environment variable `SLOT` corresponding to the blades location:
+
+     ```bash
+     ncn# SLOT="x1005c3s0"
+     ```
+
+1. Clear the Redfish event subscriptions:
+
+    ```bash
+    ncn# for BMC in $(cray hsm inventory  redfishEndpoints list --type NodeBMC --format json | jq .RedfishEndpoints[].ID -r | grep $SLOT); do
+        PASSWD=$(cray scsd bmc creds list --targets $BMC --format json | jq .Targets[].Password -r)
+        SUBS=$(curl -sk -u root:$PASSWD https://${BMC}/redfish/v1/EventService/Subscriptions | jq -r '.Members[]."@odata.id"')
+        for SUB in $SUBS; do
+            echo "Deleting event subscription: https://${BMC}${SUB}" 
+            curl -i -sk -u root:$PASSWD -X DELETE https://${BMC}${SUB}
+        done
+    done
+    ```
+
+    Each event subscription deleted that was deleted will have output like the following:
+
+    ```text
+    Deleting event subscription: https://x9000c3s2b0/redfish/v1/EventService/Subscriptions/1
+    HTTP/2 204
+    access-control-allow-credentials: true
+    access-control-allow-headers: X-Auth-Token
+    access-control-allow-origin: *
+    access-control-expose-headers: X-Auth-Token
+    cache-control: no-cache, must-revalidate
+    content-type: text/html; charset=UTF-8
+    date: Tue, 19 Jan 2038 03:14:07 GMT
+    odata-version: 4.0
+    server: Cray Embedded Software Redfish Service
     ```
 
 ### Destination: Clear the node controller settings


### PR DESCRIPTION


# Description
<!--- Describe what this change is and what it is for. -->
 Clear out redfish event subscriptions when add or removing blades from the system. This will prevent BMCs from sending multiple events out that are associated with different xnames out, and causing power events to confusing HSM when trying to keep track of power status.
# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
