### PR TITLE
CASMPET-6077 : DOCS: ncnHealthChecks add a note about postgresql-db-backup pods in Error

### DIFF
--- a/troubleshooting/known_issues/ncn_resource_checks.md
+++ b/troubleshooting/known_issues/ncn_resource_checks.md
@@ -35,3 +35,6 @@
 
   - The `hmn-discovery` and `cray-dns-unbound-manager` cronjob pods may be in a `NotReady` state. This is expected because these pods are periodically started
     and often can be caught in intermediate states.
+
+  - If some `*postgresql-db-backup` cronjob pods are in `Error` state, they can be ignored if the most recent pod `Completed`.
+    The `Error` pods are cleaned up over time but are left to troubleshoot issues in the case that all retries for the `postgresql-db-backup` job fail.


### PR DESCRIPTION
# Description

Add a statement to the ncnHealthCheck troubleshooting that postgressl-db-backup pods found in Error state can be ignored if the most recent cronjob pod Completed. Retries are expected if any intermediate issues are encountered.
# Checklist Before Merging

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
