### PR TITLE
CASMTRIAGE-4040: don't quote array

### DIFF
--- a/install/re-installation.md
+++ b/install/re-installation.md
@@ -77,13 +77,13 @@ Power each NCN off using `ipmitool` from `ncn-m001` (or the PIT node, if reinsta
 1. (`ncn#` or `pit#`) Power off NCNs.
 
     ```bash
-    printf "%s\n" "${BMCS[@]}" | xargs -t -i ipmitool -I lanplus -U "${username}" -E -H {} power off
+    printf "%s\n" ${BMCS[@]} | xargs -t -i ipmitool -I lanplus -U "${username}" -E -H {} power off
     ```
 
 1. (`ncn#` or `pit#`) Check the power status to confirm that the nodes have powered off.
 
     ```bash
-    printf "%s\n" "${BMCS[@]}" | xargs -t -i ipmitool -I lanplus -U "${username}" -E -H {} power status
+    printf "%s\n" ${BMCS[@]} | xargs -t -i ipmitool -I lanplus -U "${username}" -E -H {} power status
     ```
 
 ## Set node BMCs to DHCP
@@ -112,7 +112,7 @@ BMCs to be set back to DHCP before proceeding.
    ```bash
    function bmcs_set_dhcp {
       local lan=1
-      for bmc in "${BMCS[@]}"; do
+      for bmc in ${BMCS[@]}; do
          # by default the LAN for the BMC is lan channel 1, except on Intel systems.
          if ipmitool -I lanplus -U "${username}" -E -H "${bmc}" lan print 3 2>/dev/null; then
             lan=3
@@ -132,7 +132,7 @@ BMCs to be set back to DHCP before proceeding.
 
     ```bash
    function bmcs_cold_reset {
-      for bmc in "${BMCS[@]}"; do
+      for bmc in ${BMCS[@]}; do
          printf "Setting %s to DHCP ... " "${bmc}"
          if ipmitool -I lanplus -U "${username}" -E -H "${bmc}" mc reset cold; then
             echo "Done"


### PR DESCRIPTION
# Description

Don't quote the array when iterating over it. Doing so results
in preservation of an unwanted newline character.

```
ncn-m002:~ # for bmc in "${BMCS[@]}"; do echo "bmc: $bmc"; done
bmc: ncn-m002-mgmt

bmc: ncn-m003-mgmt

bmc: ncn-s001-mgmt

bmc: ncn-s002-mgmt

bmc: ncn-s003-mgmt

bmc: ncn-s004-mgmt

bmc: ncn-w001-mgmt

bmc: ncn-w002-mgmt

bmc: ncn-w003-mgmt

ncn-m002:~ # for bmc in ${BMCS[@]}; do echo "bmc: $bmc"; done
bmc: ncn-m002-mgmt
bmc: ncn-m003-mgmt
bmc: ncn-s001-mgmt
bmc: ncn-s002-mgmt
bmc: ncn-s003-mgmt
bmc: ncn-s004-mgmt
bmc: ncn-w001-mgmt
bmc: ncn-w002-mgmt
bmc: ncn-w003-mgmt
ncn-m002:~ #
```