### PR TITLE
CASMTRIAGE-4240: Added content-type header to curl commands

### DIFF
--- a/operations/firmware/Updating_Firmware_m001.md
+++ b/operations/firmware/Updating_Firmware_m001.md
@@ -3,8 +3,9 @@
 Retrieve the model name and firmware image required to update an HPE or Gigabyte `ncn-m001` node.
 
 > **`NOTE`**
-> * On HPE nodes, the BMC Firmware is iLO 5 and BIOS is System ROM.
-> * The commands in the procedure must be run on `ncn-m001`.
+>
+> - On HPE nodes, the BMC firmware is iLO 5 and BIOS is System ROM.
+> - The commands in the procedure must be run on `ncn-m001`.
 
 ## Prerequisites
 

--- a/operations/firmware/Updating_Firmware_m001.md
+++ b/operations/firmware/Updating_Firmware_m001.md
@@ -2,7 +2,7 @@
 
 Retrieve the model name and firmware image required to update an HPE or Gigabyte `ncn-m001` node.
 
-> **`NOTE`** 
+> **`NOTE`**
 > * On HPE nodes, the BMC Firmware is iLO 5 and BIOS is System ROM.
 > * The commands in the procedure must be run on `ncn-m001`.
 
@@ -73,7 +73,7 @@ Use one of the following commands to find the model name for the node type in us
        * `filename` = Filename of the downloaded image
 
        ```bash
-       curl -k -u root:passwd https://ipaddressOfBMC/redfish/v1/UpdateService/Actions/SimpleUpdate -d '{"ImageURI":"http://ipaddressOfM001:8770/filename", "TransferProtocol":"HTTP", "UpdateComponent":"BMC"}'
+       curl -k -u root:passwd https://ipaddressOfBMC/redfish/v1/UpdateService/Actions/SimpleUpdate -H 'Content-Type: application/json' -d '{"ImageURI":"http://ipaddressOfM001:8770/filename", "TransferProtocol":"HTTP", "UpdateComponent":"BMC"}'
        ```
 
     2. Update BIOS:
@@ -84,7 +84,7 @@ Use one of the following commands to find the model name for the node type in us
        * `filename` = Filename of the downloaded image
 
        ```bash
-       curl -k -u root:passwd https://ipaddressOfBMC/redfish/v1/UpdateService/Actions/SimpleUpdate -d '{"ImageURI":"http://ipaddressOfM001:8770/filename", "TransferProtocol":"HTTP", "UpdateComponent":"BIOS"}'
+       curl -k -u root:passwd https://ipaddressOfBMC/redfish/v1/UpdateService/Actions/SimpleUpdate -H 'Content-Type: application/json' -d '{"ImageURI":"http://ipaddressOfM001:8770/filename", "TransferProtocol":"HTTP", "UpdateComponent":"BIOS"}'
        ```
 
        > After updating BIOS, `ncn-m001` will need to be rebooted. Follow the [Reboot NCNs](../node_management/Reboot_NCNs.md) procedure to reboot `ncn-m001`.

--- a/operations/firmware/Updating_Firmware_m001.md
+++ b/operations/firmware/Updating_Firmware_m001.md
@@ -11,9 +11,9 @@ Retrieve the model name and firmware image required to update an HPE or Gigabyte
 
 The following information is needed:
 
-* IP Address of `ncn-m001` BMC
-* IP Address of `ncn-m001`
-* Root password for `ncn-m001` BMC
+- IP Address of `ncn-m001` BMC
+- IP Address of `ncn-m001`
+- Root password for `ncn-m001` BMC
 
 ## Find the Model Name
 
@@ -68,10 +68,10 @@ Use one of the following commands to find the model name for the node type in us
 
     1. Update BMC:
 
-       * `passwd` = Root password of BMC
-       * `ipaddressOfBMC` = IP address of BMC
-       * `ipaddressOfM001` = IP address of `ncn-m001` node
-       * `filename` = Filename of the downloaded image
+       - `passwd` = Root password of BMC
+       - `ipaddressOfBMC` = IP address of BMC
+       - `ipaddressOfM001` = IP address of `ncn-m001` node
+       - `filename` = Filename of the downloaded image
 
        ```bash
        curl -k -u root:passwd https://ipaddressOfBMC/redfish/v1/UpdateService/Actions/SimpleUpdate -H 'Content-Type: application/json' -d '{"ImageURI":"http://ipaddressOfM001:8770/filename", "TransferProtocol":"HTTP", "UpdateComponent":"BMC"}'
@@ -79,10 +79,10 @@ Use one of the following commands to find the model name for the node type in us
 
     2. Update BIOS:
 
-       * `passwd` = Root password of BMC
-       * `ipaddressOfBMC` = IP address of BMC
-       * `ipaddressOfM001` = IP address of `ncn-m001` node
-       * `filename` = Filename of the downloaded image
+       - `passwd` = Root password of BMC
+       - `ipaddressOfBMC` = IP address of BMC
+       - `ipaddressOfM001` = IP address of `ncn-m001` node
+       - `filename` = Filename of the downloaded image
 
        ```bash
        curl -k -u root:passwd https://ipaddressOfBMC/redfish/v1/UpdateService/Actions/SimpleUpdate -H 'Content-Type: application/json' -d '{"ImageURI":"http://ipaddressOfM001:8770/filename", "TransferProtocol":"HTTP", "UpdateComponent":"BIOS"}'

--- a/operations/firmware/Updating_Firmware_without_FAS.md
+++ b/operations/firmware/Updating_Firmware_without_FAS.md
@@ -50,7 +50,7 @@ This procedure can be followed on any Linux system with network connectivity to 
     - `filename` = Filename of the downloaded image
 
     ```bash
-    curl -k -u root:passwd https://ipaddressOfBMC/redfish/v1/UpdateService/Actions/SimpleUpdate \
+    curl -k -u root:passwd https://ipaddressOfBMC/redfish/v1/UpdateService/Actions/SimpleUpdate -H 'Content-Type: application/json' \
                   -d '{"ImageURI":"http://ipaddressOfM001:8770/filename", "TransferProtocol":"HTTP", "UpdateComponent":"BMC"}'
     ```
 
@@ -62,7 +62,7 @@ This procedure can be followed on any Linux system with network connectivity to 
     - `filename` = Filename of the downloaded image
 
     ```bash
-    curl -k -u root:passwd https://ipaddressOfBMC/redfish/v1/UpdateService/Actions/SimpleUpdate \
+    curl -k -u root:passwd https://ipaddressOfBMC/redfish/v1/UpdateService/Actions/SimpleUpdate -H 'Content-Type: application/json' \
                   -d '{"ImageURI":"http://ipaddressOfM001:8770/filename", "TransferProtocol":"HTTP", "UpdateComponent":"BIOS"}'
     ```
 


### PR DESCRIPTION
# Description

Update to firmware update docs to include "content-type" header with curl commands

# Checklist Before Merging

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
