### PR TITLE
CASMPET-6076 : DOCS: Let user know that conjobs may need to be restarted

### DIFF
--- a/operations/kubernetes/Restore_Bare-Metal_etcd_Clusters_from_an_S3_Snapshot.md
+++ b/operations/kubernetes/Restore_Bare-Metal_etcd_Clusters_from_an_S3_Snapshot.md
@@ -222,7 +222,7 @@ Repeat the steps in this section on the next master node, until they have been p
     ```
 
     The `kube-etcdbackup`, `cray-dns-unbound-manager`, `sonar-sync` and `hms-discovery` cron jobs need to be restarted.
-    For example restarting the `kube-etcdbackup` cron job:
+    For example restarting the `kube-etcdbackup` cron job.
 
     ```bash
      kubectl get cronjobs.batch -n kube-system kube-etcdbackup -o json | \

--- a/operations/kubernetes/Restore_Bare-Metal_etcd_Clusters_from_an_S3_Snapshot.md
+++ b/operations/kubernetes/Restore_Bare-Metal_etcd_Clusters_from_an_S3_Snapshot.md
@@ -192,10 +192,10 @@ Repeat the steps in this section on the next master node, until they have been p
     d5a8e497e2788510, started, ncn-m003, https://10.252.1.9:2380, https://10.252.1.9:2379,https://127.0.0.1:2379, false
     ```
 
-1. (`ncn-m#`)  After a few minutes, if any cronjobs appear stuck, and/or pods yet to reach the Running state, the conjobs will need to be restarted and the associated pods deleted.
+1. (`ncn-m#`)  After a few minutes, if any `cronjobs` appear stuck, and/or pods yet to reach the Running state, the `conjobs` will need to be restarted and the associated pods deleted.
 
-    For example, following a successful Bare-Metal etcd cluster restore it can be observed that the kube-etcdbackup,
-    cray-dns-unbound-manager and sonar-sync cronjobs have not been scheduled for 18 minutes. The hms-discovery cronjob at 20 minutes is in the same situation.
+    For example, following a successful Bare-Metal `etcd` cluster restore it can be observed that the `kube-etcdbackup`,
+    `cray-dns-unbound-manager` and `sonar-sync` `cronjobs` have not been scheduled for 18 minutes. The `hms-discovery` `cronjob` at 20 minutes is in the same situation.
 
     ```bash
     kubectl get cronjobs.batch -A
@@ -221,8 +221,8 @@ Repeat the steps in this section on the next master node, until they have been p
     vault         spire-intermediate                   0 0 * * 1      False     0        <none>          23h
     ```
 
-    The kube-etcdbackup, cray-dns-unbound-manager, sonar-sync and hms-discovery cronjobs were restarted.
-    For example restarting the kube-etcdbackup cron job:
+    The `kube-etcdbackup`, `cray-dns-unbound-manager`, `sonar-sync`, and `hms-discovery` `cronjobs` were restarted.
+    For example restarting the `kube-etcdbackup` cron job:
 
     ```bash
      kubectl get cronjobs.batch -n kube-system kube-etcdbackup -o json | \
@@ -238,7 +238,7 @@ Repeat the steps in this section on the next master node, until they have been p
     cronjob.batch/kube-etcdbackup replaced
     ```
 
-    and the stuck cronjobs are now running.
+    and the stuck `cronjobs` are now running.
 
     ```bash
     kubectl get cronjobs.batch -A

--- a/operations/kubernetes/Restore_Bare-Metal_etcd_Clusters_from_an_S3_Snapshot.md
+++ b/operations/kubernetes/Restore_Bare-Metal_etcd_Clusters_from_an_S3_Snapshot.md
@@ -192,10 +192,10 @@ Repeat the steps in this section on the next master node, until they have been p
     d5a8e497e2788510, started, ncn-m003, https://10.252.1.9:2380, https://10.252.1.9:2379,https://127.0.0.1:2379, false
     ```
 
-1. (`ncn-m#`)  After a few minutes, if any `cronjobs` appear stuck, and/or pods yet to reach the Running state, the `conjobs` will need to be restarted and the associated pods deleted.
+1. (`ncn-m#`)  After a few minutes, if any cron jobs appear stuck, and/or pods yet to reach the Running state, the cron jobs will need to be restarted and the associated pods deleted.
 
-    For example, following a successful Bare-Metal `etcd` cluster restore it can be observed that the `kube-etcdbackup`,
-    `cray-dns-unbound-manager` and `sonar-sync` `cronjobs` have not been scheduled for 18 minutes. The `hms-discovery` `cronjob` at 20 minutes is in the same situation.
+    For example, following a successful Bare-Metal etcd cluster restore it can be observed that the `kube-etcdbackup`,
+    `cray-dns-unbound-manager` and `sonar-sync` cron jobs have not been scheduled for 18 minutes. The `hms-discovery` cron job at 20 minutes is in the same situation.
 
     ```bash
     kubectl get cronjobs.batch -A
@@ -221,7 +221,7 @@ Repeat the steps in this section on the next master node, until they have been p
     vault         spire-intermediate                   0 0 * * 1      False     0        <none>          23h
     ```
 
-    The `kube-etcdbackup`, `cray-dns-unbound-manager`, `sonar-sync`, and `hms-discovery` `cronjobs` were restarted.
+    The `kube-etcdbackup`, `cray-dns-unbound-manager`, `sonar-sync` and `hms-discovery` cron jobs need to be restarted.
     For example restarting the `kube-etcdbackup` cron job:
 
     ```bash
@@ -238,7 +238,7 @@ Repeat the steps in this section on the next master node, until they have been p
     cronjob.batch/kube-etcdbackup replaced
     ```
 
-    and the stuck `cronjobs` are now running.
+    and the stuck cron jobs are now running.
 
     ```bash
     kubectl get cronjobs.batch -A

--- a/operations/kubernetes/Restore_Bare-Metal_etcd_Clusters_from_an_S3_Snapshot.md
+++ b/operations/kubernetes/Restore_Bare-Metal_etcd_Clusters_from_an_S3_Snapshot.md
@@ -26,7 +26,8 @@ This procedure can be run on any master NCN.
     1. List the available backups.
 
         ```bash
-        cd /opt/cray/platform-utils/s3 && ./list-objects.py --bucket-name etcd-backup
+        cd /opt/cray/platform-utils/s3 && ./list-objects.py \
+        --bucket-name etcd-backup | grep bare-metal
         ```
 
         Example output:
@@ -190,3 +191,90 @@ Repeat the steps in this section on the next master node, until they have been p
     986f6ff2a30b01cb, started, ncn-m002, https://10.252.1.8:2380, https://10.252.1.8:2379,https://127.0.0.1:2379, false
     d5a8e497e2788510, started, ncn-m003, https://10.252.1.9:2380, https://10.252.1.9:2379,https://127.0.0.1:2379, false
     ```
+
+1. (`ncn-m#`)  After a few minutes, if any cronjobs appear stuck, and/or pods yet to reach the Running state, the conjobs will need to be restarted and the associated pods deleted.
+
+    For example, following a successful Bare-Metal etcd cluster restore it can be observed that the kube-etcdbackup,
+    cray-dns-unbound-manager and sonar-sync cronjobs have not been scheduled for 18 minutes. The hms-discovery cronjob at 20 minutes is in the same situation.
+
+    ```bash
+    kubectl get cronjobs.batch -A
+    ```
+
+    Example output:
+
+    ```text
+    NAMESPACE     NAME                                 SCHEDULE       SUSPEND   ACTIVE   LAST SCHEDULE   AGE
+    argo          cray-nls-postgresql-db-backup        10 23 * * *    False     0        21h             26h
+    kube-system   kube-etcdbackup                      */10 * * * *   False     1        18m             33h
+    operators     kube-etcd-defrag                     0 0 * * *      False     0        20h             33h
+    operators     kube-etcd-defrag-cray-hbtd-etcd      0 */4 * * *    False     0        38m             33h
+    operators     kube-etcd-periodic-backup-cron       0 * * * *      False     0        38m             33h
+    services      cray-dns-unbound-manager             */2 * * * *    False     1        18m             33h
+    services      cray-keycloak-postgresql-db-backup   10 2 * * *     False     0        18h             33h
+    services      cray-sls-postgresql-db-backup        10 23 * * *    False     0        21h             33h
+    services      cray-smd-postgresql-db-backup        10 0 * * *     False     0        20h             33h
+    services      gitea-vcs-postgresql-db-backup       10 1 * * *     False     0        19h             33h
+    services      hms-discovery                        */3 * * * *    False     0        20m             33h
+    services      sonar-sync                           */1 * * * *    False     1        18m             34h
+    spire         spire-postgresql-db-backup           10 3 * * *     False     0        17h             33h
+    vault         spire-intermediate                   0 0 * * 1      False     0        <none>          23h
+    ```
+
+    The kube-etcdbackup, cray-dns-unbound-manager, sonar-sync and hms-discovery cronjobs were restarted.
+    For example restarting the kube-etcdbackup cron job:
+
+    ```bash
+     kubectl get cronjobs.batch -n kube-system kube-etcdbackup -o json | \
+     jq 'del(.spec.selector)' | \
+     jq 'del(.spec.template.metadata.labels."controller-uid")' | \
+     kubectl replace --force -f -
+    ```
+
+    Example output:
+
+    ```text
+    cronjob.batch "kube-etcdbackup" deleted
+    cronjob.batch/kube-etcdbackup replaced
+    ```
+
+    and the stuck cronjobs are now running.
+
+    ```bash
+    kubectl get cronjobs.batch -A
+    ```
+
+    Example output:
+
+    ```text
+     NAMESPACE     NAME                                 SCHEDULE       SUSPEND   ACTIVE   LAST SCHEDULE   AGE
+     argo          cray-nls-postgresql-db-backup        10 23 * * *    False     0        21h             26h
+     kube-system   kube-etcdbackup                      */10 * * * *   False     0        41s             33h
+     operators     kube-etcd-defrag                     0 0 * * *      False     0        20h             33h
+     operators     kube-etcd-defrag-cray-hbtd-etcd      0 */4 * * *    False     0        30m             33h
+     operators     kube-etcd-periodic-backup-cron       0 * * * *      False     0        30m             33h
+     services      cray-dns-unbound-manager             */2 * * * *    False     0        41s             33h
+     services      cray-keycloak-postgresql-db-backup   10 2 * * *     False     0        18h             33h
+     services      cray-sls-postgresql-db-backup        10 23 * * *    False     0        21h             33h
+     services      cray-smd-postgresql-db-backup        10 0 * * *     False     0        20h             33h
+     services      gitea-vcs-postgresql-db-backup       10 1 * * *     False     0        19h             33h
+     services      hms-discovery                        */3 * * * *    False     1        41s             33h
+     services      sonar-sync                           */1 * * * *    False     1        41s             33h
+     spire         spire-postgresql-db-backup           10 3 * * *     False     0        17h             33h
+     vault         spire-intermediate                   0 0 * * 1      False     0        <none>          22h
+     ```
+
+    At the same time these pods had not yet reached the running state and needed to be deleted.
+
+   ```bash
+    kubectl get pods -A -o wide | grep -v "Completed\|Running"
+    ```
+
+    Example output:
+
+    ```text
+    NAMESPACE           NAME                                                              READY   STATUS              RESTARTS   AGE   IP            NODE       NOMINATED NODE   READINESS GATES
+    kube-system         kube-etcdbackup-27758660-xj9kb                                    0/1     ContainerCreating   0          23m   <none>        ncn-w002   <none>           <none>
+    services            cray-dns-unbound-manager-27758660-d7d2l                           0/2     Init:0/1            0          23m   <none>        ncn-w003   <none>           <none>
+    services            sonar-sync-27758660-75qxb                                         0/1     ContainerCreating   0          23m   <none>        ncn-w002   <none>           <none>
+     ```

--- a/operations/kubernetes/Restore_Bare-Metal_etcd_Clusters_from_an_S3_Snapshot.md
+++ b/operations/kubernetes/Restore_Bare-Metal_etcd_Clusters_from_an_S3_Snapshot.md
@@ -264,7 +264,7 @@ Repeat the steps in this section on the next master node, until they have been p
      vault         spire-intermediate                   0 0 * * 1      False     0        <none>          22h
      ```
 
-    At the same time these pods had not yet reached the running state and needed to be deleted.
+    At the same time these associated pods had not yet reached the running state and needed to be deleted.
 
    ```bash
     kubectl get pods -A -o wide | grep -v "Completed\|Running"


### PR DESCRIPTION
### Summary and Scope
1.3 - CASMPET-6076: DOCS: Let user know that conjobs may need to be restarted after Bare-Metal etcd cluster restore.

Provide example checks that user can run after a Bare-Metal etcd cluster restore. 

### Issues and Related PRs
CASMPET-6076

### Testing
Tested on fanta, csm-1.3.0-rc.4.

Was a fresh Install tested? N - N/A
Was an Upgrade tested? N - N/A
Was a Downgrade tested? N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations
Low

### Requires:
N/A