### PR TITLE
CRAYSAT-5425: Revise NCN image customization and personalization language to fit fresh install

### DIFF
--- a/operations/configuration_management/Worker_Image_Customization.md
+++ b/operations/configuration_management/Worker_Image_Customization.md
@@ -1,6 +1,6 @@
-# Worker Upgrade Image Customization
+# Worker Image Customization
 
-When performing an upgrade, NCN image customization must be performed with the NCN worker node image to ensure the appropriate CFS layers are applied.
+When performing an upgrade or fresh install, NCN image customization must be performed with the NCN worker node image to ensure the appropriate CFS layers are applied.
 This step involves configuring CFS to use the default `sat bootprep` files from the `hpc-csm-software-recipe` repository and rebuilding the NCN worker nodes so they boot the newly customized image.
 
 The definition of the CFS configuration used for NCN worker node image customization is provided in the `hpc-csm-software-recipe` repository in VCS.

--- a/operations/configuration_management/Worker_Node_Personalization.md
+++ b/operations/configuration_management/Worker_Node_Personalization.md
@@ -1,6 +1,6 @@
-# Worker Upgrade Node Personalization
+# Worker Node Personalization
 
-When performing an upgrade, NCN personalization must be performed on the NCN worker node to ensure the appropriate CFS layers are applied post-boot.
+When performing an upgrade or fresh install, NCN personalization must be performed on the NCN worker node to ensure the appropriate CFS layers are applied post-boot.
 This step involves configuring CFS to use the default `sat bootprep` files from the `hpc-csm-software-recipe` repository and applying the resulting configuration to the NCN worker nodes.
 
 The definition of the CFS configuration used for NCN worker node personalization is provided in the `hpc-csm-software-recipe` repository in VCS.

--- a/upgrade/Stage_0_Prerequisites.md
+++ b/upgrade/Stage_0_Prerequisites.md
@@ -244,12 +244,12 @@ In most cases, administrators will be performing a standard upgrade and not a CS
 1. Prepare the pre-boot worker NCN image customizations.
 
     This will ensure that the CFS configuration layers are applied to perform image customization for the worker NCNs.
-    See [Worker Upgrade Image Customization](../operations/configuration_management/Worker_Upgrade_Image_Customization.md).
+    See [Worker Image Customization](../operations/configuration_management/Worker_Image_Customization.md).
 
 1. Prepare the post-boot worker NCN personalizations.
 
     This will ensure that the appropriate CFS configuration layers are applied when performing post-boot node personalization of the worker NCNs.
-    See [Worker Upgrade Node Personalization](../operations/configuration_management/Worker_Upgrade_Node_Personalization.md).
+    See [Worker Node Personalization](../operations/configuration_management/Worker_Node_Personalization.md).
 
 Continue on to [Stage 0.4](#stage-04---backup-workload-manager-data), skipping the [CSM-only system upgrade](#csm-only-system-upgrade) subsection below.
 


### PR DESCRIPTION
This commit removes the "upgrade" language from the following two procedures, since they are used in the context of both upgrades and fresh installs:
* Worker Image Customization
* Worker Node Personalization

Update links from Stage_0_Prerequisites.md accordingly.

# Description
This commit removes the "upgrade" language from the following two procedures, since they are used in the context of both upgrades and fresh installs:
* Worker Image Customization
* Worker Node Personalization

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
