### PR TITLE
CASMINST-5363 main : DOCS: unset command has typo in Restore Postgres doc

### DIFF
--- a/operations/kubernetes/Restore_Postgres.md
+++ b/operations/kubernetes/Restore_Postgres.md
@@ -55,7 +55,7 @@ This assumes that a dump of the database exists and the Cray command line interf
         TMP=$(echo "$DUMPFILE" | sed 's/:/-/g')
         mv $DUMPFILE $TMP
         DUMPFILE=$(echo $TMP)
-        unset $TMP
+        unset TMP
         ```
 
 1. (`ncn-mw#`) Scale the Spire service to 0.
@@ -276,7 +276,7 @@ This assumes that a dump of the database exists and the Cray command line interf
         TMP=$(echo "$DUMPFILE" | sed 's/:/-/g')
         mv $DUMPFILE $TMP
         DUMPFILE=$(echo $TMP)
-        unset $TMP
+        unset TMP
         ```
 
 1. (`ncn-mw#`) Scale the Keycloak service to 0.
@@ -545,7 +545,7 @@ the Cray command line interface \(CLI\) tool is initialized and configured on th
         TMP=$(echo "$DUMPFILE" | sed 's/:/-/g')
         mv $DUMPFILE $TMP
         DUMPFILE=$(echo $TMP)
-        unset $TMP
+        unset TMP
         ```
 
 1. (`ncn-mw#`) Scale the VCS service to 0.
@@ -684,10 +684,10 @@ the Cray command line interface \(CLI\) tool is initialized and configured on th
 1. (`ncn-mw#`) Scale the Gitea service back up.
 
     ```bash
-    kubectl scale deployment ${SERVICE} -n ${NAMESPACE} --replicas=3
+    kubectl scale deployment ${SERVICE} -n ${NAMESPACE} --replicas=1
 
     # Wait for the gitea pods to start
-    while [ $(kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/name="${SERVICELABEL}" | grep -v NAME | wc -l) != 3 ] ; do
+    while [ $(kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/name="${SERVICELABEL}" | grep -v NAME | wc -l) != 1 ] ; do
         echo "  waiting for pods to start"; sleep 2
     done
     ```


### PR DESCRIPTION
# Description

CASMINST-5363 Fix a typo on the unset command 
CASMPET-5933 Fix gitea replica on restart

# Checklist Before Merging

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
