### PR TITLE
CASMINST-5438 - create CSM 122 patch instructions

### DIFF
--- a/install/index.md
+++ b/install/index.md
@@ -1,6 +1,6 @@
 # Install CSM
 
-Note: If you are beginning an install with CSM 1.2.0, please download and proceed to install 1.2.1 instead. This will save you time performing a patch update later.
+Note: If you are beginning an install with CSM 1.2.0, please download and proceed to install 1.2.2 instead. This will save you time performing a patch update later.
 
 ## Abstract
 

--- a/upgrade/1.2.2/README.md
+++ b/upgrade/1.2.2/README.md
@@ -1,0 +1,158 @@
+# CSM 1.2.2 Patch Installation Instructions
+
+## Introduction
+
+This document guides an administrator through the patch update to Cray Systems Management `v1.2.2` from `v1.2.0` or `1.2.1`.
+If upgrading from CSM v1.0.x directly to v1.2.2, follow the procedures described in [Upgrade CSM](../1.2/README.md) instead.
+
+## Bug Fixes
+
+* Fixes the NCN boot artifacts validation test
+* Fixes the incorrect AppVersion that was being reported from csi version report
+* Updates the System Power On documentation to add a rolling restart of spire request-ncn-join-token (to avoid issues with spire tokens)
+* Fixes speed with which the pods are restarted as a part of the precache chart upgrade (for better performance)
+* Increases the timeout for the etcd_database_health check in the ncn-healthcheck
+* Fixes issue with postgres dbase backups that caused them to fail to restore and cleans up existing (bad) postgres backups on the system
+* Fixes the pod anti-affinity settings and pod disruption budget settings for cray-dns-unbound
+* Fixes a race condition between MEDS adding the initial BMC entries and Kea dhcp-helper logic updating IP addresses
+* Adds documentation for CSM post-install SNMP exporter settings
+* Fixes an issue where snmp credentials being set on leaf switches were being lost
+* Fixes an issue where cray-hmcollector-poll pod was not collecting river telemetry due to a check the collector does against the SMA kafka instance
+* Fixes CVEs in the ims-load-artifacts container image 
+* Adds documentation to remediate security issues with NCN image access and secret exposure
+
+## Known Issues
+
+* `kdump` (kernel dump) may hang and fail on NCNs in CSM 1.2 (HPE Cray EX System Software 22.07 release). During the upgrade, a workaround is applied to fix this.
+* The boot order on NCNs may not be correctly set. Because of a bug, the disk entries may be listed ahead of the PXE entries. During the upgrade, a workaround is applied to fix this. This workaround will also fix missing disk entries after an upgrade.
+
+## Steps
+
+1. [Upgrade CSM network configuration](upgrade_network.md)
+1. [Preparation](#preparation)
+1. [Setup Nexus](#setup-nexus)
+1. [Upgrade services](#upgrade-services)
+1. [Verification](#verification)
+1. [Complete upgrade](#complete-upgrade)
+
+## Optional: Upgrade CSM network configuration
+
+If you are using the CHN network tech preview, upgrade the CSM management network configuration before proceeding with the patch installation.
+
+Detailed information on the fixes and configuration updates after CANU release 1.6.5 can be found from [CANU release notes](../../operations/network/management_network/canu_install_update.md)
+
+ 1. [Upgrade CSM network configuration](upgrade_network.md)
+
+## Preparation
+
+1. Start a typescript on `ncn-m001` to capture the commands and output from this procedure.
+
+   ```bash
+   ncn-m001# script -af csm-update.$(date +%Y-%m-%d).txt
+   ncn-m001# export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
+   ```
+
+1. Download and extract the CSM `v1.2.2` release to `ncn-m001`.
+
+   See [Download and Extract CSM Product Release](../../update_product_stream/index.md#download-and-extract).
+
+1. Set `CSM_DISTDIR` to the directory of the extracted files.
+
+   **IMPORTANT**: If necessary, change this command to match the actual location of the extracted files.
+
+   ```bash
+   ncn-m001# CSM_DISTDIR="$(pwd)/csm-1.2.2"
+   ncn-m001# echo "${CSM_DISTDIR}"
+   ```
+
+1. Set `CSM_RELEASE_VERSION` to the CSM release version.
+
+   ```bash
+   ncn-m001# export CSM_RELEASE_VERSION="$(${CSM_DISTDIR}/lib/version.sh --version)"
+   ncn-m001# echo "${CSM_RELEASE_VERSION}"
+   ```
+
+1. Download and install/upgrade the **latest** documentation on `ncn-m001`.
+
+   See [Check for Latest Documentation](../../update_product_stream/index.md#check-for-latest-documentation).
+
+## Setup Nexus
+
+Run `lib/setup-nexus.sh` to configure Nexus and upload new CSM RPM
+repositories, container images, and Helm charts:
+
+```bash
+ncn-m001# cd "$CSM_DISTDIR"
+ncn-m001# ./lib/setup-nexus.sh
+```
+
+On success, `setup-nexus.sh` will output `OK` on `stderr` and exit with status
+code `0`. For example:
+
+```console
+ncn-m001# ./lib/setup-nexus.sh
+
+[... output omitted ...]
+
++ Nexus setup complete
+setup-nexus.sh: OK
+ncn-m001# echo $?
+0
+```
+
+In the event of an error, consult [Troubleshoot Nexus](../../operations/package_repository_management/Troubleshoot_Nexus.md)
+to resolve potential problems and then try running `setup-nexus.sh` again. Note that subsequent runs of `setup-nexus.sh` may
+report `FAIL` when uploading duplicate assets. This is okay as long as `setup-nexus.sh` outputs `setup-nexus.sh: OK` and exits
+with status code `0`.
+
+## Upgrade services
+
+Run `upgrade.sh` to deploy upgraded CSM applications and services:
+
+```bash
+ncn-m001# cd "$CSM_DISTDIR"
+ncn-m001# ./upgrade.sh
+```
+
+## Verification
+
+1. Verify that the new CSM version is in the product catalog.
+
+   Verify that the new CSM version is listed in the output of the following command:
+
+   ```bash
+   ncn-m001# kubectl get cm cray-product-catalog -n services -o jsonpath='{.data.csm}' | yq r -j - | jq -r 'to_entries[] | .key' | sort -V
+   ```
+
+   Example output that includes the new CSM version (`1.2.2`):
+
+   ```text
+   0.9.2
+   0.9.3
+   0.9.4
+   0.9.5
+   0.9.6
+   1.0.1
+   1.0.10
+   1.2.0
+   1.2.1
+   1.2.2
+   ```
+
+1. Confirm that the product catalog has an accurate timestamp for the CSM upgrade.
+
+   Confirm that the `import_date` reflects the timestamp of the upgrade.
+
+   ```bash
+   ncn-m001# kubectl get cm cray-product-catalog -n services -o jsonpath='{.data.csm}' | yq r  - '"1.2.2".configuration.import_date'
+   ```
+
+## Complete upgrade
+
+1. Remember to exit the typescript that was started at the beginning of the upgrade.
+
+     ```bash
+     ncn-m001# exit
+     ```
+
+It is recommended to save the typescript file for later reference.

--- a/upgrade/1.2.2/README.md
+++ b/upgrade/1.2.2/README.md
@@ -3,22 +3,22 @@
 ## Introduction
 
 This document guides an administrator through the patch update to Cray Systems Management `v1.2.2` from `v1.2.0` or `1.2.1`.
-If upgrading from CSM v1.0.x directly to v1.2.2, follow the procedures described in [Upgrade CSM](../1.2/README.md) instead.
+If upgrading from CSM v1.0.x directly to `v1.2.2`, follow the procedures described in [Upgrade CSM](../1.2/README.md) instead.
 
 ## Bug Fixes
 
 * Fixes the NCN boot artifacts validation test
-* Fixes the incorrect AppVersion that was being reported from csi version report
-* Updates the System Power On documentation to add a rolling restart of spire request-ncn-join-token (to avoid issues with spire tokens)
-* Fixes speed with which the pods are restarted as a part of the precache chart upgrade (for better performance)
-* Increases the timeout for the etcd_database_health check in the ncn-healthcheck
-* Fixes issue with postgres dbase backups that caused them to fail to restore and cleans up existing (bad) postgres backups on the system
-* Fixes the pod anti-affinity settings and pod disruption budget settings for cray-dns-unbound
-* Fixes a race condition between MEDS adding the initial BMC entries and Kea dhcp-helper logic updating IP addresses
+* Fixes the incorrect `AppVersion` that was being reported from `csi` version report
+* Updates the System Power On documentation to add a rolling restart of spire `request-ncn-join-token` (to avoid issues with spire tokens)
+* Fixes speed with which the pods are restarted as a part of the `precache` chart upgrade (for better performance)
+* Increases the timeout for the `etcd_database_health` check in the `ncn-healthcheck`
+* Fixes issue with `postgres` database backups that caused them to fail to restore and cleans up existing (bad) `postgres` backups on the system
+* Fixes the pod anti-affinity settings and pod disruption budget settings for `cray-dns-unbound`
+* Fixes a race condition between MEDS adding the initial BMC entries and Kea `dhcp-helper` logic updating IP addresses
 * Adds documentation for CSM post-install SNMP exporter settings
-* Fixes an issue where snmp credentials being set on leaf switches were being lost
-* Fixes an issue where cray-hmcollector-poll pod was not collecting river telemetry due to a check the collector does against the SMA kafka instance
-* Fixes CVEs in the ims-load-artifacts container image 
+* Fixes an issue where `snmp` credentials being set on leaf switches were being lost
+* Fixes an issue where `cray-hmcollector-poll` pod was not collecting river telemetry due to a check the collector does against the SMA `kafka` instance
+* Fixes CVEs in the `ims-load-artifacts` container image
 * Adds documentation to remediate security issues with NCN image access and secret exposure
 
 ## Known Issues

--- a/upgrade/1.2.2/upgrade_network.md
+++ b/upgrade/1.2.2/upgrade_network.md
@@ -1,0 +1,121 @@
+# Upgrade and validate Switch Configurations
+
+## Prerequisites
+
+* SSH access to the switches or the running configuration file
+* Upgrade or install latest version of CANU [Install/Upgrade CANU](../../operations/network/management_network/canu_install_update.md)
+  * Run `canu --version` to see version
+  * CANU installed with version 1.6.13 or greater.
+* Use the paddle file (CCJ) if available, or validate an up-to-date SHCD [Validate SHCD](../../operations/network/management_network/validate_shcd.md)
+* System Layout Service (SLS) input file. [Collect Data](../../operations/network/management_network/collect_data.md)
+
+> **CAUTION:** All of these steps should be done using an out-of-band connection. This process is disruptive and will require downtime.
+
+## Generate Configuration Files
+
+Ensure that the correct architecture (`-a` parameter) is selected for the setup in use.
+
+The following are the different architectures that can be specified:
+
+* `Tds` – Aruba-based Test and Development System. These are small systems characterized by Kubernetes NCNs cabled directly to the spine switches.
+* `Full` – Aruba-based Leaf-Spine systems. These are usually customer production systems.
+* `V1` – Any Dell and Mellanox based systems.
+
+Generating a configuration file can be done for a single switch, or for the full system. Below are example commands for both scenarios:
+
+**Important:** Modify the following items in your command:
+
+* `--csm` : Which CSM version configuration do you want to use? For example, `1.2` or `1.0`
+NOTE: Only major and minor versions of CSM are tracked at this time. CANU bug fixes are captured in the latest CANU version and do not align with CSM bug fix versions.
+* `--a`   : What is the system architecture? (See above)
+* `--ccj` : Match the `ccj.json` file to the one you created for your system.
+* `--sls` : Match the `sls_file.json` to the one you created for your system.
+* `--custom-config` : Pass in a switch configuration file that CANU will inject into the generated configuration. For more information, see the [CANU documentation](https://github.com/Cray-HPE/canu#generate-switch-configs-including-custom-configurations).
+
+* Generate switch configuration files for the entire system:
+
+    ```console
+    ncn# canu generate network config --csm 1.2 -a full --ccj system-ccj.json  --sls-file sls_file.json --custom-config system-custom-config.yaml --folder generated
+    ```
+
+## Compare the generated CSM 1.2 switch configurations with running configurations
+
+Compare the current running configuration with the generated configuration.
+
+Essentially this would be to backup current configuration to your workstation and comparing it against the CANU generated configuration.
+
+Example of CANU pulling configuration.
+
+```bash
+ncn# canu validate switch config --vendor <aruba/dell/mellanox> --ip <192.168.1.1> --username USERNAME --password PASSWORD --generated ./generated/sw-spine-001.cfg
+```
+
+Doing file comparisons on your local machine:
+
+* Comparing configuration file for single switch:
+
+```bash
+ncn# canu validate switch config --running ./running/sw-spine-001.cfg --generated ./generated/sw-spine-001.cfg
+```
+
+* Example of output of the validate switch configuration:
+
+```bash
+ncn# canu validate switch config --running ./running/sw-spine-001.cfg --generated ./generated/sw-spine-001.cfg
+Please enter the vendor (Aruba, Dell, Mellanox): Mellanox
+- interface mlag-port-channel 6 shutdown
+- interface mlag-port-channel 5 shutdown
++ interface mlag-port-channel 6 no shutdown
++ interface mlag-port-channel 5 no shutdown
+-------------------------------------------------------------------------
+
+Config differences between running config and generated config
+
+
+lines that start with a minus "-" and RED: Config that is present in running config but not in generated config
+lines that start with a plus "+" and GREEN: Config that is present in generated config but not in running config.
+```
+
+CANU-generated switch configurations will not include any ports or devices not defined in the model. These were previously discussed in the
+"Validate the SHCD section" but include edge uplinks (CAN/CMN) and custom configurations applied by the customer. When looking at the generated
+configurations being applied against existing running configurations CANU will recommend removal of some critical configurations. It is vital
+that these devices and configurations be identified and protected. This can be accomplished in three ways:
+
+* Generate Switch configuration including custom configurations. [Custom configuration](https://github.com/Cray-HPE/canu/blob/develop/readme.md#generate-switch-configs-including-custom-configurations)
+
+* Based on experienced networking knowledge, manually reorder the proposed upgrade configurations. This may require manual exclusion of required
+  configurations which the CANU analysis says to remove.
+
+* Some devices may be used by multiple sites and may not currently be in the CANU architecture and configuration. If a device type is more
+  universally used on several sites, then it should be added to the architectural and configuration definitions via the CANU code and
+  Pull Request (PR) process.
+
+## Analyze CSM 1.2.2 configuration upgrade
+
+Configuration updates depend on the current version of network configuration. Upgrading from CSM 1.2 or CSM 1.2.1 configuration to CSM 1.2.2 should be fairly straight forward.
+
+Always before making configuration changes, analyze the changes shown in the above configuration diff section.
+
+:exclamation: All of these steps should be done using an out of band connection. This process is disruptive and will require downtime :exclamation:
+
+## Caveats and known issues
+
+* Mellanox and Dell configuration remediation support is limited.
+* Some configuration may need to be applied in a certain order.
+  * Example: `Customer VRF` needs to be applied before adding interfaces/routes to the VRF.
+* When applying certain configuration it may wipe out pre-existing configuration.
+  * An example of this would be adding a VRF to a port.
+
+## Warnings
+
+Understanding the switch configuration changes is critical. The following configurations risk a network outage, if not applied correctly:
+
+* Generating switch configuration without preserving site-specific values (by using the `--custom-configuration` flag).
+* Changes to ISL (MAGP, VSX, etc.) configurations.
+* Changes to Spanning Tree.
+* Changes to ACLs or ACL ordering.
+* Changes to VRF.
+* Changes to default route.
+* Changes to MLAG/LACP.
+
+[Return to CSM 1.2.2 Patch Installation Instructions](README.md)

--- a/upgrade/1.2/README.md
+++ b/upgrade/1.2/README.md
@@ -6,7 +6,7 @@ This document guides an administrator through the upgrade of Cray Systems Manage
 from top to bottom. The content on this top-level page is meant to be terse. For additional reference material on the upgrade processes and scripts
 mentioned explicitly on this page, see [resource material](resource_material/README.md).
 
-If you are considering an upgrade from CSM 1.0.x to 1.2.0, please instead download and use CSM 1.2.1.
+If you are considering an upgrade from CSM 1.0.x to 1.2.0, please instead download and use CSM 1.2.2.
 
 A major feature of CSM 1.2.x is the Bifurcated CAN (BICAN). The BICAN is designed to separate administrative network traffic from user network traffic.
 For more information, see the [BICAN Summary](../../operations/network/management_network/bican_technical_summary.md).

--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -2,7 +2,7 @@
 
 > **Reminders:**
 >
-> - CSM 1.0.1 or higher is required in order to upgrade to CSM 1.2.1.
+> - CSM 1.0.1 or higher is required in order to upgrade to CSM 1.2.2.
 > - If any problems are encountered and the procedure or command output does not provide relevant guidance, see
 >   [Relevant troubleshooting links for upgrade-related issues](README.md#relevant-troubleshooting-links-for-upgrade-related-issues).
 
@@ -27,7 +27,7 @@ backup of Workload Manager configuration data and files is created. Once complet
 1. Set the `CSM_RELEASE` variable to the **target** CSM version of this upgrade.
 
    ```bash
-   ncn-m001# CSM_RELEASE=csm-1.2.1
+   ncn-m001# CSM_RELEASE=csm-1.2.2
    ```
 
 1. If there are space concerns on the node, then add an `rbd` device on the node for the CSM tarball.

--- a/upgrade/1.2/Stage_2.md
+++ b/upgrade/1.2/Stage_2.md
@@ -99,7 +99,7 @@ upgrade procedure pivots to use `ncn-m002` as the new "stable node", in order to
 1. Set the `CSM_RELEASE` variable to the **target** CSM version of this upgrade.
 
    ```bash
-   ncn-m002# CSM_RELEASE=csm-1.2.1
+   ncn-m002# CSM_RELEASE=csm-1.2.2
    ```
 
 1. Copy artifacts from `ncn-m001`.


### PR DESCRIPTION
# Description

This PR is for creating the initial CSM 122 patch instructions and ensuring we have updates in the release/1.2 branch of the 12 general upgrade instructions and fresh install instructions that refer to the 1.2.2 version as the latest CSM 1.2.x version to upgrade to or install.

I included a summary of the fixes that I found targeted (and already completed) in jira for the CSM 1.2.2 fix version.  I did NOT yet include any tickets that were marked with a fix version of CSM 1.2.2 but was not yet Done.   So all PRs that are incorporated into CSM 1.2.2 beyond the merge of this PR will need to also update the 1.2.2 patch instructions/README in order to contain a summary of the new issue under "Fixes included in 1.2.2".


