### PR TITLE
CASMTRIAGE-4351 Run the MTL-1919 WAR on installs

### DIFF
--- a/install/deploy_final_ncn.md
+++ b/install/deploy_final_ncn.md
@@ -470,7 +470,13 @@ The steps in this section load hand-off data before a later procedure reboots th
     ncn-m001# export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
     ```
 
-1. Apply the `kdump` workaround.
+1. (`ncn-m001#`) Apply the boot-order workaround.
+
+   ```bash
+   /usr/share/doc/csm/scripts/workarounds/boot-order/run.sh
+   ```
+
+1. (`ncn-m001#`) Apply the `kdump` workaround.
 
     `kdump` assists in taking a dump of the NCN if it encounters a kernel panic.
     `kdump` does not work properly in CSM 1.2. Until this workaround is applied, `kdump` may not produce a proper dump.
@@ -478,7 +484,7 @@ The steps in this section load hand-off data before a later procedure reboots th
     node. Running it now applies the fix to `ncn-m001` as well.
 
     ```bash
-    ncn-m001# /usr/share/doc/csm/scripts/workarounds/kdump/run.sh
+    /usr/share/doc/csm/scripts/workarounds/kdump/run.sh
     ```
 
     Example output:

--- a/install/deploy_management_nodes.md
+++ b/install/deploy_management_nodes.md
@@ -605,14 +605,20 @@ be performed are in the [Deploy](#deploy) section.
     **If the check fails for any nodes, then the problem must be resolved before continuing.**
     See [LVM Check Failure Recovery](#lvm-check-failure-recovery).
 
-1. Apply the `kdump` workaround.
+1. (`pit#`) Apply the boot-order workaround.
+
+   ```bash
+   /usr/share/doc/csm/scripts/workarounds/boot-order/run.sh
+   ```
+
+1. (`pit#`) Apply the `kdump` workaround.
 
     `kdump` assists in taking a dump of the NCN if it encounters a kernel panic.
     `kdump` does not work properly in CSM 1.2. Until this workaround is applied, `kdump` may not produce a proper dump.
     Running this script applies the workaround on all of the NCNs that were just deployed.
 
     ```bash
-    pit# /usr/share/doc/csm/scripts/workarounds/kdump/run.sh
+    /usr/share/doc/csm/scripts/workarounds/kdump/run.sh
     ```
 
     Example output:


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
This applies the boot-order WAR to a fresh install.

We encountered a case on LANL where 2 systems fresh installed 1.2.0 and never ran the WAR (since they were never directed). This caused both systems to encounter the same problems NERSC encountered where nothing would disk boot on the power following up.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
