### PR TITLE
Cleanup pod resource limits page and script reference (CASMPET-5929)

### DIFF
--- a/operations/kubernetes/Determine_if_Pods_are_Hitting_Resource_Limits.md
+++ b/operations/kubernetes/Determine_if_Pods_are_Hitting_Resource_Limits.md
@@ -1,134 +1,106 @@
 # Determine if Pods are Hitting Resource Limits
 
-Determine if a pod is being CPU throttled or hitting its memory limits \(OOMKilled\). Use the detect\_cpu\_throttling.sh script to determine if any pods are being CPU throttled, and check the Kubernetes events to see if any pods are hitting a memory limit.
+Determine if a pod is being CPU throttled or hitting its memory limits (`OOMKilled`).
+Use the `/opt/cray/platform-utils/detect_cpu_throttling.sh` script to determine if any pods are being CPU throttled, and check the Kubernetes events to see if any pods are hitting a memory limit.
 
-**IMPORTANT:** The presence of CPU throttling does not always indicate a problem, but if a service is being slow or experiencing latency issues, this procedure can be used to evaluate if it is not performing well as a result of CPU throttling.
+**IMPORTANT:** The presence of CPU throttling does not always indicate a problem, but if a service is being slow or experiencing latency issues,
+this procedure can be used to evaluate if it is not performing well as a result of CPU throttling.
 
 Identify pods that are hitting resource limits in order to increase the resource limits for those pods.
 
-### Prerequisites
+## Prerequisites
 
 `kubectl` is installed.
 
+## Procedure
 
-### Procedure
+1. Use the `/opt/cray/platform-utils/detect_cpu_throttling.sh` script to determine if any pods are being CPU throttled _(this script is installed on master and worker NCNs)_.  The script can be used in two different ways:
 
-1.  Use the detect\_cpu\_throttling.sh script to determine if any pods are being CP throttled.
+    1. (`ncn-mw#`) Pass in a substring of the desired pod names.
 
-    1.  Install the script.
+       In this example, the `externaldns` pods are being used:
 
-        The script can be installed on `ncn-w001`, or any NCN that can SSH to worker nodes.
+       ```bash
+       /opt/cray/platform-utils/detect_cpu_throttling.sh externaldns
+       ```
 
-        ```bash
-        ncn-w001# cat detect_cpu_throttling.sh
-        #!/bin/sh
-        # Usage: detect_cpu_throttling.sh [pod_name_substr] (default evaluates all pods)
+       Example output:
 
-        str=$1
-        : ${str:=.}
+       ```text
+       Checking cray-externaldns-coredns-58b5f8494-c45kh
 
-        while read ns pod node; do
-          echo ""
-          echo "Checking $pod"
-          while read -r container; do
-            uid=$(echo $container | awk 'BEGIN { FS = "/" } ; {print $NF}')
-            ssh -T ${node} <<-EOF
-                dir=$(find /sys/fs/cgroup/cpu,cpuacct/kubepods/burstable -name *${uid}* 2>/dev/null)
-                [ "${dir}" = "" ] && { dir=$(find /sys/fs/cgroup/cpu,cpuacct/system.slice/containerd.service -name *${uid}* 2>/dev/null); }
-                if [ "${dir}" != "" ]; then
-                  num_periods=$(grep nr_throttled ${dir}/cpu.stat | awk '{print $NF}')
-                  if [ ${num_periods} -gt 0 ]; then
-                    echo "*** CPU throttling for containerid ${uid}: ***"
-                    cat ${dir}/cpu.stat
-                    echo ""
-                  fi
-                fi
-        	EOF
-          done <<< "`kubectl -n $ns get pod $pod -o yaml | grep ' - containerID'`"
-        done <<<"$(kubectl get pods -A -o wide | grep $str | grep Running | awk '{print $1 " " $2 " " $8}')"
-        ```
+       Checking cray-externaldns-coredns-58b5f8494-pjvz6
 
-    2.  Determine if any pods are being CPU throttled.
+       Checking cray-externaldns-etcd-2kn7w6gnsx
 
-        The script can be used in two different ways:
+       Checking cray-externaldns-etcd-88x4drpv27
 
-    -   Pass in a substring of the desired pod name\(s\).
+       Checking cray-externaldns-etcd-sbnbph52vh
 
-        In the example below, the externaldns pods are being used.
+       Checking cray-externaldns-external-dns-5bb8765896-w87wb
+       *** CPU throttling: ***
+       nr_periods 1127304
+       nr_throttled 473554
+       throttled_time 71962850825439
+       ```
 
-        ```bash
-        ncn-w001# ./detect_cpu_throttling.sh externaldns
-        ```
+    1. (`ncn-mw#`) Call the script without a parameter to evaluate all pods.
 
-        Example output:
+       This can take two minutes or more to run when evaluating all pods:
 
-        ```
-        Checking cray-externaldns-coredns-58b5f8494-c45kh
+       ```bash
+       /opt/cray/platform-utils/detect_cpu_throttling.sh
+       ```
 
-        Checking cray-externaldns-coredns-58b5f8494-pjvz6
+       Example output:
 
-        Checking cray-externaldns-etcd-2kn7w6gnsx
+       ```text
+       Checking benji-k8s-fsfreeze-9zlfk
 
-        Checking cray-externaldns-etcd-88x4drpv27
+       Checking benji-k8s-fsfreeze-fgqmd
 
-        Checking cray-externaldns-etcd-sbnbph52vh
+       Checking benji-k8s-fsfreeze-qgbcp
 
-        Checking cray-externaldns-external-dns-5bb8765896-w87wb
-        *** CPU throttling: ***
-        nr_periods 1127304
-        nr_throttled 473554
-        throttled_time 71962850825439
-        ```
+       Checking benji-k8s-maint-796b444bfc-qcrhx
 
-    -   Call the script without a parameter to evaluate all pods.
+       Checking benji-k8s-postgresql-0
 
-        It can take two minutes or more to run when evaluating all pods:
+       Checking benji-k8s-pushgateway-777fd86545-qrmbr
 
-        ```bash
-        ncn-w001# ./detect_cpu_throttling.sh
-        ```
+       [...]
+       ```
 
-        Example output:
+    1. Interpret the script results.
 
-        ```
-        Checking benji-k8s-fsfreeze-9zlfk
+       * `nr_periods`: How many full periods have been elapsed.
+       * `nr_throttled`: The number of times the full allowed bandwidth was exhausted.
+       * `throttled_time`: The total time the tasks were not run because of being over quota.
+       * See [cgroup documentation](https://kernel.googlesource.com/pub/scm/linux/kernel/git/glommer/memcg/+/cpu_stat/Documentation/cgroups/cpu.txt) for more details.
 
-        Checking benji-k8s-fsfreeze-fgqmd
+1. Check if a pod was killed/restarted because it reached its memory limit.
 
-        Checking benji-k8s-fsfreeze-qgbcp
+    1. (`ncn-mw#`) Look for a Kubernetes event associated with the pod being killed/restarted.
 
-        Checking benji-k8s-maint-796b444bfc-qcrhx
+       ```bash
+       kubectl get events -A | grep -C3 OOM
+       ```
 
-        Checking benji-k8s-postgresql-0
+       Example output:
 
-        Checking benji-k8s-pushgateway-777fd86545-qrmbr
+       ```text
+       default   54m    Warning   OOMKilling  node/ncn-w003  Memory cgroup out of memory: Kill process 1223856 (prometheus) score 1966 or sacrifice child
+       default   44m    Warning   OOMKilling  node/ncn-w003  Memory cgroup out of memory: Kill process 1372634 (prometheus) score 1966 or sacrifice child
+       ```
 
-        [...]
-        ```
+    1. (`ncn-mw#`) Determine which pod was killed using the output of the previous command.
 
-2.  Check if a pod was killed/restarted because it reached its memory limit.
+       Search the pods in Kubernetes for the string returned in the previous step to find the exact pod name.
+       Based on the previous example command output, `prometheus` is used in this example:
 
-    1.  Look for a Kubernetes event associated with the pod being killed/restarted.
+       ```bash
+       kubectl get pod -A | grep prometheus
+       ```
 
-        ```bash
-        ncn-w001# kubectl get events -A | grep -C3 OOM
-        ```
+1. Increase the resource limits for the pods identified in this procedure.
 
-        Example output:
-
-        ```
-        default   54m    Warning   OOMKilling  node/ncn-w003  Memory cgroup out of memory: Kill process 1223856 (prometheus) score 1966 or sacrifice child
-        default   44m    Warning   OOMKilling  node/ncn-w003  Memory cgroup out of memory: Kill process 1372634 (prometheus) score 1966 or sacrifice child
-        ```
-
-    2.  Determine which pod was killed using the output above.
-
-        Use grep on the string returned in the previous step to find the pod name. In this example, prometheus is used.
-
-        ```bash
-        ncn-w001# kubectl get pod -A | grep prometheus
-        ```
-
-
-Follow the procedure to increase the resource limits for the pods identified in this procedure. See [Increase Pod Resource Limits](Increase_Pod_Resource_Limits.md).
-
+    See [Increase Pod Resource Limits](Increase_Pod_Resource_Limits.md) for how to increase these limits.

--- a/operations/kubernetes/Determine_if_Pods_are_Hitting_Resource_Limits.md
+++ b/operations/kubernetes/Determine_if_Pods_are_Hitting_Resource_Limits.md
@@ -16,12 +16,12 @@ Identify pods that are hitting resource limits in order to increase the resource
 
 1. Use the `/opt/cray/platform-utils/detect_cpu_throttling.sh` script to determine if any pods are being CPU throttled _(this script is installed on master and worker NCNs)_.  The script can be used in two different ways:
 
-    1. (`ncn-mw#`) Pass in a substring of the desired pod names.
+    1. Pass in a substring of the desired pod names.
 
        In this example, the `externaldns` pods are being used:
 
        ```bash
-       /opt/cray/platform-utils/detect_cpu_throttling.sh externaldns
+       ncn-mw# /opt/cray/platform-utils/detect_cpu_throttling.sh externaldns
        ```
 
        Example output:
@@ -44,12 +44,12 @@ Identify pods that are hitting resource limits in order to increase the resource
        throttled_time 71962850825439
        ```
 
-    1. (`ncn-mw#`) Call the script without a parameter to evaluate all pods.
+    1. Call the script without a parameter to evaluate all pods.
 
        This can take two minutes or more to run when evaluating all pods:
 
        ```bash
-       /opt/cray/platform-utils/detect_cpu_throttling.sh
+       ncn-mw# /opt/cray/platform-utils/detect_cpu_throttling.sh
        ```
 
        Example output:
@@ -81,10 +81,10 @@ Identify pods that are hitting resource limits in order to increase the resource
 
 1. Check if a pod was killed/restarted because it reached its memory limit.
 
-    1. (`ncn-mw#`) Look for a Kubernetes event associated with the pod being killed/restarted.
+    1. Look for a Kubernetes event associated with the pod being killed/restarted.
 
        ```bash
-       kubectl get events -A | grep -C3 OOM
+       ncn-mw# kubectl get events -A | grep -C3 OOM
        ```
 
        Example output:
@@ -94,13 +94,13 @@ Identify pods that are hitting resource limits in order to increase the resource
        default   44m    Warning   OOMKilling  node/ncn-w003  Memory cgroup out of memory: Kill process 1372634 (prometheus) score 1966 or sacrifice child
        ```
 
-    1. (`ncn-mw#`) Determine which pod was killed using the output of the previous command.
+    1. Determine which pod was killed using the output of the previous command.
 
        Search the pods in Kubernetes for the string returned in the previous step to find the exact pod name.
        Based on the previous example command output, `prometheus` is used in this example:
 
        ```bash
-       kubectl get pod -A | grep prometheus
+       ncn-mw# kubectl get pod -A | grep prometheus
        ```
 
 1. Increase the resource limits for the pods identified in this procedure.

--- a/operations/kubernetes/Determine_if_Pods_are_Hitting_Resource_Limits.md
+++ b/operations/kubernetes/Determine_if_Pods_are_Hitting_Resource_Limits.md
@@ -55,17 +55,19 @@ Identify pods that are hitting resource limits in order to increase the resource
        Example output:
 
        ```text
-       Checking benji-k8s-fsfreeze-9zlfk
+       Checking cray-ceph-csi-cephfs-nodeplugin-zqqvv
 
-       Checking benji-k8s-fsfreeze-fgqmd
+       Checking cray-ceph-csi-cephfs-provisioner-6458879894-cbhlx
 
-       Checking benji-k8s-fsfreeze-qgbcp
+       Checking cray-ceph-csi-cephfs-provisioner-6458879894-wlg86
 
-       Checking benji-k8s-maint-796b444bfc-qcrhx
+       Checking cray-ceph-csi-cephfs-provisioner-6458879894-z85vj
 
-       Checking benji-k8s-postgresql-0
-
-       Checking benji-k8s-pushgateway-777fd86545-qrmbr
+       Checking cray-ceph-csi-rbd-nodeplugin-62478
+       *** CPU throttling for containerid 0f52122395dcf209d851eed7a1125b5af8a7a6ea1d8500287cbddc0335e434a0: ***
+       nr_periods 14338
+       nr_throttled 2
+       throttled_time 590491866
 
        [...]
        ```


### PR DESCRIPTION
# Description

Remove script content for doc page and refer to the one installed by platform-utils.  Also add content for interpreting CPU results (https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5929).

# Checklist Before Merging

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
