### PR TITLE
CASMHMS-5763 HMS test additional troubleshooting no computes CSM-1.3

### DIFF
--- a/troubleshooting/interpreting_hms_health_check_results.md
+++ b/troubleshooting/interpreting_hms_health_check_results.md
@@ -421,7 +421,7 @@ Example output:
 ssh: connect to host sw-leaf-bmc-001 port 22: Connection timed out
 ```
 
-Restoring connectivity, resolving configuration issues, or restarting the relevant ports on the `leaf-bmc` switch should allow the compute hardware to issue DHCP requests again and be discovered successfully.
+Restoring connectivity, resolving configuration issues, or restarting the relevant ports on the `leaf-bmc` switch should allow the compute hardware to issue DHCP requests and be discovered successfully.
 
 ### `hsm_discovery_status_test.sh`
 

--- a/troubleshooting/interpreting_hms_health_check_results.md
+++ b/troubleshooting/interpreting_hms_health_check_results.md
@@ -421,7 +421,7 @@ Example output:
 ssh: connect to host sw-leaf-bmc-001 port 22: Connection timed out
 ```
 
-Restoring connectivity or resolving configuration issues with the `leaf-bmc` switch should allow the compute hardware to be discovered successfully.
+Restoring connectivity, resolving configuration issues, or restarting the relevant ports on the `leaf-bmc` switch should allow the compute hardware to issue DHCP requests again and be discovered successfully.
 
 ### `hsm_discovery_status_test.sh`
 

--- a/troubleshooting/interpreting_hms_health_check_results.md
+++ b/troubleshooting/interpreting_hms_health_check_results.md
@@ -363,7 +363,7 @@ FAILED test_hardware.tavern.yaml::Query the Hardware collection for Node informa
 (`ncn-mw#`) If these failures occur, confirm that there are no discovered compute nodes in HSM.
 
 ```bash
-cray hsm state components list --type=node --role=compute --format=json
+cray hsm state components list --type=Node --role=compute --format=json
 ```
 
 Example output:


### PR DESCRIPTION
### Summary and Scope

This change fixes a Cray CLI argument that needs to be capitalized in order to work, and adds additional information to the troubleshooting description for problems with leaf-bmc switches when no compute nodes are discovered in HSM.

### Issues and Related PRs

* Resolves CASMHMS-5763 in CSM-1.3

### Testing

Ran the updated Cray CLI command on Mug. Verified that it works as expected and fixes the failure that occurs with the previous command.

### Risks and Mitigations

No risk, fixes a bug in documentation.