### PR TITLE
Add env var check in ncn-common.sh to halt upgrade if not set (CASMTRIAGE-4075)

### DIFF
--- a/upgrade/scripts/common/ncn-common.sh
+++ b/upgrade/scripts/common/ncn-common.sh
@@ -30,6 +30,27 @@ trap 'err_report' ERR
 touch /etc/cray/upgrade/csm/myenv
 . /etc/cray/upgrade/csm/myenv
 
+rc=0
+
+if [[ -z ${CSM_RELEASE} ]]; then
+    echo "ERROR: CSM_RELEASE environment variable is not set and must be present in /etc/cray/upgrade/csm/myenv."
+    rc=$((rc+1))
+fi
+
+if [[ -z ${CSM_ARTI_DIR} ]]; then
+    echo "ERROR: CSM_ARTI_DIR environment variable is not set and must be present in /etc/cray/upgrade/csm/myenv."
+    rc=$((rc+1))
+fi
+
+if [[ -z ${CSM_REL_NAME} ]]; then
+    echo "ERROR: CSM_REL_NAME environment variable is not set and must be present in /etc/cray/upgrade/csm/myenv."
+    rc=$((rc+1))
+fi
+
+if [ "${rc}" -gt 0 ]; then
+  return $rc
+fi
+
 if [[ -z ${LOG_FILE} ]]; then
     #shellcheck disable=SC2155
     export LOG_FILE="/root/output.log"


### PR DESCRIPTION
# Description

Fix for https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4075 -- ensure myenv has been populated with env vars.

# Checklist Before Merging

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
