### PR TITLE
CASMINST-5208: Add CannotLoginException as known issue with SSH test

### DIFF
--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -617,7 +617,7 @@ Overall status: PASSED (Passed: 40, Failed: 0)
   Before running this procedure, the static IP address reservation data has not yet been loaded into the
   Hardware State Manager (HSM), so DNS records may be missing.
 
-- After deploying the final NCN, this test may fail with an `UnresolvedHostname` error.
+- After deploying the final NCN, this test may fail with an `UnresolvedHostname` error or a `CannotLoginException`.
 
   To work around this issue, perform the following procedure:
 


### PR DESCRIPTION
# Description

Add an additional symptom of one of the already documented known issues with the internal SSH test. See [CASMINST-5208](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5208) for full details.

This does not need a backport to any other release branches -- the test did not exist in csm-1.0, and the underlying cause of the known issues is fixed in csm-1.3.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
