### PR TITLE
CASMTRIAGE-4039 Fix disk selection

### DIFF
--- a/install/pre-installation.md
+++ b/install/pre-installation.md
@@ -206,7 +206,7 @@ On first login, the LiveCD will prompt the administrator to change the password.
       Use a local disk for `PITDATA`:
 
       ```bash
-      disk="$(lsblk -l -o SIZE,NAME,TYPE,TRAN -e7 -d -n | sort -h | awk '{print $2}' | xargs -I {} bash -c "if ! grep -Fq {} /proc/mdstat; then echo {}; fi")"
+      disk="$(lsblk -l -o SIZE,NAME,TYPE,TRAN -e7 -e11 -d -n | grep -v usb | sort -h | awk '{print $2}' | xargs -I {} bash -c "if ! grep -Fq {} /proc/mdstat; then echo {}; fi" | head -n 1)"
       echo "Using ${disk}"
       parted --wipesignatures -m --align=opt --ignore-busy -s "/dev/${disk}" -- mklabel gpt mkpart primary ext4 2048s 100%
       partprobe "/dev/${disk}"


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
The current disk selection command was providing more than 1 device.

```bash
 lsblk -l -o SIZE,NAME,TYPE,TRAN -e7 -d -n | sort -h | awk '{print $2}' | xargs -I {} bash -c "if ! grep -Fq {} /proc/mdstat; then echo {}; fi"
sr0
sdb
sde
sdd
```

The command was properly returning devices that are not included in the old RAID, but it would coincidentally return sr0 (the remoteISO) *first* in some cases. This command has previously not returned `sr0` first in other installs, in which case it has worked.

The multiple return is sloppy, but doesn't break the command. This change fixes the search command so that it ignores USBs and ROMs, preventing invalid devices like `sr0` from being used.

Before:
```bash
loki-ncn-m001-pit:~ # lsblk -l -o SIZE,NAME,TYPE,TRAN -e7 -d -n
447.1G sda  disk sata
447.1G sdb  disk sata
447.1G sdc  disk sata
923.6G sdd  disk usb
460.3G sde  disk usb
  1.6G sr0  rom  usb
```

New `lsblk`:
```bash
loki-ncn-m001-pit:~ # lsblk -l -o SIZE,NAME,TYPE,TRAN -e7 -e11 -d -n | grep -v usb
447.1G sda  disk sata
447.1G sdb  disk sata
447.1G sdc  disk sata
```

The new `lsblk` command when used in the full disk selection command now produces this (filtering the RAIDed disks out):
```bash
disk="$(lsblk -l -o SIZE,NAME,TYPE,TRAN -e7 -e11 -d -n | grep -v usb | sort -h | awk '{print $2}' | xargs -I {} bash -c "if ! grep -Fq {} /proc/mdstat; then echo {}; fi" | head -n 1)"
echo "Using ${disk}"
```
output:
```text
Using sdb
```

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
