### PR TITLE
CASMCMS-8194: Add procedure for purging CFS event queue.

### DIFF
--- a/operations/README.md
+++ b/operations/README.md
@@ -210,6 +210,7 @@ The Configuration Framework Service \(CFS\) is available on systems for remote e
   - [View Configuration Session Logs](configuration_management/View_Configuration_Session_Logs.md)
   - [Troubleshoot Ansible Play Failures in CFS Sessions](configuration_management/Troubleshoot_Ansible_Play_Failures_in_CFS_Sessions.md)
   - [Troubleshoot CFS Session Failing to Complete](configuration_management/Troubleshoot_CFS_Session_Failing_to_Complete.md)
+  - [Troubleshoot CFS Sessions Failing to Start](configuration_management/Troubleshoot_CFS_Sessions_Failing_to_Start.md)
 - [Configuration Management with the CFS Batcher](configuration_management/Configuration_Management_with_the_CFS_Batcher.md)
 - [CFS Flow Diagrams](configuration_management/CFS_Flow_Diagrams.md)
 - [Configuration Management of System Components](configuration_management/Configuration_Management_of_System_Components.md)

--- a/operations/configuration_management/Troubleshoot_CFS_Sessions_Failing_to_Start.md
+++ b/operations/configuration_management/Troubleshoot_CFS_Sessions_Failing_to_Start.md
@@ -1,0 +1,81 @@
+# Troubleshoot CFS Sessions Failing to Start
+
+Troubleshoot issues where Configuration Framework Service \(CFS\) sessions are being created, but the pods are never created and never run.
+
+## Prerequisites
+
+CFS-batcher is creating automatic sessions, but pods aren't starting for those sessions.  There are a number of communication reasons this could be happening, so check the `cfs-batcher` and `cfs-operator` logs for these signatures.
+
+CFS-batcher logs should show that it is creating sessions, but giving up waiting for those sessions to start:
+
+```bash
+2022-08-24 04:09:12,391 - WARNING - batcher.batch - Session batcher-d7f9bf52-e5f6-4742-849b-4086b1d59ab1 is stuck in pending and will be deleted.
+2022-08-24 04:09:12,492 - WARNING - batcher.batch - Session batcher-77c3c4d1-df39-4ebc-a6b4-32b8e102bdc5 is stuck in pending and will be deleted.
+2022-08-24 04:09:12,638 - WARNING - batcher.batch - Session batcher-f9a513c1-47ad-4539-98cc-b3f418f6b8bd is stuck in pending and will be deleted.
+2022-08-24 04:09:12,761 - WARNING - batcher.batch - Session batcher-7a291f2f-0149-46d7-889b-08331a46af2c is stuck in pending and will be deleted.
+2022-08-24 04:09:15,144 - WARNING - batcher.batch - Session batcher-b6c35dcc-b8b9-421b-9090-23bfc2a72ac3 is stuck in pending and will be deleted.
+```
+
+CFS-operator logs should show that it is attempting to create sessions but is unable to find the session records.
+
+```bash
+2022-08-24 05:48:06,476 - INFO    - cray.cfs.operator.events.session_events - EVENT: CREATE batcher-3b78941e-1c06-474c-89fe-bf241f5002e4
+2022-08-24 05:48:06,509 - ERROR   - cray.cfs.operator.cfs.sessions - Unexpected response from CFS: 404 Client Error: Not Found for url: http://cray-cfs-api/v2/sessions/batcher-3b78941e-1c06-474c-89fe-bf241f5002e4
+```
+
+If these two things are true, it is likely that CFS is creating new sessions faster than it can keep up with session creation events.
+
+## Procedure
+
+The primary method of handling this problem is the `batcherMaxBackoff` option.  This will slow automatic session creation in these situations and given the `cfs-operator` a chance to catch up on the backlog.
+If this value has been changed from it's default value of 3600 (1 hour), it should be set back to that value using `cray cfs options update --batcher-max-backoff 3600`.  The issue should eventually resolve automatically.
+
+If there is a reason that users cannot wait for the back-off to resolve this automatically, the following procedure can be used to purge the event queue.  This will disrupt CFS operation and may disrupt existing sessions, so caution should be used.
+
+1. (`ncn-mw#`) Slow down session creation.  If any others users or scripts are creating sessions, make sure they have stopped.  CFS-batcher should be slowed by setting it's check interval to an arbitrary high number.
+
+    ```bash
+    cray cfs options update --batcher-check-interval 99999
+    ```
+
+1. (`ncn-mw#`) Start a new consumer on the Kafka event queue.
+
+    Exec into a Kafka pod.
+
+    ```bash
+    kubectl -n services  exec -it  cray-shared-kafka-kafka-0 -c kafka -- /bin/bash
+    ```
+
+    Then start a console consumer on the cfs event topic using the `cfs-operator` consumer group.
+
+    ```bash
+    bin/kafka-console-consumer.sh --bootstrap-server cray-shared-kafka-kafka-0.cray-shared-kafka-kafka-brokers.services.svc.cluster.local:9092 --topic cfs-session-events --group cfs-operator
+    ```
+
+   This command will likely produce not output at first as Kafka re-balances the consumer group.  Leave this command running.
+
+1. (`ncn-mw#`) In a new window, scale down the `cfs-operator`.  This forces the console consumer to handle the entire event queue.
+
+    ```bash
+    kubectl -n services scale --replicas=0 deployment/cray-cfs-operator
+    ```
+
+1. (`ncn-mw#`) Wait until the output from the console consumer stops.  Once the `cfs-operator` is scaled down there should be a final burst of output.  Wait until all output has stopped for at least a minute before continuing.
+
+1. (`ncn-mw#`) Cancel out of the console consumer.
+
+1. (`ncn-mw#`) Restore `cfs-operator`.
+
+    ```bash
+    kubectl -n services scale --replicas=1 deployment/cray-cfs-operator
+    ```
+
+1. (`ncn-mw#`) Restore `cfs-batcher`.
+
+    ```bash
+    cray cfs options update --batcher-check-interval 10
+    ```
+
+    ```bash
+    kubectl -n services rollout restart deployment/cray-cfs-batcher
+    ```

--- a/operations/configuration_management/Troubleshoot_CFS_Sessions_Failing_to_Start.md
+++ b/operations/configuration_management/Troubleshoot_CFS_Sessions_Failing_to_Start.md
@@ -4,11 +4,11 @@ Troubleshoot issues where Configuration Framework Service \(CFS\) sessions are b
 
 ## Prerequisites
 
-CFS-batcher is creating automatic sessions, but pods aren't starting for those sessions.  There are a number of communication reasons this could be happening, so check the `cfs-batcher` and `cfs-operator` logs for these signatures.
+CFS-batcher is creating automatic sessions, but pods are not starting for those sessions. There are a number of communication reasons this could be happening, so check the `cfs-batcher` and `cfs-operator` logs for these signatures.
 
 CFS-batcher logs should show that it is creating sessions, but giving up waiting for those sessions to start:
 
-```bash
+```text
 2022-08-24 04:09:12,391 - WARNING - batcher.batch - Session batcher-d7f9bf52-e5f6-4742-849b-4086b1d59ab1 is stuck in pending and will be deleted.
 2022-08-24 04:09:12,492 - WARNING - batcher.batch - Session batcher-77c3c4d1-df39-4ebc-a6b4-32b8e102bdc5 is stuck in pending and will be deleted.
 2022-08-24 04:09:12,638 - WARNING - batcher.batch - Session batcher-f9a513c1-47ad-4539-98cc-b3f418f6b8bd is stuck in pending and will be deleted.
@@ -16,53 +16,67 @@ CFS-batcher logs should show that it is creating sessions, but giving up waiting
 2022-08-24 04:09:15,144 - WARNING - batcher.batch - Session batcher-b6c35dcc-b8b9-421b-9090-23bfc2a72ac3 is stuck in pending and will be deleted.
 ```
 
-CFS-operator logs should show that it is attempting to create sessions but is unable to find the session records.
+CFS-operator logs should show that it is attempting to create sessions, but is unable to find the session records.
 
-```bash
+```text
 2022-08-24 05:48:06,476 - INFO    - cray.cfs.operator.events.session_events - EVENT: CREATE batcher-3b78941e-1c06-474c-89fe-bf241f5002e4
 2022-08-24 05:48:06,509 - ERROR   - cray.cfs.operator.cfs.sessions - Unexpected response from CFS: 404 Client Error: Not Found for url: http://cray-cfs-api/v2/sessions/batcher-3b78941e-1c06-474c-89fe-bf241f5002e4
 ```
 
-If these two things are true, it is likely that CFS is creating new sessions faster than it can keep up with session creation events.
+If these two things are true, then it is likely that CFS is creating new sessions faster than it can keep up with session creation events.
 
 ## Procedure
 
-The primary method of handling this problem is the `batcherMaxBackoff` option.  This will slow automatic session creation in these situations and given the `cfs-operator` a chance to catch up on the backlog.
-If this value has been changed from it's default value of 3600 (1 hour), it should be set back to that value using `cray cfs options update --batcher-max-backoff 3600`.  The issue should eventually resolve automatically.
+The primary method of handling this problem is the `batcherMaxBackoff` option. This will slow automatic session creation in these situations and give the `cfs-operator` a chance to catch up.
 
-If there is a reason that users cannot wait for the back-off to resolve this automatically, the following procedure can be used to purge the event queue.  This will disrupt CFS operation and may disrupt existing sessions, so caution should be used.
+(`ncn-mw#`) If this value has been changed from its default value of 3600 (1 hour), then it should be set back to that value:
 
-1. (`ncn-mw#`) Slow down session creation.  If any others users or scripts are creating sessions, make sure they have stopped.  CFS-batcher should be slowed by setting it's check interval to an arbitrary high number.
+ ```bash
+cray cfs options update --batcher-max-backoff 3600
+```
+
+The issue should eventually resolve automatically.
+
+If there is a reason that users cannot wait for the back-off to resolve this automatically, then the following procedure can be used to purge the event queue. This will disrupt CFS operation and may disrupt existing sessions, so caution should be used.
+
+1. (`ncn-mw#`) Slow down session creation.
+
+    If any others users or scripts are creating sessions, make sure that they have stopped. CFS-batcher should be slowed by setting its check interval to an arbitrary high number.
 
     ```bash
     cray cfs options update --batcher-check-interval 99999
     ```
 
-1. (`ncn-mw#`) Start a new consumer on the Kafka event queue.
+1. Start a new consumer on the Kafka event queue.
 
-    Exec into a Kafka pod.
+    1. (`ncn-mw#`) Open a shell in a Kafka pod.
 
-    ```bash
-    kubectl -n services  exec -it  cray-shared-kafka-kafka-0 -c kafka -- /bin/bash
-    ```
+        ```bash
+        kubectl -n services  exec -it  cray-shared-kafka-kafka-0 -c kafka -- /bin/bash
+        ```
 
-    Then start a console consumer on the cfs event topic using the `cfs-operator` consumer group.
+    1. (`pod#`) Start a console consumer on the CFS event topic using the `cfs-operator` consumer group.
 
-    ```bash
-    bin/kafka-console-consumer.sh --bootstrap-server cray-shared-kafka-kafka-0.cray-shared-kafka-kafka-brokers.services.svc.cluster.local:9092 --topic cfs-session-events --group cfs-operator
-    ```
+        ```bash
+        bin/kafka-console-consumer.sh --bootstrap-server cray-shared-kafka-kafka-0.cray-shared-kafka-kafka-brokers.services.svc.cluster.local:9092 \
+            --topic cfs-session-events --group cfs-operator
+        ```
 
-   This command will likely produce not output at first as Kafka re-balances the consumer group.  Leave this command running.
+       This command will likely produce not output at first, while Kafka re-balances the consumer group. Leave this command running.
 
-1. (`ncn-mw#`) In a new window, scale down the `cfs-operator`.  This forces the console consumer to handle the entire event queue.
+1. (`ncn-mw#`) In a new window, scale down the `cfs-operator`.
+
+    This forces the console consumer to handle the entire event queue.
 
     ```bash
     kubectl -n services scale --replicas=0 deployment/cray-cfs-operator
     ```
 
-1. (`ncn-mw#`) Wait until the output from the console consumer stops.  Once the `cfs-operator` is scaled down there should be a final burst of output.  Wait until all output has stopped for at least a minute before continuing.
+1. (`ncn-mw#`) Wait until the output from the console consumer stops.
 
-1. (`ncn-mw#`) Cancel out of the console consumer.
+    Once the `cfs-operator` is scaled down, there should be a final burst of output from the console consumer. Wait until all output has stopped for at least a minute before continuing.
+
+1. (`pod#`) Cancel the console consumer command and exit the pod shell.
 
 1. (`ncn-mw#`) Restore `cfs-operator`.
 
@@ -72,10 +86,14 @@ If there is a reason that users cannot wait for the back-off to resolve this aut
 
 1. (`ncn-mw#`) Restore `cfs-batcher`.
 
-    ```bash
-    cray cfs options update --batcher-check-interval 10
-    ```
+    1. Restore the batcher check interval.
 
-    ```bash
-    kubectl -n services rollout restart deployment/cray-cfs-batcher
-    ```
+        ```bash
+        cray cfs options update --batcher-check-interval 10
+        ```
+
+    1. Initiate a rolling restart of the batcher.
+
+        ```bash
+        kubectl -n services rollout restart deployment/cray-cfs-batcher
+        ```


### PR DESCRIPTION
# Description

Adds a procedure for purging CFS event queue to help when CFS is stuck handling old events.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

