### PR TITLE
CASMHMS-5763 HMS test additional troubleshooting no computes CSM-1.2

### DIFF
--- a/troubleshooting/interpreting_hms_health_check_results.md
+++ b/troubleshooting/interpreting_hms_health_check_results.md
@@ -328,7 +328,7 @@ Example output:
 ssh: connect to host sw-leaf-bmc-001 port 22: Connection timed out
 ```
 
-Restoring connectivity, resolving configuration issues, or restarting the relevant ports on the `leaf-bmc` switch should allow the compute hardware to issue DHCP requests again and be discovered successfully.
+Restoring connectivity, resolving configuration issues, or restarting the relevant ports on the `leaf-bmc` switch should allow the compute hardware to issue DHCP requests and be discovered successfully.
 
 ### `smd_discovery_status_test_ncn-smoke.sh`
 

--- a/troubleshooting/interpreting_hms_health_check_results.md
+++ b/troubleshooting/interpreting_hms_health_check_results.md
@@ -270,7 +270,7 @@ FAILED opt/cray/tests/ncn-functional/hms/hms-smd/test_smd_hardware_ncn-functiona
 (`ncn-mw#`) If these failures occur, confirm that there are no discovered compute nodes in HSM.
 
 ```bash
-cray hsm state components list --type=node --role=compute --format=json
+cray hsm state components list --type=Node --role=compute --format=json
 ```
 
 Example output:

--- a/troubleshooting/interpreting_hms_health_check_results.md
+++ b/troubleshooting/interpreting_hms_health_check_results.md
@@ -328,7 +328,7 @@ Example output:
 ssh: connect to host sw-leaf-bmc-001 port 22: Connection timed out
 ```
 
-Restoring connectivity or resolving configuration issues with the `leaf-bmc` switch should allow the compute hardware to be discovered successfully.
+Restoring connectivity, resolving configuration issues, or restarting the relevant ports on the `leaf-bmc` switch should allow the compute hardware to issue DHCP requests again and be discovered successfully.
 
 ### `smd_discovery_status_test_ncn-smoke.sh`
 


### PR DESCRIPTION
### Summary and Scope

This change fixes a Cray CLI argument that needs to be capitalized in order to work, and adds additional information to the troubleshooting description for problems with leaf-bmc switches when no compute nodes are discovered in HSM.

### Issues and Related PRs

* Resolves CASMHMS-5763 in CSM-1.2

### Testing

Ran the updated Cray CLI command on Mug. Verified that it works as expected and fixes the failure that occurs with the previous command.

### Risks and Mitigations

No risk, fixes a bug in documentation.