### PR TITLE
CRAYSAT-1596: Fix typos in "Accessing SAT Bootprep Files"

### DIFF
--- a/operations/configuration_management/Accessing_Sat_Bootprep_Files.md
+++ b/operations/configuration_management/Accessing_Sat_Bootprep_Files.md
@@ -9,10 +9,9 @@ The following procedure describes how to access the CFS configuration. This proc
 
     ```bash
     cat > vcs-creds-helper.sh << EOF
-
-    > #!/bin/bash
-    > kubectl get secret -n services vcs-user-credentials -o jsonpath={.data.vcs_password} | base64 -d
-    > EOF
+    #!/bin/bash
+    kubectl get secret -n services vcs-user-credentials -o jsonpath={.data.vcs_password} | base64 -d
+    EOF
     
     chmod u+x vcs-creds-helper.sh
     
@@ -52,5 +51,5 @@ The following procedure describes how to access the CFS configuration. This proc
 1. (`ncn-m#`) List the default `sat bootprep` input files in this repository:
 
     ```bash
-    ls bootrep
+    ls bootprep
     ```


### PR DESCRIPTION
# Description

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams