### PR TITLE
CASMMON-138-main : DOCS: Update to the procedure for Restoring an etcd procedure from backup

### DIFF
--- a/operations/kubernetes/Restore_an_etcd_Cluster_from_a_Backup.md
+++ b/operations/kubernetes/Restore_an_etcd_Cluster_from_a_Backup.md
@@ -146,3 +146,18 @@ The cray-bss-etcd cluster has successfully been restored from cray-bss/etcd.back
     ```text
     etcdrestore.etcd.database.coreos.com "cray-bos-etcd" deleted
     ```
+
+1. (`ncn-mw#`) Verify that the `cray-bos-etcd-client` service was created.
+
+    ```bash
+    ncn# kubectl get service -n services cray-bos-etcd-client
+    ```
+
+    Example of output showing that the service was created:
+
+    ```text
+    NAME                   TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
+    cray-bos-etcd-client   ClusterIP   10.28.248.232   <none>        2379/TCP   2m
+    ```
+
+    If the `etcd-client` service was not created, then repeat the procedure to restore the cluster again.


### PR DESCRIPTION
# Description

Add the step to verify that the client service was created.
Will backport to release/1.2 and release/1.3
The change for release/1.0 has already merged.

# Checklist Before Merging

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
