### PR TITLE
CASMCMS-8249: Document known issue with logging into gitea web page

### DIFF
--- a/troubleshooting/known_issues/gitea_web_ui_requires_two_logins.md
+++ b/troubleshooting/known_issues/gitea_web_ui_requires_two_logins.md
@@ -1,0 +1,7 @@
+# Known Issue: Logging into the Gitea web UI requires logging in twice
+
+When using the Gitea web UI, users are redirected to a `keycloak` login.
+The redirect is expected; however, the expectation is that logging in on this page should log users into Gitea. Unfortunately, that does not happen.
+Instead users are being redirected back to Gitea and have to login again through the Gitea web page using the existing git credentials.
+To obtain the git credentials for Gitea see the [Version Control Service](../../operations/configuration_management/Version_Control_Service_VCS.md) documentation.
+Currently, logging in twice is the only workaround.


### PR DESCRIPTION
# Description

Document known issue with logging into gitea web page where users are required to log in twice.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
