### PR TITLE
CASMPET-5965 Add note about etcd backups after system power up

### DIFF
--- a/troubleshooting/known_issues/issues_with_ncn_health_checks.md
+++ b/troubleshooting/known_issues/issues_with_ncn_health_checks.md
@@ -122,3 +122,13 @@
    =- ncn-w002.nmn                  3   5   377     8  -1910us[-1910us] +/-   27ms
    =- ncn-w003.nmn                  3   8   377   74m  -1122us[-1002us] +/-   31ms
    ```
+
+- `Etcd backups missing after system power up`
+
+   After system power up, automated Etcd backups will resume within about 24 hours of the cluster being back up.  When running the `ncnHealthChecks.sh` script within this time period, it may report a failure:
+
+   ```text
+   --- FAILED --- not all Etcd clusters had expected backups.
+   ```
+
+   This is normal, and backups should resume after 24 hours.


### PR DESCRIPTION
# Description

Fix for https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5965 -- add note about etcd backups resuming after 24 hours of a system being powered back up.

# Checklist Before Merging

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
