### PR TITLE
A few additions/adjustments to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,6 +29,7 @@
 /install/*                                               @Cray-HPE/metal
 /install/livecd                                          @Cray-HPE/metal
 /operations/bare_metal                                   @Cray-HPE/metal
+/operations/system_configuration_service                 @Cray-HPE/metal
 
 # Continuous Integration Items
 Jenkinsfile.github                                       @Cray-HPE/ci
@@ -46,24 +47,29 @@ Jenkinsfile.github                                       @Cray-HPE/ci
 
 # PET Items
 /operations/artifact_management                          @Cray-HPE/platform-engineering
+/operations/argo                                         @Cray-HPE/platform-engineering
 /operations/kubernetes                                   @Cray-HPE/platform-engineering
+/operations/multi-tenancy                                @Cray-HPE/platform-engineering
+/operations/node_management/                             @Cray-HPE/platform-engineering
 /operations/package_repository_management                @Cray-HPE/platform-engineering
+/operations/resiliency                                   @Cray-HPE/platform-engineering
+/operations/security_and_authentication                  @Cray-HPE/platform-engineering
 /operations/spire                                        @Cray-HPE/platform-engineering
 /operations/system_management_health                     @Cray-HPE/platform-engineering
 /operations/utility_storage                              @Cray-HPE/platform-engineering
 troubleshooting/kubernetes                               @Cray-HPE/platform-engineering
-/workflows                                               @Cray-HPE/platform-engineering
+/workflows/                                              @Cray-HPE/platform-engineering
 
 # HMS Items
 /operations/firmware                                     @Cray-HPE/hardware-management
-/operations/hardware_state_manager                       @Cray-HPE/hardware-management
+/operations/hardware_state_manager/                      @Cray-HPE/hardware-management
 /operations/hmcollector                                  @Cray-HPE/hardware-management
 /operations/hpe_pdu                                      @Cray-HPE/hardware-management
 /operations/power_management                             @Cray-HPE/hardware-management
 /operations/system_layout_service                        @Cray-HPE/hardware-management
 
 # Network Items
-/operations/network                                      @Cray-HPE/management-network
+/operations/network/                                     @Cray-HPE/management-network
 
 # SAT Items
 /operations/sat                                          @Cray-HPE/system-admin-toolkit-admin


### PR DESCRIPTION
# Description

I found a few items in CODEOWNERS that needed to have the trailing / added because the directory had subdirectories.   While doing that I also found a few directories that have been added to the repo that should have code owners specified. 

# Checklist Before Merging

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
