### PR TITLE
MTL-1836 Add notice about missing `App. Version`

### DIFF
--- a/install/bootstrap_livecd_remote_iso.md
+++ b/install/bootstrap_livecd_remote_iso.md
@@ -116,6 +116,9 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
    recorded in the typescript file, in case it is needed later. For example, this information is useful to include in
    any bug reports or service queries for issues encountered on the PIT node.
 
+   > ***NOTE*** The `App. Version` will report incorrectly in CSM 1.2. Please obtain the
+   > version information by running the step below and by invoking `rpm -q cray-site-init`.
+
    ```bash
    pit# /root/bin/metalid.sh
    ```
@@ -348,6 +351,9 @@ On first login (over SSH or at local console) the LiveCD will prompt the adminis
    See [Check for Latest Documentation](../update_product_stream/index.md#documentation)
 
 1. Show the version of CSI installed.
+
+   > ***NOTE*** The `App. Version` will report incorrectly in CSM 1.2.0 and CSM 1.2.1. Please obtain the
+   > version information by running the step below and by invoking `rpm -q cray-site-init`.
 
    ```bash
    pit# /root/bin/metalid.sh
@@ -582,6 +588,9 @@ and [Configuration Payload Files](prepare_configuration_payload.md#configuration
       ```
 
    1. Note the version reported by the `csi` tool.
+
+      > ***NOTE*** The `App. Version` will report incorrectly in CSM 1.2.0 and CSM 1.2.1. Please obtain the
+      > version information by running the step below and by invoking `rpm -q cray-site-init`.
 
       ```bash
       pit# csi version

--- a/install/bootstrap_livecd_usb.md
+++ b/install/bootstrap_livecd_usb.md
@@ -475,6 +475,9 @@ information for this system has not yet been prepared.
 
    1. Note the version reported by the `csi` tool.
 
+      > ***NOTE*** The `App. Version` will report incorrectly in CSM 1.2.0 and CSM 1.2.1. Please obtain the
+      > version information by running the step below and by invoking `rpm -q cray-site-init`.
+
       ```bash
       linux# csi version
       ```
@@ -781,6 +784,9 @@ On first log in (over SSH or at local console), the LiveCD will prompt the admin
    There is nothing in the output that needs to be verified. This is run in order to ensure the information is
    recorded in the typescript file, in case it is needed later. For example, this information is useful to include in
    any bug reports or service queries for issues encountered on the PIT node.
+
+   > ***NOTE*** The `App. Version` will report incorrectly in CSM 1.2. Please obtain the
+   > version information by running the step below and by invoking `rpm -q cray-site-init`.
 
    ```bash
    pit# /root/bin/metalid.sh

--- a/install/deploy_final_ncn.md
+++ b/install/deploy_final_ncn.md
@@ -520,6 +520,9 @@ it is used for Cray installation and bootstrap.
 
 1. Obtain access to CSI.
 
+   > ***NOTE*** The `App. Version` will report incorrectly in CSM 1.2.0. Please refer to the `Git Version` field
+   > for this information.
+
     ```bash
     ncn-m001# mkdir -pv /mnt/livecd /mnt/rootfs /mnt/sqfs && \
               mount -v /metal/bootstrap/cray-pre-install-toolkit-*.iso /mnt/livecd/ && \

--- a/operations/node_management/Updating_Cabinet_Routes_on_Management_NCNs.md
+++ b/operations/node_management/Updating_Cabinet_Routes_on_Management_NCNs.md
@@ -5,6 +5,10 @@ This procedure will use config from System Layout Service (SLS) to set up the pr
 ## Prerequisites
 -   Passwordless SSH to all of the management NCNs is configured.
 -   Ensure Cray Site Init (CSI) is installed and available on ncn-m001.
+
+    > ***NOTE*** The `App. Version` will report incorrectly in CSM 1.2. Please refer to the `Git Version` field
+    > for this information.
+
     ```bash
     ncn-m001# csi version
     ```


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
`cray-site-init` (`csi`) fails to print the `App. Version` field when `csi version` is invoked. This commit adds a note in every instance that `csi version` or `metalid.sh` are invoked, telling the user to observe the version information by another means.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
