### PR TITLE
CASMINST-5278 force time sync should run before drain

### DIFF
--- a/workflows/ncn/worker/worker.drain.yaml
+++ b/workflows/ncn/worker/worker.drain.yaml
@@ -159,12 +159,44 @@ tasks:
                 sleep 5
               done
             done
+  - name: "force-time-sync"
+    templateRef:
+      name: ssh-template
+      template: shell-script
+    arguments:
+      parameters:
+        - name: dryRun
+          value: "{{ `{{inputs.parameters.dryRun}}` }}"
+        - name: scriptContent
+          value: |
+            {{- include "common.envar" . | indent 12 }}
+
+            SSH_OPT="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+
+            ssh $SSH_OPT "$TARGET_NCN" "TOKEN=$TOKEN /srv/cray/scripts/common/chrony/csm_ntp.py"
+            loop_idx=0
+            in_sync=$(ssh $SSH_OPT "${TARGET_NCN}" timedatectl | awk /synchronized:/'{print $NF}')
+            if [[ "$in_sync" == "no" ]]; then
+                ssh $SSH_OPT "$TARGET_NCN" chronyc makestep
+                sleep 5
+                in_sync=$(ssh $SSH_OPT "${TARGET_NCN}" timedatectl | awk /synchronized:/'{print $NF}')
+                # wait up to 90s for the node to be in sync
+                while [[ $loop_idx -lt 18 && "$in_sync" == "no" ]]; do
+                    sleep 5
+                    in_sync=$(ssh $SSH_OPT "${TARGET_NCN}" timedatectl | awk /synchronized:/'{print $NF}')
+                    loop_idx=$(( loop_idx+1 ))
+                done
+                if [[ "$in_sync" != "yes" ]]; then
+                    exit 1
+                fi
+            fi
   - name: drain
     dependencies:
       - clear-cfs-state
       - ensure-etcd-pods-are-healthy
       - ensure-pg-pods-are-healthy
       - ensure-critical-pods-are-running
+      - force-time-sync
     templateRef:
       name: kubectl-and-curl-template
       template: shell-script
@@ -185,6 +217,7 @@ tasks:
       - ensure-etcd-pods-are-healthy
       - ensure-pg-pods-are-healthy
       - ensure-critical-pods-are-running
+      - force-time-sync
     templateRef:
       name: kubectl-and-curl-template
       template: shell-script

--- a/workflows/ncn/worker/worker.wipe-and-reboot.yaml
+++ b/workflows/ncn/worker/worker.wipe-and-reboot.yaml
@@ -39,41 +39,9 @@ tasks:
               echo "${TARGET_NCN} is missing NTP data in BSS. Please see the procedure which can be found in the 'Known Issues and Bugs' section titled 'Fix BSS Metadata' on the 'Configure NTP on NCNs' page of the CSM documentation."
               exit 1
             fi
-  - name: "force-time-sync"
-    templateRef:
-      name: ssh-template
-      template: shell-script
-    arguments:
-      parameters:
-        - name: dryRun
-          value: "{{ `{{inputs.parameters.dryRun}}` }}"
-        - name: scriptContent
-          value: |
-            {{- include "common.envar" . | indent 12 }}
-
-            SSH_OPT="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
-
-            ssh $SSH_OPT "$TARGET_NCN" "TOKEN=$TOKEN /srv/cray/scripts/common/chrony/csm_ntp.py"
-            loop_idx=0
-            in_sync=$(ssh $SSH_OPT "${TARGET_NCN}" timedatectl | awk /synchronized:/'{print $NF}')
-            if [[ "$in_sync" == "no" ]]; then
-                ssh $SSH_OPT "$TARGET_NCN" chronyc makestep
-                sleep 5
-                in_sync=$(ssh $SSH_OPT "${TARGET_NCN}" timedatectl | awk /synchronized:/'{print $NF}')
-                # wait up to 90s for the node to be in sync
-                while [[ $loop_idx -lt 18 && "$in_sync" == "no" ]]; do
-                    sleep 5
-                    in_sync=$(ssh $SSH_OPT "${TARGET_NCN}" timedatectl | awk /synchronized:/'{print $NF}')
-                    loop_idx=$(( loop_idx+1 ))
-                done
-                if [[ "$in_sync" != "yes" ]]; then
-                    exit 1
-                fi
-            fi
   - name: "get-bootscript-last-access-timestamp"
     dependencies:
       - validate-bss-ntp
-      - force-time-sync
     templateRef:
       name: kubectl-and-curl-template
       template: shell-script


### PR DESCRIPTION
# Description

CASMINST-5278 force time sync should run before drain

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
