### PR TITLE
Add `@Cray-HPE/ssi-reviewers` as reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,13 +1,37 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 # Default group
-*                                                       @Cray-HPE/docs-csm-reviewers
+*                                                        @Cray-HPE/docs-csm-reviewers @Cray-HPE/pubs
 
-# Metal team items.
+# Metal Items
 /background/ncn_*                                        @Cray-HPE/metal
-/install/*                                               @Cray-HPE/metal
 /install/livecd                                          @Cray-HPE/metal
 /operations/bare_metal                                   @Cray-HPE/metal
+/operations/system_configuration_service                 @Cray-HPE/metal
 
 # Continuous Integration Items
+.github/                                                 @Cray-HPE/ci
 Jenkinsfile.github                                       @Cray-HPE/ci
 
 # CMS Items
@@ -23,25 +47,35 @@ Jenkinsfile.github                                       @Cray-HPE/ci
 
 # PET Items
 /operations/artifact_management                          @Cray-HPE/platform-engineering
+/operations/argo                                         @Cray-HPE/platform-engineering
 /operations/kubernetes                                   @Cray-HPE/platform-engineering
 /operations/multi-tenancy                                @Cray-HPE/platform-engineering
+/operations/node_management/                             @Cray-HPE/platform-engineering @Cray-HPE/metal
 /operations/package_repository_management                @Cray-HPE/platform-engineering
+/operations/resiliency                                   @Cray-HPE/platform-engineering
+/operations/security_and_authentication                  @Cray-HPE/platform-engineering
 /operations/spire                                        @Cray-HPE/platform-engineering
 /operations/system_management_health                     @Cray-HPE/platform-engineering
 /operations/utility_storage                              @Cray-HPE/platform-engineering
-troubleshooting/kubernetes                               @Cray-HPE/platform-engineering
-/workflows                                               @Cray-HPE/platform-engineering
+/troubleshooting/kubernetes                              @Cray-HPE/platform-engineering
+/workflows/                                              @Cray-HPE/platform-engineering
 
 # HMS Items
 /operations/firmware                                     @Cray-HPE/hardware-management
-/operations/hardware_state_manager                       @Cray-HPE/hardware-management
+/operations/hardware_state_manager/                      @Cray-HPE/hardware-management
 /operations/hmcollector                                  @Cray-HPE/hardware-management
 /operations/hpe_pdu                                      @Cray-HPE/hardware-management
 /operations/power_management                             @Cray-HPE/hardware-management
 /operations/system_layout_service                        @Cray-HPE/hardware-management
 
 # Network Items
-/operations/network                                      @Cray-HPE/management-network
+/operations/network/                                     @Cray-HPE/management-network
 
 # SAT Items
 /operations/sat                                          @Cray-HPE/system-admin-toolkit-admin
+
+# Include SSI on these CSM items.
+/install/                                                @Cray-HPE/metal @Cray-HPE/ssi-reviewers
+/operations/                                             @Cray-HPE/ssi-reviewers
+/upgrade/                                                @Cray-HPE/ssi-reviewers
+


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
Fix the missing leading `/` on `troubleshooting`. Add `Cray-HPE/metal` to `/operations/node_management` section. Include `Cray-HPE/ci` on all `.github/` items.

Attempt to fix CASMINST-5382 which seems fixed in `main` by using `main`'s formatting for some of the entries.

Add entries that exist in `main` that also exist in `release/1.3`.

Add LICENSE header.

This is related to #2561.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
