### PR TITLE
CASMINST-5434 Run MTL-1919 WAR after NCN Upgrade

### DIFF
--- a/scripts/workarounds/boot-order/run.sh
+++ b/scripts/workarounds/boot-order/run.sh
@@ -48,7 +48,7 @@ for ncn in "${EXPECTED_NCNS[@]}"; do
     if ping -c 1 $ncn >/dev/null 2>&1 ; then
         NCNS+=( "$ncn" )
     else
-        echo >&2 "Failed to ping [$ncn]; skipping hotfix for [$ncn]"
+        echo >&2 "Failed to ping [$ncn]; skipping workaround for [$ncn]"
     fi
 done
 

--- a/upgrade/1.2.1/README.md
+++ b/upgrade/1.2.1/README.md
@@ -19,7 +19,7 @@ If upgrading from CSM v1.0.x directly to v1.2.1, follow the procedures described
 ## Known Issues
 
 * `kdump` (kernel dump) may hang and fail on NCNs in CSM 1.2 (HPE Cray EX System Software 22.07 release). During the upgrade, a workaround is applied to fix this.
-* The boot order on NCNs may not be correctly set. Because of a bug, the disk entries may be listed ahead of the PXE entries. During the upgrade, a workaround is applied to fix this.
+* The boot order on NCNs may not be correctly set. Because of a bug, the disk entries may be listed ahead of the PXE entries. During the upgrade, a workaround is applied to fix this. This workaround will also fix missing disk entries after an upgrade.
 
 ## Steps
 

--- a/upgrade/1.2/Stage_1.md
+++ b/upgrade/1.2/Stage_1.md
@@ -5,10 +5,10 @@
 
 ## Procedure
 
-1. Apply a workaround for the boot order:
+1. (`ncn-m002#`) Apply a workaround for the boot order:
 
 ```bash
-ncn-m002# /usr/share/doc/csm/scripts/workarounds/boot-order/run.sh
+/usr/share/doc/csm/scripts/workarounds/boot-order/run.sh
 ```
 
 1. Run `ncn-upgrade-ceph-nodes.sh` for `ncn-s001`. Follow output of the script carefully. The script will pause for manual interaction.

--- a/upgrade/1.2/Stage_3.md
+++ b/upgrade/1.2/Stage_3.md
@@ -60,6 +60,14 @@
    ncn-m002# /usr/share/doc/csm/upgrade/1.2/scripts/upgrade/prepare-assets.sh --csm-version ${CSM_RELEASE} --tarball-file "${CSM_TAR_PATH}"
    ```
 
+## Fix the disk boot entries and boot order
+
+1. (`ncn-m002#`) Apply a workaround for the boot order and ensure disk boot entries appear in the BIOS boot selection menu:
+
+```bash
+/usr/share/doc/csm/scripts/workarounds/boot-order/run.sh
+```
+
 ## Perform upgrade
 
 During this stage there will be a brief (approximately five minutes) window where pods with Persistent Volumes (`PV`s) will not be able to migrate between nodes.


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
This WAR was ran before the upgrade in order to facilitate PXE booting, but it is now known that it should also run _after_ the upgrade to fix disk boot entries.

Running this after the upgrade will ensure that disk boot entries will appear properly in the BIOS boot selection menu.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
