### PR TITLE
CASMHMS-5693: Clear out redfish event subscriptions when add or removing blades

### DIFF
--- a/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System.md
+++ b/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System.md
@@ -376,23 +376,23 @@ This procedure will add a liquid-cooled blades from an HPE Cray EX system.
             curl -k -u root:password https://x1005c3s0b0/redfish/v1/Managers
             ```
 
-1. Clear out the existing Redfish event subscriptions from the BMCs on the blade.
+1. (`ncn#`) Clear out the existing Redfish event subscriptions from the BMCs on the blade.
 
-    1. (`ncn#`) Set the environment variable `SLOT` corresponding to the blades location:
+    1. Set the environment variable `SLOT` to the blade's location.
 
         ```bash
         SLOT="x1005c3s0"
         ```
 
-    1. (`ncn#`) Clear the Redfish event subscriptions:
+    1. Clear the Redfish event subscriptions.
 
         ```bash
-        for BMC in $(cray hsm inventory  redfishEndpoints list --type NodeBMC --format json | jq .RedfishEndpoints[].ID -r | grep $SLOT); do
-            PASSWD=$(cray scsd bmc creds list --targets $BMC --format json | jq .Targets[].Password -r)
-            SUBS=$(curl -sk -u root:$PASSWD https://${BMC}/redfish/v1/EventService/Subscriptions | jq -r '.Members[]."@odata.id"')
-            for SUB in $SUBS; do
+        for BMC in $(cray hsm inventory  redfishEndpoints list --type NodeBMC --format json | jq .RedfishEndpoints[].ID -r | grep ${SLOT}); do
+            PASSWD=$(cray scsd bmc creds list --targets ${BMC} --format json | jq .Targets[].Password -r)
+            SUBS=$(curl -sk -u root:"${PASSWD}" https://${BMC}/redfish/v1/EventService/Subscriptions | jq -r '.Members[]."@odata.id"')
+            for SUB in ${SUBS}; do
                 echo "Deleting event subscription: https://${BMC}${SUB}" 
-                curl -i -sk -u root:$PASSWD -X DELETE https://${BMC}${SUB}
+                curl -i -sk -u root:"${PASSWD}" -X DELETE https://${BMC}${SUB}
             done
         done
         ```

--- a/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System.md
+++ b/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System.md
@@ -139,7 +139,7 @@ This procedure will add a liquid-cooled blades from an HPE Cray EX system.
 1. (`ncn#`) Obtain an authentication token to access the API gateway.
 
     ```bash
-    TOKEN=$(curl -s -S -d grant_type=client_credentials \
+    export TOKEN=$(curl -s -S -d grant_type=client_credentials \
                 -d client_id=admin-client \
                 -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
                 https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
@@ -388,29 +388,18 @@ This procedure will add a liquid-cooled blades from an HPE Cray EX system.
 
         ```bash
         for BMC in $(cray hsm inventory  redfishEndpoints list --type NodeBMC --format json | jq .RedfishEndpoints[].ID -r | grep ${SLOT}); do
-            PASSWD=$(cray scsd bmc creds list --targets ${BMC} --format json | jq .Targets[].Password -r)
-            SUBS=$(curl -sk -u root:"${PASSWD}" https://${BMC}/redfish/v1/EventService/Subscriptions | jq -r '.Members[]."@odata.id"')
-            for SUB in ${SUBS}; do
-                echo "Deleting event subscription: https://${BMC}${SUB}" 
-                curl -i -sk -u root:"${PASSWD}" -X DELETE https://${BMC}${SUB}
-            done
+            /usr/share/doc/csm/scripts/operations/node_management/delete_bmc_subscriptions.py $BMC
         done
         ```
 
-        Each event subscription deleted that was deleted will have output like the following:
+        Each BMC on the blade will have output like the following:
 
         ```text
-        Deleting event subscription: https://x1005c3s0b0/redfish/v1/EventService/Subscriptions/1
-        HTTP/2 204
-        access-control-allow-credentials: true
-        access-control-allow-headers: X-Auth-Token
-        access-control-allow-origin: *
-        access-control-expose-headers: X-Auth-Token
-        cache-control: no-cache, must-revalidate
-        content-type: text/html; charset=UTF-8
-        date: Tue, 19 Jan 2038 03:14:07 GMT
-        odata-version: 4.0
-        server: Cray Embedded Software Redfish Service
+        Clearing subscriptions from NodeBMC x3000c0s9b0
+        Retrieving BMC credentials from SCSD
+        Retrieving Redfish Event subscriptions from the BMC: https://x3000c0s9b0/redfish/v1/EventService/Subscriptions
+        Deleting event subscription: https://x3000c0s9b0/redfish/v1/EventService/Subscriptions/1
+        Successfully deleted https://x3000c0s9b0/redfish/v1/EventService/Subscriptions/1
         ```
 
 1. (`ncn#`) Enable the nodes in the HSM database.

--- a/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System.md
+++ b/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System.md
@@ -376,6 +376,43 @@ This procedure will add a liquid-cooled blades from an HPE Cray EX system.
             curl -k -u root:password https://x1005c3s0b0/redfish/v1/Managers
             ```
 
+1. Clear out the existing Redfish event subscriptions from the BMCs on the blade.
+
+    1. (`ncn#`) Set the environment variable `SLOT` corresponding to the blades location:
+
+        ```bash
+        SLOT="x1005c3s0"
+        ```
+
+    1. (`ncn#`) Clear the Redfish event subscriptions:
+
+        ```bash
+        for BMC in $(cray hsm inventory  redfishEndpoints list --type NodeBMC --format json | jq .RedfishEndpoints[].ID -r | grep $SLOT); do
+            PASSWD=$(cray scsd bmc creds list --targets $BMC --format json | jq .Targets[].Password -r)
+            SUBS=$(curl -sk -u root:$PASSWD https://${BMC}/redfish/v1/EventService/Subscriptions | jq -r '.Members[]."@odata.id"')
+            for SUB in $SUBS; do
+                echo "Deleting event subscription: https://${BMC}${SUB}" 
+                curl -i -sk -u root:$PASSWD -X DELETE https://${BMC}${SUB}
+            done
+        done
+        ```
+
+        Each event subscription deleted that was deleted will have output like the following:
+
+        ```text
+        Deleting event subscription: https://x1005c3s0b0/redfish/v1/EventService/Subscriptions/1
+        HTTP/2 204
+        access-control-allow-credentials: true
+        access-control-allow-headers: X-Auth-Token
+        access-control-allow-origin: *
+        access-control-expose-headers: X-Auth-Token
+        cache-control: no-cache, must-revalidate
+        content-type: text/html; charset=UTF-8
+        date: Tue, 19 Jan 2038 03:14:07 GMT
+        odata-version: 4.0
+        server: Cray Embedded Software Redfish Service
+        ```
+
 1. (`ncn#`) Enable the nodes in the HSM database.
 
     For a blade with four nodes per blade:

--- a/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System_Using_SAT.md
+++ b/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System_Using_SAT.md
@@ -47,23 +47,23 @@ This procedure will add a liquid-cooled blade to an HPE Cray EX system.
    sat swap blade --action enable <SLOT_XNAME>
    ```
 
-1. Clear out the existing Redfish event subscriptions from the BMCs on the blade.
+1. (`ncn#`) Clear out the existing Redfish event subscriptions from the BMCs on the blade.
 
-    1. (`ncn#`) Set the environment variable `SLOT` corresponding to the blades location:
+    1. Set the environment variable `SLOT` to the blade's location.
 
         ```bash
         SLOT=<SLOT_XNAME>
         ```
 
-    1. (`ncn#`) Clear the Redfish event subscriptions:
+    1. Clear the Redfish event subscriptions.
 
         ```bash
-        for BMC in $(cray hsm inventory  redfishEndpoints list --type NodeBMC --format json | jq .RedfishEndpoints[].ID -r | grep $SLOT); do
-            PASSWD=$(cray scsd bmc creds list --targets $BMC --format json | jq .Targets[].Password -r)
-            SUBS=$(curl -sk -u root:$PASSWD https://${BMC}/redfish/v1/EventService/Subscriptions | jq -r '.Members[]."@odata.id"')
-            for SUB in $SUBS; do
+        for BMC in $(cray hsm inventory  redfishEndpoints list --type NodeBMC --format json | jq .RedfishEndpoints[].ID -r | grep ${SLOT}); do
+            PASSWD=$(cray scsd bmc creds list --targets ${BMC} --format json | jq .Targets[].Password -r)
+            SUBS=$(curl -sk -u root:"${PASSWD}" https://${BMC}/redfish/v1/EventService/Subscriptions | jq -r '.Members[]."@odata.id"')
+            for SUB in ${SUBS}; do
                 echo "Deleting event subscription: https://${BMC}${SUB}" 
-                curl -i -sk -u root:$PASSWD -X DELETE https://${BMC}${SUB}
+                curl -i -sk -u root:"${PASSWD}" -X DELETE https://${BMC}${SUB}
             done
         done
         ```

--- a/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System_Using_SAT.md
+++ b/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System_Using_SAT.md
@@ -58,30 +58,24 @@ This procedure will add a liquid-cooled blade to an HPE Cray EX system.
     1. Clear the Redfish event subscriptions.
 
         ```bash
+        export TOKEN=$(curl -s -S -d grant_type=client_credentials \
+                -d client_id=admin-client \
+                -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
+                https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
+
         for BMC in $(cray hsm inventory  redfishEndpoints list --type NodeBMC --format json | jq .RedfishEndpoints[].ID -r | grep ${SLOT}); do
-            PASSWD=$(cray scsd bmc creds list --targets ${BMC} --format json | jq .Targets[].Password -r)
-            SUBS=$(curl -sk -u root:"${PASSWD}" https://${BMC}/redfish/v1/EventService/Subscriptions | jq -r '.Members[]."@odata.id"')
-            for SUB in ${SUBS}; do
-                echo "Deleting event subscription: https://${BMC}${SUB}" 
-                curl -i -sk -u root:"${PASSWD}" -X DELETE https://${BMC}${SUB}
-            done
+            /usr/share/doc/csm/scripts/operations/node_management/delete_bmc_subscriptions.py $BMC
         done
         ```
 
-        Each event subscription deleted that was deleted will have output like the following:
+        Each BMC on the blade will have output like the following:
 
         ```text
-        Deleting event subscription: https://x1005c3s0b0/redfish/v1/EventService/Subscriptions/1
-        HTTP/2 204
-        access-control-allow-credentials: true
-        access-control-allow-headers: X-Auth-Token
-        access-control-allow-origin: *
-        access-control-expose-headers: X-Auth-Token
-        cache-control: no-cache, must-revalidate
-        content-type: text/html; charset=UTF-8
-        date: Tue, 19 Jan 2038 03:14:07 GMT
-        odata-version: 4.0
-        server: Cray Embedded Software Redfish Service
+        Clearing subscriptions from NodeBMC x3000c0s9b0
+        Retrieving BMC credentials from SCSD
+        Retrieving Redfish Event subscriptions from the BMC: https://x3000c0s9b0/redfish/v1/EventService/Subscriptions
+        Deleting event subscription: https://x3000c0s9b0/redfish/v1/EventService/Subscriptions/1
+        Successfully deleted https://x3000c0s9b0/redfish/v1/EventService/Subscriptions/1
         ```
 
 ## Power on and boot the nodes

--- a/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System_Using_SAT.md
+++ b/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System_Using_SAT.md
@@ -47,6 +47,43 @@ This procedure will add a liquid-cooled blade to an HPE Cray EX system.
    sat swap blade --action enable <SLOT_XNAME>
    ```
 
+1. Clear out the existing Redfish event subscriptions from the BMCs on the blade.
+
+    1. (`ncn#`) Set the environment variable `SLOT` corresponding to the blades location:
+
+        ```bash
+        SLOT=<SLOT_XNAME>
+        ```
+
+    1. (`ncn#`) Clear the Redfish event subscriptions:
+
+        ```bash
+        for BMC in $(cray hsm inventory  redfishEndpoints list --type NodeBMC --format json | jq .RedfishEndpoints[].ID -r | grep $SLOT); do
+            PASSWD=$(cray scsd bmc creds list --targets $BMC --format json | jq .Targets[].Password -r)
+            SUBS=$(curl -sk -u root:$PASSWD https://${BMC}/redfish/v1/EventService/Subscriptions | jq -r '.Members[]."@odata.id"')
+            for SUB in $SUBS; do
+                echo "Deleting event subscription: https://${BMC}${SUB}" 
+                curl -i -sk -u root:$PASSWD -X DELETE https://${BMC}${SUB}
+            done
+        done
+        ```
+
+        Each event subscription deleted that was deleted will have output like the following:
+
+        ```text
+        Deleting event subscription: https://x1005c3s0b0/redfish/v1/EventService/Subscriptions/1
+        HTTP/2 204
+        access-control-allow-credentials: true
+        access-control-allow-headers: X-Auth-Token
+        access-control-allow-origin: *
+        access-control-expose-headers: X-Auth-Token
+        cache-control: no-cache, must-revalidate
+        content-type: text/html; charset=UTF-8
+        date: Tue, 19 Jan 2038 03:14:07 GMT
+        odata-version: 4.0
+        server: Cray Embedded Software Redfish Service
+        ```
+
 ## Power on and boot the nodes
 
 1. Determine which Boot Orchestration Service \(BOS\) templates to use to shut down nodes on the target blade.

--- a/operations/node_management/Removing_a_Liquid-cooled_blade_from_a_System.md
+++ b/operations/node_management/Removing_a_Liquid-cooled_blade_from_a_System.md
@@ -56,30 +56,24 @@ This procedure will remove a liquid-cooled blades from an HPE Cray EX system.
 1. (`ncn#`) Clear the Redfish event subscriptions.
 
     ```bash
+    export TOKEN=$(curl -s -S -d grant_type=client_credentials \
+            -d client_id=admin-client \
+            -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
+            https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
+
     for BMC in $(cray hsm inventory  redfishEndpoints list --type NodeBMC --format json | jq .RedfishEndpoints[].ID -r | grep ${SLOT}); do
-        PASSWD=$(cray scsd bmc creds list --targets ${BMC} --format json | jq .Targets[].Password -r)
-        SUBS=$(curl -sk -u root:"${PASSWD}" https://${BMC}/redfish/v1/EventService/Subscriptions | jq -r '.Members[]."@odata.id"')
-        for SUB in ${SUBS}; do
-            echo "Deleting event subscription: https://${BMC}${SUB}" 
-            curl -i -sk -u root:"${PASSWD}" -X DELETE https://${BMC}${SUB}
-        done
+        /usr/share/doc/csm/scripts/operations/node_management/delete_bmc_subscriptions.py $BMC
     done
     ```
 
-    Each event subscription deleted that was deleted will have output like the following:
+    Each BMC on the blade will have output like the following:
 
     ```text
-    Deleting event subscription: https://x9000c3s2b0/redfish/v1/EventService/Subscriptions/1
-    HTTP/2 204
-    access-control-allow-credentials: true
-    access-control-allow-headers: X-Auth-Token
-    access-control-allow-origin: *
-    access-control-expose-headers: X-Auth-Token
-    cache-control: no-cache, must-revalidate
-    content-type: text/html; charset=UTF-8
-    date: Tue, 19 Jan 2038 03:14:07 GMT
-    odata-version: 4.0
-    server: Cray Embedded Software Redfish Service
+    Clearing subscriptions from NodeBMC x3000c0s9b0
+    Retrieving BMC credentials from SCSD
+    Retrieving Redfish Event subscriptions from the BMC: https://x3000c0s9b0/redfish/v1/EventService/Subscriptions
+    Deleting event subscription: https://x3000c0s9b0/redfish/v1/EventService/Subscriptions/1
+    Successfully deleted https://x3000c0s9b0/redfish/v1/EventService/Subscriptions/1
     ```
 
 ### Step 4: Clear the node controller settings

--- a/operations/node_management/Removing_a_Liquid-cooled_blade_from_a_System.md
+++ b/operations/node_management/Removing_a_Liquid-cooled_blade_from_a_System.md
@@ -45,23 +45,23 @@ This procedure will remove a liquid-cooled blades from an HPE Cray EX system.
     cray hsm inventory redfishEndpoints update --enabled false x9000c3s0b1
     ```
 
-### Step 3: Clear out the existing Redfish event subscriptions from the BMCs on the blade
+### Step 3: Clear Redfish event subscriptions from BMCs on the blade
 
-1. (`ncn#`) Set the environment variable `SLOT` corresponding to the blades location:
+1. (`ncn#`) Set the environment variable `SLOT` to the blade's location.
 
     ```bash
     SLOT="x9000c3s0"
     ```
 
-1. (`ncn#`) Clear the Redfish event subscriptions:
+1. (`ncn#`) Clear the Redfish event subscriptions.
 
     ```bash
-    for BMC in $(cray hsm inventory  redfishEndpoints list --type NodeBMC --format json | jq .RedfishEndpoints[].ID -r | grep $SLOT); do
-        PASSWD=$(cray scsd bmc creds list --targets $BMC --format json | jq .Targets[].Password -r)
-        SUBS=$(curl -sk -u root:$PASSWD https://${BMC}/redfish/v1/EventService/Subscriptions | jq -r '.Members[]."@odata.id"')
-        for SUB in $SUBS; do
+    for BMC in $(cray hsm inventory  redfishEndpoints list --type NodeBMC --format json | jq .RedfishEndpoints[].ID -r | grep ${SLOT}); do
+        PASSWD=$(cray scsd bmc creds list --targets ${BMC} --format json | jq .Targets[].Password -r)
+        SUBS=$(curl -sk -u root:"${PASSWD}" https://${BMC}/redfish/v1/EventService/Subscriptions | jq -r '.Members[]."@odata.id"')
+        for SUB in ${SUBS}; do
             echo "Deleting event subscription: https://${BMC}${SUB}" 
-            curl -i -sk -u root:$PASSWD -X DELETE https://${BMC}${SUB}
+            curl -i -sk -u root:"${PASSWD}" -X DELETE https://${BMC}${SUB}
         done
     done
     ```

--- a/operations/node_management/Removing_a_Liquid-cooled_blade_from_a_System_Using_SAT.md
+++ b/operations/node_management/Removing_a_Liquid-cooled_blade_from_a_System_Using_SAT.md
@@ -105,23 +105,23 @@ This procedure will remove a liquid-cooled blade from an HPE Cray EX system.
 
 ## Use SAT to remove the blade from hardware management
 
-1. Clear out the existing Redfish event subscriptions from the BMCs on the blade.
+1. (`ncn#`) Clear out the existing Redfish event subscriptions from the BMCs on the blade.
 
-    1. (`ncn#`) Set the environment variable `SLOT` corresponding to the blades location:
+    1. Set the environment variable `SLOT` to the blade's location.
 
         ```bash
         SLOT=x9000c3s0
         ```
 
-    1. (`ncn#`) Clear the Redfish event subscriptions:
+    1. Clear the Redfish event subscriptions.
 
         ```bash
-        for BMC in $(cray hsm inventory  redfishEndpoints list --type NodeBMC --format json | jq .RedfishEndpoints[].ID -r | grep $SLOT); do
-            PASSWD=$(cray scsd bmc creds list --targets $BMC --format json | jq .Targets[].Password -r)
-            SUBS=$(curl -sk -u root:$PASSWD https://${BMC}/redfish/v1/EventService/Subscriptions | jq -r '.Members[]."@odata.id"')
-            for SUB in $SUBS; do
+        for BMC in $(cray hsm inventory  redfishEndpoints list --type NodeBMC --format json | jq .RedfishEndpoints[].ID -r | grep ${SLOT}); do
+            PASSWD=$(cray scsd bmc creds list --targets ${BMC} --format json | jq .Targets[].Password -r)
+            SUBS=$(curl -sk -u root:"${PASSWD}" https://${BMC}/redfish/v1/EventService/Subscriptions | jq -r '.Members[]."@odata.id"')
+            for SUB in ${SUBS}; do
                 echo "Deleting event subscription: https://${BMC}${SUB}" 
-                curl -i -sk -u root:$PASSWD -X DELETE https://${BMC}${SUB}
+                curl -i -sk -u root:"${PASSWD}" -X DELETE https://${BMC}${SUB}
             done
         done
         ```

--- a/operations/node_management/Removing_a_Liquid-cooled_blade_from_a_System_Using_SAT.md
+++ b/operations/node_management/Removing_a_Liquid-cooled_blade_from_a_System_Using_SAT.md
@@ -116,30 +116,24 @@ This procedure will remove a liquid-cooled blade from an HPE Cray EX system.
     1. Clear the Redfish event subscriptions.
 
         ```bash
+        export TOKEN=$(curl -s -S -d grant_type=client_credentials \
+                -d client_id=admin-client \
+                -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
+                https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
+
         for BMC in $(cray hsm inventory  redfishEndpoints list --type NodeBMC --format json | jq .RedfishEndpoints[].ID -r | grep ${SLOT}); do
-            PASSWD=$(cray scsd bmc creds list --targets ${BMC} --format json | jq .Targets[].Password -r)
-            SUBS=$(curl -sk -u root:"${PASSWD}" https://${BMC}/redfish/v1/EventService/Subscriptions | jq -r '.Members[]."@odata.id"')
-            for SUB in ${SUBS}; do
-                echo "Deleting event subscription: https://${BMC}${SUB}" 
-                curl -i -sk -u root:"${PASSWD}" -X DELETE https://${BMC}${SUB}
-            done
+            /usr/share/doc/csm/scripts/operations/node_management/delete_bmc_subscriptions.py $BMC
         done
         ```
 
-        Each event subscription deleted that was deleted will have output like the following:
+        Each BMC on the blade will have output like the following:
 
         ```text
-        Deleting event subscription: https://x1005c3s0b0/redfish/v1/EventService/Subscriptions/1
-        HTTP/2 204
-        access-control-allow-credentials: true
-        access-control-allow-headers: X-Auth-Token
-        access-control-allow-origin: *
-        access-control-expose-headers: X-Auth-Token
-        cache-control: no-cache, must-revalidate
-        content-type: text/html; charset=UTF-8
-        date: Tue, 19 Jan 2038 03:14:07 GMT
-        odata-version: 4.0
-        server: Cray Embedded Software Redfish Service
+        Clearing subscriptions from NodeBMC x3000c0s9b0
+        Retrieving BMC credentials from SCSD
+        Retrieving Redfish Event subscriptions from the BMC: https://x3000c0s9b0/redfish/v1/EventService/Subscriptions
+        Deleting event subscription: https://x3000c0s9b0/redfish/v1/EventService/Subscriptions/1
+        Successfully deleted https://x3000c0s9b0/redfish/v1/EventService/Subscriptions/1
         ```
 
 1. Power off the slot and delete blade information from HSM.

--- a/operations/node_management/Replace_a_Compute_Blade.md
+++ b/operations/node_management/Replace_a_Compute_Blade.md
@@ -2,6 +2,23 @@
 
 Replace an HPE Cray EX liquid-cooled compute blade.
 
+## Prerequisites
+
+- The Cray command line interface \(CLI\) tool is initialized and configured on the system. See [Configure the Cray Command Line Interface](../configure_cray_cli.md).
+
+- The Slingshot fabric must be configured with the desired topology.
+
+- The System Layout Service (SLS) must have the desired HSN configuration.
+
+- Check the status of the high-speed network (HSN) and record link status before the procedure.
+
+- The blades must have the coolant drained and filled during the swap to minimize cross-contamination of cooling systems.
+
+  - Review procedures in *HPE Cray EX Coolant Service Procedures H-6199*
+  - Review the *HPE Cray EX Hand Pump User Guide H-6200*
+
+- The System Admin Toolkit \(SAT\) is installed and configured on the system.
+
 ## Shutdown software and power off the blade
 
 1. Temporarily disable endpoint discovery service (MEDS) for the compute nodes(s) being replaced.
@@ -71,7 +88,7 @@ Replace an HPE Cray EX liquid-cooled compute blade.
    blade is replaced. Their entries must be deleted from the HSM Ethernet interfaces table and be rediscovered. The BMC NIC MAC addresses for liquid-cooled blades are assigned algorithmically
    and should not be deleted from the HSM.
 
-   1. Delete the Node NIC MAC addresses from the HSM Ethernet interfaces table.
+   1. **For each** node delete the Node's NIC MAC addresses from the HSM Ethernet interfaces table.
 
       Query HSM to determine the Node NIC MAC addresses associated with the blade in cabinet 1000, chassis 3, slot 0, node card 0, node 0.
 
@@ -205,16 +222,16 @@ Replace an HPE Cray EX liquid-cooled compute blade.
 
 1. Enable each node individually in the HSM database (in this example, the nodes are `x1000c3s0b0n0-n3`).
 
-1. Optional: To force rediscovery of the components in the chassis (the example shows cabinet 1000, chassis 3).
+1. Rediscover the components in the chassis (the example shows cabinet 1000, chassis 3).
 
     ```bash
-    cray hsm inventory discover create --xnames x1000c3
+    cray hsm inventory discover create --xnames x1000c3b0
     ```
 
-1. Optional: Verify that discovery has completed (`LastDiscoveryStatus` = "`DiscoverOK`").
+1. Verify that discovery has completed (`LastDiscoveryStatus` = "`DiscoverOK`").
 
     ```bash
-    cray hsm inventory redfishEndpoints describe x1000c3
+    cray hsm inventory redfishEndpoints describe x1000c3b0
     ```
 
     Example output:
@@ -244,21 +261,6 @@ Replace an HPE Cray EX liquid-cooled compute blade.
     ```bash
     cray fas actions create CUSTOM_DEVICE_PARAMETERS.json
     ```
-
-1. Update the System Layout Service (SLS).
-
-    1. Dump the existing SLS configuration.
-
-       ```bash
-       cray sls networks describe HSN --format=json > existingHSN.json
-       ```
-
-    1. Copy `existingHSN.json` to a `newHSN.json`, edit `newHSN.json` with the changes, then run
-
-       ```bash
-       curl -s -k -H "Authorization: Bearer ${TOKEN}" https://API_SYSTEM/apis/sls/v1/networks/HSN \
-       -X PUT -d @newHSN.json
-       ```
 
 1. Optional: If necessary, reload DVS on NCNs.
 

--- a/operations/node_management/Swap_a_Compute_Blade_with_a_Different_System.md
+++ b/operations/node_management/Swap_a_Compute_Blade_with_a_Different_System.md
@@ -72,7 +72,7 @@ Swap an HPE Cray EX liquid-cooled compute blade between two systems.
 
     ```bash
     while read PAYLOAD ; do
-        curl -H "Authorization: Bearer $MY_TOKEN" -L -X POST 'https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces' \
+        curl -H "Authorization: Bearer $TOKEN" -L -X POST 'https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces' \
             -H 'Content-Type: application/json' \
             --data-raw "$(echo $PAYLOAD | jq -c '{ComponentID: .xname,Description: .Desc,MACAddress: .MAC,IPAddresses: [{IPAddress: .IP}]}')"
         sleep 5
@@ -110,38 +110,27 @@ Swap an HPE Cray EX liquid-cooled compute blade between two systems.
 
 1. (`ncn#`) Set the environment variable `SLOT` to the blade's location.
 
-     ```bash
-     SLOT="x9000c3s0"
-     ```
+    ```bash
+    SLOT="x9000c3s0"
+    ```
 
 1. (`ncn#`) Clear the Redfish event subscriptions.
 
-    ```bash
-    for BMC in $(cray hsm inventory  redfishEndpoints list --type NodeBMC --format json | jq .RedfishEndpoints[].ID -r | grep ${SLOT}); do
-        PASSWD=$(cray scsd bmc creds list --targets ${BMC} --format json | jq .Targets[].Password -r)
-        SUBS=$(curl -sk -u root:"${PASSWD}" https://${BMC}/redfish/v1/EventService/Subscriptions | jq -r '.Members[]."@odata.id"')
-        for SUB in ${SUBS}; do
-            echo "Deleting event subscription: https://${BMC}${SUB}" 
-            curl -i -sk -u root:$PASSWD -X DELETE https://${BMC}${SUB}
-        done
-    done
-    ```
+   ```bash
+   for BMC in $(cray hsm inventory  redfishEndpoints list --type NodeBMC --format json | jq .RedfishEndpoints[].ID -r | grep ${SLOT}); do
+       /usr/share/doc/csm/scripts/operations/node_management/delete_bmc_subscriptions.py $BMC
+   done
+   ```
 
-    Each event subscription deleted that was deleted will have output like the following:
+   Each BMC on the blade will have output like the following:
 
-    ```text
-    Deleting event subscription: https://x9000c3s2b0/redfish/v1/EventService/Subscriptions/1
-    HTTP/2 204
-    access-control-allow-credentials: true
-    access-control-allow-headers: X-Auth-Token
-    access-control-allow-origin: *
-    access-control-expose-headers: X-Auth-Token
-    cache-control: no-cache, must-revalidate
-    content-type: text/html; charset=UTF-8
-    date: Tue, 19 Jan 2038 03:14:07 GMT
-    odata-version: 4.0
-    server: Cray Embedded Software Redfish Service
-    ```
+   ```text
+   Clearing subscriptions from NodeBMC x3000c0s9b0
+   Retrieving BMC credentials from SCSD
+   Retrieving Redfish Event subscriptions from the BMC: https://x3000c0s9b0/redfish/v1/EventService/Subscriptions
+   Deleting event subscription: https://x3000c0s9b0/redfish/v1/EventService/Subscriptions/1
+   Successfully deleted https://x3000c0s9b0/redfish/v1/EventService/Subscriptions/1
+   ```
 
 ### Source: Clear the node controller settings
 
@@ -299,38 +288,32 @@ The hardware management network MAC and IP addresses are assigned algorithmicall
 
 1. (`ncn#`) Set the environment variable `SLOT` to the blade's location.
 
-     ```bash
-     SLOT="x1005c3s0"
-     ```
+    ```bash
+    SLOT="x9000c3s0"
+    ```
 
 1. (`ncn#`) Clear the Redfish event subscriptions.
 
-    ```bash
-    for BMC in $(cray hsm inventory  redfishEndpoints list --type NodeBMC --format json | jq .RedfishEndpoints[].ID -r | grep ${SLOT}); do
-        PASSWD=$(cray scsd bmc creds list --targets ${BMC} --format json | jq .Targets[].Password -r)
-        SUBS=$(curl -sk -u root:"${PASSWD}" https://${BMC}/redfish/v1/EventService/Subscriptions | jq -r '.Members[]."@odata.id"')
-        for SUB in ${SUBS}; do
-            echo "Deleting event subscription: https://${BMC}${SUB}" 
-            curl -i -sk -u root:"${PASSWD}" -X DELETE https://${BMC}${SUB}
-        done
-    done
-    ```
+   ```bash
+   export TOKEN=$(curl -s -S -d grant_type=client_credentials \
+           -d client_id=admin-client \
+           -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
+           https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
 
-    Each event subscription deleted that was deleted will have output like the following:
+   for BMC in $(cray hsm inventory  redfishEndpoints list --type NodeBMC --format json | jq .RedfishEndpoints[].ID -r | grep ${SLOT}); do
+       /usr/share/doc/csm/scripts/operations/node_management/delete_bmc_subscriptions.py $BMC
+   done
+   ```
 
-    ```text
-    Deleting event subscription: https://x9000c3s2b0/redfish/v1/EventService/Subscriptions/1
-    HTTP/2 204
-    access-control-allow-credentials: true
-    access-control-allow-headers: X-Auth-Token
-    access-control-allow-origin: *
-    access-control-expose-headers: X-Auth-Token
-    cache-control: no-cache, must-revalidate
-    content-type: text/html; charset=UTF-8
-    date: Tue, 19 Jan 2038 03:14:07 GMT
-    odata-version: 4.0
-    server: Cray Embedded Software Redfish Service
-    ```
+   Each BMC on the blade will have output like the following:
+
+   ```text
+   Clearing subscriptions from NodeBMC x3000c0s9b0
+   Retrieving BMC credentials from SCSD
+   Retrieving Redfish Event subscriptions from the BMC: https://x3000c0s9b0/redfish/v1/EventService/Subscriptions
+   Deleting event subscription: https://x3000c0s9b0/redfish/v1/EventService/Subscriptions/1
+   Successfully deleted https://x3000c0s9b0/redfish/v1/EventService/Subscriptions/1
+   ```
 
 ### Destination: Clear the node controller settings
 
@@ -460,13 +443,13 @@ The hardware management network NIC MAC addresses for liquid-cooled blades are a
 
    In the example below, replace `myuser`, `mypass`, and `shasta` in the `curl` command with site-specific values. Note
    the value of `access_token`. Review [Retrieve an Authentication Token](../security_and_authentication/Retrieve_an_Authentication_Token.md) for more information. The example is a
-   script to secure a token and set it to the variable `MY_TOKEN`.
+   script to secure a token and set it to the variable `TOKEN`.
 
     ```bash
-    MY_TOKEN=$(curl -s -d grant_type=password -d client_id=shasta -d \
+    export TOKEN=$(curl -s -d grant_type=password -d client_id=shasta -d \
             username=USERNAME -d password=PASSWORD \
             https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
-    echo $MY_TOKEN
+    echo $TOKEN
     ```
 
 1. (`ncn-mw#`) Stop Kea from automatically adding MAC address entries to the HSM `ethernetInterfaces` table.
@@ -518,7 +501,7 @@ The hardware management network NIC MAC addresses for liquid-cooled blades are a
     ```
 
     ```bash
-    curl -H "Authorization: Bearer ${MY_TOKEN}" -L -X POST 'https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces' \
+    curl -H "Authorization: Bearer ${TOKEN}" -L -X POST 'https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces' \
             -H 'Content-Type: application/json' --data-raw "{
                 \"Description\": \"Node Maintenance Network\",
                 \"MACAddress\": \"$MAC\",
@@ -866,7 +849,7 @@ one on `ncn-w002`, and one on `ncn-w003` or another worker node.
     > This requires an API token. See [Retrieve an Authentication Token](../security_and_authentication/Retrieve_an_Authentication_Token.md) for more information.
 
     ```bash
-    curl -H "Authorization: Bearer ${MY_TOKEN}" -X POST -H "Content-Type: application/json" \
+    curl -H "Authorization: Bearer ${TOKEN}" -X POST -H "Content-Type: application/json" \
         -d '{ "command": "lease4-get-all", "service": [ "dhcp4" ] }' https://api-gw-service-nmn.local/apis/dhcp-kea | jq
     ```
 

--- a/operations/node_management/Swap_a_Compute_Blade_with_a_Different_System.md
+++ b/operations/node_management/Swap_a_Compute_Blade_with_a_Different_System.md
@@ -106,6 +106,43 @@ Swap an HPE Cray EX liquid-cooled compute blade between two systems.
    cray hsm inventory redfishEndpoints update --enabled false x9000c3s0b1
    ```
 
+### Source: Clear out the existing Redfish event subscriptions from the BMCs on the blade
+
+1. (`ncn#`) Set the environment variable `SLOT` corresponding to the blades location:
+
+     ```bash
+     ncn# SLOT="x9000c3s0"
+     ```
+
+1. (`ncn#`) Clear the Redfish event subscriptions:
+
+    ```bash
+    ncn# for BMC in $(cray hsm inventory  redfishEndpoints list --type NodeBMC --format json | jq .RedfishEndpoints[].ID -r | grep $SLOT); do
+        PASSWD=$(cray scsd bmc creds list --targets $BMC --format json | jq .Targets[].Password -r)
+        SUBS=$(curl -sk -u root:$PASSWD https://${BMC}/redfish/v1/EventService/Subscriptions | jq -r '.Members[]."@odata.id"')
+        for SUB in $SUBS; do
+            echo "Deleting event subscription: https://${BMC}${SUB}" 
+            curl -i -sk -u root:$PASSWD -X DELETE https://${BMC}${SUB}
+        done
+    done
+    ```
+
+    Each event subscription deleted that was deleted will have output like the following:
+
+    ```text
+    Deleting event subscription: https://x9000c3s2b0/redfish/v1/EventService/Subscriptions/1
+    HTTP/2 204
+    access-control-allow-credentials: true
+    access-control-allow-headers: X-Auth-Token
+    access-control-allow-origin: *
+    access-control-expose-headers: X-Auth-Token
+    cache-control: no-cache, must-revalidate
+    content-type: text/html; charset=UTF-8
+    date: Tue, 19 Jan 2038 03:14:07 GMT
+    odata-version: 4.0
+    server: Cray Embedded Software Redfish Service
+    ```
+
 ### Source: Clear the node controller settings
 
 1. (`ncn#`) Remove the system specific settings from each node controller on the blade.
@@ -256,6 +293,43 @@ The hardware management network MAC and IP addresses are assigned algorithmicall
     ```bash
     cray hsm inventory redfishEndpoints update --enabled false x1005c3s0b0
     cray hsm inventory redfishEndpoints update --enabled false x1005c3s0b1
+    ```
+
+### Destination: Clear out the existing Redfish event subscriptions from the BMCs on the blade
+
+1. Set the environment variable `SLOT` corresponding to the blades location:
+
+     ```bash
+     ncn# SLOT="x1005c3s0"
+     ```
+
+1. Clear the Redfish event subscriptions:
+
+    ```bash
+    ncn# for BMC in $(cray hsm inventory  redfishEndpoints list --type NodeBMC --format json | jq .RedfishEndpoints[].ID -r | grep $SLOT); do
+        PASSWD=$(cray scsd bmc creds list --targets $BMC --format json | jq .Targets[].Password -r)
+        SUBS=$(curl -sk -u root:$PASSWD https://${BMC}/redfish/v1/EventService/Subscriptions | jq -r '.Members[]."@odata.id"')
+        for SUB in $SUBS; do
+            echo "Deleting event subscription: https://${BMC}${SUB}" 
+            curl -i -sk -u root:$PASSWD -X DELETE https://${BMC}${SUB}
+        done
+    done
+    ```
+
+    Each event subscription deleted that was deleted will have output like the following:
+
+    ```text
+    Deleting event subscription: https://x9000c3s2b0/redfish/v1/EventService/Subscriptions/1
+    HTTP/2 204
+    access-control-allow-credentials: true
+    access-control-allow-headers: X-Auth-Token
+    access-control-allow-origin: *
+    access-control-expose-headers: X-Auth-Token
+    cache-control: no-cache, must-revalidate
+    content-type: text/html; charset=UTF-8
+    date: Tue, 19 Jan 2038 03:14:07 GMT
+    odata-version: 4.0
+    server: Cray Embedded Software Redfish Service
     ```
 
 ### Destination: Clear the node controller settings

--- a/operations/node_management/Swap_a_Compute_Blade_with_a_Different_System.md
+++ b/operations/node_management/Swap_a_Compute_Blade_with_a_Different_System.md
@@ -106,21 +106,21 @@ Swap an HPE Cray EX liquid-cooled compute blade between two systems.
    cray hsm inventory redfishEndpoints update --enabled false x9000c3s0b1
    ```
 
-### Source: Clear out the existing Redfish event subscriptions from the BMCs on the blade
+### Source: Clear Redfish event subscriptions from BMCs on the blade
 
-1. (`ncn#`) Set the environment variable `SLOT` corresponding to the blades location:
+1. (`ncn#`) Set the environment variable `SLOT` to the blade's location.
 
      ```bash
-     ncn# SLOT="x9000c3s0"
+     SLOT="x9000c3s0"
      ```
 
-1. (`ncn#`) Clear the Redfish event subscriptions:
+1. (`ncn#`) Clear the Redfish event subscriptions.
 
     ```bash
-    ncn# for BMC in $(cray hsm inventory  redfishEndpoints list --type NodeBMC --format json | jq .RedfishEndpoints[].ID -r | grep $SLOT); do
-        PASSWD=$(cray scsd bmc creds list --targets $BMC --format json | jq .Targets[].Password -r)
-        SUBS=$(curl -sk -u root:$PASSWD https://${BMC}/redfish/v1/EventService/Subscriptions | jq -r '.Members[]."@odata.id"')
-        for SUB in $SUBS; do
+    for BMC in $(cray hsm inventory  redfishEndpoints list --type NodeBMC --format json | jq .RedfishEndpoints[].ID -r | grep ${SLOT}); do
+        PASSWD=$(cray scsd bmc creds list --targets ${BMC} --format json | jq .Targets[].Password -r)
+        SUBS=$(curl -sk -u root:"${PASSWD}" https://${BMC}/redfish/v1/EventService/Subscriptions | jq -r '.Members[]."@odata.id"')
+        for SUB in ${SUBS}; do
             echo "Deleting event subscription: https://${BMC}${SUB}" 
             curl -i -sk -u root:$PASSWD -X DELETE https://${BMC}${SUB}
         done
@@ -295,23 +295,23 @@ The hardware management network MAC and IP addresses are assigned algorithmicall
     cray hsm inventory redfishEndpoints update --enabled false x1005c3s0b1
     ```
 
-### Destination: Clear out the existing Redfish event subscriptions from the BMCs on the blade
+### Destination: Clear Redfish event subscriptions from BMCs on the blade
 
-1. Set the environment variable `SLOT` corresponding to the blades location:
+1. (`ncn#`) Set the environment variable `SLOT` to the blade's location.
 
      ```bash
-     ncn# SLOT="x1005c3s0"
+     SLOT="x1005c3s0"
      ```
 
-1. Clear the Redfish event subscriptions:
+1. (`ncn#`) Clear the Redfish event subscriptions.
 
     ```bash
-    ncn# for BMC in $(cray hsm inventory  redfishEndpoints list --type NodeBMC --format json | jq .RedfishEndpoints[].ID -r | grep $SLOT); do
-        PASSWD=$(cray scsd bmc creds list --targets $BMC --format json | jq .Targets[].Password -r)
-        SUBS=$(curl -sk -u root:$PASSWD https://${BMC}/redfish/v1/EventService/Subscriptions | jq -r '.Members[]."@odata.id"')
-        for SUB in $SUBS; do
+    for BMC in $(cray hsm inventory  redfishEndpoints list --type NodeBMC --format json | jq .RedfishEndpoints[].ID -r | grep ${SLOT}); do
+        PASSWD=$(cray scsd bmc creds list --targets ${BMC} --format json | jq .Targets[].Password -r)
+        SUBS=$(curl -sk -u root:"${PASSWD}" https://${BMC}/redfish/v1/EventService/Subscriptions | jq -r '.Members[]."@odata.id"')
+        for SUB in ${SUBS}; do
             echo "Deleting event subscription: https://${BMC}${SUB}" 
-            curl -i -sk -u root:$PASSWD -X DELETE https://${BMC}${SUB}
+            curl -i -sk -u root:"${PASSWD}" -X DELETE https://${BMC}${SUB}
         done
     done
     ```

--- a/scripts/operations/node_management/delete_bmc_subscriptions.py
+++ b/scripts/operations/node_management/delete_bmc_subscriptions.py
@@ -1,0 +1,129 @@
+#! /usr/bin/env python3
+# MIT License
+#
+# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import argparse
+import re
+import os
+import requests
+import sys
+import urllib3
+
+def is_2xx(http_status):
+    return http_status // 200 == 1
+
+def get_bmc_creds(api_token, scsd_url, target_bmc):
+    # Setup requests sessions to include our token
+    with requests.Session() as session:
+        session.verify = False
+        if api_token is not None:
+            session.headers.update({'Authorization': f'Bearer {api_token}'})
+        session.headers.update({'Content-Type': 'application/json'})
+
+        # Retrieve BMC credentials from SCSD
+        print(f"Retrieving BMC ({target_bmc}) credentials from SCSD")
+        r = session.get(f'{scsd_url}/bmc/creds', params={"targets":[target_bmc]})
+        if r.status_code != 200:
+            print(f'Unexpected status {r.status_code} from SCSD, expected 200')
+            return None
+
+        scsd_response = r.json()
+        print(scsd_response)
+        if scsd_response["Targets"] is None:
+            print(f'Unexpected number of credentials returned from SCSD found 0, excepted 1')
+            return None
+        elif len(scsd_response["Targets"]) != 1:
+            print(f'Unexpected number of credentials returned from SCSD found {len(scsd_response["Targets"])}, excepted 1')
+            return None
+
+        return scsd_response["Targets"][0]
+
+
+def clear_bmc_subscriptions(username, password, target_bmc):
+    with requests.Session() as session:
+        session.verify = False
+        session.auth = requests.auth.HTTPBasicAuth(username, password)
+ 
+        # Retrieve subscriptions from the BMC
+        url = f'https://{target_bmc}/redfish/v1/EventService/Subscriptions'
+        print(f"Retrieving Redfish Event subscriptions from the BMC: {url}")
+        r = session.get(url)
+        if r.status_code != 200:
+            print(f'Unexpected status {r.status_code}, expected 200')
+            return None
+
+        # For each subscription delete it
+        subscription_urls = list(map(lambda subscription: f'https://{target_bmc}{subscription["@odata.id"]}', r.json()["Members"]))
+        subscription_urls.sort(reverse=True)
+
+        if len(subscription_urls) == 0:
+            print("No event subscriptions present!")
+            return
+
+        for subscription_url in subscription_urls:
+            print(f"Deleting event subscription: {subscription_url}")
+            r = session.delete(subscription_url)
+            if is_2xx(r.status_code):
+                print(f"Successfully deleted {subscription_url}")
+            else:
+                print(f'Unexpected status {r.status_code} from BMC, expected 2xx status')
+                print(f'BMC Response:', r.text)
+
+
+if __name__ == "__main__":
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+    token=os.getenv("TOKEN")
+    if token is None or token == "":
+        print("Error environment variable TOKEN was not set")
+        sys.exit(1)
+
+
+    # Parse CLI Arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument("target_bmc", help="Target BMC to clear redfish subscriptions")
+    parser.add_argument("--url-scsd", type=str, required=False, default="https://api-gw-service-nmn.local/apis/scsd/v1")
+
+
+    args = parser.parse_args()
+    
+    if re.match("^x([0-9]{1,4})c([0-7])b([0])$", args.target_bmc) is not None:
+        # This is a ChassisBMC
+        print(f"Clearing subscriptions from ChassisBMC {args.target_bmc}")
+    elif re.match("^x([0-9]{1,4})c([0-7])r([0-9]+)b([0-9]+)$", args.target_bmc) is not None:
+        # This is a RouterBMC
+        print(f"Clearing subscriptions from RouterBMC {args.target_bmc}")
+    elif re.match("^x([0-9]{1,4})c([0-7])s([0-9]+)b([0-9]+)$", args.target_bmc) is not None:
+        # This is a NodeBMC
+        print(f"Clearing subscriptions from NodeBMC {args.target_bmc}")
+    else:
+        # Unsupported BMC
+        print(f"Provided xname is not supported by this script.")
+        sys.exit(1)
+
+    # Retrieve BMC creds
+    creds = get_bmc_creds(token, args.url_scsd, args.target_bmc)
+    if creds is None:
+        print("Failed to retrieve credentials from SCSD")
+        sys.exit(1)
+    
+    # Clear the subscriptions from the BMC
+    clear_bmc_subscriptions(creds["Username"], creds["Password"], args.target_bmc)


### PR DESCRIPTION


# Description
<!--- Describe what this change is and what it is for. -->
 Clear out redfish event subscriptions when add or removing blades from the system. This will prevent BMCs from sending multiple events out that are associated with different xnames out, and causing power events to confusing HSM when trying to keep track of power status.
# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
