### PR TITLE
CASMINST-5241 Added a step to clear any prior enabled CFS sessions from a previous CSM version before creating new CFS sessions for CSM 1.3 content.

### DIFF
--- a/upgrade/Stage_0_Prerequisites.md
+++ b/upgrade/Stage_0_Prerequisites.md
@@ -174,7 +174,7 @@ Stage 0 has several critical procedures which prepare the environment and verify
    [Upgrade Troubleshooting](README.md#relevant-troubleshooting-links-for-upgrade-related-issues).
    If the failure persists, then open a support ticket for guidance before proceeding.
 
-1. (`ncn-m001#`) Before creating a new CFS session for the upgraded content, clear any existing enabled CFS sessions for each Management Node that might still exist for content from the previous version of CSM.
+1. (`ncn-m001#`) Before creating a new CFS session for the upgraded content, clear any existing enabled CFS sessions for each management node that might still exist for content from the previous version of CSM.
 
    ```bash
    for TARGET_XNAME in $(cray hsm state components list --role Management --type Node | grep ^ID  | awk -F\" '{print $2}'); do echo $TARGET_XNAME;curl -s -k -H "Authorization: Bearer ${TOKEN}" -X PATCH "https://api-gw-service-nmn.local/apis/cfs/v2/components/${TARGET_XNAME}" -H 'Content-Type: application/json' -d '{"enabled": true, "state": []}';done

--- a/upgrade/Stage_0_Prerequisites.md
+++ b/upgrade/Stage_0_Prerequisites.md
@@ -174,6 +174,12 @@ Stage 0 has several critical procedures which prepare the environment and verify
    [Upgrade Troubleshooting](README.md#relevant-troubleshooting-links-for-upgrade-related-issues).
    If the failure persists, then open a support ticket for guidance before proceeding.
 
+1. (`ncn-m001#`) Before creating a new CFS session for the upgraded content, clear any existing enabled CFS sessions for each Management Node that might still exist for content from the previous version of CSM.
+
+   ```bash
+   for TARGET_XNAME in $(cray hsm state components list --role Management --type Node | grep ^ID  | awk -F\" '{print $2}'); do echo $TARGET_XNAME;curl -s -k -H "Authorization: Bearer ${TOKEN}" -X PATCH "https://api-gw-service-nmn.local/apis/cfs/v2/components/${TARGET_XNAME}" -H 'Content-Type: application/json' -d '{"enabled": true, "state": []}';done
+   ```
+
 1. (`ncn-m001#`) Assign a new CFS configuration to the worker nodes.
 
    The content of the new CFS configuration is described in *HPE Cray EX System Software Getting Started Guide S-8000*, section


### PR DESCRIPTION
# Description

This PR is to address a bug found in [CASMINST-5241](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5241). The bug indicated the issue was CFS pods in a bad state. In reality the bug is more than that. Its possible there are old or bad CFS pods that are continually trying to run that are invalid and are trying to pull from the 1.2 csm-config during the csm 1.3 upgrade. This causes CFS pods to be left in a bad state. This PR attempts to resolve the issue by finding any CFS pods for the management NCNs, and clearing any CFS state until the correct new 1.3 csm-config is uploaded and enabled.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
