### PR TITLE
CRAYSAT-1571: Fix two issues in runLint.sh

### DIFF
--- a/runLint.sh
+++ b/runLint.sh
@@ -1,10 +1,38 @@
 #!/bin/bash
-# Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+function check_quotes {
+    local error=0
+    printf "=============== Linting \” (https://www.compart.com/en/unicode/U+201C and U+201D) ... \n"
+    grep -n -RE '“|”' ./* --include "*.md" && echo >&2 'Malformed quotes detected (bad: ” vs. good: ").' && error=1
+    if [ $error = 1 ]; then
+        echo >&2 "Failed: ${FUNCNAME[0]}"
+        return 1
+    else
+        echo "OK: ${FUNCNAME[0]}"
+        return 0
+    fi
+}
+check_quotes
 
-error=0
-printf "=============== Linting \” (https://www.compart.com/en/unicode/U+201D) ... \n"
-grep -n -R \” *.md && echo >&2 'Malformed quotes detected (bad: ” vs. good: ").' && error=1
-[ $error = 1 ] && echo '^FAILED'
-
-
-printf "+++++++++++++++ ... OK\n" && exit 0


### PR DESCRIPTION
# Description

Backport of https://github.com/Cray-HPE/docs-csm/pull/2533/

<!--- Describe what this change is and what it is for. -->
This commit fixes two issues in runLint.sh
* grep for both lefthand and righthand double quote characters instead of just righthand.
* change the glob pattern so that directories other than the top level are searched.

Test Description:
* Without applying this change, I made local changes to the docs:
  * Added illegal double quote characters to a file in a directory other than the top-level directory of this repository.
  * Added a lefthand double quote character to a file at the top level of this repository.
* Ran the script without this change, which falsely reported no issues.
* After applying this change, the script correctly idenfitied the issues.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
