### PR TITLE
CASMINST-5362-1.3 : DOCS: Cray 403 error during keycloak restore/backup procedure

### DIFF
--- a/operations/kubernetes/Restore_Postgres.md
+++ b/operations/kubernetes/Restore_Postgres.md
@@ -25,7 +25,7 @@ This assumes that a dump of the database exists and the Cray command line interf
     1. List the available backups:
 
         ```bash
-        ncn# cray artifacts list postgres-backup --format json | jq -r '.artifacts[].Key | select(contains("spire"))'
+        cray artifacts list postgres-backup --format json | jq -r '.artifacts[].Key | select(contains("spire"))'
         ```
 
         Example output:
@@ -45,8 +45,8 @@ This assumes that a dump of the database exists and the Cray command line interf
     1. Download the backup files:
 
         ```bash
-        ncn# cray artifacts get postgres-backup "$DUMPFILE" "$DUMPFILE"
-        ncn# cray artifacts get postgres-backup "$MANIFEST" "$MANIFEST"
+        cray artifacts get postgres-backup "$DUMPFILE" "$DUMPFILE"
+        cray artifacts get postgres-backup "$MANIFEST" "$MANIFEST"
         ```
 
     1. Due to a `kubectl cp` bug, rename the DUMPFILE file, replacing any `:` characters with `-`:
@@ -243,10 +243,12 @@ This assumes that a dump of the database exists and the Cray command line interf
     These will be needed in the steps below. List the files in the `postgres-backup` S3 bucket and if the files exist, download the dump and secrets out of the S3 bucket.
     The `cray artifacts` CLI can be used list and download the files. Note that the `.psql` file contains the database dump and the .manifest file contains the secrets.
 
+    1. Setup the `CRAY_CREDENTIALS` environment variable to permit simple CLI operations needed while restoring the Keycloak database. See [Authenticate an Account with the Command Line](../security_and_authentication/Authenticate_an_Account_with_the_Command_Line.md).
+
     1. List the available backups:
 
         ```bash
-        ncn# cray artifacts list postgres-backup --format json | jq -r '.artifacts[].Key | select(contains("keycloak"))'
+        cray artifacts list postgres-backup --format json | jq -r '.artifacts[].Key | select(contains("keycloak"))'
         ```
 
         Example output:
@@ -266,8 +268,15 @@ This assumes that a dump of the database exists and the Cray command line interf
     1. Download the backup files:
 
         ```bash
-        ncn# cray artifacts get postgres-backup "$DUMPFILE" "$DUMPFILE"
-        ncn# cray artifacts get postgres-backup "$MANIFEST" "$MANIFEST"
+        cray artifacts get postgres-backup "$DUMPFILE" "$DUMPFILE"
+        cray artifacts get postgres-backup "$MANIFEST" "$MANIFEST"
+        ```
+
+    1. Unset the `CRAY_CREDENTIALS` environment variable:
+
+        ```bash
+        unset CRAY_CREDENTIALS
+        rm /tmp/my-token.json
         ```
 
     1. Due to a `kubectl cp` bug, rename the DUMPFILE file, replacing any `:` characters with `-`:
@@ -515,7 +524,7 @@ the Cray command line interface \(CLI\) tool is initialized and configured on th
     1. List the available backups:
 
         ```bash
-        ncn# cray artifacts list postgres-backup --format json | jq -r '.artifacts[].Key | select(contains("vcs"))'
+        cray artifacts list postgres-backup --format json | jq -r '.artifacts[].Key | select(contains("vcs"))'
         ```
 
         Example output:
@@ -535,8 +544,8 @@ the Cray command line interface \(CLI\) tool is initialized and configured on th
     1. Download the backup files:
 
         ```bash
-        ncn# cray artifacts get postgres-backup "$DUMPFILE" "$DUMPFILE"
-        ncn# cray artifacts get postgres-backup "$MANIFEST" "$MANIFEST"
+        cray artifacts get postgres-backup "$DUMPFILE" "$DUMPFILE"
+        cray artifacts get postgres-backup "$MANIFEST" "$MANIFEST"
         ```
 
     1. Due to a `kubectl cp` bug, rename the DUMPFILE file, replacing any `:` characters with `-`:


### PR DESCRIPTION
# Description

Modify the steps to restore keycloak to setup the CRAY_CREDENTIALS
Minor formatting changes
Needs to be backported to release/1.2 and release/1.3

# Checklist Before Merging

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
