### PR TITLE
CASMHMS-5569: Remove private key from SLS docs

### DIFF
--- a/operations/system_layout_service/Dump_SLS_Information.md
+++ b/operations/system_layout_service/Dump_SLS_Information.md
@@ -28,8 +28,6 @@ This procedure requires administrative privileges.
     The SLS dump will be stored in the `sls_dump.json` file. The `sls_dump.json` file is required to perform the SLS load state operation.
 
     ```bash
-    curl -X GET \
-    https://api-gw-service-nmn.local/apis/sls/v1/dumpstate \
-    -H "Authorization: Bearer $(get_token)" \
-    > sls_dump.json
+    curl -X GET https://api-gw-service-nmn.local/apis/sls/v1/dumpstate \
+        -H "Authorization: Bearer $(get_token)" > sls_dump.json
     ```

--- a/operations/system_layout_service/Dump_SLS_Information.md
+++ b/operations/system_layout_service/Dump_SLS_Information.md
@@ -13,7 +13,7 @@ This procedure preserves the information stored in SLS when backing up or reinst
 
 ## Procedure
 
-`ncn-mw#`) Perform the SLS dump.
+(`ncn-mw#`) Perform the SLS dump.
 The SLS dump will be stored in the `sls_dump.json` file. The `sls_dump.json` file is required to perform the SLS load state operation.
 
 ```bash

--- a/operations/system_layout_service/Dump_SLS_Information.md
+++ b/operations/system_layout_service/Dump_SLS_Information.md
@@ -8,7 +8,7 @@ This procedure preserves the information stored in SLS when backing up or reinst
 
 ## Prerequisites
 
-- The Cray Command Line Interface is configured. See [Configure the Cray CLI](../configure_cray_cli.md)
+- The Cray Command Line Interface is configured. See [Configure the Cray CLI](../configure_cray_cli.md).
 - This procedure requires administrative privileges.
 
 ## Procedure

--- a/operations/system_layout_service/Dump_SLS_Information.md
+++ b/operations/system_layout_service/Dump_SLS_Information.md
@@ -16,8 +16,7 @@ This procedure requires administrative privileges.
 
     ```bash
     function get_token () {
-        curl -s -S -d grant_type=client_credentials \
-            -d client_id=admin-client \
+        curl -s -S -d grant_type=client_credentials -d client_id=admin-client \
             -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
             https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token'
     }

--- a/operations/system_layout_service/Dump_SLS_Information.md
+++ b/operations/system_layout_service/Dump_SLS_Information.md
@@ -1,18 +1,18 @@
 # Dump SLS Information
 
-Perform a dump of the System Layout Service \(SLS\) database and an encrypted dump of the credentials stored in Vault.
+Perform a dump of the System Layout Service \(SLS\) database.
 
-This procedure will create three files in the current directory \(private\_key.pem, public\_key.pem, sls\_dump.json\). These files should be kept in a safe and secure place as the private key can decrypt the encrypted passwords stored in the SLS dump file.
+This procedure will create the file `sls_dump.json` in the current directory.
 
 This procedure preserves the information stored in SLS when backing up or reinstalling the system.
 
-### Prerequisites
+## Prerequisites
 
 This procedure requires administrative privileges.
 
-### Procedure
+## Procedure
 
-1.  Use the get\_token function to retrieve a token to validate requests to the API gateway.
+1. (`ncn-mw#`) Use the `get_token` function to retrieve a token to validate requests to the API gateway.
 
     ```bash
     function get_token () {
@@ -23,27 +23,13 @@ This procedure requires administrative privileges.
     }
     ```
 
-2.  Generate a private and public key pair.
+1. (`ncn-mw#`) Perform the SLS dump.
 
-    Execute the following commands to generate a private and public key to use for the dump.
-
-    ```bash
-    openssl genpkey -out private_key.pem -algorithm RSA -pkeyopt rsa_keygen_bits:2048
-    openssl rsa -in private_key.pem -outform PEM -pubout -out public_key.pem
-    ```
-
-    The above commands will create two files the private key private\_key.pem file and the public key public\_key.pem file.
-
-    Make sure to use a new private and public key pair for each dump operation, and do not reuse an existing private and public key pair. The private key should be treated securely because it will be required to decrypt the SLS dump file when the dump is loaded back into SLS. Once the private key is used to load state back into SLS, it should be considered insecure.
-
-3.  Perform the SLS dump.
-
-    The SLS dump will be stored in the sls\_dump.json file. The sls\_dump.json and private\_key.pem files are required to perform the SLS load state operation.
+    The SLS dump will be stored in the `sls_dump.json` file. The `sls_dump.json` file is required to perform the SLS load state operation.
 
     ```bash
-    curl -X POST \
+    curl -X GET \
     https://api-gw-service-nmn.local/apis/sls/v1/dumpstate \
     -H "Authorization: Bearer $(get_token)" \
-    -F public_key=@public_key.pem > sls_dump.json
+    > sls_dump.json
     ```
-

--- a/operations/system_layout_service/Dump_SLS_Information.md
+++ b/operations/system_layout_service/Dump_SLS_Information.md
@@ -8,25 +8,14 @@ This procedure preserves the information stored in SLS when backing up or reinst
 
 ## Prerequisites
 
-This procedure requires administrative privileges.
+- The Cray Command Line Interface is configured. See [Configure the Cray CLI](../configure_cray_cli.md)
+- This procedure requires administrative privileges.
 
 ## Procedure
 
-1. (`ncn-mw#`) Use the `get_token` function to retrieve a token to validate requests to the API gateway.
+`ncn-mw#`) Perform the SLS dump.
+The SLS dump will be stored in the `sls_dump.json` file. The `sls_dump.json` file is required to perform the SLS load state operation.
 
-    ```bash
-    function get_token () {
-        curl -s -S -d grant_type=client_credentials -d client_id=admin-client \
-            -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
-            https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token'
-    }
-    ```
-
-1. (`ncn-mw#`) Perform the SLS dump.
-
-    The SLS dump will be stored in the `sls_dump.json` file. The `sls_dump.json` file is required to perform the SLS load state operation.
-
-    ```bash
-    curl -X GET https://api-gw-service-nmn.local/apis/sls/v1/dumpstate \
-        -H "Authorization: Bearer $(get_token)" > sls_dump.json
-    ```
+```bash
+cray sls dumpstate list --format json > sls_dump.json
+```

--- a/operations/system_layout_service/Load_SLS_Database_with_Dump_File.md
+++ b/operations/system_layout_service/Load_SLS_Database_with_Dump_File.md
@@ -18,4 +18,3 @@ This will upload and overwrite the current SLS database with the contents of the
 ```bash
 cray sls loadstate create sls_dump.json
 ```
-

--- a/operations/system_layout_service/Load_SLS_Database_with_Dump_File.md
+++ b/operations/system_layout_service/Load_SLS_Database_with_Dump_File.md
@@ -7,25 +7,15 @@ Use this procedure to restore SLS data after a system re-install.
 ## Prerequisites
 
 - The System Layout Service \(SLS\) database has been dumped. See [Dump SLS Information](Dump_SLS_Information.md) for more information.
+- The Cray Command Line Interface is configured. See [Configure the Cray CLI](../configure_cray_cli.md)
 - This procedure requires administrative privileges.
 
 ## Procedure
 
-1. (`ncn-mw#`) Use the `get_token` function to retrieve a token to validate requests to the API gateway.
+(`ncn-mw#`) Load the dump file into SLS.
+This will upload and overwrite the current SLS database with the contents of the posted file.
 
-    ```bash
-    function get_token () {
-        curl -s -S -d grant_type=client_credentials -d client_id=admin-client \
-            -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
-            https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token'
-    }
-    ```
+```bash
+cray sls loadstate create sls_dump.json
+```
 
-1. (`ncn-mw#`) Load the dump file into SLS.
-
-    This will upload and overwrite the current SLS database with the contents of the posted file.
-
-    ```bash
-    curl -X POST https://api-gw-service-nmn.local/apis/sls/v1/loadstate \
-        -H "Authorization: Bearer $(get_token)" -F sls_dump=@sls_dump.json
-    ```

--- a/operations/system_layout_service/Load_SLS_Database_with_Dump_File.md
+++ b/operations/system_layout_service/Load_SLS_Database_with_Dump_File.md
@@ -1,16 +1,16 @@
 # Load SLS Database with Dump File
 
-Load the contents of the SLS dump file to restore SLS to the state of the system at the time of the dump. This will upload and overwrite the current SLS database with the contents of the SLS dump file, and update Vault with the encrypted credentials.
+Load the contents of the SLS dump file to restore SLS to the state of the system at the time of the dump. This will upload and overwrite the current SLS database with the contents of the SLS dump file.
 
 Use this procedure to restore SLS data after a system re-install.
 
-### Prerequisites
+## Prerequisites
 
 The System Layout Service \(SLS\) database has been dumped. See [Dump SLS Information](Dump_SLS_Information.md) for more information.
 
-### Procedure
+## Procedure
 
-1.  Use the get\_token function to retrieve a token to validate requests to the API gateway.
+1. (`ncn-mw#`) Use the `get_token` function to retrieve a token to validate requests to the API gateway.
 
     ```bash
     function get_token () {
@@ -21,17 +21,13 @@ The System Layout Service \(SLS\) database has been dumped. See [Dump SLS Inform
     }
     ```
 
-2.  Load the dump file into SLS.
+1. (`ncn-mw#`) Load the dump file into SLS.
 
-    This will upload and overwrite the current SLS database with the contents of the posted file, as well as update the Vault with the encrypted credentials. The private key that was used to generate the SLS dump file is required.
+    This will upload and overwrite the current SLS database with the contents of the posted file.
 
     ```bash
     curl -X POST \
     https://api-gw-service-nmn.local/apis/sls/v1/loadstate \
     -H "Authorization: Bearer $(get_token)" \
-    -F sls_dump=@sls_dump.json \
-    -F private_key=@private_key.pem
+    -F sls_dump=@sls_dump.json
     ```
-
-    After performing the load state operation, the private key should be considered insecure and should no longer be used.
-

--- a/operations/system_layout_service/Load_SLS_Database_with_Dump_File.md
+++ b/operations/system_layout_service/Load_SLS_Database_with_Dump_File.md
@@ -6,7 +6,8 @@ Use this procedure to restore SLS data after a system re-install.
 
 ## Prerequisites
 
-The System Layout Service \(SLS\) database has been dumped. See [Dump SLS Information](Dump_SLS_Information.md) for more information.
+- The System Layout Service \(SLS\) database has been dumped. See [Dump SLS Information](Dump_SLS_Information.md) for more information.
+- This procedure requires administrative privileges.
 
 ## Procedure
 
@@ -14,8 +15,7 @@ The System Layout Service \(SLS\) database has been dumped. See [Dump SLS Inform
 
     ```bash
     function get_token () {
-        curl -s -S -d grant_type=client_credentials \
-            -d client_id=admin-client \
+        curl -s -S -d grant_type=client_credentials -d client_id=admin-client \
             -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
             https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token'
     }

--- a/operations/system_layout_service/Load_SLS_Database_with_Dump_File.md
+++ b/operations/system_layout_service/Load_SLS_Database_with_Dump_File.md
@@ -26,8 +26,6 @@ The System Layout Service \(SLS\) database has been dumped. See [Dump SLS Inform
     This will upload and overwrite the current SLS database with the contents of the posted file.
 
     ```bash
-    curl -X POST \
-    https://api-gw-service-nmn.local/apis/sls/v1/loadstate \
-    -H "Authorization: Bearer $(get_token)" \
-    -F sls_dump=@sls_dump.json
+    curl -X POST https://api-gw-service-nmn.local/apis/sls/v1/loadstate \
+        -H "Authorization: Bearer $(get_token)" -F sls_dump=@sls_dump.json
     ```

--- a/operations/system_layout_service/Load_SLS_Database_with_Dump_File.md
+++ b/operations/system_layout_service/Load_SLS_Database_with_Dump_File.md
@@ -7,7 +7,7 @@ Use this procedure to restore SLS data after a system re-install.
 ## Prerequisites
 
 - The System Layout Service \(SLS\) database has been dumped. See [Dump SLS Information](Dump_SLS_Information.md) for more information.
-- The Cray Command Line Interface is configured. See [Configure the Cray CLI](../configure_cray_cli.md)
+- The Cray Command Line Interface is configured. See [Configure the Cray CLI](../configure_cray_cli.md).
 - This procedure requires administrative privileges.
 
 ## Procedure


### PR DESCRIPTION
# Description

This removes the part that saves vault information when saving the SLS data.

Using a private key allows one to the vault passwords in the SLS
dump. These changes simplify the procedure to save SLS's state,
by not including the vault data.

The backup of the data in Vault is left to the Vault specific
backup procedures.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
