### PR TITLE
Tech Forum: Fix `KVER` usage

### DIFF
--- a/background/ncn_kdump.md
+++ b/background/ncn_kdump.md
@@ -82,7 +82,7 @@ to be installed, the `crash` command can not thoroughly analyze a dump without t
     ```bash
     zypper ar https://packages.local/repository/csm-${CSM_RELEASE}-embedded csm-embedded
     . /srv/cray/scripts/metal/dracut-lib.sh
-    zypper in -y kernel-default-debug=${KVER}
+    zypper --plus-content debug in -y kernel-default-debuginfo=${KVER%-default}
     ```
 
     * Install from Artifactory if credentials are available.
@@ -101,7 +101,7 @@ to be installed, the `crash` command can not thoroughly analyze a dump without t
 
         ```bash
         . /srv/cray/scripts/metal/dracut-lib.sh
-        zypper in -y kernel-default-debug=${KVER}
+        zypper --plus-content debug in -y kernel-default-debuginfo=${KVER%-default}
         ```
 
 1. On the node with the dump, go to the crash directory and choose a crash dump to load.


### PR DESCRIPTION
# Description

This fixes things found in the `kdump` tech forum today held by metal internal.

<!--- Describe what this change is and what it is for. -->
The `-default` suffix needs to be stripped off when referring to the package version. The package is also called `kernel-default-debuginfo` not `kernel-default-debug`.

The `--plus-content debug` may or may not be needed but it doesn't hurt.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
