### PR TITLE
Removed prompt from bash commands

### DIFF
--- a/install/bootstrap_livecd_remote_iso.md
+++ b/install/bootstrap_livecd_remote_iso.md
@@ -106,8 +106,8 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
 1. Start a typescript to record this section of activities done on `ncn-m001` while booted from the LiveCD.
 
    ```bash
-   pit# script -af ~/csm-install-remoteiso.$(date +%Y-%m-%d).txt
-   pit# export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
+    script -af ~/csm-install-remoteiso.$(date +%Y-%m-%d).txt
+    export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
    ```
 
 1. Print information about the booted PIT image.
@@ -117,7 +117,7 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
    any bug reports or service queries for issues encountered on the PIT node.
 
    ```bash
-   pit# /root/bin/metalid.sh
+    /root/bin/metalid.sh
    ```
 
    Expected output looks similar to the following:
@@ -144,11 +144,11 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
 1. Find a local disk for storing product installers.
 
    ```bash
-   pit# disk="$(lsblk -l -o SIZE,NAME,TYPE,TRAN | grep -E '(sata|nvme|sas)' | sort -h | awk '{print $2}' | head -n 1 | tr -d '\n')"
-   pit# echo $disk
-   pit# parted --wipesignatures -m --align=opt --ignore-busy -s /dev/$disk -- mklabel gpt mkpart primary ext4 2048s 100%
-   pit# mkfs.ext4 -L PITDATA "/dev/${disk}1"
-   pit# mount -vL PITDATA
+    disk="$(lsblk -l -o SIZE,NAME,TYPE,TRAN | grep -E '(sata|nvme|sas)' | sort -h | awk '{print $2}' | head -n 1 | tr -d '\n')"
+    echo $disk
+    parted --wipesignatures -m --align=opt --ignore-busy -s /dev/$disk -- mklabel gpt mkpart primary ext4 2048s 100%
+    mkfs.ext4 -L PITDATA "/dev/${disk}1"
+    mount -vL PITDATA
    ```
 
    The `parted` command may give an error similar to the following:
@@ -164,10 +164,10 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
    `parted` command failed.**
 
    ```bash
-   pit# RAIDS=$(grep "${disk}[0-9]" /proc/mdstat | awk '{ print "/dev/"$1 }') ; echo ${RAIDS}
-   pit# VGS=$(echo ${RAIDS} | xargs -r pvs --noheadings -o vg_name 2>/dev/null) ; echo ${VGS}
-   pit# echo ${VGS} | xargs -r -t -n 1 vgremove -f -v
-   pit# echo ${RAIDS} | xargs -r -t -n 1 mdadm -S -f -v
+    RAIDS=$(grep "${disk}[0-9]" /proc/mdstat | awk '{ print "/dev/"$1 }') ; echo ${RAIDS}
+    VGS=$(echo ${RAIDS} | xargs -r pvs --noheadings -o vg_name 2>/dev/null) ; echo ${VGS}
+    echo ${VGS} | xargs -r -t -n 1 vgremove -f -v
+    echo ${RAIDS} | xargs -r -t -n 1 mdadm -S -f -v
    ```
 
    After running the above procedure, retry the `parted` command which failed. If it succeeds, resume the install from that point.
@@ -194,10 +194,10 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
       > specified, they must be separated by spaces (for example, `site_nics='p2p1 p2p2 p2p3'`).
 
       ```bash
-      pit# site_ip=172.30.XXX.YYY/20
-      pit# site_gw=172.30.48.1
-      pit# site_dns=172.30.84.40
-      pit# site_nics=em1
+       site_ip=172.30.XXX.YYY/20
+       site_gw=172.30.48.1
+       site_dns=172.30.84.40
+       site_nics=em1
       ```
 
    1. Run the `csi-setup-lan0.sh` script to set up the site link.
@@ -205,7 +205,7 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
       > **Note:** All of the `/root/bin/csi-*` scripts are harmless to run without parameters; doing so will print usage statements.
 
       ```bash
-      pit# /root/bin/csi-setup-lan0.sh $site_ip $site_gw $site_dns $site_nics
+       /root/bin/csi-setup-lan0.sh $site_ip $site_gw $site_dns $site_nics
       ```
 
    1. Verify that `lan0` has an IP address and attempt to auto-set the hostname based on DNS.
@@ -213,8 +213,8 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
       The script appends `-pit` to the end of the hostname as a means to reduce the chances of confusing the PIT node with an actual, deployed NCN.
 
       ```bash
-      pit# ip a show lan0
-      pit# /root/bin/csi-set-hostname.sh # this will attempt to set the hostname based on the site's own DNS records.
+       ip a show lan0
+       /root/bin/csi-set-hostname.sh # this will attempt to set the hostname based on the site's own DNS records.
       ```
 
    1. Add helper variables to PIT node environment.
@@ -225,9 +225,9 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
       1. Set helper variables.
 
          ```bash
-         pit# CSM_RELEASE=csm-x.y.z
-         pit# SYSTEM_NAME=eniac
-         pit# PITDATA=$(lsblk -o MOUNTPOINT -nr /dev/disk/by-label/PITDATA)
+          CSM_RELEASE=csm-x.y.z
+          SYSTEM_NAME=eniac
+          PITDATA=$(lsblk -o MOUNTPOINT -nr /dev/disk/by-label/PITDATA)
          ```
 
       1. Add variables to the PIT environment.
@@ -239,7 +239,7 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
          > and not at the end of another line.
 
          ```bash
-         pit# echo "
+          echo "
          CSM_RELEASE=${CSM_RELEASE}
          PITDATA=${PITDATA}
          CSM_PATH=${PITDATA}/${CSM_RELEASE}
@@ -249,8 +249,8 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
    1. Exit the typescript, exit the console session, and log in again using SSH.
 
       ```bash
-      pit# exit # exit the typescript started earlier
-      pit# exit # log out of the pit node
+       exit # exit the typescript started earlier
+       exit # log out of the pit node
       # Close the console session by entering &. or ~.
       # Then ssh back into the PIT node
       external# ssh root@${SYSTEM_NAME}-ncn-m001
@@ -259,20 +259,20 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
    1. After reconnecting, resume the typescript (the `-a` appends to an existing script).
 
       ```bash
-      pit# script -af $(ls -tr ~/csm-install-remoteiso*.txt | head -n 1)
-      pit# export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
+       script -af $(ls -tr ~/csm-install-remoteiso*.txt | head -n 1)
+       export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
       ```
 
    1. Verify that expected environment variables are set in the new login shell.
 
       ```bash
-      pit# echo -e "CSM_PATH=${CSM_PATH}\nCSM_RELEASE=${CSM_RELEASE}\nPITDATA=${PITDATA}\nSYSTEM_NAME=${SYSTEM_NAME}"
+       echo -e "CSM_PATH=${CSM_PATH}\nCSM_RELEASE=${CSM_RELEASE}\nPITDATA=${PITDATA}\nSYSTEM_NAME=${SYSTEM_NAME}"
       ```
 
    1. Check hostname.
 
       ```bash
-      pit# hostnamectl
+       hostnamectl
       ```
 
       > **Note:**
@@ -286,7 +286,7 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
 1. Create necessary directories.
 
    ```bash
-   pit# mkdir -pv ${PITDATA}/{admin,configs} ${PITDATA}/prep/{admin,logs} ${PITDATA}/data/{k8s,ceph}
+    mkdir -pv ${PITDATA}/{admin,configs} ${PITDATA}/prep/{admin,logs} ${PITDATA}/data/{k8s,ceph}
    ```
 
 1. Relocate the typescript to the newly mounted `PITDATA` directory.
@@ -296,14 +296,14 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
    1. Copy the typescript file to its new location.
 
       ```bash
-      pit# cp -v ~/csm-install-remoteiso.*.txt ${PITDATA}/prep/admin
+       cp -v ~/csm-install-remoteiso.*.txt ${PITDATA}/prep/admin
       ```
 
    1. Restart the typescript, appending to the previous file.
 
       ```bash
-      pit# script -af $(ls -tr ${PITDATA}/prep/admin/csm-install-remoteiso*.txt | head -n 1)
-      pit# export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
+       script -af $(ls -tr ${PITDATA}/prep/admin/csm-install-remoteiso*.txt | head -n 1)
+       export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
       ```
 
 1. Download the CSM software release to the PIT node.
@@ -311,13 +311,13 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
    1. Set variable to URL of CSM tarball.
 
       ```bash
-      pit# URL=https://arti.dev.cray.com/artifactory/shasta-distribution-stable-local/csm/${CSM_RELEASE}.tar.gz
+       URL=https://arti.dev.cray.com/artifactory/shasta-distribution-stable-local/csm/${CSM_RELEASE}.tar.gz
       ```
 
    1. Fetch the release tarball.
 
       ```bash
-      pit# wget ${URL} -O ${CSM_PATH}.tar.gz
+       wget ${URL} -O ${CSM_PATH}.tar.gz
       ```
 
    1. Expand the tarball on the PIT node.
@@ -325,13 +325,13 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
       > **Note:** Expansion of the tarball may take more than 45 minutes.
 
       ```bash
-      pit# tar -C ${PITDATA} -zxvf ${CSM_PATH}.tar.gz && ls -l ${CSM_PATH}
+       tar -C ${PITDATA} -zxvf ${CSM_PATH}.tar.gz && ls -l ${CSM_PATH}
       ```
 
    1. Copy the artifacts into place.
 
       ```bash
-      pit# rsync -a -P --delete ${CSM_PATH}/images/kubernetes/   ${PITDATA}/data/k8s/ &&
+       rsync -a -P --delete ${CSM_PATH}/images/kubernetes/   ${PITDATA}/data/k8s/ &&
            rsync -a -P --delete ${CSM_PATH}/images/storage-ceph/ ${PITDATA}/data/ceph/
       ```
 
@@ -340,7 +340,7 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
 1. <a name="install-csi-rpm"></a>Install the latest version of CSI tool.
 
    ```bash
-   pit# rpm -Uvh --force $(find ${CSM_PATH}/rpm/ -name "cray-site-init-*.x86_64.rpm" | sort -V | tail -1)
+    rpm -Uvh --force $(find ${CSM_PATH}/rpm/ -name "cray-site-init-*.x86_64.rpm" | sort -V | tail -1)
    ```
 
 1. Install the latest documentation RPM.
@@ -350,7 +350,7 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
 1. Show the version of CSI installed.
 
    ```bash
-   pit# /root/bin/metalid.sh
+    /root/bin/metalid.sh
    ```
 
    Expected output looks similar to the following:
@@ -426,7 +426,7 @@ and [Configuration Payload Files](prepare_configuration_payload.md#configuration
    1. Check for the configuration files. The needed files should be in the preparation directory.
 
       ```bash
-      pit# ls -1 ${PITDATA}/prep
+       ls -1 ${PITDATA}/prep
       ```
 
       Expected output looks similar to the following:
@@ -446,7 +446,7 @@ and [Configuration Payload Files](prepare_configuration_payload.md#configuration
       > cause clock skew as `chrony` tries to continually reach out to a server it can never reach.
 
       ```bash
-      pit# cd ${PITDATA}/prep && csi config init
+       cd ${PITDATA}/prep && csi config init
       ```
 
       A new directory matching the `system-name` field in `system_config.yaml` will now exist in the working directory.
@@ -486,7 +486,7 @@ and [Configuration Payload Files](prepare_configuration_payload.md#configuration
    1. Check for the configuration files. The needed files should be in the preparation directory.
 
       ```bash
-      pit# ls -1 ${PITDATA}/prep
+       ls -1 ${PITDATA}/prep
       ```
 
       Expected output looks similar to the following:
@@ -509,7 +509,7 @@ and [Configuration Payload Files](prepare_configuration_payload.md#configuration
       >   cause clock skew as `chrony` tries to continually reach out to a server it can never reach.
 
       ```bash
-      pit# cd ${PITDATA}/prep && csi config init <options>
+       cd ${PITDATA}/prep && csi config init <options>
       ```
 
       A new directory matching the `--system-name` argument will now exist in the working directory.
@@ -564,7 +564,7 @@ and [Configuration Payload Files](prepare_configuration_payload.md#configuration
       > **`NOTE`** This step is needed only for fresh installs where `system_config.yaml` is missing from the `prep/` directory.
 
       ```bash
-      pit# cd ${PITDATA}/prep && ln ${SYSTEM_NAME}/system_config.yaml
+       cd ${PITDATA}/prep && ln ${SYSTEM_NAME}/system_config.yaml
       ```
 
    1. Continue to the next step to [verify and backup `system_config.yaml`](#verify-csi-versions-match).
@@ -578,13 +578,13 @@ and [Configuration Payload Files](prepare_configuration_payload.md#configuration
    1. View the new `system_config.yaml` file and note the CSI version reported near the end of the file.
 
       ```bash
-      pit# cat ${PITDATA}/prep/${SYSTEM_NAME}/system_config.yaml
+       cat ${PITDATA}/prep/${SYSTEM_NAME}/system_config.yaml
       ```
 
    1. Note the version reported by the `csi` tool.
 
       ```bash
-      pit# csi version
+       csi version
       ```
 
    1. The two versions should match. If they do not, determine the cause and regenerate the file.
@@ -615,15 +615,15 @@ Prepare the `site-init` directory by performing the [Prepare `Site Init`](prepar
    > `read -s` is used in order to prevent the credentials from being displayed on the screen or recorded in the shell history.
 
    ```bash
-   pit# USERNAME=root
-   pit# read -s IPMI_PASSWORD
-   pit# export USERNAME IPMI_PASSWORD ; /root/bin/pit-init.sh
+    USERNAME=root
+    read -s IPMI_PASSWORD
+    export USERNAME IPMI_PASSWORD ; /root/bin/pit-init.sh
    ```
 
 1. Install `csm-testing`.
 
    ```bash
-   pit# rpm -Uvh --force $(find ${CSM_PATH}/rpm/ -name "csm-testing*.rpm" | sort -V | tail -1)
+    rpm -Uvh --force $(find ${CSM_PATH}/rpm/ -name "csm-testing*.rpm" | sort -V | tail -1)
    ```
 
 <a name="next-topic"></a>

--- a/install/bootstrap_livecd_usb.md
+++ b/install/bootstrap_livecd_usb.md
@@ -723,7 +723,7 @@ On first log in (over SSH or at local console), the LiveCD will prompt the admin
    > in the following `mount` command.
 
    ```bash
-   pit# mount -vL PITDATA
+    mount -vL PITDATA
    ```
 
 1. Set and export new environment variables.
@@ -731,9 +731,9 @@ On first log in (over SSH or at local console), the LiveCD will prompt the admin
    The commands below save them to `/etc/environment` as well, which makes them available in all new shell sessions on the PIT node.
 
    ```bash
-   pit# export PITDATA=$(lsblk -o MOUNTPOINT -nr /dev/disk/by-label/PITDATA)
-   pit# export CSM_PATH=${PITDATA}/${CSM_RELEASE}
-   pit# echo "
+    export PITDATA=$(lsblk -o MOUNTPOINT -nr /dev/disk/by-label/PITDATA)
+    export CSM_PATH=${PITDATA}/${CSM_RELEASE}
+    echo "
    PITDATA=${PITDATA}
    CSM_PATH=${CSM_PATH}" | tee -a /etc/environment
    ```
@@ -741,8 +741,8 @@ On first log in (over SSH or at local console), the LiveCD will prompt the admin
 1. Start a typescript to record this section of activities done on `ncn-m001` while booted from the LiveCD.
 
    ```bash
-   pit# script -af "${PITDATA}/prep/admin/booted-csm-livecd.$(date +%Y-%m-%d).txt"
-   pit# export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
+    script -af "${PITDATA}/prep/admin/booted-csm-livecd.$(date +%Y-%m-%d).txt"
+    export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
    ```
 
 1. Verify that expected environment variables are set in the new login shell.
@@ -750,19 +750,19 @@ On first log in (over SSH or at local console), the LiveCD will prompt the admin
    These were written into `/etc/environment` on the USB PIT image earlier in this procedure, before it was booted.
 
    ```bash
-   pit# echo -e "CSM_PATH=${CSM_PATH}\nCSM_RELEASE=${CSM_RELEASE}\nPITDATA=${PITDATA}\nSYSTEM_NAME=${SYSTEM_NAME}"
+    echo -e "CSM_PATH=${CSM_PATH}\nCSM_RELEASE=${CSM_RELEASE}\nPITDATA=${PITDATA}\nSYSTEM_NAME=${SYSTEM_NAME}"
    ```
 
 1. Copy the typescript made on the external system into the `PITDATA` mount.
 
    ```bash
-   pit# cp -v /root/boot.livecd.*.txt ${PITDATA}/prep/admin
+    cp -v /root/boot.livecd.*.txt ${PITDATA}/prep/admin
    ```
 
 1. Check the hostname.
 
    ```bash
-   pit# hostnamectl
+    hostnamectl
    ```
 
    > **Note:**
@@ -783,7 +783,7 @@ On first log in (over SSH or at local console), the LiveCD will prompt the admin
    any bug reports or service queries for issues encountered on the PIT node.
 
    ```bash
-   pit# /root/bin/metalid.sh
+    /root/bin/metalid.sh
    ```
 
    Expected output looks similar to the following:
@@ -816,9 +816,9 @@ On first log in (over SSH or at local console), the LiveCD will prompt the admin
    > `read -s` is used in order to prevent the credentials from being displayed on the screen or recorded in the shell history.
 
    ```bash
-   pit# read -s IPMI_PASSWORD
-   pit# USERNAME=root
-   pit# export IPMI_PASSWORD USERNAME
+    read -s IPMI_PASSWORD
+    USERNAME=root
+    export IPMI_PASSWORD USERNAME
    ```
 
 1. Initialize the PIT.
@@ -826,7 +826,7 @@ On first log in (over SSH or at local console), the LiveCD will prompt the admin
    The `pit-init.sh` script will prepare the PIT server for deploying NCNs.
 
    ```bash
-   pit# /root/bin/pit-init.sh
+    /root/bin/pit-init.sh
    ```
 
 1. Install `csm-testing`.
@@ -834,7 +834,7 @@ On first log in (over SSH or at local console), the LiveCD will prompt the admin
    The following assumes the `CSM_PATH` environment variable is set to the absolute path of the unpacked CSM release.
 
    ```bash
-   pit# rpm -Uvh --force $(find ${CSM_PATH}/rpm/ -name "csm-testing*.rpm" | sort -V | tail -1)
+    rpm -Uvh --force $(find ${CSM_PATH}/rpm/ -name "csm-testing*.rpm" | sort -V | tail -1)
    ```
 
 <a name="next-topic"></a>

--- a/install/ceph_csi_troubleshooting.md
+++ b/install/ceph_csi_troubleshooting.md
@@ -39,7 +39,7 @@ Verify that the ceph-csi requirements are in place.
       These commands can be run from any master node, any worker node, or `ncn-s001`.
 
       ```bash
-      ncn# kubectl get cm
+       kubectl get cm
       NAME               DATA   AGE
       ceph-csi-config    1      3h50m
       cephfs-csi-sc      1      3h50m
@@ -47,7 +47,7 @@ Verify that the ceph-csi requirements are in place.
       sma-csi-sc         1      3h50m
       sts-rados-config   1      4h
 
-      ncn# kubectl get secrets | grep csi
+       kubectl get secrets | grep csi
       csi-cephfs-secret             Opaque                                4      3h51m
       csi-kube-secret               Opaque                                2      3h51m
       csi-sma-secret                Opaque                                2      3h51m

--- a/install/collect_mac_addresses_for_ncns.md
+++ b/install/collect_mac_addresses_for_ncns.md
@@ -30,7 +30,7 @@ The previous step updated `ncn_metadata.csv` with the BMC MAC addresses, so seve
 1. Change into the preparation directory.
 
    ```bash
-   pit# cd /var/www/ephemeral/prep
+    cd /var/www/ephemeral/prep
    ```
 
 1. Confirm that the `ncn_metadata.csv` file in this directory has the new information.
@@ -38,7 +38,7 @@ The previous step updated `ncn_metadata.csv` with the BMC MAC addresses, so seve
    be present for the `Bootstrap MAC`, `Bond0 MAC0`, and `Bond0 MAC1` columns.
 
    ```bash
-   pit# cat ncn_metadata.csv
+    cat ncn_metadata.csv
    ```
 
 1. Rename the incorrectly generated configurations.
@@ -49,20 +49,20 @@ The previous step updated `ncn_metadata.csv` with the BMC MAC addresses, so seve
    > **Warning:** Ensure that the `SYSTEM_NAME` environment variable is correctly set.
 
    ```bash
-   pit# export SYSTEM_NAME=eniac
-   pit# echo $SYSTEM_NAME
+    export SYSTEM_NAME=eniac
+    echo $SYSTEM_NAME
    ```
 
    Rename the old directory.
 
    ```bash
-   pit# mv /var/www/ephemeral/prep/${SYSTEM_NAME} /var/www/ephemeral/prep/${SYSTEM_NAME}.oldBMC
+    mv /var/www/ephemeral/prep/${SYSTEM_NAME} /var/www/ephemeral/prep/${SYSTEM_NAME}.oldBMC
    ```
 
 1. Copy over the `system_config.yaml` file from the first attempt at generating the system configuration files.
 
    ```bash
-   pit# cp /var/www/ephemeral/prep/${SYSTEM_NAME}.oldBMC/system_config.yaml /var/www/ephemeral/prep/
+    cp /var/www/ephemeral/prep/${SYSTEM_NAME}.oldBMC/system_config.yaml /var/www/ephemeral/prep/
    ```
 
 1. Generate system configuration again.
@@ -70,7 +70,7 @@ The previous step updated `ncn_metadata.csv` with the BMC MAC addresses, so seve
    The needed files should be in the current directory.
 
    ```bash
-   pit# ls -1
+    ls -1
    ```
 
    Expected output looks similar to the following:
@@ -88,7 +88,7 @@ The previous step updated `ncn_metadata.csv` with the BMC MAC addresses, so seve
    from the command line arguments which were used initially for this command.
 
    ```bash
-   pit# csi config init
+    csi config init
    ```
 
    A new directory matching your `--system-name` argument will now exist in your working directory.
@@ -120,7 +120,7 @@ The previous step updated `ncn_metadata.csv` with the BMC MAC addresses, so seve
 1. Copy the interface configuration files generated earlier by `csi config init` into `/etc/sysconfig/network/`.
 
    ```bash
-   pit# cp -pv /var/www/ephemeral/prep/${SYSTEM_NAME}/pit-files/* /etc/sysconfig/network/ &&
+    cp -pv /var/www/ephemeral/prep/${SYSTEM_NAME}/pit-files/* /etc/sysconfig/network/ &&
         wicked ifreload all && systemctl restart wickedd-nanny && sleep 5
    ```
 
@@ -129,7 +129,7 @@ The previous step updated `ncn_metadata.csv` with the BMC MAC addresses, so seve
     > **Note:** The `bond0.can0` interface is optional in CSM 1.2+
 
     ```bash
-    pit# wicked show bond0 bond0.nmn0 bond0.hmn0 bond0.can0
+     wicked show bond0 bond0.nmn0 bond0.hmn0 bond0.can0
     ```
 
     Example output:
@@ -171,7 +171,7 @@ The previous step updated `ncn_metadata.csv` with the BMC MAC addresses, so seve
     1. Copy files (files only, `-r` is expressly not used).
 
         ```bash
-        pit# cp -pv /var/www/ephemeral/prep/${SYSTEM_NAME}/dnsmasq.d/* /etc/dnsmasq.d/ &&
+         cp -pv /var/www/ephemeral/prep/${SYSTEM_NAME}/dnsmasq.d/* /etc/dnsmasq.d/ &&
              cp -pv /var/www/ephemeral/prep/${SYSTEM_NAME}/conman.conf /etc/conman.conf &&
              cp -pv /var/www/ephemeral/prep/${SYSTEM_NAME}/basecamp/* /var/www/ephemeral/configs/
         ```
@@ -179,7 +179,7 @@ The previous step updated `ncn_metadata.csv` with the BMC MAC addresses, so seve
     1. Restart all PIT services.
 
         ```bash
-        pit# systemctl restart basecamp nexus dnsmasq conman
+         systemctl restart basecamp nexus dnsmasq conman
         ```
 
 1. Verify that all BMCs can be pinged.
@@ -190,8 +190,8 @@ The previous step updated `ncn_metadata.csv` with the BMC MAC addresses, so seve
    not be booted by itself as the PIT node.
 
    ```bash
-   pit# export mtoken='ncn-m(?!001)\w+-mgmt' ; export stoken='ncn-s\w+-mgmt' ; export wtoken='ncn-w\w+-mgmt'
-   pit# grep -oP "($mtoken|$stoken|$wtoken)" /etc/dnsmasq.d/statics.conf | sort -u | xargs -t -i ping -c3 {}
+    export mtoken='ncn-m(?!001)\w+-mgmt' ; export stoken='ncn-s\w+-mgmt' ; export wtoken='ncn-w\w+-mgmt'
+    grep -oP "($mtoken|$stoken|$wtoken)" /etc/dnsmasq.d/statics.conf | sort -u | xargs -t -i ping -c3 {}
    ```
 
 <a name="collect_the_ncn_mac_addresses"></a>
@@ -214,7 +214,7 @@ so several earlier steps need to be repeated.
 1. Change into the preparation directory.
 
    ```bash
-   pit# cd /var/www/ephemeral/prep
+    cd /var/www/ephemeral/prep
    ```
 
 1. Confirm that the `ncn_metadata.csv` file in this directory has the new information.
@@ -222,7 +222,7 @@ so several earlier steps need to be repeated.
    Every row should have uniquely different MAC addresses from the other rows.
 
    ```bash
-   pit# grep "de:ad:be:ef:00:00" ncn_metadata.csv
+    grep "de:ad:be:ef:00:00" ncn_metadata.csv
    ```
 
    Expected output looks similar to the following, that is, no lines that still have `"de:ad:be:ef:00:00"`:
@@ -234,7 +234,7 @@ so several earlier steps need to be repeated.
    Display the file and confirm the contents are unique between the different rows.
 
    ```bash
-   pit# cat ncn_metadata.csv
+    cat ncn_metadata.csv
    ```
 
 1. Remove the incorrectly generated configurations. Before deleting the incorrectly generated configurations, consider
@@ -243,20 +243,20 @@ making a backup of them, in case they need to be examined at a later time.
    > **`WARNING`** Ensure that the `SYSTEM_NAME` environment variable is correctly set.
 
    ```bash
-   pit# export SYSTEM_NAME=eniac
-   pit# echo $SYSTEM_NAME
+    export SYSTEM_NAME=eniac
+    echo $SYSTEM_NAME
    ```
 
    Rename the old directory.
 
    ```bash
-   pit# mv /var/www/ephemeral/prep/${SYSTEM_NAME} /var/www/ephemeral/prep/${SYSTEM_NAME}.oldNCN
+    mv /var/www/ephemeral/prep/${SYSTEM_NAME} /var/www/ephemeral/prep/${SYSTEM_NAME}.oldNCN
    ```
 
 1. Copy over the `system_config.yaml` file from the second attempt at generating the system configuration files.
 
    ```bash
-   pit# cp /var/www/ephemeral/prep/${SYSTEM_NAME}.oldNCN/system_config.yaml /var/www/ephemeral/prep/
+    cp /var/www/ephemeral/prep/${SYSTEM_NAME}.oldNCN/system_config.yaml /var/www/ephemeral/prep/
    ```
 
 1. Generate system configuration again.
@@ -264,7 +264,7 @@ making a backup of them, in case they need to be examined at a later time.
    Check for the expected files that should exist be in the current directory.
 
    ```bash
-   pit# ls -1
+    ls -1
    ```
 
    Expected output looks similar to the following:
@@ -281,7 +281,7 @@ making a backup of them, in case they need to be examined at a later time.
    Regenerate the system configuration. The `system_config.yaml` file contains all of the options that were used to generate the initial system configuration, and can be used in place of specifying CLI flags to CSI.
 
    ```bash
-   pit# csi config init
+    csi config init
    ```
 
    A new directory matching your `$SYSTEM_NAME` environment variable will now exist in your working directory.
@@ -313,7 +313,7 @@ making a backup of them, in case they need to be examined at a later time.
 1. Copy the interface configuration files generated earlier by `csi config init` into `/etc/sysconfig/network/`.
 
    ```bash
-   pit# cp -pv /var/www/ephemeral/prep/${SYSTEM_NAME}/pit-files/* /etc/sysconfig/network/ &&
+    cp -pv /var/www/ephemeral/prep/${SYSTEM_NAME}/pit-files/* /etc/sysconfig/network/ &&
         wicked ifreload all && systemctl restart wickedd-nanny && sleep 5
    ```
 
@@ -322,7 +322,7 @@ making a backup of them, in case they need to be examined at a later time.
     > **Note:** The `bond0.can0` interface is optional in CSM 1.2+
 
     ```bash
-    pit# wicked show bond0 bond0.nmn0 bond0.hmn0 bond0.can0
+     wicked show bond0 bond0.nmn0 bond0.hmn0 bond0.can0
     ```
 
     Example output:
@@ -364,15 +364,15 @@ making a backup of them, in case they need to be examined at a later time.
     1. Copy files (files only, `-r` is expressly not used).
 
         ```bash
-        pit# cp -pv /var/www/ephemeral/prep/${SYSTEM_NAME}/dnsmasq.d/* /etc/dnsmasq.d/
-        pit# cp -pv /var/www/ephemeral/prep/${SYSTEM_NAME}/conman.conf /etc/conman.conf
-        pit# cp -pv /var/www/ephemeral/prep/${SYSTEM_NAME}/basecamp/* /var/www/ephemeral/configs/
+         cp -pv /var/www/ephemeral/prep/${SYSTEM_NAME}/dnsmasq.d/* /etc/dnsmasq.d/
+         cp -pv /var/www/ephemeral/prep/${SYSTEM_NAME}/conman.conf /etc/conman.conf
+         cp -pv /var/www/ephemeral/prep/${SYSTEM_NAME}/basecamp/* /var/www/ephemeral/configs/
         ```
 
     1. Update CA Cert on the copied `data.json` file for Basecamp with the generated certificate in `site-init`:
 
         ```bash
-        pit# csi patch ca \
+         csi patch ca \
         --cloud-init-seed-file /var/www/ephemeral/configs/data.json \
         --customizations-file /var/www/ephemeral/prep/site-init/customizations.yaml \
         --sealed-secret-key-file /var/www/ephemeral/prep/site-init/certs/sealed_secrets.key
@@ -381,7 +381,7 @@ making a backup of them, in case they need to be examined at a later time.
     1. Restart all PIT services.
 
         ```bash
-        pit# systemctl restart basecamp nexus dnsmasq conman
+         systemctl restart basecamp nexus dnsmasq conman
         ```
 
 1. Ensure system-specific settings generated by CSI are merged into `customizations.yaml`.
@@ -389,8 +389,8 @@ making a backup of them, in case they need to be examined at a later time.
     > The `yq` tool used in the following procedures is available under `/var/www/ephemeral/prep/site-init/utils/bin` once the `SHASTA-CFG` repository has been cloned.
 
     ```bash
-    pit# alias yq="/var/www/ephemeral/prep/site-init/utils/bin/$(uname | awk '{print tolower($0)}')/yq"
-    pit# yq merge -xP -i /var/www/ephemeral/prep/site-init/customizations.yaml <(yq prefix -P "/var/www/ephemeral/prep/${SYSTEM_NAME}/customizations.yaml" spec)
+     alias yq="/var/www/ephemeral/prep/site-init/utils/bin/$(uname | awk '{print tolower($0)}')/yq"
+     yq merge -xP -i /var/www/ephemeral/prep/site-init/customizations.yaml <(yq prefix -P "/var/www/ephemeral/prep/${SYSTEM_NAME}/customizations.yaml" spec)
     ```
 
 ## Next topic

--- a/install/collecting_bmc_mac_addresses.md
+++ b/install/collecting_bmc_mac_addresses.md
@@ -21,19 +21,19 @@ Results may vary if an unconfigured switch is being used.
         * over `METAL MANAGEMENT`
 
             ```bash
-            pit# ssh admin@10.1.0.4
+             ssh admin@10.1.0.4
             ```
 
         * over `NODE MANAGEMENT`
 
             ```bash
-            pit# ssh admin@10.252.0.4
+             ssh admin@10.252.0.4
             ```
 
         * SSH over `HARDWARE MANAGEMENT`
 
             ```bash
-            pit# ssh admin@10.254.0.4
+             ssh admin@10.254.0.4
             ```
 
     * Serial
@@ -199,13 +199,13 @@ Results may vary if an unconfigured switch is being used.
    * For HPE and Gigabyte nodes:
 
      ```bash
-     pit# ipmitool lan print 1 | grep "MAC Address"
+      ipmitool lan print 1 | grep "MAC Address"
      ```
 
    * For Intel nodes:
 
      ```bash
-     pit# ipmitool lan print 3 | grep "MAC Address"
+      ipmitool lan print 3 | grep "MAC Address"
      ```
 
    Example output:

--- a/install/collecting_ncn_mac_addresses.md
+++ b/install/collecting_ncn_mac_addresses.md
@@ -52,7 +52,7 @@ For help with either of those, see [LiveCD Setup](bootstrap_livecd_remote_iso.md
     > nodes may still disk boot.
 
     ```bash
-    pit# mv /var/www/boot/script.ipxe /var/www/boot/script.ipxe.bak
+     mv /var/www/boot/script.ipxe /var/www/boot/script.ipxe.bak
     ```
 
 1. Verify that consoles are active with `conman -q`.
@@ -60,7 +60,7 @@ For help with either of those, see [LiveCD Setup](bootstrap_livecd_remote_iso.md
     The following command lists all nodes that ConMan is configured to monitor.
 
     ```bash
-    pit# conman -q
+     conman -q
     ncn-m002-mgmt
     ncn-m003-mgmt
     ncn-s001-mgmt
@@ -76,7 +76,7 @@ For help with either of those, see [LiveCD Setup](bootstrap_livecd_remote_iso.md
     1. Record the username for the NCN BMCs.
 
         ```bash
-        pit# USERNAME=root
+         USERNAME=root
         ```
 
     1. Record the password for this user.
@@ -84,18 +84,18 @@ For help with either of those, see [LiveCD Setup](bootstrap_livecd_remote_iso.md
         > `read -s` is used in order to prevent the credentials from being displayed on the screen or recorded in the shell history.
 
         ```bash
-        pit# read -r -s -p "NCN BMC ${USERNAME} password: " IPMI_PASSWORD
+         read -r -s -p "NCN BMC ${USERNAME} password: " IPMI_PASSWORD
         ```
 
     1. Set the nodes to PXE boot and restart them.
 
         ```bash
-        pit# export IPMI_PASSWORD
-        pit# grep -oP "(${mtoken}|${stoken}|${wtoken})" /etc/dnsmasq.d/statics.conf | sort -u | xargs -t -i ipmitool -I lanplus -U "${USERNAME}" -E -H {} chassis bootdev pxe options=persistent
-        pit# grep -oP "(${mtoken}|${stoken}|${wtoken})" /etc/dnsmasq.d/statics.conf | sort -u | xargs -t -i ipmitool -I lanplus -U "${USERNAME}" -E -H {} chassis bootdev pxe options=efiboot
-        pit# grep -oP "(${mtoken}|${stoken}|${wtoken})" /etc/dnsmasq.d/statics.conf | sort -u | xargs -t -i ipmitool -I lanplus -U "${USERNAME}" -E -H {} power off
-        pit# sleep 10
-        pit# grep -oP "(${mtoken}|${stoken}|${wtoken})" /etc/dnsmasq.d/statics.conf | sort -u | xargs -t -i ipmitool -I lanplus -U "${USERNAME}" -E -H {} power on
+         export IPMI_PASSWORD
+         grep -oP "(${mtoken}|${stoken}|${wtoken})" /etc/dnsmasq.d/statics.conf | sort -u | xargs -t -i ipmitool -I lanplus -U "${USERNAME}" -E -H {} chassis bootdev pxe options=persistent
+         grep -oP "(${mtoken}|${stoken}|${wtoken})" /etc/dnsmasq.d/statics.conf | sort -u | xargs -t -i ipmitool -I lanplus -U "${USERNAME}" -E -H {} chassis bootdev pxe options=efiboot
+         grep -oP "(${mtoken}|${stoken}|${wtoken})" /etc/dnsmasq.d/statics.conf | sort -u | xargs -t -i ipmitool -I lanplus -U "${USERNAME}" -E -H {} power off
+         sleep 10
+         grep -oP "(${mtoken}|${stoken}|${wtoken})" /etc/dnsmasq.d/statics.conf | sort -u | xargs -t -i ipmitool -I lanplus -U "${USERNAME}" -E -H {} power on
         ```
 
 1. Wait for the nodes to network boot.
@@ -105,7 +105,7 @@ For help with either of those, see [LiveCD Setup](bootstrap_livecd_remote_iso.md
     speed depends on how quickly the nodes POST. To see a ConMan help screen for all supported escape sequences, use `&?`.
 
     ```bash
-    pit# conman -m ncn-m002-mgmt
+     conman -m ncn-m002-mgmt
     ```
 
 1. Exit ConMan.
@@ -117,7 +117,7 @@ For help with either of those, see [LiveCD Setup](bootstrap_livecd_remote_iso.md
     This snippet will omit duplicates from multiple boot attempts:
 
     ```bash
-    pit# for file in /var/log/conman/*; do
+     for file in /var/log/conman/*; do
             echo ${file}
             grep -Eoh '(net[0-9] MAC .*)' "${file}" | sort -u | grep PCI && echo -----
          done
@@ -135,9 +135,9 @@ For help with either of those, see [LiveCD Setup](bootstrap_livecd_remote_iso.md
     Worker nodes also have the high-speed network cards. If these cards are known, filter their device IDs out from the above output using this snippet:
 
     ```bash
-    pit# unset did # clear it if set
-    pit# did=1017 # ConnectX-5 example.
-    pit# for file in /var/log/conman/*; do
+     unset did # clear it if set
+     did=1017 # ConnectX-5 example.
+     for file in /var/log/conman/*; do
              echo ${file}
              grep -Eoh '(net[0-9] MAC .*)' "${file}" | sort -u | grep PCI | grep -Ev "${did}" && echo -----
          done
@@ -148,9 +148,9 @@ For help with either of those, see [LiveCD Setup](bootstrap_livecd_remote_iso.md
     **This snippet prints out only `mgmt` MAC addresses; the `did` is the HSN and onboard NICs that are being ignored.**
 
     ```bash
-    pit# unset did # clear it if set
-    pit# did='(1017|8086|ffff)'
-    pit# for file in /var/log/conman/*; do
+     unset did # clear it if set
+     did='(1017|8086|ffff)'
+     for file in /var/log/conman/*; do
             echo ${file}
             grep -Eoh '(net[0-9] MAC .*)' "${file}" | sort -u | grep PCI | grep -Ev "${did}" && echo -----
          done
@@ -191,7 +191,7 @@ For help with either of those, see [LiveCD Setup](bootstrap_livecd_remote_iso.md
     This information will be used to populate the MAC addresses for `ncn-m001`.
 
     ```bash
-    pit# grep -i perm /proc/net/bonding/bond0
+     grep -i perm /proc/net/bonding/bond0
     ```
 
     For example:
@@ -222,13 +222,13 @@ For help with either of those, see [LiveCD Setup](bootstrap_livecd_remote_iso.md
 1. Power off the NCNs.
 
     ```bash
-    pit# grep -oP "($mtoken|$stoken|$wtoken)" /etc/dnsmasq.d/statics.conf | sort -u | xargs -t -i ipmitool -I lanplus -U $USERNAME -E -H {} power off
+     grep -oP "($mtoken|$stoken|$wtoken)" /etc/dnsmasq.d/statics.conf | sort -u | xargs -t -i ipmitool -I lanplus -U $USERNAME -E -H {} power off
     ```
 
 1. If the `script.ipxe` file was renamed in the first step of this procedure, then restore it to its original location.
 
     ```bash
-    pit# mv /var/www/boot/script.ipxe.bak /var/www/boot/script.ipxe
+     mv /var/www/boot/script.ipxe.bak /var/www/boot/script.ipxe
     ```
 
 ## Procedure: Serial consoles
@@ -258,11 +258,11 @@ If the  `ncn_metadata.csv` file is incorrect, the NCNs will be unable to deploy.
     > not set, then the command below could potentially remove the entire `prep` directory.
     >
     > ```bash
-    > pit# export SYSTEM_NAME=eniac
+    >  export SYSTEM_NAME=eniac
     > ```
 
     ```bash
-    pit# rm -rvf /var/www/ephemeral/prep/$SYSTEM_NAME
+     rm -rvf /var/www/ephemeral/prep/$SYSTEM_NAME
     ```
 
 1. Manually edit `ncn_metadata.csv`, replacing the bootstrap MAC address with `Bond0 MAC0` address for the afflicted nodes that failed to boot.
@@ -272,7 +272,7 @@ If the  `ncn_metadata.csv` file is incorrect, the NCNs will be unable to deploy.
 1. Copy all of the newly generated files into place.
 
     ```bash
-    pit# cp -pv /var/www/ephemeral/prep/$SYSTEM_NAME/dnsmasq.d/* /etc/dnsmasq.d/ &&
+     cp -pv /var/www/ephemeral/prep/$SYSTEM_NAME/dnsmasq.d/* /etc/dnsmasq.d/ &&
          cp -pv /var/www/ephemeral/prep/$SYSTEM_NAME/basecamp/* /var/www/ephemeral/configs/ &&
          cp -pv /var/www/ephemeral/prep/$SYSTEM_NAME/conman.conf /etc/ &&
          cp -pv /var/www/ephemeral/prep/$SYSTEM_NAME/pit-files/* /etc/sysconfig/network/
@@ -281,7 +281,7 @@ If the  `ncn_metadata.csv` file is incorrect, the NCNs will be unable to deploy.
 1. Update the CA certificates on the copied `data.json` file. Provide the path to the `data.json` file, the path to the `customizations.yaml` file, and the `sealed_secrets.key` file.
 
     ```bash
-    pit# csi patch ca \
+     csi patch ca \
             --cloud-init-seed-file /var/www/ephemeral/configs/data.json \
             --customizations-file /var/www/ephemeral/prep/site-init/customizations.yaml \
             --sealed-secret-key-file /var/www/ephemeral/prep/site-init/certs/sealed_secrets.key
@@ -290,7 +290,7 @@ If the  `ncn_metadata.csv` file is incorrect, the NCNs will be unable to deploy.
 1. Restart everything to apply the new configurations:
 
     ```bash
-    pit# wicked ifreload all &&
+     wicked ifreload all &&
          systemctl restart dnsmasq conman basecamp &&
          systemctl restart nexus
     ```
@@ -300,8 +300,8 @@ If the  `ncn_metadata.csv` file is incorrect, the NCNs will be unable to deploy.
     > The `yq` tool used in the following procedures is available under `/var/www/ephemeral/prep/site-init/utils/bin` once the `SHASTA-CFG` repo has been cloned.
 
     ```bash
-    pit# alias yq="/var/www/ephemeral/prep/site-init/utils/bin/$(uname | awk '{print tolower($0)}')/yq"
-    pit# yq merge -xP -i /var/www/ephemeral/prep/site-init/customizations.yaml <(yq prefix -P "/var/www/ephemeral/prep/${SYSTEM_NAME}/customizations.yaml" spec)
+     alias yq="/var/www/ephemeral/prep/site-init/utils/bin/$(uname | awk '{print tolower($0)}')/yq"
+     yq merge -xP -i /var/www/ephemeral/prep/site-init/customizations.yaml <(yq prefix -P "/var/www/ephemeral/prep/${SYSTEM_NAME}/customizations.yaml" spec)
     ```
 
 1. Wipe the disks before relaunching the NCNs.

--- a/install/configure_administrative_access.md
+++ b/install/configure_administrative_access.md
@@ -75,7 +75,7 @@ completely restarted.
 Run the `lock_management_nodes.py` script to lock all management nodes and their BMCs that are not already locked:
 
 ```bash
-ncn# /opt/cray/csm/scripts/admin_access/lock_management_nodes.py
+ /opt/cray/csm/scripts/admin_access/lock_management_nodes.py
 ```
 
 The return value of the script is 0 if locking was successful. Otherwise, a non-zero return means that manual intervention may be needed to lock the nodes and their BMCs.

--- a/install/csm_installation_failure.md
+++ b/install/csm_installation_failure.md
@@ -34,7 +34,7 @@ and the appropriate remediation steps to take if it is encountered.
     Look for a `keycloak-setup` pod still in the `Running` state:
 
     ```bash
-    pit# kubectl get pods -n services | grep keycloak-setup
+     kubectl get pods -n services | grep keycloak-setup
     ```
 
     Example output:

--- a/install/deploy_final_ncn.md
+++ b/install/deploy_final_ncn.md
@@ -60,16 +60,16 @@ The steps in this section load hand-off data before a later procedure reboots th
     1. Exit the current typescript, if one is active.
 
         ```bash
-        pit# exit
+         exit
         ```
 
     1. Start a new typescript on the PIT node.
 
         ```bash
-        pit# mkdir -pv /var/www/ephemeral/prep/admin &&
+         mkdir -pv /var/www/ephemeral/prep/admin &&
              pushd /var/www/ephemeral/prep/admin &&
              script -af csm-livecd-reboot.$(date +%Y-%m-%d).txt
-        pit# export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
+         export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
         ```
 
 1. Upload SLS file.
@@ -77,7 +77,7 @@ The steps in this section load hand-off data before a later procedure reboots th
     > **NOTE:** The environment variable `SYSTEM_NAME` must be set.
 
     ```bash
-    pit# csi upload-sls-file --sls-file /var/www/ephemeral/prep/${SYSTEM_NAME}/sls_input_file.json
+     csi upload-sls-file --sls-file /var/www/ephemeral/prep/${SYSTEM_NAME}/sls_input_file.json
     ```
 
     Expected output looks similar to the following:
@@ -93,7 +93,7 @@ The steps in this section load hand-off data before a later procedure reboots th
     > **NOTE:** `api-gw-service-nmn.local` is legacy, and will be replaced with `api-gw-service.nmn`.
 
     ```bash
-    pit# export TOKEN=$(curl -k -s -S -d grant_type=client_credentials \
+     export TOKEN=$(curl -k -s -S -d grant_type=client_credentials \
             -d client_id=admin-client \
             -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
             https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
@@ -105,7 +105,7 @@ The steps in this section load hand-off data before a later procedure reboots th
     `CSM_PATH` should be the fully-qualified path to the expanded CSM release tarball on the PIT node.
 
     ```bash
-    pit# echo "CSM_RELEASE=${CSM_RELEASE} CSM_PATH=${CSM_PATH}"
+     echo "CSM_RELEASE=${CSM_RELEASE} CSM_PATH=${CSM_PATH}"
     ```
 
 1. <a name="ncn-boot-artifacts-hand-off"></a>Upload NCN boot artifacts into S3.
@@ -113,7 +113,7 @@ The steps in this section load hand-off data before a later procedure reboots th
     1. Run the following command.
 
         ```bash
-        pit# artdir=/var/www/ephemeral/data && 
+         artdir=/var/www/ephemeral/data && 
              k8sdir=$artdir/k8s &&
              cephdir=$artdir/ceph &&
              csi handoff ncn-images \
@@ -143,19 +143,19 @@ The steps in this section load hand-off data before a later procedure reboots th
     > This step will prompt for the root password of the NCNs.
 
     ```bash
-    pit# csi handoff bss-metadata --data-file /var/www/ephemeral/configs/data.json || echo "ERROR: csi handoff bss-metadata failed"
+     csi handoff bss-metadata --data-file /var/www/ephemeral/configs/data.json || echo "ERROR: csi handoff bss-metadata failed"
     ```
 
 1. Patch the metadata for the Ceph nodes to have the correct run commands.
 
     ```bash
-    pit# python3 /usr/share/doc/csm/scripts/patch-ceph-runcmd.py
+     python3 /usr/share/doc/csm/scripts/patch-ceph-runcmd.py
     ```
 
 1. Ensure that the DNS server value is correctly set to point toward Unbound at `10.92.100.225` (NMN) and `10.94.100.225` (HMN).
 
     ```bash
-    pit# csi handoff bss-update-cloud-init --set meta-data.dns-server="10.92.100.225 10.94.100.225" --limit Global
+     csi handoff bss-update-cloud-init --set meta-data.dns-server="10.92.100.225 10.94.100.225" --limit Global
     ```
 
 1. Preserve logs and configuration files if desired (optional).
@@ -166,7 +166,7 @@ The steps in this section load hand-off data before a later procedure reboots th
     The following commands create a `tar` archive of these files, storing it in a directory that will be backed up in the next step.
 
     ```bash
-    pit# mkdir -pv /var/www/ephemeral/prep/logs &&
+     mkdir -pv /var/www/ephemeral/prep/logs &&
          ls -d \
                     /etc/dnsmasq.d \
                     /etc/os-release \
@@ -197,7 +197,7 @@ The steps in this section load hand-off data before a later procedure reboots th
         > The `ssh` commands below may prompt for the NCN root password.
 
         ```bash
-        pit# ssh ncn-m002 cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys &&
+         ssh ncn-m002 cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys &&
              ssh ncn-m003 cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys &&
              chmod 600 /root/.ssh/authorized_keys
         ```
@@ -205,7 +205,7 @@ The steps in this section load hand-off data before a later procedure reboots th
     1. Back up files from the PIT to `ncn-m002`.
 
         ```bash
-        pit# ssh ncn-m002 \
+         ssh ncn-m002 \
             "mkdir -pv /metal/bootstrap
             rsync -e 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' -rltD -P --delete pit.nmn:/var/www/ephemeral/prep /metal/bootstrap/
             rsync -e 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' -rltD -P --delete pit.nmn:${CSM_PATH}/cray-pre-install-toolkit*.iso /metal/bootstrap/"
@@ -214,7 +214,7 @@ The steps in this section load hand-off data before a later procedure reboots th
     1. Back up files from the PIT to `ncn-m003`.
 
         ```bash
-        pit# ssh ncn-m003 \
+         ssh ncn-m003 \
             "mkdir -pv /metal/bootstrap
             rsync -e 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' -rltD -P --delete pit.nmn:/var/www/ephemeral/prep /metal/bootstrap/
             rsync -e 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' -rltD -P --delete pit.nmn:${CSM_PATH}/cray-pre-install-toolkit*.iso /metal/bootstrap/"
@@ -225,7 +225,7 @@ The steps in this section load hand-off data before a later procedure reboots th
     1. List IPv4 boot options using `efibootmgr`.
 
         ```bash
-        pit# efibootmgr | grep -Ei "ip(v4|4)"
+         efibootmgr | grep -Ei "ip(v4|4)"
         ```
 
     1. Set and trim the boot order on the PIT node.
@@ -239,7 +239,7 @@ The steps in this section load hand-off data before a later procedure reboots th
         Use `efibootmgr` to set the next boot device to the first PXE boot option. This step assumes the boot order was set up in the previous step.
 
         ```bash
-        pit# efibootmgr -n $(efibootmgr | grep -Ei "ip(v4|4)" | awk '{print $1}' | head -n 1 | tr -d Boot*) | grep -i bootnext
+         efibootmgr -n $(efibootmgr | grep -Ei "ip(v4|4)" | awk '{print $1}' | head -n 1 | tr -d Boot*) | grep -i bootnext
         BootNext: 0014
         ```
 
@@ -248,7 +248,7 @@ The steps in this section load hand-off data before a later procedure reboots th
     1. Get the IP address.
 
         ```bash
-        pit# ssh ncn-m002 'ip a show bond0.cmn0 | grep inet'
+         ssh ncn-m002 'ip a show bond0.cmn0 | grep inet'
         ```
 
         Expected output will look similar to the following (exact values may differ):
@@ -281,13 +281,13 @@ The steps in this section load hand-off data before a later procedure reboots th
     1. Select disks to wipe (SATA/NVME/SAS).
 
         ```bash
-        pit# md_disks="$(lsblk -l -o SIZE,NAME,TYPE,TRAN | grep -E '(sata|nvme|sas)' | sort -h | awk '{print "/dev/" $2}')"
+         md_disks="$(lsblk -l -o SIZE,NAME,TYPE,TRAN | grep -E '(sata|nvme|sas)' | sort -h | awk '{print "/dev/" $2}')"
         ```
 
     1. Run a sanity check by printing disks into typescript or console.
 
         ```bash
-        pit# echo $md_disks
+         echo $md_disks
         ```
 
         Expected output looks similar to the following:
@@ -299,7 +299,7 @@ The steps in this section load hand-off data before a later procedure reboots th
     1. Wipe. **This is irreversible.**
 
         ```bash
-        pit# wipefs --all --force $md_disks
+         wipefs --all --force $md_disks
         ```
 
         If any disks had labels present, output looks similar to the following:
@@ -322,7 +322,7 @@ The steps in this section load hand-off data before a later procedure reboots th
     1. Stop the typescript session:
 
         ```bash
-        pit# exit
+         exit
         ```
 
     1. Back up the completed typescript file by re-running the `rsync` commands in the [Backup Bootstrap Information](#backup-bootstrap-information) section.
@@ -346,7 +346,7 @@ The steps in this section load hand-off data before a later procedure reboots th
 1. Reboot the LiveCD.
 
     ```bash
-    pit# reboot
+     reboot
     ```
 
 1. Wait for the node to boot, acquire its hostname (`ncn-m001`), and run `cloud-init`.

--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -56,8 +56,8 @@ Preparation of the environment must be done before attempting to deploy the mana
       > `read -s` is used to prevent the password from being written to the screen or the shell history.
 
       ```bash
-      pit# read -s IPMI_PASSWORD
-      pit# export IPMI_PASSWORD
+       read -s IPMI_PASSWORD
+       export IPMI_PASSWORD
       ```
 
    1. Set the remaining helper variables.
@@ -65,7 +65,7 @@ Preparation of the environment must be done before attempting to deploy the mana
       > These values do not need to be altered from what is shown.
 
       ```bash
-      pit# mtoken='ncn-m(?!001)\w+-mgmt' ; stoken='ncn-s\w+-mgmt' ; wtoken='ncn-w\w+-mgmt' ; export USERNAME=root
+       mtoken='ncn-m(?!001)\w+-mgmt' ; stoken='ncn-s\w+-mgmt' ; wtoken='ncn-w\w+-mgmt' ; export USERNAME=root
       ```
 
    Throughout the guide, simple one-liners can be used to query status of expected nodes. If the shell or environment is terminated, these
@@ -76,14 +76,14 @@ Preparation of the environment must be done before attempting to deploy the mana
    * Check power status of all NCNs.
 
       ```bash
-      pit# grep -oP "($mtoken|$stoken|$wtoken)" /etc/dnsmasq.d/statics.conf | sort -u |
+       grep -oP "($mtoken|$stoken|$wtoken)" /etc/dnsmasq.d/statics.conf | sort -u |
               xargs -t -i ipmitool -I lanplus -U $USERNAME -E -H {} power status
       ```
 
    * Power off all NCNs.
 
       ```bash
-      pit# grep -oP "($mtoken|$stoken|$wtoken)" /etc/dnsmasq.d/statics.conf | sort -u |
+       grep -oP "($mtoken|$stoken|$wtoken)" /etc/dnsmasq.d/statics.conf | sort -u |
               xargs -t -i ipmitool -I lanplus -U $USERNAME -E -H {} power off
       ```
 
@@ -104,19 +104,19 @@ proceed to step 2.
    Check the time on the PIT node to see whether it matches the current time:
 
    ```bash
-   pit# date "+%Y-%m-%d %H:%M:%S.%6N%z"
+    date "+%Y-%m-%d %H:%M:%S.%6N%z"
    ```
 
    If the time is inaccurate, set the time manually.
 
    ```bash
-   pit# timedatectl set-time "2019-11-15 00:00:00"
+    timedatectl set-time "2019-11-15 00:00:00"
    ```
 
    Run the NTP script:
 
    ```bash
-   pit# /root/bin/configure-ntp.sh
+    /root/bin/configure-ntp.sh
    ```
 
    This ensures that the PIT is configured with an accurate date/time, which will be propagated to the NCNs during boot.
@@ -124,7 +124,7 @@ proceed to step 2.
    If the error `Failed to set time: NTP unit is active` is observed, then stop `chrony` first.
 
    ```bash
-   pit# systemctl stop chronyd
+    systemctl stop chronyd
    ```
 
    Then run the commands above to complete the process.
@@ -143,19 +143,19 @@ proceed to step 2.
       **Important:** Be sure to change the below example to the appropriate NCN.
 
       ```console
-      pit# bmc=ncn-w001-mgmt
+       bmc=ncn-w001-mgmt
       ```
 
    1. Start an IPMI console session to the NCN.
 
       ```console
-      pit# conman -j $bmc
+       conman -j $bmc
       ```
 
    1. Using another terminal to watch the console, boot the node to BIOS.
 
       ```console
-      pit# ipmitool -I lanplus -U $USERNAME -E -H $bmc chassis bootdev bios &&
+       ipmitool -I lanplus -U $USERNAME -E -H $bmc chassis bootdev bios &&
            ipmitool -I lanplus -U $USERNAME -E -H $bmc chassis power off && sleep 10 &&
            ipmitool -I lanplus -U $USERNAME -E -H $bmc chassis power on
       ```
@@ -194,7 +194,7 @@ proceed to step 2.
    1. After the correct time has been verified, power off the NCN.
 
       ```bash
-      pit# ipmitool -I lanplus -U $USERNAME -E -H $bmc chassis power off
+       ipmitool -I lanplus -U $USERNAME -E -H $bmc chassis power off
       ```
 
    Repeat the above process for each NCN.
@@ -322,13 +322,13 @@ be performed are in the [Deploy](#deploy) section.
     1. Patch the `set-sqfs-links.sh` script to include the blacklisting of an undesired kernel module.
 
         ```bash
-        pit# sed -i -E 's:rd.luks=0 /:rd.luks=0 module_blacklist=rpcrdma \/:g' /root/bin/set-sqfs-links.sh
+         sed -i -E 's:rd.luks=0 /:rd.luks=0 module_blacklist=rpcrdma \/:g' /root/bin/set-sqfs-links.sh
         ```
 
     1. Invoke the script.
 
         ```bash
-        pit# /root/bin/set-sqfs-links.sh
+         /root/bin/set-sqfs-links.sh
         ```
 
         > Every NCN except for `ncn-m001` should be included in the output from this script. If that is not the case,
@@ -349,15 +349,15 @@ be performed are in the [Deploy](#deploy) section.
     > **NOTE:** This script will enable DCMI/IPMI on Hewlett-Packard Enterprise servers equipped with ILO. If `ipmitool` is not working at this time, it will after running this script.
 
     ```bash
-    pit# /root/bin/bios-baseline.sh
+     /root/bin/bios-baseline.sh
     ```
 
 1. <a name="set-uefi-and-power-off"></a>Set each node to always UEFI Network Boot, and ensure they are powered off
 
     ```bash
-    pit# grep -oP "($mtoken|$stoken|$wtoken)" /etc/dnsmasq.d/statics.conf | sort -u | xargs -t -i ipmitool -I lanplus -U $USERNAME -E -H {} chassis bootdev pxe options=persistent
-    pit# grep -oP "($mtoken|$stoken|$wtoken)" /etc/dnsmasq.d/statics.conf | sort -u | xargs -t -i ipmitool -I lanplus -U $USERNAME -E -H {} chassis bootdev pxe options=efiboot
-    pit# grep -oP "($mtoken|$stoken|$wtoken)" /etc/dnsmasq.d/statics.conf | sort -u | xargs -t -i ipmitool -I lanplus -U $USERNAME -E -H {} power off
+     grep -oP "($mtoken|$stoken|$wtoken)" /etc/dnsmasq.d/statics.conf | sort -u | xargs -t -i ipmitool -I lanplus -U $USERNAME -E -H {} chassis bootdev pxe options=persistent
+     grep -oP "($mtoken|$stoken|$wtoken)" /etc/dnsmasq.d/statics.conf | sort -u | xargs -t -i ipmitool -I lanplus -U $USERNAME -E -H {} chassis bootdev pxe options=efiboot
+     grep -oP "($mtoken|$stoken|$wtoken)" /etc/dnsmasq.d/statics.conf | sort -u | xargs -t -i ipmitool -I lanplus -U $USERNAME -E -H {} power off
     ```
 
     > **NOTE:** The NCN boot order is further explained in [NCN Boot Workflow](../background/ncn_boot_workflow.md).
@@ -371,14 +371,14 @@ be performed are in the [Deploy](#deploy) section.
       > `read -s` is used to prevent the password from being written to the screen or the shell history.
 
       ```bash
-      pit# read -s SW_ADMIN_PASSWORD
-      pit# export SW_ADMIN_PASSWORD
+       read -s SW_ADMIN_PASSWORD
+       export SW_ADMIN_PASSWORD
       ```
 
    1. Run the LiveCD preflight checks.
 
       ```bash
-      pit# csi pit validate --livecd-preflight
+       csi pit validate --livecd-preflight
       ```
 
       > Note: Ignore any errors about not being able resolve `arti.dev.cray.com`.
@@ -386,7 +386,7 @@ be performed are in the [Deploy](#deploy) section.
 1. Print the available consoles.
 
     ```bash
-    pit# conman -q
+     conman -q
     ```
 
     Expected output looks similar to the following:
@@ -410,7 +410,7 @@ be performed are in the [Deploy](#deploy) section.
     Boot all the storage nodes. `ncn-s001` will start 1 minute after the other storage nodes.
 
     ```bash
-    pit# grep -oP $stoken /etc/dnsmasq.d/statics.conf | grep -v "ncn-s001-" | sort -u |
+     grep -oP $stoken /etc/dnsmasq.d/statics.conf | grep -v "ncn-s001-" | sort -u |
             xargs -t -i ipmitool -I lanplus -U $USERNAME -E -H {} power on; \
          sleep 60; ipmitool -I lanplus -U $USERNAME -E -H ncn-s001-mgmt power on
     ```
@@ -418,7 +418,7 @@ be performed are in the [Deploy](#deploy) section.
 1. Observe the installation through the console of `ncn-s001-mgmt`.
 
     ```bash
-    pit# conman -j ncn-s001-mgmt
+     conman -j ncn-s001-mgmt
     ```
 
     From there an administrator can witness console output for the `cloud-init` scripts.
@@ -432,7 +432,7 @@ be performed are in the [Deploy](#deploy) section.
    **NOTE:** Once all storage nodes are up and the message `...sleeping 5 seconds until /etc/kubernetes/admin.conf` appears on `ncn-s001`'s console, it is safe to proceed with booting the **Kubernetes master nodes and worker nodes**
 
     ```bash
-    pit# grep -oP "($mtoken|$wtoken)" /etc/dnsmasq.d/statics.conf | sort -u | xargs -t -i ipmitool -I lanplus -U $USERNAME -E -H {} power on
+     grep -oP "($mtoken|$wtoken)" /etc/dnsmasq.d/statics.conf | sort -u | xargs -t -i ipmitool -I lanplus -U $USERNAME -E -H {} power on
     ```
 
 1. Stop watching the console from `ncn-s001`.
@@ -449,7 +449,7 @@ be performed are in the [Deploy](#deploy) section.
     Print the console name:
 
     ```bash
-    pit# conman -q | grep m002
+     conman -q | grep m002
     ```
 
     Expected output looks similar to the following:
@@ -461,7 +461,7 @@ be performed are in the [Deploy](#deploy) section.
     Then join the console:
 
     ```bash
-    pit# conman -j ncn-m002-mgmt
+     conman -j ncn-m002-mgmt
     ```
 
     **NOTE:** If the nodes have PXE boot issues (e.g. getting PXE errors, not pulling the ipxe.efi binary) see [PXE boot troubleshooting](pxe_boot_troubleshooting.md)
@@ -477,7 +477,7 @@ be performed are in the [Deploy](#deploy) section.
     > When the following command prompts for a password, enter the root password for `ncn-m002`.
 
     ```bash
-    pit# ssh ncn-m002 kubectl get nodes -o wide
+     ssh ncn-m002 kubectl get nodes -o wide
     ```
 
     Expected output looks similar to the following:
@@ -507,7 +507,7 @@ be performed are in the [Deploy](#deploy) section.
         > When the following command prompts for a password, enter the root password for `ncn-m002`.
 
         ```ShellSession
-        pit# rsync -av ncn-m002:.ssh/ /root/.ssh/
+         rsync -av ncn-m002:.ssh/ /root/.ssh/
         ```
 
         Expected output looks similar to the following:
@@ -528,7 +528,7 @@ be performed are in the [Deploy](#deploy) section.
     1. Make a list of all of the NCNs (including `ncn-m001`).
 
         ```ShellSession
-        pit# NCNS=$(grep -oP "ncn-[msw][0-9]{3}" /etc/dnsmasq.d/statics.conf | sort -u | tr '\n' ',') ; echo "${NCNS}"
+         NCNS=$(grep -oP "ncn-[msw][0-9]{3}" /etc/dnsmasq.d/statics.conf | sort -u | tr '\n' ',') ; echo "${NCNS}"
         ```
 
         Expected output looks similar to the following:
@@ -542,7 +542,7 @@ be performed are in the [Deploy](#deploy) section.
         The following command should not prompt for a password.
 
         ```ShellSession
-        pit# PDSH_SSH_ARGS_APPEND='-o StrictHostKeyChecking=no' pdsh -Sw "${NCNS}" date && echo SUCCESS || echo ERROR
+         PDSH_SSH_ARGS_APPEND='-o StrictHostKeyChecking=no' pdsh -Sw "${NCNS}" date && echo SUCCESS || echo ERROR
         ```
 
         Expected output looks similar to the following:
@@ -572,7 +572,7 @@ be performed are in the [Deploy](#deploy) section.
 1. <a name="check-lvm-on-masters-and-workers"></a>Validate that the expected LVM labels are present on disks on the master and worker nodes.
 
     ```bash
-    pit# /usr/share/doc/csm/install/scripts/check_lvm.sh
+     /usr/share/doc/csm/install/scripts/check_lvm.sh
     ```
 
     Expected output looks similar to the following:
@@ -612,7 +612,7 @@ be performed are in the [Deploy](#deploy) section.
     Running this script applies the workaround on all of the NCNs that were just deployed.
 
     ```bash
-    pit# /usr/share/doc/csm/scripts/workarounds/kdump/run.sh
+     /usr/share/doc/csm/scripts/workarounds/kdump/run.sh
     ```
 
     Example output:
@@ -819,8 +819,8 @@ The LiveCD needs to authenticate with the cluster to facilitate the rest of the 
    Run the following commands on the PIT node to extract the value of the `first-master-hostname` field from the `/var/www/ephemeral/configs/data.json` file:
 
    ```bash
-   pit# FM=$(cat /var/www/ephemeral/configs/data.json | jq -r '."Global"."meta-data"."first-master-hostname"')
-   pit# echo $FM
+    FM=$(cat /var/www/ephemeral/configs/data.json | jq -r '."Global"."meta-data"."first-master-hostname"')
+    echo $FM
    ```
 
 1. Copy the Kubernetes configuration file from that node to the LiveCD to be able to use `kubectl` as cluster administrator.
@@ -828,14 +828,14 @@ The LiveCD needs to authenticate with the cluster to facilitate the rest of the 
    Run the following commands on the PIT node:
 
    ```bash
-   pit# mkdir -v ~/.kube
-   pit# scp ${FM}.nmn:/etc/kubernetes/admin.conf ~/.kube/config
+    mkdir -v ~/.kube
+    scp ${FM}.nmn:/etc/kubernetes/admin.conf ~/.kube/config
    ```
 
 1. Validate that `kubectl` commands run successfully from the PIT node.
 
     ```bash
-    pit# kubectl get nodes -o wide
+     kubectl get nodes -o wide
     ```
 
     Expected output looks similar to the following:
@@ -856,7 +856,7 @@ The LiveCD needs to authenticate with the cluster to facilitate the rest of the 
 Run the following commands on the PIT node.
 
 ```bash
-pit# pushd /var/www/ephemeral && ${CSM_RELEASE}/lib/install-goss-tests.sh && popd
+ pushd /var/www/ephemeral && ${CSM_RELEASE}/lib/install-goss-tests.sh && popd
 ```
 
 <a name="clean-up-chrony-configurations"></a>
@@ -866,7 +866,7 @@ pit# pushd /var/www/ephemeral && ${CSM_RELEASE}/lib/install-goss-tests.sh && pop
 Run the following command without editing the value of the `TOKEN` variable.
 
 ```ShellSession
-pit# for i in $(grep -oP 'ncn-\w\d+' /etc/dnsmasq.d/statics.conf | sort -u | grep -v ncn-m001); do 
+ for i in $(grep -oP 'ncn-\w\d+' /etc/dnsmasq.d/statics.conf | sort -u | grep -v ncn-m001); do 
        ssh $i "TOKEN=token /srv/cray/scripts/common/chrony/csm_ntp.py"; done
 ```
 
@@ -895,13 +895,13 @@ Observe the output of the checks. If there are any failures, remediate them.
 1. Check the storage nodes.
 
    ```bash
-   pit# csi pit validate --ceph | tee csi-pit-validate-ceph.log
+    csi pit validate --ceph | tee csi-pit-validate-ceph.log
    ```
 
    Once that command has finished, the following will extract the test totals reported for each node:
 
    ```bash
-   pit# grep "Total Test" csi-pit-validate-ceph.log
+    grep "Total Test" csi-pit-validate-ceph.log
    ```
 
    Example output for a system with three storage nodes:
@@ -923,13 +923,13 @@ Observe the output of the checks. If there are any failures, remediate them.
    all of them and not just the final one.** A `grep` command is provided to help with this.
 
    ```bash
-   pit# csi pit validate --k8s | tee csi-pit-validate-k8s.log
+    csi pit validate --k8s | tee csi-pit-validate-k8s.log
    ```
 
    Once that command has finished, the following will extract the test totals reported for each node:
 
    ```bash
-   pit# grep "Total Test" csi-pit-validate-k8s.log
+    grep "Total Test" csi-pit-validate-k8s.log
    ```
 
    Example output for a system with five master and worker nodes (excluding the PIT node):
@@ -960,7 +960,7 @@ Observe the output of the checks. If there are any failures, remediate them.
    Run the following command on any Kubernetes master or worker node, or the PIT node:
 
    ```bash
-   ncn-mw/pit# kubectl get pods -o wide -n kube-system | grep -Ev '(Running|Completed)'
+   ncn-mw/ kubectl get pods -o wide -n kube-system | grep -Ev '(Running|Completed)'
    ```
 
    If any pods are listed by this command, it means they are not in the `Running` or `Completed` state. Do not proceed before investigating this.

--- a/install/install_csm_services.md
+++ b/install/install_csm_services.md
@@ -25,15 +25,15 @@ This procedure will install CSM applications and services into the CSM Kubernete
 1. Install YAPL.
 
    ```bash
-   pit# rpm -Uvh /var/www/ephemeral/${CSM_RELEASE}/rpm/cray/csm/sle-15sp2/x86_64/yapl-*.x86_64.rpm
+    rpm -Uvh /var/www/ephemeral/${CSM_RELEASE}/rpm/cray/csm/sle-15sp2/x86_64/yapl-*.x86_64.rpm
    ```
 
 1. Install CSM services using YAPL.
 
    ```bash
-   pit# pushd /usr/share/doc/csm/install/scripts/csm_services && \
+    pushd /usr/share/doc/csm/install/scripts/csm_services && \
         yapl -f install.yaml execute
-   pit# popd
+    popd
    ```
 
 > **NOTES:**
@@ -51,13 +51,13 @@ This procedure will install CSM applications and services into the CSM Kubernete
 1. Wait for BSS to be ready.
 
    ```bash
-   pit# kubectl -n services rollout status deployment cray-bss
+    kubectl -n services rollout status deployment cray-bss
    ```
 
 1. Retrieve an API token.
 
    ```bash
-   pit# export TOKEN=$(curl -k -s -S -d grant_type=client_credentials \
+    export TOKEN=$(curl -k -s -S -d grant_type=client_credentials \
                           -d client_id=admin-client \
                           -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
                           https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
@@ -66,7 +66,7 @@ This procedure will install CSM applications and services into the CSM Kubernete
 1. Create empty boot parameters.
 
    ```bash
-   pit# curl -i -k -H "Authorization: Bearer ${TOKEN}" -X PUT \
+    curl -i -k -H "Authorization: Bearer ${TOKEN}" -X PUT \
             https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters \
             --data '{"hosts":["Global"]}'
    ```
@@ -85,8 +85,8 @@ This procedure will install CSM applications and services into the CSM Kubernete
 1. Restart the `spire-update-bss` job.
 
    ```bash
-   pit# SPIRE_JOB=$(kubectl -n spire get jobs -l app.kubernetes.io/name=spire-update-bss -o name)
-   pit# kubectl -n spire get "${SPIRE_JOB}" -o json | jq 'del(.spec.selector)' \
+    SPIRE_JOB=$(kubectl -n spire get jobs -l app.kubernetes.io/name=spire-update-bss -o name)
+    kubectl -n spire get "${SPIRE_JOB}" -o json | jq 'del(.spec.selector)' \
             | jq 'del(.spec.template.metadata.labels."controller-uid")' \
             | kubectl replace --force -f -
    ```
@@ -94,7 +94,7 @@ This procedure will install CSM applications and services into the CSM Kubernete
 1. Wait for the `spire-update-bss` job to complete.
 
    ```bash
-   pit# kubectl -n spire wait "${SPIRE_JOB}" --for=condition=complete --timeout=5m
+    kubectl -n spire wait "${SPIRE_JOB}" --for=condition=complete --timeout=5m
    ```
 
 ## 3. Wait for everything to settle
@@ -123,7 +123,7 @@ The following error may occur during the `Deploy CSM Applications and Services` 
 1. Verify that the `sls-s3-credentials` secret exists in the `default` namespace:
 
    ```bash
-   pit# kubectl get secret sls-s3-credentials
+    kubectl get secret sls-s3-credentials
    ```
 
    Example output:
@@ -137,7 +137,7 @@ The following error may occur during the `Deploy CSM Applications and Services` 
    for copying the `sls-s3-credentials` secret from the `default` namespace to the `services` namespace.
 
    ```bash
-   pit# kubectl -n services get pods -l cronjob-name=sonar-sync
+    kubectl -n services get pods -l cronjob-name=sonar-sync
    ```
 
    Example output:
@@ -151,7 +151,7 @@ The following error may occur during the `Deploy CSM Applications and Services` 
 1. Verify that the `sls-s3-credentials` secret now exists in the `services` namespace.
 
    ```bash
-   pit# kubectl -n services get secret sls-s3-credentials
+    kubectl -n services get secret sls-s3-credentials
    ```
 
    Example output:

--- a/install/prepare_compute_nodes.md
+++ b/install/prepare_compute_nodes.md
@@ -40,8 +40,8 @@ on. The node indicator is always a 0. For example, `x3000c0s30b1n0` or
    component name (xname):
 
    ```bash
-   ncn# XNAME=x3000c0s30b1n0
-   ncn# cray hsm inventory ethernetInterfaces list --component-id \
+    XNAME=x3000c0s30b1n0
+    cray hsm inventory ethernetInterfaces list --component-id \
          ${XNAME} --format json | jq '.[]|select((.IPAddresses|length)>0)'
    {
    "ID": "6805cabbc182",
@@ -77,9 +77,9 @@ on. The node indicator is always a 0. For example, `x3000c0s30b1n0` or
    Make a note of the ID, MACAddress, and IPAddress of the entry that has the
    10.254 address listed.
    ```bash
-   ncn# ID="9440c938f7b4"
-   ncn# MAC="94:40:c9:38:f7:b4"
-   ncn# IPADDR="10.254.1.38"
+    ID="9440c938f7b4"
+    MAC="94:40:c9:38:f7:b4"
+    IPADDR="10.254.1.38"
    ```
    These will be used later to clean up KEA and Hardware State Manager (HSM).
    There may not be a 10.254 address associated with the node, that is OK, it
@@ -102,11 +102,11 @@ on. The node indicator is always a 0. For example, `x3000c0s30b1n0` or
    2. Make a note of the **MAC Address** under the **Information** section,
         that will be needed later.
         ```bash
-        ncn# ILOMAC="<MAC Address>"
+         ILOMAC="<MAC Address>"
         ```
         For example
         ```bash
-        ncn# ILOMAC="94:40:c9:38:08:c7"
+         ILOMAC="94:40:c9:38:08:c7"
         ```
    3. Click on **General** on the top menu.
    4. Under **NIC Settings** move slider to **Enable VLAN**.
@@ -179,7 +179,7 @@ on. The node indicator is always a 0. For example, `x3000c0s30b1n0` or
 
    Retrieve a bearer token if you have not done so already.
    ```bash
-   ncn# export TOKEN=$(curl -s -S -d grant_type=client_credentials \
+    export TOKEN=$(curl -s -S -d grant_type=client_credentials \
       -d client_id=admin-client \
       -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
       https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
@@ -189,7 +189,7 @@ on. The node indicator is always a 0. For example, `x3000c0s30b1n0` or
    gathered in section 1.1.
 
    ```bash
-   ncn# curl -s -k -H "Authorization: Bearer ${TOKEN}" -X POST -H \
+    curl -s -k -H "Authorization: Bearer ${TOKEN}" -X POST -H \
    "Content-Type: application/json" -d '{"command": "lease4-del", \
    "service": [ "dhcp4" ], "arguments": {"hw-address": "'${MAC}'", \
    "ip-address": "'${IPADDR}'"}}' https://api-gw-service-nmn.local/apis/dhcp-kea
@@ -207,7 +207,7 @@ on. The node indicator is always a 0. For example, `x3000c0s30b1n0` or
 
    Tell HSM to delete the bad ID out of the Ethernet Interfaces table.
    ```bash
-   ncn# cray hsm inventory ethernetInterfaces delete $ID
+    cray hsm inventory ethernetInterfaces delete $ID
    ```
    Expected results:
    ```json

--- a/install/prepare_management_nodes.md
+++ b/install/prepare_management_nodes.md
@@ -40,7 +40,7 @@ Runtime DHCP services interfere with the LiveCD's bootstrap nature to provide DH
 Scale the deployment from either the LiveCD or any Kubernetes node:
 
 ```bash
-ncn# kubectl scale -n services --replicas=0 deployment cray-dhcp-kea
+ kubectl scale -n services --replicas=0 deployment cray-dhcp-kea
 ```
 
 ## Wipe disks on booted nodes
@@ -76,13 +76,13 @@ Power each NCN off using `ipmitool` from `ncn-m001` (or the booted LiveCD, if re
 1. Power off NCNs.
 
     ```bash
-    pit# conman -q | grep mgmt | grep -v m001 | xargs -t -i ipmitool -I lanplus -U $USERNAME -E -H {} power off
+     conman -q | grep mgmt | grep -v m001 | xargs -t -i ipmitool -I lanplus -U $USERNAME -E -H {} power off
     ```
 
 1. Check the power status to confirm that the nodes have powered off.
 
     ```bash
-    pit# conman -q | grep mgmt | grep -v m001 | xargs -t -i ipmitool -I lanplus -U $USERNAME -E -H {} power status
+     conman -q | grep mgmt | grep -v m001 | xargs -t -i ipmitool -I lanplus -U $USERNAME -E -H {} power status
     ```
 
 ### Shut down from `ncn-m001`
@@ -127,7 +127,7 @@ BMCs to be set back to DHCP before proceeding.
         > This collects BMC IP addresses using the old `statics.conf` on the system, in case CSI changes IP addresses:
 
         ```bash
-        pit# BMCS=$(grep mgmt /etc/dnsmasq.d/statics.conf | grep -v m001 | awk -F ',' '{print $2}' |
+         BMCS=$(grep mgmt /etc/dnsmasq.d/statics.conf | grep -v m001 | awk -F ',' '{print $2}' |
                        grep -Eo "([0-9]{1,3}[.]){3}[0-9]{1,3}" | sort -u  | tr '\n' ' ') ; echo $BMCS
         ```
 

--- a/install/pxe_boot_troubleshooting.md
+++ b/install/pxe_boot_troubleshooting.md
@@ -353,7 +353,7 @@ In that case, then use the following recovery procedure.
         1. Once booted, log in and mount the data partition.
 
            ```bash
-           pit# mount -vL PITDATA
+            mount -vL PITDATA
            ```
 
     - If using a remote ISO PIT, follow the [Bootstrap LiveCD Remote ISO](bootstrap_livecd_remote_iso.md) procedure up through (**and including**) the [Set Up The Site Link](bootstrap_livecd_remote_iso.md#set-up-site-link) step.
@@ -368,10 +368,10 @@ In that case, then use the following recovery procedure.
     Substitute the correct values for the system in use in the following commands:
 
     ```bash
-    pit# SYSTEM_NAME=eniac
-    pit# CAN_IP_NCN_M002=a.b.c.d
-    pit# export KUBERNETES_VERSION=m.n.o
-    pit# export CEPH_VERSION=x.y.z
+     SYSTEM_NAME=eniac
+     CAN_IP_NCN_M002=a.b.c.d
+     export KUBERNETES_VERSION=m.n.o
+     export CEPH_VERSION=x.y.z
     ```
 
 1. **If using a remote ISO PIT**, run the following commands to finish configuring the network and copy files.
@@ -381,40 +381,40 @@ In that case, then use the following recovery procedure.
     1. Run the following command to copy files from `ncn-m002` to the PIT node.
 
         ```bash
-        pit# scp -p ${CAN_IP_NCN_M002}:/metal/bootstrap/prep/${SYSTEM_NAME}/pit-files/* /etc/sysconfig/network/
+         scp -p ${CAN_IP_NCN_M002}:/metal/bootstrap/prep/${SYSTEM_NAME}/pit-files/* /etc/sysconfig/network/
         ```
 
     1. Apply the network changes.
 
         ```bash
-        pit# wicked ifreload all
-        pit# systemctl restart wickedd-nanny && sleep 5
+         wicked ifreload all
+         systemctl restart wickedd-nanny && sleep 5
         ```
 
     1. Copy `data.json` from `ncn-m002` to the PIT node.
 
         ```bash
-        pit# mkdir -p /var/www/ephemeral/configs
-        pit# scp ${CAN_IP_NCN_M002}:/metal/bootstrap/prep/${SYSTEM_NAME}/basecamp/data.json /var/www/ephemeral/configs
+         mkdir -p /var/www/ephemeral/configs
+         scp ${CAN_IP_NCN_M002}:/metal/bootstrap/prep/${SYSTEM_NAME}/basecamp/data.json /var/www/ephemeral/configs
         ```
 
 1. Copy Kubernetes configuration file from `ncn-m002`.
 
     ```bash
-    pit# mkdir -pv ~/.kube
-    pit# scp ${CAN_IP_NCN_M002}:/etc/kubernetes/admin.conf ~/.kube/config
+     mkdir -pv ~/.kube
+     scp ${CAN_IP_NCN_M002}:/etc/kubernetes/admin.conf ~/.kube/config
     ```
 
 1. Set DNS to use unbound.
 
     ```bash
-    pit# echo "nameserver 10.92.100.225" > /etc/resolv.conf
+     echo "nameserver 10.92.100.225" > /etc/resolv.conf
     ```
 
 1. Export an API token.
 
     ```bash
-    pit# export TOKEN=$(curl -k -s -S -d grant_type=client_credentials \
+     export TOKEN=$(curl -k -s -S -d grant_type=client_credentials \
             -d client_id=admin-client \
             -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
             https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
@@ -425,8 +425,8 @@ In that case, then use the following recovery procedure.
     **WARNING: These commands should never be run from a node other than the PIT node or `ncn-m001`**
 
     ```bash
-    pit# csi handoff bss-metadata --data-file /var/www/ephemeral/configs/data.json || echo "ERROR: csi handoff bss-metadata failed"
-    pit# csi handoff bss-update-cloud-init --set meta-data.dns-server=10.92.100.225 --limit Global
+     csi handoff bss-metadata --data-file /var/www/ephemeral/configs/data.json || echo "ERROR: csi handoff bss-metadata failed"
+     csi handoff bss-update-cloud-init --set meta-data.dns-server=10.92.100.225 --limit Global
     ```
 
 1. Perform the [Restart BSS](#restart-bss) and the [Restart Kea](#restart-kea) procedures.

--- a/install/reinstall_livecd.md
+++ b/install/reinstall_livecd.md
@@ -5,13 +5,13 @@ Setup a re-install of LiveCD on a node using the previous configuration.
 1. Backup to the data partition:
 
     ```bash
-    pit# mkdir -pv /var/www/ephemeral/backup
-    pit# pushd /var/www/ephemeral/backup
-    pit# tar -czvf "dnsmasq-data-$(date  '+%Y-%m-%d_%H-%M-%S').tar.gz" /etc/dnsmasq.*
-    pit# tar -czvf "network-data-$(date  '+%Y-%m-%d_%H-%M-%S').tar.gz" /etc/sysconfig/network/*
-    pit# cp -pv /etc/hosts ./
-    pit# popd
-    pit# umount -v /var/www/ephemeral
+     mkdir -pv /var/www/ephemeral/backup
+     pushd /var/www/ephemeral/backup
+     tar -czvf "dnsmasq-data-$(date  '+%Y-%m-%d_%H-%M-%S').tar.gz" /etc/dnsmasq.*
+     tar -czvf "network-data-$(date  '+%Y-%m-%d_%H-%M-%S').tar.gz" /etc/sysconfig/network/*
+     cp -pv /etc/hosts ./
+     popd
+     umount -v /var/www/ephemeral
     ```
 
 1. Unplug the USB device.
@@ -58,11 +58,11 @@ Setup a re-install of LiveCD on a node using the previous configuration.
    > STOP AND INSPECT ANY FAILURE IN ANY OF THESE COMMANDS
 
    ```bash
-   pit# tar -xzvf /var/www/ephemeral/backup/dnsmasq*.tar.gz
-   pit# tar -xzvf /var/www/ephemeral/backup/network*.tar.gz
-   pit# systemctl restart wicked wickedd-nanny
-   pit# systemctl restart dnsmasq
-   pit# systemctl start basecamp nexus
+    tar -xzvf /var/www/ephemeral/backup/dnsmasq*.tar.gz
+    tar -xzvf /var/www/ephemeral/backup/network*.tar.gz
+    systemctl restart wicked wickedd-nanny
+    systemctl restart dnsmasq
+    systemctl start basecamp nexus
    ```
 
 The LiveCD is now re-installed with the previous configuration.

--- a/install/restart_network_services_and_interfaces_on_ncns.md
+++ b/install/restart_network_services_and_interfaces_on_ncns.md
@@ -31,7 +31,7 @@ sorted by safest to touch relative to keeping an SSH connection up.
     This command restarts the `wickedd` service without reconfiguring the network interfaces.
 
     ```bash
-    ncn# systemctl restart wickedd
+     systemctl restart wickedd
     ```
 
 2. `wicked.service`: The overarching service for spawning daemons and manipulating interface configuration.
@@ -39,7 +39,7 @@ sorted by safest to touch relative to keeping an SSH connection up.
     This command restarts the `wicked` service which will respawns daemons and reconfigure the network.
 
     ```bash
-    ncn# systemctl restart wicked
+     systemctl restart wicked
     ```
 
 3. `network.service`: Responsible for network configuration per interface; This does not reload `wicked`.
@@ -50,7 +50,7 @@ sorted by safest to touch relative to keeping an SSH connection up.
 
     ```bash
     # Restart the network interface configuration, but leaves wicked daemons alone.
-    ncn# systemctl restart network
+     systemctl restart network
     ```
 
 <a name="command_reference"></a>
@@ -60,13 +60,13 @@ sorted by safest to touch relative to keeping an SSH connection up.
 * Check interface status (up/down/broken):
 
    ```bash
-   ncn# wicked ifstatus
+    wicked ifstatus
    ```
 
 * Show routing and status for all devices:
 
    ```bash
-   ncn# wicked ifstatus --verbose all
+    wicked ifstatus --verbose all
    lo              up
          link:     #1, state up
          type:     loopback
@@ -142,12 +142,12 @@ sorted by safest to touch relative to keeping an SSH connection up.
 * Print real devices (ignore no-device):
 
    ```bash
-   ncn# wicked show --verbose all
+    wicked show --verbose all
    ```
 
 * Show the currently enabled network service (Wicked or Network Manager):
 
    ```bash
-   ncn# systemctl show -p Id network.service
+    systemctl show -p Id network.service
    Id=wicked.service
    ```

--- a/install/safeguards_for_csm_ncn_upgrades.md
+++ b/install/safeguards_for_csm_ncn_upgrades.md
@@ -29,23 +29,23 @@ This page covers safe-guards for preventing destructive behaviors on management 
    }
    ```
    ```bash
-   pit# vi /var/www/ephemeral/configs/data.json
+    vi /var/www/ephemeral/configs/data.json
    ```
 
 1. Quickly toggle yes or no to the file:
 
    ```bash
    # set wipe-ceph-osds=no
-   pit# sed -i 's/wipe-ceph-osds": "yes"/wipe-ceph-osds": "no"/g' /var/www/ephemeral/configs/data.json
+    sed -i 's/wipe-ceph-osds": "yes"/wipe-ceph-osds": "no"/g' /var/www/ephemeral/configs/data.json
 
    # set wipe-ceph-osds=yes
-   pit# sed -i 's/wipe-ceph-osds": "no"/wipe-ceph-osds": "yes"/g' /var/www/ephemeral/configs/data.json
+    sed -i 's/wipe-ceph-osds": "no"/wipe-ceph-osds": "yes"/g' /var/www/ephemeral/configs/data.json
    ```
 
 1. Activate the new setting:
 
    ```bash
-   pit# systemctl restart basecamp
+    systemctl restart basecamp
    ```
 
 ### Safeguard RAIDS / BOOTLOADERS / SquashFS / OverlayFS
@@ -56,6 +56,6 @@ This page covers safe-guards for preventing destructive behaviors on management 
 - `metal.no-wipe=1` will guard against touching RAIDs, disks, and partitions.
 
    ```bash
-   pit# vi /var/www/boot/script.ipxe
+    vi /var/www/boot/script.ipxe
    ```
 

--- a/install/scripts/csm_services/steps/1.initialize_bootstrap_registry.yaml
+++ b/install/scripts/csm_services/steps/1.initialize_bootstrap_registry.yaml
@@ -47,7 +47,7 @@ spec:
         
         troubleshooting: |-
           # Restart nexus service
-          `pit# systemctl start nexus`
+          ` systemctl start nexus`
       action:
         description: |-
           3.  Load the skopeo image installed by the cray-nexus RPM

--- a/install/scripts/csm_services/steps/2.create_site_init_secret.yaml
+++ b/install/scripts/csm_services/steps/2.create_site_init_secret.yaml
@@ -61,7 +61,7 @@ spec:
           > 1. First delete it:
           >
           >    ```bash
-          >    pit# kubectl delete secret -n loftsman site-init
+          >     kubectl delete secret -n loftsman site-init
           >    ```
           >
           >    Expected output looks similar to the following:
@@ -73,7 +73,7 @@ spec:
           > 2. Then recreate it:
           >
           >    ```bash
-          >    pit# kubectl create secret -n loftsman generic site-init --from-file=/var/www/ephemeral/prep/site-init/customizations.yaml
+          >     kubectl create secret -n loftsman generic site-init --from-file=/var/www/ephemeral/prep/site-init/customizations.yaml
           >    ```
           >
           >    Expected output looks similar to the following:
@@ -91,19 +91,19 @@ spec:
           > To **read** `customizations.yaml` from the `site-init` secret:
           >
           > ```bash
-          > ncn# kubectl get secrets -n loftsman site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d > customizations.yaml
+          >  kubectl get secrets -n loftsman site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d > customizations.yaml
           > ```
           >
           > To **delete** the `site-init` secret:
           >
           > ```bash
-          > ncn# kubectl -n loftsman delete secret site-init
+          >  kubectl -n loftsman delete secret site-init
           > ```
           >
           > To **recreate** the `site-init` secret:
           >
           > ```bash
-          > ncn# kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
+          >  kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
           > ```
       postValidation:
         description: |-

--- a/install/scripts/csm_services/steps/4.deploy_csm_application_and_services.yaml
+++ b/install/scripts/csm_services/steps/4.deploy_csm_application_and_services.yaml
@@ -30,15 +30,15 @@ metadata:
     Run `install.sh` to deploy CSM applications services. This command may take 25 minutes or more to run.
 
     ```bash
-    pit# cd /var/www/ephemeral/$CSM_RELEASE
-    pit# ./install.sh
+     cd /var/www/ephemeral/$CSM_RELEASE
+     ./install.sh
     ```
 
     On success, `install.sh` will output `OK` to stderr and exit with status code
     `0`, e.g.:
 
     ```bash
-    pit# ./install.sh
+     ./install.sh
     ...
     + CSM applications and services deployed
     install.sh: OK
@@ -62,14 +62,14 @@ spec:
           > Verify that the `SYSTEM_NAME` and `CSM_RELEASE` environment variables are set:
           >
           > ```bash
-          > pit# echo $SYSTEM_NAME
-          > pit# echo $CSM_RELEASE
+          >  echo $SYSTEM_NAME
+          >  echo $CSM_RELEASE
           > ```
           > If they are not set, perform the following:
           >
           > ```bash
-          > pit# export SYSTEM_NAME=eniac
-          > pit# export CSM_RELEASE=csm-x.y.z
+          >  export SYSTEM_NAME=eniac
+          >  export CSM_RELEASE=csm-x.y.z
           > ```
       action:
         description: |-
@@ -85,7 +85,7 @@ spec:
           ***IMPORTANT:*** If you have to re-run install.sh to re-deploy failed ceph-csi provisioners you must make sure to delete the jobs that have not completed. These are left there for investigation on failure. They are automatically removed on a successful deployment.
 
           ```bash
-          pit# kubectl get jobs
+           kubectl get jobs
           NAME                   COMPLETIONS   DURATION   AGE
           cray-ceph-csi-cephfs   0/1                      3m35s
           cray-ceph-csi-rbd      0/1                      8m36s
@@ -111,7 +111,7 @@ spec:
 
               1. Verify the `sls-s3-credentials` secret exists in the `default` namespace:
                 ```bash
-                pit# kubectl get secret sls-s3-credentials
+                 kubectl get secret sls-s3-credentials
                 NAME                 TYPE     DATA   AGE
                 sls-s3-credentials   Opaque   7      28d
                 ```
@@ -120,7 +120,7 @@ spec:
                 The sonar-sync cronjob is responsible for copying the `sls-s3-credentials` secret from the `default`
                 to the `services` namespaces.
                 ```bash
-                pit# kubectl -n services get pods -l cronjob-name=sonar-sync
+                 kubectl -n services get pods -l cronjob-name=sonar-sync
                 NAME                          READY   STATUS      RESTARTS   AGE
                 sonar-sync-1634322840-4fckz   0/1     Completed   0          73s
                 sonar-sync-1634322900-pnvl6   1/1     Running     0          13s
@@ -128,7 +128,7 @@ spec:
 
               3. Verify the `sls-s3-credentials` secret now exists in the `services` namespaces.
                 ```bash
-                pit# kubectl -n services get secret sls-s3-credentials
+                 kubectl -n services get secret sls-s3-credentials
                 NAME                 TYPE     DATA   AGE
                 sls-s3-credentials   Opaque   7      20s
                 ```

--- a/install/scripts/csm_services/steps/5.setup_nexus.yaml
+++ b/install/scripts/csm_services/steps/5.setup_nexus.yaml
@@ -31,14 +31,14 @@ metadata:
     container images, and Helm charts. This command may take 20 minutes or more to run.
 
     ```bash
-    pit# ./lib/setup-nexus.sh
+     ./lib/setup-nexus.sh
     ```
 
     On success, `setup-nexus.sh` will output to `OK` on stderr and exit with status
     code `0`, e.g.:
 
     ```bash
-    pit# ./lib/setup-nexus.sh
+     ./lib/setup-nexus.sh
     ...
     + Nexus setup complete
     setup-nexus.sh: OK

--- a/install/scripts/csm_services/steps/6.set_management_NCN_to_use_unbound.yaml
+++ b/install/scripts/csm_services/steps/6.set_management_NCN_to_use_unbound.yaml
@@ -30,13 +30,13 @@ metadata:
     First, verify that SLS properly reports all management NCNs in the system:
 
     ```bash
-    pit# ./lib/list-ncns.sh
+     ./lib/list-ncns.sh
     ```
 
     On success, each management NCN will be output, e.g.:
 
     ```bash
-    pit# ./lib/list-ncns.sh
+     ./lib/list-ncns.sh
     + Getting admin-client-auth secret
     + Obtaining access token
     + Querying SLS
@@ -58,7 +58,7 @@ metadata:
     /etc/resolv.conf to use Unbound as the nameserver.
 
     ```bash
-    pit# ./lib/set-ncns-to-unbound.sh
+     ./lib/set-ncns-to-unbound.sh
     ```
 
     > **`NOTE`** If passwordless SSH is not configured, the administrator will have
@@ -69,7 +69,7 @@ metadata:
     for each management NCN, e.g.,:
 
     ```bash
-    pit# ./lib/set-ncns-to-unbound.sh
+     ./lib/set-ncns-to-unbound.sh
     + Getting admin-client-auth secret
     + Obtaining access token
     + Querying SLS
@@ -135,7 +135,7 @@ spec:
           for each management NCN, e.g.,:
 
           ```bash
-          pit# ./lib/set-ncns-to-unbound.sh
+           ./lib/set-ncns-to-unbound.sh
           + Getting admin-client-auth secret
           + Obtaining access token
           + Querying SLS

--- a/install/set_gigabyte_node_bmc_to_factory_defaults.md
+++ b/install/set_gigabyte_node_bmc_to_factory_defaults.md
@@ -43,19 +43,19 @@ If booted from the PIT node:
     - **Option 1:** If the BMC is running version `12.84.01` or later, then run:
 
         ```bash
-        ncn# sh do_Redfish_BMC_Factory.sh
+         sh do_Redfish_BMC_Factory.sh
         ```
 
     - **Option 2:** Use `ipmitool` to reset the BMC to factory defaults:
 
         ```bash
-        ncn# sh do_bmc_factory_default.sh
+         sh do_bmc_factory_default.sh
         ```
 
     - **Option 3:** Use the power control script:
 
         ```bash
-        ncn# sh do_bmc_power_control.sh raw 0x32 0x66
+         sh do_bmc_power_control.sh raw 0x32 0x66
         ```
 
         (`raw 0x32 0x66` are Gigabyte/AMI vendor-specific IPMI commands to reset to factory defaults.)
@@ -63,13 +63,13 @@ If booted from the PIT node:
 1. Wait five minutes (300 seconds) for the BMC and Redfish to initialize.
 
     ```bash
-    ncn# sleep 300
+     sleep 300
     ```
 
 1. Add the default login and password to the BMC.
 
     ```bash
-    ncn# sh do_bmc_root_account.sh
+     sh do_bmc_root_account.sh
     ```
 
 1. Add the default login and password to Redfish.
@@ -77,7 +77,7 @@ If booted from the PIT node:
     **IMPORTANT:** If the BMC is version `12.84.01` or later, then **skip this step**.
 
     ```bash
-    ncn# sh do_Redfish_credentials.sh
+     sh do_Redfish_credentials.sh
     ```
 
 1. Make sure the BMC is not in failover mode.
@@ -85,7 +85,7 @@ If booted from the PIT node:
     Run the script with the `read` option to check the BMC status:
 
     ```bash
-    ncn# sh do_bmc_change_mode_to_manual.sh read
+     sh do_bmc_change_mode_to_manual.sh read
     ---------------------------------------------------
     [ BMC: 172.30.48.33 ]
     => Manual mode (O)
@@ -101,7 +101,7 @@ If booted from the PIT node:
     If the BMC is in failover mode, then change the BMC back to manual mode:
 
     ```bash
-    ncn# sh do_bmc_change_mode_to_manual.sh change
+     sh do_bmc_change_mode_to_manual.sh change
     ```
 
 1. If the BMC is in a booted management NCN running Shasta v1.3 or later, then reapply the static IP address and clear the DHCP address from HSM/KEA.
@@ -113,11 +113,11 @@ If booted from the PIT node:
 1. After the BMC is reset to factory defaults, wait 300 seconds for BMC and Redfish initialization.
 
     ```bash
-    ncn# sleep 300
+     sleep 300
     ```
 
 1. Add the default login and password to the BMC:
 
     ```bash
-    ncn# sh do_bmc_root_account.sh
+     sh do_bmc_root_account.sh
     ```

--- a/install/switch_pxe_boot_from_onboard_nic_to_pcie.md
+++ b/install/switch_pxe_boot_from_onboard_nic_to_pcie.md
@@ -38,7 +38,7 @@ On any NCN (using 0.0.10 k8s, or 0.0.8 Ceph; anything built on ncn-0.0.21 or hig
 > **NOTE:** If recovering NCNs with an earlier image without the Mellanox tools, refer to the [Obtaining Mellanox Tools](#obtaining-mellanox-tools) section.
 
 ```bash
-ncn# mst start
+ mst start
 ```
 
 Now `mst status` and other commands like `mlxfwmanager` or `mlxconfig` will work, and devices required for these commands will be created in `/dev/mst`.
@@ -52,7 +52,7 @@ Now `mst status` and other commands like `mlxfwmanager` or `mlxconfig` will work
 Use the following snippet to display device name and current UEFI PXE state.
 
 ```bash
-ncn# mst status
+ mst status
 for MST in $(ls /dev/mst/*); do
     mlxconfig -d ${MST} q | egrep "(Device|EXP_ROM|SRIOV_EN)"
 done
@@ -82,7 +82,7 @@ disabled.
 1. Run `mlxfwmanager` to probe and dump the Mellanox PCIe cards.
 
     ```bash
-    ncn# mlxfwmanager
+     mlxfwmanager
     ```
 
 2. Find the device path for the HSN card, assuming it is a ConnectX-5 or other 100GB card, this should be easy to pick out.
@@ -92,12 +92,12 @@ disabled.
     ```bash
     # Set UEFI to YES
 
-    ncn# MST=/dev/mst/mt4119_pciconf1
-    ncn# mlxconfig -d ${MST} -y set EXP_ROM_UEFI_ARM_ENABLE=0
-    ncn# mlxconfig -d ${MST} -y set EXP_ROM_UEFI_x86_ENABLE=0
-    ncn# mlxconfig -d ${MST} -y set EXP_ROM_PXE_ENABLE=0
-    ncn# mlxconfig -d ${MST} -y set SRIOV_EN=0
-    ncn# mlxconfig -d ${MST} q | egrep "EXP_ROM"
+     MST=/dev/mst/mt4119_pciconf1
+     mlxconfig -d ${MST} -y set EXP_ROM_UEFI_ARM_ENABLE=0
+     mlxconfig -d ${MST} -y set EXP_ROM_UEFI_x86_ENABLE=0
+     mlxconfig -d ${MST} -y set EXP_ROM_PXE_ENABLE=0
+     mlxconfig -d ${MST} -y set SRIOV_EN=0
+     mlxconfig -d ${MST} q | egrep "EXP_ROM"
     ```
 
 The Mellanox HSN card is now neutralized, and will only be usable in a booted system.
@@ -149,14 +149,14 @@ If the connection must be disabled, log in to the respective leaf-bmc switch.
 
    ```bash
    # SSH over METAL MANAGEMENT
-   pit# ssh admin@10.1.0.4
+    ssh admin@10.1.0.4
    # SSH over NODE MANAGEMENT
-   pit# ssh admin@10.252.0.4
+    ssh admin@10.252.0.4
    # SSH over HARDWARE MANAGEMENT
-   pit# ssh admin@10.254.0.4
+    ssh admin@10.254.0.4
 
    # or.. serial (device name will vary).
-   pit# minicom -b 115200 -D /dev/tty.USB1
+    minicom -b 115200 -D /dev/tty.USB1
    ```
 
 2. Enter configuration mode.

--- a/install/wipe_ncn_disks_for_reinstallation.md
+++ b/install/wipe_ncn_disks_for_reinstallation.md
@@ -31,15 +31,15 @@ This wipe erases the magic bits on the disk to prevent them from being recognize
 1. List the disks for verification.
 
     ```bash
-    ncn# disks_to_wipe=$(lsblk -l -o NAME,TYPE,TRAN | grep -E '[[:space:]].*(sata|nvme|sas|raid)' |
+     disks_to_wipe=$(lsblk -l -o NAME,TYPE,TRAN | grep -E '[[:space:]].*(sata|nvme|sas|raid)' |
                          awk '{ print "/dev/"$1 }' | sort -u | tr '\n' ' ')
-    ncn# echo "${disks_to_wipe}"
+     echo "${disks_to_wipe}"
     ```
 
 1. Wipe the disks and the RAIDs.
 
     ```bash
-    ncn# for disk in $disks_to_wipe; do
+     for disk in $disks_to_wipe; do
              wipefs --all --force ${disk}* 2> /dev/null
          done
     ```
@@ -66,9 +66,9 @@ This wipe erases the magic bits on the disk to prevent them from being recognize
    > ***NOTE*** The Ceph volume group will only exist on storage nodes, but this code snippet will work on all NCNs.
 
     ```bash
-    ncn# ceph_vgs='vg_name=~ceph*'
-    ncn# metal_vgs='vg_name=~metal*'
-    ncn# for volume_group in ${ceph_vgs} ${metal_vgs}; do
+     ceph_vgs='vg_name=~ceph*'
+     metal_vgs='vg_name=~metal*'
+     for volume_group in ${ceph_vgs} ${metal_vgs}; do
              vgremove -f -v --select "${volume_group}" -y >/dev/null 2>&1
          done
     ```
@@ -261,7 +261,7 @@ wiping a different type of node than what a step specifies, then skip that step.
     1. See if any `cray-sdu-rda` containers are running.
 
         ```bash
-        ncn# podman ps
+         podman ps
         ```
 
         Example output:
@@ -274,7 +274,7 @@ wiping a different type of node than what a step specifies, then skip that step.
     1. If there is a running `cray-sdu-rda` container in the above output, then stop it using the container ID:
 
         ```bash
-        ncn# podman stop 7741d5096625
+         podman stop 7741d5096625
         ```
 
         Example output:


### PR DESCRIPTION
# Description

This is to remove `pit#` and `ncn#`  prompt from commands presented on documentation, with this will be easier to copy commands with multiple lines during a new install or upgrade.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
