### PR TITLE
STP-3355 : Update URL for GSG

### DIFF
--- a/.github/config/markdown_link.json
+++ b/.github/config/markdown_link.json
@@ -31,7 +31,7 @@
             "pattern": "https?://[^/]+\\.\\\\{\\\\{network\\.dns\\.external\\\\}\\\\}(/.*)?"
         },
         {
-            "pattern": "^https://www\\.hpe\\.com/support/ex-gsg"
+            "pattern": "^https://www\\.hpe\\.com/support/ex-S-8000"
         },
         {
             "pattern": "https://jira-pro\\.its\\.hpecorp\\.net:8443(/.*)?"

--- a/install/README.md
+++ b/install/README.md
@@ -171,7 +171,7 @@ communicates with at once, or specific devices can be targeted for a firmware up
 
 > **IMPORTANT:**
 > Before FAS can be used to update firmware, refer to the 1.5 _HPE Cray EX System Software Getting Started Guide S-8000_
-> on the [HPE Customer Support Center](https://www.hpe.com/support/ex-gsg) for more information about how to install
+> on the [HPE Customer Support Center](https://www.hpe.com/support/ex-S-8000) for more information about how to install
 > the HPE Cray EX HPC Firmware Pack (HFP) product. The installation of HFP will inform FAS of the newest firmware
 > available. Once FAS is aware that new firmware is available, then see
 > [Update Firmware with FAS](../operations/firmware/Update_Firmware_with_FAS.md).
@@ -192,7 +192,7 @@ See [Prepare Compute Nodes](prepare_compute_nodes.md).
 
 After completion of the firmware update with FAS and the preparation of compute nodes, the CSM product stream has
 been fully installed and configured. Refer to the _HPE Cray EX System Software Getting Started Guide S-8000_
-on the [HPE Customer Support Center](https://www.hpe.com/support/ex-gsg) for more information on other product streams
+on the [HPE Customer Support Center](https://www.hpe.com/support/ex-S-8000) for more information on other product streams
 to be installed and configured after CSM.
 
 ### Troubleshooting installation problems

--- a/install/README.md
+++ b/install/README.md
@@ -170,8 +170,9 @@ with many devices on the system. FAS can be used to update the firmware for all 
 communicates with at once, or specific devices can be targeted for a firmware update.
 
 > **IMPORTANT:**
-> Before FAS can be used to update firmware, refer to the 1.5 _HPE Cray EX System Software Getting Started Guide S-8000_
-> on the [HPE Customer Support Center](https://www.hpe.com/support/ex-S-8000) for more information about how to install
+> Before FAS can be used to update firmware, refer to the
+> [HPE Cray EX System Software Getting Started Guide S-800](https://www.hpe.com/support/ex-S-8000)
+> on the HPE Customer Support Center for more information about how to install
 > the HPE Cray EX HPC Firmware Pack (HFP) product. The installation of HFP will inform FAS of the newest firmware
 > available. Once FAS is aware that new firmware is available, then see
 > [Update Firmware with FAS](../operations/firmware/Update_Firmware_with_FAS.md).
@@ -191,8 +192,9 @@ See [Prepare Compute Nodes](prepare_compute_nodes.md).
 ### 10. Next topic
 
 After completion of the firmware update with FAS and the preparation of compute nodes, the CSM product stream has
-been fully installed and configured. Refer to the _HPE Cray EX System Software Getting Started Guide S-8000_
-on the [HPE Customer Support Center](https://www.hpe.com/support/ex-S-8000) for more information on other product streams
+been fully installed and configured.
+Refer to the [HPE Cray EX System Software Getting Started Guide S-8000](https://www.hpe.com/support/ex-S-8000)
+on the HPE Customer Support Center for more information on other product streams
 to be installed and configured after CSM.
 
 ### Troubleshooting installation problems

--- a/install/README.md
+++ b/install/README.md
@@ -171,7 +171,7 @@ communicates with at once, or specific devices can be targeted for a firmware up
 
 > **IMPORTANT:**
 > Before FAS can be used to update firmware, refer to the
-> [HPE Cray EX System Software Getting Started Guide S-800](https://www.hpe.com/support/ex-S-8000)
+> [HPE Cray EX System Software Getting Started Guide S-8000](https://www.hpe.com/support/ex-S-8000)
 > on the HPE Customer Support Center for more information about how to install
 > the HPE Cray EX HPC Firmware Pack (HFP) product. The installation of HFP will inform FAS of the newest firmware
 > available. Once FAS is aware that new firmware is available, then see

--- a/introduction/scenarios.md
+++ b/introduction/scenarios.md
@@ -44,7 +44,7 @@ the same regardless of the starting point in the workflow.
 
 After completion of the firmware update with FAS and the preparation of compute nodes, the CSM product stream has
 been fully installed and configured. Refer to the _HPE Cray EX System Software Getting Started Guide S-8000_
-on the [HPE Customer Support Center](https://www.hpe.com/support/ex-gsg) for more information on other product streams
+on the [HPE Customer Support Center](https://www.hpe.com/support/ex-S-8000) for more information on other product streams
 to be installed and configured after CSM.
 
 See [Install CSM](../install/README.md) for the details on the installation process for either a first time install

--- a/operations/CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md
+++ b/operations/CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md
@@ -4,7 +4,7 @@ Non-compute node (NCN) personalization applies post-boot configuration to the
 HPE Cray EX management nodes. Several HPE Cray EX product environments outside
 of CSM require NCN personalization to function. Consult the manual for each
 product to configure them on NCNs by referring to the
-[1.5 HPE Cray EX System Software Getting Started Guide S-8000](https://www.hpe.com/support/ex-S-8000)
+[HPE Cray EX System Software Getting Started Guide S-8000](https://www.hpe.com/support/ex-S-8000)
 on the HPE Customer Support Center.
 
 This procedure defines the NCN personalization process for the CSM product using
@@ -146,7 +146,7 @@ documents for additional information, because role documentation is updated more
 changes are introduced.
 
 Consult the manual for each product in order to change the default configuration by
-referring to the [1.5 HPE Cray EX System Software Getting Started Guide S-8000](https://www.hpe.com/support/ex-S-8000)
+referring to the [HPE Cray EX System Software Getting Started Guide S-8000](https://www.hpe.com/support/ex-S-8000)
 on the HPE Customer Support Center. Similar configuration values for disabling the
 role will be required in these product-specific configuration repositories.
 

--- a/operations/CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md
+++ b/operations/CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md
@@ -4,7 +4,7 @@ Non-compute node (NCN) personalization applies post-boot configuration to the
 HPE Cray EX management nodes. Several HPE Cray EX product environments outside
 of CSM require NCN personalization to function. Consult the manual for each
 product to configure them on NCNs by referring to the
-[1.5 HPE Cray EX System Software Getting Started Guide S-8000](https://www.hpe.com/support/ex-gsg)
+[1.5 HPE Cray EX System Software Getting Started Guide S-8000](https://www.hpe.com/support/ex-S-8000)
 on the HPE Customer Support Center.
 
 This procedure defines the NCN personalization process for the CSM product using
@@ -146,7 +146,7 @@ documents for additional information, because role documentation is updated more
 changes are introduced.
 
 Consult the manual for each product in order to change the default configuration by
-referring to the [1.5 HPE Cray EX System Software Getting Started Guide S-8000](https://www.hpe.com/support/ex-gsg)
+referring to the [1.5 HPE Cray EX System Software Getting Started Guide S-8000](https://www.hpe.com/support/ex-S-8000)
 on the HPE Customer Support Center. Similar configuration values for disabling the
 role will be required in these product-specific configuration repositories.
 

--- a/operations/CSM_product_management/Perform_NCN_Personalization.md
+++ b/operations/CSM_product_management/Perform_NCN_Personalization.md
@@ -15,9 +15,8 @@ to create a [configuration layer](../configuration_management/Configuration_Laye
 
 Products may supply multiple plays to run, in which case multiple configuration
 layers must be created. Consult the manual for each product to configure them on
-NCNs by referring to the _HPE Cray EX
-System Software Getting Started Guide S-8000_ on the
-[HPE Customer Support Center](https://www.hpe.com/support/ex-S-8000).
+NCNs by referring to the [HPE Cray EX System Software Getting Started Guide S-8000](https://www.hpe.com/support/ex-S-8000)
+on the HPE Customer Support Center.
 
 ## Procedure: Perform NCN Personalization
 

--- a/operations/CSM_product_management/Perform_NCN_Personalization.md
+++ b/operations/CSM_product_management/Perform_NCN_Personalization.md
@@ -16,7 +16,7 @@ to create a [configuration layer](../configuration_management/Configuration_Laye
 Products may supply multiple plays to run, in which case multiple configuration
 layers must be created. Consult the manual for each product to configure them on
 NCNs by referring to the [1.5 HPE Cray EX System Software Getting Started Guide
-S-8000](https://www.hpe.com/support/ex-gsg) on the HPE Customer Support Center.
+S-8000](https://www.hpe.com/support/ex-S-8000) on the HPE Customer Support Center.
 
 ## Procedure: Perform NCN Personalization
 
@@ -42,7 +42,7 @@ error. This error can be ignored.
 
 CFS executes configuration layers in order. Refer to the _1.5 HPE Cray EX
 System Software Getting Started Guide S-8000_ on the HPE Customer Support
-Center at https://www.hpe.com/support/ex-gsg to determine if the
+Center at https://www.hpe.com/support/ex-S-8000 to determine if the
 configuration layer requires special placement in the layer list.
 
 > **`NOTE`** The CSM configuration layer _MUST_ be the first layer in the

--- a/operations/CSM_product_management/Perform_NCN_Personalization.md
+++ b/operations/CSM_product_management/Perform_NCN_Personalization.md
@@ -56,7 +56,7 @@ configuration layer requires special placement in the layer list.
      configuring the NCNs. Use the [sample file with a single layer](../configuration_management/Configuration_Layers.md#example-configuration-single-layer)
      as a template.
    * If a CFS configuration exists with one or more layers, add (or replace)
-     the corresponding layer entry(ies) with the configuration layer
+     the corresponding layer entry or entries with the configuration layer
      information gathered for this specific product. For example:
 
         ```bash

--- a/operations/CSM_product_management/Perform_NCN_Personalization.md
+++ b/operations/CSM_product_management/Perform_NCN_Personalization.md
@@ -15,8 +15,9 @@ to create a [configuration layer](../configuration_management/Configuration_Laye
 
 Products may supply multiple plays to run, in which case multiple configuration
 layers must be created. Consult the manual for each product to configure them on
-NCNs by referring to the [1.5 HPE Cray EX System Software Getting Started Guide
-S-8000](https://www.hpe.com/support/ex-S-8000) on the HPE Customer Support Center.
+NCNs by referring to the _HPE Cray EX
+System Software Getting Started Guide S-8000_ on the
+[HPE Customer Support Center](https://www.hpe.com/support/ex-S-8000).
 
 ## Procedure: Perform NCN Personalization
 
@@ -40,9 +41,9 @@ error. This error can be ignored.
 
 ### Add Layer(s) to the CFS Configuration
 
-CFS executes configuration layers in order. Refer to the _1.5 HPE Cray EX
-System Software Getting Started Guide S-8000_ on the HPE Customer Support
-Center at https://www.hpe.com/support/ex-S-8000 to determine if the
+CFS executes configuration layers in order. Refer to the _HPE Cray EX
+System Software Getting Started Guide S-8000_ on the
+[HPE Customer Support Center](https://www.hpe.com/support/ex-S-8000) to determine if the
 configuration layer requires special placement in the layer list.
 
 > **`NOTE`** The CSM configuration layer _MUST_ be the first layer in the
@@ -64,7 +65,7 @@ configuration layer requires special placement in the layer list.
 
         Example configuration:
 
-        ```
+        ```json
         {
           "layers": [
             # ...
@@ -90,7 +91,7 @@ configuration layer requires special placement in the layer list.
 
    Example output:
 
-   ```
+   ```json
    {
       "lastUpdated": "2021-07-28T03:26:01Z",
       "layers": [
@@ -110,6 +111,7 @@ configuration layer requires special placement in the layer list.
        cray cfs components update --desired-config ncn-personalization --enabled true --format json $xname
    done
    ```
+
    After this command is issued, the CFS Batcher service will dispatch a CFS
    session to configure the NCNs. Since the NCN is now managed by CFS by setting
    a desired configuration, the same will happen every time the NCN boots.
@@ -131,7 +133,7 @@ configuration layer requires special placement in the layer list.
 
    Example output:
 
-   ```
+   ```text
    x3000c0s17b0n0 status=configured
    x3000c0s19b0n0 status=pending
    x3000c0s21b0n0 status=configured

--- a/upgrade/README.md
+++ b/upgrade/README.md
@@ -84,8 +84,9 @@ The upgrade is a guided process starting with [Upgrade Management Nodes and CSM 
 ## 4. Next topic
 
 After completion of the validation of CSM health, the CSM product stream has been fully upgraded and
-configured. Refer to the `1.5 HPE Cray EX System Software Getting Started Guide S-8000`
-on the [HPE Customer Support Center](https://www.hpe.com/support/ex-S-8000)
+configured.
+Refer to the [HPE Cray EX System Software Getting Started Guide S-8000](https://www.hpe.com/support/ex-S-8000)
+on the HPE Customer Support Center
 for more information on other product streams to be upgraded and configured after CSM.
 
 > **`NOTE`** If a newer version of the HPE Cray EX HPC Firmware Pack (HFP) is available, then the next step

--- a/upgrade/README.md
+++ b/upgrade/README.md
@@ -85,7 +85,7 @@ The upgrade is a guided process starting with [Upgrade Management Nodes and CSM 
 
 After completion of the validation of CSM health, the CSM product stream has been fully upgraded and
 configured. Refer to the `1.5 HPE Cray EX System Software Getting Started Guide S-8000`
-on the [HPE Customer Support Center](https://www.hpe.com/support/ex-gsg)
+on the [HPE Customer Support Center](https://www.hpe.com/support/ex-S-8000)
 for more information on other product streams to be upgraded and configured after CSM.
 
 > **`NOTE`** If a newer version of the HPE Cray EX HPC Firmware Pack (HFP) is available, then the next step


### PR DESCRIPTION
# Description

The link to the GSG for Papaya and future releases will all use the same vanity URL (https://www.hpe.com/support/ex-S-8000), which will always points to the most current version of the GSG in HTML format. This PR replaces the old vanity URL.

This change is only needed in `release/1.3` and `main`.

**NOTE:** This link will not work until the GSG is published to the support center for the Papaya release.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
