### PR TITLE
CASMTRIAGE-4071 skip wait for cfs depends on cfs configurations

### DIFF
--- a/workflows/ncn/worker/worker.drain.yaml
+++ b/workflows/ncn/worker/worker.drain.yaml
@@ -37,15 +37,44 @@ tasks:
             TARGET_XNAME=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management" | \
                 jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"$TARGET_NCN\")) | .Xname")
 
-            ENABLED=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/cfs/v2/component/${TARGET_XNAME}" | jq -r '.enabled' | grep "true" | wc -l)
-            if [[ ${ENABLED} -eq 0 ]]; then
-              exit 0
-            fi
+            set -o pipefail
 
-            DESIRED_CONFIG_EMPTY=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/cfs/v2/component/${TARGET_XNAME}" | jq -r '.desiredConfig' | grep '^$' | wc -l )
-            if [[ ${DESIRED_CONFIG_EMPTY} -eq 1 ]]; then
+            # Retry CFS command if needed
+            COUNT=0
+            while true; do
+                ENABLED=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/cfs/v2/component/${TARGET_XNAME}" | jq -r '.enabled') && break
+                let COUNT+=1
+                if [[ ${COUNT} -gt 12 ]]; then
+                    echo "ERROR: Even after retries, command pipeline failed querying CFS component '${TARGET_XNAME}'"
+                    exit 1
+                fi
+                echo "WARNING: Command pipeline failed querying CFS component '${TARGET_XNAME}'. Retrying after 5 seconds."
+                sleep 5
+            done
+            if [[ ${ENABLED} == false ]]; then
+              exit 0
+            elif [[ ${ENABLED} != true ]]; then
+              echo "ERROR: Unexpected contents of 'enabled' field for CFS component '${TARGET_XNAME}': '${ENABLED}'"
+              exit 1
+            fi
+            echo "CFS component '${TARGET_XNAME}' is enabled"
+
+            # Retry CFS command if needed
+            COUNT=0
+            while true; do
+                DESIRED_CONFIG=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/cfs/v2/component/${TARGET_XNAME}" | jq -r '.desiredConfig') && break
+                let COUNT+=1
+                if [[ ${COUNT} -gt 12 ]]; then
+                    echo "ERROR: Even after retries, command pipeline failed querying CFS component '${TARGET_XNAME}'"
+                    exit 1
+                fi
+                echo "WARNING: Command pipeline failed querying CFS component '${TARGET_XNAME}'. Retrying after 5 seconds."
+                sleep 5
+            done
+            if [[ -z ${DESIRED_CONFIG} ]]; then
               exit 0
             fi
+            echo "Desired configuration for CFS component '${TARGET_XNAME}' is '${DESIRED_CONFIG}'"
 
             while true; do
               RESULT=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/cfs/v2/components?ids=${TARGET_XNAME}&status=pending" | jq length)

--- a/workflows/ncn/worker/worker.drain.yaml
+++ b/workflows/ncn/worker/worker.drain.yaml
@@ -37,6 +37,16 @@ tasks:
             TARGET_XNAME=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management" | \
                 jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"$TARGET_NCN\")) | .Xname")
 
+            ENABLED=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/cfs/v2/component/${TARGET_XNAME}" | jq -r '.enabled' | grep "true" | wc -l)
+            if [[ ${ENABLED} -eq 0 ]]; then
+              exit 0
+            fi
+
+            DESIRED_CONFIG_EMPTY=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/cfs/v2/component/${TARGET_XNAME}" | jq -r '.desiredConfig' | grep '^$' | wc -l )
+            if [[ ${DESIRED_CONFIG_EMPTY} -eq 1 ]]; then
+              exit 0
+            fi
+
             while true; do
               RESULT=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/cfs/v2/components?ids=${TARGET_XNAME}&status=pending" | jq length)
               if [[ "$RESULT" -eq 0 ]]; then

--- a/workflows/ncn/worker/worker.post-rebuild.yaml
+++ b/workflows/ncn/worker/worker.post-rebuild.yaml
@@ -51,10 +51,50 @@ tasks:
             TARGET_XNAME=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management" | \
                 jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"$TARGET_NCN\")) | .Xname")
 
-            DESIRED_CONFIG_EMPTY=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/cfs/v2/component/${TARGET_XNAME}" | jq -r '.desiredConfig' | grep '^$' | wc -l )
-            if [[ ${DESIRED_CONFIG_EMPTY} -eq 1 ]]; then
+            set -o pipefail
+
+            # Wait for component to become enabled (this should happen whether or not there is a desired configuration)
+            while true; do
+                # Retry CFS command if needed
+                COUNT=0
+                while true; do
+                    ENABLED=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/cfs/v2/component/${TARGET_XNAME}" | jq -r '.enabled') && break
+                    let COUNT+=1
+                    if [[ ${COUNT} -gt 12 ]]; then
+                        echo "ERROR: Even after retries, command pipeline failed querying CFS component '${TARGET_XNAME}'"
+                        exit 1
+                    fi
+                    echo "WARNING: Command pipeline failed querying CFS component '${TARGET_XNAME}'. Retrying after 5 seconds."
+                    sleep 5
+                done
+                if [[ ${ENABLED} == false ]]; then
+                    echo "CFS component '${TARGET_XNAME}' still not enabled. Checking again after 30 seconds."
+                    sleep 30
+                    continue
+                elif [[ ${ENABLED} != true ]]; then
+                    echo "ERROR: Unexpected contents of 'enabled' field for CFS component '${TARGET_XNAME}': '${ENABLED}'"
+                    exit 1
+                fi
+                echo "CFS component '${TARGET_XNAME}' is enabled"
+                break
+            done
+
+            # Retry CFS command if needed
+            COUNT=0
+            while true; do
+                DESIRED_CONFIG=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/cfs/v2/component/${TARGET_XNAME}" | jq -r '.desiredConfig') && break
+                let COUNT+=1
+                if [[ ${COUNT} -gt 12 ]]; then
+                    echo "ERROR: Even after retries, command pipeline failed querying CFS component '${TARGET_XNAME}'"
+                    exit 1
+                fi
+                echo "WARNING: Command pipeline failed querying CFS component '${TARGET_XNAME}'. Retrying after 5 seconds."
+                sleep 5
+            done
+            if [[ -z ${DESIRED_CONFIG} ]]; then
               exit 0
             fi
+            echo "Desired configuration for CFS component '${TARGET_XNAME}' is '${DESIRED_CONFIG}'"
 
             while true; do
               RESULT=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/cfs/v2/components?ids=${TARGET_XNAME}&status=pending" | jq length)

--- a/workflows/ncn/worker/worker.post-rebuild.yaml
+++ b/workflows/ncn/worker/worker.post-rebuild.yaml
@@ -51,6 +51,11 @@ tasks:
             TARGET_XNAME=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management" | \
                 jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"$TARGET_NCN\")) | .Xname")
 
+            DESIRED_CONFIG_EMPTY=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/cfs/v2/component/${TARGET_XNAME}" | jq -r '.desiredConfig' | grep '^$' | wc -l )
+            if [[ ${DESIRED_CONFIG_EMPTY} -eq 1 ]]; then
+              exit 0
+            fi
+
             while true; do
               RESULT=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/cfs/v2/components?ids=${TARGET_XNAME}&status=pending" | jq length)
               if [[ "$RESULT" -eq 0 ]]; then


### PR DESCRIPTION
# Description

CASMTRIAGE-4071 skip wait for cfs depends on cfs configurations

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
