### PR TITLE
CASMPET-6070 : DOCS Add to Power On - Rolling restart of request-ncn-join-token

### DIFF
--- a/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
@@ -320,6 +320,13 @@ Verify that the Lustre file system is available from the management cluster.
     ncn-m001# kubectl rollout restart -n spire deployment spire-jwks
     ```
 
+1. Rejoin Kubernetes to the worker and master NCNs, to avoid issues with Spire tokens.
+
+    ```bash
+    ncn-m001# kubectl rollout restart -n spire daemonset request-ncn-join-token
+    ncn-m001# kubectl rollout status -n spire daemonset request-ncn-join-token
+    ```
+
 1. Check if any pods are in `CrashLoopBackOff` state because of errors connecting to Vault.
 
     If so, restart the Vault operator, then the Vault pods, and finally the pod which is in `CrashLoopBackOff`. For example:


### PR DESCRIPTION
# Description

Add rolling restart of request-ncn-join-token to power on. 
This was hit at LANL
Needs to be backported to CSM 1.0, 1.2 and 1.3

# Checklist Before Merging

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams