### PR TITLE
Fixes #2388 by including the stale expiration

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,6 +3,7 @@
 # You can adjust the behavior by modifying this file.
 # For more information, see:
 # https://github.com/actions/stale
+---
 name: Mark stale issues and pull requests
 
 on:
@@ -18,12 +19,10 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/stale@v5
-      env:
-        expiration: 30
+    - uses: actions/stale@v5.1.1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-close: -1
-        days-before-stale: 30
-        stale-issue-message: 'This issue has not had activity in over ${expiration} days and is being marked as stale.'
-        stale-pr-message: 'This pull-request has not had activity in over ${expiration} days and is being marked as stale.'
+        days-before-stale: 20
+        stale-issue-message: 'This issue has not had activity in over 20 days and is being marked as stale.'
+        stale-pr-message: 'This pull-request has not had activity in over 20 days and is being marked as stale.'


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
Can't find an example of how to use `${expiration}`, so I am just
hardcoding it in like the examples on the plugin site.

Also updates plugin from 5.0.0 to 5.1.1.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
