### PR TITLE
CASMMON-200: Documentation update for BREAK/FIX: CSM 1.3 Fresh install service monitor failure on loki

### DIFF
--- a/operations/network/management_network/snmp_exporter_configs.md
+++ b/operations/network/management_network/snmp_exporter_configs.md
@@ -16,13 +16,13 @@ In order to provide data to the Grafana SNMP dashboards, the SNMP Exporter must 
 
     Expected output looks similar to the following:
 
-       ```
-       10.252.0.2
-       10.252.0.3
-       10.252.0.4
-       10.252.0.5
-       4 IP addresses saved to <stdout>
-       ```
+    ```bash
+    10.252.0.2
+    10.252.0.3
+    10.252.0.4
+    10.252.0.5
+    4 IP addresses saved to <stdout>
+    ```
 
 1. (`pit#`) Update `customizations.yaml` with the list of switches.
 
@@ -34,16 +34,12 @@ In order to provide data to the Grafana SNMP dashboards, the SNMP Exporter must 
               serviceMonitor:
                 enabled: true
                 params:
-                  enabled: true
-                  conf:
-                    module:
-                    - if_mib
-                    target:
-                    - 127.0.0.1
-                    - 10.252.0.2
-                    - 10.252.0.3
-                    - 10.252.0.4
-                    - 10.252.0.5
+                - name: snmp1
+                  target: 10.252.0.2
+                - name: snmp2
+                  target: 10.252.0.3
+                - name: snmp3
+                  target: 10.252.0.4
     EOF
     ```
 
@@ -59,16 +55,12 @@ In order to provide data to the Grafana SNMP dashboards, the SNMP Exporter must 
     serviceMonitor:
       enabled: true
       params:
-        enabled: true
-        conf:
-          module:
-            - if_mib
-          target:
-            - 127.0.0.1
-            - 10.252.0.2
-            - 10.252.0.3
-            - 10.252.0.4
-            - 10.252.0.5
+      - name: snmp1
+        target: 10.252.0.2
+      - name: snmp2
+        target: 10.252.0.3
+      - name: snmp3
+        target: 10.252.0.4
     ```
 
 The most common configuration parameters are specified in the following table. They must be set in the `customizations.yaml` file under the `spec.kubernetes.services.cray-sysmgmt-health.prometheus-snmp-exporter` service definition.
@@ -76,8 +68,8 @@ The most common configuration parameters are specified in the following table. T
 |Customization|Default|Description|
 |-------------|-------|-----------|
 |`serviceMonitor.enabled`|`true`|Enables `serviceMonitor` for SNMP exporter \(default chart value is `true`\)|
-|`params.enabled`|`false`|Sets the snmp exporter params change to true \(default chart value is `false`\)|
+|`params.enabled`|`true`|Sets the SNMP exporter `params` change to true \(default chart value is `false`\)|
 |`params.conf.module`|`if_mib`| SNMP exporter to select which module \(default chart value is `if_mib`\)|
-|`params.conf.target`|`127.0.0.1`| Add list of switch targets to SNMP exporter to monitor \(default chart value is `127.0.0.1`\)|
+|`params.conf.target`|`10.252.0.2`| Add list of switch targets to SNMP exporter to monitor|
 
 For a complete set of available parameters, consult the `values.yaml` file for the `cray-sysmgmt-health` chart.

--- a/upgrade/scripts/upgrade/util/update-customizations.sh
+++ b/upgrade/scripts/upgrade/util/update-customizations.sh
@@ -103,10 +103,11 @@ if [[ -z "$(yq r "$c" "spec.network.netstaticips.nmn_ncn_storage_mons")" ]]; the
   done
   yq w -i --style=single "$c" spec.kubernetes.services.cray-sysmgmt-health.cephExporter.endpoints '{{ network.netstaticips.nmn_ncn_storage_mons }}'
 fi
-
+if [[ "$(yq r "$c" "spec.kubernetes.services.cray-sysmgmt-health.prometheus-snmp-exporter.serviceMonitor.enabled")" ]]; then
+    yq d -i "$c" "spec.kubernetes.services.cray-sysmgmt-health.prometheus-snmp-exporter.serviceMonitor.params.*.module"
+fi
 if [[ "$inplace" == "yes" ]]; then
     cp "$c" "$customizations"
 else
     cat "$c"
 fi
-


### PR DESCRIPTION
# Description

CASMMON-200: Documentation update for BREAK/FIX: CSM 1.3 Fresh install failure on loki - errors on prometheus-snmp-exporter serviceMonitor params error.

## Test on loki

prometheus-snmp-exporter:
serviceMonitor:
enabled: true
params:
- name: snmp1
target: 127.0.0.1
- name: snmp2
target: 10.252.0.2
- name: snmp3
target: 10.252.0.3
- name: snmp4
target: 10

ncn-m001:~/ram # curl http://10.42.0.22:9116/snmp?target=10.254.0.3|less
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0# HELP ifAdminStatus The desired state of the interface - 1.3.6.1.2.1.2.2.1.7
### TYPE ifAdminStatus gauge
ifAdminStatus{ifAlias="",ifDescr="1/1/2",ifIndex="2",ifName="1/1/2"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/20",ifIndex="20",ifName="1/1/20"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/21",ifIndex="21",ifName="1/1/21"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/24",ifIndex="24",ifName="1/1/24"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/25",ifIndex="25",ifName="1/1/25"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/26",ifIndex="26",ifName="1/1/26"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/27",ifIndex="27",ifName="1/1/27"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/28",ifIndex="28",ifName="1/1/28"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/29",ifIndex="29",ifName="1/1/29"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/30",ifIndex="30",ifName="1/1/30"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/31",ifIndex="31",ifName="1/1/31"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/32",ifIndex="32",ifName="1/1/32"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/33",ifIndex="33",ifName="1/1/33"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/34",ifIndex="34",ifName="1/1/34"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/35",ifIndex="35",ifName="1/1/35"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/37",ifIndex="37",ifName="1/1/37"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/38",ifIndex="38",ifName="1/1/38"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/39",ifIndex="39",ifName="1/1/39"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/4",ifIndex="4",ifName="1/1/4"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/40",ifIndex="40",ifName="1/1/40"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/41",ifIndex="41",ifName="1/1/41"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/42",ifIndex="42",ifName="1/1/42"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/43",ifIndex="43",ifName="1/1/43"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/44",ifIndex="44",ifName="1/1/44"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/45",ifIndex="45",ifName="1/1/45"} 2

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
