### PR TITLE
CASMINST-5327 Update prepare-assets.sh

### DIFF
--- a/upgrade/scripts/upgrade/prepare-assets.sh
+++ b/upgrade/scripts/upgrade/prepare-assets.sh
@@ -65,7 +65,7 @@ do
 done
 
 CSM_ARTI_DIR=/etc/cray/upgrade/csm/${CSM_REL_NAME}/tarball/${CSM_REL_NAME}
-. ${locOfScript}/../common/ncn-common.sh $(hostname)
+. "${locOfScript}/../common/ncn-common.sh" "$(hostname)"
 trap 'err_report' ERR
 
 if [[ -z ${LOG_FILE} ]]; then

--- a/upgrade/scripts/upgrade/prepare-assets.sh
+++ b/upgrade/scripts/upgrade/prepare-assets.sh
@@ -38,8 +38,7 @@ do
 
     case $key in
         --csm-version)
-        CSM_RELEASE="$2"
-        CSM_REL_NAME="csm-${CSM_RELEASE}"
+        CSM_RELEASE="$2"        
         shift # past argument
         shift # past value
         ;;
@@ -64,10 +63,6 @@ do
     esac
 done
 
-CSM_ARTI_DIR=/etc/cray/upgrade/csm/${CSM_REL_NAME}/tarball/${CSM_REL_NAME}
-. "${locOfScript}/../common/ncn-common.sh" "$(hostname)"
-trap 'err_report' ERR
-
 if [[ -z ${LOG_FILE} ]]; then
     LOG_FILE="/root/output.log"
     echo
@@ -83,6 +78,11 @@ if [[ -z ${CSM_RELEASE} ]]; then
     echo "CSM RELEASE is not specified"
     exit 1
 fi
+
+CSM_REL_NAME="csm-${CSM_RELEASE}"
+CSM_ARTI_DIR="/etc/cray/upgrade/csm/${CSM_REL_NAME}/tarball/${CSM_REL_NAME}"
+. "${locOfScript}/../common/ncn-common.sh" "$(hostname)"
+trap 'err_report' ERR
 
 if [[ -z ${TARBALL_FILE} ]]; then
     # Download tarball from internet

--- a/upgrade/scripts/upgrade/prepare-assets.sh
+++ b/upgrade/scripts/upgrade/prepare-assets.sh
@@ -26,10 +26,7 @@
 set -e
 locOfScript=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 . ${locOfScript}/../common/upgrade-state.sh
-CSM_ARTI_DIR="not_set"
-#shellcheck disable=SC2046
-. ${locOfScript}/../common/ncn-common.sh $(hostname)
-trap 'err_report' ERR
+
 # array for paths to unmount after chrooting images
 #shellcheck disable=SC2034
 declare -a UNMOUNTS=()
@@ -66,6 +63,10 @@ do
         ;;
     esac
 done
+
+CSM_ARTI_DIR=/etc/cray/upgrade/csm/${CSM_REL_NAME}/tarball/${CSM_REL_NAME}
+. ${locOfScript}/../common/ncn-common.sh $(hostname)
+trap 'err_report' ERR
 
 if [[ -z ${LOG_FILE} ]]; then
     LOG_FILE="/root/output.log"
@@ -136,8 +137,7 @@ if [[ $state_recorded == "0" ]]; then
     echo "====> ${state_name} ..."
     {
     mkdir -p /etc/cray/upgrade/csm/${CSM_REL_NAME}/tarball
-    tar -xzf ${TARBALL_FILE} -C /etc/cray/upgrade/csm/${CSM_REL_NAME}/tarball
-    CSM_ARTI_DIR=/etc/cray/upgrade/csm/${CSM_REL_NAME}/tarball/${CSM_REL_NAME}
+    tar -xzf ${TARBALL_FILE} -C /etc/cray/upgrade/csm/${CSM_REL_NAME}/tarball    
     if [[ "${DELETE_TARBALL_FILE}" != N ]]; then
         rm -rf "${TARBALL_FILE}"
     fi
@@ -145,7 +145,7 @@ if [[ $state_recorded == "0" ]]; then
     # if we have to untar a file, we assume this is a new upgrade
     # remove existing myenv file just in case
     rm -rf /etc/cray/upgrade/csm/myenv
-    echo "export CSM_ARTI_DIR=/etc/cray/upgrade/csm/${CSM_REL_NAME}/tarball/${CSM_REL_NAME}" >> /etc/cray/upgrade/csm/myenv
+    echo "export CSM_ARTI_DIR=${CSM_ARTI_DIR}" >> /etc/cray/upgrade/csm/myenv
     echo "export CSM_RELEASE=${CSM_RELEASE}" >> /etc/cray/upgrade/csm/myenv
     echo "export CSM_REL_NAME=${CSM_REL_NAME}" >> /etc/cray/upgrade/csm/myenv
     } >> ${LOG_FILE} 2>&1


### PR DESCRIPTION
# Description

Proposed solution to avoid using dummy value for CSM_ARTI_DIR variable. Making this PR for Di to consider as an alternative solution to [CASMINST-5327](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5327).

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
