### PR TITLE
CASMINST-5283 - Fix missing dir when moving csm rbd device

### DIFF
--- a/scripts/csm_rbd_tool.py
+++ b/scripts/csm_rbd_tool.py
@@ -1,3 +1,4 @@
+#! /usr/bin/env python3
 #
 # MIT License
 #
@@ -21,9 +22,10 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-
 virt_file = "/opt/cray/csm/scripts/csm_rbd_tool/bin/activate_this.py"
 exec(compile(open(virt_file, "rb").read(), virt_file, 'exec'), dict(__file__=virt_file))
+
+#execfile(virt_env, dict(__file__=virt_env))
 
 import subprocess
 import socket
@@ -39,6 +41,7 @@ from fabric import *
 import paramiko
 from psutil import disk_partitions
 import shutil
+
 
 
 """
@@ -475,6 +478,10 @@ def main():
     device = ''
     local_host = local_hostname()
 
+    for manager in managers:
+        dir_exists(local_host, mnt_path, manager)
+
+
     if dev_exists:
         test, watcher_ip, watcher_name = is_watched(pool, rbd_name)
         mounted = is_mounted(local_host, mnt_path, watcher_name[0])
@@ -535,8 +542,6 @@ def main():
                 exit(1)
 
     if args.pool_action == 'create' or args.rbd_action == "create":
-        for manager in managers:
-            dir_exists(local_host, mnt_path, manager)
         if not pool_exists:
             watcher_name = ['None']
             if not args.pool_action:


### PR DESCRIPTION
# Description
Fix missing dir when moving the rbd device to another master node
<!--- Describe what this change is and what it is for. -->

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
