### PR TITLE
Apply consistency to triple-backtick markup

### DIFF
--- a/operations/argo/Using_Argo_Workflows.md
+++ b/operations/argo/Using_Argo_Workflows.md
@@ -11,28 +11,28 @@ This page provides information on operating Argo workflows in CSM and describes 
 * If any step fails, by default, that step will be continuously retried until it succeeds.
 There are two ways to make Argo not continuously retry a failed step.
 
-    1. When initiating a workflow, use the ```--no-retry``` flag.
+    1. When initiating a workflow, use the `--no-retry` flag.
 
-        (`ncn-m001#`) Example of starting a workflow with ```--no-retry``` flag
+        (`ncn-m001#`) Example of starting a workflow with `--no-retry` flag
 
         ```bash
         /usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh ncn-s001 --no-retry
         ```
 
-        > Note: ```--no-retry``` will not work if the ```--force``` flag is also used.
+        > Note: `--no-retry` will not work if the `--force` flag is also used.
 
-    1. If a workflow has already started, then the current running process can be exited with ```control-c```. The workflow will continue until all steps succeed or a step fails. If a step fails, then the workflow will stop and will not retry.
+    1. If a workflow has already started, then the current running process can be exited with `control-c`. The workflow will continue until all steps succeed or a step fails. If a step fails, then the workflow will stop and will not retry.
 
 ## Starting a new workflow after a failed workflow
 
 Generally, any workflow that is partially complete has the right of way. A partially complete workflow is any workflow that is currently running or any workflow that has a failed step that prevented it from completing successfully.
 
-* To start an entirely new workflow of the same type (worker or storage) as a workflow that is partially complete, the ```--force``` flag must be used. This deletes the partially complete workflow of the same type, and creates a new workflow.
+* To start an entirely new workflow of the same type (worker or storage) as a workflow that is partially complete, the `--force` flag must be used. This deletes the partially complete workflow of the same type, and creates a new workflow.
 
-    (`ncn-m001#`) Example of starting a new workflow with ```--force``` flag:
+    (`ncn-m001#`) Example of starting a new workflow with `--force` flag:
 
     ```bash
     /usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh ncn-s001 --force
     ```
 
-* If there is a partially complete workflow and ```--force``` is not used when starting a new workflow of the same type, then the initial workflow will be picked up where it left off. No new workflow will be created.
+* If there is a partially complete workflow and `--force` is not used when starting a new workflow of the same type, then the initial workflow will be picked up where it left off. No new workflow will be created.


### PR DESCRIPTION
# Description

This file
   - `operations/argo/Using_Argo_Workflows.md`

uses triple backticks in the running text to render command flag
arguments into teletype text.

Everywhere else (yes, I grep-ed it) within the documentation source,
just using a single backtick achieves the same thing, for example, in
   - `operations/configure_cray_cli.md`

we read

```
At this point, the script may be re-run with the `--debug` flag added,
```

which renders as

> At this point, the script may be re-run with the `--debug` flag added,

The triple ticks, whilst not being incorrect, hinder attempts to
automatically handle triple-back-ticked code blocks that contain
characters that the Jekyll renderer considers special.

Any chance of some consistency in the running text sections?

This PR, should you choose to acceot it, applies some consistency to the file in question.