### PR TITLE
CASMHMS-5693: Clear out redfish event subscriptions when add or removing blades

### DIFF
--- a/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System.md
+++ b/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System.md
@@ -368,6 +368,43 @@ This procedure will add a liquid-cooled blades from an HPE Cray EX system.
             ncn# curl -k -u root:password https://x1005c3s0b0/redfish/v1/Managers
             ```
 
+1. Clear out the existing Redfish event subscriptions from the BMCs on the blade.
+
+    1. Set the environment variable `SLOT` corresponding to the blades location:
+
+        ```bash
+        ncn# SLOT="x1005c3s0"
+        ```
+
+    1. Clear the Redfish event subscriptions:
+
+        ```bash
+        ncn# for BMC in $(cray hsm inventory  redfishEndpoints list --type NodeBMC --format json | jq .RedfishEndpoints[].ID -r | grep $SLOT); do
+            PASSWD=$(cray scsd bmc creds list --targets $BMC --format json | jq .Targets[].Password -r)
+            SUBS=$(curl -sk -u root:$PASSWD https://${BMC}/redfish/v1/EventService/Subscriptions | jq -r '.Members[]."@odata.id"')
+            for SUB in $SUBS; do
+                echo "Deleting event subscription: https://${BMC}${SUB}" 
+                curl -i -sk -u root:$PASSWD -X DELETE https://${BMC}${SUB}
+            done
+        done
+        ```
+
+        Each event subscription deleted that was deleted will have output like the following:
+
+        ```text
+        Deleting event subscription: https://x1005c3s0b0/redfish/v1/EventService/Subscriptions/1
+        HTTP/2 204
+        access-control-allow-credentials: true
+        access-control-allow-headers: X-Auth-Token
+        access-control-allow-origin: *
+        access-control-expose-headers: X-Auth-Token
+        cache-control: no-cache, must-revalidate
+        content-type: text/html; charset=UTF-8
+        date: Tue, 19 Jan 2038 03:14:07 GMT
+        odata-version: 4.0
+        server: Cray Embedded Software Redfish Service
+        ```
+
 1. Enable the nodes in the HSM database.
 
     For a blade with four nodes per blade:

--- a/operations/node_management/Removing_a_Liquid-cooled_blade_from_a_System.md
+++ b/operations/node_management/Removing_a_Liquid-cooled_blade_from_a_System.md
@@ -45,7 +45,44 @@ This procedure will remove a liquid-cooled blades from an HPE Cray EX system.
     ncn# cray hsm inventory redfishEndpoints update --enabled false x9000c3s0b1
     ```
 
-### Step 3: Clear the node controller settings
+### Step 3: Clear out the existing Redfish event subscriptions from the BMCs on the blade
+
+1. Set the environment variable `SLOT` corresponding to the blades location:
+
+     ```bash
+     ncn# SLOT="x9000c3s0"
+     ```
+
+1. Clear the Redfish event subscriptions:
+
+    ```bash
+    ncn# for BMC in $(cray hsm inventory  redfishEndpoints list --type NodeBMC --format json | jq .RedfishEndpoints[].ID -r | grep $SLOT); do
+        PASSWD=$(cray scsd bmc creds list --targets $BMC --format json | jq .Targets[].Password -r)
+        SUBS=$(curl -sk -u root:$PASSWD https://${BMC}/redfish/v1/EventService/Subscriptions | jq -r '.Members[]."@odata.id"')
+        for SUB in $SUBS; do
+            echo "Deleting event subscription: https://${BMC}${SUB}" 
+            curl -i -sk -u root:$PASSWD -X DELETE https://${BMC}${SUB}
+        done
+    done
+    ```
+
+    Each event subscription deleted that was deleted will have output like the following:
+
+    ```text
+    Deleting event subscription: https://x9000c3s2b0/redfish/v1/EventService/Subscriptions/1
+    HTTP/2 204
+    access-control-allow-credentials: true
+    access-control-allow-headers: X-Auth-Token
+    access-control-allow-origin: *
+    access-control-expose-headers: X-Auth-Token
+    cache-control: no-cache, must-revalidate
+    content-type: text/html; charset=UTF-8
+    date: Tue, 19 Jan 2038 03:14:07 GMT
+    odata-version: 4.0
+    server: Cray Embedded Software Redfish Service
+    ```
+
+### Step 4: Clear the node controller settings
 
 1. Remove the system-specific settings from each node controller on the blade.
 
@@ -61,7 +98,7 @@ This procedure will remove a liquid-cooled blades from an HPE Cray EX system.
 
    Use Ctrl-C to return to the prompt if command does not return.
 
-### Step 4: Power off the chassis slot
+### Step 5: Power off the chassis slot
 
 1. Suspend the `hms-discovery` cron job.
 
@@ -90,7 +127,7 @@ This procedure will remove a liquid-cooled blades from an HPE Cray EX system.
     ncn# cray capmc xname_off create --xnames x9000c3s0 --recursive true
     ```
 
-### Step 5: Disable the chassis slot
+### Step 6: Disable the chassis slot
 
 1. Disable the chassis slot.
 
@@ -100,7 +137,7 @@ This procedure will remove a liquid-cooled blades from an HPE Cray EX system.
     ncn# cray hsm state components enabled update --enabled false x9000c3s0
     ```
 
-### Step 6: Record MAC and IP addresses for nodes
+### Step 7: Record MAC and IP addresses for nodes
 
 **IMPORTANT**: Record the NMN MAC and IP addresses for each node in the blade (labeled `Node Maintenance Network`). To prevent disruption in DVS when over operating the NMN, these addresses must
 be maintained in the HSM when the blade is swapped and discovered.
@@ -145,7 +182,7 @@ The `NodeBMC` MAC and IP addresses are assigned algorithmically and *must not be
 
 1. Repeat the command to record the `ComponentID`, MAC addresses, and IP addresses for the `Node Maintenance Network` for the other nodes in the blade.
 
-### Step 7: Cleanup Hardware State Manager
+### Step 8: Cleanup Hardware State Manager
 
 1. Set an environment variable that corresponds to the chassis slot of the blade.
 
@@ -197,7 +234,7 @@ The `NodeBMC` MAC and IP addresses are assigned algorithmically and *must not be
     ncn-mw# kubectl delete pods -n services -l app.kubernetes.io/name=cray-dhcp-kea
     ```
 
-### Step 8: Remove the blade
+### Step 9: Remove the blade
 
 1. Remove the blade from the source location.
 
@@ -209,7 +246,7 @@ The `NodeBMC` MAC and IP addresses are assigned algorithmically and *must not be
 
 1. Install the blade from the source system in a storage rack or leave it on the cart.
 
-### Step 9: Rediscover the Chassis BMC of the chassis the blade was removed from
+### Step 10: Rediscover the Chassis BMC of the chassis the blade was removed from
 
 1. Determine the name of the Chassis BMC.
 
@@ -230,7 +267,7 @@ The `NodeBMC` MAC and IP addresses are assigned algorithmically and *must not be
     ncn-mw# cray hsm inventory discover create --xnames $CHASSIS_BMC
     ```
 
-### Step 10: Re-enable the `hms-discovery` cronjob
+### Step 11: Re-enable the `hms-discovery` cronjob
 
 1. Un-suspend the `hms-discovery` cron job if no more liquid-cooled blades are planned to be removed from the system.
 

--- a/operations/node_management/Swap_a_Compute_Blade_with_a_Different_System.md
+++ b/operations/node_management/Swap_a_Compute_Blade_with_a_Different_System.md
@@ -106,6 +106,43 @@ Swap an HPE Cray EX liquid-cooled compute blade between two systems.
    ncn# cray hsm inventory redfishEndpoints update --enabled false x9000c3s0b1
    ```
 
+### Source: Clear out the existing Redfish event subscriptions from the BMCs on the blade
+
+1. Set the environment variable `SLOT` corresponding to the blades location:
+
+     ```bash
+     ncn# SLOT="x9000c3s0"
+     ```
+
+1. Clear the Redfish event subscriptions:
+
+    ```bash
+    ncn# for BMC in $(cray hsm inventory  redfishEndpoints list --type NodeBMC --format json | jq .RedfishEndpoints[].ID -r | grep $SLOT); do
+        PASSWD=$(cray scsd bmc creds list --targets $BMC --format json | jq .Targets[].Password -r)
+        SUBS=$(curl -sk -u root:$PASSWD https://${BMC}/redfish/v1/EventService/Subscriptions | jq -r '.Members[]."@odata.id"')
+        for SUB in $SUBS; do
+            echo "Deleting event subscription: https://${BMC}${SUB}" 
+            curl -i -sk -u root:$PASSWD -X DELETE https://${BMC}${SUB}
+        done
+    done
+    ```
+
+    Each event subscription deleted that was deleted will have output like the following:
+
+    ```text
+    Deleting event subscription: https://x9000c3s2b0/redfish/v1/EventService/Subscriptions/1
+    HTTP/2 204
+    access-control-allow-credentials: true
+    access-control-allow-headers: X-Auth-Token
+    access-control-allow-origin: *
+    access-control-expose-headers: X-Auth-Token
+    cache-control: no-cache, must-revalidate
+    content-type: text/html; charset=UTF-8
+    date: Tue, 19 Jan 2038 03:14:07 GMT
+    odata-version: 4.0
+    server: Cray Embedded Software Redfish Service
+    ```
+
 ### Source: Clear the node controller settings
 
 1. Remove the system specific settings from each node controller on the blade.
@@ -256,6 +293,43 @@ The hardware management network MAC and IP addresses are assigned algorithmicall
     ```bash
     ncn# cray hsm inventory redfishEndpoints update --enabled false x1005c3s0b0
     ncn# cray hsm inventory redfishEndpoints update --enabled false x1005c3s0b1
+    ```
+
+### Destination: Clear out the existing Redfish event subscriptions from the BMCs on the blade
+
+1. Set the environment variable `SLOT` corresponding to the blades location:
+
+     ```bash
+     ncn# SLOT="x1005c3s0"
+     ```
+
+1. Clear the Redfish event subscriptions:
+
+    ```bash
+    ncn# for BMC in $(cray hsm inventory  redfishEndpoints list --type NodeBMC --format json | jq .RedfishEndpoints[].ID -r | grep $SLOT); do
+        PASSWD=$(cray scsd bmc creds list --targets $BMC --format json | jq .Targets[].Password -r)
+        SUBS=$(curl -sk -u root:$PASSWD https://${BMC}/redfish/v1/EventService/Subscriptions | jq -r '.Members[]."@odata.id"')
+        for SUB in $SUBS; do
+            echo "Deleting event subscription: https://${BMC}${SUB}" 
+            curl -i -sk -u root:$PASSWD -X DELETE https://${BMC}${SUB}
+        done
+    done
+    ```
+
+    Each event subscription deleted that was deleted will have output like the following:
+
+    ```text
+    Deleting event subscription: https://x9000c3s2b0/redfish/v1/EventService/Subscriptions/1
+    HTTP/2 204
+    access-control-allow-credentials: true
+    access-control-allow-headers: X-Auth-Token
+    access-control-allow-origin: *
+    access-control-expose-headers: X-Auth-Token
+    cache-control: no-cache, must-revalidate
+    content-type: text/html; charset=UTF-8
+    date: Tue, 19 Jan 2038 03:14:07 GMT
+    odata-version: 4.0
+    server: Cray Embedded Software Redfish Service
     ```
 
 ### Destination: Clear the node controller settings


### PR DESCRIPTION


# Description
<!--- Describe what this change is and what it is for. -->
 Clear out redfish event subscriptions when add or removing blades from the system. This will prevent BMCs from sending multiple events out that are associated with different xnames out, and causing power events to confusing HSM when trying to keep track of power status.
# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
