### PR TITLE
CASMPET-6029 1.3 : DOCS: Add Step in Stage0 of upgrade to remove old/bad pg backups & take new/good ones

### DIFF
--- a/upgrade/Stage_0_Prerequisites.md
+++ b/upgrade/Stage_0_Prerequisites.md
@@ -313,7 +313,7 @@ The current Postgres opt-in backups need to be re-generated to fix a known issue
              docker-archive:/mnt/cray-postgres-db-backup.tar docker://registry.local/artifactory.algol60.net/csm-docker/stable/cray-postgres-db-backup:0.2.3
          ```
 
-1. (`ncn-m001#`) Regenerate the postgres backups.
+1. (`ncn-m001#`) Regenerate the Postgres backups.
 
    ```bash
    /usr/share/doc/csm/upgrade/scripts/k8s/create_new_postgres_backups.sh

--- a/upgrade/Stage_0_Prerequisites.md
+++ b/upgrade/Stage_0_Prerequisites.md
@@ -17,6 +17,7 @@ Stage 0 has several critical procedures which prepare the environment and verify
   - [Standard upgrade](#standard-upgrade)
   - [CSM-only system upgrade](#csm-only-system-upgrade)
 - [Stage 0.4 - Backup workload manager data](#stage-04---backup-workload-manager-data)
+- [Stage 0.5 - Regenerate Postgres backups](#stage-05---regenerate-postgres-backups)
 - [Stop typescript](#stop-typescript)
 - [Stage completed](#stage-completed)
 
@@ -276,6 +277,53 @@ This upgrade scenario is extremely uncommon in production environments.
 To prevent any possibility of losing workload manager configuration data or files, a backup is required. Execute all backup procedures (for the workload manager in use) located in
 the `Troubleshooting and Administrative Tasks` sub-section of the `Install a Workload Manager` section of the
 `HPE Cray Programming Environment Installation Guide: CSM on HPE Cray EX`. The resulting backup data should be stored in a safe location off of the system.
+
+## Stage 0.5 - Regenerate Postgres backups
+
+The current Postgres opt-in backups need to be re-generated to fix a known issue. This requires a new image.
+
+1. (`ncn-m001#`) Load the updated `cray-postgres-db-backup` image into the nexus local registry.
+
+   - If `ncn-m001` has internet access, then use the following commands.
+
+     ```bash
+     NEXUS_USERNAME="$(kubectl -n nexus get secret nexus-admin-credential --template {{.data.username}} | base64 -d)"
+     NEXUS_PASSWORD="$(kubectl -n nexus get secret nexus-admin-credential --template {{.data.password}} | base64 -d)"
+     podman run --rm --network host -v /root:/mnt quay.io/skopeo/stable copy --dest-tls-verify=false --dest-creds "${NEXUS_USERNAME}:${NEXUS_PASSWORD}" \
+         docker-archive:/mnt/cray-postgres-db-backup.tar docker://registry.local/artifactory.algol60.net/csm-docker/stable/cray-postgres-db-backup:0.2.3
+     ```
+
+   - Otherwise, use the following procedure.
+
+      1. From a system that does have access to the internet, save the image to a `tar` file.
+
+         ```bash
+         podman pull docker://artifactory.algol60.net/csm-docker/stable/cray-postgres-db-backup:0.2.3
+         podman save -o cray-postgres-db-backup.tar docker.io/artifactory.algol60.net/csm-docker/stable/cray-postgres-db-backup:0.2.3
+         ```
+
+      1. Copy the `cray-postgres-db-backup.tar` to the target system under `/root`.
+
+      1. Then copy the `tar` file into the local registry on the target system:
+
+         ```bash
+         NEXUS_USERNAME="$(kubectl -n nexus get secret nexus-admin-credential --template {{.data.username}} | base64 -d)"
+         NEXUS_PASSWORD="$(kubectl -n nexus get secret nexus-admin-credential --template {{.data.password}} | base64 -d)"
+         podman run --rm --network host -v /root:/mnt quay.io/skopeo/stable copy --dest-tls-verify=false --dest-creds "${NEXUS_USERNAME}:${NEXUS_PASSWORD}" \
+             docker-archive:/mnt/cray-postgres-db-backup.tar docker://registry.local/artifactory.algol60.net/csm-docker/stable/cray-postgres-db-backup:0.2.3
+         ```
+
+1. (`ncn-m001#`) Regenerate the postgres backups.
+
+   ```bash
+   /usr/share/doc/csm/upgrade/scripts/k8s/create_new_postgres_backups.sh
+   ```
+
+   Successful output should end with the following line:
+
+   ```text
+   Postgres backup(s) have been successfully re-genetated.
+   ```
 
 ## Stop typescript
 

--- a/upgrade/Stage_0_Prerequisites.md
+++ b/upgrade/Stage_0_Prerequisites.md
@@ -295,7 +295,7 @@ The current Postgres opt-in backups need to be re-generated to fix a known issue
 
    - Otherwise, use the following procedure.
 
-      1. From a system that does have access to the internet, save the image to a `tar` file.
+      1. Save the image to a `tar` file from a system that does have access to the internet.
 
          ```bash
          podman pull docker://artifactory.algol60.net/csm-docker/stable/cray-postgres-db-backup:0.2.3
@@ -304,7 +304,7 @@ The current Postgres opt-in backups need to be re-generated to fix a known issue
 
       1. Copy the `cray-postgres-db-backup.tar` to the target system under `/root`.
 
-      1. Then copy the `tar` file into the local registry on the target system:
+      1. Copy the `tar` file into the local registry on the target system:
 
          ```bash
          NEXUS_USERNAME="$(kubectl -n nexus get secret nexus-admin-credential --template {{.data.username}} | base64 -d)"

--- a/upgrade/scripts/k8s/create_new_postgres_backups.sh
+++ b/upgrade/scripts/k8s/create_new_postgres_backups.sh
@@ -1,0 +1,237 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# For each cronjob based postgresql-db backup:
+#   Suspend the cronjob backup
+#   Delete existing postgresql-db-backup jobs
+#   Delete any existing backup in the postgres-backup s3 bucket
+#   Patch the cronjob to use the cray-postgres-db-backup:0.2.3 image
+#   Create a manual backup job
+#   Wait for the manual backup job to complete
+#   Delete the manual backup job (unless backup failed)
+#   Resume the cronjon backup
+# List all the postgres-backups
+
+postgres_to_backup=""  # default is all opt-in postgres clusters
+image_to_patch="artifactory.algol60.net/csm-docker/stable/cray-postgres-db-backup:0.2.3"
+
+while getopts s:i:h stack
+do
+    case "${stack}" in
+          s) postgres_to_backup=$OPTARG;;
+          i) image_to_patch=$OPTARG;;
+          h) echo "usage: create_new_postgres_backups.sh [-h] [-s <single_cluster>] [-i <image>]"
+             echo  -e "\nA tool to recreate opt-in postgres backups using a patched cray-postgres-db-backup image.\n"
+             echo "       create_new_postgres_backups.sh                     # Deletes & ReCreates postgres backups for all the opt-in postgres clusters."
+             echo "       create_new_postgres_backups.sh -s <single_cluster> # Delete & ReCreate postgres backup for a single opt-in postgres cluster."
+             echo "             select from one of: $(kubectl get cronjobs -A | grep postgresql-db-backup | awk '{printf "\n\t\t"$2}') "
+             echo "       create_new_postgres_backups.sh -i <image>          # Patches the cray-postgres-db-backup image used to create the new postgres backups."
+	     echo "             artifactory.algol60.net/csm-docker/stable/cray-postgres-db-backup:0.2.3 (default)"
+             exit 3;;
+          \?) echo "usage: create_new_postgres_backups.sh [-h] [-s <single_cluster>] [-i <image>]"
+             echo  -e "\nA tool to recreate opt-in postgres backups using a patched cray-postgres-db-backup image.\n"
+             echo "       create_new_postgres_backups.sh                     # Deletes & ReCreates postgres backups for all the opt-in postgres clusters."
+             echo "       create_new_postgres_backups.sh -s <single_cluster> # Delete & ReCreate postgres backup for a single opt-in postgres cluster."
+             echo "             select from one of: $(kubectl get cronjobs -A | grep postgresql-db-backup | awk '{printf "\n\t\t"$2}') "
+             echo "       create_new_postgres_backups.sh -i <image>          # Patches the cray-postgres-db-backup image used to create the new postgres backups."
+	     echo "             artifactory.algol60.net/csm-docker/stable/cray-postgres-db-backup:0.2.3 (default)"
+             exit 3;;
+    esac
+done
+
+function check_image()
+{
+    # Does the $image_to_patch tag exist in nexus? If not exit with an error
+    image_tag="$(echo $image_to_patch | awk -F: '{ print $2 }')"
+    image="$(echo $image_to_patch | awk -F: '{ print $1 }')"
+    registry_tag="$(curl -sk https://registry.local/v2/\\"$image\\"/tags/list | jq -r  '.tags[]' | grep $image_tag)"
+
+    if [[ "$image_tag" != "$registry_tag" ]]
+    then
+        echo "ERROR : The image $image_to_patch does not exist in the nexus registry."
+        echo "For non-airgapped system, run the following to load the cray-postgres-db-backup image into the nexus registry and then re-run."
+        echo  '    NEXUS_USERNAME="$(kubectl -n nexus get secret nexus-admin-credential --template {{.data.username}} | base64 -d)"'
+        echo  '    NEXUS_PASSWORD="$(kubectl -n nexus get secret nexus-admin-credential --template {{.data.password}} | base64 -d)"'
+        echo  "    podman run --rm --network host quay.io/skopeo/stable copy --dest-tls-verify=false --dest-creds \"\${NEXUS_USERNAME}:\${NEXUS_PASSWORD}\" docker://${image}:${image_tag} docker://registry.local/${image}:${image_tag}"
+	exit 3
+    fi
+
+}
+
+function suspend_backup()
+{
+    echo -en "    "
+    kubectl patch cronjobs ${c_cronjob_name} -n ${c_ns} -p '{"spec":{"suspend":true}}'
+}
+
+function resume_backup()
+{
+    echo -en "    "
+    kubectl patch cronjobs ${c_cronjob_name} -n ${c_ns} -p '{"spec":{"suspend":false}}'
+}
+
+function create_manual_job()
+{
+    echo -en "    "
+    kubectl create job --from=cronjobs/${c_cronjob_name} -n ${c_ns} "${c_cronjob_name}-manual"
+}
+
+function delete_manual_job()
+{
+    echo -en "    "
+    kubectl delete job -n ${c_ns} "${c_cronjob_name}-manual"
+}
+
+
+function wait_for_job()
+{
+    echo -en "    "
+    kubectl -n $c_ns wait --for=condition=complete --timeout=2m job/"${c_cronjob_name}-manual"
+}
+
+function delete_jobs()
+{
+    job_prefix=$1
+    postgres_cluster_jobs=$(kubectl get jobs -A | grep ${job_prefix} | awk '{print $1","$2}')
+
+    if [[ ! -z $postgres_cluster_jobs ]]
+    then
+
+        for c in $postgres_cluster_jobs
+        do 
+           job_ns="$(echo $c | awk -F, '{print $1;}')"
+           job_name="$(echo $c | awk -F, '{print $2;}')"
+           echo -en "    "
+	   kubectl delete job $job_name -n $job_ns
+        done
+    fi
+}
+
+function delete_backups()
+{
+    backup_prefix=$1
+    for object in $(cray artifacts list postgres-backup --format json | jq -r '.artifacts[].Key' | grep $backup_prefix)
+    do
+        echo -en "    "
+        echo -n "Deleting object $object"
+        cray artifacts delete postgres-backup $object
+    done
+}
+
+function patch_image()
+{
+    echo -en "    "
+    kubectl patch cronjobs ${c_cronjob_name} -n ${c_ns} --type=json \
+	    -p="[{'op': 'replace', 'path': '/spec/jobTemplate/spec/template/spec/containers/0/image', \
+	    'value': \"$image_to_patch\" }]"
+}
+
+
+function main()
+{
+    failed=0
+    check_image
+
+    postgres_clusters_wBackup=$(kubectl get cronjobs -A | grep postgresql-db-backup | awk '{print $1","$2}')
+    if [[ -z $postgres_clusters_wBackup ]]
+    then
+        echo "No Postgresql clusters have automatic backups set in cron jobs."
+    else
+
+        echo -e "\nList all initial postgres backups:"
+        cray artifacts list postgres-backup --format json | jq -r '.artifacts[].Key'
+	
+        echo -e "\nCreating postgresql backups for ..."
+        for c in $postgres_clusters_wBackup
+        do
+
+            c_ns="$(echo $c | awk -F, '{print $1;}')"
+            c_cronjob_name="$(echo $c | awk -F, '{print $2;}')"
+	    c_backup_prefix=${c_cronjob_name%"ql-db-backup"}              # remove suffix 'ql-db-backup'
+            c_backup_prefix=${c_backup_prefix#"cray-"}                    # remove prefix 'cray-'
+            c_backup_prefix=$(kubectl get postgresql -n ${c_ns} | grep $c_backup_prefix |awk '{print $1}')
+    
+	    # Check to see if this is only for a single cluster
+	    if [[ ! -z $postgres_to_backup ]] && [[ "$postgres_to_backup" != "$c_cronjob_name" ]]
+	    then
+	        continue
+	    fi
+
+	    echo "* $c_cronjob_name: "
+
+            echo "  - Suspend the backup"
+            suspend_backup
+
+            echo "  - Delete existing jobs"
+            delete_jobs "$c_cronjob_name"
+
+            echo "  - Delete existing backups"
+            delete_backups "$c_backup_prefix"
+
+            echo "  - Patch the cray-postgres-db-backup image"
+            patch_image
+
+            echo "  - Create manual job"
+	    create_manual_job
+
+	    echo "  - Wait for the backup job to complete"
+            wait_for_job 
+
+            postgres_backup_count=$(cray artifacts list postgres-backup --format json | jq -r '.artifacts[].Key' | grep -c "$c_backup_prefix")
+            echo "  - Checking for backups"
+            if [[ "$postgres_backup_count" -eq 2 ]]
+            then 
+	        echo "  - Delete manual job"
+                delete_manual_job
+
+                echo "  - Resume the backup"
+                resume_backup
+
+                echo "  -> Success"
+            else
+                echo "  - Resume the backup"
+                resume_backup
+    
+                echo "  -> Failed"
+                failed=1
+            fi
+        done
+
+        echo -e "\nList all current postgres backups:"
+        cray artifacts list postgres-backup --format json | jq -r '.artifacts[].Key'
+ 
+        if [[ "$failed" -eq 1 ]]
+        then 
+            echo -e "\nNot all Postgres backups have been successfully re-generated."
+        else
+            echo -e "\nPostgres backup(s) have been successfully re-genetated."
+        fi
+    fi
+}
+
+# --- main --- #
+main
+
+exit 0


### PR DESCRIPTION
# Description

Add a step 0.5 to the upgrade prereqs to regenerate the postgres backups.
This includes steps to copy the needed image to nexus (airgapped and non airgapped)

Tested on mug (1.3) and bradi (1.2).
The script takes about 2 minutes to run to re-create all the opt-in postgres backups

Usage
```
ncn-m001: # ./create_new_postgres_backups.sh -h
usage: create_new_postgres_backups.sh [-h] [-s <single_cluster>] [-i <image>]

A tool to recreate opt-in postgres backups using a patched cray-postgres-db-backup image.

       create_new_postgres_backups.sh                     # Deletes & ReCreates postgres backups for all the opt-in postgres clusters.
       create_new_postgres_backups.sh -s <single_cluster> # Delete & ReCreate postgres backup for a single opt-in postgres cluster.
             select from one of:
		cray-nls-postgresql-db-backup
		cray-hms-badger-postgresql-db-backup
		cray-keycloak-postgresql-db-backup
		cray-sls-postgresql-db-backup
		cray-smd-postgresql-db-backup
		gitea-vcs-postgresql-db-backup
		spire-postgresql-db-backup
       create_new_postgres_backups.sh -i <image>          # Patches the cray-postgres-db-backup image used to create the new postgres backups.
             artifactory.algol60.net/csm-docker/stable/cray-postgres-db-backup:0.2.3 (default)
```
Script and output
```
ncn-m001: # time ./create_new_postgres_backups.sh

List all initial postgres backups:
cray-hms-badger-postgres-2022-09-30T15:44:09.manifest
cray-hms-badger-postgres-2022-09-30T15:44:09.psql
cray-nls-postgres-2022-09-30T15:43:54.manifest
cray-nls-postgres-2022-09-30T15:43:54.psql
cray-sls-postgres-2022-09-30T15:44:42.manifest
cray-sls-postgres-2022-09-30T15:44:42.psql
cray-smd-postgres-2022-09-30T15:44:58.manifest
cray-smd-postgres-2022-09-30T15:44:58.psql
gitea-vcs-postgres-2022-09-30T15:45:14.manifest
gitea-vcs-postgres-2022-09-30T15:45:14.psql
keycloak-postgres-2022-09-30T15:44:26.manifest
keycloak-postgres-2022-09-30T15:44:26.psql
spire-postgres-2022-09-30T15:45:31.manifest
spire-postgres-2022-09-30T15:45:31.psql

Creating postgresql backups for ...
* cray-nls-postgresql-db-backup:
  - Suspend the backup
    cronjob.batch/cray-nls-postgresql-db-backup patched
  - Delete existing jobs
  - Delete existing backups
    Deleting object cray-nls-postgres-2022-09-30T15:43:54.manifest
    Deleting object cray-nls-postgres-2022-09-30T15:43:54.psql
  - Patch the cray-postgres-db-backup image
    cronjob.batch/cray-nls-postgresql-db-backup patched (no change)
  - Create manual job
    job.batch/cray-nls-postgresql-db-backup-manual created
  - Wait for the backup job to complete
    job.batch/cray-nls-postgresql-db-backup-manual condition met
  - Checking for backups
  - Delete manual job
    job.batch "cray-nls-postgresql-db-backup-manual" deleted
  - Resume the backup
    cronjob.batch/cray-nls-postgresql-db-backup patched
  -> Success
* cray-hms-badger-postgresql-db-backup:
  - Suspend the backup
    cronjob.batch/cray-hms-badger-postgresql-db-backup patched
  - Delete existing jobs
  - Delete existing backups
    Deleting object cray-hms-badger-postgres-2022-09-30T15:44:09.manifest
    Deleting object cray-hms-badger-postgres-2022-09-30T15:44:09.psql
  - Patch the cray-postgres-db-backup image
    cronjob.batch/cray-hms-badger-postgresql-db-backup patched
  - Create manual job
    job.batch/cray-hms-badger-postgresql-db-backup-manual created
  - Wait for the backup job to complete
    job.batch/cray-hms-badger-postgresql-db-backup-manual condition met
  - Checking for backups
  - Delete manual job
    job.batch "cray-hms-badger-postgresql-db-backup-manual" deleted
  - Resume the backup
    cronjob.batch/cray-hms-badger-postgresql-db-backup patched
  -> Success
* cray-keycloak-postgresql-db-backup:
  - Suspend the backup
    cronjob.batch/cray-keycloak-postgresql-db-backup patched
  - Delete existing jobs
  - Delete existing backups
    Deleting object keycloak-postgres-2022-09-30T15:44:26.manifest
    Deleting object keycloak-postgres-2022-09-30T15:44:26.psql
  - Patch the cray-postgres-db-backup image
    cronjob.batch/cray-keycloak-postgresql-db-backup patched (no change)
  - Create manual job
    job.batch/cray-keycloak-postgresql-db-backup-manual created
  - Wait for the backup job to complete
    job.batch/cray-keycloak-postgresql-db-backup-manual condition met
  - Checking for backups
  - Delete manual job
    job.batch "cray-keycloak-postgresql-db-backup-manual" deleted
  - Resume the backup
    cronjob.batch/cray-keycloak-postgresql-db-backup patched
  -> Success
* cray-sls-postgresql-db-backup:
  - Suspend the backup
    cronjob.batch/cray-sls-postgresql-db-backup patched
  - Delete existing jobs
  - Delete existing backups
    Deleting object cray-sls-postgres-2022-09-30T15:44:42.manifest
    Deleting object cray-sls-postgres-2022-09-30T15:44:42.psql
  - Patch the cray-postgres-db-backup image
    cronjob.batch/cray-sls-postgresql-db-backup patched (no change)
  - Create manual job
    job.batch/cray-sls-postgresql-db-backup-manual created
  - Wait for the backup job to complete
    job.batch/cray-sls-postgresql-db-backup-manual condition met
  - Checking for backups
  - Delete manual job
    job.batch "cray-sls-postgresql-db-backup-manual" deleted
  - Resume the backup
    cronjob.batch/cray-sls-postgresql-db-backup patched
  -> Success
* cray-smd-postgresql-db-backup:
  - Suspend the backup
    cronjob.batch/cray-smd-postgresql-db-backup patched
  - Delete existing jobs
  - Delete existing backups
    Deleting object cray-smd-postgres-2022-09-30T15:44:58.manifest
    Deleting object cray-smd-postgres-2022-09-30T15:44:58.psql
  - Patch the cray-postgres-db-backup image
    cronjob.batch/cray-smd-postgresql-db-backup patched (no change)
  - Create manual job
    job.batch/cray-smd-postgresql-db-backup-manual created
  - Wait for the backup job to complete
    job.batch/cray-smd-postgresql-db-backup-manual condition met
  - Checking for backups
  - Delete manual job
    job.batch "cray-smd-postgresql-db-backup-manual" deleted
  - Resume the backup
    cronjob.batch/cray-smd-postgresql-db-backup patched
  -> Success
* gitea-vcs-postgresql-db-backup:
  - Suspend the backup
    cronjob.batch/gitea-vcs-postgresql-db-backup patched
  - Delete existing jobs
  - Delete existing backups
    Deleting object gitea-vcs-postgres-2022-09-30T15:45:14.manifest
    Deleting object gitea-vcs-postgres-2022-09-30T15:45:14.psql
  - Patch the cray-postgres-db-backup image
    cronjob.batch/gitea-vcs-postgresql-db-backup patched (no change)
  - Create manual job
    job.batch/gitea-vcs-postgresql-db-backup-manual created
  - Wait for the backup job to complete
    job.batch/gitea-vcs-postgresql-db-backup-manual condition met
  - Checking for backups
  - Delete manual job
    job.batch "gitea-vcs-postgresql-db-backup-manual" deleted
  - Resume the backup
    cronjob.batch/gitea-vcs-postgresql-db-backup patched
  -> Success
* spire-postgresql-db-backup:
  - Suspend the backup
    cronjob.batch/spire-postgresql-db-backup patched
  - Delete existing jobs
  - Delete existing backups
    Deleting object spire-postgres-2022-09-30T15:45:31.manifest
    Deleting object spire-postgres-2022-09-30T15:45:31.psql
  - Patch the cray-postgres-db-backup image
    cronjob.batch/spire-postgresql-db-backup patched (no change)
  - Create manual job
    job.batch/spire-postgresql-db-backup-manual created
  - Wait for the backup job to complete
    job.batch/spire-postgresql-db-backup-manual condition met
  - Checking for backups
  - Delete manual job
    job.batch "spire-postgresql-db-backup-manual" deleted
  - Resume the backup
    cronjob.batch/spire-postgresql-db-backup patched
  -> Success

List all current postgres backups:
cray-hms-badger-postgres-2022-09-30T15:52:51.manifest
cray-hms-badger-postgres-2022-09-30T15:52:51.psql
cray-nls-postgres-2022-09-30T15:52:35.manifest
cray-nls-postgres-2022-09-30T15:52:35.psql
cray-sls-postgres-2022-09-30T15:53:24.manifest
cray-sls-postgres-2022-09-30T15:53:24.psql
cray-smd-postgres-2022-09-30T15:53:41.manifest
cray-smd-postgres-2022-09-30T15:53:41.psql
gitea-vcs-postgres-2022-09-30T15:53:59.manifest
gitea-vcs-postgres-2022-09-30T15:53:59.psql
keycloak-postgres-2022-09-30T15:53:07.manifest
keycloak-postgres-2022-09-30T15:53:07.psql
spire-postgres-2022-09-30T15:54:18.manifest
spire-postgres-2022-09-30T15:54:18.psql

Postgres backup(s) have been successfully re-genetated

real	2m5.695s
user	1m8.022s
sys	0m14.938s
```

# Checklist Before Merging

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
