### PR TITLE
CASMINST-5305: Correct typo in prerequisites.sh upgrade script

### DIFF
--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -756,7 +756,7 @@ if [[ ${state_recorded} == "0" && $(hostname) == "ncn-m001" ]]; then
     backupBucket="config-data"
     cray artifacts list "${backupBucket}" || backupBucket="vbis"
 
-    cray artifacts create "${backupBucket}" "bss-backup-$(date +%Y-%m-%d).json bss-backup-$(date +%Y-%m-%d).json"
+    cray artifacts create "${backupBucket}" "bss-backup-$(date +%Y-%m-%d).json" "bss-backup-$(date +%Y-%m-%d).json"
 
     } >> "${LOG_FILE}" 2>&1
     record_state "${state_name}" "$(hostname)"


### PR DESCRIPTION
# Description

When fixing a shell check error, I accidentally enclosed two whitespace-separated strings in a single set of double quotes, when they should have been separately enclosed. This problem only exists in main branch.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
