### PR TITLE
MTL-1871 Port LIVE Image cleanup to 1.3

### DIFF
--- a/operations/README.md
+++ b/operations/README.md
@@ -500,6 +500,7 @@ Monitor and manage compute nodes (CNs) and non-compute nodes (NCNs) used in the 
   - [Check and Set the `metalno-wipe` Setting on NCNs](node_management/Check_and_Set_the_metalno-wipe_Setting_on_NCNs.md)
 - [Enable Nodes](node_management/Enable_Nodes.md)
 - [Disable Nodes](node_management/Disable_Nodes.md)
+- [Remove Old SquashFS](node_management/Removing_Old_SquashFS.md)
 - [Find Node Type and Manufacturer](node_management/Find_Node_Type_and_Manufacturer.md)
 - [Add additional Liquid-Cooled Cabinets to a System](node_management/Add_additional_Liquid-Cooled_Cabinets_to_a_System.md)
 - [Updating Cabinet Routes on Management NCNs](node_management/Updating_Cabinet_Routes_on_Management_NCNs.md)

--- a/operations/node_management/Removing_Old_SquashFS.md
+++ b/operations/node_management/Removing_Old_SquashFS.md
@@ -1,0 +1,55 @@
+# Remove Old SquashFS
+
+This page will guide a user through removing old squashFS (and overlayFS) that can reside on an 
+NCN following upgrades or rebuilds.
+
+> ***NOTE*** Historically speaking, CSM V1.3.0 upgrades (and newer) pull squashFS into a new directory
+> and create a new overlayFS that corresponds to that squashFS directory. This facilitates rolling back
+> to a previous image. This page helps a user clean up old images, freeing up space for new upgrades
+> if space becomes too limited.
+
+## Prerequisites
+
+1. Deliver the cleanup script to the NCNs (this just provides the cleanup script to the NCNs).
+
+   ```bash
+   /usr/share/doc/csm/scripts/operations/node_management/copy-cleanup-live-images.sh
+   ```
+
+## Clean a single NCN
+
+1. Login to the NCN to be cleaned.
+
+1. Invoke the cleaning script on an NCN
+
+    * Clean only old squashFS
+
+      ```bash
+      /srv/cray/metal/scripts/cleanup-live-images.sh
+      ```
+
+    * Clean all squashFS including the running squashFS
+
+      > ***NOTE*** This does not clean the running overlayFS, or the system will crash.
+
+      ```bash
+      /srv/cray/metal/scripts/cleanup-live-images.sh -a
+      ```
+
+## Clean all NCNs
+
+1. (`ncn-m001#`) Invoke the cleanup script on all NCNs
+
+    * Clean only old squashFS
+
+        ```bash
+        /usr/share/doc/csm/scripts/operations/node_management/run-cleanup-live-images-on-all.sh
+        ```
+
+    * Clean all squashFS including the running squashFS
+    
+        > ***NOTE*** This does not clean the running overlayFS, or the system will crash.
+
+        ```bash
+        /usr/share/doc/csm/scripts/operations/node_management/copy-cleanup-live-images.sh -a
+        ```

--- a/scripts/operations/node_management/cleanup-live-images.sh
+++ b/scripts/operations/node_management/cleanup-live-images.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+set -euo pipefail
+
+ALL=0
+AUTO=0
+INCLUDE_OVERLAYFS=0
+SQUASHFS_DISK=$(grep -Po 'root=[\w=:]+' /proc/cmdline)
+SQUASHFS_BASE="$(lsblk -o MOUNTPOINT -nr /dev/disk/by-label/${SQUASHFS_DISK##*=})"
+OVERLAYFS_DISK=$(grep -Po 'rd.live.overlay=[\w=]+' /proc/cmdline)
+OVERLAYFS_BASE="$(lsblk -o MOUNTPOINT -nr /dev/disk/by-label/${OVERLAYFS_DISK##*=})"
+
+if [ ! -d ${SQUASHFS_BASE} ] || [ ! -d ${OVERLAYFS_BASE} ]; then
+    echo >&2 "Could not find [$SQUASHFS_BASE] or [$OVERLAYFS_BASE]!"
+    exit 1
+fi
+
+DISK="$(blkid -L SQFSRAID)"
+LIVE_DIR=$(grep -oP 'rd.live.dir=[\w\d-_.]+' /proc/cmdline)
+[ -z "$LIVE_DIR" ] && LIVE_DIR='rd.live.dir=LiveOS'
+LIVE_DIR="${LIVE_DIR#*=}"
+
+function usage {
+    cat << EOF
+$(basename 0) will cleanup squashFS and overlayFS that live in the [$SQUASHFS_BASE] and [$OVERLAYFS_BASE] directories.
+
+Without any arguments this script will prompt the user for confirmation before performing any destructive actions.
+
+By default this script will ignore the currently running squashFS.
+
+- Passing any argument other than -y or -a will print this usage.
+- Passing '-y' will automatically clean unused images, bypassing the prompt.
+- Passing '-a' will include all images (unused and used), this will break disk booting unless the node is re-imaged on the next reboot.
+- Passing '-o' will include overlayFS for each image, otherwise these are left alone. This never cleans up the active overlayFS (despite -a being given) because it will break the running operating system.
+EOF
+}
+
+while getopts "aoy" opt; do
+    case ${opt} in
+        y)
+            AUTO=1
+            ;;
+        a)
+            ALL=1
+            ;;
+        o)
+            INCLUDE_OVERLAYFS=1
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+
+if [ ${ALL} = 0 ]; then
+    readarray -t LIVE_DIRS < <(find /run/initramfs/live/* -type d -exec basename {} \; 2>/dev/null| grep -v ${LIVE_DIR})
+else
+    readarray -t LIVE_DIRS < <(find /run/initramfs/live/* -type d -exec basename {} \; 2>/dev/null)
+fi
+function print_capacity {
+    local capacity
+    local used
+
+    capacity="$(df -h /run/initramfs/live | awk '{print $2}' | sed -z 's/\n/: /g;s/: $/\n/')"
+    used="$(df -h /run/initramfs/live | awk '{print $3}' | sed -z 's/\n/: /g;s/: $/\n/')"
+
+    echo -e "Image storage status:\n\n\t$capacity\n\t$used\n" 
+}
+print_capacity
+echo "Current used image directory is: [${SQUASHFS_BASE}/${LIVE_DIR}]"
+if [ "${#LIVE_DIRS[@]}" = 0 ]; then
+    echo 'Nothing to remove.'
+    exit 1
+fi
+echo 'Found the following unused image directories: '
+for live_dir in "${LIVE_DIRS[@]}"; do
+    size=$(du -hs ${SQUASHFS_BASE}/$live_dir | awk '{print $1}')
+    printf '\t%s\t%s\n' ${live_dir} ${size}
+done
+if [ ${AUTO} = 0 ]; then
+    read -r -p "Proceed to cleanup listed image directories? [y/n]:" response
+    case "$response" in
+        [yY][eE][sS]|[yY])
+            echo 'Removing image directories ...'
+            ;;
+        *)
+            echo 'Exiting without removing anything.'
+            exit 0
+            ;;
+    esac
+else
+    echo '-y was present; automatically removing images ...'
+fi
+
+to_remove_squashfs="$(printf ${SQUASHFS_BASE}'/%s ' "${LIVE_DIRS[@]}")"
+to_remove_overlayfs="$(printf ${OVERLAYFS_BASE}'/%s ' "${LIVE_DIRS[@]}")"
+mount -o rw,remount ${DISK} ${BASE}
+echo 'Removing squashFS directories ... '
+if [ ${ALL} -eq 1 ]; then
+    echo "-a was present; removing ALL images including the currently booted image [${BASE}/${LIVE_DIR}]"
+    echo >&2 "This node will be unable to diskboot until it is reimaged with a netboot."
+    rm -rf ${to_remove_squashfs} "${SQUASHFS_BASE:?}/${LIVE_DIR}"
+else
+    rm -rf ${to_remove_squashfs}
+fi
+if [ ${INCLUDE_OVERLAYFS} -eq 1 ]; then
+    echo 'Removing overlayFS directories ... '
+    rm -rf ${to_remove_overlayfs}
+else
+    echo "Overlays were left untouched since -o was not provided, these will be present in [$OVERLAYFS_BASE]."
+fi
+echo 'Done'
+
+# Attempt to remount as ro, but don't fail
+if ! mount -o ro,remount ${DISK} ${BASE} 2>/dev/null; then
+    echo >&2 "Attempted to remount ${BASE} as read-only but the device was busy. This will correct itself on the next reboot."
+fi 
+
+# Do not reprint the size, for some reason it doesn't report properly for a given amount of time.
+#print_capacity

--- a/scripts/operations/node_management/copy-cleanup-live-images.sh
+++ b/scripts/operations/node_management/copy-cleanup-live-images.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+set -euo pipefail
+
+workdir=$(dirname $0)
+
+if [[ $(hostname) == *-pit ]]; then
+    # Exclude ncn-m001 if this is run from the PIT node.
+    readarray -t EXPECTED_NCNS < <(conman -q | grep -v m001 | sort -u | awk -F - '{print $1"-"$2}')
+    if [ ${#EXPECTED_NCNS[@]} = 0 ]; then
+        echo >&2 "No NCNs found in 'conman -q', $0 can only be invoked after pit-init.sh has completed successfully."
+        exit 1
+    fi
+else
+    readarray -t EXPECTED_NCNS < <(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u)
+    if [ ${#EXPECTED_NCNS[@]} = 0 ]; then
+        echo >&2 "No NCNs found in /etc/hosts! This NCN is not initialized, /etc/hosts should have content."
+        exit 1
+    fi
+fi
+
+export NCNS=()
+for ncn in "${EXPECTED_NCNS[@]}"; do
+    if ping -c 1 $ncn >/dev/null 2>&1 ; then
+        NCNS+=( "$ncn" )
+    else
+        echo >&2 "Failed to ping [$ncn]; skipping hotfix for [$ncn]"
+    fi
+done
+
+for ncn in "${NCNS[@]}"; do
+    printf "Uploading new cleanup-live-images.sh to $ncn:/srv/cray/scripts/metal/ ... "
+    scp ${workdir}/cleanup-live-images.sh ${ncn}:/srv/cray/scripts/metal/cleanup-live-images.sh >/dev/null
+    echo "Done" 
+done

--- a/scripts/operations/node_management/run-cleanup-live-images-on-all.sh
+++ b/scripts/operations/node_management/run-cleanup-live-images-on-all.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+set -euo pipefail
+
+workdir=$(dirname $0)
+
+
+while getopts "a" opt; do
+    case ${opt} in
+        a)
+            ALL=1
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+
+if [[ $(hostname) == *-pit ]]; then
+    # Exclude ncn-m001 if this is run from the PIT node.
+    readarray -t EXPECTED_NCNS < <(conman -q | grep -v m001 | sort -u | awk -F - '{print $1"-"$2}')
+    if [ ${#EXPECTED_NCNS[@]} = 0 ]; then
+        echo >&2 "No NCNs found in 'conman -q', $0 can only be invoked after pit-init.sh has completed successfully."
+        exit 1
+    fi
+else
+    readarray -t EXPECTED_NCNS < <(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u)
+    if [ ${#EXPECTED_NCNS[@]} = 0 ]; then
+        echo >&2 "No NCNs found in /etc/hosts! This NCN is not initialized, /etc/hosts should have content."
+        exit 1
+    fi
+fi
+
+export NCNS=()
+for ncn in "${EXPECTED_NCNS[@]}"; do
+    if ping -c 1 $ncn >/dev/null 2>&1 ; then
+        NCNS+=( "$ncn" )
+    else
+        echo >&2 "Failed to ping [$ncn]; skipping hotfix for [$ncn]"
+    fi
+done
+
+printf "Refreshing the bootorder on [${#NCNS[@]}] NCNs ... "
+if [ ${ALL} -eq 1 ]; then
+    if ! pdsh -S -b -w "$(printf '%s,' "${NCNS[@]}")" '
+    /srv/cray/scripts/metal/cleanup-live-images -y -a
+    fi
+    '
+else
+    if ! pdsh -S -b -w "$(printf '%s,' "${NCNS[@]}")" '
+    /srv/cray/scripts/metal/cleanup-live-images -y
+    fi
+    '
+fi
+echo 'Done'


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
This added page and its scripts will facilitate cleaning up old squashFS images.

The page mentions cleaning up old OverlayFS but does not include directions intentionally, that function is experimental and is not the main intention of the script.

The 1.4 PR will be just a doc page, no scripts. It'll leverage the existing scripts on the node.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
