### PR TITLE
CASMTRIAGE-4237:  Clarify the BGP reset procedures to make sure both VRFs are handled

### DIFF
--- a/operations/network/metallb_bgp/Check_BGP_Status_and_Reset_Sessions.md
+++ b/operations/network/metallb_bgp/Check_BGP_Status_and_Reset_Sessions.md
@@ -251,7 +251,7 @@ The following procedures may not resolve the problem after just one attempt. In 
         clear bgp vrf default *
         ```
 
-        Customer VRF
+        Customer VRF:
 
         ```text
         clear bgp vrf Customer *

--- a/operations/network/metallb_bgp/Check_BGP_Status_and_Reset_Sessions.md
+++ b/operations/network/metallb_bgp/Check_BGP_Status_and_Reset_Sessions.md
@@ -245,7 +245,7 @@ The following procedures may not resolve the problem after just one attempt. In 
 
         There are two VRF's that may need to be cleared. Clear the VRF that has the `Idle` session state.
 
-        Default VRF
+        Default VRF:
 
         ```text
         clear bgp vrf default *

--- a/operations/network/metallb_bgp/Check_BGP_Status_and_Reset_Sessions.md
+++ b/operations/network/metallb_bgp/Check_BGP_Status_and_Reset_Sessions.md
@@ -113,7 +113,7 @@ The following procedures may not resolve the problem after just one attempt. In 
         clear ip bgp vrf default all
         ```
 
-        Customer VRF
+        Customer VRF:
 
         ```text
         clear ip bgp vrf Customer all

--- a/operations/network/metallb_bgp/Check_BGP_Status_and_Reset_Sessions.md
+++ b/operations/network/metallb_bgp/Check_BGP_Status_and_Reset_Sessions.md
@@ -107,7 +107,7 @@ The following procedures may not resolve the problem after just one attempt. In 
 
         There are two VRF's that may need to be cleared. Clear the VRF that has the `Idle` session state.
 
-        Default VRF
+        Default VRF:
 
         ```text
         clear ip bgp vrf default all

--- a/operations/network/metallb_bgp/Check_BGP_Status_and_Reset_Sessions.md
+++ b/operations/network/metallb_bgp/Check_BGP_Status_and_Reset_Sessions.md
@@ -85,6 +85,12 @@ The following procedures may not resolve the problem after just one attempt. In 
         ssh admin@sw-spine-001.hmn
         ```
 
+    1. (`sw-spine>`) Enter enable mode
+
+        ```text
+        enable
+        ```
+
     1. (`sw-spine#`) Verify that BGP is enabled.
 
         ```text
@@ -99,9 +105,18 @@ The following procedures may not resolve the problem after just one attempt. In 
 
     1. (`sw-spine#`) Clear the BGP sessions.
 
+        There are two VRF's that may need to be cleared. Clear the VRF that has the `Idle` session state.
+
+        Default VRF
+
         ```text
-        enable
-        clear ip bgp all
+        clear ip bgp vrf default all
+        ```
+
+        Customer VRF
+
+        ```text
+        clear ip bgp vrf Customer all
         ```
 
     1. (`sw-spine#`) Check the status of the BGP sessions to see if they are now `ESTABLISHED`.
@@ -228,8 +243,18 @@ The following procedures may not resolve the problem after just one attempt. In 
 
     1. (`sw-spine#`) Clear the BGP sessions.
 
+        There are two VRF's that may need to be cleared. Clear the VRF that has the `Idle` session state.
+
+        Default VRF
+
         ```text
-        clear bgp *
+        clear bgp vrf default *
+        ```
+
+        Customer VRF
+
+        ```text
+        clear bgp vrf Customer *
         ```
 
     1. (`sw-spine#`) Check the status of the BGP sessions.

--- a/operations/network/metallb_bgp/Check_BGP_Status_and_Reset_Sessions.md
+++ b/operations/network/metallb_bgp/Check_BGP_Status_and_Reset_Sessions.md
@@ -85,7 +85,7 @@ The following procedures may not resolve the problem after just one attempt. In 
         ssh admin@sw-spine-001.hmn
         ```
 
-    1. (`sw-spine>`) Enter enable mode
+    1. (`sw-spine#`) Enter enable mode.
 
         ```text
         enable


### PR DESCRIPTION
# Description

The clear commands in Check_BGP_Status_and_Reset_Sessions.md only affect the default VRF.   Needed specify the clear commands that will work for each VRF.

Tested these commands on drax for mellanox and mug for Aruba.

# Checklist Before Merging

- [  ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [  ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
