### PR TITLE
PE-40775 Document Slurm Operator (#2470)

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -397,6 +397,7 @@ PDU
 PDUs
 PECs
 PEM-encoded
+Percona
 permissioned
 PGs
 pickup
@@ -595,6 +596,7 @@ XL645d
 XL675d
 xname
 xnames
+XtraDB
 Yum
 zeroization
 zeroize

--- a/operations/multi_tenancy/Modify_a_Tenant.md
+++ b/operations/multi_tenancy/Modify_a_Tenant.md
@@ -122,8 +122,21 @@ This page provides information about how to modify a tenant. Modifications that 
 
 ## Modify the `slurm` operator CR
 
-_placeholder for `slurm` content_
+To make changes to a Slurm tenant deployment, first update the Slurm custom
+resource file. The Slurm operator will attempt to reconcile the following
+changes:
+
+- Changing the munge key length
+- Changing the `slurmctld` PVC
+- Changing the Percona XtraDB, `slurmctld`, or `slurmdbd` deployments
 
 ## Apply the `slurm` operator CR
 
-_placeholder for `slurm` content_
+- (`ncn-mw#`) To update the Slurm custom resource, apply the changed file:
+
+    ```sh
+    kubectl apply -f <cluster>.yaml
+    ```
+
+Once the custom resource has been updated, the Slurm operator will attempt to
+update the relevant Kubernetes resources to reflect the changes.

--- a/operations/multi_tenancy/Overview.md
+++ b/operations/multi_tenancy/Overview.md
@@ -34,7 +34,8 @@ See [`TAPMS` Overview](Tapms.md) for details on this Kubernetes Operator.
 
 ### Slurm Operator
 
-_placeholder for `slurm` content_
+The Slurm operator can be used to deploy the Slurm workload manager within a
+tenant. See [Slurm Operator](SlurmOperator.md) for details.
 
 ## Getting Started
 

--- a/operations/multi_tenancy/Remove_a_Tenant.md
+++ b/operations/multi_tenancy/Remove_a_Tenant.md
@@ -6,8 +6,23 @@ This page provides describes how an infrastructure administrator (not a tenant a
 
 ## Table of Contents
 
-* [Delete the tenant's custom resource (CR)](#delete-the-tenants-custom-resource-cr)
 * [Remove the Slurm Operator Custom Resource (CR)](#remove-the-slurm-operator-custom-resource-cr)
+* [Delete the tenant's custom resource (CR)](#delete-the-tenants-custom-resource-cr)
+
+## Remove the Slurm Operator Custom Resource (CR)
+
+* (`ncn-mw#`) To remove a Slurm tenant instance, delete the custom resource with
+    `kubectl`:
+
+    ```sh
+    kubectl delete slurmcluster -n <namespace> <name>
+    ```
+
+This will remove the Slurm pods from the tenant namespace, but leave the
+persistent volumes (to avoid data loss if the cluster is recreated).
+
+In addition, remove any tenant-specific Ansible variables in the `group_vars`
+directory of the `slurm-config-management` VCS repository.
 
 ## Delete the tenant's custom resource (CR)
 
@@ -21,9 +36,3 @@ Below is an example of a `kubectl` command to remove the tenant by specifying it
     ```
 
 It can take a minute or so to fully delete the tenant and its namespaces, as `tapms` will remove `xnames` from HSM groups, remove Keycloak groups, and cleanup the HNC tree structure.
-
-## Remove the Slurm Operator Custom Resource (CR)
-
-_placeholder for `slurm` content_
-
-(should this occur first?)

--- a/operations/multi_tenancy/SlurmOperator.md
+++ b/operations/multi_tenancy/SlurmOperator.md
@@ -1,0 +1,60 @@
+# Slurm Operator
+
+The Slurm operator can be used to deploy Slurm within a tenant, so each tenant
+can have a separate instance of Slurm.
+
+## Table of Contents
+
+* [Install the Slurm Operator](#install-the-slurm-operator)
+* [Troubleshooting](#troubleshooting)
+
+## Install the Slurm Operator
+
+To create Slurm tenants, the Slurm operator must be installed. The Slurm
+Operator runs in a Kubernetes pod and watches for `SlurmCluster` custom
+resources.
+
+* (`ncn-mw#`) To install the Slurm operator, run this command in the unpacked
+    CPE Slurm release tarball:
+
+    ```sh
+    helm upgrade --install -n slurm-operator cray-slurm-operator \
+        ./helm/cray-slurm-operator-*.tgz
+    ```
+
+## Troubleshooting
+
+* (`ncn-mw#`) To check the Slurm operator logs:
+
+    ```sh
+    kubectl logs -n slurm-operator --timestamps --tail=-1 -c slurm-operator \
+        -lapp=slurm-operator
+    ```
+
+* (`ncn-mw#`) To check the status of a Slurm custom resource:
+
+    ```sh
+    kubectl describe slurmcluster -n <namespace> <name>
+    ```
+
+* (`ncn-mw#`) To check the `slurmctld` logs for a tenant:
+
+    ```sh
+    kubectl logs -n <namespace> --timestamps --tail=-1 -c slurmctld \
+        -lapp.kubernetes.io/name=slurmctld
+    ```
+
+* (`ncn-mw#`) To check the `slurmdbd` logs for a tenant:
+
+    ```sh
+    kubectl logs -n <namespace> --timestamps --tail=-1 -c slurmdbd \
+        -lapp.kubernetes.io/name=slurmdbd
+    ```
+
+* (`ncn-mw#`) To check the accounting database logs for a tenant:
+
+    ```sh
+    kubectl logs -n <namespace> <name>-slurmdb-pxc-0
+    kubectl logs -n <namespace> <name>-slurmdb-pxc-1
+    kubectl logs -n <namespace> <name>-slurmdb-pxc-2
+    ```


### PR DESCRIPTION
* PE-40775 Document Slurm Operator

Since the CPE docs cannot reference unreleased software, document the Slurm operator here by filling in the placeholder sections. In the future, we can replace the content with references to CPE documentation.

* PE-40775 Follow command prompt conventions

Follow the command prompt conventions, and fix capitalization of Ansible.

* PE-40775 Fix spelling issues

Fix spelling issues in the Slurm Multi-Tenancy documentation found by the spell checker.

* PE-40775 Fix another spelling error

Fix another spelling error found by the spell checker.

# Description

<!--- Describe what this change is and what it is for. -->

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
