### PR TITLE
CASMINST-5362-1.2 : DOCS: Cray 403 error during keycloak restore/backup procedure

### DIFF
--- a/operations/kubernetes/Restore_Postgres.md
+++ b/operations/kubernetes/Restore_Postgres.md
@@ -10,14 +10,12 @@ Restore Postgres procedures by service:
 * [Restore Postgres for HSM](../hardware_state_manager/Restore_HSM_Postgres_from_Backup.md)
 * [Restore Postgres for SLS](../system_layout_service/Restore_SLS_Postgres_Database_from_Backup.md)
 
-<a name="spire"> </a>
-
 ## Restore Postgres for Spire
 
 In the event that the Spire Postgres cluster is in a state that the cluster must be rebuilt and the data restored, the following procedures are recommended.
 This assumes that a dump of the database exists and the Cray command line interface \(CLI\) tool is initialized and configured on the system.
 
-1. Copy the database dump to an accessible location.
+1. (`ncn-mw#`) Copy the database dump to an accessible location.
 
     * If a manual dump of the database was taken, then check that the dump file exists in a location off the Postgres cluster. It will be needed in the steps below.
     * If the database is being automatically backed up, then the most recent version of the dump and the secrets should exist in the `postgres-backup` S3 bucket.
@@ -27,7 +25,7 @@ This assumes that a dump of the database exists and the Cray command line interf
     1. List the available backups:
 
         ```bash
-        ncn# cray artifacts list postgres-backup --format json | jq -r '.artifacts[].Key | select(contains("spire"))'
+        cray artifacts list postgres-backup --format json | jq -r '.artifacts[].Key | select(contains("spire"))'
         ```
 
         Example output:
@@ -47,8 +45,8 @@ This assumes that a dump of the database exists and the Cray command line interf
     1. Download the backup files:
 
         ```bash
-        ncn# cray artifacts get postgres-backup "$DUMPFILE" "$DUMPFILE"
-        ncn# cray artifacts get postgres-backup "$MANIFEST" "$MANIFEST"
+        cray artifacts get postgres-backup "$DUMPFILE" "$DUMPFILE"
+        cray artifacts get postgres-backup "$MANIFEST" "$MANIFEST"
         ```
 
     1. Due to a `kubectl cp` bug, rename the DUMPFILE file, replacing any `:` characters with `-`:
@@ -60,62 +58,62 @@ This assumes that a dump of the database exists and the Cray command line interf
         unset TMP
         ```
 
-1. Scale the Spire service to 0.
+1. (`ncn-mw#`) Scale the Spire service to 0.
 
     ```bash
-    ncn-mw# CLIENT=spire-server
-    ncn-mw# NAMESPACE=spire
-    ncn-mw# POSTGRESQL=spire-postgres
+    CLIENT=spire-server
+    NAMESPACE=spire
+    POSTGRESQL=spire-postgres
 
-    ncn-mw# kubectl scale statefulset ${CLIENT} -n ${NAMESPACE} --replicas=0
+    kubectl scale statefulset ${CLIENT} -n ${NAMESPACE} --replicas=0
 
     # Wait for the pods to terminate
-    ncn-mw# while [ $(kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/name="${CLIENT}" | grep -v NAME | wc -l) != 0 ] ; do
-                echo "  waiting for pods to terminate"; sleep 2
-            done
+    while [ $(kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/name="${CLIENT}" | grep -v NAME | wc -l) != 0 ] ; do
+        echo "  waiting for pods to terminate"; sleep 2
+    done
     ```
 
-1. Delete the Spire Postgres cluster.
+1. (`ncn-mw#`) Delete the Spire Postgres cluster.
 
     ```bash
-    ncn-mw# kubectl get postgresql ${POSTGRESQL} -n ${NAMESPACE} -o json | jq 'del(.spec.selector)' |
-                jq 'del(.spec.template.metadata.labels."controller-uid")' | jq 'del(.status)' > postgres-cr.json
+    kubectl get postgresql ${POSTGRESQL} -n ${NAMESPACE} -o json | jq 'del(.spec.selector)' |
+        jq 'del(.spec.template.metadata.labels."controller-uid")' | jq 'del(.status)' > postgres-cr.json
 
-    ncn-mw# kubectl delete -f postgres-cr.json
+    kubectl delete -f postgres-cr.json
 
     # Wait for the pods to terminate
-    ncn-mw# while [ $(kubectl get pods -l "application=spilo,cluster-name=${POSTGRESQL}" -n ${NAMESPACE} | grep -v NAME | wc -l) != 0 ] ; do
-                echo "  waiting for pods to terminate"; sleep 2
-            done
+    while [ $(kubectl get pods -l "application=spilo,cluster-name=${POSTGRESQL}" -n ${NAMESPACE} | grep -v NAME | wc -l) != 0 ] ; do
+        echo "  waiting for pods to terminate"; sleep 2
+    done
     ```
 
-1. Create a new single instance Spire Postgres cluster.
+1. (`ncn-mw#`) Create a new single instance Spire Postgres cluster.
 
     ```bash
-    ncn-mw# cp postgres-cr.json postgres-orig-cr.json
-    ncn-mw# jq '.spec.numberOfInstances = 1' postgres-orig-cr.json > postgres-cr.json
-    ncn-mw# kubectl create -f postgres-cr.json
+    cp postgres-cr.json postgres-orig-cr.json
+    jq '.spec.numberOfInstances = 1' postgres-orig-cr.json > postgres-cr.json
+    kubectl create -f postgres-cr.json
 
     # Wait for the pod and Postgres cluster to start running
-    ncn-mw# while [ $(kubectl get pods -l "application=spilo,cluster-name=${POSTGRESQL}" -n ${NAMESPACE} | grep -v NAME | wc -l) != 1 ] ; do
-                echo "  waiting for pod to start running"; sleep 2
-            done
+    while [ $(kubectl get pods -l "application=spilo,cluster-name=${POSTGRESQL}" -n ${NAMESPACE} | grep -v NAME | wc -l) != 1 ] ; do
+        echo "  waiting for pod to start running"; sleep 2
+    done
 
-    ncn-mw# while [ $(kubectl get postgresql "${POSTGRESQL}" -n "${NAMESPACE}" -o json | jq -r '.status.PostgresClusterStatus') != "Running" ] ; do
-                echo "  waiting for postgresql to start running"; sleep 2
-            done
+    while [ $(kubectl get postgresql "${POSTGRESQL}" -n "${NAMESPACE}" -o json | jq -r '.status.PostgresClusterStatus') != "Running" ] ; do
+        echo "  waiting for postgresql to start running"; sleep 2
+    done
     ```
 
-1. Copy the database dump file to the Postgres member.
+1. (`ncn-mw#`) Copy the database dump file to the Postgres member.
 
     ```bash
     kubectl cp ./${DUMPFILE} "${POSTGRESQL}-0":/home/postgres/${DUMPFILE} -c postgres -n ${NAMESPACE}
     ```
 
-1. Restore the data.
+1. (`ncn-mw#`) Restore the data.
 
     ```bash
-    ncn-mw# kubectl exec "${POSTGRESQL}-0" -c postgres -n ${NAMESPACE} -it -- psql -U postgres < ${DUMPFILE}
+    kubectl exec "${POSTGRESQL}-0" -c postgres -n ${NAMESPACE} -it -- psql -U postgres < ${DUMPFILE}
     ```
 
     Errors such as `... already exists` can be ignored; the restore can be considered successful when it completes.
@@ -129,11 +127,11 @@ This assumes that a dump of the database exists and the Cray command line interf
         Based off the four `spire-postgres` secrets, collect the password for each Postgres username: `postgres`, `service_account`, `spire`, and `standby`. Then `kubectl exec` into the Postgres pod and update the password for each user. For example:
 
         ```bash
-        ncn-mw# for secret in postgres.spire-postgres.credentials service-account.spire-postgres.credentials spire.spire-postgres.credentials standby.spire-postgres.credentials; do
-                    echo -n "secret ${secret} username & password: "
-                    echo -n "`kubectl get secret ${secret} -n ${NAMESPACE} -ojsonpath='{.data.username}' | base64 -d` "
-                    echo `kubectl get secret ${secret} -n ${NAMESPACE} -ojsonpath='{.data.password}'| base64 -d`
-                done
+        for secret in postgres.spire-postgres.credentials service-account.spire-postgres.credentials spire.spire-postgres.credentials standby.spire-postgres.credentials; do
+            echo -n "secret ${secret} username & password: "
+            echo -n "`kubectl get secret ${secret} -n ${NAMESPACE} -ojsonpath='{.data.username}' | base64 -d` "
+            echo `kubectl get secret ${secret} -n ${NAMESPACE} -ojsonpath='{.data.password}'| base64 -d`
+        done
         ```
 
         Example output:
@@ -169,88 +167,88 @@ This assumes that a dump of the database exists and the Cray command line interf
         kubectl delete secret postgres.spire-postgres.credentials service-account.spire-postgres.credentials spire.spire-postgres.credentials \
             standby.spire-postgres.credentials -n ${NAMESPACE}
 
-        ncn-mw# kubectl apply -f ${MANIFEST}
+        kubectl apply -f ${MANIFEST}
         ```
 
-1. Restart the Postgres cluster.
+1. (`ncn-mw#`) Restart the Postgres cluster.
 
     ```bash
-    ncn-mw# kubectl delete pod -n ${NAMESPACE} "${POSTGRESQL}-0"
+    kubectl delete pod -n ${NAMESPACE} "${POSTGRESQL}-0"
 
     # Wait for the postgresql pod to start
-    ncn-mw# while [ $(kubectl get pods -l "application=spilo,cluster-name=${POSTGRESQL}" -n ${NAMESPACE} | grep -v NAME | wc -l) != 1 ] ; do
-                echo "  waiting for pods to start running"; sleep 2
-            done
+    while [ $(kubectl get pods -l "application=spilo,cluster-name=${POSTGRESQL}" -n ${NAMESPACE} | grep -v NAME | wc -l) != 1 ] ; do
+        echo "  waiting for pods to start running"; sleep 2
+    done
     ```
 
-1. Scale the Postgres cluster back to 3 instances.
+1. (`ncn-mw#`) Scale the Postgres cluster back to 3 instances.
 
     ```bash
-    ncn-mw# kubectl patch postgresql "${POSTGRESQL}" -n "${NAMESPACE}" --type='json' -p='[{"op" : "replace", "path":"/spec/numberOfInstances", "value" : 3}]'
+    kubectl patch postgresql "${POSTGRESQL}" -n "${NAMESPACE}" --type='json' -p='[{"op" : "replace", "path":"/spec/numberOfInstances", "value" : 3}]'
 
     # Wait for the postgresql cluster to start running
-    ncn-mw# while [ $(kubectl get postgresql "${POSTGRESQL}" -n "${NAMESPACE}" -o json | jq -r '.status.PostgresClusterStatus') != "Running" ] ; do
-                echo "  waiting for postgresql to start running"; sleep 2
-            done
+    while [ $(kubectl get postgresql "${POSTGRESQL}" -n "${NAMESPACE}" -o json | jq -r '.status.PostgresClusterStatus') != "Running" ] ; do
+        echo "  waiting for postgresql to start running"; sleep 2
+    done
     ```
 
-1. Scale the Spire service back to 3 replicas.
+1. (`ncn-mw#`) Scale the Spire service back to 3 replicas.
 
     ```bash
-    ncn-mw# kubectl scale statefulset ${CLIENT} -n ${NAMESPACE} --replicas=3
+    kubectl scale statefulset ${CLIENT} -n ${NAMESPACE} --replicas=3
 
     # Wait for the spire pods to start
-    ncn-mw# while [ $(kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/name="${CLIENT}" | grep -v NAME | wc -l) != 3 ] ; do
-                echo "  waiting for pods to start"; sleep 2
-            done
+    while [ $(kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/name="${CLIENT}" | grep -v NAME | wc -l) != 3 ] ; do
+        echo "  waiting for pods to start"; sleep 2
+    done
     ```
 
-1. Restart the `spire-agent` `daemonset` and the `spire-jwks` service.
+1. (`ncn-mw#`) Restart the `spire-agent` `daemonset` and the `spire-jwks` service.
 
     ```bash
-    ncn-mw# kubectl rollout restart daemonset spire-agent -n ${NAMESPACE}
+    kubectl rollout restart daemonset spire-agent -n ${NAMESPACE}
     # Wait for the restart to complete
-    ncn-mw# kubectl rollout status daemonset spire-agent -n ${NAMESPACE}
+    kubectl rollout status daemonset spire-agent -n ${NAMESPACE}
 
-    ncn-mw# kubectl rollout restart deployment spire-jwks -n ${NAMESPACE}
+    kubectl rollout restart deployment spire-jwks -n ${NAMESPACE}
     # Wait for the restart to complete
-    ncn-mw# kubectl rollout status deployment spire-jwks -n ${NAMESPACE}
+    kubectl rollout status deployment spire-jwks -n ${NAMESPACE}
     ```
 
-1. Restart the `spire-agent` on all the nodes.
+1. (`ncn-mw#`) Restart the `spire-agent` on all the nodes.
 
     ```bash
-    ncn-mw# pdsh -w ncn-m00[1-3] 'systemctl restart spire-agent'
-    ncn-mw# pdsh -w ncn-w00[1-3] 'systemctl restart spire-agent'
-    ncn-mw# pdsh -w ncn-s00[1-3] 'systemctl restart spire-agent'
+    pdsh -w ncn-m00[1-3] 'systemctl restart spire-agent'
+    pdsh -w ncn-w00[1-3] 'systemctl restart spire-agent'
+    pdsh -w ncn-s00[1-3] 'systemctl restart spire-agent'
     ```
 
-1. Verify that the service is working.
+1. (`ncn-mw#`) Verify that the service is working.
 
     The following should return a token.
 
     ```bash
-    ncn-mw# /usr/bin/heartbeat-spire-agent api fetch jwt -socketPath=/root/spire/agent.sock -audience test
+    /usr/bin/heartbeat-spire-agent api fetch jwt -socketPath=/root/spire/agent.sock -audience test
     ```
-
-<a name="keycloak"> </a>
 
 ## Restore Postgres for Keycloak
 
 In the event that the Keycloak Postgres cluster is in a state that the cluster must be rebuilt and the data restored, the following procedures are recommended.
 This assumes that a dump of the database exists and the Cray command line interface \(CLI\) tool is initialized and configured on the system.
 
-1. Copy the database dump to an accessible location.
+1. (`ncn-mw#`) Copy the database dump to an accessible location.
 
     * If a manual dump of the database was taken, then check that the dump file exists in a location off the Postgres cluster. It will be needed in the steps below.
     * If the database is being automatically backed up, then the most recent version of the dump and the secrets should exist in the `postgres-backup` S3 bucket.
     These will be needed in the steps below. List the files in the `postgres-backup` S3 bucket and if the files exist, download the dump and secrets out of the S3 bucket.
     The `cray artifacts` CLI can be used list and download the files. Note that the `.psql` file contains the database dump and the .manifest file contains the secrets.
 
+    1. Setup the `CRAY_CREDENTIALS` environment variable to permit simple CLI operations needed while restoring the Keycloak database. See [Authenticate an Account with the Command Line](../security_and_authentication/Authenticate_an_Account_with_the_Command_Line.md).
+
     1. List the available backups:
 
         ```bash
-        ncn# cray artifacts list postgres-backup --format json | jq -r '.artifacts[].Key | select(contains("keycloak"))'
+        cray artifacts list postgres-backup --format json | jq -r '.artifacts[].Key | select(contains("keycloak"))'
         ```
 
         Example output:
@@ -270,8 +268,15 @@ This assumes that a dump of the database exists and the Cray command line interf
     1. Download the backup files:
 
         ```bash
-        ncn# cray artifacts get postgres-backup "$DUMPFILE" "$DUMPFILE"
-        ncn# cray artifacts get postgres-backup "$MANIFEST" "$MANIFEST"
+        cray artifacts get postgres-backup "$DUMPFILE" "$DUMPFILE"
+        cray artifacts get postgres-backup "$MANIFEST" "$MANIFEST"
+        ```
+
+    1. Unset the `CRAY_CREDENTIALS` environment variable:
+
+        ```bash
+        unset CRAY_CREDENTIALS
+        rm /tmp/my-token.json
         ```
 
     1. Due to a `kubectl cp` bug, rename the DUMPFILE file, replacing any `:` characters with `-`:
@@ -283,53 +288,53 @@ This assumes that a dump of the database exists and the Cray command line interf
         unset TMP
         ```
 
-1. Scale the Keycloak service to 0.
+1. (`ncn-mw#`) Scale the Keycloak service to 0.
 
     ```bash
-    ncn-mw# CLIENT=cray-keycloak
-    ncn-mw# NAMESPACE=services
-    ncn-mw# POSTGRESQL=keycloak-postgres
+    CLIENT=cray-keycloak
+    NAMESPACE=services
+    POSTGRESQL=keycloak-postgres
 
-    ncn-mw# kubectl scale statefulset ${CLIENT} -n ${NAMESPACE} --replicas=0
+    kubectl scale statefulset ${CLIENT} -n ${NAMESPACE} --replicas=0
 
     # Wait for the pods to terminate
-    ncn-mw# while [ $(kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/instance="${CLIENT}" | grep -v NAME | wc -l) != 0 ] ; do
-                echo "  waiting for pods to terminate"; sleep 2
-            done
+    while [ $(kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/instance="${CLIENT}" | grep -v NAME | wc -l) != 0 ] ; do
+        echo "  waiting for pods to terminate"; sleep 2
+    done
     ```
 
-1. Delete the Keycloak Postgres cluster.
+1. (`ncn-mw#`) Delete the Keycloak Postgres cluster.
 
     ```bash
-    ncn-mw# kubectl get postgresql ${POSTGRESQL} -n ${NAMESPACE} -o json | jq 'del(.spec.selector)' |
-                jq 'del(.spec.template.metadata.labels."controller-uid")' | jq 'del(.status)' > postgres-cr.json
+    kubectl get postgresql ${POSTGRESQL} -n ${NAMESPACE} -o json | jq 'del(.spec.selector)' |
+        jq 'del(.spec.template.metadata.labels."controller-uid")' | jq 'del(.status)' > postgres-cr.json
 
-    ncn-mw# kubectl delete -f postgres-cr.json
+    kubectl delete -f postgres-cr.json
 
     # Wait for the pods to terminate
-    ncn-mw# while [ $(kubectl get pods -l "application=spilo,cluster-name=${POSTGRESQL}" -n ${NAMESPACE} | grep -v NAME | wc -l) != 0 ] ; do
-                echo "  waiting for pods to terminate"; sleep 2
-            done
+    while [ $(kubectl get pods -l "application=spilo,cluster-name=${POSTGRESQL}" -n ${NAMESPACE} | grep -v NAME | wc -l) != 0 ] ; do
+        echo "  waiting for pods to terminate"; sleep 2
+    done
     ```
 
-1. Create a new single instance Keycloak Postgres cluster.
+1. (`ncn-mw#`) Create a new single instance Keycloak Postgres cluster.
 
     ```bash
-    ncn-mw# cp postgres-cr.json postgres-orig-cr.json
-    ncn-mw# jq '.spec.numberOfInstances = 1' postgres-orig-cr.json > postgres-cr.json
-    ncn-mw# kubectl create -f postgres-cr.json
+    cp postgres-cr.json postgres-orig-cr.json
+    jq '.spec.numberOfInstances = 1' postgres-orig-cr.json > postgres-cr.json
+    kubectl create -f postgres-cr.json
 
     # Wait for the pod and Postgres cluster to start running
-    ncn-mw# while [ $(kubectl get pods -l "application=spilo,cluster-name=${POSTGRESQL}" -n ${NAMESPACE} | grep -v NAME | wc -l) != 1 ] ; do
-                echo "  waiting for pod to start running"; sleep 2
-            done
+    while [ $(kubectl get pods -l "application=spilo,cluster-name=${POSTGRESQL}" -n ${NAMESPACE} | grep -v NAME | wc -l) != 1 ] ; do
+        echo "  waiting for pod to start running"; sleep 2
+    done
 
-    ncn-mw# while [ $(kubectl get postgresql "${POSTGRESQL}" -n "${NAMESPACE}" -o json | jq -r '.status.PostgresClusterStatus') != "Running" ] ; do
-                echo "  waiting for postgresql to start running"; sleep 2
-            done
+    while [ $(kubectl get postgresql "${POSTGRESQL}" -n "${NAMESPACE}" -o json | jq -r '.status.PostgresClusterStatus') != "Running" ] ; do
+        echo "  waiting for postgresql to start running"; sleep 2
+    done
     ```
 
-1. Copy the database dump file to the Postgres member.
+1. (`ncn-mw#`) Copy the database dump file to the Postgres member.
 
     ```bash
     kubectl cp ./${DUMPFILE} "${POSTGRESQL}-0":/home/postgres/${DUMPFILE} -c postgres -n ${NAMESPACE}
@@ -340,10 +345,10 @@ This assumes that a dump of the database exists and the Cray command line interf
 1. (`ncn-mw#`) Restore the data.
 
     ```bash
-    ncn-mw# kubectl exec "${POSTGRESQL}-0" -c postgres -n ${NAMESPACE} -it -- psql -U postgres < ${DUMPFILE}
+    kubectl exec "${POSTGRESQL}-0" -c postgres -n ${NAMESPACE} -it -- psql -U postgres < ${DUMPFILE}
     ```
 
-1. Either update or re-create the `keycloak-postgres` secrets.
+1. (`ncn-mw#`) Either update or re-create the `keycloak-postgres` secrets.
 
    * Update the secrets in Postgres.
 
@@ -352,11 +357,11 @@ This assumes that a dump of the database exists and the Cray command line interf
         Based off the three `keycloak-postgres` secrets, collect the password for each Postgres username: `postgres`, `service_account`, and `standby`. Then `kubectl exec` into the Postgres pod and update the password for each user. For example:
 
         ```bash
-        ncn-mw# for secret in postgres.keycloak-postgres.credentials service-account.keycloak-postgres.credentials standby.keycloak-postgres.credentials; do
-                    echo -n "secret ${secret} username & password: "
-                    echo -n "`kubectl get secret ${secret} -n ${NAMESPACE} -ojsonpath='{.data.username}' | base64 -d` "
-                    echo `kubectl get secret ${secret} -n ${NAMESPACE} -ojsonpath='{.data.password}'| base64 -d`
-                done
+        for secret in postgres.keycloak-postgres.credentials service-account.keycloak-postgres.credentials standby.keycloak-postgres.credentials; do
+            echo -n "secret ${secret} username & password: "
+            echo -n "`kubectl get secret ${secret} -n ${NAMESPACE} -ojsonpath='{.data.username}' | base64 -d` "
+            echo `kubectl get secret ${secret} -n ${NAMESPACE} -ojsonpath='{.data.password}'| base64 -d`
+        done
         ```
 
         Example output:
@@ -388,46 +393,46 @@ This assumes that a dump of the database exists and the Cray command line interf
         ```bash
         kubectl delete secret postgres.keycloak-postgres.credentials service-account.keycloak-postgres.credentials standby.keycloak-postgres.credentials -n ${NAMESPACE}
 
-        ncn-mw# kubectl apply -f ${MANIFEST}
+        kubectl apply -f ${MANIFEST}
         ```
 
-1. Restart the Postgres cluster.
+1. (`ncn-mw#`) Restart the Postgres cluster.
 
     ```bash
-    ncn-mw# kubectl delete pod -n ${NAMESPACE} "${POSTGRESQL}-0"
+    kubectl delete pod -n ${NAMESPACE} "${POSTGRESQL}-0"
 
     # Wait for the postgresql pod to start
-    ncn-mw# while [ $(kubectl get pods -l "application=spilo,cluster-name=${POSTGRESQL}" -n ${NAMESPACE} | grep -v NAME | wc -l) != 1 ] ; do
-                echo "  waiting for pods to start running"; sleep 2
-            done
+    while [ $(kubectl get pods -l "application=spilo,cluster-name=${POSTGRESQL}" -n ${NAMESPACE} | grep -v NAME | wc -l) != 1 ] ; do
+        echo "  waiting for pods to start running"; sleep 2
+    done
     ```
 
-1. Scale the Postgres cluster back to 3 instances.
+1. (`ncn-mw#`) Scale the Postgres cluster back to 3 instances.
 
     ```bash
-    ncn-mw# kubectl patch postgresql "${POSTGRESQL}" -n "${NAMESPACE}" --type='json' -p='[{"op" : "replace", "path":"/spec/numberOfInstances", "value" : 3}]'
+    kubectl patch postgresql "${POSTGRESQL}" -n "${NAMESPACE}" --type='json' -p='[{"op" : "replace", "path":"/spec/numberOfInstances", "value" : 3}]'
 
     # Wait for the postgresql cluster to start running. This may take a few minutes to complete.
-    ncn-mw# while [ $(kubectl get postgresql "${POSTGRESQL}" -n "${NAMESPACE}" -o json | jq -r '.status.PostgresClusterStatus') != "Running" ] ; do
-                echo "  waiting for postgresql to start running"; sleep 2
-            done
+    while [ $(kubectl get postgresql "${POSTGRESQL}" -n "${NAMESPACE}" -o json | jq -r '.status.PostgresClusterStatus') != "Running" ] ; do
+        echo "  waiting for postgresql to start running"; sleep 2
+    done
     ```
 
-1. Scale the Keycloak service back to 3 replicas.
+1. (`ncn-mw#`) Scale the Keycloak service back to 3 replicas.
 
     ```bash
-    ncn-mw# kubectl scale statefulset ${CLIENT} -n ${NAMESPACE} --replicas=3
+    kubectl scale statefulset ${CLIENT} -n ${NAMESPACE} --replicas=3
 
     # Wait for the keycloak pods to start
-    ncn-mw# while [ $(kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/instance="${CLIENT}" | grep -v NAME | wc -l) != 3 ] ; do
-                echo "  waiting for pods to start"; sleep 2
-            done
+    while [ $(kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/instance="${CLIENT}" | grep -v NAME | wc -l) != 3 ] ; do
+        echo "  waiting for pods to start"; sleep 2
+    done
     ```
 
-    Also check the status of the Keycloak pods. If there are pods that do not show that both containers are ready (`READY` is `2/2`), wait a few seconds and re-run the command until all containers are ready.
+    Also check the status of the Keycloak pods. If there are pods that do not show that both containers are ready (`READY` is `2/2`), then wait a few seconds and re-run the command until all containers are ready.
 
     ```bash
-    ncn-mw# kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/instance="${CLIENT}"
+    kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/instance="${CLIENT}"
     ```
 
     Example output:
@@ -439,22 +444,21 @@ This assumes that a dump of the database exists and the Cray command line interf
     cray-keycloak-2   2/2     Running   0          35s
     ```
 
-1. Re-run the `keycloak-setup` and `keycloak-users-localize` jobs, and restart Keycloak gatekeeper.
+1. (`ncn-mw#`) Re-run the `keycloak-setup` and `keycloak-users-localize` jobs, and restart Keycloak gatekeeper.
 
     * Run the `keycloak-setup` job to restore the Kubernetes client secrets:
 
         ```bash
-        ncn-mw# kubectl get job -n ${NAMESPACE} -l app.kubernetes.io/instance=cray-keycloak -o json > keycloak-setup.json
-        ncn-mw# cat keycloak-setup.json | jq '.items[0]' | jq 'del(.metadata.creationTimestamp)' |
-                    jq 'del(.metadata.managedFields)' | jq 'del(.metadata.resourceVersion)' | jq 'del(.metadata.selfLink)' |
-                    jq 'del(.metadata.uid)' | jq 'del(.spec.selector)' | jq 'del(.spec.template.metadata.labels)' |
-                    jq 'del(.status)' | kubectl replace --force -f -
+        kubectl get job -n ${NAMESPACE} -l app.kubernetes.io/instance=cray-keycloak -o json > keycloak-setup.json
+        cat keycloak-setup.json | jq '.items[0]' | jq 'del(.metadata.creationTimestamp)' | jq 'del(.metadata.managedFields)' |
+            jq 'del(.metadata.resourceVersion)' | jq 'del(.metadata.selfLink)' | jq 'del(.metadata.uid)' |
+            jq 'del(.spec.selector)' | jq 'del(.spec.template.metadata.labels)' | jq 'del(.status)' | kubectl replace --force -f -
         ```
 
         Check the status of the `keycloak-setup` job. If the `COMPLETIONS` value is not `1/1`, wait a few seconds and run the command again until the `COMPLETIONS` value is `1/1`.
 
         ```bash
-        ncn-mw# kubectl get jobs -n ${NAMESPACE} -l app.kubernetes.io/instance=cray-keycloak
+        kubectl get jobs -n ${NAMESPACE} -l app.kubernetes.io/instance=cray-keycloak
         ```
 
         Example output:
@@ -467,17 +471,17 @@ This assumes that a dump of the database exists and the Cray command line interf
     * Run the `keycloak-users-localize` job to restore the users and groups in S3 and the Kubernetes ConfigMap:
 
         ```bash
-        ncn-mw# kubectl get job -n ${NAMESPACE} -l app.kubernetes.io/instance=cray-keycloak-users-localize -o json > cray-keycloak-users-localize.json
-        ncn-mw# cat cray-keycloak-users-localize.json | jq '.items[0]' | jq 'del(.metadata.creationTimestamp)' |
-                    jq 'del(.metadata.managedFields)' | jq 'del(.metadata.resourceVersion)' | jq 'del(.metadata.selfLink)' |
-                    jq 'del(.metadata.uid)' | jq 'del(.spec.selector)' | jq 'del(.spec.template.metadata.labels)' |
-                    jq 'del(.status)' | kubectl replace --force -f -
+        kubectl get job -n ${NAMESPACE} -l app.kubernetes.io/instance=cray-keycloak-users-localize -o json > cray-keycloak-users-localize.json
+        cat cray-keycloak-users-localize.json | jq '.items[0]' | jq 'del(.metadata.creationTimestamp)' |
+            jq 'del(.metadata.managedFields)' | jq 'del(.metadata.resourceVersion)' | jq 'del(.metadata.selfLink)' |
+            jq 'del(.metadata.uid)' | jq 'del(.spec.selector)' | jq 'del(.spec.template.metadata.labels)' |
+            jq 'del(.status)' | kubectl replace --force -f -
         ```
 
         Check the status of the `cray-keycloak-users-localize` job. If the `COMPLETIONS` value is not `1/1`, wait a few minutes and run the command again until the `COMPLETIONS` value is `1/1`.
 
         ```bash
-        ncn-mw# kubectl get jobs -n ${NAMESPACE} -l app.kubernetes.io/instance=cray-keycloak-users-localize
+        kubectl get jobs -n ${NAMESPACE} -l app.kubernetes.io/instance=cray-keycloak-users-localize
         ```
 
         Example output:
@@ -495,16 +499,14 @@ This assumes that a dump of the database exists and the Cray command line interf
         kubectl rollout restart -n ${NAMESPACE} deployment/cray-oauth2-proxies-customer-management-ingress
         ```
 
-1. Verify that the service is working.
+1. (`ncn-mw#`) Verify the service is working.
 
     The following should return an `access_token` for an existing user. Replace the `<username>` and `<password>` as appropriate.
 
     ```bash
-    ncn-mw# curl -s -k -d grant_type=password -d client_id=shasta -d username=<username> -d password=<password> \
-                https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token
+    curl -s -k -d grant_type=password -d client_id=shasta -d username=<username> -d password=<password> \
+        https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token
     ```
-
-<a name="vcs"> </a>
 
 ## Restore Postgres for VCS
 
@@ -512,7 +514,7 @@ In the event that the VCS Postgres cluster is in a state that the cluster must b
 This assumes that a dump of the database exists, as well as a [backup of the VCS PVC](../configuration_management/Version_Control_Service_VCS.md#restore-pvc-data) and
 the Cray command line interface \(CLI\) tool is initialized and configured on the system.
 
-1. Copy the database dump to an accessible location.
+1. (`ncn-mw#`) Copy the database dump to an accessible location.
 
     * If a manual dump of the database was taken, then check that the dump file exists in a location off the Postgres cluster. It will be needed in the steps below.
     * If the database is being automatically backed up, then the most recent version of the dump and the secrets should exist in the `postgres-backup` S3 bucket.
@@ -522,7 +524,7 @@ the Cray command line interface \(CLI\) tool is initialized and configured on th
     1. List the available backups:
 
         ```bash
-        ncn# cray artifacts list postgres-backup --format json | jq -r '.artifacts[].Key | select(contains("vcs"))'
+        cray artifacts list postgres-backup --format json | jq -r '.artifacts[].Key | select(contains("vcs"))'
         ```
 
         Example output:
@@ -542,8 +544,8 @@ the Cray command line interface \(CLI\) tool is initialized and configured on th
     1. Download the backup files:
 
         ```bash
-        ncn# cray artifacts get postgres-backup "$DUMPFILE" "$DUMPFILE"
-        ncn# cray artifacts get postgres-backup "$MANIFEST" "$MANIFEST"
+        cray artifacts get postgres-backup "$DUMPFILE" "$DUMPFILE"
+        cray artifacts get postgres-backup "$MANIFEST" "$MANIFEST"
         ```
 
     1. Due to a `kubectl cp` bug, rename the DUMPFILE file, replacing any `:` characters with `-`:
@@ -555,54 +557,54 @@ the Cray command line interface \(CLI\) tool is initialized and configured on th
         unset TMP
         ```
 
-1. Scale the VCS service to 0.
+1. (`ncn-mw#`) Scale the VCS service to 0.
 
     ```bash
-    ncn-mw# SERVICE=gitea-vcs
-    ncn-mw# SERVICELABEL=vcs
-    ncn-mw# NAMESPACE=services
-    ncn-mw# POSTGRESQL=gitea-vcs-postgres
+    SERVICE=gitea-vcs
+    SERVICELABEL=vcs
+    NAMESPACE=services
+    POSTGRESQL=gitea-vcs-postgres
 
-    ncn-mw# kubectl scale deployment ${SERVICE} -n ${NAMESPACE} --replicas=0
+    kubectl scale deployment ${SERVICE} -n ${NAMESPACE} --replicas=0
 
     # Wait for the pods to terminate
-    ncn-mw# while [ $(kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/name="${SERVICELABEL}" | grep -v NAME | wc -l) != 0 ] ; do
-                echo "  waiting for pods to terminate"; sleep 2
-            done
+    while [ $(kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/name="${SERVICELABEL}" | grep -v NAME | wc -l) != 0 ] ; do
+        echo "  waiting for pods to terminate"; sleep 2
+    done
     ```
 
-1. Delete the VCS Postgres cluster.
+1. (`ncn-mw#`) Delete the VCS Postgres cluster.
 
     ```bash
-    ncn-mw# kubectl get postgresql ${POSTGRESQL} -n ${NAMESPACE} -o json | jq 'del(.spec.selector)' |
-                jq 'del(.spec.template.metadata.labels."controller-uid")' | jq 'del(.status)' > postgres-cr.json
+    kubectl get postgresql ${POSTGRESQL} -n ${NAMESPACE} -o json | jq 'del(.spec.selector)' |
+        jq 'del(.spec.template.metadata.labels."controller-uid")' | jq 'del(.status)' > postgres-cr.json
 
-    ncn-mw# kubectl delete -f postgres-cr.json
+    kubectl delete -f postgres-cr.json
 
     # Wait for the pods to terminate
-    ncn-mw# while [ $(kubectl get pods -l "application=spilo,cluster-name=${POSTGRESQL}" -n ${NAMESPACE} | grep -v NAME | wc -l) != 0 ] ; do
-                echo "  waiting for pods to terminate"; sleep 2
-            done
+    while [ $(kubectl get pods -l "application=spilo,cluster-name=${POSTGRESQL}" -n ${NAMESPACE} | grep -v NAME | wc -l) != 0 ] ; do
+        echo "  waiting for pods to terminate"; sleep 2
+    done
     ```
 
-1. Create a new single instance VCS Postgres cluster.
+1. (`ncn-mw#`) Create a new single instance VCS Postgres cluster.
 
     ```bash
-    ncn-mw# cp postgres-cr.json postgres-orig-cr.json
-    ncn-mw# jq '.spec.numberOfInstances = 1' postgres-orig-cr.json > postgres-cr.json
-    ncn-mw# kubectl create -f postgres-cr.json
+    cp postgres-cr.json postgres-orig-cr.json
+    jq '.spec.numberOfInstances = 1' postgres-orig-cr.json > postgres-cr.json
+    kubectl create -f postgres-cr.json
 
     # Wait for the pod and Postgres cluster to start running
-    ncn-mw# while [ $(kubectl get pods -l "application=spilo,cluster-name=${POSTGRESQL}" -n ${NAMESPACE} | grep -v NAME | wc -l) != 1 ] ; do
-                echo "  waiting for pod to start running"; sleep 2
-            done
+    while [ $(kubectl get pods -l "application=spilo,cluster-name=${POSTGRESQL}" -n ${NAMESPACE} | grep -v NAME | wc -l) != 1 ] ; do
+        echo "  waiting for pod to start running"; sleep 2
+    done
 
-    ncn-mw# while [ $(kubectl get postgresql "${POSTGRESQL}" -n "${NAMESPACE}" -o json | jq -r '.status.PostgresClusterStatus') != "Running" ] ; do
-                echo "  waiting for postgresql to start running"; sleep 2
-            done
+    while [ $(kubectl get postgresql "${POSTGRESQL}" -n "${NAMESPACE}" -o json | jq -r '.status.PostgresClusterStatus') != "Running" ] ; do
+        echo "  waiting for postgresql to start running"; sleep 2
+    done
     ```
 
-1. Copy the database dump file to the Postgres member.
+1. (`ncn-mw#`) Copy the database dump file to the Postgres member.
 
     ```bash
     kubectl cp ./${DUMPFILE} "${POSTGRESQL}-0":/home/postgres/${DUMPFILE} -c postgres -n services
@@ -613,10 +615,10 @@ the Cray command line interface \(CLI\) tool is initialized and configured on th
 1. (`ncn-mw#`) Restore the data.
 
     ```bash
-    ncn-mw# kubectl exec "${SERVICE}-0" -c postgres -n services -it -- psql -U postgres < ${DUMPFILE}
+    kubectl exec "${SERVICE}-0" -c postgres -n services -it -- psql -U postgres < ${DUMPFILE}
     ```
 
-1. Either update or re-create the `gitea-vcs-postgres` secrets.
+1. (`ncn-mw#`) Either update or re-create the `gitea-vcs-postgres` secrets.
 
    * Update the secrets in Postgres.
 
@@ -625,13 +627,13 @@ the Cray command line interface \(CLI\) tool is initialized and configured on th
         Based off the three `gitea-vcs-postgres` secrets, collect the password for each Postgres username: `postgres`, `service_account`, and `standby`. Then `kubectl exec` into the Postgres pod and update the password for each user. For example:
 
         ```bash
-        ncn-mw# for secret in postgres.gitea-vcs-postgres.credentials service-account.gitea-vcs-postgres.credentials \
-                    standby.gitea-vcs-postgres.credentials
-                do
-                    echo -n "secret ${secret} username & password: "
-                    echo -n "`kubectl get secret ${secret} -n ${NAMESPACE} -ojsonpath='{.data.username}' | base64 -d` "
-                    echo `kubectl get secret ${secret} -n ${NAMESPACE} -ojsonpath='{.data.password}'| base64 -d`
-                done
+        for secret in postgres.gitea-vcs-postgres.credentials service-account.gitea-vcs-postgres.credentials \
+            standby.gitea-vcs-postgres.credentials
+        do
+            echo -n "secret ${secret} username & password: "
+            echo -n "`kubectl get secret ${secret} -n ${NAMESPACE} -ojsonpath='{.data.username}' | base64 -d` "
+            echo `kubectl get secret ${secret} -n ${NAMESPACE} -ojsonpath='{.data.password}'| base64 -d`
+        done
         ```
 
         Example output:
@@ -663,38 +665,38 @@ the Cray command line interface \(CLI\) tool is initialized and configured on th
         ```bash
         kubectl delete secret postgres.gitea-vcs-postgres.credentials service-account.gitea-vcs-postgres.credentials standby.gitea-vcs-postgres.credentials -n services
 
-        ncn-mw# kubectl apply -f ${MANIFEST}
+        kubectl apply -f ${MANIFEST}
         ```
 
-1. Restart the Postgres cluster.
+1. (`ncn-mw#`) Restart the Postgres cluster.
 
     ```bash
-    ncn-mw# kubectl delete pod -n ${NAMESPACE} "${POSTGRESQL}-0"
+    kubectl delete pod -n ${NAMESPACE} "${POSTGRESQL}-0"
 
     # Wait for the postgresql pod to start
-    ncn-mw# while [ $(kubectl get pods -l "application=spilo,cluster-name=${POSTGRESQL}" -n ${NAMESPACE} | grep -v NAME | wc -l) != 1 ] ; do
-                echo "  waiting for pods to start running"; sleep 2
-            done
+    while [ $(kubectl get pods -l "application=spilo,cluster-name=${POSTGRESQL}" -n ${NAMESPACE} | grep -v NAME | wc -l) != 1 ] ; do
+        echo "  waiting for pods to start running"; sleep 2
+    done
     ```
 
-1. Scale the Postgres cluster back to 3 instances.
+1. (`ncn-mw#`) Scale the Postgres cluster back to 3 instances.
 
     ```bash
-    ncn-mw# kubectl patch postgresql "${POSTGRESQL}" -n "${NAMESPACE}" --type='json' -p='[{"op" : "replace", "path":"/spec/numberOfInstances", "value" : 3}]'
+    kubectl patch postgresql "${POSTGRESQL}" -n "${NAMESPACE}" --type='json' -p='[{"op" : "replace", "path":"/spec/numberOfInstances", "value" : 3}]'
 
     # Wait for the postgresql cluster to start running
-    ncn-mw# while [ $(kubectl get postgresql "${POSTGRESQL}" -n "${NAMESPACE}" -o json | jq -r '.status.PostgresClusterStatus') != "Running" ] ; do
-                echo "  waiting for postgresql to start running"; sleep 2
-            done
+    while [ $(kubectl get postgresql "${POSTGRESQL}" -n "${NAMESPACE}" -o json | jq -r '.status.PostgresClusterStatus') != "Running" ] ; do
+        echo "  waiting for postgresql to start running"; sleep 2
+    done
     ```
 
-1. Scale the Gitea service back up.
+1. (`ncn-mw#`) Scale the Gitea service back up.
 
     ```bash
-    ncn-mw# kubectl scale deployment ${SERVICE} -n ${NAMESPACE} --replicas=1
+    kubectl scale deployment ${SERVICE} -n ${NAMESPACE} --replicas=1
 
     # Wait for the gitea pods to start
-    ncn-mw# while [ $(kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/name="${SERVICELABEL}" | grep -v NAME | wc -l) != 1 ] ; do
-                echo "  waiting for pods to start"; sleep 2
-            done
+    while [ $(kubectl get pods -n ${NAMESPACE} -l app.kubernetes.io/name="${SERVICELABEL}" | grep -v NAME | wc -l) != 1 ] ; do
+        echo "  waiting for pods to start"; sleep 2
+    done
     ```


### PR DESCRIPTION
# Description

Modify the steps to restore keycloak to setup the CRAY_CREDENTIALS
Minor formatting changes
Needs to be backported to release/1.2 and release/1.3

# Checklist Before Merging

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
