### PR TITLE
CASMHMS-5782 Don't require a user to delete when configuring Aruba switches

### DIFF
--- a/operations/security_and_authentication/Change_SNMP_Credentials_on_Leaf_BMC_Switches.md
+++ b/operations/security_and_authentication/Change_SNMP_Credentials_on_Leaf_BMC_Switches.md
@@ -40,7 +40,7 @@ and then set new credentials. The script can be run either interactively (no env
    Also note that this will change the SNMP credentials in Vault. See below for details on how to do that.
 
    ```bash
-   SNMPDELUSER=testuser SNMPNEWUSER=testuser \
+   SNMPNEWUSER=testuser \
              SNMPAUTHPW=$SNMP_AUTH_PASS SNMPPRIVPW=$SNMP_PRIV_PASS \
              SNMPMGMTPW=$SWITCH_ADMIN_PASSWORD \
              /opt/cray/csm/scripts/hms_verification/leaf_switch_snmp_creds.sh


### PR DESCRIPTION
# Description

New snmp configuration script no longer requires a user to delete. Remove it from the documentation.

Requires hpe-csm-scripts RPM v0.3.0

# Checklist Before Merging

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
