### PR TITLE
 CASMINST-5384: backport root password/key docs from 1.0

### DIFF
--- a/operations/CSM_product_management/Change_Passwords_and_Credentials.md
+++ b/operations/CSM_product_management/Change_Passwords_and_Credentials.md
@@ -4,10 +4,6 @@ This is an overarching procedure to change all credentials managed by Cray Syste
 
 There are many passwords and credentials used in different contexts to manage the system. These can be changed as needed. Their initial settings are documented, so it is recommended to change them during or soon after a CSM software installation.
 
-## Prerequisites
-
-- Review procedures in [Manage System Passwords](../security_and_authentication/Manage_System_Passwords.md).
-
 ## Procedure
 
 ### 1. Change Hardware Credentials

--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
@@ -1,0 +1,417 @@
+# Change NCN Image Root Password and SSH Keys
+
+The default SSH keys in the NCN image must be removed. The default password for the root user must be changed.
+Customize the NCN images by changing the root password or adding different SSH keys for the root account.
+This procedure shows this process being done any time after the first time installation of the CSM
+software has been completed and the PIT node is booted as a regular master node. To change the NCN image
+during an installation while the PIT node is booted as the PIT node,
+see [Change NCN Image Root Password and SSH Keys PIT](#Change_NCN_Image_Root_Password_and_SSH_Keys_PIT.md).
+
+There is some common preparation before making the Kubernetes image for master nodes and worker nodes, making the Ceph image for utility storage nodes, and then some common cleanup afterwards.
+
+***Note:*** This procedure can only be done after the PIT node is rebuilt to become a normal master node.
+***Note:*** The NCNs must be rebuilt for the changes to take effect. This is covered in the last step.
+
+- [Common preparation](#common-preparation)
+- [Kubernetes image](#kubernetes-image)
+- [Ceph image](#ceph-image)
+- [Common cleanup](#common-cleanup)
+- [Deploy changes](#deploy-changes)
+
+## Common preparation
+
+1. Prepare new SSH keys for the root account in advance. The same key information will be added to both `k8s-image` and Ceph image.
+
+   Either replace the root public and private SSH keys with your own previously generated keys or generate a new
+   pair with `ssh-keygen(1)`. By default `ssh-keygen` will create an RSA key, but other types could be chosen and
+   different filenames would need to be substituted in later steps.
+
+   ***Note:*** CSM only supports key pairs with empty passphrases (`ssh-keygen -N""`, or enter an empty passphrase when prompted).
+
+   ```bash
+   ncn-mw# mkdir /root/.ssh
+   ncn-mw# ssh-keygen -f /root/.ssh/id_rsa -t rsa
+   ncn-mw# ls -l /root/.ssh/id_rsa*
+   ncn-mw# chmod 600 /root/.ssh/id_rsa
+   ```
+
+1. Change to a working directory with enough space to hold the images once they have been expanded.
+
+   ```bash
+   ncn-mw# cd /run/initramfs/overlayfs
+   ncn-mw# mkdir workingarea
+   ncn-mw# cd workingarea
+   ```
+
+## Kubernetes image
+
+The Kubernetes image `k8s-image` is used by the master and worker nodes.
+
+1. Decide which `k8s-image` to modify.
+
+   ```bash
+   ncn-mw# cray artifacts list ncn-images --format json | jq '.artifacts[] .Key' | grep k8s | grep squashfs
+   ```
+
+   Example output:
+
+   ```text
+   "k8s-filesystem.squashfs"
+   "k8s/0.1.107/filesystem.squashfs"
+   "k8s/0.1.109/filesystem.squashfs"
+   "k8s/0.1.48/filesystem.squashfs"
+   ```
+
+   This example uses `k8s/0.1.109` for the current version and adds a suffix for the new version.
+
+   ```bash
+   ncn-mw# export K8SVERSION=0.1.109
+   ncn-mw# export K8SNEW=0.1.109-2
+   ```
+
+1. Make a temporary directory for the `k8s-image` using the current version string.
+
+   ```bash
+   ncn-mw# mkdir -p k8s/${K8SVERSION}
+   ```
+
+1. Get the image.
+
+   ```bash
+   ncn-mw# cray artifacts get ncn-images k8s/${K8SVERSION}/filesystem.squashfs k8s/${K8SVERSION}/filesystem.squashfs.orig
+   ```
+
+1. Open the image.
+
+   ```bash
+   ncn-mw# unsquashfs -d k8s/${K8SVERSION}/filesystem.squashfs k8s/${K8SVERSION}/filesystem.squashfs.orig
+   ```
+
+1. If the image being modified contains the default SSH keys for the `root` user and/or the default
+   SSH host keys, remove them now. If the defaults were removed during initial system install or in
+   a subsequent rotation, then this step can be safely skipped.
+
+   ```bash
+   ncn-mw# rm -rf k8s/${K8SVERSION}/filesystem.squashfs/root/.ssh
+   ncn-mw# rm -f k8s/${K8SVERSION}/filesystem.squashfs/etc/ssh/*key*
+   ```
+
+1. Copy the generated public and private SSH keys for the `root` account into the image.
+
+   This example assumes that an RSA key was generated.
+
+   ```bash
+   ncn-mw# mkdir -m 0700 k8s/${K8SVERSION}/filesystem.squashfs/root/.ssh
+   ncn-mw# cp -p /root/.ssh/id_rsa /root/.ssh/id_rsa.pub k8s/${K8SVERSION}/filesystem.squashfs/root/.ssh
+   ```
+
+1. Replace the public SSH key for the `root` account in `authorized_keys`.
+
+   This example assumes that an RSA key was generated so it adds the `id_rsa.pub` file to `authorized_keys`. It also removes any previously authorized keys. Feel free to manage this differently to retain additional keys if desired.
+
+   ```bash
+   ncn-mw# cat /root/.ssh/id_rsa.pub > k8s/${K8SVERSION}/filesystem.squashfs/root/.ssh/authorized_keys
+   ncn-mw# chmod 640 k8s/${K8SVERSION}/filesystem.squashfs/root/.ssh/authorized_keys
+   ```
+
+1. Change into the image root.
+
+   ```bash
+   ncn-mw# chroot k8s/${K8SVERSION}/filesystem.squashfs
+   ```
+
+1. Change the password.
+
+   ```bash
+   chroot-ncn-mw# passwd
+   ```
+
+1. (Optional) If there are any other things to be changed in the image, then they could also be done at this point.
+
+   1. (Optional) Set default timezone on management nodes.
+
+      1. Check whether `TZ` variable is already set in `/etc/environment`. The setting for `NEWTZ` must be a valid timezone from the set under `/usr/share/zoneinfo`.
+
+         ```bash
+         chroot-ncn-mw# NEWTZ=US/Pacific
+         chroot-ncn-mw# grep TZ /etc/environment
+         ```
+
+         Add only if `TZ` is not present.
+
+         ```bash
+         chroot-ncn-mw# echo TZ=${NEWTZ} >> /etc/environment
+         ```
+
+      1. Check for `utc` setting.
+
+         ```bash
+         chroot-ncn-mw# grep -i utc /srv/cray/scripts/metal/ntp-upgrade-config.sh
+         ```
+
+         Change only if the `grep` command shows these lines set to UTC.
+
+         ```bash
+         chroot-ncn-mw# sed -i "s#^timedatectl set-timezone UTC#timedatectl set-timezone $NEWTZ#" /srv/cray/scripts/metal/ntp-upgrade-config.sh
+         chroot-ncn-mw# sed -i 's/--utc/--localtime/' /srv/cray/scripts/metal/ntp-upgrade-config.sh
+         ```
+
+1. Create the new SquashFS artifact.
+
+   ```bash
+   chroot-ncn-mw# /srv/cray/scripts/common/create-kis-artifacts.sh
+   ```
+
+1. Exit the `chroot` environment.
+
+   ```bash
+   chroot-ncn-mw# exit
+   ```
+
+1. Clean up the SquashFS creation.
+
+   ```bash
+   ncn-mw# umount -v k8s/${K8SVERSION}/filesystem.squashfs/mnt/squashfs
+   ```
+
+1. Move new SquashFS image, kernel, and `initrd` into place.
+
+   ```bash
+   ncn-mw# mkdir k8s/${K8SNEW}
+   ncn-mw# mv -v k8s/${K8SVERSION}/filesystem.squashfs/squashfs/* k8s/${K8SNEW}
+   ```
+
+1. Update file permissions on `initrd`.
+
+   ```bash
+   ncn-mw# chmod -v 644 k8s/${K8SNEW}/initrd.img.xz
+   ```
+
+1. Put the new `squashfs`, `kernel`, and `initrd` into S3.
+
+   ```bash
+   ncn-mw# cd k8s/${K8SNEW}
+   ncn-mw# /usr/share/doc/csm/scripts/ceph-upload-file-public-read.py --bucket-name ncn-images --key-name k8s/${K8SNEW}/filesystem.squashfs --file-name filesystem.squashfs
+   ncn-mw# /usr/share/doc/csm/scripts/ceph-upload-file-public-read.py --bucket-name ncn-images --key-name k8s/${K8SNEW}/initrd --file-name initrd.img.xz
+   ncn-mw# /usr/share/doc/csm/scripts/ceph-upload-file-public-read.py --bucket-name ncn-images --key-name k8s/${K8SNEW}/kernel --file-name 5.3.18-24.75-default.kernel
+   ncn-mw# cd ../..
+   ```
+
+1. The Kubernetes image now has the image changes.
+
+1. Update BSS with the new image for the master nodes and worker nodes.
+
+   **WARNING:** If doing a CSM software upgrade, then skip this section and proceed to [Ceph image](#ceph-image).
+
+   > If not doing a CSM software upgrade, this process will update the entries in BSS for the master nodes and worker nodes to use the new `k8s-image`.
+   >
+   > 1. Set all master nodes and worker nodes to use newly created `k8s-image`.
+   >
+   >     This will use the `K8SVERSION` and `K8SNEW` variables defined earlier.
+   >
+   >     ```bash
+   >     ncn-mw# for node in $(grep -oP "(ncn-[mw]\w+)" /etc/hosts | sort -u)
+   >             do
+   >                 echo $node
+   >                 xname=$(ssh $node cat /etc/cray/xname)
+   >                 echo $xname
+   >                 cray bss bootparameters list --name $xname --format json > bss_$xname.json
+   >                 sed -i.$(date +%Y%m%d_%H%M%S%N).orig "s@/k8s/${K8SVERSION}\([\"/[:space:]]\)@/k8s/${K8SNEW}\1@g" bss_$xname.json
+   >                 kernel=$(cat bss_$xname.json | jq '.[]  .kernel')
+   >                 initrd=$(cat bss_$xname.json | jq '.[]  .initrd')
+   >                 params=$(cat bss_$xname.json | jq '.[]  .params')
+   >                cray bss bootparameters update --initrd $initrd --kernel $kernel --params "$params" --hosts $xname --format json
+   >             done
+   >     ```
+   >
+   > BSS will be updated to use the new versions when `/etc/cray/upgrade/csm/myenv` is manually updated.
+   > See [Stage 0.9 - Modify NCN Images](../../upgrade/1.0.11/Stage_0_Prerequisites.md#stage-09---modify-ncn-images)for more information.
+
+## Ceph image
+
+The Ceph image is used by the utility storage nodes.
+
+1. Decide which Ceph image to modify.
+
+   ```bash
+   ncn-mw# cray artifacts list ncn-images --format json | jq '.artifacts[] .Key' | grep ceph | grep squashfs
+   ```
+
+   Example output:
+
+   ```text
+   "ceph-filesystem.squashfs"
+   "ceph/0.1.107/filesystem.squashfs"
+   "ceph/0.1.113/filesystem.squashfs"
+   "ceph/0.1.48/filesystem.squashfs"
+   ```
+
+   This example uses `ceph/0.1.113` for the current version and adds a suffix for the new version.
+
+   ```bash
+   ncn-mw# export CEPHVERSION=0.1.113
+   ncn-mw# export CEPHNEW=0.1.113-2
+   ```
+
+1. Make a temporary directory for the Ceph image using the current version string.
+
+   ```bash
+   ncn-mw# mkdir -p ceph/${CEPHVERSION}
+   ```
+
+1. Get the image.
+
+   ```bash
+   ncn-mw# cray artifacts get ncn-images ceph/${CEPHVERSION}/filesystem.squashfs ceph/${CEPHVERSION}/filesystem.squashfs.orig
+   ```
+
+1. Open the image.
+
+   ```bash
+   ncn-mw# unsquashfs -d ceph/${CEPHVERSION}/filesystem.squashfs ceph/${CEPHVERSION}/filesystem.squashfs.orig
+   ```
+
+1. Copy the generated public and private SSH keys for the `root` account into the image.
+
+   This example assumes that an RSA key was generated.
+
+   ```bash
+   ncn-mw# cp -p /root/.ssh/id_rsa /root/.ssh/id_rsa.pub ceph/${CEPHVERSION}/filesystem.squashfs/root/.ssh
+   ```
+
+1. Replace the public SSH key for the `root` account in `authorized_keys`.
+
+   This example assumes that an RSA key was generated so it adds the `id_rsa.pub` file to `authorized_keys`. It also removes any previously authorized keys. Feel free to manage this differently to retain additional keys if desired.
+
+   ```bash
+   ncn-mw# cat /root/.ssh/id_rsa.pub > ceph/${CEPHVERSION}/filesystem.squashfs/root/.ssh/authorized_keys
+   ncn-mw# chmod 640 ceph/${CEPHVERSION}/filesystem.squashfs/root/.ssh/authorized_keys
+   ```
+
+1. Change into the image root.
+
+   ```bash
+   ncn-mw# chroot ceph/${CEPHVERSION}/filesystem.squashfs
+   ```
+
+1. Change the password.
+
+   ```bash
+   chroot-ncn-mw# passwd
+   ```
+
+1. (Optional) If there are any other things to be changed in the image, then they could also be done at this point.
+
+   1. (Optional) Set default timezone on management nodes.
+
+      1. Check whether `TZ` variable is already set in `/etc/environment`. The setting for `NEWTZ` must be a valid timezone from the set under `/usr/share/zoneinfo`.
+
+         ```bash
+         chroot-ncn-mw# NEWTZ=US/Pacific
+         chroot-ncn-mw# grep TZ /etc/environment
+         ```
+
+         Add only if `TZ` is not present.
+
+         ```bash
+         chroot-ncn-mw# echo TZ=${NEWTZ} >> /etc/environment
+         ```
+
+      1. Check for `utc` setting.
+
+         ```bash
+         chroot-ncn-mw# grep -i utc /srv/cray/scripts/metal/ntp-upgrade-config.sh
+         ```
+
+         Change only if the `grep` command shows these lines set to UTC.
+
+         ```bash
+         chroot-ncn-mw# sed -i "s#^timedatectl set-timezone UTC#timedatectl set-timezone $NEWTZ#" /srv/cray/scripts/metal/ntp-upgrade-config.sh
+         chroot-ncn-mw# sed -i 's/--utc/--localtime/' /srv/cray/scripts/metal/ntp-upgrade-config.sh
+         ```
+
+1. Create the new SquashFS artifact.
+
+   ```bash
+   chroot-ncn-mw# /srv/cray/scripts/common/create-kis-artifacts.sh
+   ```
+
+1. Exit the `chroot` environment.
+
+   ```bash
+   chroot-ncn-mw# exit
+   ```
+
+1. Clean up the SquashFS creation.
+
+   ```bash
+   ncn-mw# umount -v ceph/${CEPHVERSION}/filesystem.squashfs/mnt/squashfs
+   ```
+
+1. Move the new SquashFS image, kernel, and `initrd` into place.
+
+   ```bash
+   ncn-mw# mkdir ceph/$CEPHNEW
+   ncn-mw# mv -v ceph/$CEPHVERSION/filesystem.squashfs/squashfs/* ceph/$CEPHNEW
+   ```
+
+1. Update file permissions on `initrd`.
+
+   ```bash
+   ncn-mw# chmod -v 644 ceph/${CEPHNEW}/initrd.img.xz
+   ```
+
+1. Put the new `initrd.img.xz`, `kernel`, and SquashFS into S3.
+
+   ***Note:*** The version string for the kernel file may be different.
+
+   ```bash
+   ncn-mw# cd ceph/${CEPHNEW}
+   ncn-mw# /usr/share/doc/csm/scripts/ceph-upload-file-public-read.py --bucket-name ncn-images --key-name ceph/${CEPHNEW}/filesystem.squashfs --file-name filesystem.squashfs
+   ncn-mw# /usr/share/doc/csm/scripts/ceph-upload-file-public-read.py --bucket-name ncn-images --key-name ceph/${CEPHNEW}/initrd --file-name initrd.img.xz
+   ncn-mw# /usr/share/doc/csm/scripts/ceph-upload-file-public-read.py --bucket-name ncn-images --key-name ceph/${CEPHNEW}/kernel --file-name 5.3.18-24.75-default.kernel
+   ncn-mw# cd ../..
+   ```
+
+1. The Ceph image now has the image changes.
+
+1. Update BSS with the new image for utility storage nodes.
+
+   **WARNING:** If doing a CSM software upgrade, then skip this section and proceed to [Common cleanup](#common-cleanup).
+
+   > If not doing a CSM software upgrade, this process will update the entries in BSS for the utility storage nodes to use the new Ceph image.
+   >
+   > 1. Set all utility storage nodes to use newly created Ceph image.
+   >
+   >     This will use the `CEPHVERSION` and `CEPHNEW` variables defined earlier.
+   >
+   >     ```bash
+   >     ncn-mw# for node in $(grep -oP "(ncn-s\w+)" /etc/hosts | sort -u)
+   >             do
+   >                 echo $node
+   >                 xname=$(ssh $node cat /etc/cray/xname)
+   >                 echo $xname
+   >                 cray bss bootparameters list --name $xname --format json > bss_$xname.json
+   >                 sed -i.$(date +%Y%m%d_%H%M%S%N).orig "s@/ceph/${CEPHVERSION}\([\"/[:space:]]\)@/ceph/${CEPHNEW}\1@g" bss_$xname.json
+   >                 kernel=$(cat bss_$xname.json | jq '.[]  .kernel')
+   >                 initrd=$(cat bss_$xname.json | jq '.[]  .initrd')
+   >                 params=$(cat bss_$xname.json | jq '.[]  .params')
+   >                 cray bss bootparameters update --initrd $initrd --kernel $kernel --params "$params" --hosts $xname --format json
+   >             done
+   >     ```
+
+## Common cleanup
+
+1. Remove the work area so the space can be reused.
+
+   ```bash
+   ncn-mw# rm -rf /run/initramfs/overlayfs/workingarea
+   ```
+
+## Deploy changes
+
+1. Rebuild nodes.
+
+   **WARNING:** If doing a CSM software upgrade, then skip this step because the upgrade process does a rolling rebuild with some additional steps.
+
+   > If not doing a CSM software upgrade, then follow the procedure to do a [Rolling Rebuild](../node_management/Rebuild_NCNs.md) of all management nodes.

--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
@@ -57,16 +57,16 @@ The Kubernetes image `k8s-image` is used by the master and worker nodes.
 
    ```text
    "k8s-filesystem.squashfs"
-   "k8s/0.1.107/filesystem.squashfs"
-   "k8s/0.1.109/filesystem.squashfs"
-   "k8s/0.1.48/filesystem.squashfs"
+   "k8s/0.0.47/filesystem.squashfs"
+   "k8s/0.0.46/filesystem.squashfs"
+   "k8s/0.0.38/filesystem.squashfs"
    ```
 
-   This example uses `k8s/0.1.109` for the current version and adds a suffix for the new version.
+   This example uses `k8s/0.0.47` for the current version and adds a suffix for the new version.
 
    ```bash
-   ncn-mw# export K8SVERSION=0.1.109
-   ncn-mw# export K8SNEW=0.1.109-2
+   ncn-mw# export K8SVERSION=0.0.47
+   ncn-mw# export K8SNEW=0.0.47-2
    ```
 
 1. Make a temporary directory for the `k8s-image` using the current version string.
@@ -241,9 +241,9 @@ The Ceph image is used by the utility storage nodes.
 
    ```text
    "ceph-filesystem.squashfs"
-   "ceph/0.1.107/filesystem.squashfs"
-   "ceph/0.1.113/filesystem.squashfs"
-   "ceph/0.1.48/filesystem.squashfs"
+   "ceph/0.0.47/filesystem.squashfs"
+   "ceph/0.0.46/filesystem.squashfs"
+   "ceph/0.0.38/filesystem.squashfs"
    ```
 
    This example uses `ceph/0.1.113` for the current version and adds a suffix for the new version.

--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md
@@ -1,0 +1,363 @@
+# Change NCN Image Root Password and SSH Keys on PIT Node
+
+The default SSH keys in the NCN image must be removed. The default password for the root user must be changed.
+Customize the NCN images by changing the root password and adding different SSH keys for the root account.
+This procedure shows this process being done on the PIT node during a first time installation of the CSM
+software.
+
+There is some common preparation before making the Kubernetes image for master nodes and worker nodes, making the Ceph image for utility storage nodes, and then some common cleanup afterwards.
+
+***Note:*** This procedure can only be done before the PIT node is rebuilt to become a normal master node.
+
+## Common Preparation
+
+1. Prepare new SSH keys on the PIT node for the root account in advance. The same key information will be added to both `k8s-image` and `ceph-image`.
+
+   Either replace the root public and private SSH keys with your own previously generated keys or generate a new pair
+   with `ssh-keygen(1)`. By default `ssh-keygen` will create an RSA key, but other types could be chosen and different
+   filenames would need to be substituted in later steps.
+
+   ***Note:*** CSM only supports key pairs with empty passphrases (`ssh-keygen -N""`, or enter an empty passphrase when prompted).
+
+   ```bash
+   pit# mkdir /root/.ssh
+   pit# ssh-keygen -f /root/.ssh/id_rsa -t rsa
+   pit# ls -l /root/.ssh/id_rsa*
+   pit# chmod 600 /root/.ssh/id_rsa
+   ```
+
+## Kubernetes Image
+
+The Kubernetes image is used by the master and worker nodes.
+
+1. Change to the working directory for the Kubernetes image.
+
+   ```bash
+   pit# cd /var/www/ephemeral/data/k8s
+   ```
+
+1. Open the image.
+
+   The Kubernetes image will be of the form `kubernetes-0.1.69.squashfs` in `/var/www/ephemeral/data/k8s`, but the version number may be different.
+
+   ```bash
+   pit# unsquashfs kubernetes-0.1.69.squashfs
+   ```
+
+1. Remove default SSH keys
+
+   ```bash
+   pit# rm -rf squashfs-root/root/.ssh
+   pit# rm -f /etc/ssh/*key*
+   ```
+
+1. Copy the generated public and private SSH keys for the root account into the image.
+
+   This example assumes that an RSA key was generated.
+
+   ```bash
+   pit# mkdir -m 0700 squashfs-root/root/.ssh
+   pit# cp -p /root/.ssh/id_rsa /root/.ssh/id_rsa.pub squashfs-root/root/.ssh
+   ```
+
+1. Add the public SSH key for the root account to `authorized_keys`.
+
+   This example assumes that an RSA key was generated so it adds the `id_rsa.pub` file to `authorized_keys`. Note
+   that `authorized_keys` is being overwritten, not appended.
+
+   ```bash
+   pit# cat /root/.ssh/id_rsa.pub > squashfs-root/root/.ssh/authorized_keys
+   pit# chmod 640 squashfs-root/root/.ssh/authorized_keys
+   ```
+
+1. Change into the image root.
+
+   ```bash
+   pit# chroot ./squashfs-root
+   ```
+
+1. Change the password.
+
+   ```bash
+   chroot-pit# passwd
+   ```
+
+1. (Optional) If there are any other things to be changed in the image, they could also be done at this point.
+
+   1. (Optional) Set default timezone on management nodes.
+
+      1. Check whether TZ variable is already set in `/etc/environment`. The setting for NEWTZ must be a valid timezone from the set under `/usr/share/zoneinfo`.
+
+         ```bash
+         chroot-pit# NEWTZ=US/Pacific
+         chroot-pit# grep TZ /etc/environment
+         ```
+
+         Add only if TZ is not present.
+
+         ```bash
+         chroot-pit# echo TZ=${NEWTZ} >> /etc/environment
+         ```
+
+      1. Check for `utc` setting.
+
+         ```bash
+         chroot-pit# grep -i utc /srv/cray/scripts/metal/ntp-upgrade-config.sh
+         ```
+
+         Change only if the `grep` command shows these lines set to UTC.
+
+         ```bash
+         chroot-pit# sed -i "s#^timedatectl set-timezone UTC#timedatectl set-timezone $NEWTZ#" /srv/cray/scripts/metal/ntp-upgrade-config.sh
+         chroot-pit# sed -i 's/--utc/--localtime/' /srv/cray/scripts/metal/ntp-upgrade-config.sh
+         ```
+
+1. Create the new SquashFS artifact.
+
+   ```bash
+   chroot-pit# /srv/cray/scripts/common/create-kis-artifacts.sh
+   ```
+
+1. Exit the `chroot` environment.
+
+   ```bash
+   chroot-pit# exit
+   ```
+
+1. Clean up the SquashFS creation.
+
+   The Kubernetes image directory is `/var/www/ephemeral/data/k8s`.
+
+   ```bash
+   pit# umount -v /var/www/ephemeral/data/k8s/squashfs-root/mnt/squashfs
+   ```
+
+1. Move new SquashFS image, kernel, and `initrd` into place.
+
+   ```bash
+   pit# mv -v squashfs-root/squashfs/* .
+   ```
+
+1. Update file permissions on `initrd`.
+
+   ```bash
+   pit# chmod -v 644 initrd.img.xz
+   ```
+
+1. Rename the new SquashFS, kernel, and `initrd` to include a new version string.
+
+   If the old name of the SquashFS was `kubernetes-0.1.69.squashfs`, then its version was '0.1.69',
+   so the newly created version should be renamed to include a version of '0.1.69-1' with an
+   additional dash and a build iteration number of 1. This will help to track what base version was used.
+
+   ```bash
+   pit# ls -l old/*squashfs
+   -rw-r--r--  1 root root 5135859712 Aug 19 19:10 kubernetes-0.1.69.squashfs
+   ```
+
+   Set the VERSION variable based on the version string displayed by the above command with an incremented suffix added to show a build iteration.
+
+   ```bash
+   pit# export VERSION=0.1.69-1
+   pit# mv filesystem.squashfs kubernetes-${VERSION}.squashfs
+   pit# mv initrd.img.xz initrd.img-${VERSION}.xz
+   ```
+
+   The kernel file will have a name with the kernel version but not this new $VERSION.
+
+   ```bash
+   pit# ls -l *kernel
+   -rw-r--r--  1 root root    8552768 Aug 19 19:09 5.3.18-24.75-default.kernel
+   ```
+
+   Rename it to include the version string.
+
+   ```bash
+   pit# mv 5.3.18-24.75-default.kernel 5.3.18-24.75-default-${VERSION}.kernel
+   ```
+
+1. Set the boot links. Skip this step if proceeding to the Ceph Image section below.
+
+   ```bash
+   pit# cd
+   pit# set-sqfs-links.sh
+   ```
+
+The Kubernetes image will have the image changes for the next boot.
+
+## Ceph Image
+
+The Ceph image is used by the utility storage nodes.
+
+1. Change to the working directory for the Ceph image.
+
+   ```bash
+   pit# cd /var/www/ephemeral/data/ceph
+   ```
+
+1. Open the image.
+
+   The Ceph image will be of the form `storage-ceph-0.1.69.squashfs` in `/var/www/ephemeral/data/ceph`, but the version number may be different.
+
+   ```bash
+   pit# unsquashfs storage-ceph-0.1.69.squashfs
+   ```
+
+1. Save the old SquashFS image, kernel, and `initrd`.
+
+   ```bash
+   pit# mkdir -v old
+   pit# mv -v *squashfs *kernel initrd* old
+   ```
+
+1. Copy the generated public and private SSH keys for the root account into the image.
+
+   This example assumes that an RSA key was generated.
+
+   ```bash
+   pit# cp -p /root/.ssh/id_rsa /root/.ssh/id_rsa.pub squashfs-root/root/.ssh
+   ```
+
+1. Add the public SSH key for the root account to `authorized_keys`.
+
+   This example assumes that an RSA key was generated so it adds the `id_rsa.pub` file to `authorized_keys`.
+
+   Note that `authorized_keys` is being overwritten, not appended.
+
+   ```bash
+   pit# cat /root/.ssh/id_rsa.pub > squashfs-root/root/.ssh/authorized_keys
+   pit# chmod 640 squashfs-root/root/.ssh/authorized_keys
+   ```
+
+1. Change into the image root.
+
+   ```bash
+   pit# chroot ./squashfs-root
+   ```
+
+1. Change the password.
+
+   ```bash
+   chroot-pit# passwd
+   ```
+
+1. (Optional) If there are any other things to be changed in the image, they could also be done at this point.
+
+   1. (Optional) Set default timezone on management nodes.
+
+      1. Check whether TZ variable is already set in `/etc/environment`. The setting for NEWTZ must be a valid timezone from the set under `/usr/share/zoneinfo`.
+
+         ```bash
+         chroot-pit# NEWTZ=US/Pacific
+         chroot-pit# grep TZ /etc/environment
+         ```
+
+         Add only if TZ is not present.
+
+         ```bash
+         chroot-pit# echo TZ=${NEWTZ} >> /etc/environment
+         ```
+
+      1. Check for `utc` setting.
+
+         ```bash
+         chroot-pit# grep -i utc /srv/cray/scripts/metal/ntp-upgrade-config.sh
+         ```
+
+         Change only if the `grep` command shows these lines set to UTC.
+
+         ```bash
+         chroot-pit# sed -i "s#^timedatectl set-timezone UTC#timedatectl set-timezone $NEWTZ#" /srv/cray/scripts/metal/ntp-upgrade-config.sh
+         chroot-pit# sed -i 's/--utc/--localtime/' /srv/cray/scripts/metal/ntp-upgrade-config.sh
+         ```
+
+1. Create the new SquashFS artifact.
+
+   ```bash
+   chroot-pit# /srv/cray/scripts/common/create-kis-artifacts.sh
+   ```
+
+1. Exit the `chroot` environment.
+
+   ```bash
+   chroot-pit# exit
+   ```
+
+1. Clean up the SquashFS creation.
+
+   The Ceph image directory is `/var/www/ephemeral/data/ceph`.
+
+   ```bash
+   pit# umount -v /var/www/ephemeral/data/ceph/squashfs-root/mnt/squashfs
+   ```
+
+1. Save old SquashFS image.
+
+   ```bash
+   pit# mkdir -v old
+   pit# mv -v *squashfs old
+   ```
+
+1. Move new SquashFS image, kernel, and `initrd` into place.
+
+   ```bash
+   pit# mv -v squashfs-root/squashfs/* .
+   ```
+
+1. Update file permissions on `initrd`.
+
+   ```bash
+   pit# chmod -v 644 initrd.img.xz
+   ```
+
+1. Rename the new SquashFS, kernel, and `initrd` to include a new version string.
+
+   If the old name of the SquashFS was `storage-ceph-0.1.69.squashfs`, then its version was '0.1.69',
+   so the newly created version should be renamed to include a version of '0.1.69-1' with an
+   additional dash and a build iteration number of 1. This will help to track what base version was used.
+
+   ```bash
+   pit# ls -l old/*squashfs
+   -rw-r--r--  1 root root 5135859712 Aug 19 19:10 storage-ceph-0.1.69.squashfs
+   ```
+
+   Set the VERSION variable based on the version string displayed by the above command with an incremented suffix added to show a build iteration.
+
+   ```bash
+   pit# VERSION=0.1.69-1
+   pit# mv filesystem.squashfs storage-ceph-${VERSION}.squashfs
+   pit# mv initrd.img.xz initrd.img-${VERSION}.xz
+   ```
+
+   The kernel file will have a name with the kernel version but not this new $VERSION.
+
+   ```bash
+   pit# ls -l *kernel
+   -rw-r--r--  1 root root    8552768 Aug 19 19:09 5.3.18-24.75-default.kernel
+   ```
+
+   Rename it to include the version string.
+
+   ```bash
+   pit# mv 5.3.18-24.75-default.kernel 5.3.18-24.75-default-${VERSION}.kernel
+   ```
+
+1. Set the boot links.
+
+   ```bash
+   pit# cd
+   pit# set-sqfs-links.sh
+   ```
+
+The Ceph image will have the image changes for the next boot.
+
+## Common Cleanup
+
+1. Clean up temporary storage used to prepare images.
+
+   These could be removed now or after verification that the nodes are able to boot successfully with the new images.
+
+   ```bash
+   pit# cd /var/www/ephemeral/data
+   pit# rm -rf ceph/old k8s/old
+   ```

--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md
@@ -38,10 +38,10 @@ The Kubernetes image is used by the master and worker nodes.
 
 1. Open the image.
 
-   The Kubernetes image will be of the form `kubernetes-0.1.69.squashfs` in `/var/www/ephemeral/data/k8s`, but the version number may be different.
+   The Kubernetes image will be of the form `kubernetes-0.0.57.squashfs` in `/var/www/ephemeral/data/k8s`, but the version number may be different.
 
    ```bash
-   pit# unsquashfs kubernetes-0.1.69.squashfs
+   pit# unsquashfs kubernetes-0.0.57.squashfs
    ```
 
 1. Remove default SSH keys
@@ -146,19 +146,19 @@ The Kubernetes image is used by the master and worker nodes.
 
 1. Rename the new SquashFS, kernel, and `initrd` to include a new version string.
 
-   If the old name of the SquashFS was `kubernetes-0.1.69.squashfs`, then its version was '0.1.69',
-   so the newly created version should be renamed to include a version of '0.1.69-1' with an
+   If the old name of the SquashFS was `kubernetes-0.0.57.squashfs`, then its version was '0.0.57',
+   so the newly created version should be renamed to include a version of '0.0.57-1' with an
    additional dash and a build iteration number of 1. This will help to track what base version was used.
 
    ```bash
    pit# ls -l old/*squashfs
-   -rw-r--r--  1 root root 5135859712 Aug 19 19:10 kubernetes-0.1.69.squashfs
+   -rw-r--r--  1 root root 5135859712 Aug 19 19:10 kubernetes-0.0.57.squashfs
    ```
 
    Set the VERSION variable based on the version string displayed by the above command with an incremented suffix added to show a build iteration.
 
    ```bash
-   pit# export VERSION=0.1.69-1
+   pit# export VERSION=0.0.57-1
    pit# mv filesystem.squashfs kubernetes-${VERSION}.squashfs
    pit# mv initrd.img.xz initrd.img-${VERSION}.xz
    ```
@@ -197,10 +197,10 @@ The Ceph image is used by the utility storage nodes.
 
 1. Open the image.
 
-   The Ceph image will be of the form `storage-ceph-0.1.69.squashfs` in `/var/www/ephemeral/data/ceph`, but the version number may be different.
+   The Ceph image will be of the form `storage-ceph-0.0.47.squashfs` in `/var/www/ephemeral/data/ceph`, but the version number may be different.
 
    ```bash
-   pit# unsquashfs storage-ceph-0.1.69.squashfs
+   pit# unsquashfs storage-ceph-0.0.47.squashfs
    ```
 
 1. Save the old SquashFS image, kernel, and `initrd`.
@@ -312,19 +312,19 @@ The Ceph image is used by the utility storage nodes.
 
 1. Rename the new SquashFS, kernel, and `initrd` to include a new version string.
 
-   If the old name of the SquashFS was `storage-ceph-0.1.69.squashfs`, then its version was '0.1.69',
-   so the newly created version should be renamed to include a version of '0.1.69-1' with an
+   If the old name of the SquashFS was `storage-ceph-0.0.47.squashfs`, then its version was '0.0.47',
+   so the newly created version should be renamed to include a version of '0.0.47-1' with an
    additional dash and a build iteration number of 1. This will help to track what base version was used.
 
    ```bash
    pit# ls -l old/*squashfs
-   -rw-r--r--  1 root root 5135859712 Aug 19 19:10 storage-ceph-0.1.69.squashfs
+   -rw-r--r--  1 root root 5135859712 Aug 19 19:10 storage-ceph-0.0.47.squashfs
    ```
 
    Set the VERSION variable based on the version string displayed by the above command with an incremented suffix added to show a build iteration.
 
    ```bash
-   pit# VERSION=0.1.69-1
+   pit# VERSION=0.0.47-1
    pit# mv filesystem.squashfs storage-ceph-${VERSION}.squashfs
    pit# mv initrd.img.xz initrd.img-${VERSION}.xz
    ```

--- a/operations/security_and_authentication/Update_NCN_Passwords.md
+++ b/operations/security_and_authentication/Update_NCN_Passwords.md
@@ -1,0 +1,113 @@
+# Update NCN Passwords
+
+The management nodes deploy with a default password in the image, so it is a recommended best
+practice for system security to change the root password in the image so that it is
+not the documented default password. In addition to the root password in the image, NCN
+personalization should be used to change the password as part of post-boot CFS. The password
+in the image should be used when console access is desired during the network boot of a management
+node that is being rebuilt, but this password should be different than the one stored in Vault
+that is applied by CFS during post-boot NCN personalization to change the on-disk password. Once
+NCN personalization has been run, then the password in Vault should be used for console access.
+
+Use one of these methods to change the root password in the image.
+
+1. If the PIT node is booted, see
+[Change NCN Image Root Password and SSH Keys on PIT Node](Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md)
+for more information.
+
+1. If the PIT node is not booted, see
+[Change NCN Image Root Password and SSH Keys](Change_NCN_Image_Root_Password_and_SSH_Keys.md)
+for more information.
+
+The rest of this procedure describes how to change the root password stored in the HashiCorp
+Vault instance and then apply it immediately to management nodes with the `csm.password` Ansible
+role via a CFS session. The same root password from Vault will be applied anytime that the NCN
+personalization including the CSM layer is run.
+
+## Procedure: Configure `root` password in Vault
+
+1. Generate a new password hash for the `root` user.
+
+   > This script uses `read -s` to prevent the password from being echoed to the screen or saved
+   > in the shell history. It unsets the plaintext password variables at the end, so that they
+   > cannot be viewed later.
+
+   ```bash
+   ncn# read -r -s -p "New root password for NCN images: " PW1 ; echo ; if [[ -z ${PW1} ]]; then
+            echo "ERROR: Password cannot be blank"
+        else
+            read -r -s -p "Enter again: " PW2
+            echo
+            if [[ ${PW1} != ${PW2} ]]; then
+                echo "ERROR: Passwords do not match"        
+            else
+                echo -n "${PW1}" | openssl passwd -6 -salt $(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c4) --stdin
+            fi
+        fi ; unset PW1 PW2
+   ```
+
+1. Get the HashiCorp Vault root token:
+
+   ```bash
+   ncn-mw# kubectl get secrets -n vault cray-vault-unseal-keys -o jsonpath='{.data.vault-root}' | base64 -d; echo
+   ```
+
+1. Write the password hash from step 1 to the HashiCorp Vault. The `vault login`
+   command will request the token value from the output of step 2 above. The
+   `vault read` command verifies the hash was stored correctly.
+
+   ***NOTE***: It is important to enclose the hash in single quotes to preserve
+   any special characters.
+
+   ```bash
+   ncn-mw# kubectl exec -itn vault cray-vault-0 -- sh
+   cray-vault-0# export VAULT_ADDR=http://cray-vault:8200
+   cray-vault-0# vault login
+   cray-vault-0# vault write secret/csm/management_nodes root_password='HASH'
+   cray-vault-0# vault read secret/csm/management_nodes
+   cray-vault-0# exit
+   ```
+
+## Procedure: Apply `root` password to NCNs (standalone)
+
+Use the following procedure with the `rotate-pw-mgmt-nodes.yml` playbook to
+**only** change the root password on NCNs. This is a quick alternative to
+running a [full NCN personalization](../CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md#set_root_password),
+where passwords are also applied using the password stored in Vault set in the
+procedure above.
+
+1. Create a CFS configuration layer to run the password change Ansible playbook.
+
+   ```bash
+   ncn# cat ncn-password-update-config.json
+   ```
+
+   Example output:
+
+   ```json
+   {
+     "layers": [
+       {
+         "name": "ncn-password-update",
+         "cloneUrl": "https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git",
+         "playbook": "rotate-pw-mgmt-nodes.yml",
+         "commit": "<INSERT GIT COMMIT ID>"
+       }
+     ]
+   }
+   ```
+
+   ```bash
+   ncn# cray cfs configurations update ncn-password-update --file ./ncn-password-update-config.json
+   ```
+
+1. Create a CFS configuration session to apply the password update.
+
+   ```bash
+   ncn# cray cfs sessions create --name ncn-password-update-`date +%Y%m%d%H%M%S` --configuration-name ncn-password-update
+   ```
+
+   **NOTE:** Subsequent password changes need only update the password hash in
+   HashiCorp Vault and create the CFS session as long as the commit in the CSM
+   configuration management repository has not changed. If the commit has
+   changed, repeat this procedure from the beginning.

--- a/scripts/ceph-upload-file-public-read.py
+++ b/scripts/ceph-upload-file-public-read.py
@@ -1,0 +1,97 @@
+#! /usr/bin/env python3
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+
+import os
+import sys
+from argparse import ArgumentParser
+import json
+import subprocess
+from base64 import b64decode
+import boto3
+import botocore
+from botocore.config import Config
+S3_CONNECT_TIMEOUT=60
+S3_READ_TIMEOUT=1
+
+
+
+def main():
+
+    parser = ArgumentParser(description='Creates a bucket')
+    parser.add_argument('--bucket-name',
+                        dest='bucket_name',
+                        action='store',
+                        required=True,
+                        help='the name of the bucket to create')
+    parser.add_argument('--key-name',
+                        dest='key_name',
+                        action='store',
+                        required=True,
+                        help='the objects key name')
+    parser.add_argument('--file-name',
+                        dest='file_name',
+                        action='store',
+                        required=True,
+                        help='the file to upload')
+    args = parser.parse_args()
+
+    s3_config = Config(connect_timeout=S3_CONNECT_TIMEOUT,
+                           read_timeout=S3_READ_TIMEOUT)
+
+    #
+    # These bucket names have K8S secrets with non-standard names
+    #
+    non_std_bucket_map = {'ssm': 'ssm-swm-s3-credentials',
+                          'boot-images': 'ims-s3-credentials',
+                          'install-artifacts': 'artifacts-s3-credentials',
+                          'ncn-images': 'sds-s3-credentials'}
+    if args.bucket_name in non_std_bucket_map:
+        secret_name = non_std_bucket_map[args.bucket_name]
+    else:
+        secret_name = "%s-%s" % (args.bucket_name, "s3-credentials")
+
+    # get credentials
+    a_key = b64decode(subprocess.check_output(
+        ['kubectl', 'get', 'secret', secret_name, '-o', "jsonpath='{.data.access_key}'"])).decode()
+    s_key = b64decode(subprocess.check_output(
+        ['kubectl', 'get', 'secret', secret_name, '-o', "jsonpath='{.data.secret_key}'"])).decode()
+    credentials = {'endpoint_url': 'http://rgw-vip',
+                   'access_key': a_key, 'secret_key': s_key}
+    s3 = boto3.resource('s3',
+                        endpoint_url=credentials['endpoint_url'],
+                        aws_access_key_id=credentials['access_key'],
+                        aws_secret_access_key=credentials['secret_key'],
+                        config=s3_config)
+
+    bucket = s3.Bucket(args.bucket_name)
+
+    bucket.upload_file(Filename=args.file_name,
+                       Key=args.key_name,
+                       ExtraArgs={'ACL': 'public-read'})
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
# Description

Backport root password/key docs from 1.0.
<!--- Describe what this change is and what it is for. -->

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
