### PR TITLE
CASMPET-6072 : DOCS: Backport cert renewal of client certs to 0.9 docs for CAST-31230

### DIFF
--- a/operations/kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md
+++ b/operations/kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md
@@ -487,3 +487,108 @@ Check the expiration of the certificates.
       WARNING: 2021/09/24 17:35:11 grpc: addrConn.createTransport failed to connect to {0.0.0.0:2379 0  <nil>}. Err :connection error: desc = "transport: authentication handshake failed: remote error: tls: bad certificate". Reconnecting...
       ```
 
+## Update client secrets
+
+Run the following steps from a master node.
+
+1. Update the client certificate for `kube-etcdbackup`.
+
+   1. Update the `kube-etcdbackup-etcd` secret.
+
+      ```bash
+      kubectl --namespace=kube-system create secret generic kube-etcdbackup-etcd \
+                     --from-file=/etc/kubernetes/pki/etcd/ca.crt \
+                     --from-file=tls.crt=/etc/kubernetes/pki/etcd/server.crt \
+                     --from-file=tls.key=/etc/kubernetes/pki/etcd/server.key \
+                     --save-config --dry-run=client -o yaml | kubectl apply -f -
+      ```
+
+   1. Check the certificate's expiration date to verify that the certificate is not expired.
+
+      ```bash
+      kubectl get secret -n kube-system kube-etcdbackup-etcd -o json | jq -r '.data."tls.crt" | @base64d' | openssl x509 -noout -enddate
+      ```
+
+      Example output:
+
+      ```text
+      notAfter=May  4 22:37:16 2023 GMT
+      ```
+
+   1. Check that the next `kube-etcdbackup` cronjob `Completed`. This cronjob runs every 10 minutes.
+
+      ```bash
+      kubectl get pod -l app.kubernetes.io/instance=cray-baremetal-etcd-backup -n kube-system
+      ```
+
+      Example output:
+
+      ```text
+      NAME                               READY   STATUS      RESTARTS   AGE
+      kube-etcdbackup-1652201400-czh5p   0/1     Completed   0          107s
+      ```
+
+1. Update the client certificate for `etcd-client`.
+
+   1. Update the `etcd-client-cert` secret.
+
+      ```bash
+      kubectl --namespace=sysmgmt-health create secret generic etcd-client-cert \
+                     --from-file=etcd-client=/etc/kubernetes/pki/apiserver-etcd-client.crt \
+                     --from-file=etcd-client-key=/etc/kubernetes/pki/apiserver-etcd-client.key \
+                     --from-file=etcd-ca=/etc/kubernetes/pki/etcd/ca.crt \
+                     --save-config --dry-run=client -o yaml | kubectl apply -f -
+      ```
+
+   1. Check the certificates' expiration dates to verify that none of the certificate are expired.
+
+      1. Check the `etcd-ca` expiration date.
+
+         ```bash
+         kubectl get secret -n sysmgmt-health etcd-client-cert -o json | jq -r '.data."etcd-ca" | @base64d' | openssl x509 -noout -enddate
+         ```
+
+         Example output:
+
+         ```text
+         notAfter=May  1 18:20:23 2032 GMT
+         ```
+
+      1. Check the `etcd-client` expiration date.
+
+         ```bash
+         kubectl get secret -n sysmgmt-health etcd-client-cert -o json | jq -r '.data."etcd-client" | @base64d' | openssl x509 -noout -enddate
+         ```
+
+         Example output:
+
+         ```text
+         notAfter=May  4 18:20:24 2023 GMT
+         ```
+
+   1. Restart Prometheus.
+
+      ```bash
+      kubectl rollout restart -n sysmgmt-health statefulSet/prometheus-cray-sysmgmt-health-promet-prometheus
+      kubectl rollout status -n sysmgmt-health statefulSet/prometheus-cray-sysmgmt-health-promet-prometheus
+      ```
+
+      Example output:
+
+      ```text
+      Waiting for 1 pods to be ready...
+      statefulset rolling update complete ...
+      ```
+
+   1. Check for any `tls` errors from the active Prometheus targets. No errors are expected.
+
+      ```bash
+      PROM_IP=$(kubectl get services -n sysmgmt-health cray-sysmgmt-health-promet-prometheus -o json | jq -r '.spec.clusterIP')
+      curl -s http://${PROM_IP}:9090/api/v1/targets | jq -r '.data.activeTargets[] | select(."scrapePool" == "sysmgmt-health/cray-sysmgmt-health-promet-kube-etcd/0")' | grep lastError | sort -u
+      ```
+
+      Example output:
+
+      ```text
+        "lastError": "",
+      ```


### PR DESCRIPTION
# Description

Backporting the client secrets renewal steps to CSM 0.9 docs

# Checklist Before Merging

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
