### PR TITLE
MTL-1970: add a clarification about --target-group for cfs session create

### DIFF
--- a/operations/configuration_management/Management_Node_Image_Customization.md
+++ b/operations/configuration_management/Management_Node_Image_Customization.md
@@ -72,6 +72,14 @@ This document describes the configuration of a Kubernetes NCN image. The same st
 
 1. [Create an Image Customization CFS Session](Create_an_Image_Customization_CFS_Session.md).
 
+   In this section, use the following values for the target definition and target group for the
+   `cray cfs session create` command invocation:
+
+   ```text
+   --target-definition image
+   --target-group Management_Worker
+   ```
+
 1. (`ncn-mw#`) Update boot parameters for a Kubernetes NCN.
 
     1. Get the existing `metal.server` setting for the component name (xname) of the node of interest:


### PR DESCRIPTION
# Description

Add a clarification about which target group to use when using CFS to modify an NCN image.
<!--- Describe what this change is and what it is for. -->

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
