### PR TITLE
CASMINST-5470: Variable name and path consistency in IMS Image Import

### DIFF
--- a/operations/image_management/Import_External_Image_to_IMS.md
+++ b/operations/image_management/Import_External_Image_to_IMS.md
@@ -35,9 +35,16 @@ This procedure may be run on any master or worker NCN.
 
 ### Create image record
 
-1. Choose a descriptive name for the new IMS image record.
+1. Check if `IMS_ROOTFS_FILENAME` is already set. If you are following the steps in
+   [Management Node Image Customization](../configuration_management/Management_Node_Image_Customization.md), then
+   this should already be set.
 
-    Set the `IMS_ROOTFS_FILENAME` variable to the chosen name.
+    ```bash
+    echo $IMS_ROOTFS_FILENAME
+    ```
+
+1. If the above variable is not set, then set `IMS_ROOTFS_FILENAME` to the file name of the `rootfs` file
+   to be uploaded.
 
     ```bash
     IMS_ROOTFS_FILENAME=sles_15_image.squashfs
@@ -65,51 +72,100 @@ This procedure may be run on any master or worker NCN.
     IMS_IMAGE_ID=4e78488d-4d92-4675-9d83-97adfc17cb19
     ```
 
-### Upload to S3
+### Upload image to S3
 
 1. Upload the image root to S3.
 
-    1. Set an environment variable with the actual path and filename of the image root to be uploaded.
-
-        > This may be the same name as `IMS_ROOTFS_FILENAME`, but it is not required to be.
+    1. Navigate to the directory containing the `rootfs` file. Verify that it exists in your current working
+       directory.
 
         ```bash
-        ROOTFS_FILENAME=/home/rootfs.squashfs
+        ls $IMS_ROOTFS_FILENAME
         ```
 
     1. Record the `md5sum` of the image root to be uploaded.
 
         ```bash
-        IMS_ROOTFS_MD5SUM=$(md5sum $ROOTFS_FILENAME | awk '{ print $1 }')
+        IMS_ROOTFS_MD5SUM=$(md5sum $IMS_ROOTFS_FILENAME | awk '{ print $1 }')
         ```
 
     1. Upload the image root to S3.
 
         ```bash
-        cray artifacts create boot-images $IMS_IMAGE_ID/$IMS_ROOTFS_FILENAME $ROOTFS_FILENAME
+        cray artifacts create boot-images $IMS_IMAGE_ID/$IMS_ROOTFS_FILENAME $IMS_ROOTFS_FILENAME
         ```
 
 1. Optionally, upload the kernel for the image to S3.
 
-    > In this example, the relative path to the kernel from the working directory is
-    > `image-root/boot/vmlinuz`.
+    1. Check if `IMS_KERNEL_FILENAME` is already set. If you are following the steps in
+       [Management Node Image Customization](../configuration_management/Management_Node_Image_Customization.md), then
+       this should already be set.
 
-    ```bash
-    IMS_KERNEL_FILENAME=vmlinuz
-    cray artifacts create boot-images $IMS_IMAGE_ID/$IMS_KERNEL_FILENAME image-root/boot/$IMS_KERNEL_FILENAME
-    IMS_KERNEL_MD5SUM=`md5sum image-root/boot/$IMS_KERNEL_FILENAME | awk '{ print $1 }'`
-    ```
+        ```bash
+        echo $IMS_KERNEL_FILENAME
+        ```
+
+    1. If the above variable is not set, then set `IMS_KERNEL_FILENAME` to the file name of the kernel file
+       to be uploaded.
+
+        ```bash
+        IMS_KERNEL_FILENAME=vmlinuz
+        ```
+
+    1. Navigate to the directory containing the kernel file. Verify that it exists in your current working
+       directory.
+
+        ```bash
+        ls $IMS_KERNEL_FILENAME
+        ```
+
+    1. Record the `md5sum` of the kernel to be uploaded.
+
+        ```bash
+        IMS_KERNEL_MD5SUM=$(md5sum $IMS_KERNEL_FILENAME | awk '{ print $1 }')
+        ```
+
+    1. Upload the kernel to S3.
+
+        ```bash
+        cray artifacts create boot-images $IMS_IMAGE_ID/$IMS_KERNEL_FILENAME $IMS_KERNEL_FILENAME
+        ```
 
 1. Optionally, upload the `initrd` for the image to S3.
 
-    > In this example, the relative path to the `initrd` file from working directory is
-    > `image-root/boot/initrd`.
+    1. Check if `IMS_INITRD_FILENAME` is already set. If you are following the steps in
+       [Management Node Image Customization](../configuration_management/Management_Node_Image_Customization.md), then
+       this should already be set.
 
-    ```bash
-    IMS_INITRD_FILENAME=initrd
-    cray artifacts create boot-images $IMS_IMAGE_ID/$IMS_INITRD_FILENAME image-root/boot/$IMS_INITRD_FILENAME
-    IMS_INITRD_MD5SUM=`md5sum image-root/boot/$IMS_INITRD_FILENAME | awk '{ print $1 }'`
-    ```
+        ```bash
+        echo $IMS_INITRD_FILENAME
+        ```
+
+    1. If the above variable is not set, then set `IMS_INITRD_FILENAME` to the file name of the initrd file
+       to be uploaded.
+
+        ```bash
+        IMS_INITRD_FILENAME=initrd
+        ```
+
+    1. Navigate to the directory containing the initrd file. Verify that it exists in your current working
+       directory.
+
+        ```bash
+        ls $IMS_INITRD_FILENAME
+        ```
+
+    1. Record the `md5sum` of the initrd to be uploaded.
+
+        ```bash
+        IMS_INITRD_MD5SUM=$(md5sum $IMS_INITRD_FILENAME | awk '{ print $1 }')
+        ```
+
+    1. Upload the initrd to S3.
+
+        ```bash
+        cray artifacts create boot-images $IMS_IMAGE_ID/$IMS_INITRD_FILENAME $IMS_INITRD_FILENAME
+        ```
 
 ### Image manifest
 


### PR DESCRIPTION
This commit adds variable name consistency to "Import an External Image to IMS". In the event that the user is following "Management Node Image Customization," they will have already set the following three variables:

* IMS_ROOTFS_FILENAME
* IMS_KERNEL_FILENAME
* IMS_INITRD_FILENAME

This commit adds a reference to the "Management Node Image Customization" procedure in "Import an External Image to IMS", reminding the user that they may have already set these variables.

The variable is used in a slightly different way between the two procedures. In "Management Node Image Customization" it is assumed that the variables directly refer to filenames that exist locally. In "Import an External Image to IMS", this was not being assumed, and as a result a second variable called "ROOTFS_FILENAME" was being defined which referred to the exact path to the file (confusingly, a nearly simimlar name to IMS_ROOTFS_FILENAME).

This commit changes the procedure such that all three variables MUST be the names of files that exist in your local working directory. In the case of uploading the kernel and initrd, this also means that the `image-root/boot/` directories are no longer specified when uploading the kernel and initrd via `cray artifacts` - (in the context of "Management Node Image Customization" these were completely incorrect anyway).

As a small fix, the steps to calculate the initrd for kernel and ramdisk are now their own steps instead of included in the code blocks under the `cray artifacts` commands that upload them.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams