### PR TITLE
Add note about myenv file if re-using rbd device (CASMINST-5489)

### DIFF
--- a/upgrade/Stage_0_Prerequisites.md
+++ b/upgrade/Stage_0_Prerequisites.md
@@ -109,6 +109,7 @@ after a break, always be sure that a typescript is running before proceeding.
       >```
 
       If the `rbd` device already exists and is mounted, it can be moved to the desired node, if not already mounted there.
+      **IMPORTANT:** *If upgrading from a CSM version that had previously mounted this rbd device, the `/etc/cray/upgrade/csm/myenv` file will need to be removed before proceeding with this upgrade as it will contain information from the previous install.*
 
       ```bash
       /usr/share/doc/csm/scripts/csm_rbd_tool.py --rbd_action move --target_host ncn-m001


### PR DESCRIPTION
# Description

Instruct admins to cleanup myenv file if rbd device has been used in previous upgrade (https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5489).

# Checklist Before Merging

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
