### PR TITLE
CASMCMS-8257 - add IMS import/export documentation.

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -199,6 +199,7 @@ DVS-specific
 eBGP
 eC
 Elasticsearch
+etag
 etcd
 EX
 exascale

--- a/operations/image_management/IMS_export_import.md
+++ b/operations/image_management/IMS_export_import.md
@@ -5,18 +5,16 @@ either using an automated script, or manually one at a time.
 
 ## Exporting Images and Recipes
 
-### Automated Procedure
-
-#### Prerequisites
+### Prerequisites
 
 * Ensure that the `cray` command line interface (CLI) is authenticated and configured to talk to
 system management services.
 
-#### Procedure
+### Automated Exporting Procedure
 
 1. (`ncn-mw`) Run the `ims-import-export.py` script located [here](../../scripts/operations/system_recovery). The `ims-import-export.py`
    script will create a directory named `ims-import-export-data` containing information about the recipes and images
-   that are registered with IMS. 
+   that are registered with IMS.
 
    ```bash
    ims-import-export.py --export --include-linked-artifacts
@@ -32,14 +30,7 @@ system management services.
    INFO:__main__:DONE!!
    ```
 
-### Manual Procedure
-
-#### Prerequisites
-
-* Ensure that the `cray` command line interface (CLI) is authenticated and configured to talk to
-system management services.
-
-#### Procedure
+### Manual Recipe Exporting Procedure
 
 1. (`ncn-mw`) Identify the recipes that you wish to manually export.
 
@@ -74,15 +65,17 @@ system management services.
    * Recipe Name
    * Recipe Link Path
 
-1. (`ncn-mw`) For each recipe that you wish to export, use the `cray artifacts` cli to download the recipe archive from Ceph S3.
+1. (`ncn-mw`) For each recipe that you wish to export, use the `cray artifacts` CLI to download the recipe archive from Ceph S3.
 
    ```bash
    export RECIPE_ID=1dd47f2f-aa37-4f17-9e9c-4e17a3675a92
    mkdir -p recipes/$RECIPE_ID
-   cray artifacts get ims recipes/$RECIPE_ID/recipe.tar.gz recipes/$RECIPE_ID/recipe.tar.gz 
+   cray artifacts get ims recipes/$RECIPE_ID/recipe.tar.gz recipes/$RECIPE_ID/recipe.tar.gz
    ```
 
-1. (`ncn-mw`) Identify the images that you wish to manually export. 
+### Manual Image Exporting Procedure
+
+1. (`ncn-mw`) Identify the images that you wish to manually export.
 
    ```bash
    cray ims images list --format json | jq
@@ -110,8 +103,8 @@ system management services.
    * Image ID
    * Image Name
    * Recipe Link Path
-    
-1. (`ncn-mw`) For each image that you wish to export, use the `cray artifacts` cli to download the image manifest from Ceph S3.
+
+1. (`ncn-mw`) For each image that you wish to export, use the `cray artifacts` CLI to download the image manifest from Ceph S3.
 
    ```bash
    export IMAGE_ID=0f1acea4-2bf1-4931-ac19-ce3c484af540
@@ -175,21 +168,19 @@ system management services.
 
 NOTE: recipes and images imported using these procedures will have their IMS ID and S3 location of linked artifacts
       changed during the import process. Any BOS Session templates, or other references to recipes, images or their
-      artifacts will need to be updated to use the new identifiers. 
+      artifacts will need to be updated to use the new identifiers.
 
-### Automated Procedure
-
-#### Prerequisites
+### Importing Prerequisites
 
 * Ensure that the `cray` command line interface (CLI) is authenticated and configured to talk to
 system management services.
 
-#### Procedure
+### Automated Importing Procedure
 
 1. (`ncn-mw`) If IMS data was previously exported using the `ims-import-export.py` script, the same script can be used to
    import IMS recipes and images that are missing after an upgrade. To do so, run the `ims-import-export.py` script
    located [here](../../scripts/operations/system_recovery).
-   
+
    ```bash
    ims-import-export.py --import
    ```
@@ -204,21 +195,12 @@ system management services.
    INFO:__main__:DONE!!
    ```
 
-### Manual Procedure
-
-#### Prerequisites
-
-* Ensure that the `cray` command line interface (CLI) is authenticated and configured to talk to
-system management services.
-
-#### Recipe Import
-
-##### Procedure
+### Manual Recipe Importing Procedure
 
 Using the recipe information previously noted, for each recipe that you wish to restore, perform the following steps:
 
 Note: In the example below, we are creating a new IMS recipe record for the recipe previously known as IMS recipe
-      ID 1dd47f2f-aa37-4f17-9e9c-4e17a3675a92.
+      ID `1dd47f2f-aa37-4f17-9e9c-4e17a3675a92`.
 
 1. (`ncn-mw`) Create a new IMS recipe record.
 
@@ -253,7 +235,7 @@ Note: In the example below, we are creating a new IMS recipe record for the reci
    ```
 
 1. (`ncn-mw`) Determine the S3 etag for the recipe archive
-   
+
    ```bash
    cray artifacts describe ims recipes/$NEW_RECIPE_ID/recipe.tar.gz --format json
    ```
@@ -274,7 +256,7 @@ Note: In the example below, we are creating a new IMS recipe record for the reci
      }
    } 
    ```
-   
+
 1. (`ncn-mw`) Update the IMS recipe record with the Ceph S3 location of the recipe archive
 
    ```bash
@@ -283,14 +265,12 @@ Note: In the example below, we are creating a new IMS recipe record for the reci
      --link-etag dd95e38bf328dd31d83d661877df8fcf
    ```
 
-#### Image Import
-
-##### Procedure
+### Manual Image Importing Procedure
 
 Using the image information previously noted, for each image that you wish to restore, perform the following steps:
 
 Note: In the example below, we are creating a new IMS image record for the image previously known as IMS image
-      ID 0f1acea4-2bf1-4931-ac19-ce3c484af540.
+      ID `0f1acea4-2bf1-4931-ac19-ce3c484af540`.
 
 1. (`ncn-mw`) Create a new IMS image record.
 
@@ -389,8 +369,8 @@ Note: In the example below, we are creating a new IMS image record for the image
    }
    ```
 
-1. (`ncn-mw`) Make a copy of the original IMS manifest.json and update with the new S3 link and etag values.
-   
+1. (`ncn-mw`) Make a copy of the original IMS `manifest.json` and update with the new S3 link and etag values.
+
    ```bash
    cp images/$OLD_IMAGE_ID/manifest.json images/$OLD_IMAGE_ID/manifest-new.json
    vi images/$OLD_IMAGE_ID/manifest-new.json
@@ -440,7 +420,7 @@ Note: In the example below, we are creating a new IMS image record for the image
    cray artifacts create boot-images $NEW_IMAGE_ID/manifest.json images/$OLD_IMAGE_ID/manifest-new.json
    ```
 
-1. (`ncn-mw`) Determine the S3 etag for the manifest.json
+1. (`ncn-mw`) Determine the S3 etag for the `manifest.json`
 
    ```bash
    cray artifacts describe ims $NEW_IMAGE_ID/manifest.json --format json
@@ -463,7 +443,7 @@ Note: In the example below, we are creating a new IMS image record for the image
    }
    ```
 
-1. (`ncn-mw`) Update the IMS image record with the Ceph S3 location of the manifest.json
+1. (`ncn-mw`) Update the IMS image record with the Ceph S3 location of the `manifest.json`
 
    ```bash
    cray ims images update $NEW_IMAGE_ID \

--- a/operations/image_management/IMS_export_import.md
+++ b/operations/image_management/IMS_export_import.md
@@ -1,0 +1,472 @@
+# IMS - Exporting and Importing for System Recovery or in the case of a fresh install
+
+IMS recipe and image data, including associated artifacts stored in Ceph S3, can be exported and imported
+either using an automated script, or manually one at a time.
+
+## Exporting Images and Recipes
+
+### Automated Procedure
+
+#### Prerequisites
+
+* Ensure that the `cray` command line interface (CLI) is authenticated and configured to talk to
+system management services.
+
+#### Procedure
+
+1. (`ncn-mw`) Run the `ims-import-export.py` script located [here](../../scripts/operations/system_recovery). The `ims-import-export.py`
+   script will create a directory named `ims-import-export-data` containing information about the recipes and images
+   that are registered with IMS. 
+
+   ```bash
+   ims-import-export.py --export --include-linked-artifacts
+   ```
+
+   Expected output:
+
+   ```text
+   INFO:__main__:Exporting recipes
+   ...
+   INFO:__main__:Exporting images
+   ...
+   INFO:__main__:DONE!!
+   ```
+
+### Manual Procedure
+
+#### Prerequisites
+
+* Ensure that the `cray` command line interface (CLI) is authenticated and configured to talk to
+system management services.
+
+#### Procedure
+
+1. (`ncn-mw`) Identify the recipes that you wish to manually export.
+
+   ```bash
+   cray ims recipes list --format json | jq
+   ```
+
+   Expected output:
+
+   ```text
+     [
+       {
+         "created": "2021-03-29T15:22:50.039151+00:00",
+         "id": "1dd47f2f-aa37-4f17-9e9c-4e17a3675a92",
+         "link": {
+           "etag": "dd95e38bf328dd31d83d661877df8fcf",
+           "path": "s3://ims/recipes/1dd47f2f-aa37-4f17-9e9c-4e17a3675a92/recipe.tar.gz",
+           "type": "s3"
+         },
+         "linux_distribution": "sles15",
+         "name": "cray-shasta-csm-sles15sp1-barebones.x86_64-shasta-1.4",
+         "recipe_type": "kiwi-ng"
+       },
+       ...
+     ]
+   ```
+
+   For each recipe that you wish to export, make note of the recipe details including:
+   * Recipe ID
+   * Recipe Type
+   * Recipe Linux Distribution
+   * Recipe Name
+   * Recipe Link Path
+
+1. (`ncn-mw`) For each recipe that you wish to export, use the `cray artifacts` cli to download the recipe archive from Ceph S3.
+
+   ```bash
+   export RECIPE_ID=1dd47f2f-aa37-4f17-9e9c-4e17a3675a92
+   mkdir -p recipes/$RECIPE_ID
+   cray artifacts get ims recipes/$RECIPE_ID/recipe.tar.gz recipes/$RECIPE_ID/recipe.tar.gz 
+   ```
+
+1. (`ncn-mw`) Identify the images that you wish to manually export. 
+
+   ```bash
+   cray ims images list --format json | jq
+   ```
+
+   Expected output:
+
+   ```text
+     [
+       {
+         "created": "2021-04-28T20:48:44.007816+00:00",
+         "id": "0f1acea4-2bf1-4931-ac19-ce3c484af540",
+         "link": {
+           "etag": "393ac6e2c56c56cf96398d7a31b87445",
+           "path": "s3://boot-images/0f1acea4-2bf1-4931-ac19-ce3c484af540/manifest.json",
+           "type": "s3"
+         },
+         "name": "cray-shasta-csm-sles15sp1-barebones.x86_64-shasta-1.4"
+       },
+       ...
+     ]
+   ```
+
+   For each image that you wish to export, make note of the image details including:
+   * Image ID
+   * Image Name
+   * Recipe Link Path
+    
+1. (`ncn-mw`) For each image that you wish to export, use the `cray artifacts` cli to download the image manifest from Ceph S3.
+
+   ```bash
+   export IMAGE_ID=0f1acea4-2bf1-4931-ac19-ce3c484af540
+   mkdir -p images/$IMAGE_ID
+   cray artifacts get boot-images $IMAGE_ID/manifest.json images/$IMAGE_ID/manifest.json
+   ```
+
+   Review the image manifest and download any linked artifacts
+
+   ```bash
+   cat images/$IMAGE_ID/manifest.json | jq
+   ```
+
+   Expected output:
+
+   ```text
+   {
+     "version": "1.0",
+     "created": "2021-04-01 21:24:23.161422",
+     "artifacts": [
+       {
+         "md5": "6e784dc8519baffc2177b0b70f3f8f89",
+         "type": "application/vnd.cray.image.rootfs.squashfs",
+         "link": {
+           "etag": "f99dcad6c55a52904a8fee283b0dad22-204",
+           "path": "s3://boot-images/0f1acea4-2bf1-4931-ac19-ce3c484af540/rootfs",
+           "type": "s3"
+         }
+       },
+       {
+         "md5": "175f0c1363c9e3a4840b08570a923bc5",
+         "type": "application/vnd.cray.image.kernel",
+         "link": {
+           "etag": "175f0c1363c9e3a4840b08570a923bc5",
+           "path": "s3://boot-images/0f1acea4-2bf1-4931-ac19-ce3c484af540/kernel",
+           "type": "s3"
+         }
+       },
+       { 
+         "md5": "2e8fadafab28081d6018ecfd479206d8",
+         "type": "application/vnd.cray.image.initrd",
+         "link": {
+           "etag": "cad6c356f72e3dc65b6a28610629cba5-5",
+           "path": "s3://boot-images/0f1acea4-2bf1-4931-ac19-ce3c484af540/initrd",
+           "type": "s3"
+         }
+       }
+     ]
+   }
+   ```
+
+   Export each of the images referenced in the manifest file:
+
+   ```bash
+   cray artifacts get boot-images $IMAGE_ID/rootfs images/$IMAGE_ID/rootfs
+   cray artifacts get boot-images $IMAGE_ID/kernel images/$IMAGE_ID/kernel
+   cray artifacts get boot-images $IMAGE_ID/initrd images/$IMAGE_ID/initrd
+   ```
+
+## Importing Images and Recipes
+
+NOTE: recipes and images imported using these procedures will have their IMS ID and S3 location of linked artifacts
+      changed during the import process. Any BOS Session templates, or other references to recipes, images or their
+      artifacts will need to be updated to use the new identifiers. 
+
+### Automated Procedure
+
+#### Prerequisites
+
+* Ensure that the `cray` command line interface (CLI) is authenticated and configured to talk to
+system management services.
+
+#### Procedure
+
+1. (`ncn-mw`) If IMS data was previously exported using the `ims-import-export.py` script, the same script can be used to
+   import IMS recipes and images that are missing after an upgrade. To do so, run the `ims-import-export.py` script
+   located [here](../../scripts/operations/system_recovery).
+   
+   ```bash
+   ims-import-export.py --import
+   ```
+
+   Expected output:
+
+   ```text
+   INFO:__main__:Importing recipes
+   ...
+   INFO:__main__:Importing images
+   ...
+   INFO:__main__:DONE!!
+   ```
+
+### Manual Procedure
+
+#### Prerequisites
+
+* Ensure that the `cray` command line interface (CLI) is authenticated and configured to talk to
+system management services.
+
+#### Recipe Import
+
+##### Procedure
+
+Using the recipe information previously noted, for each recipe that you wish to restore, perform the following steps:
+
+Note: In the example below, we are creating a new IMS recipe record for the recipe previously known as IMS recipe
+      ID 1dd47f2f-aa37-4f17-9e9c-4e17a3675a92.
+
+1. (`ncn-mw`) Create a new IMS recipe record.
+
+   ```bash
+   cray ims recipes create --name <name> --recipe-type <type> --linux-distribution <linux-distribution> --format json
+   ```
+
+   Expected output:
+
+   ```text
+   {
+     "name": "cray-shasta-csm-sles15sp1-barebones.x86_64-shasta-1.4",
+     "linux_distribution": "sles15",
+     "link": null,
+     "id": "e5b9a5f9-cd75-4cb2-870a-48c42c009d4b",
+     "created": "2021-05-05T15:16:08.621668+00:00",
+     "recipe_type": "kiwi-ng"
+   }
+   ```
+
+   Note the new and old recipe IDs:
+
+   ```bash
+   export NEW_RECIPE_ID=e5b9a5f9-cd75-4cb2-870a-48c42c009d4b
+   export OLD_RECIPE_ID=1dd47f2f-aa37-4f17-9e9c-4e17a3675a92
+   ```
+
+1. (`ncn-mw`) Upload the IMS Recipe archive to Ceph S3
+
+   ```bash
+   cray artifacts create ims recipes/$NEW_RECIPE_ID/recipe.tar.gz recipes/$OLD_RECIPE_ID/recipe.tar.gz
+   ```
+
+1. (`ncn-mw`) Determine the S3 etag for the recipe archive
+   
+   ```bash
+   cray artifacts describe ims recipes/$NEW_RECIPE_ID/recipe.tar.gz --format json
+   ```
+
+   Expected output:
+
+   ```text
+   {
+     "artifact": {
+       "AcceptRanges": "bytes",
+       "LastModified": "2021-03-29T15:22:50+00:00",
+       "ContentLength": 11799,
+       "ETag": "\"dd95e38bf328dd31d83d661877df8fcf\"",
+       "ContentType": "binary/octet-stream",
+       "Metadata": {
+         "md5sum": "dd95e38bf328dd31d83d661877df8fcf"
+       }
+     }
+   } 
+   ```
+   
+1. (`ncn-mw`) Update the IMS recipe record with the Ceph S3 location of the recipe archive
+
+   ```bash
+   cray ims recipes update $NEW_RECIPE_ID \
+     --link-type s3 --link-path s3://ims/recipes/$NEW_RECIPE_ID/recipe.tar.gz \
+     --link-etag dd95e38bf328dd31d83d661877df8fcf
+   ```
+
+#### Image Import
+
+##### Procedure
+
+Using the image information previously noted, for each image that you wish to restore, perform the following steps:
+
+Note: In the example below, we are creating a new IMS image record for the image previously known as IMS image
+      ID 0f1acea4-2bf1-4931-ac19-ce3c484af540.
+
+1. (`ncn-mw`) Create a new IMS image record.
+
+   ```bash
+   cray ims images create --name <name> --format json
+   ```
+
+   Expected output:
+
+   ```text
+   {
+     "name": "cray-shasta-csm-sles15sp1-barebones.x86_64-shasta-1.4",
+     "link": null,
+     "id": "b5ac5d8a-0fac-470f-88a5-26c1276961e7",
+     "created": "2021-05-05T15:16:08.621668+00:00",
+   }
+   ```
+
+   Note the old and new image ID:
+
+   ```bash
+   export OLD_IMAGE_ID=0f1acea4-2bf1-4931-ac19-ce3c484af540
+   export NEW_IMAGE_ID=b5ac5d8a-0fac-470f-88a5-26c1276961e7
+   ```
+
+1. (`ncn-mw`) Upload each associated image artifact to Ceph S3
+
+   ```bash
+   cray artifacts create boot-images $NEW_IMAGE_ID/rootfs images/$OLD_IMAGE_ID/rootfs
+   cray artifacts create boot-images $NEW_IMAGE_ID/kernel images/$OLD_IMAGE_ID/kernel
+   cray artifacts create boot-images $NEW_IMAGE_ID/initrd images/$OLD_IMAGE_ID/initrd
+   ```
+
+1. (`ncn-mw`) Determine the S3 etag for each associated image artifact
+
+   ```bash
+   cray artifacts describe boot-images $NEW_IMAGE_ID/rootfs --format json
+   ```
+
+   Expected output:
+
+   ```text
+   {
+     "artifact": {
+       "AcceptRanges": "bytes",
+       "LastModified": "2021-03-29T15:22:50+00:00",
+       "ContentLength": 11799,
+       "ETag": "\"17574f7ce0d7b5e2b35913669347afca\"",
+       "ContentType": "binary/octet-stream",
+       "Metadata": {
+         "md5sum": "dd95e38bf328dd31d83d661877df8fcf"
+       }
+     }
+   }
+   ```
+
+   ```bash
+   cray artifacts describe boot-images $NEW_IMAGE_ID/kernel --format json
+   ```
+
+   Expected output:
+
+   ```text
+   {
+     "artifact": {
+       "AcceptRanges": "bytes",
+       "LastModified": "2021-03-29T15:22:50+00:00",
+       "ContentLength": 11799,
+       "ETag": "\"d2572e79e99bdf408bb2f65cd4b209f3\"",
+       "ContentType": "binary/octet-stream",
+       "Metadata": {
+         "md5sum": "dd95e38bf328dd31d83d661877df8fcf"
+       }
+     }
+   }
+   ```
+
+   ```bash
+   cray artifacts describe boot-images $NEW_IMAGE_ID/initrd --format json
+   ```
+
+   Expected output:
+
+   ```text
+   {
+     "artifact": {
+       "AcceptRanges": "bytes",
+       "LastModified": "2021-03-29T15:22:50+00:00",
+       "ContentLength": 11799,
+       "ETag": "\"87adf3df69224d1b5f1449d21999ab52\"",
+       "ContentType": "binary/octet-stream",
+       "Metadata": {
+         "md5sum": "dd95e38bf328dd31d83d661877df8fcf"
+       }
+     }
+   }
+   ```
+
+1. (`ncn-mw`) Make a copy of the original IMS manifest.json and update with the new S3 link and etag values.
+   
+   ```bash
+   cp images/$OLD_IMAGE_ID/manifest.json images/$OLD_IMAGE_ID/manifest-new.json
+   vi images/$OLD_IMAGE_ID/manifest-new.json
+   ```
+
+   Expected file contents:
+
+   ```text
+   {
+     "version": "1.0",
+     "created": "2021-04-01 21:24:23.161422",
+     "artifacts": [
+       {
+         "md5": "6e784dc8519baffc2177b0b70f3f8f89",
+         "type": "application/vnd.cray.image.rootfs.squashfs",
+         "link": {
+           "etag": "17574f7ce0d7b5e2b35913669347afca-204",
+           "path": "s3://boot-images/e5b9a5f9-cd75-4cb2-870a-48c42c009d4b/rootfs",
+           "type": "s3"
+         }
+       },
+       {
+         "md5": "175f0c1363c9e3a4840b08570a923bc5",
+         "type": "application/vnd.cray.image.kernel",
+         "link": {
+           "etag": "d2572e79e99bdf408bb2f65cd4b209f3",
+           "path": "s3://boot-images/e5b9a5f9-cd75-4cb2-870a-48c42c009d4b/kernel",
+           "type": "s3"
+         }
+       },
+       { 
+         "md5": "2e8fadafab28081d6018ecfd479206d8",
+         "type": "application/vnd.cray.image.initrd",
+         "link": {
+           "etag": "87adf3df69224d1b5f1449d21999ab52",
+           "path": "s3://boot-images/e5b9a5f9-cd75-4cb2-870a-48c42c009d4b/initrd",
+           "type": "s3"
+         }
+       }
+     ]
+   }
+   ```
+
+1. (`ncn-mw`) Upload the IMS image manifest to Ceph S3
+
+   ```bash
+   cray artifacts create boot-images $NEW_IMAGE_ID/manifest.json images/$OLD_IMAGE_ID/manifest-new.json
+   ```
+
+1. (`ncn-mw`) Determine the S3 etag for the manifest.json
+
+   ```bash
+   cray artifacts describe ims $NEW_IMAGE_ID/manifest.json --format json
+   ```
+
+   Expected output:
+
+   ```text
+   {
+     "artifact": {
+       "AcceptRanges": "bytes",
+       "LastModified": "2021-03-29T15:22:50+00:00",
+       "ContentLength": 11799,
+       "ETag": "\"ab3ffecdd1299bbda6c373824c9d0870\"",
+       "ContentType": "binary/octet-stream",
+       "Metadata": {
+         "md5sum": "dd95e38bf328dd31d83d661877df8fcf"
+       }
+     }
+   }
+   ```
+
+1. (`ncn-mw`) Update the IMS image record with the Ceph S3 location of the manifest.json
+
+   ```bash
+   cray ims images update $NEW_IMAGE_ID \
+     --link-type s3 --link-path s3://ims/$NEW_IMAGE_ID/manifest.json \
+     --link-etag ab3ffecdd1299bbda6c373824c9d0870
+   ```

--- a/scripts/operations/system_recovery/ims-import-export.py
+++ b/scripts/operations/system_recovery/ims-import-export.py
@@ -1,5 +1,26 @@
 #! /usr/bin/env python3
-# Copyright 2021 Hewlett Packard Enterprise Development LP
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 
 import argparse
 import json

--- a/scripts/operations/system_recovery/ims-import-export.py
+++ b/scripts/operations/system_recovery/ims-import-export.py
@@ -1,0 +1,644 @@
+#! /usr/bin/env python3
+# Copyright 2021 Hewlett Packard Enterprise Development LP
+
+import argparse
+import json
+import logging
+import os
+import subprocess
+import sys
+import tempfile
+from os import path
+from urllib.parse import urlparse
+
+LOGGER = logging.getLogger(__name__)
+ch = logging.StreamHandler()
+ch.setLevel(logging.ERROR)
+LOGGER.addHandler(ch)
+
+
+def create_parser(program_name):
+    """ Creates the parent parser and adds the subparsers """
+    parser = argparse.ArgumentParser(prog=program_name)
+
+    parser.add_argument(
+        'import_export_root',
+        nargs='?',
+        default=path.join(os.getcwd(), 'ims-import-export-data'),
+        help='Location to import/export IMS data from/to'
+    )
+
+    parser.add_argument(
+        '-l', '--log-level', type=str, default="INFO",
+        choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
+        help='Set the logging level'
+    )
+
+    parser.add_argument(
+        '--include-deleted',
+        action='store_true',
+        help="Include deleted IMS recipe and image records"
+    )
+
+    parser.add_argument(
+        '--include-linked-artifacts',
+        action='store_true',
+        help="Include linked recipe and image artifacts stored in S3."
+    )
+
+    import_export_action = parser.add_mutually_exclusive_group(required=True)
+    import_export_action.add_argument('-e', '--export', dest="action", action="store_const", const="export")
+    import_export_action.add_argument('-i', '--import', dest="action", action="store_const", const="import")
+    return parser
+
+
+class ImsImportExportBaseError(Exception):
+    pass
+
+
+class ImsImportExportRecoverableError(ImsImportExportBaseError):
+    pass
+
+
+class ImsImportExportNonrecoverableError(ImsImportExportBaseError):
+    pass
+
+
+class S3Url:
+    """
+    https://stackoverflow.com/questions/42641315/s3-urls-get-bucket-name-and-path/42641363
+    """
+
+    def __init__(self, url):
+        self._parsed = urlparse(url, allow_fragments=False)
+
+    @property
+    def bucket(self):
+        """ return the S3 bucket name """
+        return self._parsed.netloc
+
+    @property
+    def key(self):
+        """ return the S3 key name """
+        if self._parsed.query:  # pylint: disable=no-else-return
+            return self._parsed.path.lstrip('/') + '?' + self._parsed.query
+        else:
+            return self._parsed.path.lstrip('/')
+
+    @property
+    def url(self):
+        """ return the combined S3 url """
+        return self._parsed.geturl()
+
+    @property
+    def filename(self):
+        """ return just the filename portion of the key """
+        return self._parsed.path.split('/')[-1]
+
+    def __repr__(self):
+        return self._parsed.geturl()
+
+
+def safe_list_get(lst, idx, default):
+    """
+    https://stackoverflow.com/questions/5125619/why-doesnt-list-have-safe-get-method-like-dictionary
+    """
+    try:
+        return lst[idx]
+    except KeyError:
+        return default
+
+
+def export_ims_recipe(recipe, recipes_dir, args):
+    recipe_dir = path.join(recipes_dir, recipe['id'])
+
+    def _export_s3_recipe_artifact():
+        os.mkdir(recipe_dir)
+        s3url = S3Url(recipe['link']['path'])
+        local_artifact_path = path.join(recipe_dir, s3url.filename)
+
+        command = ['cray', 'artifacts', 'get', s3url.bucket, s3url.key, local_artifact_path]
+        LOGGER.debug(' '.join(command))
+        result = subprocess.check_output(command)
+        LOGGER.debug(result)
+
+        return {
+            'linked_artifacts': {
+                'recipe_archive': local_artifact_path[len(args.import_export_root) + 1:],
+            }
+        }
+
+    return_value = recipe
+    LOGGER.info(f'Exporting IMS recipe id {recipe["id"]}')
+    if args.include_linked_artifacts and recipe['link']['type'] and recipe['link']['path']:
+        return_value.update(
+            {
+                's3': _export_s3_recipe_artifact
+            }.get(recipe['link']['type'])()
+        )
+    return return_value
+
+
+def export_ims_recipes(args):
+    for deleted in (False, True):
+
+        if deleted and not args.include_deleted:
+            continue
+
+        recipes_path = args.import_export_root
+        if deleted:
+            recipes_path = path.join(recipes_path, 'deleted')
+        recipes_path = path.join(recipes_path, 'recipes')
+
+        if args.include_linked_artifacts:
+            os.makedirs(recipes_path)
+
+        LOGGER.info(f'Exporting {"recipes" if not deleted else "deleted recipes"}')
+
+        command = ['cray', 'ims']
+        if deleted:
+            command.append('deleted')
+        command.extend(['recipes', 'list', '--format', 'json'])
+
+        export_data = []
+        LOGGER.debug(' '.join(command))
+        recipes = json.loads(subprocess.check_output(command))
+        LOGGER.debug(recipes)
+
+        for recipe in recipes:
+            export_data.append(export_ims_recipe(recipe, recipes_path, args))
+
+        export_file = 'recipes.json' if not deleted else 'deleted_recipes.json'
+        with open(path.join(args.import_export_root, export_file), 'w') as outfile:
+            json.dump(
+                {
+                    'version': '1.0',
+                    'records': export_data
+                },
+                outfile)
+
+
+def export_ims_image(image, recipes_dir, args):
+    image_dir = path.join(recipes_dir, image['id'])
+
+    def _export_linked_image_artifact(artifact):
+        s3url = S3Url(artifact['link']['path'])
+        local_artifact_path = path.join(image_dir, s3url.filename)
+        command = ['cray', 'artifacts', 'get', s3url.bucket, s3url.key, local_artifact_path]
+
+        LOGGER.debug(' '.join(command))
+        result = subprocess.check_output(command)
+        LOGGER.debug(result)
+
+        return {
+            "md5": safe_list_get(artifact, 'md5', ''),
+            "type": artifact['type'],
+            'path': local_artifact_path[len(args.import_export_root) + 1:],
+        }
+
+    def _export_linked_image_artifacts(manifest_json):
+        linked_artifacts = []
+        for artifact in manifest_json['artifacts']:
+            linked_artifacts.append(_export_linked_image_artifact(artifact))
+        return linked_artifacts
+
+    def _export_s3_image_artifacts():
+        os.mkdir(image_dir)
+        s3url = S3Url(image['link']['path'])
+        local_artifact_path = path.join(image_dir, s3url.filename)
+        command = ['cray', 'artifacts', 'get', s3url.bucket, s3url.key, local_artifact_path]
+        LOGGER.debug(' '.join(command))
+        result = subprocess.check_output(command)
+        LOGGER.debug(result)
+
+        # export artifacts linked in the manifest json
+        with open(local_artifact_path) as manifest_file:
+            manifest_json = json.load(manifest_file)
+            image_artifacts = {
+                "1.0": _export_linked_image_artifacts,
+            }.get(manifest_json['version'])(manifest_json)
+
+            return {
+                'linked_artifacts': {
+                    'manifest_json': local_artifact_path[len(args.import_export_root) + 1:],
+                    'image_artifacts': image_artifacts
+                }
+            }
+
+    return_value = image
+    LOGGER.info(f'Exporting IMS image id {image["id"]}')
+    if args.include_linked_artifacts and image['link']['type'] and image['link']['path']:
+        return_value.update(
+            {
+                's3': _export_s3_image_artifacts
+            }.get(image['link']['type'])()
+        )
+    return return_value
+
+
+def export_ims_images(args):
+    for deleted in (False, True):
+
+        if deleted and not args.include_deleted:
+            continue
+
+        images_path = args.import_export_root
+        if deleted:
+            images_path = path.join(images_path, 'deleted')
+        images_path = path.join(images_path, 'images')
+
+        if args.include_linked_artifacts:
+            os.makedirs(images_path)
+
+        LOGGER.info(f'Exporting {"images" if not deleted else "deleted images"}')
+
+        command = ['cray', 'ims']
+        if deleted:
+            command.append('deleted')
+        command.extend(['images', 'list', '--format', 'json'])
+
+        export_data = []
+        LOGGER.debug(' '.join(command))
+        images = json.loads(subprocess.check_output(command))
+        LOGGER.debug(images)
+
+        for image in images:
+            export_data.append(export_ims_image(image, images_path, args))
+
+        export_file = 'images.json' if not deleted else 'deleted_images.json'
+        with open(path.join(args.import_export_root, export_file), 'w') as outfile:
+            json.dump(
+                {
+                    'version': '1.0',
+                    'records': export_data
+                },
+                outfile)
+
+
+def export_ims_artifacts(args):
+    # TODO Verify path doesn't exist
+    try:
+        os.makedirs(args.import_export_root)
+
+        export_ims_recipes(args)
+        export_ims_images(args)
+    except ImsImportExportBaseError as ims_exc:
+        LOGGER.warning('Error exporting IMS data', exc_info=ims_exc)
+        return False
+
+    return True
+
+
+def artifact_exists(link, md5=''):
+    def _check_s3_artifact():
+        s3url = S3Url(link['path'])
+        command = ['cray', 'artifacts', 'describe', s3url.bucket, s3url.key, '--format', 'json']
+
+        try:
+            LOGGER.info(f'Checking if s3 artifact {link["path"]} exists')
+            LOGGER.debug(' '.join(command))
+            artifact_info = json.loads(subprocess.check_output(command))
+            LOGGER.debug(artifact_info)
+            LOGGER.info(f'The artifact {link["path"]} exists in S3')
+
+            if md5:
+                try:
+                    if md5 != artifact_info['artifact']['Metadata']['md5sum']:
+                        LOGGER.warning('MD5 sums do not match for the artifact {link["path"]}')
+                        return False
+                except KeyError:
+                    pass
+
+        except subprocess.CalledProcessError as err:
+            LOGGER.warning(f'The artifact {link["path"]} does not exist in S3', exc_info=err)
+            return False
+
+        return True
+
+    if link['type'] and link['path']:
+        return {
+            's3': _check_s3_artifact
+        }.get(link['type'])()
+
+    return True
+
+
+def artifact_upload(link_type, link_path, artifact_path):
+    def _upload_s3_artifact():
+        s3url = S3Url(link_path)
+
+        try:
+            # Upload the artifact to S3
+            command = ['cray', 'artifacts', 'create', s3url.bucket, s3url.key, artifact_path, '--format', 'json']
+            try:
+                LOGGER.debug(' '.join(command))
+                result = subprocess.check_output(command)
+                LOGGER.debug(result)
+            except subprocess.CalledProcessError:
+                LOGGER.warning(f'Failed to upload artifact {link_path} to s3')
+                raise
+
+            # get the etag value for the artifact
+            command = ['cray', 'artifacts', 'describe', s3url.bucket, s3url.key, '--format', 'json']
+            try:
+                LOGGER.debug(' '.join(command))
+                result = json.loads(subprocess.check_output(command))
+                LOGGER.debug(result)
+                etag = result['artifact']['ETag'].strip('\"')
+            except subprocess.CalledProcessError:
+                LOGGER.warning(f'Failed to get etag for artifact {link_path} to s3')
+                raise
+
+        except subprocess.CalledProcessError:
+            # TODO Fix
+            return False, ""
+
+        return True, etag
+
+    return {
+        's3': _upload_s3_artifact
+    }.get(link_type)()
+
+
+def recipe_exists(recipe):
+    command = ['cray', 'ims', 'recipes', 'describe', recipe['id'], '--format', 'json']
+
+    try:
+        LOGGER.info(f'Checking if IMS recipe ID {recipe["id"]} exists in IMS')
+        LOGGER.debug(' '.join(command))
+        result = json.loads(subprocess.check_output(command))
+        LOGGER.debug(result)
+    except subprocess.CalledProcessError:
+        LOGGER.info(f'IMS recipe {recipe["id"]} was not found in IMS.')
+        return False
+
+    return artifact_exists(recipe['link'])
+
+
+def import_ims_recipe(recipe, recipes_path):
+    try:
+        # Check if the recipe is in IMS. If it is missing or doesn't match,
+        # then let's import a new one.
+        if not recipe_exists(recipe):
+
+            s3url = S3Url(recipe['link']['path'])
+            recipe_path = path.join(recipes_path, recipe['id'])
+
+            # verify if we can find the recipe archive to upload
+            if not path.isfile(path.join(recipe_path, s3url.filename)):
+                raise (ImsImportExportRecoverableError(
+                    f'Recipe archive not found for IMS recipe {recipe["id"]}. Cannot import recipe.'
+                ))
+
+            # create a new ims recipe record
+            command = [
+                'cray',
+                'ims',
+                'recipes',
+                'create',
+                '--name', recipe['name'],
+                '--recipe-type', recipe['recipe_type'],
+                '--linux-distribution', recipe['linux_distribution'],
+                '--format', 'json'
+            ]
+            LOGGER.debug(' '.join(command))
+            new_recipe = json.loads(subprocess.check_output(command))
+            LOGGER.debug(new_recipe)
+
+            # upload recipe archive
+            new_recipe_link_path = \
+                f'{recipe["link"]["type"]}://{s3url.bucket}/recipes/{new_recipe["id"]}/{s3url.filename}'
+            success, new_recipe_link_etag = artifact_upload(
+                recipe['link']['type'],
+                new_recipe_link_path,
+                path.join(recipe_path, s3url.filename)
+            )
+
+            # patch recipe record
+            command = [
+                'cray',
+                'ims',
+                'recipes',
+                'update',
+                new_recipe['id'],
+                '--link-type', recipe['link']['type'],
+                '--link-path', new_recipe_link_path,
+                '--link-etag', new_recipe_link_etag,
+                '--format', 'json'
+            ]
+            LOGGER.debug(' '.join(command))
+            result = json.loads(subprocess.check_output(command))
+            LOGGER.debug(result)
+
+            return new_recipe['id']
+
+    except ImsImportExportRecoverableError:
+        # TODO
+        pass
+    except subprocess.CalledProcessError as call_proc_exc:
+        LOGGER.warning(f'An error was encountered while importing IMS image {recipe["id"]}.', exc_info=call_proc_exc)
+
+    return None
+
+
+def import_ims_recipes(args):
+    def _import_v1_0_recipes(recipes):
+
+        for recipe in recipes:
+            new_recipe_id = import_ims_recipe(recipe, recipes_path)
+            if new_recipe_id and new_recipe_id != recipe['id']:
+                imported_recipes[recipe['id']] = new_recipe_id
+
+    imported_recipes = {}
+    LOGGER.info(f'Importing recipes')
+    recipes_path = path.join(args.import_export_root, 'recipes')
+    with open(path.join(args.import_export_root, 'recipes.json')) as infile:
+        import_json = json.load(infile)
+        {
+            '1.0': _import_v1_0_recipes
+        }.get(import_json['version'])(import_json['records'])
+
+    return imported_recipes
+
+
+def image_exists(image):
+    command = ['cray', 'ims', 'images', 'describe', image['id'], '--format', 'json']
+
+    try:
+        LOGGER.info(f'Checking if IMS image ID {image["id"]} exists in IMS')
+        LOGGER.debug(' '.join(command))
+        result = json.loads(subprocess.check_output(command))
+        LOGGER.debug(result)
+    except subprocess.CalledProcessError:
+        LOGGER.info(f'IMS image {image["id"]} was not found in IMS.')
+        return False
+
+    # TODO Don't just check image manifest, check for linked artifacts too!
+    return artifact_exists(image['link'])
+
+
+def import_ims_image(image, images_path):
+    def _upload_1_0_linked_artifacts(artifacts):
+        ret_value = []
+        for artifact in artifacts:
+            artifact_url = S3Url(artifact['link']['path'])
+            artifact_file = path.join(images_path, image['id'], artifact_url.filename)
+            if path.isfile(artifact_file):
+                new_artifact_link_path = \
+                    f'{image["link"]["type"]}://{artifact_url.bucket}/{new_image["id"]}/{artifact_url.filename}'
+
+                _, new_artifact_link_etag = artifact_upload(image['link']['type'],
+                                                            new_artifact_link_path,
+                                                            artifact_file)
+
+                ret_value.append({
+                    'md5': artifact['md5'],
+                    'type': artifact['type'],
+                    'link': {
+                        'etag': new_artifact_link_etag,
+                        'path': new_artifact_link_path,
+                        'type': artifact['link']['type']
+                    }
+                })
+        return ret_value
+
+    try:
+        # Check if the image is in IMS. If it is missing or doesn't match,
+        # then let's import a new one.
+        if not image_exists(image):
+
+            s3url = S3Url(image['link']['path'])
+            image_path = path.join(images_path, image['id'])
+
+            # verify if we can find the recipe archive to upload
+            if not path.isfile(path.join(image_path, s3url.filename)):
+                raise (ImsImportExportRecoverableError(
+                    f'Image manifest.json not found for IMS image {image["id"]}. Cannot import image.'
+                ))
+
+            # create a new ims image record
+            command = [
+                'cray',
+                'ims',
+                'images',
+                'create',
+                '--name', image['name'],
+                '--format', 'json'
+            ]
+            LOGGER.debug(' '.join(command))
+            new_image = json.loads(subprocess.check_output(command))
+            LOGGER.debug(new_image)
+
+            # TODO Read manifest.json and upload linked artifacts
+            with open(path.join(image_path, s3url.filename)) as manifest_fp:
+                manifest_json = json.load(manifest_fp)
+                artifact_manifest = {
+                    '1.0': _upload_1_0_linked_artifacts
+                }.get(manifest_json['version'])(manifest_json['artifacts'])
+
+            # TODO Generate new manifest.json file
+            tmp_manifest_fd, tmp_manifest_path = tempfile.mkstemp()
+            try:
+                # create a new image manifest.json file
+                with open(tmp_manifest_fd, 'w') as tmp:
+                    # do stuff with temp file
+                    json.dump({
+                        'version': manifest_json['version'],
+                        'created': manifest_json['created'],
+                        'artifacts': artifact_manifest
+                    }, tmp)
+
+                new_image_manifest_json_link_path = \
+                    f'{image["link"]["type"]}://{s3url.bucket}/{new_image["id"]}/{s3url.filename}'
+
+                # upload image manifest.json
+                success, new_image_manifest_json_link_etag = artifact_upload(
+                    image['link']['type'], new_image_manifest_json_link_path,
+                    tmp_manifest_path
+                )
+
+                # patch image record
+                command = [
+                    'cray',
+                    'ims',
+                    'images',
+                    'update',
+                    new_image['id'],
+                    '--link-type', image['link']['type'],
+                    '--link-path', new_image_manifest_json_link_path,
+                    '--link-etag', new_image_manifest_json_link_etag,
+                    '--format', 'json'
+                ]
+                LOGGER.debug(' '.join(command))
+                result = json.loads(subprocess.check_output(command))
+                LOGGER.debug(result)
+
+                return new_image['id']
+            finally:
+                os.remove(tmp_manifest_path)
+
+    except ImsImportExportRecoverableError:
+        # TODO
+        pass
+    except subprocess.CalledProcessError as call_proc_exc:
+        LOGGER.warning(f'An error was encountered while importing IMS image {image["id"]}.', exc_info=call_proc_exc)
+
+    return None
+
+
+def import_ims_images(args):
+    def _import_v1_0_images(images):
+        for image in images:
+            new_image_id = import_ims_image(image, images_path)
+            if new_image_id and new_image_id != image['id']:
+                imported_images[image['id']] = new_image_id
+
+    imported_images = {}
+    LOGGER.info(f'Importing images')
+    images_path = path.join(args.import_export_root, 'images')
+    with open(path.join(args.import_export_root, 'images.json')) as infile:
+        import_json = json.load(infile)
+        {
+            '1.0': _import_v1_0_images
+        }.get(import_json['version'])(import_json['records'])
+
+    return imported_images
+
+
+def import_ims_artifacts(args):
+    try:
+        recipe_map = import_ims_recipes(args)
+        image_map = import_ims_images(args)
+
+        for old_recipe_id, new_recipe_id in recipe_map.items():
+            LOGGER.info(f'The IMS recipe {old_recipe_id} was imported as {new_recipe_id}')
+
+        for old_image_id, new_image_id in image_map.items():
+            LOGGER.info(f'The IMS image {old_image_id} was imported as {new_image_id}')
+
+    except ImsImportExportBaseError as ims_exc:
+        LOGGER.warning('Error importing IMS data', exc_info=ims_exc)
+        return False
+
+    return True
+
+
+def main(program_name, args):
+    """ Main function """
+
+    parser = create_parser(program_name)
+    args = parser.parse_args(args)
+    logging.basicConfig(level=args.log_level)
+
+    result = {
+        "import": import_ims_artifacts,
+        "export": export_ims_artifacts,
+    }.get(args.action)(args)
+
+    LOGGER.info('DONE!')
+
+    return result
+
+
+if __name__ == "__main__":
+    sys.exit(main("ims-import-export", sys.argv[1:]))


### PR DESCRIPTION
# Description

Adding documentation and script for IMS data import/export for disaster recovery.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.