### PR TITLE
Pawsey install noticed `s/s/S/` typo

### DIFF
--- a/upgrade/1.0.11/Stage_0_Prerequisites.md
+++ b/upgrade/1.0.11/Stage_0_Prerequisites.md
@@ -215,7 +215,7 @@ for more information.
 
       ```bash
       ncn-m001# echo $CEPHNEW
-      ncn-m001# echo $K8sNEW
+      ncn-m001# echo $K8SNEW
       ```
 
     2. Check current versions in `/etc/cray/upgrade/csm/myenv`.


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
During the Pawsey 22.03 (CSM 1.0.11) upgrade the `K8sNEW` typo was noticed. This change just `s/s/S/` on the single instance of the typo.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
