### PR TITLE
CASMINST-5299: Properly generate NTP information for CSM 1.3

### DIFF
--- a/scripts/operations/node_management/Add_Remove_Replace_NCNs/add_management_ncn.py
+++ b/scripts/operations/node_management/Add_Remove_Replace_NCNs/add_management_ncn.py
@@ -1694,8 +1694,10 @@ def ncn_data_command(session: requests.Session, args, state: State):
     bootparams["cloud-init"]["user-data"]["local_hostname"] = state.ncn_alias
     if "ntp" in bootparams["cloud-init"]["user-data"]:
         bootparams["cloud-init"]["user-data"]["ntp"]["allow"] = []
-        for network_name, ip_cidr in ncn_cidrs.items():
-            bootparams["cloud-init"]["user-data"]["ntp"]["allow"].append(ip_cidr)
+        for network_name in ["HMN", "NMN", "HMN_RVR", "NMN_RVR", "NMN_MTN", "HMN_MTN"]:
+            if  network_name in sls_networks:
+                subnet_cidr = str(sls_networks[network_name].ipv4_address())
+                bootparams["cloud-init"]["user-data"]["ntp"]["allow"].append(subnet_cidr)
     bootparams["cloud-init"]["meta-data"]["availability-zone"] = cabinet_xname
     bootparams["cloud-init"]["meta-data"]["instance-id"] = generate_instance_id()
     bootparams["cloud-init"]["meta-data"]["local-hostname"] = state.ncn_alias
@@ -1853,8 +1855,9 @@ def ncn_data_command(session: requests.Session, args, state: State):
 
         if interface == "mgmt0":
             ei["Description"] = "- kea"
-            for network in ["NMN", "CAN", "MTL", "HMN"]:
-                ei["IPAddresses"].append({"IPAddress": str(state.ncn_ips[network])})
+            for network in ["NMN", "CAN", "CMN", "MTL", "HMN"]:
+                if network in state.ncn_ips:
+                    ei["IPAddresses"].append({"IPAddress": str(state.ncn_ips[network])})
 
         print(f"Adding MAC Addresses {mac} to HSM Inventory EthernetInterfaces")
         print(json.dumps(ei, indent=2))


### PR DESCRIPTION
# Description
Properly generate NTP information for CSM 1.3 (and later) when adding a management NCN. Between CSM 1.2 and CSM 1.3 the format of the ntp.allow cloud-init data changed, and this PR aligns the `add_management_ncn.py` script to what CSI generates.

# Testing
I took a capture of the SLS/HSM/BSS data from Surtur and loaded it into a local instance of the hms-simulation-environment. This is a similar test environment to how the `add_management_ncn.py`.

For the test scenario I removed ncn-w001/x3000c0s4b0n0 from SLS/BSS/HSM using the `./remove_management_ncn.py` script with the following command:
```bash
./remove_management_ncn.py --xname x3000c0s4b0n0 --test-urls --skip-kea --skip-etc-hosts
```

Then I added back in ncn-w001 with the modified version of `add_management_ncn.py` from this PR:
```
./add_management_ncn.py ncn-data \
    --xname x3000c0s4b0n0 \
    --alias ncn-w001 \
    --mac-mgmt0 14:02:ec:d9:7c:40 \
    --mac-mgmt1 14:02:ec:d9:7c:41 \
    --mac-hsn0 11:11:11:22:22:22 \
    --mac-bmc b4:7a:f1:c2:12:d8 \
    --bmc-mgmt-switch-connector x3000c0w14j43 \
    --url-bss http://localhost:27778/boot/v1 \
    --url-hsm http://localhost:27779/hsm/v2 \
    --url-sls http://localhost:8376/v1  \
    --url-kea http://localhost:8090/api \
    --perform-changes
```

I verified that the NTP information generated from CSI (`ncn-w001-old.json` contains the bootparameters from CSI) also matches what the `add_management_ncn.py` script generated (`ncn-w001-new.json` contains the bootparameters from the add script):
```
$ cat ncn-w001-old.json | jq '."cloud-init"."user-data".ntp' > ncn-w001-old.ntp.json
$ cat ncn-w001-new.json | jq '."cloud-init"."user-data".ntp' > ncn-w001-new.ntp.json 
$ diff ncn-w001-old.ntp.json ncn-w001-new.ntp.json                                                                                                                                                                                                            
$  
```
No changes were found in the generated NTP data!

The following is the generated bootparameters for ncn-w001:
```json
{
    "hosts": [
        "x3000c0s4b0n0"
    ],
    "params": "ifname=mgmt0:14:02:ec:d9:7c:40 ifname=mgmt1:14:02:ec:d9:7c:41 ifname=hsn0:11:11:11:22:22:22 biosdevname=1 pcie_ports=native transparent_hugepage=never console=tty0 console=ttyS0,115200 iommu=pt metal.server=http://rgw-vip.nmn/ncn-images/k8s/0.3.31 ds=nocloud-net;s=http://10.92.100.81:8888/ rootfallback=LABEL=BOOTRAID initrd=initrd.img.xz root=live:LABEL=SQFSRAID rd.live.ram=0 rd.writable.fsimg=0 rd.skipfsck rd.live.squashimg=filesystem.squashfs rd.live.overlay=LABEL=ROOTRAID rd.live.overlay.thin=1 rd.live.overlay.overlayfs=1 rd.luks=0 module_blacklist=rpcrdma rd.luks.crypttab=0 rd.lvm.conf=0 rd.lvm=1 rd.auto=1 rd.md=1 rd.dm=0 rd.neednet=0 rd.md.waitclean=1 rd.multipath=0 rd.md.conf=1 rd.bootif=0 hostname=ncn-w001 rd.net.timeout.carrier=120 rd.net.timeout.ifup=120 rd.net.timeout.iflink=120 rd.net.timeout.ipv6auto=0 rd.net.timeout.ipv6dad=0 append nosplash quiet crashkernel=360M log_buf_len=1 rd.retry=10 rd.shell ip=mgmt0:dhcp rd.peerdns=0 rd.net.dhcp.retry=5 psi=1 metal.no-wipe=0",
    "kernel": "s3://ncn-images/k8s/0.3.31/kernel",
    "initrd": "s3://ncn-images/k8s/0.3.31/initrd",
    "cloud-init": {
        "meta-data": {
            "availability-zone": "x3000",
            "instance-id": "i-5639F97D",
            "ipam": {
                "cmn": {
                    "gateway": "10.103.11.1",
                    "ip": "10.103.11.24/25",
                    "parent_device": "bond0",
                    "vlanid": 7
                },
                "hmn": {
                    "gateway": "10.254.0.1",
                    "ip": "10.254.1.14/17",
                    "parent_device": "bond0",
                    "vlanid": 4
                },
                "nmn": {
                    "gateway": "10.252.0.1",
                    "ip": "10.252.1.9/17",
                    "parent_device": "bond0",
                    "vlanid": 2
                },
                "mtl": {
                    "gateway": "10.1.0.1",
                    "ip": "10.1.1.7/16",
                    "parent_device": "bond0",
                    "vlanid": 0
                }
            },
            "local-hostname": "ncn-w001",
            "region": "surtur",
            "shasta-role": "ncn-worker",
            "xname": "x3000c0s4b0n0"
        },
        "user-data": {
            "hostname": "ncn-w001",
            "local_hostname": "ncn-w001",
            "mac0": {
                "gateway": "10.252.0.1",
                "ip": "",
                "mask": "10.252.2.0/23"
            },
            "ntp": {
                "allow": [
                    "10.254.0.0/17",
                    "10.252.0.0/17",
                    "10.107.0.0/17",
                    "10.106.0.0/17"
                ],
                "config": {
                    "confpath": "/etc/chrony.d/cray.conf",
                    "template": "## template: jinja\n# csm-generated config for {{ local_hostname }}. Do not modify--changes can be overwritten\n{% for pool in pools | sort -%}\n{% if local_hostname == 'ncn-m001' and pool == 'ncn-m001' %}\n{% endif %}\n{% if local_hostname != 'ncn-m001' and pool != 'ncn-m001' %}\n{% else %}\npool {{ pool }} iburst\n{% endif %}\n{% endfor %}\n{% for server in servers | sort -%}\n{% if local_hostname == 'ncn-m001' and server == 'ncn-m001' %}\n# server {{ server }} will not be used as itself for a server\n{% else %}\nserver {{ server }} iburst trust\n{% endif %}\n{% if local_hostname != 'ncn-m001' and server != 'ncn-m001' %}\n# {{ local_hostname }}\n{% endif %}\n{% endfor %}\n{% for peer in peers | sort -%}\n{% if local_hostname == peer %}\n{% else %}\n{% if loop.index <= 9 %}\n{# Only add 9 peers to prevent too much NTP traffic #}\npeer {{ peer }} minpoll -2 maxpoll 9 iburst\n{% endif %}\n{% endif %}\n{% endfor %}\n{% for net in allow | sort -%}\nallow {{ net }}\n{% endfor %}\n{% if local_hostname == 'ncn-m001' %}\n# {{ local_hostname }} has a lower stratum than other NCNs since it is the primary server\nlocal stratum 8 orphan\n{% else %}\n# {{ local_hostname }} has a higher stratum so it selects ncn-m001 in the event of a tie\nlocal stratum 10 orphan\n{% endif %}\nlog measurements statistics tracking\nlogchange 1.0\nmakestep 0.1 3\n"
                },
                "enabled": true,
                "ntp_client": "chrony",
                "peers": [
                    "ncn-m001",
                    "ncn-m002",
                    "ncn-m003",
                    "ncn-w001",
                    "ncn-w002",
                    "ncn-w003",
                    "ncn-s001",
                    "ncn-s002",
                    "ncn-s003"
                ],
                "servers": [
                    "ncn-m001",
                    "ntp.hpecorp.net"
                ]
            },
            "runcmd": [
                "/srv/cray/scripts/metal/net-init.sh",
                "/srv/cray/scripts/common/update_ca_certs.py",
                "/srv/cray/scripts/metal/install.sh",
                "/srv/cray/scripts/common/kubernetes-cloudinit.sh",
                "/srv/cray/scripts/common/join-spire-on-storage.sh",
                "touch /etc/cloud/cloud-init.disabled"
            ],
            "timezone": "UTC",
            "write_files": [
                {
                    "content": "10.106.0.0/22 10.252.0.1 - bond0.nmn0\n10.1.0.0/16 10.252.0.1 - bond0.nmn0\n10.92.100.0/24 10.252.0.1 - bond0.nmn0\n",
                    "owner": "root:root",
                    "path": "/etc/sysconfig/network/ifroute-bond0.nmn0",
                    "permissions": "0644"
                },
                {
                    "content": "10.107.0.0/22 10.254.0.1 - bond0.hmn0\n10.94.100.0/24 10.254.0.1 - bond0.hmn0\n",
                    "owner": "root:root",
                    "path": "/etc/sysconfig/network/ifroute-bond0.hmn0",
                    "permissions": "0644"
                }
            ]
        },
        "phone-home": {
            "pub_key_dsa": "",
            "pub_key_rsa": "",
            "pub_key_ecdsa": "",
            "instance_id": "",
            "hostname": "",
            "fqdn": ""
        }
    }
}
```


# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
