### PR TITLE
CASMINST-5390: Move worker NCN image customization steps back to stage 0; Linting; Disable CFS on all NCNs in prerequisites.sh

### DIFF
--- a/operations/configuration_management/Accessing_Sat_Bootprep_Files.md
+++ b/operations/configuration_management/Accessing_Sat_Bootprep_Files.md
@@ -1,0 +1,56 @@
+# Accessing SAT `Bootprep` Files
+
+When performing an upgrade, NCN image customization and node personalization must be performed with the NCN worker node image to ensure the appropriate CFS layers are applied.
+This step involves configuring CFS to use the default SAT `bootprep` files from the `hpc-csm-software-recipe` repository, and rebuilding the NCN worker nodes so they boot the newly customized image.
+
+The following procedure describes how to access the CFS configuration. This procedure is used for both image customization and node personalization of NCNs.
+
+1. (`ncn-m#`) Set up a script to obtain the `crayvcs` user password from the Kubernetes secret.
+
+    ```bash
+    cat > vcs-creds-helper.sh << EOF
+
+    > #!/bin/bash
+    > kubectl get secret -n services vcs-user-credentials -o jsonpath={.data.vcs_password} | base64 -d
+    > EOF
+    
+    chmod u+x vcs-creds-helper.sh
+    
+    export GIT_ASKPASS="$PWD/vcs-creds-helper.sh"
+    ```
+
+1. (`ncn-m#`) Clone the software recipe repo from the local Version Control Service (VCS).
+
+    ```bash
+    git clone https://crayvcs@api-gw-service-nmn.local/vcs/cray/hpc-csm-software-recipe.git
+    ```
+
+1. (`ncn-m#`) Change the current directory to the cloned repository.
+
+    ```bash
+    cd hpc-csm-software-recipe
+    ```
+
+1. (`ncn-m#`) (Optional) Disable the pager for Git command output.
+
+    ```bash
+    export GIT_PAGER=
+    ```
+
+1. (`ncn-m#`) Show the remote branches.
+
+    ```bash
+    git branch -r 
+    ```
+
+1. (`ncn-m#`) Check out the branch for the installed version.
+
+    ```bash
+    git checkout cray/hpc-csm-software-recipe/22.11
+    ```
+
+1. (`ncn-m#`) List the default SAT `bootprep` input files in this repository:
+
+    ```bash
+    ls bootrep
+    ```

--- a/operations/configuration_management/Management_Node_Image_Customization.md
+++ b/operations/configuration_management/Management_Node_Image_Customization.md
@@ -22,7 +22,7 @@ This document describes the configuration of a Kubernetes NCN image. The same st
 
     cray artifacts get boot-images "k8s/${ARTIFACT_VERSION}/initrd" "./${ARTIFACT_VERSION}-initrd"
 
-    export IMS_ROOTFS_FILENAME="${ARTIFACT_VERSION}-filesystem.squashfs"
+    export IMS_ROOTFS_FILENAME="${ARTIFACT_VERSION}-rootfs"
 
     export IMS_KERNEL_FILENAME="${ARTIFACT_VERSION}-kernel"
 

--- a/operations/configuration_management/Worker_Upgrade_Image_Customization.md
+++ b/operations/configuration_management/Worker_Upgrade_Image_Customization.md
@@ -1,0 +1,37 @@
+# Worker Upgrade Image Customization
+
+When performing an upgrade, NCN image customization must be performed with the NCN worker node image to ensure the appropriate CFS layers are applied.
+This step involves configuring CFS to use the default SAT `bootprep` files from the `hpc-csm-software-recipe` repository, and rebuilding the NCN worker nodes so they boot the newly customized image.
+
+The definition of the CFS configuration used for NCN worker node Image Customization is provided in the `hpc-csm-software-recipe` repository in VCS.
+The following procedure describes how to correctly edit the `bootprep` files to be able to use them to perform image customization.
+
+1. (`ncn-m#`) Perform the steps in the [Accessing SAT `Bootprep` Files](Accessing_Sat_Bootprep_Files.md) procedure to gather a copy of the SAT `Bootprep` files.
+
+1. (`ncn-m#`) Create a local copy of the `management-bootprep-yaml` file and delete the `ncn-personalization` configuration. The `ncn-image-customization` configuration will be the only entry remaining in the file.
+
+    ```bash
+    cp management-bootprep.yaml management-bootprep-image-customization.yaml
+    vi management-bootprep-image-customization.yaml
+    ```
+
+    Edit the `management-bootprep-image-customization.yaml` file to delete the ncn-personalization configuration definition.
+
+    Verify the content now starts with just the image customization section.
+
+    ```bash
+    # (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+    ---
+    schema_version: 1.0.2
+    configurations:
+    - name: ncn-image-customization
+    ```
+
+1. (`ncn-m#`) Run `sat bootprep` against the `management-bootprep-image-customization.yaml` file to create CFS configuration that will be used to customize the worker image.
+
+    ```bash
+    sat bootprep run management-bootprep-image-customization.yaml
+    ```
+
+1. (`ncn-m#`) Perform the steps in [Management Node Image Customization](Management_Node_Image_Customization.md). Use the CFS configuration created in the previous step when
+    customizing the image.

--- a/operations/configuration_management/Worker_Upgrade_Node_Personalization.md
+++ b/operations/configuration_management/Worker_Upgrade_Node_Personalization.md
@@ -1,10 +1,10 @@
 # Worker Upgrade Node Personalization
 
 When performing an upgrade, NCN image customization must be performed with the NCN worker node image to ensure the appropriate CFS layers are applied.
- This step involves configuring CFS to use the default SAT `bootprep` files from the `hpc-csm-software-recipe` repository, and rebuilding the NCN worker nodes so they boot the newly customized image.
+This step involves configuring CFS to use the default SAT `bootprep` files from the `hpc-csm-software-recipe` repository, and rebuilding the NCN worker nodes so they boot the newly customized image.
 
 The definition of the CFS configuration used for NCN worker node personalization is provided in the `hpc-csm-software-recipe` repository in VCS.
- The following procedure describes how to correctly edit the SAT `bootprep` files to be able to use them to perform node personalization.
+The following procedure describes how to correctly edit the SAT `bootprep` files to be able to use them to perform node personalization.
 
 1. (`ncn-m#`) Perform the steps in the [Accessing SAT `Bootprep` Files](Accessing_Sat_Bootprep_Files.md) procedure to gather a copy of the SAT `Bootprep` files.
 
@@ -19,7 +19,7 @@ The definition of the CFS configuration used for NCN worker node personalization
 
     Verify the content now starts with just the `ncn-personalization` section.
 
-    ```bash
+    ```yaml
     # (C) Copyright 2022 Hewlett Packard Enterprise Development LP
     ---
     schema_version: 1.0.2
@@ -42,5 +42,5 @@ This must be done because the new version of CPE and Analytics has not yet been 
 1. (`ncn-m#`) Run `sat bootprep` against the `management-bootprep-node-personalization.yaml` file to create the CFS configuration that will be used for node personalization on worker NCN.
 
     ```bash
-    sat bootprep run `management-bootprep-node-personalization.yaml`
+    sat bootprep run management-bootprep-node-personalization.yaml
     ```

--- a/operations/configuration_management/Worker_Upgrade_Node_Personalization.md
+++ b/operations/configuration_management/Worker_Upgrade_Node_Personalization.md
@@ -1,0 +1,46 @@
+# Worker Upgrade Node Personalization
+
+When performing an upgrade, NCN image customization must be performed with the NCN worker node image to ensure the appropriate CFS layers are applied.
+ This step involves configuring CFS to use the default SAT `bootprep` files from the `hpc-csm-software-recipe` repository, and rebuilding the NCN worker nodes so they boot the newly customized image.
+
+The definition of the CFS configuration used for NCN worker node personalization is provided in the `hpc-csm-software-recipe` repository in VCS.
+ The following procedure describes how to correctly edit the SAT `bootprep` files to be able to use them to perform node personalization.
+
+1. (`ncn-m#`) Perform the steps in the [Accessing SAT `Bootprep` Files](Accessing_Sat_Bootprep_Files.md) procedure to gather a copy of the SAT `Bootprep` files.
+
+1. (`ncn-m#`) Create a local copy of the `management-bootprep-yaml` file and delete the `ncn-image-customization` configuration. The `ncn-personalization` configuration should  be the only entry remaining in the file if completed correctly.
+
+    ```bash
+    cp management-bootprep.yaml management-bootprep-node-personalization.yaml
+    vi management-bootprep-node-personalization.yaml
+    ```
+
+    Edit the `management-bootprep-node-personalization.yaml` file to delete the `ncn-image-customization` configuration definition, leaving only the node personalization section.
+
+    Verify the content now starts with just the `ncn-personalization` section.
+
+    ```bash
+    # (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+    ---
+    schema_version: 1.0.2
+    configurations:
+    - name: ncn-personalization
+    ```
+
+1. (`ncn-m#`) Use the `management-bootprep-node-personalization.yaml` file as input when customizing the new NCN worker node image with CFS in the CSM documentation.
+
+1. (`ncn-m#`) Acquire a copy of the current CPE and Analytics products CFS configuration values already in use.
+ Obtain the values for the `cloneUrl`, `commit`, and `playbook` lines for each of those two layers in the next step to ensure that when the nodes boot later during upgrade, they come up with the desired configuration for CPE and Analytics.
+
+    ```bash
+    cray cfs components describe <ncn-xname> --format json
+    ```
+
+1. (`ncn-m#`) Edit the `management-bootprep-node-personalization.yaml` file to replace the CPE and Analytics layer with the playbook, commit hash, and product values already in use on the NCNs for CPE.
+This must be done because the new version of CPE and Analytics has not yet been installed at this time in the upgrade procedure.
+
+1. (`ncn-m#`) Run `sat bootprep` against the `management-bootprep-node-personalization.yaml` file to create the CFS configuration that will be used for node personalization on worker NCN.
+
+    ```bash
+    sat bootprep run `management-bootprep-node-personalization.yaml`
+    ```

--- a/upgrade/Stage_0_Prerequisites.md
+++ b/upgrade/Stage_0_Prerequisites.md
@@ -226,8 +226,8 @@ There are two possible scenarios. Follow the procedure for the scenario that is 
 
 ### Standard upgrade
 
-The procedures for customizing the NCN image and updating NCN personalization configurations are found in the *HPE Cray EX System Software Getting Started Guide S-8000*, section
-"HPE Cray EX Software Upgrade Workflow", subsection "Cray System Management (CSM)".
+In most cases, administrators will be performing a standard upgrade and not a CSM-only system upgrade. The image customization and node personalization steps that should be used come in a later section Stage 2.2.
+Continue on to Stage 0.4, skipping the CSM-only system upgrade section below.
 
 ### CSM-only system upgrade
 

--- a/upgrade/Stage_0_Prerequisites.md
+++ b/upgrade/Stage_0_Prerequisites.md
@@ -226,8 +226,32 @@ There are two possible scenarios. Follow the procedure for the scenario that is 
 
 ### Standard upgrade
 
-In most cases, administrators will be performing a standard upgrade and not a CSM-only system upgrade. The image customization and node personalization steps that should be used come in a later section Stage 2.2.
-Continue on to Stage 0.4, skipping the CSM-only system upgrade section below.
+In most cases, administrators will be performing a standard upgrade and not a CSM-only system upgrade. In the standard upgrade, worker NCN image customization and node personalization steps are required.
+
+1. Consult the `HPE Cray EX System Software Getting Started Guide`.
+
+    Read the `HPE Cray EX software upgrade workflow` section. Pay particular attention to the `HPC CSM Software Recipe` and `Cray System Management (CSM)` subsections,
+    as well as any `NCN Personalization` subsections.
+
+1. Get a current copy of the SAT `Bootprep` files.
+
+    See [Accessing SAT `Bootprep` Files](../operations/configuration_management/Accessing_Sat_Bootprep_Files.md).
+
+1. Prepare the pre-boot worker NCN image customizations.
+
+    This will ensure that the CFS configuration layers are applied to perform image customization for the worker NCNs.
+    See [Worker Upgrade Image Customization](../operations/configuration_management/Worker_Upgrade_Image_Customization.md).
+
+1. Prepare the post-boot worker NCN image personalizations.
+
+    This will ensure that the CFS configuration layers are applied to perform node personalization during the post-boot of the worker NCNs.
+    See [Worker Upgrade Node Personalization](../operations/configuration_management/Worker_Upgrade_Node_Personalization.md).
+
+1. Customize the worker NCN images and apply their new boot parameters.
+
+    See [Management Node Image Customization](../operations/configuration_management/Management_Node_Image_Customization.md).
+
+Continue on to [Stage 0.4](#stage-04---backup-workload-manager-data), skipping the [CSM-only system upgrade](#csm-only-system-upgrade) subsection below.
 
 ### CSM-only system upgrade
 

--- a/upgrade/Stage_2.md
+++ b/upgrade/Stage_2.md
@@ -62,6 +62,16 @@ For more information, see [Using the Argo UI](../operations/argo/Using_the_Argo_
 
 ## Stage 2.2 - Worker node image upgrade
 
+1. Follow the steps in the [Accessing Sat `Bootprep` Files](../operations/configuration_management/Accessing_Sat_Bootprep_Files.md) document to acquire a current copy of the SAT `Bootprep` files.
+
+1. Follow the steps in the [Worker Upgrade Image Customization](../operations/configuration_management/Worker_Upgrade_Image_Customization.md) document.
+ This will ensure the CFS configuration Layers are applied to perform Image Customization for the nodes which will be rebooted during the upgrade.
+
+1. Follow the steps in the [Worker Upgrade Node Personalization](../operations/configuration_management/Worker_Upgrade_Node_Personalization.md) document.
+ This will ensure the CFS configuration Layers are applied to perform Node Personalization during the post-boot of the Management NCNs.
+
+1. Now that you've updated CFS for Image Customization and Node personalization, follow the [Management Node Image Customization](../operations/configuration_management/Management_Node_Image_Customization.md) document to apply new CSM boot parameters.
+
 There are two options available for upgrading worker nodes.
 
 ### Option 1 - Serial upgrade

--- a/upgrade/Stage_2.md
+++ b/upgrade/Stage_2.md
@@ -62,16 +62,6 @@ For more information, see [Using the Argo UI](../operations/argo/Using_the_Argo_
 
 ## Stage 2.2 - Worker node image upgrade
 
-1. Follow the steps in the [Accessing Sat `Bootprep` Files](../operations/configuration_management/Accessing_Sat_Bootprep_Files.md) document to acquire a current copy of the SAT `Bootprep` files.
-
-1. Follow the steps in the [Worker Upgrade Image Customization](../operations/configuration_management/Worker_Upgrade_Image_Customization.md) document.
- This will ensure the CFS configuration Layers are applied to perform Image Customization for the nodes which will be rebooted during the upgrade.
-
-1. Follow the steps in the [Worker Upgrade Node Personalization](../operations/configuration_management/Worker_Upgrade_Node_Personalization.md) document.
- This will ensure the CFS configuration Layers are applied to perform Node Personalization during the post-boot of the Management NCNs.
-
-1. Now that you've updated CFS for Image Customization and Node personalization, follow the [Management Node Image Customization](../operations/configuration_management/Management_Node_Image_Customization.md) document to apply new CSM boot parameters.
-
 There are two options available for upgrading worker nodes.
 
 ### Option 1 - Serial upgrade


### PR DESCRIPTION
This is the main backport of https://github.com/Cray-HPE/docs-csm/pull/2571