### PR TITLE
CASMTRIAGE-4021 Fix call to `install_grub2` to allow failure

### DIFF
--- a/upgrade/scripts/common/ncn-rebuild-common.sh
+++ b/upgrade/scripts/common/ncn-rebuild-common.sh
@@ -224,7 +224,7 @@ EOF
         if [[ -f ${basedir}/standdown.sh ]]; then
             chmod +x "${basedir}/standdown.sh"
             scp "${basedir}/standdown.sh" "${target_ncn}:/tmp/standdown.sh"
-            # Disable errors, the standdown.sh scripts do not run with set -e and this SSH call shouldn't care either.
+            # Disable errors. The standdown.sh scripts do not run with set -e and this SSH call shouldn't care either.
             set +e
             ssh "${target_ncn}" '/tmp/standdown.sh'
             set -e

--- a/upgrade/scripts/common/ncn-rebuild-common.sh
+++ b/upgrade/scripts/common/ncn-rebuild-common.sh
@@ -224,7 +224,10 @@ EOF
         if [[ -f ${basedir}/standdown.sh ]]; then
             chmod +x "${basedir}/standdown.sh"
             scp "${basedir}/standdown.sh" "${target_ncn}:/tmp/standdown.sh"
+            # Disable errors, the standdown.sh scripts do not run with set -e and this SSH call shouldn't care either.
+            set +e
             ssh "${target_ncn}" '/tmp/standdown.sh'
+            set -e
         else
             echo >&2 "${target_ncn} has nothing to standdown! This is not expected."
             exit 1


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
This will allow failures from the `install_grub2` function, which should not be failing but is not the primary objective of the workaround. The primary objective of the bootorder workaround is to ensure that `setup_uefi_bootorder` is invoked.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
