### PR TITLE
Add note about myenv file if re-using rbd device (and update with recent 1.3 changes -- CASMINST-5489)

### DIFF
--- a/upgrade/Stage_0_Prerequisites.md
+++ b/upgrade/Stage_0_Prerequisites.md
@@ -84,11 +84,42 @@ after a break, always be sure that a typescript is running before proceeding.
 
    1. Create and map the `rbd` device.
 
-      **IMPORTANT:** This mounts the `rbd` device at `/etc/cray/upgrade/csm` on `ncn-m001`. This mount is available to stage content for the install/upgrade process.
+      **IMPORTANT:** This mounts the `rbd` device at `/etc/cray/upgrade/csm` on `ncn-m001`. This mount is available to stage content for the install/upgrade process. First, check if this device already exists.
 
       ```bash
       source /opt/cray/csm/scripts/csm_rbd_tool/bin/activate
-      python /usr/share/doc/csm/scripts/csm_rbd_tool.py --pool_action create --rbd_action create --target_host ncn-m001
+      /usr/share/doc/csm/scripts/csm_rbd_tool.py --status
+      ```
+
+      >Expected output if `rbd` device does not exist:
+      >
+      >```text
+      >Pool csm_admin_pool does not exist
+      >Pool csm_admin_pool exists: False
+      >RBD device exists None
+      >```
+      >
+      >Example output if `rbd` device already exist:
+      >
+      >```text
+      >[{"id":"0","pool":"csm_admin_pool","namespace":"","name":"csm_scratch_img","snap":"-","device":"/dev/rbd0"}]
+      >Pool csm_admin_pool exists: True
+      >RBD device exists True
+      >RBD device mounted at - ncn-m002.nmn:/etc/cray/upgrade/csm
+      >```
+
+      If the `rbd` device already exists and is mounted, it can be moved to the desired node, if not already mounted there.
+      **IMPORTANT:** *If upgrading from a CSM version that had previously mounted this rbd device, the `/etc/cray/upgrade/csm/myenv` file will need to be removed before proceeding with this upgrade as it will contain information from the previous install.*
+
+      ```bash
+      /usr/share/doc/csm/scripts/csm_rbd_tool.py --rbd_action move --target_host ncn-m001
+      deactivate
+      ```
+
+      If the `rbd` device does not exists, create it.
+
+      ```bash
+      /usr/share/doc/csm/scripts/csm_rbd_tool.py --pool_action create --rbd_action create --target_host ncn-m001
       deactivate
       ```
 

--- a/upgrade/Stage_0_Prerequisites.md
+++ b/upgrade/Stage_0_Prerequisites.md
@@ -116,7 +116,7 @@ after a break, always be sure that a typescript is running before proceeding.
       deactivate
       ```
 
-      If the `rbd` device does not exists, create it.
+      If the `rbd` device does not exist, create it.
 
       ```bash
       /usr/share/doc/csm/scripts/csm_rbd_tool.py --pool_action create --rbd_action create --target_host ncn-m001


### PR DESCRIPTION
# Description

Instruct admins to cleanup myenv file if rbd device has been used in previous upgrade (https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5489).

# Checklist Before Merging

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
