### PR TITLE
CASMPET-6002: Document Ceph workarounds for System Power On Procedures

### DIFF
--- a/operations/README.md
+++ b/operations/README.md
@@ -233,7 +233,7 @@ The Configuration Framework Service \(CFS\) is available on systems for remote e
 - [Write Ansible Code for CFS](configuration_management/Write_Ansible_Code_for_CFS.md)
   - [Target Ansible Tasks for Image Customization](configuration_management/Target_Ansible_Tasks_for_Image_Customization.md)
 - [CFS Key Management](configuration_management/CFS_Key_Management.md)
-- [Pre-Boot Configuration of NCN Images](configuration_management/Pre_Boot_Configuration_of_NCN_Images.md)
+- [Management Node Image Customization](configuration_management/Management_Node_Image_Customization.md)
 
 ## Kubernetes
 

--- a/operations/README.md
+++ b/operations/README.md
@@ -381,6 +381,7 @@ services running on Kubernetes, as well as for telemetry data coming from the co
 - [Adjust Ceph Pool Quotas](utility_storage/Adjust_Ceph_Pool_Quotas.md)
 - [Add Ceph OSDs](utility_storage/Add_Ceph_OSDs.md)
 - [Ceph Health States](utility_storage/Ceph_Health_States.md)
+- [Ceph Deep Scrubs](utility_storage/Ceph_Deep_Scrubs.md)
 - [Ceph Daemon Memory Profiling](utility_storage/Ceph_Daemon_Memory_Profiling.md)
 - [Ceph Service Check Script Usage](utility_storage/Ceph_Service_Check_Script_Usage.md)
 - [Ceph Orchestrator Usage](utility_storage/Ceph_Orchestrator_Usage.md)

--- a/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
@@ -250,6 +250,17 @@ Verify that the Lustre file system is available from the management cluster.
 
     To resolve the space issue, see [Troubleshoot Ceph OSDs Reporting Full](../utility_storage/Troubleshoot_Ceph_OSDs_Reporting_Full.md).
 
+1. (`ncn-m001#`) Manually mount S3 filesystems on the master and worker nodes. The workers try
+    to mount several S3 filesystems when they are booted, but Ceph is not available yet at that
+    time, so this workaround is required. The `boot-images` S3 filesystem is required for CPS pods
+    to successfully start on workers.
+
+    ```bash
+    pdsh -w ncn-m00[1-3],ncn-w00[1-3] "awk '{ if (\$3 == \"fuse.s3fs\") { print \$2; }}' /etc/fstab | xargs -I {} -n 1 sh -c \"mountpoint {} || mount {}\""
+    ```
+
+    Ensure all masters and workers are included in the host list for this `pdsh` command.
+
 1. (`ncn-m001#`) Monitor the status of the management cluster and which pods are restarting (as indicated by either a `Running` or `Completed` state).
 
     ```bash

--- a/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
@@ -203,16 +203,19 @@ Verify that the Lustre file system is available from the management cluster.
     2021-08-04 17:28:21,945 - INFO - sat.cli.bootsys.ceph - Ceph is not healthy: The following fatal Ceph health warnings were found: POOL_NO_REDUNDANCY
     ```
 
-    The particular Ceph health warning may vary. In this example, it is `POOL_NO_REDUNDANCY`. See
-    [Manage Ceph Services](../utility_storage/Manage_Ceph_Services.md) for Ceph troubleshooting
-    steps, which may include restarting Ceph services as described below for convenience.
+    The particular Ceph health warning may vary. In this example, it is `POOL_NO_REDUNDANCY`.
 
-    Verify that the Ceph services started.
+    If the warning is `PG_NOT_DEEP_SCRUBBED`, this alert should clear once Ceph deep scrubs of PGs
+    have completed. The time to complete this operation depends on the number of outstanding deep
+    scrub operations and the load on the Ceph cluster. See [Ceph Deep
+    Scrubs](../utility_storage/Ceph_Deep_Scrubs.md) for more information on deep scrubs. This alert
+    is more likely to occur if the system is powered off for an extended duration.
 
-    * If the Ceph services did not start, then see [Manage Ceph Services](../utility_storage/Manage_Ceph_Services.md)
-      for instruction on starting Ceph services.
+    See [Manage Ceph Services](../utility_storage/Manage_Ceph_Services.md) for Ceph troubleshooting
+    steps, which may include restarting Ceph services.
 
-    Once Ceph is healthy, repeat the `sat bootsys boot` to finish starting the Kubernetes cluster.
+    Once Ceph is healthy, repeat the `sat bootsys boot --stage platform-services` command to finish
+    starting the Kubernetes cluster.
 
 1. (`ncn-m001#`) Check the space available on the Ceph cluster.
 

--- a/operations/utility_storage/Ceph_Deep_Scrubs.md
+++ b/operations/utility_storage/Ceph_Deep_Scrubs.md
@@ -1,0 +1,58 @@
+# Ceph Deep Scrubs
+
+During normal operation, the Ceph cluster performs deep scrubs of the placement groups (PGs) during
+intervals of low I/O activity on the cluster. By default, these deep scrubs occur on a weekly
+interval. Scheduling of deep scrubs is staggered across the PGs in the Ceph cluster, so that all PGs
+are not deep-scrubbed at the same time.
+
+## Ceph Deep Scrub Behavior During Outages
+
+When one or more OSDs are down, the deep scrubbing of the PGs on those OSDs can't be performed. If a
+deep scrub of a PG is scheduled to occur while the OSD is down, the deep scrubbing will be delayed
+until the OSDs are available. This commonly occurs when the storage nodes are powered down as part
+of the [System Power Off Procedures](../power_management/System_Power_Off_Procedures.md).
+
+After a prolonged power outage, for example after weekend power maintenance activities, some number
+of PGs may begin a deep scrub after the system is powered on. An alert will be displayed in the Ceph
+status while the deep scrub is occurring. Ceph is fully operational while that alert is present, and
+the alert should clear when scrubbing is completed. The time to complete deep scrubbing depends on
+the size of the cluster and the length of the outage. If the alert remains for more than a day,
+contact support.
+
+The following example output from `ceph -s` shows Ceph in a `HEALTH_WARN` state due to some deep
+scrubs missed after the system was brought up after power down:
+
+```text
+  cluster:
+    id:     e67366fb-7d13-4219-bdb4-44a5f7e06bf9
+    health: HEALTH_WARN
+            7 pgs not deep-scrubbed in time
+  ...
+```
+
+Note the message accompanying the `HEALTH_WARN` state indicating `7 pgs not deep-scrubbed in time`.
+This alert will clear when deep scrubbing completes.
+
+## Viewing Ceph Deep Scrub Schedule
+
+The `ceph pg dump` command shows information about the PGs in the Ceph cluster. This command can be
+used to see the last time PGs were scrubbed and thus infer the next time they will be scrubbed. For
+example, the following command will get the last deep scrub time for each PG, convert it to the day
+of the week, and then count the number of PGs scheduled for deep scrub each day of the week:
+
+```bash
+ceph pg dump -f json | jq -r '.pg_map.pg_stats | .[].last_deep_scrub_stamp' | xargs -n 1 date +%A -d | sort | uniq -c
+```
+
+The output of this command will look something like the following:
+
+```text
+dumped all
+     52 Friday
+     89 Monday
+     61 Saturday
+     57 Sunday
+     54 Thursday
+    156 Tuesday
+    116 Wednesday
+```


### PR DESCRIPTION
# Description

Add information about Ceph deep scrubbing and how to proceed when the
Ceph cluster is in a `HEALTH_WARN` state during the system power on
procedures.

When the worker nodes boot, they try to mount the boot-images bucket as
an s3fs mount. However, the Ceph cluster is not unfrozen yet, so this
mount will fail. After `sat bootsys boot --stage platform-services` is
executed, Ceph will be unfrozen, and at this point, it will be possible
to mount the `boot-images` filesystem. This filesystem is needed to
allow the cray-cps-cm pods to start successfully.

Add a manual workaround to mount this filesystem on worker nodes.

# Checklist Before Merging

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
