### PR TITLE
CASMPET-6004: Add validation for checking the user input against etcd

### DIFF
--- a/scripts/operations/kubernetes/encryption.sh
+++ b/scripts/operations/kubernetes/encryption.sh
@@ -27,11 +27,11 @@ _dir=$(cd -P -- "$(dirname -- "$(command -v -- "$0")")" && pwd -P || exit 126)
 export _base _dir
 set "${SETOPTS:--eu}"
 
-tmpfiles=
+# Where we store all our temp dirs/files
+RUNDIR="${TMPDIR:-/tmp}/encryption-tmp-$$"
+
 cleanup() {
-  if [ "" != "${tmpfiles}" ]; then
-    rm -fr "${tmpfiles}"
-  fi
+  rm -fr "${RUNDIR}"
 }
 
 trap cleanup EXIT
@@ -58,33 +58,19 @@ validprovider() {
   return 0
 }
 
-# Note identity is a "special" secret allowing a caller to control where/when
-# the identity provider shows up in the list
-#
-# Called like so:
-# - encryptionconfig identity aescbc:keydata aesgcm:keydata
-# - encryptionconfig identity aescbc:keydata aescbc:keydata
-# - encryptionconfig aescbc:keydata aescbc:keydata identity
-# - encryptionconfig identity
-# - etc.....
-# - Note that a call of encryptionconfig identity should only occur when turning encryption off entirely after it was on.
-# - Identity is *always* required, it controls where in the provider array the identity provider shows up. This is used for key rotation and to bring k8s up when switching to a new encryption key. As any data is not encrypted at that point in etcd we need to be able to read the data to re-encrypt later.
-# - Note: identity is an internal only thing, users don't specify this directly but implicitly by turning encryption on or off.
-# - Order of callers determines what will/can be used for encryption.
-# - Note: This encryptionconfig could use some cleaning up in how it lays out providers less redundantly. But an added bonus is it makes positional keys easy to specify.
-encryptionconfig() {
+validateinput() {
   identok=0
-  encryptionsetup=
   ok=0
+  encryptionsetup=""
 
   if [ $# -eq 0 ]; then
-    printf "fatal: bug? no args passed to encryptionconfig()\n" >&2
+    printf "fatal: bug? no args passed to validateinput()\n" >&2
     return 1
   fi
 
   # Non odd number of args is definitely wrong
   if [ $(($# % 2)) -ne 1 ]; then
-    printf "fatal: bug? even number of args for encryptionconfig()\n" >&2
+    printf "fatal: bug? even number of args for validateinput()\n" >&2
     return 1
   fi
 
@@ -104,7 +90,13 @@ encryptionconfig() {
       shift || :
 
       if ! validatelen "${key}"; then
-        encryptionsetup=" ${encryptionsetup} ${input} ${key}"
+        sha=$(echo "${key}" | sha256sum | awk '{print $1}')
+        name="${input}-${sha}"
+        # Note: printf to ensure we're not passing in newlines no matter what
+        # shell we're run against.
+        b64secret=$(printf "%s" "${key}" | base64)
+
+        encryptionsetup="${encryptionsetup-}${encryptionsetup:+ }${name} ${b64secret}"
       else
         printf "fatal: invalid key length\n" >&2
         ok=$((ok + 1))
@@ -121,15 +113,35 @@ encryptionconfig() {
   fi
 
   if [ ${identok} -eq 0 ]; then
-    printf "fatal: bug? no identity provider provided for encryptionconfig()\n" >&2
+    printf "fatal: bug? no identity provider provided for validateinput()\n" >&2
     return 1
   elif [ ${identok} -ne 1 ]; then
-    printf "fatal: bug? more than one identity arg provided to identityconfig()\n" >&2
+    printf "fatal: bug? more than one identity arg provided to validateinput()\n" >&2
     return 1
   fi
 
-  (
-    cat << FIN
+  printf "%s" "${encryptionsetup}"
+  return ${ok}
+}
+
+# Note identity is a "special" secret allowing a caller to control where/when
+# the identity provider shows up in the list
+#
+# Called like so:
+# - encryptionconfig identity aescbc:keydata aesgcm:keydata
+# - encryptionconfig identity aescbc:keydata aescbc:keydata
+# - encryptionconfig aescbc:keydata aescbc:keydata identity
+# - encryptionconfig identity
+# - etc.....
+# - Note that a call of encryptionconfig identity should only occur when turning encryption off entirely after it was on.
+# - Identity is *always* required, it controls where in the provider array the identity provider shows up. This is used for key rotation and to bring k8s up when switching to a new encryption key. As any data is not encrypted at that point in etcd we need to be able to read the data to re-encrypt later.
+# - Note: identity is an internal only thing, users don't specify this directly but implicitly by turning encryption on or off.
+# - Order of callers determines what will/can be used for encryption.
+# - Note: This encryptionconfig could use some cleaning up in how it lays out providers less redundantly. But an added bonus is it makes positional keys easy to specify.
+encryptionconfig() {
+  # we do not want this here actually
+  #shellcheck disable=SC2086
+  cat << FIN
 ---
 apiVersion: apiserver.config.k8s.io/v1
 kind: EncryptionConfiguration
@@ -137,30 +149,39 @@ resources:
   - resources:
       - secrets
     providers:
+$(sutencryptionconfig "$@")
 FIN
-    curr=""
-    for x in ${encryptionsetup}; do
-      if [ "identity" = "${x}" ]; then
-        cat << FIN
+}
+
+sutencryptionconfig() {
+  curr=""
+  until [ $# -eq 0 ]; do
+    curr="${1}"
+    shift
+
+    if [ "identity" = "${curr}" ]; then
+      cat << FIN
       - identity: {}
 FIN
-      elif [ "aescbc" = "${x}" ] || [ "aesgcm" = "${x}" ]; then
-        curr="${x}"
-      else
-        sha=$(echo "${x}" | sha256sum | awk '{print $1}')
-        name="${curr}-${sha}"
-        # Note: printf to ensure we're not passing in newlines no matter what
-        # shell we're run against.
-        b64secret=$(printf "%s" "${x}" | base64)
-        cat << FIN
+    else
+      val="${1:-bug}"
+      shift || break
+      sha=$(echo "${val}" | sha256sum | awk '{print $1}')
+      name="${curr}-${sha}"
+      b64secret=$(printf "%s" "${val}" | base64)
+
+      cat << FIN
       - ${curr}:
           keys:
             - name: "${name}"
               secret: "${b64secret}"
 FIN
-      fi
-    done
-  )
+    fi
+  done
+}
+
+mkrundir() {
+  install -dm755 "${RUNDIR}"
 }
 
 # Write out a configfile to PREFIX, note PREFIX *MUST* exist
@@ -171,9 +192,8 @@ writeconfig() {
     return 1
   fi
 
-  tmpfile=$(mktemp sha256sum.XXXXXXXX)
-
-  tmpfiles="${tmpfiles} ${tmpfile}"
+  mkrundir
+  tmpfile=$(mktemp -p "${RUNDIR}" sha256sum.XXXXXXXX)
 
   # Write out whatever we got passed into a tempfile so we can get the sha256sum
   # of the contents to move it into PREFIX
@@ -260,15 +280,15 @@ restartk8s() {
     # kubectl wait for the pod to come back for 60 seconds or bail
     if ! sutkubectlwait; then
       printf "fatal: kubectl wait on %s timed out\n" "${apiserver}" >&2
-      return $?
+      return 1
     fi
   else
     printf "fatal: kubectl delete on %s timed out\n" "${apiserver}" >&2
-    return $?
+    return 1
   fi
   if ! sutpgrep "${file}"; then
     printf "fatal: kubeapi args do not contain expected arg %s\n" "%{file}" >&2
-    return $?
+    return 1
   fi
 }
 
@@ -287,7 +307,7 @@ sutpgrep() {
 #
 # Additionally, just have kubectl wait for one minute to delete the pod if not give up and let caller decide on actions.
 sutkubectldelete() {
-  kubectl delete pod --namespace kube-system "kube-apiserver-$(uname -n)" --timeout=60s > /dev/null 2>&1
+  kubectl delete pod --namespace kube-system "kube-apiserver-$(uname -n)" --timeout=300s > /dev/null 2>&1
 }
 
 # Similarly just wrapping:
@@ -297,19 +317,365 @@ sutkubectldelete() {
 #
 # Additionally, just have kubectl wait for one minute to delete the pod if not give up and let caller decide on actions.
 sutkubectlwait() {
-  kubectl wait pod --namespace kube-system --for condition=ready "kube-apiserver-$(uname -n)" --timeout=60s > /dev/null 2>&1
+  kubectl wait pod --namespace kube-system --for condition=ready "kube-apiserver-$(uname -n)" --timeout=300s > /dev/null 2>&1
+}
+
+# Etcd related functions, here to let us peek into the etcd db directly to get
+# at if a secret key (namely the cray-k8s-encryption key by default) is
+# encrypted or not. We (ab)use that as an indicator of what keys are in use in etcd
+# and what the user may be requesting to say yea/nay to the configuration requested.
+#
+# Mostly here to prevent a user from trying to swap a key from A -> B without
+# going through a 2 phase commit of A && B (rewrite) and then just A (removal of
+# B requires no rewrite of secret data)
+#
+# Note etcdctl has no sut prefix to make usage of the commands equal what you
+# would type at a shell commandline.
+
+# Wrap up etcdctl calls in a function with all the needed env vars.
+etcdprefix="/etc/kubernetes/pki"
+export ETCDCTL_ENDPOINTS='https://127.0.0.1:2381'
+export ETCDCTL_CACERT="${etcdprefix}/etcd/ca.crt"
+export ETCDCTL_CERT="${etcdprefix}/apiserver-etcd-client.crt"
+export ETCDCTL_KEY="${etcdprefix}/apiserver-etcd-client.key"
+export ETCDCTL_API=3
+
+sutetcdctl() {
+  ${ETCDCTL} "$@"
+}
+
+# Before running any etcdctl commands run etcdctl version to establish if we can
+# even get at data from etcd.
+sutetcdok() {
+  sutetcdctl version
+}
+
+# Just a wrapper around etcdctl get ... that handles unencrypted and encrypted
+# contents of a k8s secret in etcd db.
+#
+# args are namespace then keyname
+sutkeyencryption() {
+  keyval=$(sutetcdctlkeyval "$@" 2>&1)
+  rc=$?
+
+  encryptionval="unknown"
+
+  # etcdctl get ... has a horrible interface
+  #
+  # If you do a get on a nonexistent key, it returns 0 and no output
+  # So special case that so we can know if we are looking for a nonexistent key or not
+  #
+  # Special case this to string dne (Does Not Exist)
+  if [ 0 -eq "${rc}" ] && [ "" = "${keyval}" ]; then
+    printf "dne"
+    return 1
+  fi
+
+  # Non zero return code is special case etcderror and etcdtimeout
+  if [ 0 -ne "${rc}" ]; then
+    if echo "${keyval}" | grep DeadlineExceeded > /dev/null 2>&1; then
+      printf "etcdtimeout"
+    else
+      printf "etcderror"
+    fi
+    return 1
+  fi
+
+  # Ok as there are any number of secret types, the real logic here is simply:
+  # If we can detect the "this is totes encrypted" string, its encrypted we return the name of that encryption provider
+  # Otherwise we call it identity cause it probably is
+  # as long as etcdctl returned 0 if it was 1 we call it unknown
+  if echo "${keyval}" | grep 'k8s:enc' > /dev/null 2>&1; then
+    # Overly pedantic nit not applicable here or rather isn't an issue
+    #shellcheck disable=SC2086
+    encryptionval="$(echo ${keyval} | awk -F: '{print $5}')"
+  else
+    encryptionval="identity"
+  fi
+
+  printf "%s" "${encryptionval}"
+  if [ "unknown" = "${encryptionval}" ]; then
+    return 1
+  fi
+
+  return 0
+}
+
+# For unit testing ^^^^ Just wraps
+# etcdctl get --print-value-only /registry/secrets/$namespace/$name
+#
+# args are namespace then keyname
+sutetcdctlkeyval() {
+  namespace="${1}"
+  shift
+  name="${1}"
+
+  # Note we have to strip off null bytes as this is raw binary data and if bash
+  # is running us prints a useless warning
+  sutetcdctl get --print-value-only "/registry/secrets/${namespace}/${name}" | head -n 2 | tr -d '\0'
+}
+
+# Just wraps etcdctl get ... /registry/secrets so we get just the keys
+sutallkeys() {
+  sutetcdctl get --keys-only=true --prefix /registry/secrets | awk '/\/registry/ {print}'
+}
+
+# Loop through all secrets and find any/all names in use and sorted/uniqued
+sutexistingetcdencryption() {
+  existing=""
+
+  rc=0
+
+  baton=0
+
+  if [ -t 1 ]; then
+    printf "reading all etcd keys this takes a while please wait\n" >&2
+  fi
+
+  for secret in $(sutallkeys); do
+    # Print a baton to stderr if we are on a tty
+    if [ -t 1 ]; then
+      baton=$((baton + 1))
+      if [ 1 -eq "${baton}" ]; then
+        printf "\b|" >&2
+      elif [ 2 -eq "${baton}" ]; then
+        printf "\b/" >&2
+      elif [ 3 -eq "${baton}" ]; then
+        printf "\b-" >&2
+      else
+        baton=0
+      fi
+    fi
+
+    ns=$(echo "${secret?}" | awk -F/ '{print $4}')
+    name=$(echo "${secret?}" | awk -F/ '{print $5}')
+
+    # Not great but if/since we're running in set -e the return 1 can bite us
+    if sutkeyencryption "${ns}" "${name}" > /dev/null 2>&1; then
+      val=$(sutkeyencryption "${ns}" "${name}")
+      existing="${val}${existing:+ }${existing-}"
+    else
+      printf "\ndebug: key %s %s cannot be determined\n" "${ns}" "${name}" >&2
+      existing="etcderror${existing:+ }${existing-}"
+    fi
+  done
+
+  if [ -t 1 ]; then
+    printf "\b\b\b" >&2
+  fi
+  echo "${existing?}" | tr ' ' '\n' | sort -u
+}
+
+# Note lhs is the input (quote it if spaces!) as well as rhs Internally this
+# function creates files for awk to use to calculate the seet operation, cause
+# this is shell and thats the easiest way to leverage existing programs.
+complement() {
+  dlhs="${1}"
+  shift
+  drhs="${1}"
+  mkrundir
+  lhsf=$(mktemp -p "${RUNDIR}" lhs-XXXXXXXX)
+  rhsf=$(mktemp -p "${RUNDIR}" rhs-XXXXXXXX)
+  echo "${dlhs}" | tr ' ' '\n' | sort -u > "${lhsf}"
+  echo "${drhs}" | tr ' ' '\n' | sort -u > "${rhsf}"
+  comm -23 "${lhsf}" "${rhsf}"
+}
+
+# Same applies here as complement
+difference() {
+  elhs="${1}"
+  shift
+  erhs="${1}"
+  mkrundir
+  lhsf=$(mktemp -p "${RUNDIR}" lhs-XXXXXXXX)
+  rhsf=$(mktemp -p "${RUNDIR}" rhs-XXXXXXXX)
+  echo "${elhs}" | tr ' ' '\n' | sort -u > "${lhsf}"
+  echo "${erhs}" | tr ' ' '\n' | sort -u > "${rhsf}"
+  comm -3 "${lhsf}" "${rhsf}" | tr -d '\t'
+}
+
+# Everything in disjoint applies here too
+subset() {
+  subsetlhs="${1}"
+  shift
+  subsetrhs="${1}"
+  mkrundir
+  lhsf=$(mktemp -p "${RUNDIR}" lhs-XXXXXXXX)
+  rhsf=$(mktemp -p "${RUNDIR}" rhs-XXXXXXXX)
+  echo "${subsetlhs}" | tr ' ' '\n' | sort -u > "${lhsf}"
+  echo "${subsetrhs}" | tr ' ' '\n' | sort -u > "${rhsf}"
+  comm -23 "${lhsf}" "${rhsf}" | grep -q '^'
+}
+
+# Take the inputs the user has given, compare it to what we have found, and yea/nay it.
+#
+# Just a bunch of set operations to determine if what we found is covered by
+# what they have specified.
+#
+# lhs is what we found, rhs is what the user entered/hopes for.
+#
+# Current is what the existing encryption key is known to be
+# Goal similarly is the upcoming goal of encryption
+usergoalvalid() {
+  lhs="${1}"
+  shift
+  rhs="${1}"
+  shift
+  curr="${1}"
+  # needed?
+  # shift
+  # goal="${1}"
+
+  ok=0
+  nok=0
+
+  # Special case when both inputs are equal count it as valid
+  if [ "${lhs}" = "${rhs}" ]; then
+    ok=$((ok + 1))
+  fi
+
+  # Validate case where what we the user is requesting is a subset of what is
+  # wanted (adding a new goal)
+  if subset "${rhs}" "${lhs}"; then
+    ok=$((ok + 1))
+  fi
+
+  # mostly add use cases
+  if subset "${curr}" "${rhs}"; then
+    if subset "${lhs}" "${rhs}"; then
+      ok=$((ok + 1))
+    fi
+  fi
+
+  # Mostly removal of written/committed to etcd ciphers
+  if subset "${curr}" "${lhs}"; then
+    if subset "${rhs}" "${lhs}"; then
+      ok=$((ok + 1))
+    fi
+  fi
+
+  diff=$(difference "${lhs}" "${rhs}")
+  comp=$(complement "${lhs}" "${rhs}")
+
+  # If we have differences thats generally OK due to addition or removal but if
+  # the complement and differences don't match we have input ciphers missing
+  # existing on disk ciphers.
+  if [ "" != "${diff}" ] && [ "" != "${comp}" ]; then
+    # Not ok difference != complement
+    if [ "${diff}" != "${comp}" ]; then
+      nok=$((nok + 1))
+    fi
+  fi
+
+  if [ "${ok}" -gt 0 ]; then
+    if [ "${nok}" -gt 0 ]; then
+      return 1
+    fi
+    return 0
+  else
+    return 1
+  fi
+}
+
+# Just strips off the b64 encoded strings from a string of space delimted "things"
+# internal helper function.
+tovalid() {
+  out=""
+  until [ $# -eq 0 ]; do
+    x="${1}"
+    shift
+
+    provider=$(echo "${x}" | awk -F- '{print $1}')
+    if [ "identity" = "${x}" ] || [ "aesgcm" = "${provider}" ] || [ "aescbc" = "${provider}" ]; then
+      out="${out-}${out:+ }${x}"
+    fi
+  done
+  echo "${out}"
+}
+
+# The goal of encryption aka what encryption key name we want things to be rewritten with
+secret_goal() {
+  kubectl get secret -n kube-system cray-k8s-encryption -o jsonpath='{range .items[*]}{.metadata.annotations.goal}'
+}
+
+# Current encryption configuration, or rather last known configuration based off last rewrite of data in k8s
+secret_current() {
+  kubectl get secret -n kube-system cray-k8s-encryption -o jsonpath='{range.items[*]}{.metadata.annotations.current}'
 }
 
 # Logic is simply write out our new encryption config
 # iff thats ok restart k8s apiserver pod
 # iff that was ok then symlink the new config to current.yaml so daemon can pickup the new setup in k8s.
 main() {
+  if $restart; then
+    kubectl annotate secret --namespace kube-system cray-k8s-encryption current=rewrite --overwrite
+    kubectl rollout restart daemonset --namespace kube-system cray-k8s-encryption
+    kubectl rollout status --namespace kube-system ds/cray-k8s-encryption --timeout 300s
+    exit $?
+  fi
+
+  curr="$(secret_current | awk -F: '{print $2}')"
+  goal="$(secret_goal | awk -F: '{print $2}')"
+
+  if $status; then
+    synced=false
+    etcd="$(sutexistingetcdencryption)"
+    printf "k8s encryption status\ncurrent: %s\ngoal: %s\n" "${curr?}" "${goal?}"
+    printf "etcd: %s\n" "${etcd}"
+
+    if [ "${curr}" = "${goal}" ] && [ "${curr}" = "${etcd}" ] && [ "${goal}" = "${etcd}" ]; then
+      synced=true
+    fi
+
+    if ${synced}; then
+      exit 0
+    else
+      if [ -t 1 ]; then
+        printf "interim/invalid state all should be equal when in a steady state\n" >&2
+      fi
+      exit 1
+    fi
+  fi
+
+  # General validation for --enable/disable, if this doesn't pass we don't allow
+  # the input at all to go any further
+
+  usergoal=$(validateinput "$@")
+  #shellcheck disable=SC2181
+  if [ "${?}" -ne 0 ]; then
+    return $?
+  fi
+
+  # Grab the current configuration off of etcd, then we use the usergoal above
+  # to call usergoalvalid to see if the request makes sense from a logical
+  # perspective.
+
+  # We can't quote this call
+  #shellcheck disable=SC2086
+  usersgoal=$(tovalid ${usergoal})
+  etcd="$(sutexistingetcdencryption)"
+
+  if ! usergoalvalid "${etcd}" "${usersgoal}" "${curr}" "${goal}"; then
+    printf "fatal: requested goal conflicts with existing etcd encryption\netcd: %s\nrequested: %s\n" "${etcd}" "${usersgoal}" >&2
+    printf "To fix add the keys that correspond with that encryption secret to the end of this command. Failure to do so would mean k8s cannot read existing secrets.\n" >&2
+    exit 1
+  fi
+
+  mkrundir
+  cd "${RUNDIR}" || exit 126
+
   curr="${PREFIX}/current.yaml"
+
   src=$(writeconfig "$@")
-  if [ $? ]; then
+  # Needed as we are using stdout and don't want to run things twice.
+  #shellcheck disable=SC2181
+  if [ $? -eq 0 ]; then
     if restartk8s "${src}"; then
       if [ -e "${src}" ]; then
-        ln -sf "${src}" "${curr}"
+        cd "${PREFIX}" || exit 126
+        # not really applicable
+        #shellcheck disable=SC2086
+        ln -sf "$(basename ${src})" "$(basename ${curr})"
       else
         printf "fatal: cannot symlink %s as it does not exist?\n" "${src}" >&2
         exit 1
@@ -330,9 +696,13 @@ main() {
 # Ref: https://github.com/shellspec/shellspec#testing-shell-functions
 ${__SOURCED__:+return}
 
+# If needed at runtime to specify what etcdctl to (ab)use, note after
+# __SOURCED__ to allow for runtime detection
+ETCDCTL=${ETCDCTL:-$(command -v etcdctl)}
+
 usage() {
   cat << FIN
-usage: $0 [-h|--help] [--enable|--disable] --aescbc VALUE --aesgcm VALUE ...
+usage: $0 [-h|--help] [--enable|--disable|--status] [--aescbc|aesgcm] VALUE ...
 FIN
 }
 
@@ -340,6 +710,8 @@ FIN
 encryptionopts=
 enabled=false
 disabled=false
+restart=false
+status=false
 ciphers=0
 help=true
 
@@ -353,6 +725,16 @@ while true; do
     -d | --disable)
       help=false
       disabled=true
+      shift
+      ;;
+    -r | --restart)
+      help=false
+      restart=true
+      shift
+      ;;
+    -s | --status)
+      help=false
+      status=true
       shift
       ;;
     --aescbc)
@@ -381,13 +763,16 @@ if ${help}; then
   exit 1
 fi
 
-if ${enabled} && ${disabled}; then
-  printf "fatal: --enable and --disable cannot be used together\n" 2>&1
+if (${enabled} && ${disabled}) || (${enabled} && ${status}) || (${enabled} && ${restart}) \
+  || (${disabled} && ${status}) || (${disabled} && ${restart}) \
+  || (${status} && ${restart}); then
+  printf "enabled: %s disabled: %s status: %s restart: %s\n" "${enabled}" "${disabled}" "${status}" "${restart}" >&2
+  printf "fatal: --enable, --disable, --status, and --restart cannot be used together\n" >&2
   usage
   exit 1
 elif ${enabled}; then
   if [ ${ciphers} -lt 1 ]; then
-    printf "fatal: --enable requires at least one cipher to be provided\n" 2>&1
+    printf "fatal: --enable requires at least one cipher to be provided\n" >&2
     usage
     exit 1
   fi

--- a/scripts/operations/kubernetes/encryption.sh
+++ b/scripts/operations/kubernetes/encryption.sh
@@ -644,8 +644,8 @@ main() {
     exit $?
   fi
 
-  curr="$(secret_current | awk -F: '{print $2}')"
-  goal="$(secret_goal | awk -F: '{print $2}')"
+  curr="$(stripetcdprefix "$(secret_current)")"
+  goal="$(stripetcdprefix "$(secret_goal)")"
 
   if $status; then
     synced=false

--- a/spec/encryption_spec.sh
+++ b/spec/encryption_spec.sh
@@ -26,7 +26,7 @@
 # Note using function mocks for testing ref:
 # https://github.com/shellspec/shellspec#mocking
 Describe 'encryption.sh logic'
-  Include scripts/operations/node_management/encryption.sh
+  Include scripts/operations/kubernetes/encryption.sh
 
   # Valid secret lengths, some caveats apply....
   secret16=0123456789abcdef
@@ -97,6 +97,81 @@ Describe 'encryption.sh logic'
 
   End
 
+  Context 'Valid validateinput calls'
+    # Only used for unit tests, hopefully nobody ever tries to use this secret in
+    # real life.
+    secretsut=sutsutsutsutsutsutsutsutsutsutsu
+
+    It 'allows a simple identity config'
+      When call validateinput identity
+      The status should equal 0
+      The stdout should equal identity
+    End
+
+    It 'sets up aescbc and aesgcm correctly'
+      When call validateinput identity aescbc "${secretsut}" aesgcm "${secretsut}"
+      The status should equal 0
+      The stdout should equal "identity aescbc-46d5bd8c2001d07ded05687fe51b517033dc609e69fe4dddaa6e05656cf6e907 c3V0c3V0c3V0c3V0c3V0c3V0c3V0c3V0c3V0c3V0c3U= aesgcm-46d5bd8c2001d07ded05687fe51b517033dc609e69fe4dddaa6e05656cf6e907 c3V0c3V0c3V0c3V0c3V0c3V0c3V0c3V0c3V0c3V0c3U="
+    End
+
+  End
+
+  Context 'Internal function to remove b64 secrets from encryption data'
+    It 'yeets out the base64 secret'
+      When call tovalid identity aescbc-46d5bd8c2001d07ded05687fe51b517033dc609e69fe4dddaa6e05656cf6e907 c3V0c3V0c3V0c3V0c3V0c3V0c3V0c3V0c3V0c3V0c3U= aesgcm-46d5bd8c2001d07ded05687fe51b517033dc609e69fe4dddaa6e05656cf6e907 c3V0c3V0c3V0c3V0c3V0c3V0c3V0c3V0c3V0c3V0c3U=
+      The status should equal 0
+      The stdout should equal "identity aescbc-46d5bd8c2001d07ded05687fe51b517033dc609e69fe4dddaa6e05656cf6e907 aesgcm-46d5bd8c2001d07ded05687fe51b517033dc609e69fe4dddaa6e05656cf6e907"
+    End
+
+  End
+
+  Context 'Invalid validateinput calls'
+    It 'fails when called without args'
+      When call validateinput
+      The status should equal 1
+      The stderr should equal "fatal: bug? no args passed to validateinput()"
+    End
+
+    It 'fails when called with an even number of args'
+      When call validateinput a b
+      The status should equal 1
+      The stderr should equal "fatal: bug? even number of args for validateinput()"
+    End
+
+    It 'fails when called with some random input that makes no sense'
+      When call validateinput invalid
+      The status should equal 1
+      The stderr should equal "fatal: invalid provider specified invalid"
+    End
+
+    It 'fails if every arg is just identity'
+      When call validateinput identity identity identity
+      The status should equal 1
+      The stderr should equal "fatal: bug? more than one identity arg provided to validateinput()"
+    End
+
+    # Note valid calls will *always* be odd aka identity provider data
+    # if we somehow get provider data provider data2 thats invalid/a bug
+    It 'fails when called with an even number of args'
+      When call validateinput invalid aescbc
+      The status should equal 1
+      The stderr should equal "fatal: bug? even number of args for validateinput()"
+    End
+
+    # A bit redundant but why not make sure calls are kosher
+    It 'fails when called with an invalid provider but valid data'
+      When call validateinput identity invalid secret16
+      The status should equal 1
+      The stderr should equal "fatal: invalid provider specified invalid"
+    End
+
+    It 'fails when called with a valid provider but invalid data'
+      When call validateinput identity aescbc blah
+      The status should equal 1
+      The stderr should equal "fatal: invalid key length"
+    End
+  End
+
   # Make sure the encryptionconfig function works the way we expect it to.
   Context 'Valid encryptionconfig calls'
     # Only used for unit tests, hopefully nobody ever tries to use this secret in
@@ -148,53 +223,6 @@ Describe 'encryption.sh logic'
       The stdout should equal "$(beginencryption)"
     End
 
-  End
-
-  Context 'Invalid encryptionconfig calls'
-    It 'fails when called without args'
-      When call encryptionconfig
-      The status should equal 1
-      The stderr should equal "fatal: bug? no args passed to encryptionconfig()"
-    End
-
-    It 'fails when called with an even number of args'
-      When call encryptionconfig a b
-      The status should equal 1
-      The stderr should equal "fatal: bug? even number of args for encryptionconfig()"
-    End
-
-    It 'fails when called with some random input that makes no sense'
-      When call encryptionconfig invalid
-      The status should equal 1
-      The stderr should equal "fatal: invalid provider specified invalid"
-    End
-
-    It 'fails if every arg is just identity'
-      When call encryptionconfig identity identity identity
-      The status should equal 1
-      The stderr should equal "fatal: bug? more than one identity arg provided to identityconfig()"
-    End
-
-    # Note valid calls will *always* be odd aka identity provider data
-    # if we somehow get provider data provider data2 thats invalid/a bug
-    It 'fails when called with an even number of args'
-      When call encryptionconfig invalid aescbc
-      The status should equal 1
-      The stderr should equal "fatal: bug? even number of args for encryptionconfig()"
-    End
-
-    # A bit redundant but why not make sure calls are kosher
-    It 'fails when called with an invalid provider but valid data'
-      When call encryptionconfig identity invalid secret16
-      The status should equal 1
-      The stderr should equal "fatal: invalid provider specified invalid"
-    End
-
-    It 'fails when called with a valid provider but invalid data'
-      When call encryptionconfig identity aescbc blah
-      The status should equal 1
-      The stderr should equal "fatal: invalid key specified blah"
-    End
   End
 
   # This stuff is rather key to how all this setup is to work, takes the
@@ -305,6 +333,257 @@ Describe 'encryption.sh logic'
         When call sutkubectldelete
         The status should equal 0
         The stderr should equal 'pod "kube-apiserver-ncn-m001" deleted'
+      End
+    End
+
+    # Etcd related spelunking code
+    #
+    # Here to try to prevent users from shooting their own feet off when
+    # updating encryption configurations.
+    Describe 'etcd suite of functions'
+      It 'sutetcdok can determine if etcd is working if it is'
+        sutetcdok() {
+          printf "etcdctl version: 3.5.0\nAPI version: 3.5\n"
+          return 0
+        }
+        When call sutetcdok
+        The stdout should equal "etcdctl version: 3.5.0
+API version: 3.5"
+        The status should equal 0
+      End
+
+      # I can't get etcdctl version to fail ever not sure what it looks like
+      # when it fails so just having it return 1, if/when I can get this to fail
+      # mimic it here.
+      It 'sutetcdok can determine if etcd is working if it is not'
+        sutetcdok() {
+          return 1
+        }
+        When call sutetcdok
+        The status should equal 1
+      End
+
+      # Inspect our secret for its keyvalue to get at if it is encrypted or not,
+      # and if it is what the encryption key name is/was.
+      #
+      # If it can't figure that out returns 1 and the caller gets to determine
+      # the right thing to do (bail basically and dump to stderr).
+      It 'sutkeyencryption can return identity for an unencrypted key'
+        # etcdctl get --print-value-only /registry/secrets/kube-system/cray-k8s-encryption
+        # on an unencrypted setup with the default helm key data (for any
+        # reviewers there is *NO* secret data in this text)
+        identitycontent() {
+          %text
+          #|k8s
+          #|
+          #|
+          #|v1Secret
+          #|
+          #|cray-k8s-encryption
+          #|                   kube-system"*$1a18ede0-2506-4268-836c-c0062dcfc3de2ϪؘZ$
+          #|app.kubernetes.io/managed-byHelmb
+          #|changedneverb
+          #|currentunknownb
+          #|
+          #|generation0b
+          #|goalunknownb0
+          #|meta.helm.sh/release-namecray-k8s-encryptionb-
+          #|meta.helm.sh/release-namespace
+          #|                              kube-systemz
+          #|helmUpdatevϪؘFieldsV1:
+          #|{"f:metadata":{"f:annotations":{".":{},"f:changed":{},"f:current":{},"f:generation":{},"f:goal":{},"f:meta.helm.sh/release-name":{},"f:meta.helm.sh/release-namespace":{}},"f:labels":{".":{},"f:app.kubernetes.io/managed-by":{}}},"f:type":{}}Opaque"
+        }
+
+        sutetcdctlkeyval() {
+            identitycontent
+            return 0
+        }
+
+        When call sutkeyencryption kube-system cray-k8s-encryption
+        The status should equal 0
+        The stdout should equal "identity"
+      End
+
+      # Same as above but with an aescbc cipher, again, nothing in here is
+      # secret its using the sut encyption string in this test suite to encrypt
+      # the secret however. But nobody should use sut(repeated) as an encryption
+      # secret cipher anyway. This output may be a bit mangled due to there
+      # being newlinesetc... all over but its OK for test data.
+      It 'sutkeyencryption can return the cipher string name for an encrypted aescbc key'
+        aescbc() {
+          %text
+          #|k8s:enc:aescbc:v1:aescbc-46d5bd8c2001d07ded05687fe51b517033dc609e69fe4dddaa6e05656cf6e907:_3dUZ%
+          #|Hz6:    G;%@-/'e^?NK[g<,zq~SF7}@<X<CisO!@ΔQm35n3Z9]uNA8725ૺ12R2Gy\a'=t;RIP,(nUY#{>kL5SDeaXwɠR/$dq$
+          #|[cNd~2G0gy[-9p]Q%:EnѲmWi-T!>E)z
+          #|                               4u?9%3dy
+          #|թ`Wvel~tBJ}K
+          #|            n#l_I;[TJ>L8,7*'F-<(ۇDjZgq
+          #|                                      5SD!#Ӛ6oXV2woz8ݷy'v!_Uu@F<[/}ehCӤ:(AGA$RD0YՌmR4= @+6u>0$yFQ/||
+          #|                                                                                                    /7
+        }
+
+        sutetcdctlkeyval() {
+            aescbc
+            return 0
+        }
+
+        When call sutkeyencryption kube-system cray-k8s-encryption
+        The status should equal 0
+        The stdout should equal "aescbc-46d5bd8c2001d07ded05687fe51b517033dc609e69fe4dddaa6e05656cf6e907"
+      End
+
+      # Same as above but with an aesgcm cipher, actually just repeated the cbc but as the encrypted data isn't important just copied ^^^ directly out of laziness.
+      It 'sutkeyencryption can return the cipher string name for an encrypted aesgcm key'
+        aesgcm() {
+          %text
+          #|k8s:enc:aesgcm:v1:aesgcm-46d5bd8c2001d07ded05687fe51b517033dc609e69fe4dddaa6e05656cf6e907:_3dUZ%
+          #|Hz6:    G;%@-/'e^?NK[g<,zq~SF7}@<X<CisO!@ΔQm35n3Z9]uNA8725ૺ12R2Gy\a'=t;RIP,(nUY#{>kL5SDeaXwɠR/$dq$
+          #|[cNd~2G0gy[-9p]Q%:EnѲmWi-T!>E)z
+          #|                               4u?9%3dy
+          #|թ`Wvel~tBJ}K
+          #|            n#l_I;[TJ>L8,7*'F-<(ۇDjZgq
+          #|                                      5SD!#Ӛ6oXV2woz8ݷy'v!_Uu@F<[/}ehCӤ:(AGA$RD0YՌmR4= @+6u>0$yFQ/||
+          #|                                                                                                    /7
+        }
+
+        sutetcdctlkeyval() {
+            aesgcm
+            return 0
+        }
+
+        When call sutkeyencryption kube-system cray-k8s-encryption
+        The status should equal 0
+        The stdout should equal "aesgcm-46d5bd8c2001d07ded05687fe51b517033dc609e69fe4dddaa6e05656cf6e907"
+      End
+
+      # FAILURE CASES
+      #
+      # Not entirely sure what this looks like directly but lets handle an error case of etcdctl get failing for a non existent namespace/keyname pair.
+      It 'sutkeyencryption complains on a nonexistent namespace/keyname'
+        sutetcdctlkeyval() {
+            return 0
+        }
+
+        When call sutkeyencryption doesnt exist
+        The status should equal 1
+        The stdout should equal "dne"
+      End
+
+      # Just to be sure a non zero exit code from etcdctl will propogate up right
+      #
+      # Whatever stdout/err have here isn't a concern or rather we won't care about.
+      It 'sutkeyencryption complains on a nonexistent namespace/keyname deadline exceeded'
+        sutetcdctlkeyval() {
+            printf "stdout\n"
+            printf "stderr\n" >&2
+            return 1
+        }
+
+        When call sutkeyencryption doesnt exist
+        The status should equal 1
+        The stdout should equal "etcderror"
+      End
+
+      It 'sutkeyencryption handles etcd not returning in time correctly'
+        sutetcdctlkeyval() {
+          printf '{"level":"warn","ts":"2022-09-19T17:50:15.910Z","logger":"etcd-client","caller":"v3/retry_interceptor.go:62","msg":"retrying of unary invoker failed","target":"etcd-endpoints://0xc00024c380/#initially=[127.0.0.1:2379]","attempt":0,"error":"rpc error: code = DeadlineExceeded desc = latest balancer error: last connection error: connection closed"}\nError: context deadline exceeded\n'
+          return 1
+        }
+
+        When call sutkeyencryption etcd wickedslow
+        The status should equal 1
+        The stdout should equal "etcdtimeout"
+      End
+
+      It 'works with disjoint set operations'
+        When call disjoint "a b c" "b"
+        The status should equal 1
+      End
+
+      It 'works with disjoint set operations'
+        When call disjoint "a b c" "d"
+        The status should equal 0
+      End
+
+      It 'works with complement set operations'
+        When call complement "a b c" "a b"
+        The status should equal 0
+        The stdout should equal "c"
+      End
+
+      It 'works with complement set operations'
+        When call complement "a b c" "a b d"
+        The status should equal 0
+        The stdout should equal "c"
+      End
+
+      It 'works with complement set operations'
+        When call complement "a b c" "b c"
+        The status should equal 0
+        The stdout should equal "a"
+      End
+
+      It 'works with subset set operations'
+        When call subset "a" "a b"
+        The status should equal 1
+      End
+
+      It 'works with subset set operations'
+        When call subset "a b" "a b c"
+        The status should equal 1
+      End
+
+      It 'works with subset set operations'
+        When call subset "a b" "b c"
+        The status should equal 0
+      End
+
+      It 'works with subset set operations'
+        When call subset "a" "a"
+        The status should equal 1
+      End
+
+      # Okie dokie, now the fun bits, this function will loop over every secret
+      # and extract out each secret's encryption status of identity or its name.
+      #
+      # This will be used to determine if what the user is requesting makes any
+      # sense whatsoever later on.
+      #
+      # This covers any subfunctions used as well.
+      It 'detects possible user input goals'
+        When call usergoalvalid "identity" "identity" "identity" "identity"
+        The status should equal 0
+      End
+
+      It 'detects possible user input goals adding an end goal'
+        When call usergoalvalid "identity" "identity goal" "identity" "identity"
+        The status should equal 0
+      End
+
+      It 'detects possible user input goals adding an end goal'
+        When call usergoalvalid "identity" "goal identity" "identity" "identity"
+        The status should equal 0
+      End
+
+
+      It 'detects possible user input goals adding an end goal in progress'
+        When call usergoalvalid "identity" "identity goal" "identity" "goal"
+        The status should equal 0
+      End
+
+      It 'detects possible user input goals removing a written end goal'
+        When call usergoalvalid "identity goal" "identity" "goal" "goal"
+        The status should equal 0
+      End
+
+      It 'detects possible user input goals removing an end goal in progress and not written to disk yet'
+        When call usergoalvalid "identity" "identity" "identity" "goal"
+        The status should equal 0
+      End
+
+      It 'fails if we have a new goal but are missing an existing goal'
+        When call usergoalvalid "identity goal" "identity new" "goal" "goal"
+        The status should equal 1
       End
 
     End


### PR DESCRIPTION
This adds the ability for encryption.sh --enable/disable --aesgcm ... to validate the user input makes logical sense against what is found in the etcd database.

What this means is essentially if a user tries to setup encryption with a key that isn't found in etcd, the script will reject the update as being logically invalid.

This is to ensure that kubernetes secrets can always be read given a specific encryptionn configuration.

Also added switches --status to display the status of encryption.

And added a --restart switch to make restarting the daemonset easier to force updates.

# Description

Adds a layer of validation to prevent a user from setting up an encryption configuration that would be invalid or result in existing encrypted secrets from being readable by the kube api server.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
