### PR TITLE
CASMPET-5918 storage upgrade workflow now uses ceph-service-status.sh in csm-testing

### DIFF
--- a/workflows/ncn/worker/storage.rebuild.yaml
+++ b/workflows/ncn/worker/storage.rebuild.yaml
@@ -115,7 +115,7 @@ spec:
                   value: "{{$.DryRun}}"
                 - name: scriptContent
                   value: |
-                    /opt/cray/platform-utils/ceph-service-status.sh -v true || /opt/cray/platform-utils/ceph-service-status.sh -A true -v true
+                    /opt/cray/tests/install/ncn/scripts/ceph-service-status.sh -v true || /opt/cray/tests/install/ncn/scripts/ceph-service-status.sh -A true -v true
           {{- range $index,$value := .TargetNcns}}
           - name: upgrade-{{$value}}
             templateRef:
@@ -148,8 +148,8 @@ spec:
                   value: "{{$.DryRun}}"  
                 - name: scriptContent
                   value: |
-                    /opt/cray/platform-utils/ceph-service-status.sh -v true
-                    /opt/cray/platform-utils/ceph-service-status.sh -n {{$value}} -a true -v true
+                    /opt/cray/tests/install/ncn/scripts/ceph-service-status.sh -v true
+                    /opt/cray/tests/install/ncn/scripts/ceph-service-status.sh -n {{$value}} -a true -v true
           {{- end }}
           - name: rescan-ssh-keys
             templateRef:


### PR DESCRIPTION
… in goss-testing

# Description

<!--- Describe what this change is and what it is for. -->

Storage upgrade workflow now uses ceph-service-status.sh in csm-testing.

Tested on Fanta upgrade to from 1.2.1 -> 1.3.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I don't have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
