### PR TITLE
CASMHMS-5481: Add procedures to remove and replace standard rack nodes, and updates to the Add standard rack node procedure

### DIFF
--- a/operations/README.md
+++ b/operations/README.md
@@ -504,6 +504,8 @@ Monitor and manage compute nodes (CNs) and non-compute nodes (NCNs) used in the 
   - [Adding a Liquid-cooled blade to a System](node_management/Adding_a_Liquid-cooled_blade_to_a_System.md)
   - [Adding a Liquid-cooled blade to a System Using SAT](node_management/Adding_a_Liquid-cooled_blade_to_a_System_Using_SAT.md)
 - [Add a Standard Rack Node](node_management/Add_a_Standard_Rack_Node.md)
+  - [Removing a Standard rack node from a System](node_management/Removing_a_Standard_Node_from_a_System.md)
+  - [Replace a Standard rack node from a System](node_management/Replace_a_Standard_Rack_Node.md)
   - [Move a Standard Rack Node](node_management/Move_a_Standard_Rack_Node.md)
   - [Move a Standard Rack Node (Same Rack/Same HSN Ports)](node_management/Move_a_Standard_Rack_Node_SameRack_SameHSNPorts.md)
   - [Verify Node Removal](node_management/Verify_Node_Removal.md)

--- a/operations/node_management/Add_a_Standard_Rack_Node.md
+++ b/operations/node_management/Add_a_Standard_Rack_Node.md
@@ -13,28 +13,42 @@ For this procedure, a new object must be created in the SLS and modifications wi
 
 ## Prerequisites
 
-- The Cray command line interface \(CLI\) tool is initialized and configured on the system. See [Configure the Cray CLI](../configure_cray_cli.md).
+* The Cray command line interface \(CLI\) tool is initialized and configured on the system. See [Configure the Cray CLI](../configure_cray_cli.md).
+* Knowledge of whether DVS is operating over the Node Management Network (NMN) or the High Speed Network (HSN).
+* Blade is being added to an existing liquid-cooled cabinet in the system.
+* The Slingshot fabric must be configured with the desired topology for desired state of the blades in the system.
+* The System Layout Service (SLS) must have the desired HSN configuration.
+* Check the status of the high-speed network (HSN) and record link status before the procedure.
 
 ## Procedure
 
+### Step 1: Update SLS with node information
+
 1. (`ncn#`) Retrieve an authentication token.
 
-    ```bash
-    TOKEN=$(curl -k -s -S -d grant_type=client_credentials \
-                -d client_id=admin-client \
-                -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
-                https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
-    ```
+     ```bash
+    export TOKEN=$(curl -k -s -S -d grant_type=client_credentials \
+                 -d client_id=admin-client \
+                 -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
+                 https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
+     ```
 
-1. Create a new node object in SLS.
+1. (`ncn#`) Create a new node object in SLS.
 
     New node objects require the following information:
-    - `Parent`: component name (xname) of the new node's BMC.
-    - `Xname`: xname of the new node.
-    - `Role`: `Compute` or `Application`.
-    - `Aliases`: Array of aliases for the node. For compute nodes, this is in the form of `nid000000`
-    - NID: The Node ID integer for the node. This applies only to compute nodes.
-    - SubRole: Such as `UAN`, `Gateway`, or other valid HSM SubRoles.
+    * `Xname`: The component name (xname) for the Node in the form of `xXcCsSbBnN`
+      * `xX`: where `X` is the cabinet or rack identification number.
+      * `cC`: where `C` is the chassis identification number.
+        * If the node is within an air-cooled cabinet, then this should be `0`.
+        * If the node is within an air-cooled chassis in an EX2500 cabinet, then this should be `4`.
+      * `sS`: where `S` is the lowest slot the node chassis occupies.
+      * `bB`: where `B` is the ordinal of the node BMC. This should be `0`.
+      * `nN`: where `N` is the ordinal of the node This should be `0`.
+
+    * `Role`: `Compute` or `Application`.
+    * `Aliases`: Array of aliases for the node. For compute nodes, this is in the form of `nid000000`
+    * NID: The Node ID integer for the node. This applies only to compute nodes.
+    * SubRole: Such as `UAN`, `Gateway`, or other valid HSM SubRoles.
         > (`ncn#`) Valid HSM SubRoles can be viewed with the following command. To add additional sub roles to HSM refer to [Add Custom Roles and Subroles](../hardware_state_manager/HSM_Roles_and_Subroles.md#add-custom-roles-and-subroles).
         >
         > ```bash
@@ -47,78 +61,270 @@ For this procedure, a new object must be created in the SLS and modifications wi
         > SubRole = [ "Visualization", "UserDefined", "Master", "Worker", "Storage", "UAN", "Gateway", "LNETRouter",]
         > ```
 
-    - (`ncn#`) If adding a compute node:
+    * (`ncn#`) If adding a compute node:
 
         ```bash
-        curl -s -k -H "Authorization: Bearer ${TOKEN}" -X POST --data '{
-                "Parent": "x3000c0s27b0",
-                "Xname": "x3000c0s27b0n0",
-                "Type": "comptype_node",
-                "Class": "River",
-                "TypeString": "Node",
-                "ExtraProperties": {
-                    "Aliases": [
-                        "nid000001"
-                    ],
-                    "NID": 1,
-                    "Role": "Compute"
-                }
-            }' https://api-gw-service-nmn.local/apis/sls/v1/hardware | jq
+        NID=1
+        ALIAS=nid000001
+        jq -n --arg ALIAS "${ALIAS}" --arg NID "${NID}" '{
+            Aliases:[$ALIAS],
+            NID: $NID, 
+            Role: "Compute"
+        }' | tee node_extraproperties.json  
         ```
 
-    - (`ncn#`) If adding a UAN:
+        Expected output:
+
+        ```json
+        {
+          "Aliases": [
+            "nid000001"
+          ],
+          "NID": "1",
+          "Role": "Compute"
+        }
+        ```
+
+    * (`ncn#`) If adding a application node:
 
         ```bash
-        curl -s -k -H "Authorization: Bearer ${TOKEN}" -X POST --data '{
-                "Parent": "x3000c0s27b0",
-                "Xname": "x3000c0s27b0n0",
-                "Type": "comptype_node",
-                "Class": "River",
-                "TypeString": "Node",
-                "ExtraProperties": {
-                    "Aliases": [
-                        "uan04"
-                    ],
-                    "Role": "Application",
-                    "SubRole": "UAN"
-                }
-            }' https://api-gw-service-nmn.local/apis/sls/v1/hardware
+        SUB_ROLE=UAN
+        ALIAS=uan04
+        jq -n --arg ALIAS "${ALIAS}" --arg SUB_ROLE "${SUB_ROLE}" '{
+            Aliases:[$ALIAS],
+            Role: "Application",
+            SubRole: $SUB_ROLE
+        }' | tee node_extraproperties.json  
         ```
+
+        Expected output:
+
+        ```bash
+        {
+          "Aliases": [
+            "uan04"
+          ],
+          "Role": "Application",
+          "SubRole": "UAN"
+        }
+        ```
+
+    Create the new object in SLS.
+
+    ```bash
+    NODE_XNAME=x3000c0s27b0n0
+    cray sls hardware create --xname "${NODE_XNAME}" --class River --extra-properties "$(cat node_extraproperties.json)"
+    ```
 
 1. (`ncn#`) Create a new `MgmtSwitchConnector` object in SLS.
 
     The `MgmtSwitchConnector` connector is used by the `hms-discovery` job to determine which management switch port is connected to the node's BMC. The SLS requires the following information:
 
-    - The management switch port that is connected to the new node's BMC
-    - `Xname`: The component name (xname) for the `MgmtSwitchConnector` in the form of `xXcCwWjJ`
-      - `X` is the rack number
-      - `C` is the chassis
-        - If the destination `LeafBMC` switch is within a standard rack, then this should be `0`
-        - If the destination `LeafBMC` switch is located within an air-cooled chassis in an EX2500 cabinet, then this should be `4`
-      - `W` is the rack U position of the management network leaf switch
-      - `J` is the switch port number
-    - `NodeNics`: The component name (xname) of the new node's BMC; this field is an array in the payloads below, but should only contain one element
-      - `VendorName`: This field varies depending on the OEM for the management switch; for example, if the BMC is plugged into switch port 36, then the following vendor names could apply:
-      - Aruba leaf switches use this format: `1/1/36`
-      - Dell leaf switches use this format: `ethernet1/1/36`
+    * The management switch port that is connected to the new node's BMC
+    * `Xname`: The component name (xname) for the `MgmtSwitchConnector` in the form of `xXcCwWjJ`
+      * `xX`: where `X` is the cabinet or rack identification number.
+      * `cC`: where `C` is the chassis identification number.
+        * If the destination `LeafBMC` switch is within a standard rack, then this should be `0`
+        * If the destination `LeafBMC` switch is located within an air-cooled chassis in an EX2500 cabinet, then this should be `4`
+      * `wW`: where `W` is the rack U position of the management network leaf switch
+      * `jJ`: where `J` is the switch port number
+
+    * `NodeNics`: The component name (xname) of the new node's BMC; this field is an array in the payloads below, but should only contain one element
+      * `VendorName`: This field varies depending on the OEM for the management switch; for example, if the BMC is plugged into switch port 36, then the following vendor names could apply:
+      * Aruba leaf switches use this format: `1/1/36`
+      * Dell leaf switches use this format: `ethernet1/1/36`
+
+    1. Build up the hardware extra properties:
+
+        ```bash
+        BMC_XNAME=$(echo "${NODE_XNAME}" | grep -E -o 'x[0-9]+c[0-9]+s[0-9]+b[0-9]+')
+        VENDOR_NAME="1/1/36"
+        jq -n --arg BMC_XNAME "${BMC_XNAME}" --arg VENDOR_NAME "${VENDOR_NAME}" '{
+            NodeNics: [$BMC_XNAME],
+            VendorName: $VENDOR_NAME
+        }' | tee mgmt_switch_connector_extraproperties.json
+        ```
+
+        Expected output:
+
+        ```json
+        {
+          "NodeNics": [
+            "x3000c0s27b0"
+          ],
+          "VendorName": "1/1/36"
+        }
+        ```
+
+    1. Create the new object in SLS.
+
+        ```bash
+        MGMT_SWITCH_CONNECTOR_XNAME=x3000c0w14j36
+        cray sls hardware create --xname "${MGMT_SWITCH_CONNECTOR_XNAME}" --class River --extra-properties "$(cat mgmt_switch_connector_extraproperties.json)"
+        ```
+
+1. (`ncn#`) **If adding a UAN application node**, then remove the IP address reservation for the node in the `CAN` or `CHN` networks.
+
+    **Node** If the the UAN is being replaced within the same rack slot, then this step can be skipped.
+
+    1. Perform a dry-run:
+
+        ```bash
+        /usr/share/doc/csm/scripts/operations/node_management/allocate_uan_ip.py allocate-uan-ip \
+            --xname "${NODE_XNAME}"
+        ```  
+
+        Example output:
+
+        ```text
+        Performing validation checks against SLS
+        Called:  GET https://api-gw-service-nmn.local/apis/sls/v1/hardware/x3000c0s19b0n0 with params None
+                Pass x3000c0s19b0n0 exists in SLS
+                Pass node x3000c0s19b0n0 has expected node Role of Application
+                Pass node x3000c0s19b0n0 has expected SubRole of UAN
+                Pass node x3000c0s19b0n0 has alias of uan01
+        WARNING: Gateway not in Subnet for uai_macvlan (possibly supernetting).
+        Called:  GET https://api-gw-service-nmn.local/apis/sls/v1/networks with params None
+                Allocating UAN node IP address in network CAN
+                Allocated IP 10.102.4.144 on the CAN network
+                Pass x3000c0s19b0n0 (uan01) does not currently exist in SLS Networks
+                Pass allocated IPs for UAN Node x3000c0s19b0n0 (uan01) are not currently in use in SLS Networks
+                Skipping network CHN as it does not exist in SLS
+        Performing validation checks against HSM
+        Called:  GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces with params {'IPAddress': IPAddress('10.102.4.144')}
+                Pass CHN IP address 10.102.4.144 is not currently in use in HSM Ethernet Interfaces
+        Adding UAN IP reservation to bootstrap_dhcp subnet in the CAN network
+        {
+          "Name": "uan01",
+          "IPAddress": "10.102.4.144",
+          "Comment": "x3000c0s19b0n0"
+        }
+        Updating CAN network in SLS with updated IP reservations
+        Skipping due to dry run!
+
+        IP Addresses have been allocated for x3000c0s19b0n0 (uan01) and been added to SLS
+                Network | IP Address
+                --------|-----------
+                CAN     | 10.102.4.144
+        ```
+
+    1. Apply changes to SLS:
+
+        ```bash
+        /usr/share/doc/csm/scripts/operations/node_management/allocate_uan_ip.py allocate-uan-ip \
+            --xname "${NODE_XNAME}" \
+            --perform-changes
+        ```
+
+        Example output:
+
+        ```text
+        Performing validation checks against SLS
+        Called:  GET https://api-gw-service-nmn.local/apis/sls/v1/hardware/x3000c0s19b0n0 with params None
+                Pass x3000c0s19b0n0 exists in SLS
+                Pass node x3000c0s19b0n0 has expected node Role of Application
+                Pass node x3000c0s19b0n0 has expected SubRole of UAN
+                Pass node x3000c0s19b0n0 has alias of uan01
+        WARNING: Gateway not in Subnet for uai_macvlan (possibly supernetting).
+        Called:  GET https://api-gw-service-nmn.local/apis/sls/v1/networks with params None
+                Allocating UAN node IP address in network CAN
+                Allocated IP 10.102.4.144 on the CAN network
+                Pass x3000c0s19b0n0 (uan01) does not currently exist in SLS Networks
+                Pass allocated IPs for UAN Node x3000c0s19b0n0 (uan01) are not currently in use in SLS Networks
+                Skipping network CHN as it does not exist in SLS
+        Performing validation checks against HSM
+        Called:  GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces with params {'IPAddress': IPAddress('10.102.4.144')}
+                Pass CHN IP address 10.102.4.144 is not currently in use in HSM Ethernet Interfaces
+        Adding UAN IP reservation to bootstrap_dhcp subnet in the CAN network
+        {
+          "Name": "uan01",
+          "IPAddress": "10.102.4.144",
+          "Comment": "x3000c0s19b0n0"
+        }
+        Updating CAN network in SLS with updated IP reservations
+        Called:  PUT https://api-gw-service-nmn.local/apis/sls/v1/networks/CAN with params None
+
+        IP Addresses have been allocated for x3000c0s19b0n0 (uan01) and been added to SLS
+                Network | IP Address
+                --------|-----------
+                CAN     | 10.102.4.144
+        ```
+
+1. **Repeat for each** node present in the blade.
+
+### Step 3: Update SLS with CMC information
+
+**If adding an a Gigabyte dense compute node**, then add the Gigabyte CMC data. **Otherwise, for other node types this step can be skipped**.
+
+1. (`ncn#`) Set `CMC_XNAME` environment variable with the xname of the CMC.
+
+   The xname for the CMC in the form of `xXcCsSbB`
+      * `xX`: where `X` is the cabinet or rack identification number.
+      * `cC`: where `C` is the chassis identification number.
+        * If the node is within an air-cooled cabinet, then this should be `0`.
+        * If the node is within an air-cooled chassis in an EX2500 cabinet, then this should be `4`.
+      * `sS`: where `S` is the lowest slot the node chassis occupies.
+      * `bB`: where `B` is the ordinal of the node BMC. This should be `999`.
 
     ```bash
-    curl -s -k -H "Authorization: Bearer ${TOKEN}" -X POST --data '{
-            "Parent": "x3000c0w14",
-            "Xname": "x3000c0w14j36",
-            "Type": "comptype_mgmt_switch_connector",
-            "Class": "River",
-            "TypeString": "MgmtSwitchConnector",
-            "ExtraProperties": {
-                "NodeNics": [
-                    "x3000c0s27b0"
-                ],
-                "VendorName": "1/1/36"
-            }
-        }' https://api-gw-service-nmn.local/apis/sls/v1/hardware | jq
+    CMC_XNAME=x3000c0s17b999
     ```
 
-### Install the node hardware in the rack
+1. (`ncn#`) Create a new CMC object in SLS.
+
+    Create the new object in SLS.
+
+    ```bash
+    cray sls hardware create --xname "${CMC_XNAME}" --class River
+    ```
+
+1. (`ncn#`) Create a new `MgmtSwitchConnector` object in SLS.
+
+    The `MgmtSwitchConnector` connector is used by the `hms-discovery` job to determine which management switch port is connected to the node's BMC. The SLS requires the following information:
+
+    * The management switch port that is connected to the new node's BMC
+    * `Xname`: The component name (xname) for the `MgmtSwitchConnector` in the form of `xXcCwWjJ`
+      * `xX`: where `X` is the cabinet or rack identification number.
+      * `cC`: where `C` is the chassis identification number.
+        * If the destination `LeafBMC` switch is within a standard rack, then this should be `0`
+        * If the destination `LeafBMC` switch is located within an air-cooled chassis in an EX2500 cabinet, then this should be `4`
+      * `wW`: where `W` is the rack U position of the management network leaf switch
+      * `jJ`: where `J` is the switch port number
+
+    * `NodeNics`: The component name (xname) of the new node's BMC; this field is an array in the payloads below, but should only contain one element
+      * `VendorName`: This field varies depending on the OEM for the management switch; for example, if the BMC is plugged into switch port 36, then the following vendor names could apply:
+      * Aruba leaf switches use this format: `1/1/37`
+      * Dell leaf switches use this format: `ethernet1/1/37`
+
+    1. Build up the hardware extra properties:
+
+        ```bash
+        VENDOR_NAME="1/1/37"
+        jq -n --arg CMC_XNAME "${CMC_XNAME}" --arg VENDOR_NAME "${VENDOR_NAME}" '{
+            NodeNics: [$CMC_XNAME],
+            VendorName: $VENDOR_NAME
+        }' | tee cmc_mgmt_switch_connector_extraproperties.json
+        ```
+
+        Expected output:
+
+        ```json
+        {
+          "NodeNics": [
+            "x3000c0s17b999"
+          ],
+          "VendorName": "1/1/37"
+        }
+        ```
+
+    1. Create the new object in SLS.
+
+        ```bash
+        CMC_MGMT_SWITCH_CONNECTOR_XNAME=x3000c0w14j37
+        cray sls hardware create --xname "${CMC_MGMT_SWITCH_CONNECTOR_XNAME}" --class River --extra-properties "$(cat cmc_mgmt_switch_connector_extraproperties.json)"
+        ```
+
+### Step 4: Install the node hardware in the rack
 
 1. Install the new node hardware in the rack and connect power cables, HSN cables, and management network cables \(if it has not already been installed\).
 
@@ -126,24 +332,35 @@ For this procedure, a new object must be created in the SLS and modifications wi
 
     Refer to the OEM documentation for the node for information about the hardware installation and cabling.
 
-### Power on and boot compute node
+### Step 5: Update management network
 
-1. Power on the node to boot the BMC.
+Follow the [Added Hardware](../network/management_network/added_hardware.md) procedure in the Management network documentation.
+
+### Step 6: Discover the Node BMC
+
+1. When the node was installed into the rack the node will have powered on, and have started to attempt to DHCP.
 
 1. Wait for the `hms-discovery` cronjob to run, and for DNS to update.
 
     The `hms-discovery` cronjob will attempt to correctly identity the new node by comparing node and BMC MAC addresses from the HSM Ethernet interfaces table with the connection information present in SLS.
 
+1. (`ncn#`) Set `NODE_XNAME` to the xname of the node.
+
+    ```bash
+    NODE_XNAME=x3000c0s27b0n0
+    BMC_XNAME=$(echo "${NODE_XNAME}" | grep -E -o 'x[0-9]+c[0-9]+s[0-9]+b[0-9]+')
+    ```
+
 1. (`ncn#`) After roughly 5-10 minutes, the node's BMC should be discovered by the HSM, and the node's BMC can be resolved by using its component name (xname) in DNS.
 
     ```bash
-    ping x3000c0s27b0
+    ping "${BMC_XNAME}"
     ```
 
 1. (`ncn#`) Verify that discovery has completed.
 
     ```bash
-    cray hsm inventory redfishEndpoints describe x3000c0s27b0 --format toml
+    cray hsm inventory redfishEndpoints describe "${BMC_XNAME}" --format toml
     ```
 
     Example output:
@@ -166,29 +383,15 @@ For this procedure, a new object must be created in the SLS and modifications wi
     LastDiscoveryStatus = "DiscoverOK"
     ```
 
-    - When `LastDiscoveryStatus` displays as `DiscoverOK`, the node BMC has been successfully discovered.
-    - If the last discovery state is `DiscoveryStarted` then the BMC is currently being inventoried by HSM.
-    - If the last discovery state is `HTTPsGetFailed` or `ChildVerificationFailed`, then an error has
+    * When `LastDiscoveryStatus` displays as `DiscoverOK`, the node BMC has been successfully discovered.
+    * If the last discovery state is `DiscoveryStarted` then the BMC is currently being inventoried by HSM.
+    * If the last discovery state is `HTTPsGetFailed` or `ChildVerificationFailed`, then an error has
       occurred during the discovery process.
-
-1. (`ncn#`) Verify that the nodes are enabled in the HSM.
-
-    ```bash
-    cray hsm state components describe x3000c0s27b0n0 --format toml
-    ```
-
-    Example output (truncated):
-
-    ```toml
-    Type = "Node"
-    Enabled = true
-    State = "Off"
-    ```
 
 1. (`ncn#`) Verify that the node BMC has been discovered by the HSM.
 
     ```bash
-    cray hsm inventory redfishEndpoints describe x3000c0s27b0 --format json
+    cray hsm inventory redfishEndpoints describe "${BMC_XNAME}" --format json
     ```
 
     Example output:
@@ -214,9 +417,23 @@ For this procedure, a new object must be created in the SLS and modifications wi
         }
     ```
 
-    - When `LastDiscoveryStatus` displays as `DiscoverOK`, the node BMC has been successfully discovered.
-    - If the last discovery state is `DiscoveryStarted` then the BMC is currently being inventoried by HSM.
-    - If the last discovery state is `HTTPsGetFailed` or `ChildVerificationFailed` then an error occurred during the discovery process.
+    * When `LastDiscoveryStatus` displays as `DiscoverOK`, the node BMC has been successfully discovered.
+    * If the last discovery state is `DiscoveryStarted` then the BMC is currently being inventoried by HSM.
+    * If the last discovery state is `HTTPsGetFailed` or `ChildVerificationFailed` then an error occurred during the discovery process.
+
+1. (`ncn#`) Verify that the node are enabled in the HSM.
+
+    ```bash
+    cray hsm state components describe "${NODE_XNAME}" --format toml
+    ```
+
+    Example output (truncated):
+
+    ```toml
+    Type = "Node"
+    Enabled = true
+    State = "Off"
+    ```
 
 1. (`ncn#`) Enable the nodes in the HSM database.
 
@@ -224,8 +441,57 @@ For this procedure, a new object must be created in the SLS and modifications wi
 
     ```bash
     cray hsm state components bulkEnabled update --enabled true \
-        --component-ids x3000c0s27b1n0,x3000c0s27b1n1,x3000c0s27b1n2,x3000c0s27b1n3
+        --component-ids "${NODE_XNAME}"
     ```
+
+1. **Repeat for each** node present in the blade.
+
+### Step 7: Discover the CMC
+
+1. (`ncn#`) Set `CMC_XNAME` environment variable with the xname of the CMC.
+
+    ```bash
+    CMC_XNAME=x3000c0s17b999
+    ```
+
+1. (`ncn#`) After roughly 5-10 minutes, the node's BMC should be discovered by the HSM, and the node's BMC can be resolved by using its component name (xname) in DNS.
+
+    ```bash
+    ping "${CMC_XNAME}"
+    ```
+
+1. (`ncn#`) Verify that discovery has completed.
+
+    ```bash
+    cray hsm inventory redfishEndpoints describe "${CMC_XNAME}" --format toml
+    ```
+
+    Example output:
+
+    ```toml
+    ID = "x3000c0s3b0"
+    Type = "NodeBMC"
+    Hostname = ""
+    Domain = ""
+    FQDN = "x3000c0s3b0"
+    Enabled = true
+    UUID = "fe1ce24e-f3cc-42d9-990b-6a23b7279562"
+    User = "root"
+    Password = ""
+    RediscoverOnUpdate = true
+
+    [DiscoveryInfo]
+    LastDiscoveryAttempt = "2022-09-12T15:33:24.317016Z"
+    LastDiscoveryStatus = "DiscoverOK"
+    RedfishVersion = "1.7.0"
+    ```
+
+    * When `LastDiscoveryStatus` displays as `DiscoverOK`, the node BMC has been successfully discovered.
+    * If the last discovery state is `DiscoveryStarted` then the BMC is currently being inventoried by HSM.
+    * If the last discovery state is `HTTPsGetFailed` or `ChildVerificationFailed`, then an error has
+      occurred during the discovery process.
+
+### Step 8: Update firmware
 
 1. Verify that the correct firmware versions are present for node BIOS, BMC, HSN NICs, GPUs, and so on.
 
@@ -237,11 +503,13 @@ For this procedure, a new object must be created in the SLS and modifications wi
 
     See [Update Firmware with FAS](../firmware/Update_Firmware_with_FAS.md).
 
+### Step 9: Power on and boot the node
+
 1. Update workload manager configuration to include any newly added compute nodes to the system.
 
-   - **If Slurm is the installed workload manager**, then see section *10.3.1 Add a New or Configure an Existing Slurm Template* in the *`HPE Cray Programming Environment Installation Guide: CSM on HPE Cray EX Systems (S-8003)`* to regenerate the Slurm
+   * **If Slurm is the installed workload manager**, then see section *10.3.1 Add a New or Configure an Existing Slurm Template* in the *`HPE Cray Programming Environment Installation Guide: CSM on HPE Cray EX Systems (S-8003)`* to regenerate the Slurm
       configuration to include any new compute nodes added to the system.
-   - **If PBS Pro is the installed workload manager**: *Coming soon*
+   * **If PBS Pro is the installed workload manager**: *Coming soon*
 
 1. (`ncn#`) Use the Boot Orchestration Service \(BOS\) to power on and boot the nodes.
 
@@ -252,4 +520,286 @@ For this procedure, a new object must be created in the SLS and modifications wi
         --operation reboot --limit x3000c0s27b0n0,x3000c0s27b0n1,x3000c0s27b0n2,x3000c0s27b00n3
     ```
 
-1. Verify that the chassis status LEDs indicate normal operation.
+## Troubleshooting
+
+### Check DVS
+
+**These troubleshooting steps are applicable when DVS is operating over the NMN network, and not the HSN network.**
+
+There should be a `cray-cps` pod (the broker), three `cray-cps-etcd` pods and their waiter, and at least one `cray-cps-cm-pm` pod.
+Usually there are two `cray-cps-cm-pm` pods, one on `ncn-w002` and one on `ncn-w003` and other worker nodes.
+
+1. (`ncn-mw#`) Verify that the `cray-cps` pods on worker nodes are `Running`.
+
+    ```bash
+    kubectl get pods -Ao wide | grep cps
+    ```
+
+    Example output:
+
+    ```text
+    services   cray-cps-75cffc4b94-j9qzf    2/2  Running   0   42h 10.40.0.57  ncn-w001
+    services   cray-cps-cm-pm-g6tjx         5/5  Running   21  41h 10.42.0.77  ncn-w003
+    services   cray-cps-cm-pm-kss5k         5/5  Running   21  41h 10.39.0.80  ncn-w002
+    services   cray-cps-etcd-knt45b8sjf     1/1  Running   0   42h 10.42.0.67  ncn-w003
+    services   cray-cps-etcd-n76pmpbl5h     1/1  Running   0   42h 10.39.0.49  ncn-w002
+    services   cray-cps-etcd-qwdn74rxmp     1/1  Running   0   42h 10.40.0.42  ncn-w001
+    services   cray-cps-wait-for-etcd-jb95m 0/1  Completed
+    ```
+
+1. (`ncn-w#`) SSH to each worker node running CPS/DVS, and run ensure that there are no recurring `"DVS: merge_one"` error messages as shown.
+
+    The error messages indicate that DVS is detecting an IP address change for one of the client nodes.
+
+    ```bash
+    dmesg -T | grep "DVS: merge_one"
+    ```
+
+    Example output that shows the IP address for `x3000c0s19b1n0` has changed its NMN IP address from `10.252.0.26` to `10.252.0.33`:
+
+    ```text
+    [Tue Jul 21 13:09:54 2020] DVS: merge_one#351: New node map entry does not match the existing entry
+    [Tue Jul 21 13:09:54 2020] DVS: merge_one#353:   nid: 8 -> 8
+    [Tue Jul 21 13:09:54 2020] DVS: merge_one#355:   name: 'x3000c0s19b1n0' -> 'x3000c0s19b1n0'
+    [Tue Jul 21 13:09:54 2020] DVS: merge_one#357:   address: '10.252.0.26@tcp99' -> '10.252.0.33@tcp99'
+    [Tue Jul 21 13:09:54 2020] DVS: merge_one#358:   Ignoring.
+    ```
+
+1. (`ncn-mw#`) **If the `"DVS: merge_one"` error messages is shown**, then the IP address of the node needs to be corrected. This will prevent the need to reload DVS.
+
+    1. Set the following environment variables based on the output collected in the previous step.
+
+        ```bash
+        NODE_XNAME=x3000c0s19b1n0
+        CURRENT_IP_ADDRESS=10.252.0.33
+        DESIRED_IP_ADDRESS=10.252.0.26
+        ```
+
+    1. Determine the HSM EthenretInterface entry holding onto the desired IP address.
+
+        ```bash
+        cray hsm inventory ethernetInterfaces list --ip-address "${DESIRED_IP_ADDRESS}" --output toml
+        ```
+
+        * **If no EthernetInterfaces are found**, then continue on to the next step.
+
+            Example output:
+
+            ```bash
+            results = []
+            ```
+
+        * **If an EthernetInterface is found**, then it needs to be removed from HSM.
+
+            Example output:
+
+            ```toml
+            [[results]]
+            ID = "b42e99dfecf0"
+            Description = "Ethernet Interface Lan2"
+            MACAddress = "b4:2e:99:df:ec:f0"
+            LastUpdate = "2022-08-08T10:10:57.527819Z"
+            ComponentID = "x3000c0s17b2n0"
+            Type = "Node"
+            [[results.IPAddresses]]
+            IPAddress = "10.252.1.26"
+            ```
+
+            1. Record the returned `ID` value into the `EI_ID` environment variable.
+
+                ```bash
+                OLD_EI_ID=b42e99dfecf0
+                ```
+
+            1. Delete the EthernetInterfaces from HSM.
+
+                ```bash
+                cray hsm inventory ethernetInterfaces delete ${OLD_EI_ID}
+                ```
+
+    1. Determine the HSM EthernetInterface entry holding onto the current IP address.
+
+        ```bash
+        cray hsm inventory ethernetInterfaces list --component-id "${NODE_XNAME}" --ip-address "${CURRENT_IP_ADDRESS}" --output toml
+        ```
+
+        Example output:
+
+        ```toml
+        [[results]]
+        ID = "b42e99dff35f"
+        Description = "Ethernet Interface Lan1"
+        MACAddress = "b4:2e:99:df:f3:5f"
+        LastUpdate = "2022-08-18T16:38:21.13173Z"
+        ComponentID = "x3000c0s17b1n0"
+        Type = "Node"
+        [[results.IPAddresses]]
+        IPAddress = "10.252.1.69"
+        ```
+
+        Record the returned `ID` value into the `EI_ID` environment variable.
+
+        ```bash
+        CURRENT_EI_ID=b42e99dff35f
+        ```
+
+    1. Update the EthernetInterface to have the desired IP address:
+
+        ```bash
+        cray hsm inventory ethernetInterfaces update "$CURRENT_EI_ID" --component-id "${NODE_XNAME}" --ip-addresses--ip-address "${DESIRED_IP_ADDRESS}"
+        ```
+
+1. Reboot the node.
+
+1. (`nid#`) SSH to the node and check each DVS mount.
+
+    ```bash
+    mount | grep dvs | head -1
+    ```
+
+    Example output:
+
+    ```text
+    /var/lib/cps-local/0dbb42538e05485de6f433a28c19e200 on /var/opt/cray/gpu/nvidia-squashfs-21.3 type dvs (ro,relatime,blksize=524288,statsfile=/sys/kernel/debug/dvs/mounts/1/stats,attrcache_timeout=14400,cache,nodatasync,noclosesync,retry,failover,userenv,noclusterfs,killprocess,noatomic,nodeferopens,no_distribute_create_ops,no_ro_cache,loadbalance,maxnodes=1,nnodes=6,nomagic,hash_on_nid,hash=modulo,nodefile=/sys/kernel/debug/dvs/mounts/1/nodenames,nodename=x3000c0s6b0n0:x3000c0s5b0n0:x3000c0s4b0n0:x3000c0s9b0n0:x3000c0s8b0n0:x3000c0s7b0n0)
+    ```
+
+### Check the HSN for the affected nodes
+
+1. (`ncn-mw#`) Determine the pod name for the Slingshot fabric manager pod and check the status of the fabric.
+
+    ```bash
+    kubectl exec -it -n services $(kubectl get pods --all-namespaces |grep slingshot | awk '{print $2}') -- fmn_status
+    ```
+
+#### Check for duplicate IP address entries
+
+1. (`ncn#`) Retrieve an authentication token.
+
+     ```bash
+    TOKEN=$(curl -k -s -S -d grant_type=client_credentials \
+                 -d client_id=admin-client \
+                 -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
+                 https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
+     ```
+
+1. (`ncn#`) Check for duplicate IP address entries in the Hardware State Management Database (HSM).
+
+    Duplicate entries will cause DNS operations to fail.
+
+    1. Verify that each node hostname resolves to one IP address.
+
+        ```bash
+        nslookup x1005c3s0b0n0
+        ```
+
+        Example output with one IP address resolving:
+
+        ```text
+        Server:         10.92.100.225
+        Address:        10.92.100.225#53
+
+        Name:   x1005c3s0b0n0
+        Address: 10.100.0.26
+        ```
+
+    1. Reload the Kea configuration.
+
+        ```bash
+        curl -s -k -H "Authorization: Bearer ${TOKEN}" -X POST -H "Content-Type: application/json" -d '{ "command": "config-reload",  "service": [ "dhcp4" ] }' https://api-gw-service-nmn.local/apis/dhcp-kea |jq
+        ```
+
+        If there are no duplicate IP addresses within HSM, then the following response is expected:
+
+        ```json
+        [
+            {
+            "result": 0,
+            "text": "Configuration successful."
+            }
+        ]
+        ```
+
+        If there is a duplicate IP address in the HSM, then an error message similar to the message below will be returned.
+
+        ```text
+        [{'result': 1, 'text': "Config reload failed: configuration error using file '/usr/local/kea/cray-dhcp-kea-dhcp4.conf': 
+        failed to add new host using the HW address '00:40:a6:83:50:a4 and DUID '(null)' to the IPv4 subnet id '0' for the 
+        address 10.100.0.105: There's already a reservation for this address"}]
+        ```
+
+1. (`ncn#`) Check for active DHCP leases.
+
+    If there are no DHCP leases, then there is a configuration error.
+
+    ```bash
+    curl -H "Authorization: Bearer ${TOKEN}" -X POST -H "Content-Type: application/json" \
+        -d '{ "command": "lease4-get-all", "service": [ "dhcp4" ] }' https://api-gw-service-nmn.local/apis/dhcp-kea | jq
+    ```
+
+    Example output with no active DHCP leases:
+
+    ```json
+    [
+      {
+        "arguments": {
+          "leases": []
+        },
+        "result": 3,
+        "text": "0 IPv4 lease(s) found."
+      }
+    ]
+    ```
+
+1. (`ncn#`) If there are duplicate entries in the HSM as a result of this procedure (`10.100.0.105` in this example), then delete the duplicate entry.
+
+    1. Show the `EthernetInterfaces` for the duplicate IP address:
+
+       ```bash
+       cray hsm inventory ethernetInterfaces list --ip-address 10.100.0.105 --format json | jq
+       ```
+
+       Example output for an IP address that is associated with two MAC addresses:
+
+       ```json
+       [
+         {
+           "ID": "0040a68350a4",
+           "Description": "Node Maintenance Network",
+           "MACAddress": "00:40:a6:83:50:a4",
+           "IPAddress": "10.100.0.105",
+           "LastUpdate": "2021-08-24T20:24:23.214023Z",
+           "ComponentID": "x1005c3s0b0n0",
+           "Type": "Node"
+         },
+         {
+           "ID": "0040a683639a",
+           "Description": "Node Maintenance Network",
+           "MACAddress": "00:40:a6:83:63:9a",
+           "IPAddress": "10.100.0.105",
+           "LastUpdate": "2021-08-27T19:15:53.697459Z",
+           "ComponentID": "x1005c3s0b0n0",
+           "Type": "Node"
+         }
+       ]
+       ```
+
+    1. Delete the older entry.
+
+       ```bash
+       cray hsm inventory ethernetInterfaces delete 0040a68350a4
+       ```
+
+1. (`ncn#`) Check DNS.
+
+    ```bash
+    nslookup 10.100.0.105
+    ```
+
+    Example output:
+
+    ```text
+    105.0.100.10.in-addr.arpa        name = nid001032-nmn.
+    105.0.100.10.in-addr.arpa        name = nid001032-nmn.local.
+    105.0.100.10.in-addr.arpa        name = x1005c3s0b0n0.
+    105.0.100.10.in-addr.arpa        name = x1005c3s0b0n0.local.
+    ```

--- a/operations/node_management/Removing_a_Standard_Node_from_a_System.md
+++ b/operations/node_management/Removing_a_Standard_Node_from_a_System.md
@@ -1,0 +1,515 @@
+# Removing a Standard rack node from a System
+
+This procedure will remove one or more air-cooled standard node from an HPE Cray EX system.
+
+This procedure is applicable for the following types of standard rack nodes:
+
+* Single node chassis (DL325, DL385, etc...)
+* Dual node chassis (Apollo 6500 XL645d, etc...)
+* Quad dense node chassis (Gigabyte compute node chassis)
+
+## Perquisites
+
+* The Cray command line interface \(CLI\) tool is initialized and configured on the system. See [Configure the Cray CLI](../configure_cray_cli.md).
+* Knowledge of whether Data Virtualization Service (DVS) is operating over the Node Management Network (NMN) or the High Speed Network (HSN).
+* The Slingshot fabric must be configured with the desired topology for desired state of the blades in the system.
+* The System Layout Service (SLS) must have the desired HSN configuration.
+* Check the status of the HSN and record link status before the procedure.
+
+## Procedure
+
+### Step 1: Retrieve an API token
+
+1. (`ncn-mw#`) Retrieve an API token.
+
+    ```bash
+    export TOKEN=$(curl -s -S -d grant_type=client_credentials \
+                -d client_id=admin-client \
+                -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
+                https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
+    ```
+
+### Step 2: Power down node
+
+1. Use the workload manager (WLM) to drain running jobs from the affected nodes on the blade.
+
+    Refer to the vendor documentation for the WLM for more information.
+
+1. (`ncn#`) Use Boot Orchestration Services (BOS) to shut down the affected nodes in the source blade.
+
+    In this example, `x9000c3s0` is the source blade. Specify the appropriate component name (xname) and BOS
+    template for the node type in the following command.
+
+    ```bash
+    BOS_TEMPLATE=cos-2.0.30-slurm-healthy-compute
+    cray bos session create --template-uuid $BOS_TEMPLATE --operation shutdown --limit x9000c3s0b0n0,x9000c3s0b0n1,x9000c3s0b1n0,x9000c3s0b1n1
+    ```
+
+### Step 3: Remove Data from SLS and HSM
+
+1. (`ncn#`) Set `NODE_XNAME` environment variable with the nodes xname:
+
+    ```bash
+    NODE_XNAME=x3000c0s19b0n0
+    ```
+
+1. (`ncn#`) Verify the node to be removed is powered off:
+
+    ```bash
+    cray capmc get_xname_status create --xnames "${NODE_XNAME}" --format toml
+    ```
+
+    Expected output:
+
+    ```toml
+    e = 0
+    err_msg = ""
+    off = [ "x3000c0s19b0n0",]
+    ```
+
+1. (`ncn#`) **If the node being removed is an UAN**, then remove the IP address reservation for the node in the `CAN` or `CHN` networks.
+
+    **Node** If the the UAN is being replaced within the same rack slot, then this step can be skipped.
+
+   1. Perform a dry-run:
+
+        ```bash
+        /usr/share/doc/csm/scripts/operations/node_management/allocate_uan_ip.py allocate-uan-ip \
+            --xname "${NODE_XNAME}"
+        ```  
+
+        Example output:
+
+        ```text
+        ncn-m001:~/rsjostrand/scripts # ./allocate_uan_ip.py  deallocate-uan-ip --xname x3000c0s19b0n0
+        Called:  GET https://api-gw-service-nmn.local/apis/sls/v1/hardware/x3000c0s19b0n0 with params None
+                Pass x3000c0s19b0n0 exists in SLS
+                Pass node x3000c0s19b0n0 has expected node Role of Application
+                Pass node x3000c0s19b0n0 has expected SubRole of UAN
+                Pass node x3000c0s19b0n0 has alias of uan01
+        WARNING: Gateway not in Subnet for uai_macvlan (possibly supernetting).
+        Called:  GET https://api-gw-service-nmn.local/apis/sls/v1/networks with params None
+                Removing existing UAN node IP Reservation in subnet bootstrap_dhcp of network CAN: {'Name': 'uan01', 'IPAddress': '10.102.4.144', 'Comment': 'x3000c0s19b0n0'}
+                Skipping network CHN as it does not exist in SLS
+        Updating CAN network in SLS with updated IP reservations
+        Skipping due to dry run!
+        ```
+
+      1. Apply changes to SLS:
+
+        ```bash
+        /usr/share/doc/csm/scripts/operations/node_management/allocate_uan_ip.py deallocate-uan-ip \
+            --xname "${NODE_XNAME}" \
+            --perform-changes
+        ```
+
+        Example output:
+
+        ```text
+        Called:  GET https://api-gw-service-nmn.local/apis/sls/v1/hardware/x3000c0s19b0n0 with params None
+                Pass x3000c0s19b0n0 exists in SLS
+                Pass node x3000c0s19b0n0 has expected node Role of Application
+                Pass node x3000c0s19b0n0 has expected SubRole of UAN
+                Pass node x3000c0s19b0n0 has alias of uan01
+        WARNING: Gateway not in Subnet for uai_macvlan (possibly supernetting).
+        Called:  GET https://api-gw-service-nmn.local/apis/sls/v1/networks with params None
+                Removing existing UAN node IP Reservation in subnet bootstrap_dhcp of network CAN: {'Name': 'uan01', 'IPAddress': '10.102.4.144', 'Comment': 'x3000c0s19b0n0'}
+                Skipping network CHN as it does not exist in SLS
+        Updating CAN network in SLS with updated IP reservations
+        Called:  PUT https://api-gw-service-nmn.local/apis/sls/v1/networks/CAN with params None
+                ```
+
+1. (`ncn#`) Remove node data:
+
+    ```bash
+    /usr/share/doc/csm/scripts/operations/node_management/remove_standard_rack_node.sh "${NODE_XNAME}"
+    ```
+
+    Example output:
+
+    ```text
+    ==================================================
+    Xname Summary
+    ==================================================
+    Node:          x3000c0s19b0n0
+    NodeBMC:       x3000c0s19b0
+    NodeEnclosure: x3000c0s19e0
+
+    ==================================================
+    Verifying BMC exists as a RedfishEndpoint in HSM
+    ==================================================
+    {
+      "ID": "x3000c0s19b0",
+      "Type": "NodeBMC",
+      "Hostname": "x3000c0s19b0",
+      "Domain": "",
+      "FQDN": "x3000c0s19b0",
+      "Enabled": true,
+      "UUID": "92d4acf5-a95a-4908-97e7-cdd8d269f540",
+      "User": "root",
+      "Password": "",
+      "MACAddr": "a4bf0138ed46",
+      "RediscoverOnUpdate": true,
+      "DiscoveryInfo": {
+        "LastDiscoveryAttempt": "2022-09-05T16:09:57.620526Z",
+        "LastDiscoveryStatus": "DiscoverOK",
+        "RedfishVersion": "1.1.0"
+      }
+    }
+
+    ==================================================
+    Removing BMC Event subscriptions
+    ==================================================
+    Clearing subscriptions from NodeBMC x3000c0s19b0
+    Retrieving BMC (x3000c0s19b0) credentials from SCSD
+    {'Targets': [{'Xname': 'x3000c0s19b0', 'Username': 'root', 'Password': 'initial0', 'StatusCode': 200, 'StatusMsg': 'OK'}]}
+    Retrieving Redfish Event subscriptions from the BMC: https://x3000c0s19b0/redfish/v1/EventService/Subscriptions
+    No event subscriptions present!
+
+    ==================================================
+    Removing node data from SLS
+    ==================================================
+    Deleting MmgtSwitchConnector from SLS: x3000c0w25j37
+    {
+      "Parent": "x3000c0w25",
+      "Xname": "x3000c0w25j37",
+      "Type": "comptype_mgmt_switch_connector",
+      "Class": "River",
+      "TypeString": "MgmtSwitchConnector",
+      "LastUpdated": 1662392014,
+      "LastUpdatedTime": "2022-09-05 15:33:34.496642 +0000 +0000",
+      "ExtraProperties": {
+        "NodeNics": [
+          "x3000c0s19b0"
+        ],
+        "VendorName": "ethernet1/1/37"
+      }
+    }
+    code = 0
+    message = "deleted entry and its descendants"
+
+    Deleting Node from SLS: x3000c0s19b0n0
+    {
+      "Parent": "x3000c0s19b0",
+      "Xname": "x3000c0s19b0n0",
+      "Type": "comptype_node",
+      "Class": "River",
+      "TypeString": "Node",
+      "LastUpdated": 1662392014,
+      "LastUpdatedTime": "2022-09-05 15:33:34.496642 +0000 +0000",
+      "ExtraProperties": {
+        "Aliases": [
+          "uan01"
+        ],
+        "Role": "Application",
+        "SubRole": "UAN"
+      }
+    }
+    code = 0
+    message = "deleted entry and its descendants"
+
+
+    ==================================================
+    Removing node data from HSM
+    ==================================================
+    Deleting component from HSM State Components: x3000c0s19b0n0
+    {
+      "ID": "x3000c0s19b0n0",
+      "Type": "Node",
+      "State": "Off",
+      "Flag": "OK",
+      "Enabled": true,
+      "Role": "Application",
+      "SubRole": "UAN",
+      "NID": 49168992,
+      "NetType": "Sling",
+      "Arch": "X86",
+      "Class": "River"
+    }
+    code = 0
+    message = "deleted 1 entry"
+
+    Deleting component from HSM State Components: x3000c0s19b0
+    {
+      "ID": "x3000c0s19b0",
+      "Type": "NodeBMC",
+      "State": "Ready",
+      "Flag": "OK",
+      "Enabled": true,
+      "NetType": "Sling",
+      "Arch": "X86",
+      "Class": "River"
+    }
+    code = 0
+    message = "deleted 1 entry"
+
+    Deleting component from HSM State Components: x3000c0s19e0
+    {
+      "ID": "x3000c0s19e0",
+      "Type": "NodeEnclosure",
+      "State": "Off",
+      "Flag": "Warning",
+      "Enabled": true,
+      "NetType": "Sling",
+      "Arch": "X86",
+      "Class": "River"
+    }
+    code = 0
+    message = "deleted 1 entry"
+
+    Deleting Node MAC address: a4bf0138ed42
+    {
+      "ID": "a4bf0138ed42",
+      "Description": "Missing interface 1, MAC computed via workaround",
+      "MACAddress": "a4:bf:01:38:ed:42",
+      "LastUpdate": "2022-09-05T16:09:57.641759Z",
+      "ComponentID": "x3000c0s19b0n0",
+      "Type": "Node",
+      "IPAddresses": []
+    }
+    code = 0
+    message = "deleted 1 entry"
+
+    Deleting Node MAC address: a4bf0138ed43
+    {
+      "ID": "a4bf0138ed43",
+      "Description": "Missing interface 2, MAC computed via workaround",
+      "MACAddress": "a4:bf:01:38:ed:43",
+      "LastUpdate": "2022-09-05T16:09:57.641759Z",
+      "ComponentID": "x3000c0s19b0n0",
+      "Type": "Node",
+      "IPAddresses": []
+    }
+    code = 0
+    message = "deleted 1 entry"
+
+    Deleting BMC MAC address: a4bf0138ed46
+    {
+      "ID": "a4bf0138ed46",
+      "Description": "",
+      "MACAddress": "a4:bf:01:38:ed:46",
+      "LastUpdate": "2022-09-05T16:06:10.381742Z",
+      "ComponentID": "x3000c0s19b0",
+      "Type": "NodeBMC",
+      "IPAddresses": [
+        {
+          "IPAddress": "10.254.1.28"
+        }
+      ]
+    }
+    code = 0
+    message = "deleted 1 entry"
+
+    Deleting BMC MAC address: a4bf0138ed44
+    {
+      "ID": "a4bf0138ed44",
+      "Description": "Network Interface on the Baseboard Management Controller",
+      "MACAddress": "a4:bf:01:38:ed:44",
+      "LastUpdate": "2022-09-05T16:09:57.641759Z",
+      "ComponentID": "x3000c0s19b0",
+      "Type": "NodeBMC",
+      "IPAddresses": []
+    }
+    code = 0
+    message = "deleted 1 entry"
+
+    Deleting BMC MAC address: a4bf0138ed45
+    {
+      "ID": "a4bf0138ed45",
+      "Description": "Network Interface on the Baseboard Management Controller",
+      "MACAddress": "a4:bf:01:38:ed:45",
+      "LastUpdate": "2022-09-05T16:09:57.641759Z",
+      "ComponentID": "x3000c0s19b0",
+      "Type": "NodeBMC",
+      "IPAddresses": []
+    }
+    code = 0
+    message = "deleted 1 entry"
+
+    Deleting RedfishEndpoint from HSM: x3000c0s19b0
+    {
+      "ID": "x3000c0s19b0",
+      "Type": "NodeBMC",
+      "Hostname": "x3000c0s19b0",
+      "Domain": "",
+      "FQDN": "x3000c0s19b0",
+      "Enabled": true,
+      "UUID": "92d4acf5-a95a-4908-97e7-cdd8d269f540",
+      "User": "root",
+      "Password": "",
+      "MACAddr": "a4bf0138ed46",
+      "RediscoverOnUpdate": true,
+      "DiscoveryInfo": {
+        "LastDiscoveryAttempt": "2022-09-05T16:09:57.620526Z",
+        "LastDiscoveryStatus": "DiscoverOK",
+        "RedfishVersion": "1.1.0"
+      }
+    }
+    code = 0
+    message = "deleted 1 entry"
+    ```
+
+1. **Repeat for each** node being removed on the blade.
+
+### Step 4: Remove Gigabyte CMC
+
+**If removing an a Gigabyte dense compute node** remove the Gigabyte CMC data. **Otherwise, for other node types this step can be skipped**.
+
+1. (`ncn#`) Set `CMC_XNAME` environment variable with the xname of the CMC.
+
+    ```bash
+    CMC_XNAME=x3000c0s17b999
+    ```
+
+1. (`ncn#`) Remove the Gigabyte CMC data.
+
+    ```bash
+    /usr/share/doc/csm/scripts/operations/node_management/remove_gigabyte_cmc.sh "${CMC_XNAME}"
+    ```
+
+    Example output:
+
+    ```bash
+    ==================================================
+    Xname Summary
+    ==================================================
+    CMC: x3000c0s17b999
+
+    ==================================================
+    Removing CMC data from SLS
+    ==================================================
+    Verifying CMC exists in SLS hardware: x3000c0s17b999
+    {
+      "Parent": "x3000",
+      "Xname": "x3000c0s17b999",
+      "Type": "comptype_chassis_bmc",
+      "Class": "River",
+      "TypeString": "ChassisBMC",
+      "LastUpdated": 1663264176,
+      "LastUpdatedTime": "2022-09-15 17:49:36.469256 +0000 UTC"
+    }
+    CMC exists: x3000c0s17b999
+    Deleting CMC from SLS: x3000c0s17b999
+    {
+      "Parent": "x3000",
+      "Xname": "x3000c0s17b999",
+      "Type": "comptype_chassis_bmc",
+      "Class": "River",
+      "TypeString": "ChassisBMC",
+      "LastUpdated": 1663264176,
+      "LastUpdatedTime": "2022-09-15 17:49:36.469256 +0000 UTC"
+    }
+    code = 0
+    message = "deleted entry and its descendants"
+
+    Deleting MgmtSwitchConnector from SLS: x3000c0w14j32
+    {
+      "Parent": "x3000c0w14",
+      "Xname": "x3000c0w14j32",
+      "Type": "comptype_mgmt_switch_connector",
+      "Class": "River",
+      "TypeString": "MgmtSwitchConnector",
+      "LastUpdated": 1663264176,
+      "LastUpdatedTime": "2022-09-15 17:49:36.469256 +0000 UTC",
+      "ExtraProperties": {
+        "NodeNics": [
+          "x3000c0s17b999"
+        ],
+        "VendorName": "1/1/32"
+      }
+    }
+    code = 0
+    message = "deleted entry and its descendants"
+
+
+    ==================================================
+    Removing node data from HSM
+    ==================================================
+    Disabling Redfish Endpoint in HSM: x3000c0s17b999
+    ID = "x3000c0s17b999"
+    Type = "NodeBMC"
+    Hostname = "x3000c0s17b999"
+    Domain = ""
+    FQDN = "x3000c0s17b999"
+    Enabled = false
+    UUID = "009ea76e-debf-0010-ef03-b42e99bdd255"
+    User = "root"
+    Password = ""
+    MACAddr = "b42e99bdd255"
+    RediscoverOnUpdate = true
+
+    [DiscoveryInfo]
+    LastDiscoveryAttempt = "2022-08-08T10:11:10.208211Z"
+    LastDiscoveryStatus = "DiscoverOK"
+    RedfishVersion = "1.7.0"
+
+    Deleting component from HSM State Components: x3000c0s17b999
+    {
+      "ID": "x3000c0s17b999",
+      "Type": "NodeBMC",
+      "State": "Empty",
+      "Flag": "OK",
+      "Enabled": true,
+      "NetType": "Sling",
+      "Arch": "X86",
+      "Class": "River"
+    }
+    code = 0
+    message = "deleted 1 entry"
+
+    Deleting CMC MAC address: b42e99bdd255
+    {
+      "ID": "b42e99bdd255",
+      "Description": "",
+      "MACAddress": "b4:2e:99:bd:d2:55",
+      "LastUpdate": "2022-08-08T10:07:01.928963Z",
+      "ComponentID": "x3000c0s17b999",
+      "Type": "NodeBMC",
+      "IPAddresses": [
+        {
+          "IPAddress": "10.254.1.42"
+        }
+      ]
+    }
+    code = 0
+    message = "deleted 1 entry"
+
+    Deleting CMC MAC address: 0234e854d178
+    {
+      "ID": "0234e854d178",
+      "Description": "Ethernet Interface usb0",
+      "MACAddress": "02:34:e8:54:d1:78",
+      "LastUpdate": "2022-08-08T10:11:10.210893Z",
+      "ComponentID": "x3000c0s17b999",
+      "Type": "NodeBMC",
+      "IPAddresses": []
+    }
+    code = 0
+    message = "deleted 1 entry"
+
+    Deleting RedfishEndpoint from HSM: x3000c0s17b999
+    {
+      "ID": "x3000c0s17b999",
+      "Type": "NodeBMC",
+      "Hostname": "x3000c0s17b999",
+      "Domain": "",
+      "FQDN": "x3000c0s17b999",
+      "Enabled": false,
+      "UUID": "009ea76e-debf-0010-ef03-b42e99bdd255",
+      "User": "root",
+      "Password": "",
+      "MACAddr": "b42e99bdd255",
+      "RediscoverOnUpdate": true,
+      "DiscoveryInfo": {
+        "LastDiscoveryAttempt": "2022-08-08T10:11:10.208211Z",
+        "LastDiscoveryStatus": "DiscoverOK",
+        "RedfishVersion": "1.7.0"
+      }
+    }
+    code = 0
+    message = "deleted 1 entry"
+    ```
+
+### Step 5: Remove the blade
+
+The node can now be physically removed from the system.

--- a/operations/node_management/Replace_a_Standard_Rack_Node.md
+++ b/operations/node_management/Replace_a_Standard_Rack_Node.md
@@ -1,0 +1,8 @@
+# Replace a Standard rack node from a System
+
+This procedure will replace a standard node from an HPE Cray EX system.
+
+## Procedure
+
+1. Follow [Removing a Standard Node from a System procedure](Removing_a_Standard_Node_from_a_System.md) procedure to remove the node from the system.
+1. Follow [Add a Standard Node from a System procedure](Add_a_Standard_Rack_Node.md) procedure to add the replacement node to the system.

--- a/scripts/operations/node_management/allocate_uan_ip.py
+++ b/scripts/operations/node_management/allocate_uan_ip.py
@@ -1,0 +1,425 @@
+#! /usr/bin/env python3
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+#pylint: disable=missing-docstring, C0301, C0103, C0302
+
+import argparse
+import json
+import netaddr
+import os
+import sys
+import re
+import requests
+import urllib3
+
+# Need to add an import path so we can reuse code from the Add_Remove_Replace_NCNs
+# scripts.
+sys.path.append(os.path.join(os.path.dirname(__file__), "Add_Remove_Replace_NCNs"))
+
+import add_management_ncn
+
+from add_management_ncn import(
+    # Exceptions
+    AllocatedIPIsOutsideStaticRange,
+    ExhaustedAvailableIPAddressSpace,
+
+    # HTTP Helpers
+    http_put,
+    action_log,
+    print_action,
+
+    # SLS Helpers
+    get_sls_networks,
+    get_sls_hardware,
+
+    # SLS IPAM Helpers
+    allocate_ip_address_in_subnet,
+
+    # HSM Helpers
+    search_hsm_inventory_ethernet_interfaces,
+    delete_hsm_inventory_ethernet_interfaces,
+)
+from sls_utils.Reservations import Reservation as IPReservation
+
+# Global variables for service URLs. These get set in main.
+HSM_URL = None
+SLS_URL = None
+
+#
+# UAN IP Allocation functions
+#
+def allocate_uan_ip_cmd(session: requests.Session, args):
+    print("Performing validation checks against SLS")
+
+    # Verify the UAN node exists in SLS with the correct role and expected alias
+    action, node = get_sls_hardware(session, args.xname)
+
+    # Verify the node has the role of application
+    if node["ExtraProperties"]["Role"] != "Application":
+        action_log(action, f'Unexpected node Role for {args.xname} of {node["ExtraProperties"]["Role"]}, expected Application')
+        print_action(action)
+        sys.exit(1)
+    else:
+        action_log(action, f'Pass node {args.xname} has expected node Role of Application')
+
+
+    # Verify the node has the sub-role of UAN
+    if node["ExtraProperties"]["SubRole"] != "UAN":
+        action_log(action, f'Unexpected node SubRole for {args.xname} of {node["ExtraProperties"]["SubRole"]}, expected UAN')
+        print_action(action)
+        sys.exit(1)
+    else:
+        action_log(action, f'Pass node {args.xname} has expected SubRole of UAN')
+
+    # Verify the node has a alias
+    alias = None
+    if len(node["ExtraProperties"]["Aliases"]) == 0:
+        action_log(action, f'Error node {args.xname} has no aliases defined in SLS hardware')
+    else:
+        alias = node["ExtraProperties"]["Aliases"][0]
+        action_log(action, f'Pass node {args.xname} has alias of {alias}')
+
+    print_action(action)
+
+    # Retrieve all Network data from SLS
+    validate_sls = False
+    action, sls_networks = get_sls_networks(session, validate=validate_sls)
+
+    # For each network allocate an IP address for the UAN
+    allocated_ips = {}
+    for network_name in ["CAN", "CHN"]:
+        if network_name not in sls_networks:
+            action_log(action, f"Skipping network {network_name} as it does not exist in SLS")
+            continue
+
+        sls_network = sls_networks[network_name]
+
+        # This will add a new line between each iteration of this loop if both the CAN and CHN are present
+        # for some reason.
+        if len(allocated_ips) > 0:
+            action_log(action, "")
+
+        #
+        # Check to see if a UAN IP address reservation already exists for the UAN.
+        # If it has the same Alias and Xname(Comment) then there is nothing to allocate.
+        #
+        bootstrap_dhcp_subnet = sls_network.subnets()["bootstrap_dhcp"]
+        # for name, ip_res in bootstrap_dhcp_subnet_reservations.items():
+        #     print(name, json.dumps(ip_res.to_sls()))
+        if alias in bootstrap_dhcp_subnet.reservations() and bootstrap_dhcp_subnet.reservations()[alias].comment() == args.xname:
+            action_log(action, f"Found existing UAN node IP Reservation in subnet bootstrap_dhcp in network {network_name} in SLS: {bootstrap_dhcp_subnet.reservations()[alias].to_sls()}")
+            continue
+
+        #
+        # Allocate an IP address on the network
+        #
+        action_log(action, f"Allocating UAN node IP address in network {network_name}")
+
+        try:
+            allocated_ips[network_name] = allocate_ip_address_in_subnet(action, sls_networks, network_name, "bootstrap_dhcp", args.network_allowed_in_dhcp_range)
+
+        except ExhaustedAvailableIPAddressSpace:
+            # This indicates that the network is too small
+            print_action(action)
+            sys.exit(1)
+        except AllocatedIPIsOutsideStaticRange:
+            action_log(action, f"Static range in the bootstrap_dhcp subnet of network {network_name} is too small. Attempting to expand the subnet")
+
+
+            # Retrieve the existing DHCP range start IP address
+            old_dhcp_start_address = netaddr.IPAddress(str(bootstrap_dhcp_subnet.dhcp_start_address()))
+            # Get the next IP address
+            new_dhcp_start_address = old_dhcp_start_address+1
+            bootstrap_dhcp_subnet.dhcp_start_address(str(new_dhcp_start_address))
+            action_log(action, f"Adjusting DHCP start of the bootstrap_dhcp subnet of network {network_name} from {str(old_dhcp_start_address)} to {str(new_dhcp_start_address)}")
+
+            # Verify the next IP address is within the subnet
+            subnet = netaddr.IPNetwork(str(bootstrap_dhcp_subnet.ipv4_address()))
+            if new_dhcp_start_address not in subnet[2:-2]:
+                action_log(action, f"Failed to expand the static IP address range of the bootstrap_dhcp subnet in network {network_name}")
+                print_action(action)
+                sys.exit(1)
+
+            # Attempt to allocate the IP address again with the expanded IP address range
+            try:
+                allocated_ips[network_name] = allocate_ip_address_in_subnet(action, sls_networks, network_name, "bootstrap_dhcp", args.network_allowed_in_dhcp_range)
+            except (AllocatedIPIsOutsideStaticRange, ExhaustedAvailableIPAddressSpace):
+                print_action(action)
+                sys.exit(1)
+
+        #
+        # Verify allocated IP address
+        # Validate the application node IP to be added does not have an IP reservation already defined for it
+        # Also validate that none of the IP addresses we have allocated are currently in use in SLS.
+        #
+        fail_sls_network_check = False
+        for subnet in sls_network.subnets().values():
+            for ip_reservation in subnet.reservations().values():
+                # Verify no IP Reservations exist for the UAN
+                same_alias = ip_reservation.name() == alias
+                same_xname = ip_reservation.comment() == args.xname
+                if same_alias and same_xname:
+                    fail_sls_network_check = True
+                    action_log(action, f'Error found existing IP Reservation in subnet {subnet.name()} of network {network_name} in SLS: {ip_reservation.to_sls()}')
+                elif same_alias:
+                    fail_sls_network_check = True
+                    action_log(action, f'Error found existing IP Reservation in subnet {subnet.name()} of network {network_name} in SLS with same alias and different xname: {ip_reservation.to_sls()}')
+                elif same_xname:
+                    fail_sls_network_check = True
+                    action_log(action, f'Error found existing IP Reservation in subnet {subnet.name()} of network {network_name} in SLS with same xname and different alias: {ip_reservation.to_sls()}')
+
+                # Verify no IP Reservations exist with any NCN IP
+                if ip_reservation.ipv4_address() == allocated_ips[network_name]:
+                    fail_sls_network_check = True
+                    action_log(action, f'Error found allocated UAN node IP {allocated_ips[network_name]} in subnet {subnet.name()} of network {network_name} in SLS: {ip_reservation.to_sls()}')
+
+        if fail_sls_network_check:
+            print_action(action)
+            sys.exit(1)
+        action_log(action, f'Pass {args.xname} ({alias}) does not currently exist in SLS Networks')
+        action_log(action, f'Pass allocated IPs for UAN Node {args.xname} ({alias}) are not currently in use in SLS Networks')
+
+    print_action(action)
+
+    if len(allocated_ips) == 0:
+        sys.exit(0)
+
+    #
+    # Validate contents of HSM
+    #
+    print("Performing validation checks against HSM")
+
+    # Validate allocated IPs are not in use in the HSM EthernetInterfaces table
+    for network, ip in allocated_ips.items():
+        action, found_ethernet_interfaces = search_hsm_inventory_ethernet_interfaces(session, ip_address=ip)
+        if len(found_ethernet_interfaces) == 0:
+            action_log(action, f"Pass {network_name} IP address {ip} is not currently in use in HSM Ethernet Interfaces")
+        else:
+            # An IP address that has been allocated for the NCN is present in HSM.
+            # If the component ID is not set, then this is not a real IP reservation and can be removed, as it is most likely
+            # cruft from the past that was not cleaned up.
+            for found_ie in found_ethernet_interfaces:
+                if found_ie["ComponentID"] == "":
+                    print(f'Removing stale Ethernet Interface from HSM: {found_ie}')
+                    if args.perform_changes:
+                        delete_hsm_inventory_ethernet_interfaces(session, found_ie)
+                    else:
+                        print("Skipping due to dry run!")
+                else:
+                    action_log(action, f'Error found EthernetInterfaces with allocated IP address {ip} in HSM: {found_ie}')
+                    print_action(action)
+                    sys.exit(1)
+
+        print_action(action)
+
+    #
+    # Update SLS networking for the new UAN
+    #
+    for network_name, ip in allocated_ips.items():
+        sls_network = sls_networks[network_name]
+
+        ip_reservation = IPReservation(alias, ip, comment=args.xname, aliases=[])
+
+        print(f"Adding UAN IP reservation to bootstrap_dhcp subnet in the {network_name} network")
+        print(json.dumps(ip_reservation.to_sls(), indent=2))
+
+        # Add the reservation to the subnet
+        sls_network.subnets()["bootstrap_dhcp"].reservations().update(
+            {
+                ip_reservation.name(): ip_reservation
+            }
+        )
+
+        print(f"Updating {network_name} network in SLS with updated IP reservations")
+        if args.perform_changes:
+            action = http_put(session, f'{SLS_URL}/networks/{network_name}', payload=sls_network.to_sls())
+            if action["error"] is not None:
+                action_log(action, f'Error failed to update {network_name} in SLS')
+                print_action(action)
+                sys.exit(1)
+            print_action(action)
+        else:
+            print("Skipping due to dry run!")
+
+    print('')
+    print(f'IP Addresses have been allocated for {args.xname} ({alias}) and been added to SLS')
+    print("        Network | IP Address")
+    print("        --------|-----------")
+    for network in sorted(allocated_ips):
+        ip = allocated_ips[network]
+        print(f'        {network:<8}| {ip}')
+
+
+def deallocate_uan_ip_cmd(session: requests.Session, args):
+    # Verify the UAN node exists in SLS with the correct role and expected alias
+    action, node = get_sls_hardware(session, args.xname)
+
+    # Verify the node has the role of application
+    if node["ExtraProperties"]["Role"] != "Application":
+        action_log(f'Unexpected node Role for {args.xname} of {node["ExtraProperties"]["Role"]}, expected Application')
+        print_action(action)
+        sys.exit(1)
+    else:
+        action_log(action, f'Pass node {args.xname} has expected node Role of Application')
+
+
+    # Verify the node has the sub-role of UAN
+    if node["ExtraProperties"]["SubRole"] != "UAN":
+        action_log(action, f'Unexpected node SubRole for {args.xname} of {node["ExtraProperties"]["SubRole"]}, expected UAN')
+        print_action(action)
+        sys.exit(1)
+    else:
+        action_log(action, f'Pass node {args.xname} has expected SubRole of UAN')
+
+    # Verify the node has a alias
+    alias = None
+    if len(node["ExtraProperties"]["Aliases"]) == 0:
+        action_log(action, f'Error node {args.xname} has no aliases defined in SLS hardware')
+    else:
+        alias = node["ExtraProperties"]["Aliases"][0]
+        action_log(action, f'Pass node {args.xname} has alias of {alias}')
+
+    print_action(action)
+
+    # Retrieve all Network data from SLS
+    validate_sls = False
+    action, sls_networks = get_sls_networks(session, validate=validate_sls)
+
+    modified_networks = []
+    for network_name in ["CAN", "CHN"]:
+        if network_name not in sls_networks:
+            action_log(action, f"Skipping network {network_name} as it does not exist in SLS")
+            continue
+
+        sls_network = sls_networks[network_name]
+
+        # Check to see if a IP address reservation exists
+        bootstrap_dhcp_subnet_reservations = sls_network.subnets()["bootstrap_dhcp"].reservations()
+
+        fail_sls_network_check = False
+        for ip_reservation in  list(bootstrap_dhcp_subnet_reservations.values()):
+            same_alias = ip_reservation.name() == alias
+            same_xname = ip_reservation.comment() == args.xname
+            if same_alias and same_xname:
+                # Remove the IP reservations
+                action_log(action, f"Removing existing UAN node IP Reservation in subnet bootstrap_dhcp of network {network_name}: {ip_reservation.to_sls()}")
+                del bootstrap_dhcp_subnet_reservations[alias]
+                modified_networks.append(network_name)
+            elif same_alias:
+                fail_sls_network_check = True
+                action_log(action, f'Error found existing IP Reservation in subnet bootstrap_dhcp of network {network_name} in SLS with same alias and different xname: {ip_reservation.to_sls()}')
+            elif same_xname:
+                fail_sls_network_check = True
+                action_log(action, f'Error found existing IP Reservation in subnet bootstrap_dhcp of network {network_name} in SLS with same xname and different alias: {ip_reservation.to_sls()}')
+
+        if fail_sls_network_check:
+            print_action(action)
+            sys.exit(1)
+
+        if network_name not in modified_networks:
+            action_log(action, f"No IP Reservations for {args.xname} ({alias}) exist in network {network_name}")
+
+    print_action(action)
+
+    #
+    # Update SLS networking for the new UAN
+    #
+    for network_name in modified_networks:
+        sls_network = sls_networks[network_name]
+
+        print(f"Updating {network_name} network in SLS with updated IP reservations")
+        if args.perform_changes:
+            action = http_put(session, f'{SLS_URL}/networks/{network_name}', payload=sls_network.to_sls())
+            if action["error"] is not None:
+                action_log(action, f'Error failed to update {network_name} in SLS')
+                print_action(action)
+                sys.exit(1)
+            print_action(action)
+        else:
+            print("Skipping due to dry run!")
+
+#
+# Main
+#
+def main():
+    global HSM_URL
+    global SLS_URL
+
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+    token = os.environ.get('TOKEN')
+    if token is None or token == "":
+        print("Error environment variable TOKEN was not set")
+        sys.exit(1)
+
+    # Parse CLI Arguments
+    parser = argparse.ArgumentParser()
+    parser.set_defaults(show_help=True)
+
+    subparsers = parser.add_subparsers()
+
+
+    # Global arguments
+    base_parser = argparse.ArgumentParser(add_help=False)
+    base_parser.add_argument("--perform-changes", action="store_true", help="Allow modification of SLS, HSM, and BSS. When this option is not specified a dry run is performed")
+    base_parser.add_argument("--xname", type=str, required=True, help="The xname of the ncn to add")
+    base_parser.add_argument("--url-hsm", type=str, required=False, default="https://api-gw-service-nmn.local/apis/smd/hsm/v2")
+    base_parser.add_argument("--url-sls", type=str, required=False, default="https://api-gw-service-nmn.local/apis/sls/v1")
+    base_parser.add_argument("--network-allowed-in-dhcp-range", action="append", type=str, required=False, default=[], help=argparse.SUPPRESS)
+
+    # allocate-uan-ip arguments
+    allocate_ip_parser = subparsers.add_parser("allocate-uan-ip", parents=[base_parser])
+    allocate_ip_parser.set_defaults(func=allocate_uan_ip_cmd, show_help=False)
+
+    # allocate-uan-ip arguments
+    allocate_ip_parser = subparsers.add_parser("deallocate-uan-ip", parents=[base_parser])
+    allocate_ip_parser.set_defaults(func=deallocate_uan_ip_cmd, show_help=False)
+
+    args = parser.parse_args()
+
+    if args.show_help:
+        parser.print_help(sys.stdout)
+        sys.exit(1)
+
+    HSM_URL = args.url_hsm
+    SLS_URL = args.url_sls
+    add_management_ncn.HSM_URL = HSM_URL
+    add_management_ncn.SLS_URL = SLS_URL
+
+    # Validate provided node xname (used by both)
+    if re.match("^x([0-9]{1,4})c[0,4]s([0-9]+)b([0-9]+)n([0-9]+)$", args.xname) is None:
+        print("Invalid node xname provided: ", args.xname, ", expected format xXcCsSbBn0")
+        sys.exit(1)
+
+    with requests.Session() as session:
+        session.verify = False
+        if token is not None:
+            session.headers.update({'Authorization': f'Bearer {token}'})
+        session.headers.update({'Content-Type': 'application/json'})
+
+        args.func(session, args)
+
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/operations/node_management/remove_gigabyte_cmc.sh
+++ b/scripts/operations/node_management/remove_gigabyte_cmc.sh
@@ -1,0 +1,103 @@
+#! /usr/bin/env bash
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+set -ue
+
+CMC_XNAME=$1 # x3000c0s17b999
+
+# Verify the provided xname is valid
+if [[ ! "${CMC_XNAME}" =~ ^x([0-9]{1,4})c([0-7])s([0-9]+)b999$ ]]; then
+    echo "Invalid CMC xname provided: ${CMC_XNAME}"
+    echo "Needs to be in the format of xXcCsSb999"
+    exit 1
+fi
+
+
+echo "=================================================="
+echo "Xname Summary"
+echo "=================================================="
+echo "CMC: ${CMC_XNAME}"
+
+echo
+echo "=================================================="
+echo "Removing CMC data from SLS"
+echo "=================================================="
+
+echo "Verifying CMC exists in SLS hardware: ${CMC_XNAME}"
+if cray sls hardware describe "${CMC_XNAME}" --format json; then
+    echo "CMC exists: ${CMC_XNAME}"
+else
+    echo "CMC does not exist in SLS Hardware: ${CMC_XNAME}"
+    exit 1
+fi
+
+echo "Deleting CMC from SLS: ${CMC_XNAME}"
+cray sls hardware describe "${CMC_XNAME}" --format json
+cray sls hardware delete "${CMC_XNAME}"
+
+
+# Remove from SLS
+MGMT_SWITCH_CONNECTOR_RESULT="$(cray sls search hardware list --node-nics "${CMC_XNAME}" --format json)"
+if [[ "$(echo "${MGMT_SWITCH_CONNECTOR_RESULT}" | jq 'length')" -eq 0 ]]; then
+    echo "Nothing more to remove as there is no MgmtSwitchConnector associated with ${CMC_XNAME} in SLS"
+    exit 0
+elif [[ "$(echo "${MGMT_SWITCH_CONNECTOR_RESULT}" | jq 'length')" -gt 1 ]]; then
+    echo "Unexpected number of MgmtSwitchConnectors found in SLS for ${CMC_XNAME}"
+    echo "${MGMT_SWITCH_CONNECTOR_RESULT}" | jq
+    exit 1
+fi
+
+MGMT_SWITCH_CONNECTOR="$(echo "${MGMT_SWITCH_CONNECTOR_RESULT}" | jq  -r .[0].Xname)"
+
+echo "Deleting MgmtSwitchConnector from SLS: ${MGMT_SWITCH_CONNECTOR}"
+cray sls hardware describe "${MGMT_SWITCH_CONNECTOR}" --format json
+cray sls hardware delete "${MGMT_SWITCH_CONNECTOR}"
+
+echo
+echo "=================================================="
+echo "Removing node data from HSM"
+echo "=================================================="
+
+# Remove from HSM
+## Disable the Redfish Endpoint
+echo "Disabling Redfish Endpoint in HSM: ${CMC_XNAME}"
+cray hsm inventory redfishEndpoints update "${CMC_XNAME}" --enabled false --id "${CMC_XNAME}"
+
+## Remove from state components
+echo "Deleting component from HSM State Components: ${CMC_XNAME}"
+cray hsm state components describe "${CMC_XNAME}" --format json
+cray hsm state components delete "${CMC_XNAME}"
+
+# Delete each `NodeBMC` MAC address from the Hardware State Manager \(HSM\) Ethernet interfaces table.
+for ID in $(cray hsm inventory ethernetInterfaces list --component-id "${CMC_XNAME}" --format json | jq -r .[].ID); do
+    echo "Deleting CMC MAC address: ${ID}"
+    cray hsm inventory ethernetInterfaces describe "${ID}" --format json
+    cray hsm inventory ethernetInterfaces delete "${ID}"
+done
+
+# Delete the Redfish endpoint for the removed node.
+echo "Deleting RedfishEndpoint from HSM: ${CMC_XNAME}"
+cray hsm inventory redfishEndpoints describe "${CMC_XNAME}" --format json
+cray hsm inventory redfishEndpoints delete "${CMC_XNAME}"

--- a/scripts/operations/node_management/remove_standard_rack_node.sh
+++ b/scripts/operations/node_management/remove_standard_rack_node.sh
@@ -1,0 +1,129 @@
+#! /usr/bin/env bash
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+set -ue
+
+NODE_XNAME=$1 # x3000c0s17b3n0
+
+# Verify the provided xname is valid
+if [[ ! "${NODE_XNAME}" =~ ^x([0-9]{1,4})c([0-7])s([0-9]+)b([0-9]+)n([0-9]+)$ ]]; then
+    echo "Invalid node xname provided: ${NODE_XNAME}"
+    echo "Needs to be in the format of xXcCsSbBnN"
+    exit 1
+fi
+
+BMC_XNAME=$(echo "${NODE_XNAME}" | grep -E -o 'x[0-9]+c[0-9]+s[0-9]+b[0-9]+')
+NODE_ENCLOSURE_XNAME="${BMC_XNAME/b/e}" # Replace bB with eE
+
+# TOKEN is required to be exported for the delete_bmc_subscriptions.py script.
+if [[ -z "${TOKEN}" ]]; then
+    echo "Environment variable TOKEN is not set"
+    exit 1
+fi
+
+echo "=================================================="
+echo "Xname Summary"
+echo "=================================================="
+echo "Node:          ${NODE_XNAME}"
+echo "NodeBMC:       ${BMC_XNAME}"
+echo "NodeEnclosure: ${NODE_ENCLOSURE_XNAME}"
+
+echo
+echo "=================================================="
+echo "Verifying BMC exists as a RedfishEndpoint in HSM"
+echo "=================================================="
+
+if ! cray hsm inventory redfishEndpoints describe "${BMC_XNAME}" --format json; then
+    echo "NodeBMC does not exist in HSM RedfishEndpoints: ${BMC_XNAME}"
+    exit 1
+fi
+
+echo
+echo "=================================================="
+echo "Removing BMC Event subscriptions"
+echo "=================================================="
+/usr/share/doc/csm/scripts/operations/node_management/delete_bmc_subscriptions.py "${BMC_XNAME}"
+
+echo
+echo "=================================================="
+echo "Removing node data from SLS"
+echo "=================================================="
+
+# Remove from SLS
+MGMT_SWITCH_CONNECTOR_RESULT="$(cray sls search hardware list --node-nics "${BMC_XNAME}" --format json)"
+
+
+if [[ "$(echo "${MGMT_SWITCH_CONNECTOR_RESULT}" | jq 'length')" -ne 1 ]]; then
+    echo "Unexpected number of MgmtSwitchConnectors found in SLS for ${BMC_XNAME}"
+    echo "${MGMT_SWITCH_CONNECTOR_RESULT}" | jq
+    exit 1
+fi
+
+MGMT_SWITCH_CONNECTOR="$(echo "${MGMT_SWITCH_CONNECTOR_RESULT}" | jq  -r .[0].Xname)"
+
+echo "Deleting MmgtSwitchConnector from SLS: ${MGMT_SWITCH_CONNECTOR}"
+cray sls hardware describe "${MGMT_SWITCH_CONNECTOR}" --format json
+cray sls hardware delete "${MGMT_SWITCH_CONNECTOR}"
+
+echo "Deleting Node from SLS: ${NODE_XNAME}"
+cray sls hardware describe "${NODE_XNAME}" --format json
+cray sls hardware delete "${NODE_XNAME}"
+
+echo
+echo "=================================================="
+echo "Removing node data from HSM"
+echo "=================================================="
+
+# Remove from HSM
+
+## Disable the Redfish Endpoint
+echo "Disabling Redfish Endpoint in HSM: ${BMC_XNAME}"
+cray hsm inventory redfishEndpoints update "${BMC_XNAME}" --enabled false --id "${BMC_XNAME}"
+
+## Remove from state components
+for XNAME in "$NODE_XNAME" "$BMC_XNAME" "${NODE_ENCLOSURE_XNAME}"; do
+    echo "Deleting component from HSM State Components: ${XNAME}"
+    cray hsm state components describe "${XNAME}" --format json
+    cray hsm state components delete "${XNAME}"
+done
+
+## Delete the `Node` MAC addresses from the HSM.
+for ID in $(cray hsm inventory ethernetInterfaces list --component-id "${NODE_XNAME}" --format json | jq -r .[].ID); do
+    echo "Deleting Node MAC address: ${ID}"
+    cray hsm inventory ethernetInterfaces describe "${ID}" --format json
+    cray hsm inventory ethernetInterfaces delete "${ID}"
+done
+
+# Delete each `NodeBMC` MAC address from the Hardware State Manager \(HSM\) Ethernet interfaces table.
+for ID in $(cray hsm inventory ethernetInterfaces list --component-id "${BMC_XNAME}" --format json | jq -r .[].ID); do
+    echo "Deleting BMC MAC address: ${ID}"
+    cray hsm inventory ethernetInterfaces describe "${ID}" --format json
+    cray hsm inventory ethernetInterfaces delete "${ID}"
+done
+
+# Delete the Redfish endpoint for the removed node.
+echo "Deleting RedfishEndpoint from HSM: ${BMC_XNAME}"
+cray hsm inventory redfishEndpoints describe "${BMC_XNAME}" --format json
+cray hsm inventory redfishEndpoints delete "${BMC_XNAME}"


### PR DESCRIPTION
# Description
Tickets:
- [CASMHMS-5481](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5481)
- [CASMHMS-5491](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5491)

Add procedures to remove and replace standard rack nodes, and updates to the Add standard rack node procedure

The following are new procedures:
1. `Removing a Standard rack node from a System` was created for the process of removing a river node from a system. It does the following:
   1. If an application node is being removed, deallocate an IP address from the CAN or CHN network. This is done via python script that reuses parts of the add_managmemnt_ncn.py script.
   1. Remove node data from SLS hardware and HMS. This is scripted.
   2. Remove a Gigabyte CMC if present
2. `Replace a Standard rack node from a System` procedure for replacing river application and compute nodes. This is a procedure that reuses the    `Removing a Standard rack node from a System` and `Add a Standard Rack Node` procedures.

The `Add a Standard Rack Node` procedure was updated to account for the following:

1. Add steps to properly troubleshoot DVS related issues taken from the add liquid cooled node.
4. Add steps to add a Gigabyte CMC to the system, as these steps were missing.
5. Add wording to deal with adding all of the nodes within a blade, like a the dense quad gigabyte computes.
6. Add a step to allocate an CAN/CHN IP addresses when a UAN is added.

The `Add a Liquid-cooled blade` procedure was updated to account for the following:
1. Add steps to properly troubleshoot DVS related issues when IP address of a node shifts after a replacement. 

These procedures were tested on Fanta with replacing (removing and adding) an application node. Also the scripts were tested against the hms-simulation-environment.
 

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
