### PR TITLE
CASMPET-5853: Remove special case for hmnlb.  No longer needed.

### DIFF
--- a/scripts/operations/gateway-test/gateway-test.py
+++ b/scripts/operations/gateway-test/gateway-test.py
@@ -334,11 +334,7 @@ if __name__ == '__main__':
                   continue
 
           if net['gateway'] not in svcgws:
-            # HMNLB behaves differently than other networks right now (CASMPET-5853)
-            if netname == "hmnlb":
-              svcexp = 403
-            else:
-              svcexp = 404
+            svcexp = 404
           # if the token we have does not match the network we are testing, we expect a 403
           # CMN tokens will work with NMN and vice versa, because they are using the same gateway in 1.2.
           elif tokname == "cmn" and netname != tokname and netname != "nmnlb":


### PR DESCRIPTION
# Description

We've found that a combination of CASMTRIAGE-4336 and CASMPET-6043 are what was causing the different behavior for APIs on the HMNLB.   With both of those fixed, the endpoints that are not on the HMNLB API gateway now return 404 instead of 403.   The special case in the test can be removed.

# Testing

Tested on drax and mug.

```
------------- api.hmnlb.mug.dev.cray.com -------------------
api.hmnlb.mug.dev.cray.com is reachable
PASS - [cray-argo]: https://api.hmnlb.mug.dev.cray.com/apis/nls/v1/readiness - 404
PASS - [cray-bos]: https://api.hmnlb.mug.dev.cray.com/apis/bos/v1/session - 404
PASS - [cray-bss]: https://api.hmnlb.mug.dev.cray.com/apis/bss/boot/v1/bootparameters - 404
PASS - [cray-capmc]: https://api.hmnlb.mug.dev.cray.com/apis/capmc/capmc/v1/health - 404
PASS - [cray-cfs-api]: https://api.hmnlb.mug.dev.cray.com/apis/cfs/v2/sessions - 404
PASS - [cray-console-data]: https://api.hmnlb.mug.dev.cray.com/apis/consoledata/liveness - 404
PASS - [cray-console-node]: https://api.hmnlb.mug.dev.cray.com/apis/console-node/console-node/liveness - 404
PASS - [cray-console-operator]: https://api.hmnlb.mug.dev.cray.com/apis/console-operator/console-operator/liveness - 404
SKIP - [cray-cps]: https://api.hmnlb.mug.dev.cray.com/apis/v2/cps/contents - virtual service not found
PASS - [cray-fas]: https://api.hmnlb.mug.dev.cray.com/apis/fas/v1/snapshots - 404
PASS - [cray-hbtd]: https://api.hmnlb.mug.dev.cray.com/apis/hbtd/hmi/v1/health - 404
PASS - [cray-hmnfd]: https://api.hmnlb.mug.dev.cray.com/apis/hmnfd/hmi/v2/health - 404
PASS - [cray-ims]: https://api.hmnlb.mug.dev.cray.com/apis/ims/images - 404
PASS - [cray-powerdns-manager]: https://api.hmnlb.mug.dev.cray.com/apis/powerdns-manager/v1/liveness - 404
PASS - [cray-reds]: https://api.hmnlb.mug.dev.cray.com/apis/reds/v1/liveness - 404
PASS - [cray-scsd]: https://api.hmnlb.mug.dev.cray.com/apis/scsd/v1/health - 404
PASS - [cray-sls]: https://api.hmnlb.mug.dev.cray.com/apis/sls/v1/health - 404
PASS - [cray-smd]: https://api.hmnlb.mug.dev.cray.com/apis/smd/hsm/v2/service/ready - 404
PASS - [cray-sts]: https://api.hmnlb.mug.dev.cray.com/apis/sts/healthz - 404
PASS - [cray-uas-mgr]: https://api.hmnlb.mug.dev.cray.com/apis/uas-mgr/v1/images - 404
SKIP - [nmdv2-service]: https://api.hmnlb.mug.dev.cray.com/apis/v2/nmd/dumps - virtual service not found
PASS - [sma-telemetry]: https://api.hmnlb.mug.dev.cray.com/apis/sma-telemetry-api/v1/ping - 404
```

# Checklist Before Merging

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
