### PR TITLE
CASMCMS-7474 - create a script to automate cray cli auth.

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -552,6 +552,7 @@ un-deprecated
 Un-rack
 Un-suspend
 unconfigured
+uninitialize
 unixODBC
 unmap
 unregister

--- a/install/configure_administrative_access.md
+++ b/install/configure_administrative_access.md
@@ -21,16 +21,7 @@ BMC/controller passwords.
 > **`NOTE`** The procedures in this section of installation documentation are intended to be done in order, even though the topics are
 > administrative or operational procedures. The topics themselves do not have navigational links to the next topic in the sequence.
 
-## 1. Configure Keycloak account
-
-Upcoming steps in the installation workflow require an account to be configured in Keycloak for
-authentication. This can be either a local Keycloak account or an external Identity Provider (IdP),
-such as LDAP. Having an account in Keycloak with administrative credentials enables the use of many
-management services via the `cray` command.
-
-See [Configure Keycloak Account](../operations/CSM_product_management/Configure_Keycloak_Account.md).
-
-## 2. Configure the Cray command line interface
+## 1. Configure the Cray command line interface
 
 The `cray` command line interface (CLI) is a framework created to integrate all of the system management REST
 APIs into easily usable commands.
@@ -39,9 +30,27 @@ Later procedures in the installation workflow use the `cray` command to interact
 The `cray` CLI configuration needs to be initialized for the Linux account. The Keycloak user who initializes the
 CLI configuration needs to be authorized for administrative actions.
 
-See [Configure the Cray command line interface](../operations/configure_cray_cli.md).
+There are two options to proceed with `cray` CLI authentication:
 
-## 3. Set `Management` role on the BMCs of management nodes
+1. Manually configure the `cray` CLI with a valid Keycloak account.
+
+    1. Configure Keycloak account
+        Upcoming steps in the installation workflow require an account to be configured in Keycloak for
+        authentication. This can be either a local Keycloak account or an external Identity Provider (IdP),
+        such as LDAP. Having an account in Keycloak with administrative credentials enables the use of many
+        management services via the `cray` command.
+
+        See [Configure Keycloak Account](../operations/CSM_product_management/Configure_Keycloak_Account.md).
+
+    1. Initialize and Authorize the `cray` CLI on each NCN being used.
+
+        See [Single User Already Configured in Keycloak](../operations/configure_cray_cli.md#single-user-already-configured-in-keycloak)
+
+1. Configure all NCN's with a temporary Keycloak account for the duration of the install.
+
+    See [Configure All NCNs With Temporary Keycloak User](../operations/configure_cray_cli.md#configure-all-ncns-with-temporary-keycloak-user)
+
+## 2. Set `Management` role on the BMCs of management nodes
 
 The BMCs that control management nodes will not have been marked with the `Management` role in HSM. It is important
 to mark them with the `Management` role so that they can be easily included in the locking/unlocking operations required
@@ -51,7 +60,7 @@ as protections for FAS and CAPMC actions.
 
 See [Set BMC `Management` Role](../operations/hardware_state_manager/Set_BMC_Management_Role.md).
 
-## 4. Lock management nodes
+## 3. Lock management nodes
 
 The management nodes are unlocked at this point in the installation. Locking the management nodes and their BMCs will
 prevent actions from FAS to update their firmware or CAPMC to power off or do a power reset. Doing any of these by
@@ -74,7 +83,7 @@ The return value of the script is 0 if locking was successful. Otherwise, a non-
 
 For more information about locking and unlocking nodes, see [Lock and Unlock Nodes](../operations/hardware_state_manager/Lock_and_Unlock_Management_Nodes.md).
 
-## 5. Configure BMC and controller parameters with SCSD
+## 4. Configure BMC and controller parameters with SCSD
 
 > **`NOTE`** If there are no liquid-cooled cabinets present in the HPE Cray EX system, then this step can be skipped.
 
@@ -86,7 +95,7 @@ on the BMC for node power down or node power up.
 
 See [Configure BMC and Controller Parameters with SCSD](../operations/system_configuration_service/Configure_BMC_and_Controller_Parameters_with_scsd.md).
 
-## 6. Configure non-compute nodes with CFS
+## 5. Configure non-compute nodes with CFS
 
 Non-compute Nodes (NCN) need to be configured after booting for administrative access, security, and other
 purposes. The [Configuration Framework Service (CFS)](../operations/configuration_management/Configuration_Management.md)
@@ -95,7 +104,7 @@ CSM provide one or more layers of configuration in a process called "NCN persona
 
 See [Configure Non-Compute Nodes with CFS](../operations/CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md).
 
-## 7. Upload Olympus BMC recovery firmware into TFTP server
+## 6. Upload Olympus BMC recovery firmware into TFTP server
 
 > **`NOTE`** This step requires the CSM software, Cray CLI, and HPC Firmware Pack (HFP) to be installed.
 > If these are not currently installed, then skip this step and perform it later.
@@ -106,7 +115,7 @@ This procedure does not modify any BMC firmware, but only stages the firmware on
 
 See [Load Olympus BMC Recovery Firmware into TFTP server](../operations/firmware/Upload_Olympus_BMC_Recovery_Firmware_into_TFTP_Server.md).
 
-## 8. Proceed to next topic
+## 7. Proceed to next topic
 
 After completing the operational procedures above which configure administrative access, the next step is to validate the health of management nodes and CSM services.
 

--- a/install/configure_administrative_access.md
+++ b/install/configure_administrative_access.md
@@ -31,23 +31,31 @@ CLI configuration needs to be authorized for administrative actions.
 
 There are two options to proceed with `cray` CLI authentication:
 
-1. Manually configure the `cray` CLI with a valid Keycloak account.
+- [Automatic configuration using temporary Keycloak account](#automatic-configuration-using-temporary-Keycloak-account)
+- [Manual configuration](#manual configuration)
 
-    1. Configure Keycloak account
-        Upcoming steps in the installation workflow require an account to be configured in Keycloak for
-        authentication. This can be either a local Keycloak account or an external Identity Provider (IdP),
-        such as LDAP. Having an account in Keycloak with administrative credentials enables the use of many
-        management services via the `cray` command.
+### Automatic configuration using temporary Keycloak account
 
-        See [Configure Keycloak Account](../operations/CSM_product_management/Configure_Keycloak_Account.md).
+Configure all NCNs with a temporary Keycloak account for the duration of the install.
 
-    1. Initialize and Authorize the `cray` CLI on each NCN being used.
+See [Configure All NCNs With Temporary Keycloak User](../operations/configure_cray_cli.md#configure-all-ncns-with-temporary-keycloak-user).
 
-        See [Single User Already Configured in Keycloak](../operations/configure_cray_cli.md#single-user-already-configured-in-keycloak).
+### Manual configuration
 
-1. Configure all NCNs with a temporary Keycloak account for the duration of the install.
+Manually configure the `cray` CLI with a valid Keycloak account using the following steps:
 
-    See [Configure All NCNs With Temporary Keycloak User](../operations/configure_cray_cli.md#configure-all-ncns-with-temporary-keycloak-user).
+1. Configure Keycloak account
+
+    Upcoming steps in the installation workflow require an account to be configured in Keycloak for
+    authentication. This can be either a local Keycloak account or an external Identity Provider (IdP),
+    such as LDAP. Having an account in Keycloak with administrative credentials enables the use of many
+    management services via the `cray` command.
+
+    See [Configure Keycloak Account](../operations/CSM_product_management/Configure_Keycloak_Account.md).
+
+1. Initialize and authorize the `cray` CLI on each NCN being used.
+
+    See [Single User Already Configured in Keycloak](../operations/configure_cray_cli.md#single-user-already-configured-in-keycloak).
 
 ## 2. Set `Management` role on the BMCs of management nodes
 

--- a/install/configure_administrative_access.md
+++ b/install/configure_administrative_access.md
@@ -43,11 +43,11 @@ There are two options to proceed with `cray` CLI authentication:
 
     1. Initialize and Authorize the `cray` CLI on each NCN being used.
 
-        See [Single User Already Configured in Keycloak](../operations/configure_cray_cli.md#single-user-already-configured-in-keycloak)
+        See [Single User Already Configured in Keycloak](../operations/configure_cray_cli.md#single-user-already-configured-in-keycloak).
 
-1. Configure all NCN's with a temporary Keycloak account for the duration of the install.
+1. Configure all NCNs with a temporary Keycloak account for the duration of the install.
 
-    See [Configure All NCNs With Temporary Keycloak User](../operations/configure_cray_cli.md#configure-all-ncns-with-temporary-keycloak-user)
+    See [Configure All NCNs With Temporary Keycloak User](../operations/configure_cray_cli.md#configure-all-ncns-with-temporary-keycloak-user).
 
 ## 2. Set `Management` role on the BMCs of management nodes
 

--- a/install/configure_administrative_access.md
+++ b/install/configure_administrative_access.md
@@ -9,14 +9,13 @@ BMC/controller passwords.
 
 ## Topics
 
-1. [Configure Keycloak account](#1-configure-keycloak-account)
-1. [Configure the Cray command line interface](#2-configure-the-cray-command-line-interface)
-1. [Set `Management` role on the BMCs of management nodes](#3-set-management-role-on-the-bmcs-of-management-nodes)
-1. [Lock management nodes](#4-lock-management-nodes)
-1. [Configure BMC and controller parameters with SCSD](#5-configure-bmc-and-controller-parameters-with-scsd)
-1. [Configure non-compute nodes with CFS](#6-configure-non-compute-nodes-with-cfs)
-1. [Upload Olympus BMC recovery firmware into TFTP server](#7-upload-olympus-bmc-recovery-firmware-into-tftp-server)
-1. [Proceed to next topic](#8-proceed-to-next-topic)
+1. [Configure the Cray command line interface](#1-configure-the-cray-command-line-interface)
+1. [Set `Management` role on the BMCs of management nodes](#2-set-management-role-on-the-bmcs-of-management-nodes)
+1. [Lock management nodes](#3-lock-management-nodes)
+1. [Configure BMC and controller parameters with SCSD](#4-configure-bmc-and-controller-parameters-with-scsd)
+1. [Configure non-compute nodes with CFS](#5-configure-non-compute-nodes-with-cfs)
+1. [Upload Olympus BMC recovery firmware into TFTP server](#6-upload-olympus-bmc-recovery-firmware-into-tftp-server)
+1. [Proceed to next topic](#7-proceed-to-next-topic)
 
 > **`NOTE`** The procedures in this section of installation documentation are intended to be done in order, even though the topics are
 > administrative or operational procedures. The topics themselves do not have navigational links to the next topic in the sequence.

--- a/install/scripts/craycli_init.py
+++ b/install/scripts/craycli_init.py
@@ -1,0 +1,788 @@
+#!/usr/bin/env python3
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+"""
+This script will set up a new 'temporary' user in Keycloak and use that
+account to initialize the cray CLI on all master, worker, and storage
+nodes of the kubernetes cluster.  Call the script with the '--run'
+option to do this.
+
+If any of the nodes do not have the correct python modules installed,
+or do have have kubernetes configured, the script will fail on that node.
+
+When the install is complete, this script can also remove the temporary
+user and uninitialize the cray CLI on all master and worker node in the
+cluster.  Call the script with the '--cleanup' option to do this.
+
+During the cleanup operation, it is possible to initialze the cray CLI with
+a different existing Keycloak user account.  To do this add a valid username
+and password to the cleanup call:
+python3 craycli_init.py --cleanup --username MY_USER --password MY_PASSWORD
+
+The --nodeinit and --nodecleanup options are intended primarily to be called
+automatically during the 'run' or 'cleanup' operations, but may be used on
+individual nodes to replicate the initialization or cleanup operation on
+a specific individual node.  Just ssh to that node, then call it from there.
+"""
+
+import argparse
+import base64
+import errno
+import logging
+import oauthlib.oauth2
+import os
+import pexpect
+import time
+import requests
+import requests_oauthlib
+import secrets
+import string
+import subprocess
+import sys
+from threading import Thread, Lock
+from kubernetes import client, config
+
+# defaults
+REMOTE_FILE_DIR = "/tmp/"
+CRAYCLI_CONFIG_FILE = "/root/.config/cray/configurations/default"
+DEFAULT_HOSTNAME = 'api-gw-service-nmn.local'
+DEFAULT_KEYCLOAK_BASE = 'https://' + DEFAULT_HOSTNAME + '/keycloak'
+DEFAULT_SLS_BASE = 'https://' + DEFAULT_HOSTNAME + '/apis/sls/v1'
+
+# Global file names and locations
+THIS_FILE_FULL_PATH = os.path.abspath(__file__)
+REMOTE_FILE_NAME = REMOTE_FILE_DIR + os.path.basename(__file__)
+
+# Logger for this script
+LOGGER = logging.getLogger('craycli-init')
+
+# dictionary of [host]:(return code, full remote call output string)
+remote_init_results = dict()
+rir_mutex = Lock()
+
+# error codes for remote initialization
+# NOTE: process return codes are 8 bit so keep these small
+MSG_USER_SECRET = 101
+MSG_REMOTE_COPY_FAILURE = 102
+MSG_CRAY_INIT = 103
+MSG_CRAY_AUTH = 104
+MSG_CRAY_VERIFY = 105
+MSG_MISSING_SCRIPT = 106
+MSG_CONFIGFILE_NOT_PRESENT = 107
+MSG_PYTHON_SCRIPT_ERROR = 108
+MSG_LAST = 109
+INIT_FAILURE_MSG = {
+    MSG_USER_SECRET : "Failed to obtain user secret",
+    MSG_REMOTE_COPY_FAILURE : "Failed to copy script to remote host",
+    MSG_CRAY_INIT : "Call to cray init failed",
+    MSG_CRAY_AUTH : "Call to cray auth login failed",
+    MSG_CRAY_VERIFY : "Verification that cray CLI is operational failed",
+    MSG_MISSING_SCRIPT : "Script missing on remote node",
+    MSG_CONFIGFILE_NOT_PRESENT : "Initialization file not present",
+    MSG_PYTHON_SCRIPT_ERROR : "Python script failed",
+}
+
+class CliUserAuth(object):
+    """
+    Class to manage access to the secret that holds the username and password
+    being used for cray CLI authentication/initialization.
+
+    The information is stored in a k8s secret so that it can be accessed from multiple
+    nodes at different times to get the same information.
+    """
+
+    # defaults - make settable later if needed
+    CLI_USER_AUTH_SECRET_NAME = "craycli-install-tmp-user-auth"
+    CLI_USER_PASSWORD_LENGTH = 40
+    CLI_USER_USERNAME = "craycli_tmp_user"
+
+    def __init__(
+            self,
+            k8sClientApi,
+            createIfNeeded,
+            username = None,
+            password = None
+            ):
+        self._k8sClientApi = k8sClientApi
+        self._createIfNeeded = createIfNeeded
+        self._tu_username = ""
+        self._tu_password = ""
+        self._newUser = username
+        self._newPassword = password
+
+    @property
+    def tu_username(self):
+        if self._tu_username == "":
+            self._getOrCreateUser()
+        return self._tu_username
+
+    @property
+    def tu_password(self):
+        if self._tu_password == "":
+            self._getOrCreateUser()
+        return self._tu_password
+
+    def deleteSecret(self):
+        # delete the secret if it exists
+        sec = None
+        try: 
+            sec = self._k8sClientApi.read_namespaced_secret(self.CLI_USER_AUTH_SECRET_NAME, "services").data
+        except client.exceptions.ApiException:
+            LOGGER.info(f"Secret not present - no need to delete")
+
+        # delete the secret
+        if sec != None:
+            try:
+                self._k8sClientApi.delete_namespaced_secret(name=self.CLI_USER_AUTH_SECRET_NAME, namespace="services", body=sec)
+            except client.exceptions.ApiException:
+                LOGGER.error(f"Error attempting to delete CLI user secret: {err}")
+
+    def _getOrCreateUser(self):
+        # if the secret already exists, read the username and password
+        sec = None
+        try: 
+            sec = self._k8sClientApi.read_namespaced_secret(self.CLI_USER_AUTH_SECRET_NAME, "services")
+            LOGGER.debug(f"Read existing tmp CLI user secret")
+        except client.exceptions.ApiException:
+            LOGGER.debug(f"Temp CLI user secret not present")
+
+        # if the secret does not exist, create a new one
+        if sec == None and self._createIfNeeded:
+            LOGGER.debug(f"Creating new tmp CLI user secret")
+
+            # get username and password to use - defaults or specified
+            newUser = self.CLI_USER_USERNAME
+            if self._newUser != None:
+                newUser = self._newUser
+
+            newPassword = self._newPassword
+            if newPassword == None:
+                # generate a random password
+                alphabet = string.ascii_letters + string.digits
+                newPassword = ''.join(secrets.choice(alphabet) for i in range(self.CLI_USER_PASSWORD_LENGTH))
+
+            # create a secret with the new password and default username
+            sec  = client.V1Secret()
+            sec.metadata = client.V1ObjectMeta(name=self.CLI_USER_AUTH_SECRET_NAME)
+            sec.type = "Opaque"
+            sec.data = {"user": base64.b64encode(newUser.encode('ascii')).decode('ascii'), 
+                        "password": base64.b64encode(newPassword.encode('ascii')).decode('ascii')}
+            try:
+                self._k8sClientApi.create_namespaced_secret(namespace="services", body=sec)
+            except client.exceptions.ApiException as err:
+                # if we can't create the secret, bail
+                LOGGER.error(f"Error attempting to create CLI user secret: {err}")
+                sys.exit(1)
+
+        # pull the values from the secret if present
+        if sec != None:
+            self._tu_username = base64.b64decode(sec.data['user']).decode('ascii')
+            self._tu_password = base64.b64decode(sec.data['password']).decode('ascii')
+        return
+
+class KeycloakSetup(object):
+    """
+    Class to wrap Keycloak authentication with calls to the Keycloak rest api.
+    """
+
+    MASTER_REALM_NAME = 'master'
+    SHASTA_REALM_NAME = 'shasta'
+
+    def __init__(
+            self,
+            keycloak_base,
+            kc_master_admin_client_id,
+            kc_master_admin_username,
+            kc_master_admin_password):
+        self.keycloak_base = keycloak_base
+        self.kc_master_admin_client_id = kc_master_admin_client_id
+        self.kc_master_admin_username = kc_master_admin_username
+        self.kc_master_admin_password = kc_master_admin_password
+
+        self._kc_master_admin_client_cache = None
+
+    # creates/gets a client object with the correct auth tokens present
+    @property
+    def _kc_master_admin_client(self):
+        if self._kc_master_admin_client_cache:
+            return self._kc_master_admin_client_cache
+
+        kc_master_token_endpoint = (
+            '{}/realms/{}/protocol/openid-connect/token'.format(
+                self.keycloak_base, self.MASTER_REALM_NAME))
+
+        kc_master_client = oauthlib.oauth2.LegacyApplicationClient(
+            client_id=self.kc_master_admin_client_id)
+
+        client = requests_oauthlib.OAuth2Session(
+            client=kc_master_client, auto_refresh_url=kc_master_token_endpoint,
+            auto_refresh_kwargs={
+                'client_id': self.kc_master_admin_client_id,
+            },
+            token_updater=lambda t: LOGGER.info("Refreshed Keycloak master admin token"))
+        LOGGER.debug("Fetching initial KC master admin token.")
+        client.fetch_token(
+            token_url=kc_master_token_endpoint,
+            client_id=self.kc_master_admin_client_id,
+            username=self.kc_master_admin_username,
+            password=self.kc_master_admin_password)
+
+        self._kc_master_admin_client_cache = client
+        return self._kc_master_admin_client_cache
+
+    # Create the user in Keycloak with the given password
+    def create_user(self, username, password):
+        # check for valid input
+        if username == "" or password == "":
+            LOGGER.error(f"May not create user with empty name or password")
+            return
+
+        # construct the url and request body to create the user
+        createUserUrl = f"{self.keycloak_base}/admin/realms/{self.SHASTA_REALM_NAME}/users"
+        req_body = {
+            'username': username,
+            'enabled': True,
+            'credentials': [
+                {
+                    'type': 'password',
+                    'value': password,
+                },
+            ]
+        }
+
+        # make the call and parse response
+        response = self._kc_master_admin_client.post(createUserUrl, json=req_body)
+        if response.status_code == 409:
+            LOGGER.debug("User %r already exists", username)
+            return
+        response.raise_for_status()
+
+        # get the id of the user just created
+        userId = self.get_cli_user_id(username)
+        if userId == "":
+            LOGGER.error(f"Unable to get Keycloak user: {username} - user creation failed")
+            sys.exit(1)
+
+        # add the following roles to allow correct permissions to run cray CLI
+        addedShastaRole = self.add_role(userId, "shasta", "admin")
+        addedCrayRole = self.add_role(userId, "cray", "admin")
+
+        # make sure adding at least one role succeeded
+        if not addedShastaRole and not addedCrayRole:
+            LOGGER.warning(f"Did not add user roles, this user may not have the correct permissions required.")
+
+        LOGGER.info(f"Created user {username}")
+
+    # delete the given user from Keycloak
+    def delete_user(self, username):
+        # check the input
+        if username == "":
+            LOGGER.error("Attempting to delete empty username")
+            return
+
+        # get the user id of the desired user
+        userId = self.get_cli_user_id(username)
+        if userId == "":
+            LOGGER.debug(f"Specified user {username} does not exist in Keycloak")
+            return
+
+        # user exists, so delete this user from Keycloak
+        url = f"{self.keycloak_base}/admin/realms/{self.SHASTA_REALM_NAME}/users/{userId}"
+        response = self._kc_master_admin_client.delete(url)
+        response.raise_for_status()
+        LOGGER.info("Deleted user %r", username)
+
+    # get the Keycloak user id for a given username
+    def get_cli_user_id(self, username):
+        LOGGER.debug(f"Looking for id of user: {username}")
+        # check the input
+        if username == "":
+            LOGGER.error("Attempting to find the user id of an empty username")
+            return ""
+
+        # search for the users that match the expected user
+        url = (f"{self.keycloak_base}/admin/realms"
+               f"/{self.SHASTA_REALM_NAME}/users/?username={username}")
+        response = self._kc_master_admin_client.get(url)
+        response.raise_for_status()
+
+        # parse through the responses - returns a list of json objects
+        user_id = ""
+        items = response.json()
+        for item in items:
+            if item["username"] == username:
+                user_id = item["id"]
+                break
+
+        # report what we found
+        LOGGER.debug(f"Keycloak user id: {user_id}")
+        return user_id
+
+    # get the Keycloak client id for a given client name
+    def add_role(self, user_id, clientName, roleName):
+        # search for the users that match the expected user
+        url = (f"{self.keycloak_base}/admin/realms/{self.SHASTA_REALM_NAME}/"
+                f"clients?search={clientName}")
+        response = self._kc_master_admin_client.get(url)
+        response.raise_for_status()
+
+        # parse through the responses - returns a list of json objects
+        client_id = ""
+        items = response.json()
+        for item in items:
+            if item["clientId"] == clientName:
+                client_id = item["id"]
+
+        # make sure we found something
+        if client_id == "":
+            LOGGER.error(f"Unable to find client: {clientName} - unable to add role:{clientName}:{roleName}")
+            return False
+
+        # find the requested role under the client
+        role_id = ""
+        role_name = ""
+        url = (f"{self.keycloak_base}/admin/realms/{self.SHASTA_REALM_NAME}/clients/{client_id}/roles")
+        response = self._kc_master_admin_client.get(url)
+        response.raise_for_status()
+        roles = response.json()
+        for role in roles:
+            if role["name"] == roleName:
+                role_id = role["id"]
+                role_name = role["name"]
+                LOGGER.debug(f"  Found: {role_id}:{role_name}")
+        
+        # make sure we found one
+        if role_id == "":
+            LOGGER.error(f"Unable to find client role: {roleName} - unable to add role:{clientName}:{roleName}")
+            return False
+
+        # add the role to the user
+        addRoleUrl = (f"{self.keycloak_base}/admin/realms/{self.SHASTA_REALM_NAME}/users/{user_id}/role-mappings/clients/{client_id}")
+        req_body = [
+            {
+                "id": role_id,
+                "name": role_name
+            }
+        ]
+        response = self._kc_master_admin_client.post(addRoleUrl, json=req_body)
+        if response.status_code > 399:
+            LOGGER.info(f"Unable to add role: {clientName}:{roleName}")
+            return False
+
+        LOGGER.debug(f"Added role: {clientName}:{roleName}")
+        return True
+
+def read_keycloak_master_admin_secrets(k8sClientApi):
+    # read the secrets from the k8s client
+    try:
+        sec = k8sClientApi.read_namespaced_secret("keycloak-master-admin-auth",
+                "services").data
+        return {
+            'client_id': base64.b64decode(sec['client-id']),
+            'user': base64.b64decode(sec['user']),
+            'password': base64.b64decode(sec['password'])
+        }
+    except client.exceptions.ApiException as err:
+        LOGGER.error(f"Keycloak master admin secret not present: {err}")
+        sys.exit(1)
+
+def run_remote_command(host, cmdOpt):
+    # copy the script file to the remote host
+    fileCpCmd = ["scp", THIS_FILE_FULL_PATH, f"{host}:{REMOTE_FILE_NAME}"]
+    cpOut = subprocess.run(fileCpCmd, shell=False, stdout=subprocess.PIPE, 
+        stderr=subprocess.STDOUT)
+
+    # check for copy failure
+    outStr = cpOut.stdout.decode().rstrip()
+    rc = cpOut.returncode
+    if rc == 0:
+        # copying the script was successful - run the script command on the
+        # remote host using ssh - capture output
+        cmdStr = f"python3 {REMOTE_FILE_NAME} {cmdOpt}"
+        exeOut = subprocess.run(["ssh","-oStrictHostKeyChecking=no", host, cmdStr], 
+            shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+        # if the script file is not present on the remote machine, we need to
+        # interpret that and intercept the error message here
+        outStr = exeOut.stdout.decode().rstrip()
+        rc = exeOut.returncode
+        if rc == 1 and "python3: can't open file" in outStr:
+            rc = MSG_MISSING_SCRIPT
+        elif rc == 1 and "Traceback" in outStr:
+            rc = MSG_PYTHON_SCRIPT_ERROR
+    else:
+        # failed to copy the script to the remote host
+        rc = MSG_REMOTE_COPY_FAILURE
+
+    # report results for this host in a thread safe manner
+    report_remote_init_results(host, rc, outStr)
+
+# mechanism for reporting remote initialization results
+def report_remote_init_results(host, retCode, message):
+    # add the item to the results list
+    global remote_init_results
+    global rir_mutex
+    with rir_mutex:
+        remote_init_results[host] = (retCode, message)
+
+# get the access token to use the k8s gateway
+def getToken(k8sClientApi):
+    # get the secret to request a token for gateway access
+    LOGGER.debug(f"Getting k8s gateway access token")
+    cs = ""
+    try:
+        sec = k8sClientApi.read_namespaced_secret("admin-client-auth","services").data
+        cs = base64.b64decode(sec["client-secret"])
+        LOGGER.debug(f"Read client auth secret")
+    except client.exceptions.ApiException as err:
+        LOGGER.error(f"Unable to read Keycloak client auth secret: {err}")
+        raise SystemExit(err)
+
+    # construct the http call information
+    keycloak_endpoint = DEFAULT_KEYCLOAK_BASE + "/realms/shasta/protocol/openid-connect/token"
+    req_body = {
+        'grant_type': 'client_credentials',
+        'client_id': 'admin-client',
+        'client_secret': cs 
+    }
+
+    # make the call and parse response
+    token = ""
+    try:
+        LOGGER.debug(f"Querying Keycloak for access token")
+        response = requests.post(keycloak_endpoint, data=req_body)
+        response.raise_for_status()
+        token = response.json()["access_token"]
+    except requests.exceptions.ConnectionError as err:
+        LOGGER.error(f"Unable to connect to Keycloak endpoint: {err}")
+        raise SystemExit(err)
+    except requests.exceptions.HTTPError as err:
+        LOGGER.error(f"Unable to obtain gateway token: {err}")
+        raise SystemExit(err)
+
+    return token
+
+# get the management nodes from sls
+def getSlsNodes(k8sClientApi):
+    # TODO: with powerDNS changes, need to add '.hmn' or '.nmn' to the hostnames
+    # https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7474
+
+    LOGGER.debug(f"Finding ncn nodes on the cluster through SLS")
+
+    # mimic the call: 
+    # cray sls hardware list --format json | jq '.[]|select(.ExtraProperties.Role=="Management")|.ExtraProperties.Aliases[0]' | sort
+
+    # get the gateway access token
+    token = getToken(k8sClientApi)
+
+    # search for the users that match the expected user
+    sls_url = f"{DEFAULT_SLS_BASE}/hardware"
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    response = requests.get(sls_url, headers=headers)
+    response.raise_for_status()
+
+    # parse through the responses - returns a list of json objects
+    nodes = []
+    for item in response.json():
+        # filter out the management nodes
+        if 'TypeString' in item and item['TypeString']=="Node" and 'ExtraProperties' in item:
+            # have a node with extra properties defined - see if this is a management node
+            ep = item['ExtraProperties']
+            if 'Role' in ep and ep['Role'] == "Management" and 'Aliases' in ep:
+                nodes.append(ep['Aliases'][0])
+
+    # sort the node names just for fun
+    if len(nodes) > 1:
+        nodes.sort()
+
+    LOGGER.debug(f"Nodes found: {nodes}")
+    return nodes
+
+def doRun(k8sClientApi, makeUserOnly):
+    # Read or create the CLI user secret
+    tmpUser = CliUserAuth(
+            createIfNeeded = True,
+            k8sClientApi = k8sClientApi)
+
+    # initialize the Keycloak access helper
+    LOGGER.info("Loading Keycloak secrets.")
+    kc_master_admin_secrets = read_keycloak_master_admin_secrets(k8sClientApi)
+    keycloak_base = os.environ.get('KEYCLOAK_BASE', DEFAULT_KEYCLOAK_BASE)
+    ks = KeycloakSetup(
+        keycloak_base=keycloak_base,
+        kc_master_admin_client_id=kc_master_admin_secrets['client_id'],
+        kc_master_admin_username=kc_master_admin_secrets['user'],
+        kc_master_admin_password=kc_master_admin_secrets['password'],
+    )
+
+    # create the user in Keycloak
+    ks.create_user(tmpUser.tu_username, tmpUser.tu_password)
+
+    # call the initialization on the set of nodes
+    if makeUserOnly:
+        LOGGER.info("Set to only make user, not initializing nodes")
+    else:
+        LOGGER.info("Initializing nodes:")
+        nodes = getSlsNodes(k8sClientApi)
+        cmdOpt = "--initnode"
+        callRemoteFunc(nodes, cmdOpt)
+
+def callRemoteFunc(nodes, cmdOpt):
+    # reset the remote call results
+    global remote_init_results
+    remote_init_results = dict()
+
+    # call remoteFunc on each host in a separate thread
+    runThreads = []
+    for node in nodes:
+        t = Thread(target=run_remote_command, args=(node,cmdOpt))
+        runThreads.append(t)
+        t.start()
+
+    # wait for all threads to finish
+    for t in runThreads:
+        t.join()
+
+    # report successful initializations first, collecting failed nodes
+    failedNodes = []
+    for host, results in sorted(remote_init_results.items()):
+        if results[0]==0:
+            LOGGER.info(f"{host}: Success")
+        else:
+            failedNodes.append(host)
+
+    # report errors
+    for fn in failedNodes:
+        results = remote_init_results[fn]
+        if results[0] >= MSG_USER_SECRET and results[0]<MSG_LAST:
+            # given a failure code we know - log the message
+            LOGGER.error(f"{fn}: ERROR: {INIT_FAILURE_MSG[results[0]]}")
+            # log the entire call output if debug logging requested
+            LOGGER.debug(f"{fn}: {results[1]}")
+        else:
+            # unknown message, display the entire thing
+            LOGGER.error(f"{fn}: {results[1]}")
+
+# Do initialization of cray CLI on an individual node
+def doIndividualInit(k8sClientApi):
+    """
+    This will only read the user secret and use it to initialize and
+    authorize the cray CLI, it will not create the user secret.  That
+    must be done before calling this function.
+
+    Return codes signify the following:
+    0 - success
+    MSG_USER_SECRET - failed to get user secret
+    MSG_CRAY_INIT - calling 'cray init' failed
+    MSG_CRAY_AUTH - calling 'cray auth login' failed
+    MSG_CRAY_VERIFY - CLI usage verification failed
+    """
+    # get the CLI user secret - should not need to be created
+    tmpUser = CliUserAuth(
+            createIfNeeded = False,
+            k8sClientApi = k8sClientApi)
+    if tmpUser.tu_username == "":
+        LOGGER.error(f"User not found")
+        sys.exit(MSG_USER_SECRET)
+
+    # call cray init with user
+    LOGGER.info("Calling cray init")
+    callExpect("cray init --overwrite",
+        [('Hostname: ', DEFAULT_HOSTNAME),
+        ('Username: ', tmpUser.tu_username),
+        ('Password: ', tmpUser.tu_password)], MSG_CRAY_INIT)
+
+    # call cray auth with user
+    LOGGER.info("Calling cray auth login")
+    callExpect("cray auth login",
+        [('Username: ', tmpUser.tu_username),
+        ('Password: ', tmpUser.tu_password)], MSG_CRAY_AUTH)
+
+    # verify cray CLI is working
+    checkCrayCli(MSG_CRAY_VERIFY)
+
+# Helper function to try a cray CLI call to verify it works
+def checkCrayCli(exitErr):
+    # check that the cray CLI works using the below command:
+    # cray artifacts buckets list -vvv
+    output = subprocess.run(["cray","artifacts","buckets", "list", "-vvv"], 
+        stdout=subprocess.PIPE)
+    outStr = output.stdout.decode()
+    s3Pass = "S3 credentials retrieved successfully" in outStr
+    imsPass = "ims" in outStr
+    slsPass = "sls" in outStr
+    if s3Pass and imsPass and slsPass:
+        LOGGER.info(f"Verified - cray CLI working correctly")
+    else:
+        LOGGER.error(f"FAILED: Cray CLI check failed with: {outStr}")
+        sys.exit(exitErr)
+
+# Helper function to call expect script with command and input pairs
+def callExpect(cmdStr, inputPairs, exitErr):
+    # Use expect to call cray init with the temporary user
+    child = pexpect.spawn(cmdStr)
+
+    # loop through the expected input/output args
+    for elem in inputPairs:
+        child.expect(elem[0])
+        child.sendline(elem[1])
+
+    # capture the rest of the output and wait for the process to exit
+    child.expect(pexpect.EOF)
+    child.wait()
+
+    # check on the status and exit program on failure
+    if child.exitstatus != 0:
+        # something went wrong - pull info out and bail
+        LOGGER.error(f"Error detected")
+        bStr = child.before.decode()
+        errPos = bStr.find("Error")
+        if errPos != -1:
+            LOGGER.error(f"During cray init: {bStr[errPos:].rstrip()}")
+        sys.exit(exitErr)
+
+# Clear the initialization on this node
+def doIndividualCleanup():
+    # remove the config file to 'uninitialize' the cray CLI
+    # NOTE: suppress 'file does not exist' error and re-raise any other errors
+    try:
+        os.remove(CRAYCLI_CONFIG_FILE)
+    except OSError as e:
+        if e.errno == errno.ENOENT:
+            sys.exit(MSG_CONFIGFILE_NOT_PRESENT)
+        else:
+            raise
+
+def doCleanup(k8sClientApi):
+    LOGGER.info("Removing temporary user and uninitializing the cray CLI")
+    # get the CLI user information - should not need to be created
+    tmpUser = CliUserAuth(
+            createIfNeeded = False,
+            k8sClientApi = k8sClientApi)
+    if tmpUser.tu_username != "":
+        # remove the user from Keycloak
+        kc_master_admin_secrets = read_keycloak_master_admin_secrets(k8sClientApi)
+        keycloak_base = os.environ.get('KEYCLOAK_BASE', DEFAULT_KEYCLOAK_BASE)
+        ks = KeycloakSetup(
+            keycloak_base=keycloak_base,
+            kc_master_admin_client_id=kc_master_admin_secrets['client_id'],
+            kc_master_admin_username=kc_master_admin_secrets['user'],
+            kc_master_admin_password=kc_master_admin_secrets['password'],
+        )
+        ks.delete_user(tmpUser.tu_username)
+    else:
+        LOGGER.error("During cleanup no CLI User Auth Secret present")
+
+    # remove the secret from k8s
+    tmpUser.deleteSecret()
+
+    # remove the individual configuration files to 'uninitialize' cray CLI
+    LOGGER.info("Uninitializing nodes:")
+    nodes = getSlsNodes(k8sClientApi)
+    cmdOpt = "--cleanupnode"
+    callRemoteFunc(nodes, cmdOpt)
+
+def doReinitCleanup(k8sClientApi, username, password):
+    # clean out the temporary user initialization
+    doCleanup(k8sClientApi)
+
+    LOGGER.info(f"Re-initializing the cray CLI with existing Keycloak user {username}")
+
+    # create a new secret with the new username and password - used
+    # by individual node initialization
+    reinitUser = CliUserAuth(
+            createIfNeeded = True,
+            k8sClientApi = k8sClientApi,
+            username = username,
+            password = password)
+    if reinitUser.tu_username != "":
+        # the initnode function pulls user/password from secret we just created
+        LOGGER.info("Initializing nodes:")
+        nodes = getSlsNodes(k8sClientApi)
+        cmdOpt = "--initnode"
+        callRemoteFunc(nodes, cmdOpt)
+    else:
+        LOGGER.error("Failed to create new reinitialization user secret")
+
+    # remove the secret from k8s
+    reinitUser.deleteSecret()
+
+def main():
+    # get the command line arguments
+    # NOTE: user must specify one of the following
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--run", action="store_true", 
+        help="Run the script to create Keycloak user and initialize craycli on all ncn hosts")
+    parser.add_argument("--cleanup", action="store_true", 
+        help="Remove craycli initialization and clean up Keycloak user")
+    parser.add_argument("--initnode", action="store_true", 
+        help="Initiailze craycli on this host")
+    parser.add_argument("--cleanupnode", action="store_true", 
+        help="Cleanup craycli on this host")
+    parser.add_argument("--debug", action="store_true", 
+        help="Display debug level log messages")
+    parser.add_argument('-u', "--username", nargs='?', 
+        help='Optional new user for re-init on cleanup')
+    parser.add_argument('-p', "--password", nargs='?', 
+        help='Optional password for re-init on cleanup')
+    parser.add_argument('-userOnly', action="store_true",
+        help='Only create a new user and exit - used with --run')
+    args = parser.parse_args()
+
+    # set up logging
+    logLevel = logging.INFO
+    if args.debug:
+        logLevel = logging.DEBUG
+    log_format = "%(asctime)-15s - %(levelname)-7s - %(message)s"
+    logging.basicConfig(level=logLevel, format=log_format)
+
+    # make sure a selection has been chosen
+    if not args.run and not args.initnode and not args.cleanup and not args.cleanupnode:
+        LOGGER.error("Incorrect input syntax")
+        parser.print_help()
+        sys.exit(1)
+
+    # Load K8s configuration
+    k8sConfig = config.load_kube_config()
+    k8sClientApi = client.CoreV1Api()
+
+    # figure out which part we are running
+    if args.run:
+        doRun(k8sClientApi, args.userOnly)
+    elif args.cleanup:
+        # see if there is a re-init or just cleanup
+        if args.username != None and args.password != None:
+            doReinitCleanup(k8sClientApi, args.username, args.password)
+        elif args.username != None and args.password == None:
+            LOGGER.error("Must supply a password with username for reinitialization")
+        else:
+            doCleanup(k8sClientApi)
+    elif args.initnode:
+        doIndividualInit(k8sClientApi)
+    elif args.cleanupnode:
+        doIndividualCleanup()
+
+if __name__ == '__main__':
+    main()

--- a/install/scripts/craycli_init.py
+++ b/install/scripts/craycli_init.py
@@ -26,25 +26,25 @@
 """
 This script will set up a new 'temporary' user in Keycloak and use that
 account to initialize the cray CLI on all master, worker, and storage
-nodes of the kubernetes cluster.  Call the script with the '--run'
+nodes of the Kubernetes cluster.  Call the script with the '--run'
 option to do this.
 
-If any of the nodes do not have the correct python modules installed,
-or do have have kubernetes configured, the script will fail on that node.
+If any of the nodes do not have the correct Python modules installed,
+or do have have Kubernetes configured, the script will fail on that node.
 
 When the install is complete, this script can also remove the temporary
-user and uninitialize the cray CLI on all master and worker node in the
+user and uninitialize the cray CLI on all master and worker nodes in the
 cluster.  Call the script with the '--cleanup' option to do this.
 
 During the cleanup operation, it is possible to initialize the cray CLI with
-a different existing Keycloak user account.  To do this add a valid username
+a different existing Keycloak user account.  To do this, add a valid username
 and password to the cleanup call:
 python3 craycli_init.py --cleanup --username MY_USER --password MY_PASSWORD
 
 The --nodeinit and --nodecleanup options are intended primarily to be called
 automatically during the 'run' or 'cleanup' operations, but may be used on
 individual nodes to replicate the initialization or cleanup operation on
-a specific individual node.  Just ssh to that node, then call it from there.
+that specific individual node.  Just ssh to that node, then call it from there.
 """
 
 import argparse

--- a/install/scripts/craycli_init.py
+++ b/install/scripts/craycli_init.py
@@ -36,7 +36,7 @@ When the install is complete, this script can also remove the temporary
 user and uninitialize the cray CLI on all master and worker node in the
 cluster.  Call the script with the '--cleanup' option to do this.
 
-During the cleanup operation, it is possible to initialze the cray CLI with
+During the cleanup operation, it is possible to initialize the cray CLI with
 a different existing Keycloak user account.  To do this add a valid username
 and password to the cleanup call:
 python3 craycli_init.py --cleanup --username MY_USER --password MY_PASSWORD
@@ -738,7 +738,7 @@ def main():
     parser.add_argument("--cleanup", action="store_true", 
         help="Remove craycli initialization and clean up Keycloak user")
     parser.add_argument("--initnode", action="store_true", 
-        help="Initiailze craycli on this host")
+        help="Initialize cray CLI on this host")
     parser.add_argument("--cleanupnode", action="store_true", 
         help="Cleanup craycli on this host")
     parser.add_argument("--debug", action="store_true", 

--- a/operations/artifact_management/Manage_Artifacts_with_the_Cray_CLI.md
+++ b/operations/artifact_management/Manage_Artifacts_with_the_Cray_CLI.md
@@ -1,8 +1,10 @@
 # Manage Artifacts with the Cray CLI
 
-The artifacts \(objects\) available for use on the system are created and managed with the Cray CLI. The cray artifacts command provides the ability to manage any given artifact. The Cray CLI automatically authenticates users and provides Simple Storage Service \(S3\) credentials.
+The artifacts \(objects\) available for use on the system are created and managed with the Cray CLI.
+The `cray artifacts` command provides the ability to manage any given artifact. The Cray CLI automatically
+authenticates users and provides Simple Storage Service \(S3\) credentials.
 
-All operations with the cray artifacts command assume that the user has already been authenticated. If the user has not been authenticated with the Cray CLI, run the following command:
+All operations with the `cray artifacts` command assume that the user has already been authenticated. If the user has not been authenticated with the Cray CLI, run the following command:
 
 ```bash
 cray auth login
@@ -10,16 +12,16 @@ cray auth login
 
 Enter the appropriate credentials when prompted:
 
-```
+```bash
 Username: adminuser
 Password:
 ```
 
 `Success!` will be returned if the user is successfully authenticated.
 
-**Authorization is Local to a Host:** whenever you are using the CLI (`cray` command) on a host (e.g. a workstation or NCN) where it has not been used before, it is necessary to authenticate on that host using `cray auth login`. There is no mechanism to distribute CLI authorization amongst hosts.
+For more information on how to initialize and authenticate the `cray` CLI see [Configure the Cray Command Line Interface](../configure_cray_cli.md)
 
-### View S3 Buckets
+## View S3 Buckets
 
 There are several S3 buckets available that can be used to upload and download files with the `cray artifacts` command. To see the list of available S3 buckets:
 
@@ -29,15 +31,15 @@ cray artifacts buckets list
 
 Example output:
 
-```
+```bash
 results = [ "alc", "badger", "benji-backups", "boot-images", "etcd-backup", "fw-update", "ims", "nmd", "sds", "ssm", "vbis", "wlm",]
 ```
 
-### Create and Upload Artifacts
+## Create and Upload Artifacts
 
 Use the `cray artifacts create` command to create an object and upload it to S3.
 
-In the example below, S3\_BUCKET is a placeholder for the bucket name, site/repos/repo.tgz is the object name, and /path/to/repo.tgz is the location of the file to be uploaded to S3 on the local file system.
+In the example below, S3\_BUCKET is a placeholder for the bucket name, `site/repos/repo.tgz` is the object name, and `/path/to/repo.tgz` is the location of the file to be uploaded to S3 on the local file system.
 
 ```bash
 cray artifacts create S3_BUCKET site/repos/repo.tgz /path/to/repo.tgz
@@ -45,7 +47,7 @@ cray artifacts create S3_BUCKET site/repos/repo.tgz /path/to/repo.tgz
 
 Example output:
 
-```
+```bash
 artifact = "5c5b6ae5-64da-4212-887a-301087a17099"
 Key = "site/repos/repo.tgz"
 ```
@@ -54,9 +56,9 @@ In S3, the object name can be path-like and include slashes to resemble files in
 
 When interacting with Cray services, use the artifact value returned by the `cray artifacts create` command. This will ensure that Cray services can access the uploaded object.
 
-### Download Artifacts
+## Download Artifacts
 
-Artifacts are downloaded with the cray artifacts get command. Provide the object name, the bucket, and a file path to download the artifact in order to use this command.
+Artifacts are downloaded with the `cray artifacts get` command. Provide the object name, the bucket, and a file path to download the artifact in order to use this command.
 
 ```bash
 cray artifacts get S3_BUCKET S3_OBJECT_KEY DOWNLOAD_FILEPATH
@@ -70,7 +72,7 @@ cray artifacts get boot-images 5c5b6ae5-64da-4212-887a-301087a17099 /path/to/dow
 
 No output is shown unless an error occurs.
 
-### Delete Artifacts
+## Delete Artifacts
 
 Artifacts are removed from buckets with the `cray artifacts delete` command. Provide the object name and the bucket to delete it.
 
@@ -80,7 +82,7 @@ cray artifacts delete S3_BUCKET S3_OBJECT_KEY
 
 No output is shown unless an error occurs.
 
-### List Artifacts
+## List Artifacts
 
 Use the `cray artifacts list` command to list all artifacts in a bucket.
 
@@ -90,7 +92,7 @@ cray artifacts list S3_BUCKET
 
 Example output:
 
-```
+```bash
 [[artifacts]]
 LastModified = "2020-04-03T12:20:23.876000+00:00"
 ETag = "\"e3f195c20a2399bf1b5a20df12416115\""
@@ -105,7 +107,7 @@ ID = "IMS"
 [...]
 ```
 
-### Retrieve Artifact Details
+## Retrieve Artifact Details
 
 Details of an artifact object in a bucket are found with the `cray artifacts describe` command. The output of this command provides information about the size of the artifact and any metadata associated with the object.
 
@@ -117,7 +119,7 @@ cray artifacts describe S3_BUCKET S3_OBJECT_KEY
 
 Example output:
 
-```
+```bash
 [artifact]
 AcceptRanges = "bytes"
 ContentType = "binary/octet-stream"
@@ -129,4 +131,3 @@ ETag = "\"e3f195c20a2399bf1b5a20df12416115\""
 [artifact.Metadata]
 md5sum = "e3f195c20a2399bf1b5a20df12416115"
 ```
-

--- a/operations/artifact_management/Manage_Artifacts_with_the_Cray_CLI.md
+++ b/operations/artifact_management/Manage_Artifacts_with_the_Cray_CLI.md
@@ -4,7 +4,18 @@ The artifacts \(objects\) available for use on the system are created and manage
 The `cray artifacts` command provides the ability to manage any given artifact. The Cray CLI automatically
 authenticates users and provides Simple Storage Service \(S3\) credentials.
 
-All operations with the `cray artifacts` command assume that the user has already been authenticated. If the user has not been authenticated with the Cray CLI, run the following command:
+- [Authenticate with the CLI](#authenticate-with-the-cli)
+- [View S3 buckets](#view-s3-buckets)
+- [Create and upload artifacts](#create-and-upload-artifacts)
+- [Download artifacts](#download-artifacts)
+- [Delete artifacts](#delete-artifacts)
+- [List artifacts](#list-artifacts)
+- [Retrieve artifact details](#retrieve-artifact-details)
+
+## Authenticate with the CLI
+
+(`ncn#`) All operations with the `cray artifacts` command assume that the user has already been authenticated.
+If the user has not been authenticated with the Cray CLI, then run the following command:
 
 ```bash
 cray auth login
@@ -21,12 +32,13 @@ Password:
 
 For more information on how to initialize and authenticate the `cray` CLI, see [Configure the Cray Command Line Interface](../configure_cray_cli.md).
 
-## View S3 Buckets
+## View S3 buckets
 
-There are several S3 buckets available that can be used to upload and download files with the `cray artifacts` command. To see the list of available S3 buckets:
+(`ncn#`) There are several S3 buckets available that can be used to upload and download files with the `cray artifacts` command.
+In order to see the list of available S3 buckets, run the following command:
 
 ```bash
-cray artifacts buckets list
+cray artifacts buckets list --format toml
 ```
 
 Example output:
@@ -35,7 +47,7 @@ Example output:
 results = [ "alc", "badger", "benji-backups", "boot-images", "etcd-backup", "fw-update", "ims", "nmd", "sds", "ssm", "vbis", "wlm",]
 ```
 
-## Create and Upload Artifacts
+## Create and upload artifacts
 
 Use the `cray artifacts create` command to create an object and upload it to S3.
 
@@ -56,9 +68,9 @@ In S3, the object name can be path-like and include slashes to resemble files in
 
 When interacting with Cray services, use the artifact value returned by the `cray artifacts create` command. This will ensure that Cray services can access the uploaded object.
 
-## Download Artifacts
+## Download artifacts
 
-Artifacts are downloaded with the `cray artifacts get` command. Provide the object name, the bucket, and a file path to download the artifact in order to use this command.
+Artifacts are downloaded with the `cray artifacts get` command. The command requires the object name, the bucket, and a file path for the downloaded artifact.
 
 ```bash
 cray artifacts get S3_BUCKET S3_OBJECT_KEY DOWNLOAD_FILEPATH
@@ -72,9 +84,9 @@ cray artifacts get boot-images 5c5b6ae5-64da-4212-887a-301087a17099 /path/to/dow
 
 No output is shown unless an error occurs.
 
-## Delete Artifacts
+## Delete artifacts
 
-Artifacts are removed from buckets with the `cray artifacts delete` command. Provide the object name and the bucket to delete it.
+Artifacts are removed from buckets with the `cray artifacts delete` command. The command requires the object name and the bucket name.
 
 ```bash
 cray artifacts delete S3_BUCKET S3_OBJECT_KEY
@@ -82,17 +94,17 @@ cray artifacts delete S3_BUCKET S3_OBJECT_KEY
 
 No output is shown unless an error occurs.
 
-## List Artifacts
+## List artifacts
 
 Use the `cray artifacts list` command to list all artifacts in a bucket.
 
 ```bash
-cray artifacts list S3_BUCKET
+cray artifacts list S3_BUCKET --format toml
 ```
 
 Example output:
 
-```bash
+```toml
 [[artifacts]]
 LastModified = "2020-04-03T12:20:23.876000+00:00"
 ETag = "\"e3f195c20a2399bf1b5a20df12416115\""
@@ -103,23 +115,22 @@ Size = 11234
 [artifacts.Owner]
 DisplayName = "Image Management Service User"
 ID = "IMS"
-
-[...]
 ```
 
-## Retrieve Artifact Details
+## Retrieve artifact details
 
-Details of an artifact object in a bucket are found with the `cray artifacts describe` command. The output of this command provides information about the size of the artifact and any metadata associated with the object.
+Details of an artifact object in a bucket are displayed using the `cray artifacts describe` command.
+The output of this command provides information about the size of the artifact and any metadata associated with the object.
 
 **IMPORTANT:** The Cray-specific metadata provided by this command is automatically generated. This metadata should be considered deprecated and should not be used for future development.
 
 ```bash
-cray artifacts describe S3_BUCKET S3_OBJECT_KEY
+cray artifacts describe S3_BUCKET S3_OBJECT_KEY --format toml
 ```
 
 Example output:
 
-```bash
+```toml
 [artifact]
 AcceptRanges = "bytes"
 ContentType = "binary/octet-stream"

--- a/operations/artifact_management/Manage_Artifacts_with_the_Cray_CLI.md
+++ b/operations/artifact_management/Manage_Artifacts_with_the_Cray_CLI.md
@@ -12,14 +12,14 @@ cray auth login
 
 Enter the appropriate credentials when prompted:
 
-```bash
+```text
 Username: adminuser
 Password:
 ```
 
 `Success!` will be returned if the user is successfully authenticated.
 
-For more information on how to initialize and authenticate the `cray` CLI see [Configure the Cray Command Line Interface](../configure_cray_cli.md)
+For more information on how to initialize and authenticate the `cray` CLI, see [Configure the Cray Command Line Interface](../configure_cray_cli.md).
 
 ## View S3 Buckets
 
@@ -31,7 +31,7 @@ cray artifacts buckets list
 
 Example output:
 
-```bash
+```toml
 results = [ "alc", "badger", "benji-backups", "boot-images", "etcd-backup", "fw-update", "ims", "nmd", "sds", "ssm", "vbis", "wlm",]
 ```
 
@@ -39,15 +39,15 @@ results = [ "alc", "badger", "benji-backups", "boot-images", "etcd-backup", "fw-
 
 Use the `cray artifacts create` command to create an object and upload it to S3.
 
-In the example below, S3\_BUCKET is a placeholder for the bucket name, `site/repos/repo.tgz` is the object name, and `/path/to/repo.tgz` is the location of the file to be uploaded to S3 on the local file system.
+In the example below, `S3_BUCKET` is a placeholder for the bucket name, `site/repos/repo.tgz` is the object name, and `/path/to/repo.tgz` is the location of the file to be uploaded to S3 on the local file system.
 
 ```bash
-cray artifacts create S3_BUCKET site/repos/repo.tgz /path/to/repo.tgz
+cray artifacts create S3_BUCKET site/repos/repo.tgz /path/to/repo.tgz --format toml
 ```
 
 Example output:
 
-```bash
+```toml
 artifact = "5c5b6ae5-64da-4212-887a-301087a17099"
 Key = "site/repos/repo.tgz"
 ```

--- a/operations/configure_cray_cli.md
+++ b/operations/configure_cray_cli.md
@@ -2,161 +2,403 @@
 
 The `cray` command line interface (CLI) is a framework created to integrate all of the system management REST APIs into easily usable commands.
 
-Procedures in the CSM installation workflow use the `cray` CLI to interact with multiple services.
+Later procedures in the installation workflow use the `cray` CLI to interact with multiple services.
 The `cray` CLI configuration needs to be initialized for the Linux account, and the Keycloak user running
 the procedure needs to be authorized. This section describes how to initialize the `cray` CLI for use by
 a user and how to authorize that user.
 
 The `cray` CLI only needs to be initialized once per user on a node.
 
-## Procedure
+There are two ways to initialize the `cray` CLI:
 
-1. Unset the `CRAY_CREDENTIALS` environment variable, if previously set.
+1. [Single User Already Configured in Keycloak](#single-user-already-configured-in-keycloak)
 
-   Some CSM installation procedures use the CLI with a Kubernetes managed service
-   account that is normally used for internal operations. There is a procedure for extracting the OAUTH token for
-   this service account and assigning it to the `CRAY_CREDENTIALS` environment variable to permit simple CLI operations.
-   It must be unset in order to validate that the CLI is working with user authentication.
+1. [Configure All NCNs With Temporary Keycloak User](#configure-all-ncns-with-temporary-keycloak-user)
 
-   ```bash
-   unset CRAY_CREDENTIALS
-   ```
+## Single User Already Configured in Keycloak
 
-1. Initialize the `cray` CLI for the `root` account.
+   There are times in normal operation that a particular user must be authenticated on the `cray` CLI. In
+   this case, the user must already be present in Keycloak and have the correct permissions to access the
+   system.
 
-   The `cray` CLI needs to know what host to use to obtain authorization and what user is requesting authorization,
-   so it can obtain an OAUTH token to talk to the API gateway. This is accomplished by initializing the CLI
-   configuration.
+### Procedure For Existing Keycloak User
 
-   In this example, the `vers` username is used. It should be replaced with an appropriate user account:
+1. If a Keycloak user needs to be created, see [Keycloak User Management](security_and_authentication/Access_the_Keycloak_User_Management_UI.md)
 
-   - If LDAP configuration was enabled, then use a valid account in LDAP.
-   - If LDAP configuration was not enabled, or is not working, then a Keycloak local account may be created.
-     See [Configure Keycloak Account](CSM_product_management/Configure_Keycloak_Account.md) to create this local account in Keycloak.
+1. (`ncn-mws#`) Initialize the `cray` CLI
 
-   ```bash
-   cray init --hostname api-gw-service-nmn.local
-   ```
+    ```bash
+    cray init
+    ```
 
-   Expected output (including the typed input) should look similar to the following:
+    Expect the following prompts:
 
-   ```text
-   Username: vers
-   Password:
-   Success!
+    ```bash
+    Overwrite configuration file at: MY_HOME_DIR/.config/cray/configurations/default ? [y/N]: y
+    Cray Hostname: api-gw-service-nmn.local
+    Username: MY_KEYCLOAK_USER_NAME
+    Password: MY_PASSWORD
+    Success!
 
-   Initialization complete.
-   ```
+    Initialization complete.
+    ```
 
-1. Verify that the `cray` CLI is operational.
+1. (`ncn-mws#`) The `cray` CLI may need to be authenticated to complete the setup.
+
+    Use the same Keycloak username and password from the above initialization command. To authenticate to the `cray` CLI:
+
+    ```bash
+    cray auth login
+    ```
+
+    Expect the following prompts:
+
+    ```bash
+    Username: MY_KEYCLOAK_USER_NAME
+    Password: MY_PASSWORD
+    Success!
+    ```
+
+## Configure All NCNs With Temporary Keycloak User
+
+This script will create a new Keycloak account that is authorized for the `cray` CLI and use that account
+to initialize and authorize the `cray` CLI on all master and worker nodes in the cluster. This account is
+only intended to be used for the duration of the install and should be removed when the install is complete.
+
+### Procedure For Temporary Keycloak User
+
+1. (`ncn-mws#`) Unset the `CRAY_CREDENTIALS` environment variable, if previously set.
+
+    Some of the installation procedures leading up to this point use the CLI with a Kubernetes managed service
+    account that is normally used for internal operations. There is a procedure for extracting the OAUTH token for
+    this service account and assigning it to the `CRAY_CREDENTIALS` environment variable to permit simple CLI
+    operations. This needs to be removed prior to `cray` CLI initialization.
+
+    ```bash
+    unset CRAY_CREDENTIALS
+    ```
+
+1. (`ncn-mws#`) Initialize the `cray` CLI for the root account on all master and worker nodes.
+
+    The script will handle creation of the temporary Keycloak user and initialize all master and
+    worker nodes that are in a ready state. Call the script with the `--run` option:
+
+    ```bash
+    python3 /usr/share/doc/csm/install/scripts/craycli_init.py --run
+    ```
+
+    Expect output showing the results of the operation on each node:
+
+    ```bash
+    2021-12-21 15:50:47,814 - INFO    - Loading Keycloak secrets.
+    2021-12-21 15:50:48,095 - INFO    - Created user 'craycli_tmp_user'
+    2021-12-21 15:50:52,714 - INFO    - Initializing nodes:
+    2021-12-21 15:50:52,714 - INFO    - ncn-m001: Success
+    2021-12-21 15:50:52,714 - INFO    - ncn-m002: Success
+    2021-12-21 15:50:52,714 - INFO    - ncn-m003: Success
+    2021-12-21 15:50:52,714 - INFO    - ncn-s001: Success
+    2021-12-21 15:50:52,714 - INFO    - ncn-s002: Success
+    2021-12-21 15:50:52,714 - INFO    - ncn-s003: Success
+    2021-12-21 15:50:52,714 - INFO    - ncn-w001: Success
+    2021-12-21 15:50:52,714 - INFO    - ncn-w002: Success
+    2021-12-21 15:50:52,714 - INFO    - ncn-w003: Success
+    ```
+
+    The `cray` CLI is now operational on all nodes where success was reported. If a node was
+    unsuccessful with initialization, there will be an error reported. See the
+    [troubleshooting](#troubleshooting-results-of-the-automated-script) section for additional information.
+
+1. (`ncn-mws#`) Remove the temporary user after the install is complete.
+
+    **IMPORTANT:** If this section is not followed the temporary user will remain as a valid
+    account in Keycloak. Be sure to clean this up when this user is no longer required.
+
+    When the install is complete and Keycloak is fully populated with the correct end users,
+    call this script again with the `--cleanup` option to remove the temporary user from Keycloak
+    and uninitialize the `cray` CLI on all master and worker nodes in the cluster.
+
+    ```bash
+    python3 /usr/share/doc/csm/install/scripts/craycli_init.py --cleanup
+    ```
+
+    Expect output showing the results of the operation on each node:
+
+    ```bash
+    2021-12-21 15:52:31,611 - INFO    - Removing temporary user and uninitializing the cray CLI
+    2021-12-21 15:52:31,783 - INFO    - Deleted user 'craycli_tmp_user'
+    2021-12-21 15:52:31,798 - INFO    - Uninitializing nodes:
+    2021-12-21 15:52:32,714 - INFO    - ncn-m001: Success
+    2021-12-21 15:52:32,714 - INFO    - ncn-m002: Success
+    2021-12-21 15:52:32,714 - INFO    - ncn-m003: Success
+    2021-12-21 15:52:32,714 - INFO    - ncn-s001: Success
+    2021-12-21 15:52:32,714 - INFO    - ncn-s002: Success
+    2021-12-21 15:52:32,714 - INFO    - ncn-s003: Success
+    2021-12-21 15:52:32,714 - INFO    - ncn-w001: Success
+    2021-12-21 15:52:32,714 - INFO    - ncn-w002: Success
+    2021-12-21 15:52:32,714 - INFO    - ncn-w003: Success
+    ```
+
+    At this point the `cray` CLI will no longer be operational on these nodes until they are
+    initialized and authorized again with a valid Keycloak user.
+
+    Optionally, the `cray` CLI may be initialized with a valid Keycloak user during the cleanup
+    operation so that it is left operational. To do this pass in a user and password with the
+    cleanup command:
+
+    ```bash
+    python3 /usr/share/doc/csm/install/scripts/craycli_init.py --cleanup -u MY_USERNAME -p MY_PASSWORD
+    ```
+
+    Expect output showing the cleanup of the temporary user on each node, then the results of
+    using the input user to initialize and authorize the `cray` CLI on each node:
+
+    ```bash
+    2021-12-21 15:52:31,611 - INFO    - Removing temporary user and uninitializing the cray CLI
+    2021-12-21 15:52:31,783 - INFO    - Deleted user 'craycli_tmp_user'
+    2021-12-21 15:52:31,798 - INFO    - Uninitializing nodes:
+    2021-12-21 15:52:32,714 - INFO    - ncn-m001: Success
+    2021-12-21 15:52:32,714 - INFO    - ncn-m002: Success
+    2021-12-21 15:52:32,714 - INFO    - ncn-m003: Success
+    2021-12-21 15:52:32,714 - INFO    - ncn-s001: Success
+    2021-12-21 15:52:32,714 - INFO    - ncn-s002: Success
+    2021-12-21 15:52:32,714 - INFO    - ncn-s003: Success
+    2021-12-21 15:52:32,714 - INFO    - ncn-w001: Success
+    2021-12-21 15:52:32,714 - INFO    - ncn-w002: Success
+    2021-12-21 15:52:32,714 - INFO    - ncn-w003: Success
+    2021-12-21 15:52:33,079 - INFO    - Re-initializing the cray CLI with existing Keycloak user MY_USERNAME
+    2021-12-21 15:52:33,131 - INFO    - Initializing nodes:
+    2021-12-21 15:52:37,714 - INFO    - ncn-m001: Success
+    2021-12-21 15:52:37,714 - INFO    - ncn-m002: Success
+    2021-12-21 15:52:37,714 - INFO    - ncn-m003: Success
+    2021-12-21 15:52:37,714 - INFO    - ncn-s001: Success
+    2021-12-21 15:52:38,714 - INFO    - ncn-s002: Success
+    2021-12-21 15:52:38,714 - INFO    - ncn-s003: Success
+    2021-12-21 15:52:38,714 - INFO    - ncn-w001: Success
+    2021-12-21 15:52:38,714 - INFO    - ncn-w002: Success
+    2021-12-21 15:52:38,714 - INFO    - ncn-w003: Success
+    ```
+
+    At this point the `cray` CLI will be operational on all successful nodes and authenticated with
+    the input Keycloak account.
+
+## Troubleshooting Results of the Automated Script
+
+Each node will have `Success` reported if everything worked and the node was initialized
+and the `cray` CLI is operational for that node. For nodes with problems, there will be a
+brief error message that reports what the problem is on that node.
+
+Results with problems on some nodes may look like the following:
+
+```bash
+2021-12-21 15:50:47,814 - INFO    - Loading Keycloak secrets.
+2021-12-21 15:50:48,095 - INFO    - Created user 'craycli_tmp_user'
+2021-12-21 15:50:52,714 - INFO    - Initializing nodes:
+2021-12-21 15:50:52,714 - INFO    - ncn-m001: Success
+2021-12-21 15:50:52,714 - INFO    - ncn-m002: Success
+2021-12-21 15:50:52,714 - INFO    - ncn-w001: Success
+2021-12-21 15:50:52,714 - ERROR   - ncn-m003: ERROR: Call to cray init failed
+2021-12-21 15:50:52,714 - ERROR   - ncn-s001: ERROR: Python script failed
+2021-12-21 15:50:52,714 - ERROR   - ncn-w002: ERROR: Failed to copy script to remote host
+2021-12-21 15:50:52,714 - ERROR   - ncn-w003: ERROR: Verification that cray CLI is operational failed
+```
+
+At this point the entire operation may be repeated with the `--debug` flag added for
+debug level log messages displayed or each failing node may be looked at individually.
+
+### Debugging an Individual Node
+
+1. (`ncn-mws#`) Log into the node that failed
+    To try re-running the initialization on only a single node, `ssh` to that node, then run
+    the script with the `--initnode` option and `--debug` option to enable increased logging:
+
+    **NOTE:** Part of the script is copying itself to the `/tmp/` directory on each target node.
+    The script should still be there, but if not just copy the script somewhere accessible.
+
+    ```bash
+    ssh NODE_THAT_FAILED
+    python3 /tmp/craycli_init.py --initnode --debug
+    ```
+
+    Now use the enhanced messages to determine what is wrong on this node.
+
+    1. (`ncn-mws#`) Check for missing Python Modules
+
+        It is possible that some Python modules required for the script are missing on individual
+        nodes - particularly on the `PIT` node if that is still active. This script could run from
+        any of the NCNs, so if it fails on one node, copy it to any location on another node
+        and try to run it from there.
+
+        In the following example the script fails on 'ncn' due to the missing Python module 'oauthlib'
+        so it is copied to 'ncn-m002' and successfully runs from that node:
+
+        ```bash
+        python3 /usr/share/doc/csm/install/scripts/craycli_init.py --run
+        ```
+
+        Error output:
+
+        ```bash
+        Traceback (most recent call last):
+            File "craycli_init.py", line 50, in <module>
+            import oauthlib.oauth2
+        ModuleNotFoundError: No module named 'oauthlib'
+        ```
+
+        Copy the script to the `ncn-m002` node and run from there:
+
+        ``` bash
+        scp /usr/share/doc/csm/install/scripts/craycli_init.py ncn-m002:'~/my_dir/'
+        ssh ncn-m002 'cd my_dir && python3 ./craycli_init.py --run'
+        ```
+
+        At this point expect it to proceed as documented, but it will fail again on the node
+        originally attempted on due to the lack of critical Python modules on that node, but
+        may complete successfully on the rest of the nodes.
+
+        Alternatively, the modules could be installed using 'pip' or 'pip3' if that is available on the node.
+
+    1. (`ncn-mws#`) Check for Kubernetes setup on the node
+
+        The script relies on Kubernetes Secrets to store the credentials of the temporary Keycloak user. If
+        a does not have Kubernetes initialized on it, the user must manually initialize the `cray` CLI with a
+        valid Keycloak user.
+
+        Run the following command:
+
+        ```bash
+        kubectl get nodes
+        ```
+
+        If Kubernetes is configured and operating correctly you should see a list of the master and worker nodes:
+
+        ```bash
+        NAME       STATUS   ROLES                  AGE    VERSION
+        ncn-m001   Ready    control-plane,master   120d   v1.20.13
+        ncn-m002   Ready    control-plane,master   120d   v1.20.13
+        ncn-m003   Ready    control-plane,master   120d   v1.20.13
+        ncn-w001   Ready    <none>                 120d   v1.20.13
+        ncn-w002   Ready    <none>                 120d   v1.20.13
+        ncn-w003   Ready    <none>                 120d   v1.20.13
+        ```
+
+        If Kubernetes is not configured or operating correctly you will see an error:
+
+        ```bash
+        W0902 16:06:38.726121   61796 loader.go:223] Config not found: /etc/kubernetes/admin.conf
+        error: the server doesn't have a resource type "nodes"
+        ```
+
+        If Kubernetes is not operational on this node, the `cray` CLI may still be initialized and authorized manually
+        with a valid existing Keycloak user following the process
+        [Single User Already Configured in Keycloak](#single-user-already-configured-in-keycloak).
+
+### Debugging Problems with Initialization or Authorization
+
+**NOTE:**  While resolving the following issues is beyond the scope of this section, more information about what is failing can be found by adding `-vvvvv` to the `cray init ...` commands.
+
+1. (`ncn-mws#`) Troubleshoot Failed Initialization
+
+    If initialization fails in the above step, there are several common causes:
+
+    * DNS failure looking up `api-gw-service-nmn.local` may be preventing the CLI from reaching the API Gateway and Keycloak for authorization
+    * Network connectivity issues with the NMN may be preventing the CLI from reaching the API Gateway and Keycloak for authorization
+    * Certificate mismatch or trust issues may be preventing a secure connection to the API Gateway
+    * Istio failures may be preventing traffic from reaching Keycloak
+    * Keycloak may not yet be set up to authorize the user
+
+    If the initialization fails and the reason output is similar to the following example, restart `radosgw` on the storage nodes.
 
     ```bash
     cray artifacts buckets list -vvv
     ```
 
-    Expected output looks similar to the following:
+    The output may look something like:
 
-    ```text
+    ```bash
     Loaded token: /root/.config/cray/tokens/api_gw_service_nmn_local.vers
     REQUEST: PUT to https://api-gw-service-nmn.local/apis/sts/token
+
     OPTIONS: {'verify': False}
-    S3 credentials retrieved successfully
-    results = [ "alc", "badger", "benji-backups", "boot-images", "etcd-backup", "fw-update", "ims", "install-artifacts", "nmd", "postgres-backup",
-    "prs", "sat", "sds", "sls", "sma", "ssd", "ssm", "vbis", "velero", "wlm",]
+
+    ERROR: {
+    "detail": "The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application.",
+        "status": 500,
+        "title": "Internal Server Error",
+        "type": "about:blank"
+    }
+
+    Usage: cray artifacts buckets list [OPTIONS]
+
+    Try 'cray artifacts buckets list --help' for help.
+
+    Error: Internal Server Error: The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application.
     ```
 
-    If an error occurs, then continue to the troubleshooting section below.
+    1. SSH to ncn-s001/2/3.
 
-## Troubleshooting
+    1. (`ncn-s#`) Restart the Ceph radosgw process.
 
-More information about what is failing can be found by adding `-vvvvv` to the `cray init ...` commands.
+        ```bash
+        ceph orch restart rgw.site1.zone1
+        ```
 
-### Initialization fails
+        The expected output will be similar to the following, but it will vary based on the number of nodes running radosgw:
 
-If CLI initialization fails, there are several common causes:
+        ```bash
+        restart rgw.site1.zone1.ncn-s001.cshvbb from host 'ncn-s001'
+        restart rgw.site1.zone1.ncn-s002.tlegbb from host 'ncn-s002'
+        restart rgw.site1.zone1.ncn-s003.vwjwew from host 'ncn-s003'
+        ```
 
-- DNS failure looking up `api-gw-service-nmn.local` may be preventing the CLI from reaching the API Gateway and Keycloak for authorization
-- Network connectivity issues with the NMN may be preventing the CLI from reaching the API Gateway and Keycloak for authorization
-- Certificate mismatch or trust issues may be preventing a secure connection to the API Gateway
-- Istio failures may be preventing traffic from reaching Keycloak
-- Keycloak may not yet be set up to authorize the user
+    1. (`ncn-s#`) Check to see that the processes restarted.
 
-### Internal error
+       ```bash
+       ceph orch ps --daemon_type rgw
+       ```
 
-If an error similar to the following is seen, then restart `radosgw` on the storage nodes.
+        The "running" time should be in seconds. Restarting all of them could require a couple of minutes depending on how many.
 
-```text
-The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application.
-```
+        ```bash
+        NAME                             HOST      STATUS         REFRESHED  AGE  VERSION  IMAGE NAME                        IMAGE ID      CONTAINER ID
+        rgw.site1.zone1.ncn-s001.cshvbb  ncn-s001  running (29s)  23s ago    9h   15.2.8   registry.local/ceph/ceph:v15.2.8  5553b0cb212c  2a712824adc1
+        rgw.site1.zone1.ncn-s002.tlegbb  ncn-s002  running (29s)  28s ago    9h   15.2.8   registry.local/ceph/ceph:v15.2.8  5553b0cb212c  e423f22d06a5
+        rgw.site1.zone1.ncn-s003.vwjwew  ncn-s003  running (29s)  23s ago    9h   15.2.8   registry.local/ceph/ceph:v15.2.8  5553b0cb212c  1e6ad6bc2c62
+        ```
 
-Restart `radosgw` using the following steps. These steps must be run on one of the storage nodes running the Ceph `radosgw` process.
-By default these nodes are `ncn-s001`, `ncn-s002`, and `ncn-s003`.
+    1. (`ncn-s#`) In the event that more than 5 minutes has passed and the `radosgw` services have not restarted, fail the `ceph-mgr` process to the standby.
 
-1. Restart the Ceph `radosgw` process.
+        There are cases where an orchestration task gets stuck and the current remediation is to fail the Ceph manager process.
 
-    > The expected output will be similar to the following, but it will vary based on the nodes running `radosgw`.
-
-    ```bash
-    ceph orch restart rgw.site1.zone1
-    ```
-
-    Example output:
-
-    ```text
-    restart rgw.site1.zone1.ncn-s001.cshvbb from host 'ncn-s001'
-    restart rgw.site1.zone1.ncn-s002.tlegbb from host 'ncn-s002'
-    restart rgw.site1.zone1.ncn-s003.vwjwew from host 'ncn-s003'
-    ```
-
-1. Check to see that the processes restarted.
-
-    ```bash
-    ceph orch ps --daemon_type rgw
-    ```
-
-    Example output:
-
-    ```text
-    NAME                             HOST      STATUS         REFRESHED  AGE  VERSION  IMAGE NAME                        IMAGE ID      CONTAINER ID
-    rgw.site1.zone1.ncn-s001.cshvbb  ncn-s001  running (29s)  23s ago    9h   15.2.8   registry.local/ceph/ceph:v15.2.8  5553b0cb212c  2a712824adc1
-    rgw.site1.zone1.ncn-s002.tlegbb  ncn-s002  running (29s)  28s ago    9h   15.2.8   registry.local/ceph/ceph:v15.2.8  5553b0cb212c  e423f22d06a5
-    rgw.site1.zone1.ncn-s003.vwjwew  ncn-s003  running (29s)  23s ago    9h   15.2.8   registry.local/ceph/ceph:v15.2.8  5553b0cb212c  1e6ad6bc2c62
-    ```
-
-    > A process which has restarted should have an `AGE` in seconds. Restarting all of them could require a couple of minutes depending on how many.
-
-1. In the event that more than five minutes have passed and the `radosgw` processes have not restarted, then fail the `ceph-mgr` process.
-
-    1. Determine the active `ceph-mgr`.
+        Get active `ceph-mgr`:
 
         ```bash
         ceph mgr dump | jq -r .active_name
         ```
 
-        Example output:
+        Expected output will be something similar to:
 
-        ```text
+        ```bash
         ncn-s002.zozbqp
         ```
 
-    1. Fail the active `ceph-mgr`.
+        Fail the active ceph-mgr:
 
         ```bash
         ceph mgr fail $(ceph mgr dump | jq -r .active_name)
         ```
 
-    1. Confirm that `ceph-mgr` has moved to a different `ceph-mgr` container.
+        Confirm ceph-mgr has moved to a different ceph-mgr container:
 
         ```bash
         ceph mgr dump | jq -r .active_name
         ```
 
-        Example output:
+        Expect the output to be a different manager than was prevoiusly reported:
 
-        ```text
+        ```bash
         ncn-s001.qucrpr
         ```
 
-    1. Verify that the `radosgw` processes restarted using the command from the previous step.
+    1. Verify that the processes restarted using the command from step 3.
 
-        At this point the processes should restart. If they do not, then attempt this remediation procedure a second time.
+        At this point the processes should restart. If they do not, it is possible that steps 2 and 3 will need to be done again.

--- a/operations/configure_cray_cli.md
+++ b/operations/configure_cray_cli.md
@@ -11,19 +11,20 @@ The `cray` CLI only needs to be initialized once per user on a node.
 
 There are two ways to initialize the `cray` CLI:
 
-1. [Single User Already Configured in Keycloak](#single-user-already-configured-in-keycloak)
+- [Single user already configured in Keycloak](#single-user-already-configured-in-keycloak)
 
-1. [Configure All NCNs With Temporary Keycloak User](#configure-all-ncns-with-temporary-keycloak-user)
+- [Configure all NCNs with temporary Keycloak user](#configure-all-ncns-with-temporary-keycloak-user)
 
-## Single User Already Configured in Keycloak
+## Single user already configured in Keycloak
 
-   There are times in normal operation that a particular user must be authenticated on the `cray` CLI. In
-   this case, the user must already be present in Keycloak and have the correct permissions to access the
-   system.
+There are times in normal operation that a particular user must be authenticated on the `cray` CLI. In
+this case, the user must already be present in Keycloak and have the correct permissions to access the
+system.
 
-### Procedure For Existing Keycloak User
+If a Keycloak user needs to be created, then see [Keycloak User Management](security_and_authentication/Access_the_Keycloak_User_Management_UI.md)
+before proceeding.
 
-1. If a Keycloak user needs to be created, see [Keycloak User Management](security_and_authentication/Access_the_Keycloak_User_Management_UI.md)
+### Procedure for existing Keycloak user
 
 1. (`ncn-mws#`) Initialize the `cray` CLI
 
@@ -31,7 +32,7 @@ There are two ways to initialize the `cray` CLI:
     cray init
     ```
 
-    Expect the following prompts:
+    Expected output (including responses to the prompts):
 
     ```text
     Overwrite configuration file at: MY_HOME_DIR/.config/cray/configurations/default ? [y/N]: y
@@ -59,20 +60,20 @@ There are two ways to initialize the `cray` CLI:
     Success!
     ```
 
-## Configure All NCNs With Temporary Keycloak User
+## Configure all NCNs with temporary Keycloak user
 
-This script will create a new Keycloak account that is authorized for the `cray` CLI and use that account
-to initialize and authorize the `cray` CLI on all master and worker nodes in the cluster. This account is
-only intended to be used for the duration of the install and should be removed when the install is complete.
+The `craycli_init.py` script can be used to create a new Keycloak account that is authorized for the `cray` CLI.
+That account can in turn be used to initialize and authorize the `cray` CLI on all master and worker nodes in the cluster.
+This account is only intended to be used for the duration of the install and should be removed when the install is complete.
 
-### Procedure For Temporary Keycloak User
+### Procedure for temporary Keycloak user
 
 1. (`ncn-mws#`) Unset the `CRAY_CREDENTIALS` environment variable, if previously set.
 
     Some of the installation procedures leading up to this point use the CLI with a Kubernetes managed service
     account that is normally used for internal operations. There is a procedure for extracting the OAUTH token for
     this service account and assigning it to the `CRAY_CREDENTIALS` environment variable to permit simple CLI
-    operations. This needs to be removed prior to `cray` CLI initialization.
+    operations. This environment variable must be removed prior to `cray` CLI initialization.
 
     ```bash
     unset CRAY_CREDENTIALS
@@ -87,9 +88,9 @@ only intended to be used for the duration of the install and should be removed w
     python3 /usr/share/doc/csm/install/scripts/craycli_init.py --run
     ```
 
-    Expect output showing the results of the operation on each node:
+    Expected output showing the results of the operation on each node:
 
-    ```bash
+    ```text
     2021-12-21 15:50:47,814 - INFO    - Loading Keycloak secrets.
     2021-12-21 15:50:48,095 - INFO    - Created user 'craycli_tmp_user'
     2021-12-21 15:50:52,714 - INFO    - Initializing nodes:
@@ -105,16 +106,17 @@ only intended to be used for the duration of the install and should be removed w
     ```
 
     The `cray` CLI is now operational on all nodes where success was reported. If a node was
-    unsuccessful with initialization, there will be an error reported. See the
-    [troubleshooting](#troubleshooting-results-of-the-automated-script) section for additional information.
+    unsuccessful with initialization, then there will be an error reported. See
+    [Troubleshooting results of the automated script](#troubleshooting-results-of-the-automated-script)
+    for additional information.
 
 1. (`ncn-mws#`) Remove the temporary user after the install is complete.
 
-    **IMPORTANT:** If this section is not followed the temporary user will remain as a valid
+    **IMPORTANT:** If this section is not followed, then the temporary user will remain as a valid
     account in Keycloak. Be sure to clean this up when this user is no longer required.
 
-    When the install is complete and Keycloak is fully populated with the correct end users,
-    call this script again with the `--cleanup` option to remove the temporary user from Keycloak
+    When the install is completed and Keycloak is fully populated with the correct end users,
+    then call this script again with the `--cleanup` option to remove the temporary user from Keycloak
     and uninitialize the `cray` CLI on all master and worker nodes in the cluster.
 
     ```bash
@@ -123,7 +125,7 @@ only intended to be used for the duration of the install and should be removed w
 
     Expect output showing the results of the operation on each node:
 
-    ```bash
+    ```text
     2021-12-21 15:52:31,611 - INFO    - Removing temporary user and uninitializing the cray CLI
     2021-12-21 15:52:31,783 - INFO    - Deleted user 'craycli_tmp_user'
     2021-12-21 15:52:31,798 - INFO    - Uninitializing nodes:
@@ -138,7 +140,7 @@ only intended to be used for the duration of the install and should be removed w
     2021-12-21 15:52:32,714 - INFO    - ncn-w003: Success
     ```
 
-    At this point the `cray` CLI will no longer be operational on these nodes until they are
+    At this point, the `cray` CLI will no longer be operational on these nodes until they are
     initialized and authorized again with a valid Keycloak user.
 
     Optionally, the `cray` CLI may be initialized with a valid Keycloak user during the cleanup
@@ -149,10 +151,10 @@ only intended to be used for the duration of the install and should be removed w
     python3 /usr/share/doc/csm/install/scripts/craycli_init.py --cleanup -u MY_USERNAME -p MY_PASSWORD
     ```
 
-    Expect output showing the cleanup of the temporary user on each node, then the results of
+    Expected output showing the cleanup of the temporary user on each node, then the results of
     using the input user to initialize and authorize the `cray` CLI on each node:
 
-    ```bash
+    ```text
     2021-12-21 15:52:31,611 - INFO    - Removing temporary user and uninitializing the cray CLI
     2021-12-21 15:52:31,783 - INFO    - Deleted user 'craycli_tmp_user'
     2021-12-21 15:52:31,798 - INFO    - Uninitializing nodes:
@@ -181,15 +183,15 @@ only intended to be used for the duration of the install and should be removed w
     At this point the `cray` CLI will be operational on all successful nodes and authenticated with
     the input Keycloak account.
 
-## Troubleshooting Results of the Automated Script
+## Troubleshooting results of the automated script
 
-Each node will have `Success` reported if everything worked and the node was initialized
+Each node will have `Success` reported if everything worked, the node was initialized,
 and the `cray` CLI is operational for that node. For nodes with problems, there will be a
 brief error message that reports what the problem is on that node.
 
 Results with problems on some nodes may look like the following:
 
-```bash
+```text
 2021-12-21 15:50:47,814 - INFO    - Loading Keycloak secrets.
 2021-12-21 15:50:48,095 - INFO    - Created user 'craycli_tmp_user'
 2021-12-21 15:50:52,714 - INFO    - Initializing nodes:
@@ -202,14 +204,15 @@ Results with problems on some nodes may look like the following:
 2021-12-21 15:50:52,714 - ERROR   - ncn-w003: ERROR: Verification that cray CLI is operational failed
 ```
 
-At this point the entire operation may be repeated with the `--debug` flag added for
-debug level log messages displayed or each failing node may be looked at individually.
+At this point, the script may be re-run with the `--debug` flag added, in order for
+debug level log messages to be displayed. Alternatively, each failing node may be looked at individually.
 
-### Debugging an Individual Node
+### Debugging an individual node
 
-1. (`ncn-mws#`) Log into the node that failed
+1. (`ncn-mws#`) Log into the node that failed.
+
     To try re-running the initialization on only a single node, `ssh` to that node, then run
-    the script with the `--initnode` option and `--debug` option to enable increased logging:
+    the script with the `--initnode` and `--debug` options:
 
     **NOTE:** Part of the script is copying itself to the `/tmp/` directory on each target node.
     The script should still be there, but if not just copy the script somewhere accessible.
@@ -221,84 +224,84 @@ debug level log messages displayed or each failing node may be looked at individ
 
     Now use the enhanced messages to determine what is wrong on this node.
 
-    1. (`ncn-mws#`) Check for missing Python Modules
+1. (`ncn-mws#`) Check for missing Python Modules
 
-        It is possible that some Python modules required for the script are missing on individual
-        nodes - particularly on the `PIT` node if that is still active. This script could run from
-        any of the NCNs, so if it fails on one node, copy it to any location on another node
-        and try to run it from there.
+   It is possible that some Python modules required for the script are missing on individual
+   nodes - particularly on the `PIT` node if that is still active. This script could run from
+   any of the NCNs, so if it fails on one node, copy it to any location on another node
+   and try to run it from there.
 
-        In the following example the script fails on 'ncn' due to the missing Python module 'oauthlib'
-        so it is copied to 'ncn-m002' and successfully runs from that node:
+   In the following example the script fails on 'ncn' due to the missing Python module 'oauthlib'
+   so it is copied to 'ncn-m002' and successfully runs from that node:
 
-        ```bash
-        python3 /usr/share/doc/csm/install/scripts/craycli_init.py --run
-        ```
+   ```bash
+   python3 /usr/share/doc/csm/install/scripts/craycli_init.py --run
+   ```
 
-        Error output:
+   Error output:
 
-        ```bash
-        Traceback (most recent call last):
-            File "craycli_init.py", line 50, in <module>
-            import oauthlib.oauth2
-        ModuleNotFoundError: No module named 'oauthlib'
-        ```
+   ```text
+   Traceback (most recent call last):
+       File "craycli_init.py", line 50, in <module>
+       import oauthlib.oauth2
+   ModuleNotFoundError: No module named 'oauthlib'
+   ```
 
-        Copy the script to the `ncn-m002` node and run from there:
+   Copy the script to the `ncn-m002` node and run from there:
 
-        ``` bash
-        scp /usr/share/doc/csm/install/scripts/craycli_init.py ncn-m002:'~/my_dir/'
-        ssh ncn-m002 'cd my_dir && python3 ./craycli_init.py --run'
-        ```
+   ``` bash
+   scp /usr/share/doc/csm/install/scripts/craycli_init.py ncn-m002:'~/my_dir/'
+   ssh ncn-m002 'cd my_dir && python3 ./craycli_init.py --run'
+   ```
 
-        At this point expect it to proceed as documented, but it will fail again on the node
-        originally attempted on due to the lack of critical Python modules on that node, but
-        may complete successfully on the rest of the nodes.
+   At this point expect it to proceed as documented, but it will fail again on the node
+   originally attempted on, because of the lack of critical Python modules on that node. However,
+   it may complete successfully on the rest of the nodes.
 
-        Alternatively, the modules could be installed using 'pip' or 'pip3' if that is available on the node.
+   Alternatively, the modules could be installed using 'pip' or 'pip3' if that is available on the node.
 
-    1. (`ncn-mws#`) Check for Kubernetes setup on the node
+1. (`ncn-mws#`) Check for Kubernetes setup on the node
 
-        The script relies on Kubernetes Secrets to store the credentials of the temporary Keycloak user. If
-        a does not have Kubernetes initialized on it, the user must manually initialize the `cray` CLI with a
-        valid Keycloak user.
+   The script relies on Kubernetes Secrets to store the credentials of the temporary Keycloak user. If
+   a does not have Kubernetes initialized on it, the user must manually initialize the `cray` CLI with a
+   valid Keycloak user.
 
-        Run the following command:
+   Run the following command:
 
-        ```bash
-        kubectl get nodes
-        ```
+   ```bash
+   kubectl get nodes
+   ```
 
-        If Kubernetes is configured and operating correctly you should see a list of the master and worker nodes:
+   If Kubernetes is configured and operating correctly, then the output should show a list of the master and worker nodes:
 
-        ```bash
-        NAME       STATUS   ROLES                  AGE    VERSION
-        ncn-m001   Ready    control-plane,master   120d   v1.20.13
-        ncn-m002   Ready    control-plane,master   120d   v1.20.13
-        ncn-m003   Ready    control-plane,master   120d   v1.20.13
-        ncn-w001   Ready    <none>                 120d   v1.20.13
-        ncn-w002   Ready    <none>                 120d   v1.20.13
-        ncn-w003   Ready    <none>                 120d   v1.20.13
-        ```
+   ```text
+   NAME       STATUS   ROLES                  AGE    VERSION
+   ncn-m001   Ready    control-plane,master   120d   v1.21.12
+   ncn-m002   Ready    control-plane,master   120d   v1.21.12
+   ncn-m003   Ready    control-plane,master   120d   v1.21.12
+   ncn-w001   Ready    <none>                 120d   v1.21.12
+   ncn-w002   Ready    <none>                 120d   v1.21.12
+   ncn-w003   Ready    <none>                 120d   v1.21.12
+   ```
 
-        If Kubernetes is not configured or operating correctly you will see an error:
+   If Kubernetes is not configured or operating correctly, then an error will be displayed instead. For example:
 
-        ```bash
-        W0902 16:06:38.726121   61796 loader.go:223] Config not found: /etc/kubernetes/admin.conf
-        error: the server doesn't have a resource type "nodes"
-        ```
+   ```text
+   W0902 16:06:38.726121   61796 loader.go:223] Config not found: /etc/kubernetes/admin.conf
+   error: the server doesn't have a resource type "nodes"
+   ```
 
-        If Kubernetes is not operational on this node, the `cray` CLI may still be initialized and authorized manually
-        with a valid existing Keycloak user following the process
-        [Single User Already Configured in Keycloak](#single-user-already-configured-in-keycloak).
+   If Kubernetes is not operational on this node, the `cray` CLI may still be initialized and authorized manually
+   with a valid existing Keycloak user following the process
+   [Single User Already Configured in Keycloak](#single-user-already-configured-in-keycloak).
 
-### Debugging Problems with Initialization or Authorization
+### Debugging problems with initialization or authorization
 
-**NOTE:**  While resolving the following issues is beyond the scope of this section, more information about what is failing can be found by adding `-vvvvv` to the `cray init ...` commands.
+**NOTE:**  While resolving the following issues is beyond the scope of this section, more information about what is failing can be found by adding `-vvvvv` to the `cray init` commands.
 
-1. (`ncn-mws#`) Troubleshoot Failed Initialization
+1. (`ncn-mws#`) Troubleshoot failed initialization.
 
-    If initialization fails in the above step, there are several common causes:
+    If initialization fails in the above step, then there are several common causes:
 
     * DNS failure looking up `api-gw-service-nmn.local` may be preventing the CLI from reaching the API Gateway and Keycloak for authorization
     * Network connectivity issues with the NMN may be preventing the CLI from reaching the API Gateway and Keycloak for authorization
@@ -306,7 +309,7 @@ debug level log messages displayed or each failing node may be looked at individ
     * Istio failures may be preventing traffic from reaching Keycloak
     * Keycloak may not yet be set up to authorize the user
 
-    If the initialization fails and the reason output is similar to the following example, restart `radosgw` on the storage nodes.
+    If the initialization fails and the reason output is similar to the following example, then restart `radosgw` on the storage nodes.
 
     ```bash
     cray artifacts buckets list -vvv
@@ -314,7 +317,7 @@ debug level log messages displayed or each failing node may be looked at individ
 
     The output may look something like:
 
-    ```bash
+    ```text
     Loaded token: /root/.config/cray/tokens/api_gw_service_nmn_local.vers
     REQUEST: PUT to https://api-gw-service-nmn.local/apis/sts/token
 
@@ -334,9 +337,7 @@ debug level log messages displayed or each failing node may be looked at individ
     Error: Internal Server Error: The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application.
     ```
 
-    1. SSH to ncn-s001/2/3.
-
-    1. (`ncn-s#`) Restart the Ceph radosgw process.
+    1. (`ncn-s#`) Restart the Ceph radosgw process on one of the first three storage nodes.
 
         ```bash
         ceph orch restart rgw.site1.zone1
@@ -344,7 +345,7 @@ debug level log messages displayed or each failing node may be looked at individ
 
         The expected output will be similar to the following, but it will vary based on the number of nodes running radosgw:
 
-        ```bash
+        ```text
         restart rgw.site1.zone1.ncn-s001.cshvbb from host 'ncn-s001'
         restart rgw.site1.zone1.ncn-s002.tlegbb from host 'ncn-s002'
         restart rgw.site1.zone1.ncn-s003.vwjwew from host 'ncn-s003'
@@ -352,53 +353,53 @@ debug level log messages displayed or each failing node may be looked at individ
 
     1. (`ncn-s#`) Check to see that the processes restarted.
 
-       ```bash
-       ceph orch ps --daemon_type rgw
-       ```
-
-        The "running" time should be in seconds. Restarting all of them could require a couple of minutes depending on how many.
-
         ```bash
+        ceph orch ps --daemon_type rgw
+        ```
+
+        The `REFRESHED` time should be in seconds. Restarting all of them could require a couple of minutes depending on how many.
+
+        ```text
         NAME                             HOST      STATUS         REFRESHED  AGE  VERSION  IMAGE NAME                        IMAGE ID      CONTAINER ID
         rgw.site1.zone1.ncn-s001.cshvbb  ncn-s001  running (29s)  23s ago    9h   15.2.8   registry.local/ceph/ceph:v15.2.8  5553b0cb212c  2a712824adc1
         rgw.site1.zone1.ncn-s002.tlegbb  ncn-s002  running (29s)  28s ago    9h   15.2.8   registry.local/ceph/ceph:v15.2.8  5553b0cb212c  e423f22d06a5
         rgw.site1.zone1.ncn-s003.vwjwew  ncn-s003  running (29s)  23s ago    9h   15.2.8   registry.local/ceph/ceph:v15.2.8  5553b0cb212c  1e6ad6bc2c62
         ```
 
-    1. (`ncn-s#`) In the event that more than 5 minutes has passed and the `radosgw` services have not restarted, fail the `ceph-mgr` process to the standby.
+    1. (`ncn-s#`) In the event that more than 5 minutes has passed and the `radosgw` services have not restarted, then fail the `ceph-mgr` process over to the standby.
 
         There are cases where an orchestration task gets stuck and the current remediation is to fail the Ceph manager process.
 
-        Get active `ceph-mgr`:
+        1. Get active `ceph-mgr`.
 
-        ```bash
-        ceph mgr dump | jq -r .active_name
-        ```
+            ```bash
+            ceph mgr dump | jq -r .active_name
+            ```
 
-        Expected output will be something similar to:
+            Expected output will be something similar to:
 
-        ```bash
-        ncn-s002.zozbqp
-        ```
+            ```text
+            ncn-s002.zozbqp
+            ```
 
-        Fail the active ceph-mgr:
+        1. Fail the active `ceph-mgr`.
 
-        ```bash
-        ceph mgr fail $(ceph mgr dump | jq -r .active_name)
-        ```
+            ```bash
+            ceph mgr fail $(ceph mgr dump | jq -r .active_name)
+            ```
 
-        Confirm ceph-mgr has moved to a different ceph-mgr container:
+        1. Confirm that `ceph-mgr` has moved to a different `ceph-mgr` container.
 
-        ```bash
-        ceph mgr dump | jq -r .active_name
-        ```
+            ```bash
+            ceph mgr dump | jq -r .active_name
+            ```
 
-        Expect the output to be a different manager than was prevoiusly reported:
+            Expect the output to be a different manager than was prevoiusly reported:
 
-        ```bash
-        ncn-s001.qucrpr
-        ```
+            ```text
+            ncn-s001.qucrpr
+            ```
 
-    1. Verify that the processes restarted using the command from step 3.
+        1. Verify that the processes restarted using the command from step 3.
 
-        At this point the processes should restart. If they do not, it is possible that steps 2 and 3 will need to be done again.
+            At this point the processes should restart. If they do not, then retry steps 2 and 3.

--- a/operations/configure_cray_cli.md
+++ b/operations/configure_cray_cli.md
@@ -33,7 +33,7 @@ There are two ways to initialize the `cray` CLI:
 
     Expect the following prompts:
 
-    ```bash
+    ```text
     Overwrite configuration file at: MY_HOME_DIR/.config/cray/configurations/default ? [y/N]: y
     Cray Hostname: api-gw-service-nmn.local
     Username: MY_KEYCLOAK_USER_NAME
@@ -53,7 +53,7 @@ There are two ways to initialize the `cray` CLI:
 
     Expect the following prompts:
 
-    ```bash
+    ```text
     Username: MY_KEYCLOAK_USER_NAME
     Password: MY_PASSWORD
     Success!

--- a/operations/configure_cray_cli.md
+++ b/operations/configure_cray_cli.md
@@ -231,8 +231,8 @@ debug level log messages to be displayed. Alternatively, each failing node may b
    any of the NCNs, so if it fails on one node, copy it to any location on another node
    and try to run it from there.
 
-   In the following example the script fails on 'ncn' due to the missing Python module 'oauthlib'
-   so it is copied to 'ncn-m002' and successfully runs from that node:
+   In the following example the script fails on an NCN because of the missing Python module `oauthlib`.
+   To work around that, the script is copied to `ncn-m002`, where it is successfully run.
 
    ```bash
    python3 /usr/share/doc/csm/install/scripts/craycli_init.py --run
@@ -258,7 +258,7 @@ debug level log messages to be displayed. Alternatively, each failing node may b
    originally attempted on, because of the lack of critical Python modules on that node. However,
    it may complete successfully on the rest of the nodes.
 
-   Alternatively, the modules could be installed using 'pip' or 'pip3' if that is available on the node.
+   Alternatively, the modules could be installed using `pip` or `pip3` if that is available on the node.
 
 1. (`ncn-mws#`) Check for Kubernetes setup on the node
 
@@ -303,11 +303,11 @@ debug level log messages to be displayed. Alternatively, each failing node may b
 
     If initialization fails in the above step, then there are several common causes:
 
-    * DNS failure looking up `api-gw-service-nmn.local` may be preventing the CLI from reaching the API Gateway and Keycloak for authorization
-    * Network connectivity issues with the NMN may be preventing the CLI from reaching the API Gateway and Keycloak for authorization
-    * Certificate mismatch or trust issues may be preventing a secure connection to the API Gateway
-    * Istio failures may be preventing traffic from reaching Keycloak
-    * Keycloak may not yet be set up to authorize the user
+    - DNS failure looking up `api-gw-service-nmn.local` may be preventing the CLI from reaching the API Gateway and Keycloak for authorization
+    - Network connectivity issues with the NMN may be preventing the CLI from reaching the API Gateway and Keycloak for authorization
+    - Certificate mismatch or trust issues may be preventing a secure connection to the API Gateway
+    - Istio failures may be preventing traffic from reaching Keycloak
+    - Keycloak may not yet be set up to authorize the user
 
     If the initialization fails and the reason output is similar to the following example, then restart `radosgw` on the storage nodes.
 

--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -52,8 +52,7 @@ descriptions below. These tests may be skipped but **this is not recommended**.
 
 The Cray CLI must be configured on all NCNs and the PIT node. The following procedures explain how to do this:
 
-1. [Configure Keycloak Account](../install/configure_administrative_access.md#1-configure-keycloak-account)
-1. [Configure the Cray Command Line Interface (CLI)](../install/configure_administrative_access.md#2-configure-the-cray-command-line-interface)
+1. [Configure the Cray command line interface](../install/configure_administrative_access.md#1-configure-the-cray-command-line-interface)
 
 ## 1. Platform health checks
 


### PR DESCRIPTION
# Description

This creates a script that will generate a new Keycloak user with a random password, store that information in a k8s secret, then initialize and authorize cray cli on all NCN's using that temporary Keycloak user.  This allows the install to have a working cray cli even if Keycloak has not been populated with the correct end users.

The documentation has also been updated to show how to use the new script, or the regular way of authenticating against an existing Keycloak user.

NOTE: this only works on NCN's that have the correct python modules present to run the script (currently all master, worker, and storage nodes) and nodes that are set up with k8s (currently all master and worker nodes, but only ncn-s001 from the storage nodes).

https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7474 

# Checklist Before Merging
- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

