### PR TITLE
CASMTRIAGE-4240 Added content-type header to curl commands

### DIFF
--- a/operations/firmware/Updating_Firmware_m001.md
+++ b/operations/firmware/Updating_Firmware_m001.md
@@ -2,9 +2,11 @@
 
 Retrieve the model name and firmware image required to update an HPE or Gigabyte `ncn-m001` node.
 
-> **NOTE:**
-> * On HPE nodes, the BMC Firmware is iLO 5 and BIOS is System ROM.
-> * The commands in the procedure must be run on `ncn-m001`.
+> **`NOTE`**
+>
+> - On HPE nodes, the BMC firmware is iLO 5 and BIOS is System ROM.
+> - The commands in the procedure must be run on `ncn-m001`.
+> - This procedure should only be used if FAS is not available, such as during initial CSM install.
 
 ## Prerequisites
 
@@ -67,10 +69,10 @@ Use one of the following commands to find the model name for the node type in us
 
     1. Update BMC:
 
-       * `passwd` = Root password of BMC
-       * `ipaddressOfBMC` = IP address of BMC
-       * `ipaddressOfM001` = IP address of `ncn-m001` node
-       * `filename` = Filename of the downloaded image
+       - `passwd` = Root password of BMC
+       - `ipaddressOfBMC` = IP address of BMC
+       - `ipaddressOfM001` = IP address of `ncn-m001` node
+       - `filename` = Filename of the downloaded image
 
        ```bash
        ncn-m001# curl -k -u root:passwd https://ipaddressOfBMC/redfish/v1/UpdateService/Actions/SimpleUpdate -H 'Content-Type: application/json' \
@@ -79,10 +81,10 @@ Use one of the following commands to find the model name for the node type in us
 
     2. Update BIOS:
 
-       * `passwd` = Root password of BMC
-       * `ipaddressOfBMC` = IP address of BMC
-       * `ipaddressOfM001` = IP address of `ncn-m001` node
-       * `filename` = Filename of the downloaded image
+       - `passwd` = Root password of BMC
+       - `ipaddressOfBMC` = IP address of BMC
+       - `ipaddressOfM001` = IP address of `ncn-m001` node
+       - `filename` = Filename of the downloaded image
 
        ```bash
        ncn-m001# curl -k -u root:passwd https://ipaddressOfBMC/redfish/v1/UpdateService/Actions/SimpleUpdate -H 'Content-Type: application/json' \

--- a/operations/firmware/Updating_Firmware_m001.md
+++ b/operations/firmware/Updating_Firmware_m001.md
@@ -12,9 +12,9 @@ Retrieve the model name and firmware image required to update an HPE or Gigabyte
 
 The following information is needed:
 
-* IP address of `ncn-m001` BMC
-* IP address of `ncn-m001`
-* Root password for `ncn-m001` BMC
+- IP address of `ncn-m001` BMC
+- IP address of `ncn-m001`
+- Root password for `ncn-m001` BMC
 
 ## Find the Model Name
 

--- a/operations/firmware/Updating_Firmware_m001.md
+++ b/operations/firmware/Updating_Firmware_m001.md
@@ -2,7 +2,7 @@
 
 Retrieve the model name and firmware image required to update an HPE or Gigabyte `ncn-m001` node.
 
-> **NOTE:** 
+> **NOTE:**
 > * On HPE nodes, the BMC Firmware is iLO 5 and BIOS is System ROM.
 > * The commands in the procedure must be run on `ncn-m001`.
 
@@ -33,7 +33,7 @@ Use one of the following commands to find the model name for the node type in us
 ## Get the Firmware Images
 
 1. View a list of images stored in FAS that are ready to be flashed:
-    
+
     In the following example, `ModelName` is the name from the previous command.
 
     ```bash
@@ -73,7 +73,7 @@ Use one of the following commands to find the model name for the node type in us
        * `filename` = Filename of the downloaded image
 
        ```bash
-       ncn-m001# curl -k -u root:passwd https://ipaddressOfBMC/redfish/v1/UpdateService/Actions/SimpleUpdate \
+       ncn-m001# curl -k -u root:passwd https://ipaddressOfBMC/redfish/v1/UpdateService/Actions/SimpleUpdate -H 'Content-Type: application/json' \
                   -d '{"ImageURI":"http://ipaddressOfM001:8770/filename", "TransferProtocol":"HTTP", "UpdateComponent":"BMC"}'
        ```
 
@@ -85,7 +85,8 @@ Use one of the following commands to find the model name for the node type in us
        * `filename` = Filename of the downloaded image
 
        ```bash
-       ncn-m001# curl -k -u root:passwd https://ipaddressOfBMC/redfish/v1/UpdateService/Actions/SimpleUpdate -d '{"ImageURI":"http://ipaddressOfM001:8770/filename", "TransferProtocol":"HTTP", "UpdateComponent":"BIOS"}'
+       ncn-m001# curl -k -u root:passwd https://ipaddressOfBMC/redfish/v1/UpdateService/Actions/SimpleUpdate -H 'Content-Type: application/json' \
+                  -d '{"ImageURI":"http://ipaddressOfM001:8770/filename", "TransferProtocol":"HTTP", "UpdateComponent":"BIOS"}'
        ```
 
        > After updating BIOS, `ncn-m001` will need to be rebooted. Follow the [Reboot NCNs](../node_management/Reboot_NCNs.md) procedure to reboot `ncn-m001`.


### PR DESCRIPTION
# Description

Update to firmware update docs to include "content-type" header with curl commands

# Checklist Before Merging

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
