### PR TITLE
CASMPET-6005: Fix variable scoping issue

### DIFF
--- a/scripts/operations/kubernetes/encryption.sh
+++ b/scripts/operations/kubernetes/encryption.sh
@@ -254,8 +254,9 @@ updatek8sconfig() {
 # in a real boy system.
 restartk8s() {
   file="${1:-invalid}"
+  apiserver="kube-apiserver-$(uname -n)"
+
   if sutkubectldelete "${file}"; then
-    apiserver="kube-apiserver-$(uname -n)"
     # kubectl wait for the pod to come back for 60 seconds or bail
     if ! sutkubectlwait; then
       printf "fatal: kubectl wait on %s timed out\n" "${apiserver}" >&2


### PR DESCRIPTION
# Description

The else clause can't address this variable as it was assigned in the if block. Move its scope to the function outside of the contditional.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
