### PR TITLE
CASMINST-5469: DOCS: drax docs-csm rpm not installed on ncn-m003, enc…

### DIFF
--- a/operations/kubernetes/encryption/README.md
+++ b/operations/kubernetes/encryption/README.md
@@ -47,9 +47,8 @@ Shown here for `ncn-m003`.
 
     ```bash
     mkdir -pv $ENCRYPTION_CMD_PATH
-    cd $ENCRYPTION_CMD_PATH
-    scp -p ncn-m001:${ENCRYPTION_CMD_PATH}/encryption.sh .
-    ls -l
+    scp -p ncn-m001:${ENCRYPTION_CMD_PATH}/encryption.sh $ENCRYPTION_CMD_PATH
+    ls -l $ENCRYPTION_CMD_PATH
     ```
 
     Example output:

--- a/operations/kubernetes/encryption/README.md
+++ b/operations/kubernetes/encryption/README.md
@@ -35,7 +35,7 @@ For further information, refer to the [official Kubernetes documentation](https:
 The `encryption.sh` command will need to be made available on all control plane nodes beyond `ncn-m002`.
 Shown here for `ncn-m003`.
 
-1. (`ncn-m>002#`) Set the `ENCRYPTION_CMD_PATH` variable to `/usr/share/doc/csm/scripts/operations/kubernetes`.
+1. (`ncn-m003#`) Set the `ENCRYPTION_CMD_PATH` variable to `/usr/share/doc/csm/scripts/operations/kubernetes`.
 
     For example:
 
@@ -43,7 +43,7 @@ Shown here for `ncn-m003`.
     ENCRYPTION_CMD_PATH=/usr/share/doc/csm/scripts/operations/kubernetes
     ```
 
-1. (`ncn-m>002#`) Copy the `encryption.sh` command from `ncn-m001`.
+1. (`ncn-m003#`) Copy the `encryption.sh` command from `ncn-m001`.
 
     ```bash
     mkdir -pv $ENCRYPTION_CMD_PATH

--- a/operations/kubernetes/encryption/README.md
+++ b/operations/kubernetes/encryption/README.md
@@ -11,6 +11,7 @@ Note that control plane is used in this document elsewhere master or management 
 ## Table of contents
 
 * [Implementation details](#implementation-details)
+* [Setup](#setup)
 * [Enabling encryption](#enabling-encryption)
 * [Disabling encryption](#disabling-encryption)
 * [Encryption status](#encryption-status)
@@ -29,15 +30,53 @@ For Kubernetes secret encryption, once all control plane nodes agree on encrypti
 
 For further information, refer to the [official Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/).
 
+## Setup
+
+The `encryption.sh` command will need to be made available on all control plane nodes beyond `ncn-m002`.
+Shown here for `ncn-m003`.
+
+1. (`ncn-m>002#`) Set the `ENCRYPTION_CMD_PATH` variable to `/usr/share/doc/csm/scripts/operations/kubernetes`.
+
+    For example:
+
+    ```bash
+    ENCRYPTION_CMD_PATH=/usr/share/doc/csm/scripts/operations/kubernetes
+    ```
+
+1. (`ncn-m>002#`) Copy the `encryption.sh` command from `ncn-m001`.
+
+    ```bash
+    mkdir -pv $ENCRYPTION_CMD_PATH
+    cd $ENCRYPTION_CMD_PATH
+    scp -p ncn-m001:${ENCRYPTION_CMD_PATH}/encryption.sh .
+    ls -l
+    ```
+
+    Example output:
+
+    ```text
+    ncn-m003:~ # mkdir -pv $ENCRYPTION_CMD_PATH
+    mkdir: created directory '/usr/share/doc/csm'
+    mkdir: created directory '/usr/share/doc/csm/scripts'
+    mkdir: created directory '/usr/share/doc/csm/scripts/operations'
+    mkdir: created directory '/usr/share/doc/csm/scripts/operations/kubernetes'
+    ncn-m003:~ # scp -p ncn-m001:${ENCRYPTION_CMD_PATH}/encryption.sh $ENCRYPTION_CMD_PATH
+    encryption.sh
+    ncn-m003:~ # ls -l $ENCRYPTION_CMD_PATH
+    total 28
+    -rwxr-xr-x 1 root root 27658 Oct 11 20:20 encryption.sh
+    ncn-m003:~ #
+    ```
+
 ## Enabling encryption
 
 Before encryption is enabled, it is recommend that a Bare-Metal etcd backup is taken only if the etcd cluster is healthy.
 
 See [Create a manual Backup of a Healthy Bare-Metal etcd Cluster](../Create_a_Manual_Backup_of_a_Healthy_Bare-Metal_etcd_Cluster.md) for details.
 
-When enabling encryption it is important to ensure all 3 nodes are enabled in short order. However that does not mean all control plane nodes should run the script in parallel.
+When enabling encryption it is important to ensure all control plane nodes are enabled in short order. However that does not mean all control plane nodes should run the script in parallel.
 
-When encryption is enabled a Bare-Metal etcd cluster can not be restored from a backup taken before encryption is enabled. Such a backup can be used to restore etcd in the event that encryption is later disabled.
+When encryption is enabled a Bare-Metal etcd cluster can not be restored from a backup taken before encryption is enabled. Such a backup can be used to restore etcd in the event that encryption is later fully disabled.
 
 It is recommended to enable encryption on one node first. If successful may enable encryption in parallel on the remaining nodes.
 
@@ -169,7 +208,7 @@ Encryption status is obtained through the `--status` switch of the `encryption.s
 
 If necessary, a forced rewrite of secret data can be performed. Generally unnecessary but can be used to reduce the time for nodes to synchronize status.
 
-* (`ncn-mw#`) Force a rewrite of existing data:
+* (`ncn-m#`) Force a rewrite of existing data:
 
     ```bash
     /usr/share/doc/csm/scripts/operations/kubernetes/encryption.sh --restart


### PR DESCRIPTION
### Summary and Scope
1.3 - CASMINST-5469: DOCS: drax docs-csm rpm not installed on ncn-m003, encryption.sh command missing.

The docs-csm rpm is not currently being installed on master nodes greater than ncn-m002. To workaround this in 1.3, added Setup procedure to Kube api encryption documentation to install the encryption.sh command on master nodes greater than ncn-m002.

### Issues and Related PRs
CASMINST-5469
Main [2665](https://github.com/Cray-HPE/docs-csm/pull/2665)

### Testing
Tested encryption setup WAR on fanta, csm-1.3.0-beta.75, drax csm-1.3.0-rc.4  & 1.3.0-beta.75.

Was a fresh Install tested? N - N/A
Was an Upgrade tested? N - N/A
Was a Downgrade tested? N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations
Low

### Requires:
N/A