### PR TITLE
MTL-1954 Refactor to use `check_bootloader.sh`.

### DIFF
--- a/operations/index.md
+++ b/operations/index.md
@@ -482,7 +482,7 @@ Monitor and manage compute nodes (CNs) and non-compute nodes (NCNs) used in the 
   - [Adding a Ceph Node to the Ceph Cluster](node_management/Rebuild_NCNs/Re-add_Storage_Node_to_Ceph.md)
   - [Customize PCIe Hardware](node_management/customize_pcie_hardware.md)
   - [Customize Disk Hardware](node_management/customize_disk_hardware.md)
-  - [Validate Boot Raid](node_management/Rebuild_NCNs/Validate_Boot_Raid.md)
+  - [Validate Boot Loader](node_management/Rebuild_NCNs/Validate_Boot_Loader.md)
   - [Validate Storage Node](node_management/Rebuild_NCNs/Post_Rebuild_Storage_Node_Validation.md)
   - [Final Validation Steps](node_management/Rebuild_NCNs/Final_Validation_Steps.md)
 - [Reboot NCNs](node_management/Reboot_NCNs.md)

--- a/operations/node_management/Rebuild_NCNs/Power_Cycle_and_Rebuild_Nodes.md
+++ b/operations/node_management/Rebuild_NCNs/Power_Cycle_and_Rebuild_Nodes.md
@@ -161,4 +161,4 @@ This section applies to all node types. The commands in this section assume the 
 
 ## Next step
 
-Proceed to the next step to [Validate Boot Raid](Validate_Boot_Raid.md).
+Proceed to the next step to [Validate Boot Loader](Validate_Boot_Loader.md).

--- a/operations/node_management/Rebuild_NCNs/Validate_Boot_Loader.md
+++ b/operations/node_management/Rebuild_NCNs/Validate_Boot_Loader.md
@@ -1,17 +1,11 @@
-# Validate `BOOTRAID` Artifacts
+# Validate Boot Loader
 
-Perform the following steps **on `ncn-m001`**.
-
-1. Initialize the `cray` command and follow the prompts (required for the next step).
-
-   ```screen
-   ncn-m001# cray init
-   ```
+Perform the following steps **on `ncn-m001`** (where the latest `docs-csm` is installed).
 
 1. Run the script to ensure the local BOOTRAID has a valid kernel and initrd.
 
-    ```screen
-    ncn-m001# /opt/cray/tests/install/ncn/scripts/validate-bootraid-artifacts.sh
+    ```bash
+    /usr/share/doc/csm/scripts/check_bootloader_all_ncns.sh
     ```
 
 ## Workaround: CASMINST-2015
@@ -19,7 +13,7 @@ Perform the following steps **on `ncn-m001`**.
 As a result of rebuilding any NCN(s), remove any dynamically assigned interface IP addresses that did not get released automatically by running the CASMINST-2015 script:
 
 ```bash
-ncn-m001# /usr/share/doc/csm/scripts/CASMINST-2015.sh
+/usr/share/doc/csm/scripts/CASMINST-2015.sh
 ```
 
 Once that is done only follow the steps in the section for the node type that was rebuilt:

--- a/scripts/check_bootloader.sh
+++ b/scripts/check_bootloader.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+set -euo pipefail
+
+ERROR=0
+
+if [ -f /etc/pit-release ]; then
+    echo >&2 'This must run from an NCN and is not allowed to run from the PIT node'
+    exit 1
+fi
+
+if ! mount -v -L BOOTRAID -T /etc/fstab.metal 2>/dev/null; then
+    if ! grep -q BOOTRAID /etc/fstab.metal; then
+        echo >&2 'BOOTRAID is missing from /etc/fstab.metal'
+        exit 1
+    fi
+fi
+BOOTRAID=$(lsblk -o MOUNTPOINT -nr /dev/disk/by-label/BOOTRAID)
+
+# validate the kernel exists, use the one that matches the --no-hostonly initrd
+function verify_kernel {
+    if [ ! -f ${BOOTRAID}/boot/kernel ];then 
+        echo >&2 "kernel missing at ${BOOTRAID}/boot"
+        return 1
+    else
+        echo "The disk's kernel exists and is validated."
+    fi
+}
+
+# verify initrd
+function verify_initrd {
+    
+    local image_error=0
+    local error=0
+    local needed_initrd_name
+    local needed_initrd
+    
+    needed_initrd_name="$(grep -oP '(?<=initrdefi \$prefix/\.\./)(initrd[a-zA-Z.\-_]*)' ${BOOTRAID}/boot/grub2/grub.cfg)"
+    needed_initrd="${BOOTRAID}/boot/${needed_initrd_name}"
+    if [ ! -f $needed_initrd ]; then
+
+        echo >&2 "Grub expects ${needed_initrd} but it did not exist!"
+        error=1
+
+        if [ -f ${BOOTRAID}/boot/initrd ]; then
+            
+            echo >&2 "Found [${BOOTRAID}/boot/initrd] which differs from the expected [$needed_initrd]."
+
+        elif [ -f ${BOOTRAID}/boot/initrd.img.xz ]; then
+
+            echo >&2 "Found [${BOOTRAID}/boot/initrd.img.xz] which differs from the expected [$needed_initrd]."
+
+        else
+
+            echo >&2 "No initrd was found in the bootloader; [${BOOTRAID}] is missing an initrd!"
+
+            if [ ! -f /squashfs/initrd.img.xz ]; then
+
+                echo >&2 "The original initrd is also missing [/squashfs/initrd.img.xz]."
+                image_error=1
+
+            else
+
+                echo "The original initrd exists [/squashfs/initrd.img.xz]."
+
+            fi
+        fi
+    fi
+
+    if [ ${error} -ne 0 ]; then
+        echo >&2 "The errors that were found will prevent the disk bootloader from working."
+        if [ ${image_error} -ne 0 ]; then
+
+            echo >&2 "Cloud-init seems to have failed because the expected [/squashfs/initrd.img.xz] is missing."
+            echo >&2 "The squashFS that is currently booted is missing a dependency for the bootloader to work."
+
+        fi
+        return 1
+    fi
+    
+    # After finding the initrd we care about, verify it is a proper cpio archive.
+    if [[ $(file $needed_initrd) != *cpio* ]]; then
+
+        echo >&2 'initrd is corrupt! The initrd is not a CPIO archive.'
+        return 1
+    else
+
+        echo "The disk's initrd was validated. The initrd name in GRUB's configuration exists on the filesystem and is a proper CPIO archive."
+        return 0
+    fi
+}
+
+if ! verify_kernel; then
+    ERROR=1
+fi 
+if ! verify_initrd; then
+    ERROR=1
+fi
+if [ ${ERROR} -ne 0 ]; then
+    echo >&2 'The disk bootloader will not work and is broken.'
+    echo >&2 'This means that either the used squashFS has a failed customization or that cloud-init failed to run the metal install.'
+    echo >&2 'This could also mean that the cmdline has the wrong `initrd=` argument set, and cloud-init was unable to find the `initrd` in S3.'
+    exit 1
+else
+    exit 0
+fi

--- a/scripts/check_bootloader_all_ncns.sh
+++ b/scripts/check_bootloader_all_ncns.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+set -euo pipefail
+
+workdir=/usr/share/doc/csm/scripts/
+
+if [[ -f /etc/pit-release ]]; then
+    # Exclude ncn-m001 if this is run from the PIT node.
+    readarray -t EXPECTED_NCNS < <(conman -q | grep -v m001 | sort -u | awk -F - '{print $1"-"$2}')
+    if [ ${#EXPECTED_NCNS[@]} = 0 ]; then
+        echo >&2 "No NCNs found in 'conman -q', $0 can only be invoked after pit-init.sh has completed successfully."
+        exit 1
+    fi
+else
+    readarray -t EXPECTED_NCNS < <(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u)
+    if [ ${#EXPECTED_NCNS[@]} = 0 ]; then
+        echo >&2 "No NCNs found in /etc/hosts! This NCN is not initialized, /etc/hosts should have content."
+        exit 1
+    fi
+fi
+
+export NCNS=()
+for ncn in "${EXPECTED_NCNS[@]}"; do
+    if ping -c 1 $ncn >/dev/null 2>&1 ; then
+        NCNS+=( "$ncn" )
+    else
+        echo >&2 "Failed to ping [$ncn]; skipping hotfix for [$ncn]"
+    fi
+done
+
+for ncn in "${NCNS[@]}"; do
+    printf "Uploading check_bootloader.sh to $ncn:/tmp/ ... "
+    scp ${workdir}/check_bootloader.sh ${ncn}:/tmp/ >/dev/null
+    echo "Done" 
+done
+
+# Do not run with -S, let the bootloader check report failures on every node and not exit early.
+pdsh -b -w "$(printf '%s,' "${NCNS[@]}")" '
+/tmp/check_bootloader.sh
+'
+echo "Done"

--- a/upgrade/1.2/scripts/upgrade/prerequisites.sh
+++ b/upgrade/1.2/scripts/upgrade/prerequisites.sh
@@ -582,8 +582,6 @@ if [[ $state_recorded == "0" ]]; then
     echo "====> ${state_name} ..."
     {
     export PDSH_SSH_ARGS_APPEND="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
-    rpm --force -Uvh "$(find $CSM_ARTI_DIR/rpm/cray/csm/ -name \*csm-testing\*.rpm | sort -V | tail -1)"
-    /opt/cray/tests/install/ncn/scripts/validate-bootraid-artifacts.sh
 
     # get all installed csm version into a file
     kubectl get cm -n services cray-product-catalog -o json | jq  -r '.data.csm' | yq r -  -d '*' -j | jq -r 'keys[]' > /tmp/csm_versions


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
This script will validate that the bootloader is correct on an NCN. The included `check_bootloader_all_ncns.sh` will copy the script `check_bootloader.sh` script to every pingable NCN before running it.

This is a backport of:
- #2444 
- #2445 

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
