### PR TITLE
Add script and doc note to take manual etcd backup after install/upgrade (CASMINST-5380)

### DIFF
--- a/install/install_csm_services.md
+++ b/install/install_csm_services.md
@@ -100,6 +100,14 @@ This procedure will install CSM applications and services into the CSM Kubernete
 Wait **at least 15 minutes** to let the various Kubernetes resources initialize and start before proceeding with the rest of the install.
 Because there are a number of dependencies between them, some services are not expected to work immediately after the install script completes.
 
+1. After having waited until services are healthy (run `kubectl get po -A | grep -v 'Completed\|Running'` to see which pods may still be `Pending`), take a manual backup of all Etcd clusters.
+These clusters are automatically backed up every 24 hours, but not until the clusters have been up that long.
+Taking a manual backup enables restoring from backup later in this install process if needed.
+
+   ```bash
+   /usr/share/doc/csm/scripts/operations/etcd/take-etcd-manual-backups.sh post_install
+   ```
+
 1. The next step is to validate CSM health before redeploying the final NCN. See [Validate CSM health before final NCN deployment](./README.md#3-validate-csm-health-before-final-ncn-deployment).
 
 ## Known issues

--- a/scripts/operations/etcd/take-etcd-manual-backups.sh
+++ b/scripts/operations/etcd/take-etcd-manual-backups.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+usage() {
+        echo "
+Usage:
+
+$0 context
+
+context - Description of when the backups are being taken (e.g. 'post_install').
+          This string is used for the backup name so the backup can be easily
+          identified (e.g. cray-bss/post_install.backup_2022-09-30-20:51:46).
+          Note the string proviced for context should contain '_' in order
+          for the ncnHealthChecks.sh script to properly parse the timestamp
+          from the backup name.
+"
+}
+
+backup_clusters() {
+  context=$1
+  etcd_clusters_to_backup=$(kubectl get configmap -n operators etcd-backup-restore-config -o json | jq -r '.data."clusters.txt"' | awk -F "." '{print $1}')
+  for cluster in $etcd_clusters_to_backup
+  do
+    backup_name=$(echo "$context.backup_$(date +%Y-%m-%d-%H:%M:%S)")
+    echo "Creating manual etcd backup for '$cluster' named '$backup_name'."
+    kubectl exec -it -n operators "$(kubectl get pod -n operators | grep etcd-backup-restore | head -1 | awk '{print $1}')" -c util -- create_backup $cluster $backup_name
+  done
+}
+
+if [ "$#" -lt 1 ]; then
+        usage
+        exit 1
+fi
+
+context=$1
+echo $context | grep -q '_'
+if [ $? -ne 0 ]; then
+  echo "ERROR: '$context' needs to contain '_' for proper timestamp parsing."
+  exit 1
+fi
+
+backup_clusters $context
+exit 0

--- a/upgrade/Stage_3.md
+++ b/upgrade/Stage_3.md
@@ -6,6 +6,7 @@
 - [Start typescript](#start-typescript)
 - [Perform upgrade](#perform-upgrade)
 - [Verify Keycloak users](#verify-keycloak-users)
+- [Take Etcd Manual Backup](#take-etcd-manual-backup)
 - [Stop typescript](#stop-typescript)
 - [Stage completed](#stage-completed)
 
@@ -56,6 +57,16 @@ This is due to a redeployment of the Ceph `csi` provisioners into namespaces, in
     After an upgrade, it is possible that all expected Keycloak users were not localized.
     See [Verification procedure](../operations/security_and_authentication/Keycloak_User_Localization.md#Verification-procedure)
     to confirm that Keycloak localization has completed as expected.
+
+## Take Etcd Manual Backup
+
+1. (`ncn-m002#`) Execute the following script to take a manual backup of the Etcd clusters.
+   These clusters are automatically backed up every 24 hours, but taking a manual backup
+   at this stage in the upgrade enables restoring from backup later in this process if needed.
+
+   ```bash
+   /usr/share/doc/csm/scripts/operations/etcd/take-etcd-manual-backups.sh post_upgrade
+   ```
 
 ## Stop typescript
 


### PR DESCRIPTION
# Description

Fix for https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5380 -- add script to take manual etcd backups, and point to it in the install docs after CSM services are installed (and settled).

```
ncn-m001:~/bklein/etcd # ./take-etcd-manual-backups.sh post.install
Creating manual etcd backup for 'cray-bos' named 'post.install.backup_2022-09-30-21:19:47'.
etcdbackup.etcd.database.coreos.com/cray-bos-etcd-cluster-manual-backup-3238 created
Creating manual etcd backup for 'cray-bss' named 'post.install.backup_2022-09-30-21:19:49'.
etcdbackup.etcd.database.coreos.com/cray-bss-etcd-cluster-manual-backup-30936 created
Creating manual etcd backup for 'cray-crus' named 'post.install.backup_2022-09-30-21:19:51'.
etcdbackup.etcd.database.coreos.com/cray-crus-etcd-cluster-manual-backup-4481 created
Creating manual etcd backup for 'cray-fas' named 'post.install.backup_2022-09-30-21:19:53'.
etcdbackup.etcd.database.coreos.com/cray-fas-etcd-cluster-manual-backup-18960 created
Creating manual etcd backup for 'cray-uas-mgr' named 'post.install.backup_2022-09-30-21:19:55'.
etcdbackup.etcd.database.coreos.com/cray-uas-mgr-etcd-cluster-manual-backup-26167 created

```

# Checklist Before Merging

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
