### PR TITLE
CASMINST-5390: Move worker NCN image customization steps back to stage 0; Linting; Disable CFS on all NCNs in prerequisites.sh

### DIFF
--- a/operations/configuration_management/Worker_Upgrade_Node_Personalization.md
+++ b/operations/configuration_management/Worker_Upgrade_Node_Personalization.md
@@ -1,10 +1,10 @@
 # Worker Upgrade Node Personalization
 
 When performing an upgrade, NCN image customization must be performed with the NCN worker node image to ensure the appropriate CFS layers are applied.
- This step involves configuring CFS to use the default SAT `bootprep` files from the `hpc-csm-software-recipe` repository, and rebuilding the NCN worker nodes so they boot the newly customized image.
+This step involves configuring CFS to use the default SAT `bootprep` files from the `hpc-csm-software-recipe` repository, and rebuilding the NCN worker nodes so they boot the newly customized image.
 
 The definition of the CFS configuration used for NCN worker node personalization is provided in the `hpc-csm-software-recipe` repository in VCS.
- The following procedure describes how to correctly edit the SAT `bootprep` files to be able to use them to perform node personalization.
+The following procedure describes how to correctly edit the SAT `bootprep` files to be able to use them to perform node personalization.
 
 1. (`ncn-m#`) Perform the steps in the [Accessing SAT `Bootprep` Files](Accessing_Sat_Bootprep_Files.md) procedure to gather a copy of the SAT `Bootprep` files.
 
@@ -19,7 +19,7 @@ The definition of the CFS configuration used for NCN worker node personalization
 
     Verify the content now starts with just the `ncn-personalization` section.
 
-    ```bash
+    ```yaml
     # (C) Copyright 2022 Hewlett Packard Enterprise Development LP
     ---
     schema_version: 1.0.2
@@ -42,5 +42,5 @@ This must be done because the new version of CPE and Analytics has not yet been 
 1. (`ncn-m#`) Run `sat bootprep` against the `management-bootprep-node-personalization.yaml` file to create the CFS configuration that will be used for node personalization on worker NCN.
 
     ```bash
-    sat bootprep run `management-bootprep-node-personalization.yaml`
+    sat bootprep run management-bootprep-node-personalization.yaml
     ```

--- a/upgrade/Stage_0_Prerequisites.md
+++ b/upgrade/Stage_0_Prerequisites.md
@@ -226,8 +226,32 @@ There are two possible scenarios. Follow the procedure for the scenario that is 
 
 ### Standard upgrade
 
-In most cases, administrators will be performing a standard upgrade and not a CSM-only system upgrade. The image customization and node personalization steps that should be used come in a later section Stage 2.2.
-Continue on to Stage 0.4, skipping the CSM-only system upgrade section below.
+In most cases, administrators will be performing a standard upgrade and not a CSM-only system upgrade. In the standard upgrade, worker NCN image customization and node personalization steps are required.
+
+1. Consult the `HPE Cray EX System Software Getting Started Guide`.
+
+    Read the `HPE Cray EX software upgrade workflow` section. Pay particular attention to the `HPC CSM Software Recipe` and `Cray System Management (CSM)` subsections,
+    as well as any `NCN Personalization` subsections.
+
+1. Get a current copy of the SAT `Bootprep` files.
+
+    See [Accessing SAT `Bootprep` Files](../operations/configuration_management/Accessing_Sat_Bootprep_Files.md).
+
+1. Prepare the pre-boot worker NCN image customizations.
+
+    This will ensure that the CFS configuration layers are applied to perform image customization for the worker NCNs.
+    See [Worker Upgrade Image Customization](../operations/configuration_management/Worker_Upgrade_Image_Customization.md).
+
+1. Prepare the post-boot worker NCN image personalizations.
+
+    This will ensure that the CFS configuration layers are applied to perform node personalization during the post-boot of the worker NCNs.
+    See [Worker Upgrade Node Personalization](../operations/configuration_management/Worker_Upgrade_Node_Personalization.md).
+
+1. Customize the worker NCN images and apply their new boot parameters.
+
+    See [Management Node Image Customization](../operations/configuration_management/Management_Node_Image_Customization.md).
+
+Continue on to [Stage 0.4](#stage-04---backup-workload-manager-data), skipping the [CSM-only system upgrade](#csm-only-system-upgrade) subsection below.
 
 ### CSM-only system upgrade
 

--- a/upgrade/Stage_2.md
+++ b/upgrade/Stage_2.md
@@ -62,16 +62,6 @@ For more information, see [Using the Argo UI](../operations/argo/Using_the_Argo_
 
 ## Stage 2.2 - Worker node image upgrade
 
-1. Follow the steps in the [Accessing Sat `Bootprep` Files](../operations/configuration_management/Accessing_Sat_Bootprep_Files.md) document to acquire a current copy of the SAT `Bootprep` files.
-
-1. Follow the steps in the [Worker Upgrade Image Customization](../operations/configuration_management/Worker_Upgrade_Image_Customization.md) document.
- This will ensure the CFS configuration Layers are applied to perform Image Customization for the nodes which will be rebooted during the upgrade.
-
-1. Follow the steps in the [Worker Upgrade Node Personalization](../operations/configuration_management/Worker_Upgrade_Node_Personalization.md) document.
- This will ensure the CFS configuration Layers are applied to perform Node Personalization during the post-boot of the Management NCNs.
-
-1. Now that you've updated CFS for Image Customization and Node personalization, follow the [Management Node Image Customization](../operations/configuration_management/Management_Node_Image_Customization.md) document to apply new CSM boot parameters.
-
 There are two options available for upgrading worker nodes.
 
 ### Option 1 - Serial upgrade

--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -857,6 +857,42 @@ else
     echo "====> ${state_name} has been completed" | tee -a "${LOG_FILE}"
 fi
 
+# Disable CFS on the NCNs, to prevent new sessions from being launched during the upgrade.
+# Note that it is possible CFS sessions are currently underway on the NCNs. Disabling them
+# will not prevent currently scheduled CFS sessions from executing -- it will just prevent
+# new sessions from being scheduled. It will also not prevent current sessions from updating
+# the status of the component when they complete. However, that update will not re-enable
+# the component.
+state_name="DISABLE_CFS_ON_NCNS"
+state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
+if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
+    echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
+    {
+        echo "Retrieving a list of all management node component names (xnames)"
+        set -o pipefail
+        XNAMES=$(cray hsm state components list --role Management --type Node --format json | jq -r '.Components | map(.ID) | join(",")')
+        set +o pipefail
+        [[ -n "${XNAMES}" ]]
+        XNAME_LIST=${XNAMES//,/ }
+
+        echo "Disabling CFS configuration for all NCNs"
+        for xname in ${XNAME_LIST}; do
+            echo "Disabling CFS on ${xname}"
+            cray cfs components update "${xname}" --enabled false --format json
+
+            # Make sure it is actually disabled
+            echo "Verifying that CFS is now disabled on ${xname}"
+            set -o pipefail            
+            cray cfs components describe "${xname}" --format json | jq '.enabled' | grep "^false$"
+            set +o pipefail
+        done
+
+    } >> "${LOG_FILE}" 2>&1
+    record_state "${state_name}" "$(hostname)" | tee -a "${LOG_FILE}"
+else
+    echo "====> ${state_name} has been completed" | tee -a "${LOG_FILE}"
+fi
+
 # restore previous ssh config if there was one, remove ours
 rm -f /root/.ssh/config
 test -f /root/.ssh/config.bak && mv /root/.ssh/config.bak /root/.ssh/config


### PR DESCRIPTION
# Description

This PR does 3 things (at Dennis's request)
1. Moves the NCN worker image customization steps from Stage 2.2 to Stage 0.3
2. Adds a first step to that procedure, indicating that the upgrader should read the relevant sections of the GSG.
3. Adds a stage to the end of prerequisites.sh in stage 0 that disables CFS on all NCNs
4. Minor doc linting.

There are still significant problems with the NCN worker image customization procedure. However, they are beyond the scope of this ticket, so please do not include them in the review of this PR. I will be opening another ticket to capture the work that I'm aware of that remains for this procedure. I'll comment [CASMINST-5390](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5390) with that ticket number, once I've opened it. Comments in that vein can either be added to that ticket, or can be documented in a new ticket.

# Checklist Before Merging

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
