### PR TITLE
CASMINST-5207: Add typescripts to upgrade procedure & back them up

### DIFF
--- a/upgrade/README.md
+++ b/upgrade/README.md
@@ -56,7 +56,48 @@ The upgrade is a guided process starting with [Upgrade Management Nodes and CSM 
 - Although it is not recommended, the [Booting CSM `barebones` image](../operations/validate_csm_health.md#5-booting-csm-barebones-image)
   test may be skipped if all compute nodes are active running application workloads.
 
-See [Validate CSM Health](../operations/validate_csm_health.md).
+1. (`ncn-m002#`) If a typescript session is already running in the shell, then first stop it with the `exit` command.
+
+1. (`ncn-m002#`) Start a typescript.
+
+    ```bash
+    script -af /root/csm_upgrade.$(date +%Y%m%d_%H%M%S).post_upgrade_health_validation.txt
+    export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
+    ```
+
+    If additional shells are opened during this procedure, then record those with typescripts as well. When resuming a procedure
+    after a break, always be sure that a typescript is running before proceeding.
+
+1. Validate CSM health.
+
+    See [Validate CSM Health](../operations/validate_csm_health.md).
+
+1. (`ncn-m002#`) Stop typescripts.
+
+    Stop any typescripts that were started during the health validation procedure.
+
+1. (`ncn-m002#`) Backup upgrade logs and typescript files to a safe location.
+
+    1. If any typescript files are on different NCNs, then copy them to `/root` on `ncn-m002`.
+
+    1. Create tar file containing the logs and typescript files.
+
+        > If any typescript file names are not of the form `csm_upgrade.*.txt`, then append their names
+        > to the following `tar` command in order to include them.
+
+        ```bash
+        TARFILE="csm_upgrade.$(date +%Y%m%d_%H%M%S).logs.tgz"
+        tar -czvf "/root/${TARFILE}" /root/csm_upgrade.*.txt /root/output.log /root/pre-m001-reboot-upgrade.log
+        ```
+
+    1. Upload the tar file into S3.
+
+        This step requires that the Cray Command Line Interface is configured on the node. This should have already
+        been done on `ncn-m002` during the upgrade process. If needed, see [Configure the Cray CLI](../operations/configure_cray_cli.md).
+
+        ```bash
+        cray artifacts create config-data "${TARFILE}" "/root/${TARFILE}"
+        ```
 
 ## 5. Next topic
 

--- a/upgrade/Stage_0_Prerequisites.md
+++ b/upgrade/Stage_0_Prerequisites.md
@@ -8,13 +8,28 @@
 
 Stage 0 has several critical procedures which prepare the environment and verify if the environment is ready for the upgrade.
 
-- [Stage 0 - Prerequisites and Preflight Checks](#stage-0---prerequisites-and-preflight-checks)
-  - [Stage 0.1 - Prepare assets](#stage-01---prepare-assets)
-    - [Direct download](#direct-download)
-    - [Manual copy](#manual-copy)
-  - [Stage 0.2 - Prerequisites check](#stage-03---prerequisites-check)
-  - [Stage 0.3 - Backup workload manager data](#stage-04---backup-workload-manager-data)
-  - [Stage completed](#stage-completed)
+- [Start typescript](#start-typescript)
+- [Stage 0.1 - Prepare assets](#stage-01---prepare-assets)
+  - [Direct download](#direct-download)
+  - [Manual copy](#manual-copy)
+- [Stage 0.2 - Prerequisites check](#stage-03---prerequisites-check)
+- [Stage 0.3 - Backup workload manager data](#stage-04---backup-workload-manager-data)
+- [Stop typescript](#stop-typescript)
+- [Stage completed](#stage-completed)
+
+## Start typescript
+
+1. (`ncn-m001#`) If a typescript session is already running in the shell, then first stop it with the `exit` command.
+
+1. (`ncn-m001#`) Start a typescript.
+
+    ```bash
+    script -af /root/csm_upgrade.$(date +%Y%m%d_%H%M%S).stage_0.txt
+    export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
+    ```
+
+If additional shells are opened during this procedure, then record those with typescripts as well. When resuming a procedure
+after a break, always be sure that a typescript is running before proceeding.
 
 ## Stage 0.1 - Prepare assets
 
@@ -207,6 +222,10 @@ Stage 0 has several critical procedures which prepare the environment and verify
 To prevent any possibility of losing workload manager configuration data or files, a backup is required. Execute all backup procedures (for the workload manager in use) located in
 the `Troubleshooting and Administrative Tasks` sub-section of the `Install a Workload Manager` section of the
 `HPE Cray Programming Environment Installation Guide: CSM on HPE Cray EX`. The resulting backup data should be stored in a safe location off of the system.
+
+## Stop typescript
+
+Stop any typescripts that were started during this stage.
 
 ## Stage completed
 

--- a/upgrade/Stage_1.md
+++ b/upgrade/Stage_1.md
@@ -3,7 +3,27 @@
 **Reminder:** If any problems are encountered and the procedure or command output does not provide relevant guidance, see
 [Relevant troubleshooting links for upgrade-related issues](README.md#relevant-troubleshooting-links-for-upgrade-related-issues).
 
-Before starting Stage 1, access the Argo UI to view the progress of this stage. For more information, see [Using the Argo UI](../operations/argo/Using_the_Argo_UI.md).
+- [Start typescript](#start-typescript)
+- [Apply boot order workaround](#apply-boot-order-workaround)
+- [Argo web UI](#argo-web-ui)
+- [Storage node image upgrade](#storage-node-image-upgrade)
+- [Ensure that `rbd` stats monitoring is enabled](#ensure-that-rbd-stats-monitoring-is-enabled)
+- [Stop typescript](#stop-typescript)
+- [Stage completed](#stage-completed)
+
+## Start typescript
+
+1. (`ncn-m001#`) If a typescript session is already running in the shell, then first stop it with the `exit` command.
+
+1. (`ncn-m001#`) Start a typescript.
+
+    ```bash
+    script -af /root/csm_upgrade.$(date +%Y%m%d_%H%M%S).stage_1.txt
+    export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
+    ```
+
+If additional shells are opened during this procedure, then record those with typescripts as well. When resuming a procedure
+after a break, always be sure that a typescript is running before proceeding.
 
 ## Apply boot order workaround
 
@@ -12,6 +32,13 @@ Before starting Stage 1, access the Argo UI to view the progress of this stage. 
 ```bash
 /usr/share/doc/csm/scripts/workarounds/boot-order/run.sh
 ```
+
+## Argo web UI
+
+Before starting [Storage node image upgrade](#storage-node-image-upgrade), access the Argo UI to view the progress of this stage.
+Note that the progress for the current stage will not show up in Argo before the storage node image upgrade script has been started.
+
+For more information, see [Using the Argo UI](../operations/argo/Using_the_Argo_UI.md).
 
 ## Storage node image upgrade
 
@@ -36,6 +63,10 @@ It is possible to upgrade a single storage node at a time using the following co
 ceph config set mgr mgr/prometheus/rbd_stats_pools "kube,smf"
 ceph config set mgr mgr/prometheus/rbd_stats_pools_refresh_interval 600
 ```
+
+## Stop typescript
+
+Stop any typescripts that were started during this stage.
 
 ## Stage completed
 

--- a/upgrade/Stage_3.md
+++ b/upgrade/Stage_3.md
@@ -3,12 +3,32 @@
 **Reminder:** If any problems are encountered and the procedure or command output does not provide relevant guidance, see
 [Relevant troubleshooting links for upgrade-related issues](README.md#relevant-troubleshooting-links-for-upgrade-related-issues).
 
+- [Start typescript](#start-typescript)
+- [Perform upgrade](#perform-upgrade)
+- [Verify Keycloak users](#verify-keycloak-users)
+- [Stop typescript](#stop-typescript)
+- [Stage completed](#stage-completed)
+
+## Start typescript
+
+1. (`ncn-m002#`) If a typescript session is already running in the shell, then first stop it with the `exit` command.
+
+1. (`ncn-m002#`) Start a typescript.
+
+    ```bash
+    script -af /root/csm_upgrade.$(date +%Y%m%d_%H%M%S).stage_3.txt
+    export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
+    ```
+
+If additional shells are opened during this procedure, then record those with typescripts as well. When resuming a procedure
+after a break, always be sure that a typescript is running before proceeding.
+
 ## Perform upgrade
 
 During this stage there will be a brief (approximately five minutes) window where pods with Persistent Volumes (`PV`s) will not be able to migrate between nodes.
 This is due to a redeployment of the Ceph `csi` provisioners into namespaces, in order to accommodate the newer charts and a better upgrade strategy.
 
-1. Set the `SW_ADMIN_PASSWORD` environment variable.
+1. (`ncn-m002#`) Set the `SW_ADMIN_PASSWORD` environment variable.
 
    Set it to the `admin` user password for the switches. This is required for post-upgrade tests.
 
@@ -19,7 +39,7 @@ This is due to a redeployment of the Ceph `csi` provisioners into namespaces, in
    export SW_ADMIN_PASSWORD
    ```
 
-1. Perform the upgrade.
+1. (`ncn-m002#`) Perform the upgrade.
 
    Run `csm-upgrade.sh` to deploy upgraded CSM applications and services.
 
@@ -29,12 +49,17 @@ This is due to a redeployment of the Ceph `csi` provisioners into namespaces, in
 
 ## Verify Keycloak users
 
-Verify that the Keycloak users localize job has completed as expected.
+1. (`ncn-m002#`) Verify that the Keycloak users localize job has completed as expected.
 
-> This section can be skipped if user localization is not required.
+    > This step can be skipped if user localization is not required.
 
-After an upgrade, it is possible that all expected Keycloak users were not localized.
-See [Verification procedure](../operations/security_and_authentication/Keycloak_User_Localization.md#Verification-procedure) to confirm that Keycloak localization has completed as expected.
+    After an upgrade, it is possible that all expected Keycloak users were not localized.
+    See [Verification procedure](../operations/security_and_authentication/Keycloak_User_Localization.md#Verification-procedure)
+    to confirm that Keycloak localization has completed as expected.
+
+## Stop typescript
+
+Stop any typescripts that were started during this stage.
 
 ## Stage completed
 

--- a/upgrade/Stage_4.md
+++ b/upgrade/Stage_4.md
@@ -3,15 +3,39 @@
 **Reminder:** If any problems are encountered and the procedure or command output does not provide relevant guidance, then see
 [Relevant troubleshooting links for upgrade-related issues](README.md#relevant-troubleshooting-links-for-upgrade-related-issues).
 
+- [Ceph upgrade contents](#ceph-upgrade-contents)
+- [Start typescript](#start-typescript)
+- [Procedure](#procedure)
+  - [Initiate upgrade](#initiate-upgrade)
+  - [Diagnose a stalled upgrade](#diagnose-a-stalled-upgrade)
+    - [`UPGRADE_FAILED_PULL: Upgrade: failed to pull target image`](#upgrade_failed_pull-upgrade-failed-to-pull-target-image)
+  - [Troubleshoot a failed upgrade](#troubleshoot-a-failed-upgrade)
+- [Stop typescript](#stop-typescript)
+- [Stage completed](#stage-completed)
+
 ## Ceph upgrade contents
 
 The upgrade includes all fixes from `v15.2.15` through `v16.2.9`. See the [Ceph version index](https://docs.ceph.com/en/latest/releases/pacific/) for details.
 
+## Start typescript
+
+1. (`ncn-m002#`) If a typescript session is already running in the shell, then first stop it with the `exit` command.
+
+1. (`ncn-m002#`) Start a typescript.
+
+    ```bash
+    script -af /root/csm_upgrade.$(date +%Y%m%d_%H%M%S).stage_4.txt
+    export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
+    ```
+
+If additional shells are opened during this procedure, then record those with typescripts as well. When resuming a procedure
+after a break, always be sure that a typescript is running before proceeding.
+
 ## Procedure
 
-* This upgrade is performed using the `cubs_tool`.
-* The `cubs_tool.py` can be found on `ncn-s00[1-3]` in `/srv/cray/script/common/`
-* Unless otherwise noted, all `ceph` commands that may need to be used in this stage may be run on any master node or any of the first three storage
+- This upgrade is performed using the `cubs_tool`.
+- The `cubs_tool.py` can be found on `ncn-s00[1-3]` in `/srv/cray/script/common/`
+- Unless otherwise noted, all `ceph` commands that may need to be used in this stage may be run on any master node or any of the first three storage
   nodes (`ncn-s001`, `ncn-s002`, or `ncn-s003`).
 
 ### Initiate upgrade
@@ -197,6 +221,10 @@ If these steps do not resolve the issue, then contact support for further assist
 ### Troubleshoot a failed upgrade
 
 See [Ceph Orchestrator Usage](../operations/utility_storage/Ceph_Orchestrator_Usage.md) for additional usage and troubleshooting.
+
+## Stop typescript
+
+Stop any typescripts that were started during this stage.
 
 ## Stage completed
 

--- a/upgrade/Stage_5.md
+++ b/upgrade/Stage_5.md
@@ -3,6 +3,25 @@
 **Reminder:** If any problems are encountered and the procedure or command output does not provide relevant guidance, see
 [Relevant troubleshooting links for upgrade-related issues](README.md#relevant-troubleshooting-links-for-upgrade-related-issues).
 
+- [Start typescript](#start-typescript)
+- [Procedure](#procedure)
+- [Stop typescript](#stop-typescript)
+- [Stage completed](#stage-completed)
+
+## Start typescript
+
+1. (`ncn-m002#`) If a typescript session is already running in the shell, then first stop it with the `exit` command.
+
+1. (`ncn-m002#`) Start a typescript.
+
+    ```bash
+    script -af /root/csm_upgrade.$(date +%Y%m%d_%H%M%S).stage_5.txt
+    export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
+    ```
+
+If additional shells are opened during this procedure, then record those with typescripts as well. When resuming a procedure
+after a break, always be sure that a typescript is running before proceeding.
+
 ## Procedure
 
 1. If custom configuration content was merged with content from a previous CSM
@@ -45,14 +64,14 @@
 
    > **IMPORTANT:**
    >
-   > * If using a different branch than the default to include custom
+   > - If using a different branch than the default to include custom
        changes, use the `--git-commit` argument to specify the desired commit on
        the branch including the customizations. Otherwise this argument is not needed.
-   > * By default the latest available CSM release will be applied. Otherwise, the
+   > - By default the latest available CSM release will be applied. Otherwise, the
        release may be specified explicitly using the `--csm-release` argument.
        This argument is not needed if using the default CSM configuration found in the
        product catalog in the earlier step.
-   > * If the existing `ncn-personalization` configuration contains layers other than
+   > - If the existing `ncn-personalization` configuration contains layers other than
        the CSM layer from the `csm-config-management` repository, then the arguments
        to the script should include `--ncn-config-file`. If this argument is not specified,
        then any existing non-`csm` layers will not be preserved in the new
@@ -70,6 +89,10 @@
    ```bash
    cray cfs configurations describe ncn-personalization --format json | tee ncn-personalization.json.new
    ```
+
+## Stop typescript
+
+Stop any typescripts that were started during this stage.
 
 ## Stage completed
 

--- a/upgrade/prepare_for_upgrade.md
+++ b/upgrade/prepare_for_upgrade.md
@@ -2,58 +2,90 @@
 
 Before beginning an upgrade to a new version of CSM, there are a few things to do on the system first.
 
-1. Understand that management service resiliency is reduced during the upgrade.
+- [Reduced resiliency during upgrade](#reduced-resiliency-during-upgrade)
+- [Start typescript](#start-typescript)
+- [Running sessions](#running-sessions)
+- [Health validation](#health-validation)
+- [Stop typescript](#stop-typescript)
+- [Preparation completed](#preparation-completed)
 
-   **Warning:** Although it is expected that compute nodes and application nodes will continue to provide their services
-   without interruption, it is important to be aware that the degree of management services resiliency is reduced during the
-   upgrade. If, while one node is being upgraded, another node of the same type has an unplanned fault that removes it from service,
-   there may be a degraded system. For example, if there are three Kubernetes master nodes and one is being upgraded, the quorum is
-   maintained by the remaining two nodes. If one of those two nodes has a fault before the third node completes its upgrade,
-   then quorum would be lost.
+## Reduced resiliency during upgrade
 
-1. Check for BOS, CFS, CRUS, FAS, or NMD sessions.
+**Warning:** Management service resiliency is reduced during the upgrade.
 
-    1. (`ncn-m001#`) Ensure that these services do not have any sessions in progress.
+Although it is expected that compute nodes and application nodes will continue to provide their services
+without interruption, it is important to be aware that the degree of management services resiliency is reduced during the
+upgrade. If, while one node is being upgraded, another node of the same type has an unplanned fault that removes it from service,
+there may be a degraded system. For example, if there are three Kubernetes master nodes and one is being upgraded, the quorum is
+maintained by the remaining two nodes. If one of those two nodes has a fault before the third node completes its upgrade,
+then quorum would be lost.
 
-        > This SAT command has `shutdown` as one of the command line options, but it will not start a shutdown process on the system.
+## Start typescript
 
-        ```bash
-        sat bootsys shutdown --stage session-checks
-        ```
+1. (`ncn-m001#`) If a typescript session is already running in the shell, then first stop it with the `exit` command.
 
-        Example output:
+1. (`ncn-m001#`) Start a typescript.
 
-        ```text
-        Checking for active BOS sessions.
-        Found no active BOS sessions.
-        Checking for active CFS sessions.
-        Found no active CFS sessions.
-        Checking for active CRUS upgrades.
-        Found no active CRUS upgrades.
-        Checking for active FAS actions.
-        Found no active FAS actions.
-        Checking for active NMD dumps.
-        Found no active NMD dumps.
-        No active sessions exist. It is safe to proceed with the shutdown procedure.
-        ```
+    ```bash
+    script -af /root/csm_upgrade.$(date +%Y%m%d_%H%M%S).prepare_for_upgrade.txt
+    export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
+    ```
 
-        If active sessions are running, then either wait for them to complete or shut down, cancel, or delete them.
+If additional shells are opened during this procedure, then record those with typescripts as well. When resuming a procedure
+after a break, always be sure that a typescript is running before proceeding.
 
-    1. Coordinate with the site to prevent new sessions from starting in these services.
+## Running sessions
 
-        There is currently no method to prevent new sessions from being created as long as the service APIs are accessible on the API gateway.
+BOS, CFS, CRUS, FAS, and NMD sessions should not be started or underway during the CSM upgrade process.
 
-1. Validate CSM Health
+1. (`ncn-m001#`) Ensure that these services do not have any sessions in progress.
+
+    > This SAT command has `shutdown` as one of the command line options, but it will not start a shutdown process on the system.
+
+    ```bash
+    sat bootsys shutdown --stage session-checks
+    ```
+
+    Example output:
+
+    ```text
+    Checking for active BOS sessions.
+    Found no active BOS sessions.
+    Checking for active CFS sessions.
+    Found no active CFS sessions.
+    Checking for active CRUS upgrades.
+    Found no active CRUS upgrades.
+    Checking for active FAS actions.
+    Found no active FAS actions.
+    Checking for active NMD dumps.
+    Found no active NMD dumps.
+    No active sessions exist. It is safe to proceed with the shutdown procedure.
+    ```
+
+    If active sessions are running, then either wait for them to complete or shut down, cancel, or delete them.
+
+1. Coordinate with the site to prevent new sessions from starting in these services.
+
+    There is currently no method to prevent new sessions from being created as long as the service APIs are accessible on the API gateway.
+
+## Health validation
+
+1. Validate CSM health.
 
     Run the CSM health checks to ensure that everything is working properly before the upgrade starts.
 
     **`IMPORTANT`**: See the `CSM Install Validation and Health Checks` procedures in the documentation for the **`CURRENT`** CSM version on
-    the system. The validation procedures in the CSM documentation are not all intended to work on previous versions of CSM.
+    the system. The validation procedures in the CSM documentation are only intended to work with that specific version of CSM.
 
-1. Validate Lustre Health
+1. Validate Lustre health.
 
-   If a Lustre file system is being used, then see the ClusterStor documentation for details on how to check
-   for Lustre health.
+   If a Lustre file system is being used, then see the ClusterStor documentation for details on how to validate Lustre health.
+
+## Stop typescript
+
+Stop any typescripts that were started during this stage.
+
+## Preparation completed
 
 After completing the above steps, proceed to
 [Upgrade Management Nodes and CSM Services](README.md#2-upgrade-management-nodes-and-csm-services).


### PR DESCRIPTION
# Description

This PR adds a step to start a typescript at the beginning of each section of the upgrade procedure, and to stop it at the end of the section. It also makes sure that these are copied over to ncn-m002 when the upgrade moves over to there. A final step is added to the upgrade procedure to back up all of the upgrade log files and typescript files into S3.

I also added a table of contents header to the files which lacked one.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
