### PR TITLE
Clarify text about istio containers & CSM 1.3 upgrades

### DIFF
--- a/upgrade/1.2.1/README.md
+++ b/upgrade/1.2.1/README.md
@@ -10,7 +10,7 @@ Earlier version of CSM must first be upgraded to at least `v1.2.0`. For informat
 * Fixes two issues in CFS, restoring the additional inventory field functionality.
 * Fixes an issue restoring console services functionality on "Hill" cabinets.
 * Fixes a few issues in PowerDNS where various records were missing in the AXFR transfer.
-* Fixes a rare issue where the Istio container is not available during the upgrade to CSM 1.3.0.
+* Fixes a rare issue where the Istio container would not be available during a future upgrade to CSM 1.3.0.
 * Fixes an issue where a modified NCN image can no longer boot to disk when specified instead of the default PXE boot.
 * Fixes a rare issue where NCNs booted with a modified image containing Slingshot Host Software had NO-CARRIER on all network interfaces.
 * Fixes an issue where CANU generates incorrect VLANs for switch ports connected to UANs over the CHN.


### PR DESCRIPTION
The original text was a little confusing about whether the reference to a CSM 1.3 upgrade was a typo for 1.2 when instead it's about a future upgrade.

This change attempts to clarify that.

Signed-off-by: Chris Samuel (NERSC) <74568771+nerscchris@users.noreply.github.com>

# Description

A minor documentation change to clarify that the mention of CSM 1.3 is a reference to fixing a future upgrade, and not a typo for fixing upgrades to CSM 1.2.

# Checklist Before Merging

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
