### PR TITLE
CASMINST-5284: Update Copy Artifacts instructions in Stage 2.3, step #5.

### DIFF
--- a/upgrade/Stage_2.md
+++ b/upgrade/Stage_2.md
@@ -109,10 +109,9 @@ upgrade procedure pivots to use `ncn-m002` as the new "stable node", in order to
    ```bash
    scp ncn-m001:/root/output.log /root/pre-m001-reboot-upgrade.log &&
              cray artifacts create config-data pre-m001-reboot-upgrade.log /root/pre-m001-reboot-upgrade.log
-   csi_rpm=$(ssh ncn-m001 "find /etc/cray/upgrade/csm/${CSM_REL_NAME}/tarball/${CSM_REL_NAME}/rpm/cray/csm/ -name 'cray-site-init*.rpm'") &&
-             scp ncn-m001:${csi_rpm} /tmp/cray-site-init.rpm &&
+   csi_rpm=$(find /etc/cray/upgrade/csm/${CSM_REL_NAME}/tarball/${CSM_REL_NAME}/rpm/cray/csm/ -name 'cray-site-init*.rpm') &&
              scp ncn-m001:/root/docs-csm-*.noarch.rpm /root/docs-csm-latest.noarch.rpm &&
-             rpm -Uvh --force /tmp/cray-site-init.rpm /root/docs-csm-latest.noarch.rpm
+             rpm -Uvh --force ${csi_rpm} /root/docs-csm-latest.noarch.rpm
    ```
 
 1. Upgrade `ncn-m001`.

--- a/upgrade/Stage_2.md
+++ b/upgrade/Stage_2.md
@@ -109,9 +109,9 @@ upgrade procedure pivots to use `ncn-m002` as the new "stable node", in order to
    ```bash
    scp ncn-m001:/root/output.log /root/pre-m001-reboot-upgrade.log &&
              cray artifacts create config-data pre-m001-reboot-upgrade.log /root/pre-m001-reboot-upgrade.log
-   csi_rpm=$(find /etc/cray/upgrade/csm/${CSM_REL_NAME}/tarball/${CSM_REL_NAME}/rpm/cray/csm/ -name 'cray-site-init*.rpm') &&
+   csi_rpm=$(find "/etc/cray/upgrade/csm/${CSM_REL_NAME}/tarball/${CSM_REL_NAME}/rpm/cray/csm/" -name 'cray-site-init*.rpm') &&
              scp ncn-m001:/root/docs-csm-*.noarch.rpm /root/docs-csm-latest.noarch.rpm &&
-             rpm -Uvh --force ${csi_rpm} /root/docs-csm-latest.noarch.rpm
+             rpm -Uvh --force "${csi_rpm}" /root/docs-csm-latest.noarch.rpm
    ```
 
 1. Upgrade `ncn-m001`.


### PR DESCRIPTION
# Description

Update the instructions to copy artifacts from ncn-m001 to ncn-m002 during the upgrade process to account for the rbd device being moved to ncn-m002 at this point in the upgrade instructions.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
