### PR TITLE
put cps label back after rebuild

### DIFF
--- a/workflows/ncn/worker/worker.drain.yaml
+++ b/workflows/ncn/worker/worker.drain.yaml
@@ -294,4 +294,10 @@ tasks:
                 jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"$TARGET_NCN\")) | .Xname")
             /host_usr_bin/csi handoff bss-update-param --delete metal.no-wipe --limit $TARGET_XNAME
             /host_usr_bin/csi handoff bss-update-param --set metal.no-wipe=0 --limit $TARGET_XNAME
+            CPS_PM_NODE=$( kubectl get node ${TARGET_NCN} -o json | jq -r '.metadata.labels."cps-pm-node"')
+            if [ "$CPS_PM_NODE" = "True" ]; then
+              /host_usr_bin/csi handoff bss-update-param --set cps.pm-node=1 --limit $TARGET_XNAME
+            else 
+              /host_usr_bin/csi handoff bss-update-param --set cps.pm-node=0 --limit $TARGET_XNAME
+            fi
 {{end}}

--- a/workflows/ncn/worker/worker.post-rebuild.yaml
+++ b/workflows/ncn/worker/worker.post-rebuild.yaml
@@ -37,6 +37,10 @@ tasks:
             TARGET_XNAME=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management" | \
                 jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"$TARGET_NCN\")) | .Xname")
             /host_usr_bin/csi handoff bss-update-param --set metal.no-wipe=1 --limit $TARGET_XNAME
+            CPS_PM_NODE=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" -X GET https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters?name=${TARGET_XNAME} | jq -r '.[].params' | grep -c "cps.pm-node=1")
+            if [[ ${CPS_PM_NODE} -eq 1 ]]; then
+              kubectl label nodes ${TARGET_NCN} "cps-pm-node=True"
+            fi
   - name: wait-for-cfs-after-rebuild
     templateRef:
       name: kubectl-and-curl-template


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
