### PR TITLE
CASMPET-5846 from 1.3 to main

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -40,7 +40,7 @@ Jenkinsfile.github                                       @Cray-HPE/ci
 /operations/conman                                       @Cray-HPE/cms-core-console-logging
 /operations/compute_rolling_upgrades                     @Cray-HPE/cms-core-crus
 /operations/configuration_management                     @Cray-HPE/cms-core-cfs @Cray-HPE/cms-core-vcs
-/operations/image_management                             @Cray-HPE/cms-core-ims @Cray-HPE/cms-core-images                             
+/operations/image_management                             @Cray-HPE/cms-core-ims @Cray-HPE/cms-core-images
 
 # User Access items
 /operations/UAS_user_and_admin_topics                    @Cray-HPE/user-access

--- a/.shellspec
+++ b/.shellspec
@@ -1,0 +1,12 @@
+--require spec_helper
+
+## Default kcov (coverage) options
+# --kcov-options "--include-path=. --path-strip-level=1"
+# --kcov-options "--include-pattern=.sh"
+# --kcov-options "--exclude-pattern=/.shellspec,/spec/,/coverage/,/report/"
+
+## Example: Include script "myprog" with no extension
+# --kcov-options "--include-pattern=.sh,myprog"
+
+## Example: Only specified files/directories
+# --kcov-options "--include-pattern=myprog,/lib/"

--- a/install/README.md
+++ b/install/README.md
@@ -43,6 +43,8 @@ shown here with numbered topics.
     1. [Prepare compute nodes](#9-prepare-compute-nodes)
     1. [Next topic](#10-next-topic)
     - [Troubleshooting installation problems](#troubleshooting-installation-problems)
+1. [Post-installation](#post-installation)
+    1. [Kubernetes encryption](#11-encryption)
 
 > **`NOTE`** If problems are encountered during the installation,
 > [Troubleshooting installation problems](#troubleshooting-installation-problems) and
@@ -200,3 +202,10 @@ switches for the HPE Cray EX system. The procedures in this section should be re
 for additional information on system hardware, troubleshooting, and administrative tasks related to CSM.
 
 See [Troubleshooting Installation Problems](troubleshooting_installation.md).
+
+### 11. Kubernetes encryption
+
+As an optional post installation task, encryption of Kubernetes secrets may be enabled. This enables
+at rest encryption of data in the `etcd` database used by Kubernetes.
+
+See [Kubernetes Encryption](../operations/kubernetes/encryption/README.md).

--- a/operations/kubernetes/encryption/README.md
+++ b/operations/kubernetes/encryption/README.md
@@ -1,0 +1,157 @@
+# Kubernetes Encryption
+
+Beginning in CSM 1.3, support is enabled for data encryption in `etcd` for Kubernetes secrets at rest.
+
+This controller is deployed by default in CSM with the `cray-kubernetes-encryption` Helm chart.
+
+By default, encryption is not enabled and must be enabled after install.
+
+## Table of contents
+
+* [Implementation details](#implementation-details)
+* [Enabling encryption](#enabling-encryption)
+* [Disabling encryption](#disabling-encryption)
+* [Encryption status](#encryption-status)
+* [Force rewrite](#force-rewrite)
+
+## Implementation details
+
+In order to better understand current limitations to the implementation, it is important to understand how encryption is enabled.
+
+There are two aspects to encryption. The first aspect is the aforementioned `cray-kubernetes-encryption` Helm chart, which runs within Kubernetes and determines
+when existing secret data can be rewritten. The second aspect is control plane configuration of the `kubeapi` process.
+
+For control plane nodes encryption, configuration is written to `/etc/cray/kubernetes/encryption` and `kubeapi` containers are restarted.
+
+For Kubernetes secret encryption, once all control plane nodes agree on encryption ciphers and their keys, `cray-kubernetes-encryption` will rewrite all secret data.
+
+For further information, refer to the [official Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/).
+
+## Enabling encryption
+
+In order to enable encryption, a 16, 24, or 32 byte string must be provided and retained. It is important not to lose this key, because once secrets
+are encrypted in `etcd`, Kubernetes must be configured with this secret before it can start.
+
+Note that all control plane nodes must be updated. Also note that once a node is updated, any new secret data writes performed by `kubeapi` for that node will be encrypted. All control plane nodes should be updated as close to the same time as possible.
+
+There are two allowed encryption methods that may be chosen: `aescbc` and `aesgcm`.
+
+Both ciphers allow the same input string type. Note that while it is possible to specify multiple encryption keys, only the first key will be used for encryption of any newly written Kubernetes secret.
+
+* (`ncn-m#`) The `encryption.sh` script can be used to enable encryption on all control plane nodes.
+
+    As shown in the following command example, always run `encryption.sh` with a leading space on the command line. This will cause Bash to not record the command in the `.bash_history` file.
+
+    ```bash
+     /usr/share/doc/csm/scripts/operations/kubernetes/encryption.sh --enable --aescbc KEYVALUE
+    ```
+
+    Example output:
+
+    ```text
+    encryption configuration updated
+    ```
+
+## Disabling encryption
+
+Safely disabling encryption requires two steps to ensure no access to Kubernetes secret data is lost:
+
+1. (`ncn-m#`) Disable encryption but retain the existing encryption key.
+
+    This ensures that if a node is rebooted, or if Kubernetes is restarted, then Kubernetes can still read
+    existing encrypted secret data.
+
+    The following command disables encryption on all control plane nodes.
+
+    ```bash
+     /usr/share/doc/csm/scripts/operations/kubernetes/encryption.sh --disable --aescbc KEYVALUE
+    ```
+
+    Example output:
+
+    ```text
+    encryption configuration updated
+    ```
+
+1. Fully disable all encryption by removing all keys from the control plane nodes.
+
+    1. Verify that the `current` encryption is reported as `identity`.
+
+        See [Encryption status](#encryption-status) for details on how to check this.
+
+    1. (`ncn-m#`) Fully disable all encryption.
+
+        ```bash
+         /usr/share/doc/csm/scripts/operations/kubernetes/encryption.sh --disable
+        ```
+
+        Example output:
+
+        ```text
+        encryption configuration updated
+        ```
+
+        At this point, encryption of `etcd` secrets will be back to default.
+
+## Encryption status
+
+Encryption status is recorded in a Kubernetes secret `cray-k8s-encryption` via annotations.
+
+* (`ncn-mw#`) The following command reports the encryption status.
+
+    ```bash
+    kubectl get secret cray-k8s-encryption -o json -n kube-system | jq ".metadata.annotations | {changed, current, goal}"
+    ```
+
+    The command output will show the last time any change was performed, the goal encryption name, and the current encryption name.
+
+* Example output on a new or upgraded installation with the default of no encryption.
+
+    ```json
+    {
+      "changed": "1970-01-01 12:00:00+0000",
+      "current": "identity",
+      "goal": "identity"
+    }
+    ```
+
+    The string `identity` indicates that the identity encryption provider is in use. This provider performs no encryption.
+
+* Example command output when enabling encryption but secrets are not yet rewritten.
+
+    ```json
+    {
+      "changed": "1970-01-01 12:00:00+0000",
+      "current": "identity",
+      "goal": "aescbc-46d5bd8c2001d07ded05687fe51b517033dc609e69fe4dddaa6e05656cf6e907"
+    }
+    ```
+
+    The goal is an `aescbc` cipher. The `goal` string corresponds to the name in the
+    `/etc/cray/kubernetes/encryption/current.yaml` file on all control plane nodes after the `encryption.sh` script has
+    been run. Only a goal that all control plane nodes agree on will be reported.
+
+* Example command output after secrets are rewritten.
+
+    ```json
+    {
+      "changed": "1970-01-01 12:00:00+0000",
+      "current": "aescbc-46d5bd8c2001d07ded05687fe51b517033dc609e69fe4dddaa6e05656cf6e907",
+      "goal": "aescbc-46d5bd8c2001d07ded05687fe51b517033dc609e69fe4dddaa6e05656cf6e907"
+    }
+    ```
+
+    The output shows that the `current` key and `goal` keys are in agreement. This indicates that all secret data in `etcd`
+    is now encrypted with this key provider's name.
+
+## Forcing encryption
+
+If necessary, a forced rewrite of secret data can be done by overwriting the annotation used by `cray-k8s-encryption`.
+
+* (`ncn-mw#`) Force a rewrite of existing data:
+
+    ```bash
+    kubectl annotate secret --namespace kube-system cray-k8s-encryption current=rewrite --overwrite
+    ```
+
+    This command gives no output on success.

--- a/operations/kubernetes/encryption/index.md
+++ b/operations/kubernetes/encryption/index.md
@@ -1,0 +1,1 @@
+README.md

--- a/scripts/operations/kubernetes/encryption.sh
+++ b/scripts/operations/kubernetes/encryption.sh
@@ -1,0 +1,401 @@
+#!/usr/bin/env sh
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+_base=$(basename "$0")
+_dir=$(cd -P -- "$(dirname -- "$(command -v -- "$0")")" && pwd -P || exit 126)
+export _base _dir
+set "${SETOPTS:--eu}"
+
+tmpfiles=
+cleanup() {
+  if [ "" != "${tmpfiles}" ]; then
+    rm -fr "${tmpfiles}"
+  fi
+}
+
+trap cleanup EXIT
+
+# Secret data length must be 16, 24, or 32 bytes long or it is invalid. A valid
+# secret's data can only be 16, 24, or 32 bytes long, according to the k8s documentation and testing.
+# If we provide data of any length that isn't these lengths, k8s will *not* start.
+validatelen() {
+  len=$(echo "$@" | awk '{print length}')
+  if [ 16 -eq "${len}" ] \
+    || [ 24 -eq "${len}" ] \
+    || [ 32 -eq "${len}" ]; then
+    return "${len}"
+  fi
+  return 0
+}
+
+# Allow aescbc or aesgcm provider types only
+validprovider() {
+  provider=${1:-invalid}
+  if [ "aesgcm" = "${provider}" ] || [ "aescbc" = "${provider}" ]; then
+    return 1
+  fi
+  return 0
+}
+
+# Note identity is a "special" secret allowing a caller to control where/when
+# the identity provider shows up in the list
+#
+# Called like so:
+# - encryptionconfig identity aescbc:keydata aesgcm:keydata
+# - encryptionconfig identity aescbc:keydata aescbc:keydata
+# - encryptionconfig aescbc:keydata aescbc:keydata identity
+# - encryptionconfig identity
+# - etc.....
+# - Note that a call of encryptionconfig identity should only occur when turning encryption off entirely after it was on.
+# - Identity is *always* required, it controls where in the provider array the identity provider shows up. This is used for key rotation and to bring k8s up when switching to a new encryption key. As any data is not encrypted at that point in etcd we need to be able to read the data to re-encrypt later.
+# - Note: identity is an internal only thing, users don't specify this directly but implicitly by turning encryption on or off.
+# - Order of callers determines what will/can be used for encryption.
+# - Note: This encryptionconfig could use some cleaning up in how it lays out providers less redundantly. But an added bonus is it makes positional keys easy to specify.
+encryptionconfig() {
+  identok=0
+  encryptionsetup=
+  ok=0
+
+  if [ $# -eq 0 ]; then
+    printf "fatal: bug? no args passed to encryptionconfig()\n" >&2
+    return 1
+  fi
+
+  # Non odd number of args is definitely wrong
+  if [ $(($# % 2)) -ne 1 ]; then
+    printf "fatal: bug? even number of args for encryptionconfig()\n" >&2
+    return 1
+  fi
+
+  # Shift through args to find identity string and build up the encryption setup
+  until [ $# -eq 0 ]; do
+    input=${1:-nothing}
+    shift > /dev/null 2>&1 || :
+
+    if [ "identity" = "${input}" ]; then
+      identok=$((identok + 1))
+      encryptionsetup="${encryptionsetup-}${encryptionsetup:+ }identity"
+      continue
+    fi
+
+    if ! validprovider "${input}"; then
+      key=${1:-none}
+      shift || :
+
+      if ! validatelen "${key}"; then
+        encryptionsetup=" ${encryptionsetup} ${input} ${key}"
+      else
+        printf "fatal: invalid key length\n" >&2
+        ok=$((ok + 1))
+      fi
+    else
+      printf "fatal: invalid provider specified %s\n" "${input}" >&2
+      ok=$((ok + 1))
+      shift > /dev/null 2>&1 || :
+    fi
+  done
+
+  if [ ${ok} -ne 0 ]; then
+    return 1
+  fi
+
+  if [ ${identok} -eq 0 ]; then
+    printf "fatal: bug? no identity provider provided for encryptionconfig()\n" >&2
+    return 1
+  elif [ ${identok} -ne 1 ]; then
+    printf "fatal: bug? more than one identity arg provided to identityconfig()\n" >&2
+    return 1
+  fi
+
+  (
+    cat << FIN
+---
+apiVersion: apiserver.config.k8s.io/v1
+kind: EncryptionConfiguration
+resources:
+  - resources:
+      - secrets
+    providers:
+FIN
+    curr=""
+    for x in ${encryptionsetup}; do
+      if [ "identity" = "${x}" ]; then
+        cat << FIN
+      - identity: {}
+FIN
+      elif [ "aescbc" = "${x}" ] || [ "aesgcm" = "${x}" ]; then
+        curr="${x}"
+      else
+        sha=$(echo "${x}" | sha256sum | awk '{print $1}')
+        name="${curr}-${sha}"
+        # Note: printf to ensure we're not passing in newlines no matter what
+        # shell we're run against.
+        b64secret=$(printf "%s" "${x}" | base64)
+        cat << FIN
+      - ${curr}:
+          keys:
+            - name: "${name}"
+              secret: "${b64secret}"
+FIN
+      fi
+    done
+  )
+}
+
+# Write out a configfile to PREFIX, note PREFIX *MUST* exist
+PREFIX=${PREFIX:-/etc/cray/kubernetes/encryption}
+writeconfig() {
+  if [ ! -d "${PREFIX}" ]; then
+    printf "fatal: %s does not exist or is not a directory\n" "${PREFIX}" >&2
+    return 1
+  fi
+
+  tmpfile=$(mktemp sha256sum.XXXXXXXX)
+
+  tmpfiles="${tmpfiles} ${tmpfile}"
+
+  # Write out whatever we got passed into a tempfile so we can get the sha256sum
+  # of the contents to move it into PREFIX
+  encryptionconfig "$@" > "${tmpfile?}"
+  shasum=$(sha256sum "${tmpfile?}" | awk '{print $1}')
+
+  curr="${PREFIX}/current.yaml"
+
+  # The sha256sum of the default.yaml file the ncn image has, used as a bit of a
+  # fix point.
+  if [ "a4bc1911a877c9c28b5f4493ca314ba2f26f759cc8d9e7ac3ebf2c3d752c25a8" = "${shasum}" ]; then
+    reset=true
+  else
+    reset=false
+    mv "${tmpfile?}" "${PREFIX?}/${shasum?}.yaml"
+  fi
+
+  # This function is here for mostly unit testing reasons but replaces the
+  # encryption configuration line in the kubeadm config file to the file we just
+  # created. If kubeadm then restarts/updates OK then we symlink current.yaml to point to that file. Logic in here is rather simple. The encryption pods will read current.yaml and decide if/when to update/replace secrets.
+
+  if ${reset}; then
+    # Default source is the default.yaml file
+    src="${PREFIX}/default.yaml"
+  else
+    src="${PREFIX?}/${shasum?}.yaml"
+  fi
+
+  if ! updatek8sconfig "${src}" /etc/kubernetes/manifests/kube-apiserver.yaml /srv/cray/resources/common/kubeadm.cfg /etc/cray/kubernetes/kubeadm.yaml; then
+    printf "fatal: Update of k8s config to use %s failed\n" "${src}" >&2
+    return 1
+  fi
+
+  # For callers to know what the new config file is supposed to be.
+  printf "%s\n" "${src}"
+
+  return 0
+}
+
+# This is largely the only thing that can't easily be unit tested only
+# mocked/mimic'd, basically this is responsible for updating the following files:
+# /etc/kubernetes/manifests/kube-apiserver.yaml
+# /srv/cray/resources/common/kubeadm.cfg
+# /etc/cray/kubernetes/kubeadm.yaml
+#
+# Might pay off to fake this somehow...
+updatek8sconfig() {
+  config=$1
+  shift
+  kubeapiyaml=$1
+  shift
+  kubeadmcfg=$1
+  shift
+  kubeadmyaml=$1
+
+  # Note kubeadmyaml isn't on every master node
+  sed -i -e "s|--encryption-provider-config=.*|--encryption-provider-config=${config}|" "${kubeapiyaml}"
+  sed -i -e "s|encryption-provider-config:.*|encryption-provider-config: ${config}|" "${kubeadmcfg}"
+  if [ -e "${kubeadmyaml}" ]; then
+    sed -i -e "s|encryption-provider-config:.*|encryption-provider-config: ${config}|" "${kubeadmyaml}"
+  fi
+}
+
+# Note as I'm modifying all the same files that kubeadm upgrade apply does we
+# can skip that and modify the input file as well as the runtime files.
+#
+# Whilst not perhaps ideal it saves on the chances that the the kubeadm config
+# file has deviated from the running config and I would rather not have turning
+# on encryption breaking anything that it didn't setup.
+#
+# So instead of kubeadm upgrade .. to restart the kubeadm containers, we simply
+# kubectl delete the local nodes kubeapi pod. Then validate that we have the
+# encryption config file passed into kubeapi's process args list. If yes, yatta,
+# we can then symlink curren.yaml to that file, if not we abort something is
+# amiss.
+#
+# Arg is simply the full encryption filename path that we'll pass to pgrep -lif
+# in a real boy system.
+restartk8s() {
+  file="${1:-invalid}"
+  if sutkubectldelete "${file}"; then
+    apiserver="kube-apiserver-$(uname -n)"
+    # kubectl wait for the pod to come back for 60 seconds or bail
+    if ! sutkubectlwait; then
+      printf "fatal: kubectl wait on %s timed out\n" "${apiserver}" >&2
+      return $?
+    fi
+  else
+    printf "fatal: kubectl delete on %s timed out\n" "${apiserver}" >&2
+    return $?
+  fi
+  if ! sutpgrep "${file}"; then
+    printf "fatal: kubeapi args do not contain expected arg %s\n" "%{file}" >&2
+    return $?
+  fi
+}
+
+# Glorified wrapper functions for unit tests.
+
+# Simply wrapping around:
+# pgrep -lif proces.*something in the arg list
+sutpgrep() {
+  pgrep -lif "kube-apiserver.*${1:-invalid}" > /dev/null 2>&1
+}
+
+# Similarly just wrapping:
+# kubectl delete pod --namespace kube-system kube-apiserver-$(uname -n)
+# Note as we're expecting to be run on the node in question $(uname -n) should
+# be ok to use, not dealing with that being different in this instance.
+#
+# Additionally, just have kubectl wait for one minute to delete the pod if not give up and let caller decide on actions.
+sutkubectldelete() {
+  kubectl delete pod --namespace kube-system "kube-apiserver-$(uname -n)" --timeout=60s > /dev/null 2>&1
+}
+
+# Similarly just wrapping:
+# kubectl delete pod --namespace kube-system kube-apiserver-$(uname -n)
+# Note as we're expecting to be run on the node in question $(uname -n) should
+# be ok to use, not dealing with that being different in this instance.
+#
+# Additionally, just have kubectl wait for one minute to delete the pod if not give up and let caller decide on actions.
+sutkubectlwait() {
+  kubectl wait pod --namespace kube-system --for condition=ready "kube-apiserver-$(uname -n)" --timeout=60s > /dev/null 2>&1
+}
+
+# Logic is simply write out our new encryption config
+# iff thats ok restart k8s apiserver pod
+# iff that was ok then symlink the new config to current.yaml so daemon can pickup the new setup in k8s.
+main() {
+  curr="${PREFIX}/current.yaml"
+  src=$(writeconfig "$@")
+  if [ $? ]; then
+    if restartk8s "${src}"; then
+      if [ -e "${src}" ]; then
+        ln -sf "${src}" "${curr}"
+      else
+        printf "fatal: cannot symlink %s as it does not exist?\n" "${src}" >&2
+        exit 1
+      fi
+    else
+      printf "fatal: could not restart k8s to update encryption configuration\n" >&2
+      exit 1
+    fi
+  else
+    printf "fatal: could not write config file\n" >&2
+    exit 1
+  fi
+  printf "encryption configuration updated\n" >&2
+}
+
+# Note: this line allows shellspec to source this script for unit testing functions above.
+# DO NOT REMOVE IT!
+# Ref: https://github.com/shellspec/shellspec#testing-shell-functions
+${__SOURCED__:+return}
+
+usage() {
+  cat << FIN
+usage: $0 [-h|--help] [--enable|--disable] --aescbc VALUE --aesgcm VALUE ...
+FIN
+}
+
+# Main() related stuff here/arg parsing etc...
+encryptionopts=
+enabled=false
+disabled=false
+ciphers=0
+help=true
+
+while true; do
+  case "${1:-}" in
+    -e | --enable)
+      help=false
+      enabled=true
+      shift
+      ;;
+    -d | --disable)
+      help=false
+      disabled=true
+      shift
+      ;;
+    --aescbc)
+      help=false
+      ciphers=$((ciphers + 1))
+      encryptionopts="${encryptionopts-}${encryptionopts:+ }aescbc ${2}"
+      shift 2
+      ;;
+    --aesgcm)
+      help=false
+      ciphers=$((ciphers + 1))
+      encryptionopts="${encryptionopts-}${encryptionopts:+ }aesgcm ${2}"
+      shift 2
+      ;;
+    -h | --help)
+      break
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+if ${help}; then
+  usage
+  exit 1
+fi
+
+if ${enabled} && ${disabled}; then
+  printf "fatal: --enable and --disable cannot be used together\n" 2>&1
+  usage
+  exit 1
+elif ${enabled}; then
+  if [ ${ciphers} -lt 1 ]; then
+    printf "fatal: --enable requires at least one cipher to be provided\n" 2>&1
+    usage
+    exit 1
+  fi
+  encryptionopts="${encryptionopts-}${encryptionopts:+ }identity"
+elif ${disabled}; then
+  encryptionopts="identity${encryptionopts:+ }${encryptionopts-}"
+fi
+
+# Not really applicable for this, if we quote here we send every arg as a single
+# arg, we need word splitting. Shellcheck is being over pedantic.
+#shellcheck disable=SC2086
+main ${encryptionopts}

--- a/spec/encryption_spec.sh
+++ b/spec/encryption_spec.sh
@@ -1,0 +1,312 @@
+#!/usr/bin/env sh
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# Note using function mocks for testing ref:
+# https://github.com/shellspec/shellspec#mocking
+Describe 'encryption.sh logic'
+  Include scripts/operations/node_management/encryption.sh
+
+  # Valid secret lengths, some caveats apply....
+  secret16=0123456789abcdef
+  secret24=0123456789abcdeffedcba98
+  secret32=0123456789abcdeffedcba9876543210
+
+  # Control if an input is of correct input length, e.g. 16, 24, or 32 bytes
+  # long
+  Context 'Valid encryption key input lengths'
+
+    It 'secret of length 16 is OK'
+      When call validatelen "${secret16}"
+      The status should equal 16
+    End
+
+    It 'secret of length 24 is OK'
+      When call validatelen "${secret24}"
+      The status should equal 24
+    End
+
+    It 'secret of length 32 is OK'
+      When call validatelen "${secret32}"
+      The status should equal 32
+    End
+  End
+
+  # Invalid secret length data
+  Context 'Invalid encryption key input lengths'
+    It 'invalid length fails'
+      When call validatelen "123"
+      The status should equal 0
+    End
+
+    It 'crazy long input fails'
+      When call validatelen "alsjflkdjflkjafljdalskfjldkjsfkjdsfkljfdlkjdf"
+      The status should equal 0
+    End
+
+    It 'null/empty string fails'
+      When call validatelen ""
+      The status should equal 0
+    End
+  End
+
+  # Validate provider types/strings
+  Context 'Valid provider provided'
+    It 'allows aescbc as a provider'
+      When call validprovider aescbc
+      The status should equal 1
+    End
+
+    It 'allows aesgcm as a provider'
+      When call validprovider aesgcm
+      The status should equal 1
+    End
+  End
+
+  Context 'Invalid provider provided'
+    It 'fails with a random string that makes no sense'
+      When call validprovider abc
+      The status should equal 0
+    End
+
+    It 'fails with no args'
+      When call validprovider
+      The status should equal 0
+    End
+
+  End
+
+  # Make sure the encryptionconfig function works the way we expect it to.
+  Context 'Valid encryptionconfig calls'
+    # Only used for unit tests, hopefully nobody ever tries to use this secret in
+    # real life.
+    secretsut=sutsutsutsutsutsutsutsutsutsutsu
+
+    identity() {
+      %text
+      #|---
+      #|apiVersion: apiserver.config.k8s.io/v1
+      #|kind: EncryptionConfiguration
+      #|resources:
+      #|  - resources:
+      #|      - secrets
+      #|    providers:
+      #|      - identity: {}
+    }
+
+    beginencryption() {
+      %text
+      #|---
+      #|apiVersion: apiserver.config.k8s.io/v1
+      #|kind: EncryptionConfiguration
+      #|resources:
+      #|  - resources:
+      #|      - secrets
+      #|    providers:
+      #|      - identity: {}
+      #|      - aescbc:
+      #|          keys:
+      #|            - name: "aescbc-46d5bd8c2001d07ded05687fe51b517033dc609e69fe4dddaa6e05656cf6e907"
+      #|              secret: "c3V0c3V0c3V0c3V0c3V0c3V0c3V0c3V0c3V0c3V0c3U="
+      #|      - aesgcm:
+      #|          keys:
+      #|            - name: "aesgcm-46d5bd8c2001d07ded05687fe51b517033dc609e69fe4dddaa6e05656cf6e907"
+      #|              secret: "c3V0c3V0c3V0c3V0c3V0c3V0c3V0c3V0c3V0c3V0c3U="
+      #|
+    }
+
+    It 'allows a simple identity config'
+      When call encryptionconfig identity
+      The status should equal 0
+      The stdout should equal "$(identity)"
+    End
+
+    It 'sets up aescbc and aesgcm correctly'
+      When call encryptionconfig identity aescbc "${secretsut}" aesgcm "${secretsut}"
+      The status should equal 0
+      The stdout should equal "$(beginencryption)"
+    End
+
+  End
+
+  Context 'Invalid encryptionconfig calls'
+    It 'fails when called without args'
+      When call encryptionconfig
+      The status should equal 1
+      The stderr should equal "fatal: bug? no args passed to encryptionconfig()"
+    End
+
+    It 'fails when called with an even number of args'
+      When call encryptionconfig a b
+      The status should equal 1
+      The stderr should equal "fatal: bug? even number of args for encryptionconfig()"
+    End
+
+    It 'fails when called with some random input that makes no sense'
+      When call encryptionconfig invalid
+      The status should equal 1
+      The stderr should equal "fatal: invalid provider specified invalid"
+    End
+
+    It 'fails if every arg is just identity'
+      When call encryptionconfig identity identity identity
+      The status should equal 1
+      The stderr should equal "fatal: bug? more than one identity arg provided to identityconfig()"
+    End
+
+    # Note valid calls will *always* be odd aka identity provider data
+    # if we somehow get provider data provider data2 thats invalid/a bug
+    It 'fails when called with an even number of args'
+      When call encryptionconfig invalid aescbc
+      The status should equal 1
+      The stderr should equal "fatal: bug? even number of args for encryptionconfig()"
+    End
+
+    # A bit redundant but why not make sure calls are kosher
+    It 'fails when called with an invalid provider but valid data'
+      When call encryptionconfig identity invalid secret16
+      The status should equal 1
+      The stderr should equal "fatal: invalid provider specified invalid"
+    End
+
+    It 'fails when called with a valid provider but invalid data'
+      When call encryptionconfig identity aescbc blah
+      The status should equal 1
+      The stderr should equal "fatal: invalid key specified blah"
+    End
+  End
+
+  # This stuff is rather key to how all this setup is to work, takes the
+  # encryptionconfigs generated ^^^ and sets up the k8s path, e.g.
+  # /etc/cray/kubernetes/encryption .... and sets up/resets the encryption files. As
+  # this is critical to operational aspects, ensure the logic is as expected by
+  # stubbing in/using tempdirs to validate we get expected behavior.
+  Context 'File setup/symlink validation success cases'
+    sutdir=""
+    before() { sutdir=$(mktemp -d sut.XXXXXXXXX); }
+    after() { rm -fr "${sutdir}"; }
+
+    prefixhook() { PREFIX="${sutdir}"; }
+    restartk8s() { return 0; }
+
+    Before 'before' 'prefixhook'
+    After 'after'
+
+    Describe 'Edge case of PREFIX not existing'
+      # I hope this never exists anywhere...
+      noprefixdir() { PREFIX=/sut/no/such/dir; }
+      Before 'noprefixdir'
+
+      # We have default.yaml with a symlink of current.yaml
+      #
+      # We expect a file of sha256sumofcontents.yaml to symlink to current.yaml on
+      # a success case. Note this means kubeadm update worked, if that failed current.yaml
+      # is not updated. That is a different test block later.
+      It 'fails when PREFIX is not an existing directory'
+        When call writeconfig
+        The status should equal 1
+        The stderr should equal "fatal: ${PREFIX} does not exist or is not a directory"
+      End
+    End
+
+    Describe 'Edge case of PREFIX not being a directory'
+      # I hope this never exists anywhere...
+      notadir() { PREFIX=/dev/null; }
+      Before 'notadir'
+
+      # We have default.yaml with a symlink of current.yaml
+      #
+      # We expect a file of sha256sumofcontents.yaml to symlink to current.yaml on
+      # a success case. Note this means kubeadm update worked, if that failed current.yaml
+      # is not updated. That is a different test block later.
+      It 'fails when PREFIX is not an existing directory'
+        When call writeconfig
+        The status should equal 1
+        The stderr should equal "fatal: ${PREFIX} does not exist or is not a directory"
+      End
+    End
+
+    Describe 'Write out a default config, should be a nop and point current.yaml to default.yaml,'
+      # I hope this never exists anywhere...
+      notadir() { PREFIX=/dev/null; }
+      Before 'notadir'
+
+      # We have default.yaml with a symlink of current.yaml
+      #
+      # We expect a file of sha256sumofcontents.yaml to symlink to current.yaml on
+      # a success case. Note this means kubeadm update worked, if that failed current.yaml
+      # is not updated. That is a different test block later.
+      It 'fails when PREFIX is not an existing directory'
+        When call writeconfig
+        The status should equal 1
+        The stderr should equal "fatal: ${PREFIX} does not exist or is not a directory"
+      End
+    End
+
+    # This simply restarts the k8s kubeapi pod/containers and makes sure we can
+    # see the updated encryption configuration file in the process args.
+    Describe 'restartk8s function dependencies'
+      # We're running with something we aren't expecting... aka pgrep can't find that file in any process arguments.
+      It 'returns non zero when pgrep returns no match'
+        sutpgrep() {
+          return 1
+        }
+        When call sutpgrep "/etc/cray/kubernetes/encryption/whatever.yaml"
+        The status should equal 1
+      End
+
+      It 'returns ok when pgrep returns a kubeapi proces that matches'
+        sutpgrep() {
+          printf '12345 kube-api\n'
+          return 0
+        }
+        When call sutpgrep "/etc/cray/kubernetes/encryption/whatever.yaml"
+        The status should equal 0
+        The stdout should equal "12345 kube-api"
+      End
+
+      # TODO: What does a failure look like here besides non 0 return code? aka
+      # what does stdout/stderr output? Not critical but nice to match what real
+      # life has.
+      It 'returns nonzero if kubectl delete fails'
+        sutkubectldelete() {
+          return 1
+        }
+        When call sutkubectldelete
+        The status should equal 1
+      End
+
+      It 'returns zero if kubectl delete succeeds'
+        sutkubectldelete() {
+          printf 'pod "kube-apiserver-ncn-m001" deleted\n' >&2
+          return 0
+        }
+        When call sutkubectldelete
+        The status should equal 0
+        The stderr should equal 'pod "kube-apiserver-ncn-m001" deleted'
+      End
+
+    End
+  End
+End

--- a/spec/spec_helper.sh
+++ b/spec/spec_helper.sh
@@ -1,0 +1,48 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# shellcheck shell=sh
+
+# Defining variables and functions here will affect all specfiles.
+# Change shell options inside a function may cause different behavior,
+# so it is better to set them here.
+# set -eu
+
+# This callback function will be invoked only once before loading specfiles.
+spec_helper_precheck() {
+  # Available functions: info, warn, error, abort, setenv, unsetenv
+  # Available variables: VERSION, SHELL_TYPE, SHELL_VERSION
+  : minimum_version "0.28.1"
+}
+
+# This callback function will be invoked after a specfile has been loaded.
+spec_helper_loaded() {
+  :
+}
+
+# This callback function will be invoked after core modules has been loaded.
+spec_helper_configure() {
+  # Available functions: import, before_each, after_each, before_all, after_all
+  : import 'support/custom_matcher'
+}


### PR DESCRIPTION
Backporting from 1.3 to main

* CASMPET-5846: Initial encryption.sh implementation

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
