### PR TITLE
CASMTRIAGE-4154 - DOCS: --format json missing when checking cray cfs component list

### DIFF
--- a/operations/node_management/Reboot_NCNs.md
+++ b/operations/node_management/Reboot_NCNs.md
@@ -161,7 +161,7 @@ Execute the rolling NCN reboot procedure steps for the particular node type bein
    This can be run on any NCN where the Cray CLI is configured. See [Configure the Cray CLI](../configure_cray_cli.md).
 
    ```bash
-   cray cfs components list --status failed | jq .[].id -r | while read -r xname ; do
+   cray cfs components list --status failed --format json | jq .[].id -r | while read -r xname ; do
        echo "${xname}"
        cray cfs components update "${xname}" --enabled False --error-count 0
    done
@@ -170,7 +170,7 @@ Execute the rolling NCN reboot procedure steps for the particular node type bein
    Alternatively, this can be done manually. To get a list of nodes in the failed state:
 
    ```bash
-   cray cfs components list --status failed | jq .[].id
+   cray cfs components list --status failed --format json | jq .[].id
    ```
 
    To reset the error count and disable a node:


### PR DESCRIPTION
# Description

Add missing `--format json` so command doesn't fail with a jq error if the default `cray` output format (TOML) is used.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
