### PR TITLE
CASMMON-200:  Documentation update for BREAK/FIX: CSM 1.4 Fresh install failure on loki - errors on prometheus-snmp-exporter serviceMonitor params error.

### DIFF
--- a/install/prepare_site_init.md
+++ b/install/prepare_site_init.md
@@ -1,10 +1,10 @@
-# Prepare Site Init
+# Prepare `site init`
 
 These procedures guide administrators through setting up the `site-init`
 directory which contains important customizations for various products.
 
 1. [Background](#1-background)
-1. [Create and Initialize Site-Init Directory](#2-create-and-initialize-site-init-directory)
+1. [Create and Initialize `site-init` Directory](#2-create-and-initialize-site-init-directory)
 1. [Create Baseline System Customizations](#3-create-baseline-system-customizations)
 1. [Customer-Specific Customizations](#4-customer-specific-customizations)
 
@@ -18,7 +18,7 @@ installation-centric artifacts, such as:
 - Sealed Secret Generate Blocks -- a form of plain-text input that renders to a Sealed Secret
 - Helm chart value overrides that are merged into Loftsman manifests by product stream installers
 
-## 2. Create and initialize Site-Init directory
+## 2. Create and initialize `site-init` directory
 
 > **`NOTE`** If the pre-installation is resuming here, ensure the environment variables have been properly set
 > by following [Set reusable environment variables](pre-installation.md#15-set-reusable-environment-variables) and then coming back
@@ -358,7 +358,7 @@ with system-specific customizations.
 
    - If DNSSEC is to be used, then add the desired keys into the `dnssec` SealedSecret.
 
-1. (Optional) Configure Prometheus SNMP Exporter.
+1. Configure Prometheus SNMP Exporter.
 
    The Prometheus SNMP exporter needs to be configured with a list of management network switches to scrape metrics from in
    order to populate the System Health Service Grafana dashboards.

--- a/upgrade/scripts/upgrade/util/update-customizations.sh
+++ b/upgrade/scripts/upgrade/util/update-customizations.sh
@@ -104,7 +104,15 @@ if [[ -z "$(yq r "$c" "spec.network.netstaticips.nmn_ncn_storage_mons")" ]]; the
   yq w -i --style=single "$c" spec.kubernetes.services.cray-sysmgmt-health.cephExporter.endpoints '{{ network.netstaticips.nmn_ncn_storage_mons }}'
 fi
 if [[ "$(yq r "$c" "spec.kubernetes.services.cray-sysmgmt-health.prometheus-snmp-exporter.serviceMonitor.enabled")" ]]; then
-    yq d -i "$c" "spec.kubernetes.services.cray-sysmgmt-health.prometheus-snmp-exporter.serviceMonitor.params.*.module"
+    idx=0
+    temp=1
+    mon_node=$(yq r "$c" 'spec.kubernetes.services.cray-sysmgmt-health.prometheus-snmp-exporter.serviceMonitor.params.conf.target' | awk '{print $2}')
+    for node in ${mon_node}; do
+      yq w -i "$c" "spec.kubernetes.services.cray-sysmgmt-health.prometheus-snmp-exporter.serviceMonitor.params[${idx}].name" "snmp$temp"
+      yq w -i "$c" "spec.kubernetes.services.cray-sysmgmt-health.prometheus-snmp-exporter.serviceMonitor.params[${idx}].target" "${node}"
+      idx=$(( idx+1 ))
+      temp=$(( temp+1 ))
+    done
 fi
 if [[ "$inplace" == "yes" ]]; then
     cp "$c" "$customizations"


### PR DESCRIPTION
# Description

CASMMON-200: Documentation update for BREAK/FIX: CSM 1.4 Fresh install failure on loki - errors on prometheus-snmp-exporter serviceMonitor params error.

## Test on loki 

ncn-m001:~/shreni # yq r customizations.yaml spec.kubernetes.services.cray-sysmgmt-health.prometheus-snmp-exporter
serviceMonitor:
  enabled: true
  params:
    enabled: true
    conf:
      module:
        - if_mib
      target:
        - 10.254.0.2
        - 10.254.0.3

Run script using - ./update-customizations.sh a.yaml
ncn-m001:~/shreni # yq r customizations.yaml spec.kubernetes.services.cray-sysmgmt-health.prometheus-snmp-exporter

serviceMonitor:
  enabled: true
  params:
    - name: snmp1
      target: 10.252.0.2
    - name: snmp2
      target: 10.252.0.3

ncn-m001:~/shreni # curl http://10.42.0.22:9116/snmp?target=10.254.0.3|less
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0# HELP ifAdminStatus The desired state of the interface - 1.3.6.1.2.1.2.2.1.7
TYPE ifAdminStatus gauge
ifAdminStatus{ifAlias="",ifDescr="1/1/2",ifIndex="2",ifName="1/1/2"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/20",ifIndex="20",ifName="1/1/20"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/21",ifIndex="21",ifName="1/1/21"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/24",ifIndex="24",ifName="1/1/24"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/25",ifIndex="25",ifName="1/1/25"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/26",ifIndex="26",ifName="1/1/26"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/27",ifIndex="27",ifName="1/1/27"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/28",ifIndex="28",ifName="1/1/28"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/29",ifIndex="29",ifName="1/1/29"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/30",ifIndex="30",ifName="1/1/30"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/31",ifIndex="31",ifName="1/1/31"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/32",ifIndex="32",ifName="1/1/32"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/33",ifIndex="33",ifName="1/1/33"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/34",ifIndex="34",ifName="1/1/34"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/35",ifIndex="35",ifName="1/1/35"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/37",ifIndex="37",ifName="1/1/37"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/38",ifIndex="38",ifName="1/1/38"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/39",ifIndex="39",ifName="1/1/39"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/4",ifIndex="4",ifName="1/1/4"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/40",ifIndex="40",ifName="1/1/40"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/41",ifIndex="41",ifName="1/1/41"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/42",ifIndex="42",ifName="1/1/42"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/43",ifIndex="43",ifName="1/1/43"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/44",ifIndex="44",ifName="1/1/44"} 2
ifAdminStatus{ifAlias="",ifDescr="1/1/45",ifIndex="45",ifName="1/1/45"} 2

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
