### PR TITLE
CASMHMS-5690 Update HMS test known issues section with ComponentEndpoint EthernetInterfaces failure and remediation csm-1.2

### DIFF
--- a/troubleshooting/interpreting_hms_health_check_results.md
+++ b/troubleshooting/interpreting_hms_health_check_results.md
@@ -15,7 +15,7 @@
   - [Warning flags incorrectly set in HSM for Mountain BMCs](#warning-flags-incorrectly-set-in-hsm-for-mountain-bmcs)
   - [BMCs set to `On` state in HSM](#bmcs-set-to-on-state-in-hsm)
   - [`ComponentEndpoints` of Redfish subtype `AuxiliaryController` in HSM](#componentendpoints-of-redfish-subtype-auxiliarycontroller-in-hsm)
-  - [`ComponentEndpoints` with `EthernetInterfaces` named `DE*` in HSM](#componentendpoints-of-ethernetinterfaces-named-de-in-hsm)
+  - [`ComponentEndpoints` with `EthernetInterfaces` named `DE*` in HSM](#componentendpoints-with-ethernetinterfaces-named-de-in-hsm)
   - [Custom Roles and SubRoles for Components in HSM](#custom-roles-and-subroles-for-components-in-hsm)
 
 ## Introduction
@@ -315,7 +315,7 @@ This section outlines known issues that cause HMS health check failures. Some of
 - [Warning flags incorrectly set in HSM for Mountain BMCs](#warning-flags-incorrectly-set-in-hsm-for-mountain-bmcs)
 - [BMCs set to `On` state in HSM](#bmcs-set-to-on-state-in-hsm)
 - [`ComponentEndpoints` of Redfish subtype `AuxiliaryController` in HSM](#componentendpoints-of-redfish-subtype-auxiliarycontroller-in-hsm)
-- [`ComponentEndpoints` with `EthernetInterfaces` named `DE*` in HSM](#componentendpoints-of-ethernetinterfaces-named-de-in-hsm)
+- [`ComponentEndpoints` with `EthernetInterfaces` named `DE*` in HSM](#componentendpoints-with-ethernetinterfaces-named-de-in-hsm)
 - [Custom Roles and SubRoles for Components in HSM](#custom-roles-and-subroles-for-components-in-hsm)
 
 ### Warning flags incorrectly set in HSM for Mountain BMCs

--- a/troubleshooting/interpreting_hms_health_check_results.md
+++ b/troubleshooting/interpreting_hms_health_check_results.md
@@ -15,6 +15,7 @@
   - [Warning flags incorrectly set in HSM for Mountain BMCs](#warning-flags-incorrectly-set-in-hsm-for-mountain-bmcs)
   - [BMCs set to `On` state in HSM](#bmcs-set-to-on-state-in-hsm)
   - [`ComponentEndpoints` of Redfish subtype `AuxiliaryController` in HSM](#componentendpoints-of-redfish-subtype-auxiliarycontroller-in-hsm)
+  - [`ComponentEndpoints` with `EthernetInterfaces` named `DE*` in HSM](#componentendpoints-of-ethernetinterfaces-named-de-in-hsm)
   - [Custom Roles and SubRoles for Components in HSM](#custom-roles-and-subroles-for-components-in-hsm)
 
 ## Introduction
@@ -303,17 +304,18 @@ The following types of HMS test failures should be considered blocking for syste
 
 The following types of HMS test failures should **not** be considered blocking for system installations:
 
-- Failures due to hardware issues on individual compute nodes (alerts or warning flags set in HSM)
+- Failures due to hardware issues on individual nodes (alerts or warning flags set in HSM)
 
 It is typically safe to postpone the investigation and resolution of non-blocking failures until after the CSM installation or upgrade has completed.
 
 ## Known issues
 
-This section outlines known issues that cause HMS health check failures. These issues have been fixed in `CSM-1.2` but may still be encountered on `CSM-1.2` systems that have been upgraded from a previous release.
+This section outlines known issues that cause HMS health check failures. Some of these issues have been fixed in `CSM-1.2` but may still be encountered on `CSM-1.2` systems that have been upgraded from a previous release.
 
 - [Warning flags incorrectly set in HSM for Mountain BMCs](#warning-flags-incorrectly-set-in-hsm-for-mountain-bmcs)
 - [BMCs set to `On` state in HSM](#bmcs-set-to-on-state-in-hsm)
 - [`ComponentEndpoints` of Redfish subtype `AuxiliaryController` in HSM](#componentendpoints-of-redfish-subtype-auxiliarycontroller-in-hsm)
+- [`ComponentEndpoints` with `EthernetInterfaces` named `DE*` in HSM](#componentendpoints-of-ethernetinterfaces-named-de-in-hsm)
 - [Custom Roles and SubRoles for Components in HSM](#custom-roles-and-subroles-for-components-in-hsm)
 
 ### Warning flags incorrectly set in HSM for Mountain BMCs
@@ -428,6 +430,33 @@ This issue looks similar to the following in the test output:
 ```
 
 Failures of this test caused by `AuxiliaryController` endpoints for Cassini mezzanine cards can be safely ignored.
+
+### `ComponentEndpoints` with `EthernetInterfaces` named `DE*` in HSM
+
+The following HMS functional test may fail due to a known issue because of `ComponentEndpoints` with `EthernetInterfaces` named `DE*` in HSM:
+
+- `test_smd_component_endpoints_ncn-functional_remote-functional.tavern.yaml`
+
+This issue looks similar to the following in the test output:
+
+```text
+        Traceback (most recent call last):
+          File "/usr/lib/python3.8/site-packages/tavern/schemas/files.py", line 106, in verify_generic
+            verifier.validate()
+          File "/usr/lib/python3.8/site-packages/pykwalify/core.py", line 166, in validate
+            raise SchemaError(u"Schema validation failed:\n - {error_msg}.".format(
+        pykwalify.errors.SchemaError: <SchemaError: error code 2: Schema validation failed:
+         - Value 'DE07A000' does not match pattern '^$|[0-9]+|HPCNet[0-9]+|ManagementEthernet'. Path: '/ComponentEndpoints/34/RedfishSystemInfo/EthernetNICInfo/0/RedfishId'.
+         - Value 'DE07A001' does not match pattern '^$|[0-9]+|HPCNet[0-9]+|ManagementEthernet'. Path: '/ComponentEndpoints/34/RedfishSystemInfo/EthernetNICInfo/1/RedfishId'.: Path: '/'>
+```
+
+Failures of this test caused by `EthernetInterface` IDs of the form `DE*` can be safely ignored.
+
+This issue may be remediated by rediscovering the BMCs with `EthernetInterfaces` named `DE*`.
+
+```bash
+ncn-mw# cray hsm inventory discover create --xnames <xname>
+```
 
 ### Custom Roles and SubRoles for Components in HSM
 

--- a/troubleshooting/interpreting_hms_health_check_results.md
+++ b/troubleshooting/interpreting_hms_health_check_results.md
@@ -304,7 +304,7 @@ The following types of HMS test failures should be considered blocking for syste
 
 The following types of HMS test failures should **not** be considered blocking for system installations:
 
-- Failures due to hardware issues on individual nodes (alerts or warning flags set in HSM)
+- Failures because of hardware issues on individual nodes (alerts or warning flags set in HSM)
 
 It is typically safe to postpone the investigation and resolution of non-blocking failures until after the CSM installation or upgrade has completed.
 

--- a/troubleshooting/interpreting_hms_health_check_results.md
+++ b/troubleshooting/interpreting_hms_health_check_results.md
@@ -433,7 +433,7 @@ Failures of this test caused by `AuxiliaryController` endpoints for Cassini mezz
 
 ### `ComponentEndpoints` with `EthernetInterfaces` named `DE*` in HSM
 
-The following HMS functional test may fail due to a known issue because of `ComponentEndpoints` with `EthernetInterfaces` named `DE*` in HSM:
+There is a known issue that causes the HMS functional test to fail when HSM `ComponentEndpoints` have `EthernetInterfaces` with names of the format `DE*`.
 
 - `test_smd_component_endpoints_ncn-functional_remote-functional.tavern.yaml`
 
@@ -452,7 +452,7 @@ This issue looks similar to the following in the test output:
 
 Failures of this test caused by `EthernetInterface` IDs of the form `DE*` can be safely ignored.
 
-This issue may be remediated by rediscovering the BMCs with `EthernetInterfaces` named `DE*`.
+This issue may be remediated by rediscovering the BMCs associated with these `EthernetInterfaces`.
 
 ```bash
 ncn-mw# cray hsm inventory discover create --xnames <xname>


### PR DESCRIPTION
### Summary and Scope

This PR documents a known issue for the HMS ComponentEndpoints test for HSM in CSM-1.2 where the names of certain EthernetInterfaces in Redfish change and become out-of-sync with HSM.

### Issues and Related PRs

* Resolves CASMHMS-5690.

### Testing

The remediation steps were tested on Frigg by rediscovering the BMC where the failure occurred, rerunning the HMS tests, and verifying that the previously failing test case began to pass.

Was a fresh Install tested? Y
Was an Upgrade tested? N
Was a Downgrade tested? N

### Risks and Mitigations

Documents a known test issue, no risk.