### PR TITLE
CASMINST-5474: Explicit instructions for setting layers

### DIFF
--- a/operations/configuration_management/NCN_Node_Personalization.md
+++ b/operations/configuration_management/NCN_Node_Personalization.md
@@ -36,11 +36,53 @@ The following procedure describes how to correctly edit the `sat bootprep` files
         cray cfs components describe <ncn-xname> --format json
         ```
 
-    1. (`ncn-m#`) Edit the `management-bootprep-node-personalization.yaml` file to replace the CPE and Analytics layers with the playbook, commit hash, and product values already in use on the NCNs for CPE and Analytics.
-    This must be done because the new versions of CPE and Analytics have not yet been installed at this time in the upgrade procedure.
+        Example output:
+
+        ```json
+        {
+            "cloneUrl": "https://api-gw-service-nmn.local/vcs/cray/cpe-config-management.git",
+            "commit": "22056808ccf5e7994e75bb246df0abe550a1fe0f",
+            "lastUpdated": "...",
+            "playbook": "pe_deploy.yml",
+            "sessionName": "..."
+        },
+        {
+           "cloneUrl": "https://api-gw-service-nmn.local/vcs/cray/analytics-config-management.git",
+           "commit": "dbe24d4521155a683c52a14b39991aa3f410954e",
+           "lastUpdated": "..."
+           "playbook": "site.yml",
+           "sessionName": "..."
+        }
+        ```
+
+    1. (`ncn-m#`) Edit the `management-bootprep-node-personalization.yaml` file to replace the CPE and Analytics layers with the `cloneUrl`, `commit` and `playbook` values already in use on the NCNs for CPE and Analytics.
+       This must be done because the new versions of CPE and Analytics have not yet been installed at this time in the upgrade procedure.
+
+       In order to accurately represent the exact configuration already in use for CPE and Analytics, use the `git` key in the `bootprep` layer definition. Ensure that the values of `commit` and `playbook`
+       match their equivalents from the output of `cray cfs components describe`, and ensure that `url` matches the `cloneUrl` shown in that output. The example below shows what the CPE and Analytics
+       layers should look like.
+
+       ```yaml
+       - name: cpe-pe_deploy-integration-{{cpe.version}}
+         playbook: pe_deploy.yml
+         git:
+           url: https://api-gw-service-nmn.local/vcs/cray/cpe-config-management.git
+           commit: 22056808ccf5e7994e75bb246df0abe550a1fe0f
+       - name: analytics-site-integration-{{analytics.version}}
+         playbook: site.yml
+         git:
+           url: https://api-gw-service-nmn.local/vcs/cray/analytics-config-management.git
+           commit: dbe24d4521155a683c52a14b39991aa3f410954e
+       ```
 
 1. (`ncn-m#`) Run `sat bootprep` against the `management-bootprep-node-personalization.yaml` file to create the CFS configuration that will be used for node personalization on management NCNs.
 
     ```bash
     sat bootprep run management-bootprep-node-personalization.yaml
+    ```
+
+1. (`ncn-m#`) Optionally, delete `management-bootprep-node-personalization.yaml`, which is no longer needed.
+
+    ```bash
+    rm management-bootprep-node-personalization.yaml
     ```

--- a/operations/configuration_management/Worker_Image_Customization.md
+++ b/operations/configuration_management/Worker_Image_Customization.md
@@ -35,3 +35,9 @@ The following procedure describes how to correctly edit the `bootprep` files to 
 
 1. (`ncn-m#`) Perform the steps in [Management Node Image Customization](Management_Node_Image_Customization.md). Use the CFS configuration created in the previous step when
     customizing the image.
+
+1. (`ncn-m#`) Optionally, delete `management-bootprep-image-customization.yaml`, which is no longer needed.
+
+    ```bash
+    rm management-bootprep-image-customization.yaml
+    ```


### PR DESCRIPTION
This commit provides more explicit instructions for setting up the CPE
and Analytics layers in NCN personalization in the case of an upgrade,
in which CPE and Analytics have not yet been installed. Prior to this
change, some knowledge was assumed about how to determine the current
playbook, commit hash and product values already in use. This commit
provides example output from `cray cfs components describe` as well
as explicit instructions on how to edit the bootprep file so that the
`playbook`, `url` and `commit` values are correct. It explicitly says
to use the `git` key in the bootprep layer definitions and provides
an example of what those layers should look like, based on the example
output of `cray cfs components describe`.

Finally, add optional steps to delete the temporary files,
management-bootprep-node-personalization.yml and
management-node-image-customizatino.yml, both of which are only needed
temporarily in the context of their respective procedures.
This is an especially good idea in the upgrade context of ncn personalization,
in which this file will likely become stale after the new versions of CPE and
Analytics have eventually been installed.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
