### PR TITLE
CASMCMS-8261 : BOS session templates export/import

### DIFF
--- a/operations/boot_orchestration/BOS_export_import.md
+++ b/operations/boot_orchestration/BOS_export_import.md
@@ -1,0 +1,61 @@
+# BOS - Exporting and Importing for System Recovery or in the case of a fresh install
+
+## BOS Session Templates
+The primary BOS data that should be saved is the BOS session template. BOS session templates can be exported and later imported.
+
+### Automatically export/import BOS session templates
+Product specified session templates can be re-installed using their associated Helm charts. This recreates the session template data within BOS.
+Existing BOS session semplates can be backed up and restored using the automated scripts. See scripts/operations/system_recovery/export_bos_sessiontemplates.sh and scripts/operations/system_recovery/import_bos_sessiontemplates.sh
+To export BOS session templates, simply run the script scripts/operations/system_recovery/export_bos_sessiontemplates.sh. Copy the archive file it outputs to a safe location.
+To import the BOS session templates, run the scripts/operations/system_recovery/import_bos_sessiontemplates.sh providing as input the archive file that was created by the export_bos_sessiontemplates.sh script.
+
+BOS session templates can also be manually exported and imported onto a given system using the Cray CLI tool. For each session template that you wish to export, use `cray bos sessiontemplate describe` cli. For example:
+     
+### Manually export any session template as needed
+```bash
+ncn# cray bos sessiontemplate describe uan-sessiontemplate-2.0.27 --format json > ~/uan-sessiontemplate-2.0.27.json
+ncn# cat ~/uan-sessiontemplate-2.0.27.json
+{
+  "boot_sets": {
+    "uan": {
+      "boot_ordinal": 2,
+      "kernel_parameters": "console=ttyS0,115200 bad_page=panic crashkernel=340M hugepagelist=2m-2g intel_iommu=off intel_pstate=disable iommu=pt ip=nmn0:dhcp numa_interleave_omit=headless numa_zonelist_order=node oops=panic pageblock_order=14 pcie_ports=native printk.synchronous=y quiet rd.neednet=1 rd.retry=10 rd.shell turbo_boost_limit=999 ifmap=net2:nmn0,lan0:hsn0,lan1:hsn1 spire_join_token=${SPIRE_JOIN_TOKEN}",
+      "network": "nmn",
+      "node_list": [
+        "x3000c0s15b0n0"
+      ],
+      "path": "s3://boot-images/c23f3d5e-223a-4fb9-b305-0c2be8e63615/manifest.json",
+      "rootfs_provider": "cpss3",
+      "rootfs_provider_passthrough": "dvs:api-gw-service-nmn.local:300:nmn0",
+      "type": "s3"
+    }
+  },
+  "boot_sets": {
+    "uan": {
+      "boot_ordinal": 2,
+      "kernel_parameters": "console=ttyS0,115200 bad_page=panic crashkernel=340M hugepagelist=2m-2g intel_iommu=off intel_pstate=disable iommu=pt ip=nmn0:dhcp numa_interleave_omit=headless numa_zonelist_order=node oops=panic pageblock_order=14 pcie_ports=native printk.synchronous=y quiet rd.neednet=1 rd.retry=10 rd.shell turbo_boost_limit=999 ifmap=net2:nmn0,lan0:hsn0,lan1:hsn1 spire_join_token=${SPIRE_JOIN_TOKEN}",
+      "network": "nmn",
+      "node_list": [
+        "x3000c0s15b0n0"
+      ],
+      "path": "s3://boot-images/c23f3d5e-223a-4fb9-b305-0c2be8e63615/manifest.json",
+      "rootfs_provider": "cpss3",
+      "rootfs_provider_passthrough": "dvs:api-gw-service-nmn.local:300:nmn0",
+      "type": "s3"
+    }
+  },
+  "cfs": {
+    "configuration": "uan-config-2.0.0"
+  },
+  "enable_cfs": true,
+  "name": "uan-sessiontemplate-2.0.27"
+}
+```
+
+### Import/restore any session template as needed
+```bash
+ncn# cray bos sessiontemplate create --file ~/uan-sessiontemplate-2.0.27.json --name uan-sessiontemplate-2.0.27
+```
+
+## BOS Database PVCs
+Since the release BOS V2, it is not recommended that the BOS redis database be saved and restored. This database contains the desired state of components. If a system is in recovery and all of the compute nodes shut down, restoring the database will restore BOS' desired state for the components. BOS will attempt to move these compute nodes into that desired state. This may mean attempting to boot compute nodes to the previous desired state, which may contain old, stale state, such as stale compute images. It is better to let BOS recreate the databases from scratch. Then, apply the desired state to the components with the latest up to date state.

--- a/operations/boot_orchestration/BOS_export_import.md
+++ b/operations/boot_orchestration/BOS_export_import.md
@@ -1,20 +1,23 @@
 # BOS - Exporting and Importing for System Recovery or in the case of a fresh install
 
 ## BOS Session Templates
+
 The primary BOS data that should be saved is the BOS session template. BOS session templates can be exported and later imported.
 
 ### Automatically export/import BOS session templates
+
 Product specified session templates can be re-installed using their associated Helm charts. This recreates the session template data within BOS.
-Existing BOS session semplates can be backed up and restored using the automated scripts. See scripts/operations/system_recovery/export_bos_sessiontemplates.sh and scripts/operations/system_recovery/import_bos_sessiontemplates.sh
+Existing BOS session templates can be backed up and restored using the automated scripts. See scripts/operations/system_recovery/export_bos_sessiontemplates.sh and scripts/operations/system_recovery/import_bos_sessiontemplates.sh
 To export BOS session templates, simply run the script scripts/operations/system_recovery/export_bos_sessiontemplates.sh. Copy the archive file it outputs to a safe location.
 To import the BOS session templates, run the scripts/operations/system_recovery/import_bos_sessiontemplates.sh providing as input the archive file that was created by the export_bos_sessiontemplates.sh script.
 
 BOS session templates can also be manually exported and imported onto a given system using the Cray CLI tool. For each session template that you wish to export, use `cray bos sessiontemplate describe` cli. For example:
-     
+
 ### Manually export any session template as needed
+
 ```bash
-ncn# cray bos sessiontemplate describe uan-sessiontemplate-2.0.27 --format json > ~/uan-sessiontemplate-2.0.27.json
-ncn# cat ~/uan-sessiontemplate-2.0.27.json
+cray bos sessiontemplate describe uan-sessiontemplate-2.0.27 --format json > ~/uan-sessiontemplate-2.0.27.json
+cat ~/uan-sessiontemplate-2.0.27.json
 {
   "boot_sets": {
     "uan": {
@@ -53,9 +56,11 @@ ncn# cat ~/uan-sessiontemplate-2.0.27.json
 ```
 
 ### Import/restore any session template as needed
+
 ```bash
-ncn# cray bos sessiontemplate create --file ~/uan-sessiontemplate-2.0.27.json --name uan-sessiontemplate-2.0.27
+cray bos sessiontemplate create --file ~/uan-sessiontemplate-2.0.27.json --name uan-sessiontemplate-2.0.27
 ```
 
 ## BOS Database PVCs
+
 Since the release BOS V2, it is not recommended that the BOS redis database be saved and restored. This database contains the desired state of components. If a system is in recovery and all of the compute nodes shut down, restoring the database will restore BOS' desired state for the components. BOS will attempt to move these compute nodes into that desired state. This may mean attempting to boot compute nodes to the previous desired state, which may contain old, stale state, such as stale compute images. It is better to let BOS recreate the databases from scratch. Then, apply the desired state to the components with the latest up to date state.

--- a/scripts/operations/system_recovery/export_bos_sessiontemplates.sh
+++ b/scripts/operations/system_recovery/export_bos_sessiontemplates.sh
@@ -1,0 +1,28 @@
+#! /bin/sh
+
+################################################################################
+# This script exports all existing BOS session templates.
+# Specifically, it creates an archive file containing a JSON file for each
+# session template. These files can be used to re-create the session templates.
+#
+# The name of the archive file is defined in the ARCHIVE variable.
+################################################################################
+ARCHIVE="bos-session-templates.tgz"
+
+if [ -e ${ARCHIVE} ]; then
+    echo "Error archive file '${ARCHIVE}' already exists!";
+    exit 1;
+fi
+
+# Create a JSON file for each session template
+TMPDIR=`mktemp -d` || exit 1;
+for st in $(cray bos v2 sessiontemplates list --format json | jq .[].name|tr -d \"); do
+    cray bos v2 sessiontemplates describe $st --format json > ${TMPDIR}/${st}.json;
+done
+
+# Store the JSON files in an archive
+tar --create --file ${ARCHIVE} -v -z -C ${TMPDIR} . 1>/dev/null
+echo "BOS session templates stored in archive: ${ARCHIVE}"
+
+# Clean up
+rm -rf $TMPDIR

--- a/scripts/operations/system_recovery/export_bos_sessiontemplates.sh
+++ b/scripts/operations/system_recovery/export_bos_sessiontemplates.sh
@@ -1,4 +1,27 @@
 #! /bin/sh
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 
 ################################################################################
 # This script exports all existing BOS session templates.

--- a/scripts/operations/system_recovery/import_bos_sessiontemplates.sh
+++ b/scripts/operations/system_recovery/import_bos_sessiontemplates.sh
@@ -1,4 +1,27 @@
 #! /bin/sh
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 
 ################################################################################
 # This script imports BOS session templates from an archive and recreates them.
@@ -16,7 +39,7 @@ else
     ARCHIVE=$1
 fi
 
-if [[ ! -f $ARCHIVE ]]; then
+if [ ! -f "$ARCHIVE" ]; then
     echo "Error: archive file '${ARCHIVE}' does not exist!";
     exit 1;
 fi
@@ -27,7 +50,8 @@ tar xvfz ${ARCHIVE} --directory $TMPDIR
 
 # Create a BOS session template for each file it contains.
 # The 'name' attribute must be removed and the resulting file massaged.
-for st in $(find $TMPDIR -name "*.json"); do
+find $TMPDIR -name '*.json' -print0 | while IFS= read -r -d '' st
+do
     name=$(cat $st | jq -r '.name' )
     if [ ! -z "$name" ]; then
 	cat $st | sed -z 's/,\n\s*"name": ".*"//' > ${st}.tmp

--- a/scripts/operations/system_recovery/import_bos_sessiontemplates.sh
+++ b/scripts/operations/system_recovery/import_bos_sessiontemplates.sh
@@ -1,0 +1,42 @@
+#! /bin/sh
+
+################################################################################
+# This script imports BOS session templates from an archive and recreates them.
+################################################################################
+usage()
+{
+    echo "Usage: $0 <*.tgz file containing session template files>"
+    exit 1
+} 
+
+#!/bin/sh
+if [ $# -ne 1 ] ; then
+    usage
+else
+    ARCHIVE=$1
+fi
+
+if [[ ! -f $ARCHIVE ]]; then
+    echo "Error: archive file '${ARCHIVE}' does not exist!";
+    exit 1;
+fi
+
+# Unpack the archive in temporary directory
+TMPDIR=`mktemp -d` || exit 1;
+tar xvfz ${ARCHIVE} --directory $TMPDIR
+
+# Create a BOS session template for each file it contains.
+# The 'name' attribute must be removed and the resulting file massaged.
+for st in $(find $TMPDIR -name "*.json"); do
+    name=$(cat $st | jq -r '.name' )
+    if [ ! -z "$name" ]; then
+	cat $st | sed -z 's/,\n\s*"name": ".*"//' > ${st}.tmp
+	cray bos v2 sessiontemplates create --file $st.tmp $name
+    else
+	echo "ERROR: Could not create a session template for ${st}."
+	continue
+    fi
+done
+
+# Clean up
+rm -rf $TMPDIR


### PR DESCRIPTION
# Description

Provide scripts to automatically export and import BOS session templates to support system recovery. Provide documentation mentioning these scripts as well as manual ways to export and import session templates.

(cherry picked from commit d2ab26a8446e27efca59248bd9b7b4549c1eca78)

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
