### PR TITLE
CASMMON-138-1.2 : DOCS: Update to the procedure for Restoring an etcd procedure from backup

### DIFF
--- a/operations/kubernetes/Restore_an_etcd_Cluster_from_a_Backup.md
+++ b/operations/kubernetes/Restore_an_etcd_Cluster_from_a_Backup.md
@@ -4,15 +4,10 @@ Use an existing backup of a healthy etcd cluster to restore an unhealthy cluster
 
 The commands in this procedure can be run on any master node \(`ncn-mXXX`\) or worker node \(`ncn-wXXX`\) on the system.
 
----
-**NOTE**
-
-Etcd Clusters can be restored using the automation script or the manual procedure below. The automation script follows the same steps as the manual procedure.
+**NOTE:** Etcd Clusters can be restored using the automation script or the manual procedure below. The automation script follows the same steps as the manual procedure.
 If the automation script fails to get the date from backups, follow the manual procedure.
 
----
-
-### Prerequisites
+## Prerequisites
 
 A backup of a healthy etcd cluster has been created.
 
@@ -21,7 +16,7 @@ A backup of a healthy etcd cluster has been created.
 The automated script will restore the cluster from the most recent backup if it finds a backup created within the last 7 days.
 If it does not discover a backup within the last 7 days, it will ask the user if they would like to rebuild the cluster.
 
-```
+```bash
 ncn-w001# cd /opt/cray/platform-utils/etcd_restore_rebuild_util
 
 # rebuild/restore a single cluster
@@ -35,7 +30,8 @@ ncn-w001:/opt/cray/platform-utils/etcd_restore_rebuild_util # ./etcd_restore_reb
 ```
 
 An example using the automation script is below.
-```
+
+```bash
 ncn-m001:/opt/cray/platform-utils/etcd_restore_rebuild_util # ./etcd_restore_rebuild.sh -s cray-externaldns-etcd
 The following etcd clusters will be restored/rebuilt:
 cray-externaldns-etcd
@@ -53,7 +49,7 @@ etcdrestore.etcd.database.coreos.com "cray-externaldns-etcd" deleted
 
 ### Restore with Manual Procedure
 
-1.  List the backups for the desired etcd cluster.
+1. List the backups for the desired etcd cluster.
 
     The example below uses the Boot Orchestration Service \(BOS\).
 
@@ -65,7 +61,7 @@ etcdrestore.etcd.database.coreos.com "cray-externaldns-etcd" deleted
 
     Example output:
 
-    ```
+    ```text
     cray-bos/etcd.backup_v108497_2020-03-20-23:42:37
     cray-bos/etcd.backup_v125815_2020-03-21-23:42:37
     cray-bos/etcd.backup_v143095_2020-03-22-23:42:38
@@ -75,9 +71,9 @@ etcdrestore.etcd.database.coreos.com "cray-externaldns-etcd" deleted
     cray-bos/etcd.backup_v86767_2020-03-19-18:00:05
     ```
 
-2.  Restore the cluster using a backup.
+2. Restore the cluster using a backup.
 
-    Replace etcd.backup\_v277935\_2020-03-30-23:52:54 in the command below with the name of the backup being used.
+    Replace `etcd.backup\_v277935\_2020-03-30-23:52:54` in the command below with the name of the backup being used.
 
     ```bash
     ncn-w001# kubectl exec -it -n operators \
@@ -87,13 +83,13 @@ etcdrestore.etcd.database.coreos.com "cray-externaldns-etcd" deleted
 
     Example output:
 
-    ```
+    ```text
     etcdrestore.etcd.database.coreos.com/cray-bos-etcd created
     ```
 
-3.  Restart the pods for the etcd cluster.
+3. Restart the pods for the etcd cluster.
 
-    1.  Watch the pods come back online.
+    1. Watch the pods come back online.
 
         This may take a couple minutes.
 
@@ -103,13 +99,13 @@ etcdrestore.etcd.database.coreos.com "cray-externaldns-etcd" deleted
 
         Example output:
 
-        ```
+        ```text
         cray-bos-etcd-498jn7th6p             1/1     Running              0          4h1m
         cray-bos-etcd-dj7d894227             1/1     Running              0          3h59m
         cray-bos-etcd-tk4pr4kgqk             1/1     Running              0          4
         ```
 
-    2.  Delete the EtcdRestore custom resource.
+    2. Delete the EtcdRestore custom resource.
 
         This step will make it possible for future restores to occur. Replace the etcdrestore.etcd.database.coreos.com/cray-bos-etcd value with the name returned in step 2.
 
@@ -119,7 +115,21 @@ etcdrestore.etcd.database.coreos.com "cray-externaldns-etcd" deleted
 
         Example output:
 
-        ```
+        ```text
         etcdrestore.etcd.database.coreos.com "cray-bos-etcd" deleted
         ```
 
+4. Verify that the `cray-bos-etcd-client` service was created.
+
+    ```bash
+    ncn# kubectl get service -n services cray-bos-etcd-client
+    ```
+
+    Example of output showing that the service was created:
+
+    ```text
+    NAME                   TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
+    cray-bos-etcd-client   ClusterIP   10.28.248.232   <none>        2379/TCP   2m
+    ```
+
+    If the `etcd-client` service was not created, then repeat the procedure to restore the cluster again.


### PR DESCRIPTION
# Description

Add the step to verify that the client service was created.

# Checklist Before Merging

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams