### PR TITLE
CASMTRIAGE-4241 Remove extra hypens (`-`)

### DIFF
--- a/operations/image_management/Create_UAN_Boot_Images.md
+++ b/operations/image_management/Create_UAN_Boot_Images.md
@@ -63,7 +63,7 @@ and the HPE Cray Programming Environment\) that must be configured on the UANs.
     > Do not omit the `-n` from the echo command. It is necessary to generate a valid hash.
 
     ```bash
-    ncn# echo -n PASSWORD | openssl passwd -6 -salt $(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c4) --stdin
+    ncn# echo -n PASSWORD | openssl passwd -6 -salt $(< /dev/urandom tr -dc _A-Za-z0-9 | head -c4) --stdin
     ```
 
 1. Obtain the HashiCorp Vault `root` token.

--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
@@ -216,7 +216,7 @@ ncn-mw# read -r -s -p "Enter root password for NCN images: " PW1 ; echo ; if [[ 
             if [[ ${PW1} != ${PW2} ]]; then
                 echo "ERROR: Passwords do not match"
             else
-                export SQUASHFS_ROOT_PW_HASH=$(echo -n "${PW1}" | openssl passwd -6 -salt $(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c4) --stdin)
+                export SQUASHFS_ROOT_PW_HASH=$(echo -n "${PW1}" | openssl passwd -6 -salt $(< /dev/urandom tr -dc _A-Za-z0-9 | head -c4) --stdin)
                 [[ -n ${SQUASHFS_ROOT_PW_HASH} ]] && echo "Password hash set and exported" || echo "ERROR: Problem generating hash"
             fi
         fi ; unset PW1 PW2

--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md
@@ -105,7 +105,7 @@ pit# read -r -s -p "Enter root password for NCN images: " PW1 ; echo ; if [[ -z 
          if [[ ${PW1} != ${PW2} ]]; then
              echo "ERROR: Passwords do not match"
          else
-             export SQUASHFS_ROOT_PW_HASH=$(echo -n "${PW1}" | openssl passwd -6 -salt $(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c4) --stdin)
+             export SQUASHFS_ROOT_PW_HASH=$(echo -n "${PW1}" | openssl passwd -6 -salt $(< /dev/urandom tr -dc _A-Za-z0-9 | head -c4) --stdin)
              [[ -n ${SQUASHFS_ROOT_PW_HASH} ]] && echo "Password hash set and exported" || echo "ERROR: Problem generating hash"
          fi
      fi ; unset PW1 PW2

--- a/operations/security_and_authentication/Update_NCN_Passwords.md
+++ b/operations/security_and_authentication/Update_NCN_Passwords.md
@@ -45,7 +45,7 @@ for it to be applied to the NCNs.
             if [[ ${PW1} != ${PW2} ]]; then
                 echo "ERROR: Passwords do not match"        
             else
-                echo -n "${PW1}" | openssl passwd -6 -salt $(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c4) --stdin
+                echo -n "${PW1}" | openssl passwd -6 -salt $(< /dev/urandom tr -dc _A-Za-z0-9 | head -c4) --stdin
             fi
         fi ; unset PW1 PW2
    ```


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
The extra hyphens in `tr -dc _A-Z-a-z-0-9` was enabling a chance that the generated salt would contain hyphens. Hyphens are not a viable character to be used in a salt, at least in this context where they could accidentally be interpreted by `openssl` as a parameter.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
