### PR TITLE
CASMTRIAGE-4240: Added content-type header to curl commands - release 1.2

### DIFF
--- a/operations/firmware/Updating_Firmware_m001.md
+++ b/operations/firmware/Updating_Firmware_m001.md
@@ -2,17 +2,18 @@
 
 Retrieve the model name and firmware image required to update an HPE or Gigabyte `ncn-m001` node.
 
-> **NOTE:** 
-> * On HPE nodes, the BMC Firmware is iLO 5 and BIOS is System ROM.
-> * The commands in the procedure must be run on `ncn-m001`.
+> **`NOTE`**
+>
+> - On HPE nodes, the BMC firmware is iLO 5 and BIOS is System ROM.
+> - The commands in the procedure must be run on `ncn-m001`.
 
 ## Prerequisites
 
 The following information is needed:
 
-* IP Address of `ncn-m001` BMC
-* IP Address of `ncn-m001`
-* Root password for `ncn-m001` BMC
+- IP Address of `ncn-m001` BMC
+- IP Address of `ncn-m001`
+- Root password for `ncn-m001` BMC
 
 ## Find the Model Name
 
@@ -33,7 +34,7 @@ Use one of the following commands to find the model name for the node type in us
 ## Get the Firmware Images
 
 1. View a list of images stored in FAS that are ready to be flashed:
-    
+
     In the following example, `ModelName` is the name from the previous command.
 
     ```bash
@@ -67,24 +68,24 @@ Use one of the following commands to find the model name for the node type in us
 
     1. Update BMC:
 
-       * `passwd` = Root password of BMC
-       * `ipaddressOfBMC` = IP address of BMC
-       * `ipaddressOfM001` = IP address of `ncn-m001` node
-       * `filename` = Filename of the downloaded image
+       - `passwd` = Root password of BMC
+       - `ipaddressOfBMC` = IP address of BMC
+       - `ipaddressOfM001` = IP address of `ncn-m001` node
+       - `filename` = Filename of the downloaded image
 
        ```bash
-       ncn-m001# curl -k -u root:passwd https://ipaddressOfBMC/redfish/v1/UpdateService/Actions/SimpleUpdate -d '{"ImageURI":"http://ipaddressOfM001:8770/filename", "TransferProtocol":"HTTP", "UpdateComponent":"BMC"}'
+       ncn-m001# curl -k -u root:passwd https://ipaddressOfBMC/redfish/v1/UpdateService/Actions/SimpleUpdate -H 'Content-Type: application/json' -d '{"ImageURI":"http://ipaddressOfM001:8770/filename", "TransferProtocol":"HTTP", "UpdateComponent":"BMC"}'
        ```
 
     2. Update BIOS:
 
-       * `passwd` = Root password of BMC
-       * `ipaddressOfBMC` = IP address of BMC
-       * `ipaddressOfM001` = IP address of `ncn-m001` node
-       * `filename` = Filename of the downloaded image
+       - `passwd` = Root password of BMC
+       - `ipaddressOfBMC` = IP address of BMC
+       - `ipaddressOfM001` = IP address of `ncn-m001` node
+       - `filename` = Filename of the downloaded image
 
        ```bash
-       ncn-m001# curl -k -u root:passwd https://ipaddressOfBMC/redfish/v1/UpdateService/Actions/SimpleUpdate -d '{"ImageURI":"http://ipaddressOfM001:8770/filename", "TransferProtocol":"HTTP", "UpdateComponent":"BIOS"}'
+       ncn-m001# curl -k -u root:passwd https://ipaddressOfBMC/redfish/v1/UpdateService/Actions/SimpleUpdate -H 'Content-Type: application/json' -d '{"ImageURI":"http://ipaddressOfM001:8770/filename", "TransferProtocol":"HTTP", "UpdateComponent":"BIOS"}'
        ```
 
        > After updating BIOS, `ncn-m001` will need to be rebooted. Follow the [Reboot NCNs](../node_management/Reboot_NCNs.md) procedure to reboot `ncn-m001`.

--- a/operations/firmware/Updating_Firmware_without_FAS.md
+++ b/operations/firmware/Updating_Firmware_without_FAS.md
@@ -50,7 +50,7 @@ This procedure can be followed on any Linux system with network connectivity to 
     - `filename` = Filename of the downloaded image
 
     ```bash
-    curl -k -u root:passwd https://ipaddressOfBMC/redfish/v1/UpdateService/Actions/SimpleUpdate \
+    curl -k -u root:passwd https://ipaddressOfBMC/redfish/v1/UpdateService/Actions/SimpleUpdate -H 'Content-Type: application/json' \
                   -d '{"ImageURI":"http://ipaddressOfM001:8770/filename", "TransferProtocol":"HTTP", "UpdateComponent":"BMC"}'
     ```
 
@@ -62,7 +62,7 @@ This procedure can be followed on any Linux system with network connectivity to 
     - `filename` = Filename of the downloaded image
 
     ```bash
-    curl -k -u root:passwd https://ipaddressOfBMC/redfish/v1/UpdateService/Actions/SimpleUpdate \
+    curl -k -u root:passwd https://ipaddressOfBMC/redfish/v1/UpdateService/Actions/SimpleUpdate -H 'Content-Type: application/json' \
                   -d '{"ImageURI":"http://ipaddressOfM001:8770/filename", "TransferProtocol":"HTTP", "UpdateComponent":"BIOS"}'
     ```
 


### PR DESCRIPTION
# Description

Update to firmware docs to include "content-type" headers with curl commands
Docs release/1.2

# Checklist Before Merging

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
