### PR TITLE
CASMPET-5977 stage4 Add note about 'in family' upgrades to stage 4

### DIFF
--- a/upgrade/Stage_4.md
+++ b/upgrade/Stage_4.md
@@ -56,6 +56,12 @@ after a break, always be sure that a typescript is running before proceeding.
    **Note:** The source version in the output may vary, but the target version should match what is shown above. If the output does not match what is expected, then this can indicate that a previous step has failed.
    Review the output from [Stage 1](Stage_1.md) for errors or contact support.
 
+   If this is an in family upgrade and the Ceph upgrade was completed during [Stage 1](Stage_1.md), then the upgrade will not run again. The expected output is stated below.
+
+   ```text
+   Your current version is the same as the proposed version 16.2.9
+   ```
+
 1. Monitor the upgrade.
 
    The `cubs_tool` will automatically watch the upgrade.


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
Add information to stage 4 about expected behavior during in family upgrades.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
