### PR TITLE
Shell shenanigans

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,10 +1,13 @@
 root = true
 
 [*]
-end_of_line = lf
-charset = utf-8
-
-[*.sh]
-charset = utf-8
 indent_style = space
 indent_size = 2
+end_of_line = lf
+trim_trailing_spaces = true
+insert_final_newline = true
+
+# trailing spaces in markdown indicate word wrap
+[*.md]
+trim_trailing_spaces = false
+max_line_length = 80

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+
+[*.sh]
+charset = utf-8
+indent_style = space
+indent_size = 2

--- a/.github/workflows/sh-checker.yaml
+++ b/.github/workflows/sh-checker.yaml
@@ -26,21 +26,23 @@ on:
   pull_request:
 
 jobs:
-  shell-check:
+  sh-checker:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v18.7
+        with:
+          files: "**/*.sh"
+          files_ignore: ".github/**/*"
 
-    - name: Get changed files
-      id: changed-files
-      uses: tj-actions/changed-files@v18.7
-      with:
-        files: "**/*.sh"
-        files_ignore: ".github/**/*"
-
-    - uses: docker://koalaman/shellcheck:stable
-      if: ${{ steps.changed-files.outputs.all_changed_files }}
-      id: shell-check
-      with:
-        args: --severity=warning --color=always ${{ steps.changed-files.outputs.all_changed_files }}
-
+      - name: Run the sh-checker
+        uses: luizm/action-sh-checker@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHELLCHECK_OPTS: --severity=warning --color=always ${{ steps.changed-files.outputs.all_changed_files }} # We can globally ignore things here if we want with -e SC1234
+          SHFMT_OPTS: -ci -p -i 2 -bn -sr ${{ steps.changed-files.outputs.all_changed_files }}
+        with:
+          sh_checker_comment: true
+          sh_checker_exclude: "spec" # We can exclude things here as well that should never be checked spec excluded as sh-fmt can't parse them sanely


### PR DESCRIPTION
# Description

This is a POC branch to add shfmt github actions on merge and an editorconfig. As I couldn't find "standards" I'm just running with the defaults that the editorconfig community uses and it appears based on the shell that already is present is using. Which means 2 spaces no tabs. If we want to change that we can.

If you want to run this locally you may by using:
https://github.com/nektos/act

And running *act -j sh-checker*

Note I am using the default editorconfig from here:
https://github.com/editorconfig/editorconfig-defaults/blob/master/.editorconfig

It is setup so we don't need to muck with yaml files.

shfmt is this tool: https://github.com/mvdan/sh

As well as I am using the following for shell format as that changes the least amount of shell in this repo and makes the most sense in my opinion:

shfmt -ci -p -i 2 -bn -sr

Each switch in turn is:
- -ci, --case-indent Switch cases will be indented.
- -p, --posix Shorthand for -ln=posix. (in spite of all our bash this helps change as little as possible, I'd prefer .sh be posix and .bash be actual bash scripts so we can be a bit better about this but its not critical)
- -i, --indent Indent: 0 for tabs (default), >0 for number of spaces. (the vast majority of our scripts are already this, most of our changes are invalid indentation that doesn't follow this so just running with it)
- -bn, --binary-next-line Binary ops like && and | may start a line. (only a few scripts seem to violate this one, so seems like this is already our standard)
- -sr, --space-redirects Redirect operators will be followed by a space. (seems the right thing to be honest)

I also setup the action for now to comment on the changes in the pr. We can turn this off when we want to merge.

The blocker I can see for now to not use this is that I will likely need to add support to the action to only check changed files.

What I want to do is submit a PR for this line https://github.com/luizm/action-sh-checker/blob/master/entrypoint.sh#L39 to allow for an env var to pass in the files to be checked. For now this checks everything but it runs a lot more than just shellcheck.

We could fork this action in the interim to accomplish that. There is an upstream issue for that specific use case but I think letting the action specify what it wants checked via an env var is probably better as it allows for more control than just updated xyz. 

Upstream pr https://github.com/luizm/action-sh-checker/issues/27

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
