### PR TITLE
CASMCMS-8213 - document fixing IMS metallb pool for running jobs.

### DIFF
--- a/operations/CSM_product_management/Apply_Security_Hardening.md
+++ b/operations/CSM_product_management/Apply_Security_Hardening.md
@@ -26,7 +26,7 @@ None.
 
 4. Update IMS Job Access Network.
 
-   Perform procedure(s) in [Update IMS Job Access Network](../../operations/image_management/Update_IMS_Job_Access_Network.md)
+   Perform procedure(s) in [Update IMS Job Access Network](../../operations/image_management/Update_IMS_Job_Access_Network.md).
 
 5. (Optional) Change Keycloak OAuth token lifetime.
 

--- a/operations/CSM_product_management/Apply_Security_Hardening.md
+++ b/operations/CSM_product_management/Apply_Security_Hardening.md
@@ -24,10 +24,14 @@ None.
 
    Failure to apply the referenced configuration could result in NCN disk space exhaustion on Kubernetes Master Nodes.
 
-4. (Optional) Change Keycloak OAuth token lifetime.
+4. Update IMS Job Access Network.
+
+   Perform procedure(s) in [Update IMS Job Access Network](../../operations/image_management/Update_IMS_Job_Access_Network.md)
+
+5. (Optional) Change Keycloak OAuth token lifetime.
 
    Perform procedure(s) in [Change Keycloak token lifetime](../security_and_authentication/Change_Keycloak_Token_Lifetime.md).
 
-5. (Optional) Remove Kiali.
+6. (Optional) Remove Kiali.
 
    Perform procedure(s) in [Remove Kiali](../system_management_health/Remove_Kiali.md).

--- a/operations/image_management/Update_IMS_Job_Access_Network.md
+++ b/operations/image_management/Update_IMS_Job_Access_Network.md
@@ -1,13 +1,14 @@
 # Update IMS Job Access Network
+
    In the CSM V1.2.0 and V1.2.1 releases, the IMS jobs template was set up with the wrong
    service address pool. This means that the IMS job pods are unable to start on the
    customer-management network where they have permission to run.
 
-   To fix this on a running system, the `ims-config` configmap will need to updated to use
-   the correct address pool when starting jobs.
+   To fix this on a running system, the `ims-config` configuration map will need to updated
+   to use the correct address pool when starting jobs.
 
    **IMPORTANT:** Once this procedure has been done, it will not fix jobs that are currently
-   running. This will only impact new jobs created after the settings have been updated. Old 
+   running. This will only impact new jobs created after the settings have been updated. Old
    jobs that can not be accessed must be deleted and recreated.
 
 ## Procedure
@@ -26,7 +27,7 @@
 
 3. Exit the editor, saving the new value.
 
-4. Restart the cray-ims pod.
+4. Restart the `cray-ims` pod.
 
     ```bash
     ncn-mw# IMS_POD=$(kubectl get pods -n services -o wide | grep cray-ims | awk '{print $1}')

--- a/operations/image_management/Update_IMS_Job_Access_Network.md
+++ b/operations/image_management/Update_IMS_Job_Access_Network.md
@@ -1,0 +1,50 @@
+# Update IMS Job Access Network
+   In the CSM V1.2.0 and V1.2.1 releases, the IMS jobs template was set up with the wrong
+   service address pool. This means that the IMS job pods are unable to start on the
+   customer-management network where they have permission to run.
+
+   To fix this on a running system, the `ims-config` configmap will need to updated to use
+   the correct address pool when starting jobs.
+
+   **IMPORTANT:** Once this procedure has been done, it will not fix jobs that are currently
+   running. This will only impact new jobs created after the settings have been updated. Old 
+   jobs that can not be accessed must be deleted and recreated.
+
+## Procedure
+
+1. Enter into editing mode for the `ims-config` settings.
+
+    ```bash
+    ncn-mw# kubectl -n services edit cm ims-config
+    ```
+
+2. Find the `JOB_CUSTOMER_ACCESS_NETWORK_ACCESS_POOL` variable and edit the value to:
+
+    ```text
+      JOB_CUSTOMER_ACCESS_NETWORK_ACCESS_POOL: customer-management
+    ```
+
+3. Exit the editor, saving the new value.
+
+4. Restart the cray-ims pod.
+
+    ```bash
+    ncn-mw# IMS_POD=$(kubectl get pods -n services -o wide | grep cray-ims | awk '{print $1}')
+    ncn-mw# kubectl -n services delete pod $IMS_POD
+    ```
+
+5. Wait for the new pod to be ready.
+
+    ```bash
+      ncn-mw# watch 'kubectl -n services get pods | grep cray-ims'
+    ```
+
+    Watch the status of the pod, you should see something like:
+
+    ```text
+    cray-ims-fbc5c5b45-lq4h7   0/2  PodInitializing 0 10s
+    ```
+
+    When it transitions to `2/2  Running`, use `Ctl-c` to exit the `watch` command.
+
+6. New jobs will now be created with the correct network settings.

--- a/operations/image_management/Update_IMS_Job_Access_Network.md
+++ b/operations/image_management/Update_IMS_Job_Access_Network.md
@@ -1,25 +1,25 @@
 # Update IMS Job Access Network
 
-   In the CSM V1.2.0 and V1.2.1 releases, the IMS jobs template was set up with the wrong
-   service address pool. This means that the IMS job pods are unable to start on the
-   customer-management network where they have permission to run.
+In the CSM V1.2.0 and V1.2.1 releases, the IMS jobs template was set up with the wrong
+service address pool. This means that the IMS job pods are unable to start on the
+customer-management network where they have permission to run.
 
-   To fix this on a running system, the `ims-config` configuration map will need to updated
-   to use the correct address pool when starting jobs.
+To fix this on a running system, the `ims-config` configuration map will need to updated
+to use the correct address pool when starting jobs.
 
-   **IMPORTANT:** Once this procedure has been done, it will not fix jobs that are currently
-   running. This will only impact new jobs created after the settings have been updated. Old
-   jobs that can not be accessed must be deleted and recreated.
+**IMPORTANT:** Once this procedure has been done, it will not fix jobs that are currently
+running. This will only impact new jobs created after the settings have been updated. Old
+jobs that can not be accessed must be deleted and recreated.
 
 ## Procedure
 
-1. Enter into editing mode for the `ims-config` settings.
+1. Edit the `ims-config` settings.
 
     ```bash
     ncn-mw# kubectl -n services edit cm ims-config
     ```
 
-2. Find the `JOB_CUSTOMER_ACCESS_NETWORK_ACCESS_POOL` variable and edit the value to:
+2. Find the `JOB_CUSTOMER_ACCESS_NETWORK_ACCESS_POOL` variable and set the value to `customer-management`.
 
     ```text
       JOB_CUSTOMER_ACCESS_NETWORK_ACCESS_POOL: customer-management
@@ -40,7 +40,7 @@
       ncn-mw# watch 'kubectl -n services get pods | grep cray-ims'
     ```
 
-    Watch the status of the pod, you should see something like:
+    Watch the status of the pod for output similar to the following:
 
     ```text
     cray-ims-fbc5c5b45-lq4h7   0/2  PodInitializing 0 10s
@@ -48,4 +48,4 @@
 
     When it transitions to `2/2  Running`, use `Ctl-c` to exit the `watch` command.
 
-6. New jobs will now be created with the correct network settings.
+New jobs will now be created with the correct network settings.


### PR DESCRIPTION
# Description

The CSM releases v1.2.0 and v1.2.1 contained an error in the ims configuration where the wrong metallb pool was used to create jobs. This prevents the network service from starting up so ssh access to the customize jobs might not work correctly.

This documents how to fix this on a running system with v1.2.0 or v1.2.1 installed. This does not impact new installs and upgrades as those are handled in the install documentation already.

# Checklist Before Merging

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
