### PR TITLE
CASMINST-5525 - change CSM 1.2 upgrade and install references to 1.2.2 once it's ready

### DIFF
--- a/install/index.md
+++ b/install/index.md
@@ -1,6 +1,6 @@
 # Install CSM
 
-Note: If you are beginning an install with CSM 1.2.0, please download and proceed to install 1.2.2 instead. This will save you time performing a patch update later.
+Note: If you are beginning an install with CSM 1.2.0, please download and proceed to install 1.2.1 instead. This will save you time performing a patch update later.
 
 ## Abstract
 

--- a/upgrade/1.2/README.md
+++ b/upgrade/1.2/README.md
@@ -6,7 +6,7 @@ This document guides an administrator through the upgrade of Cray Systems Manage
 from top to bottom. The content on this top-level page is meant to be terse. For additional reference material on the upgrade processes and scripts
 mentioned explicitly on this page, see [resource material](resource_material/README.md).
 
-If you are considering an upgrade from CSM 1.0.x to 1.2.0, please instead download and use CSM 1.2.2.
+If you are considering an upgrade from CSM 1.0.x to 1.2.0, please instead download and use CSM 1.2.1.
 
 A major feature of CSM 1.2.x is the Bifurcated CAN (BICAN). The BICAN is designed to separate administrative network traffic from user network traffic.
 For more information, see the [BICAN Summary](../../operations/network/management_network/bican_technical_summary.md).

--- a/upgrade/1.2/Stage_0_Prerequisites.md
+++ b/upgrade/1.2/Stage_0_Prerequisites.md
@@ -2,7 +2,7 @@
 
 > **Reminders:**
 >
-> - CSM 1.0.1 or higher is required in order to upgrade to CSM 1.2.2.
+> - CSM 1.0.1 or higher is required in order to upgrade to CSM 1.2.1.
 > - If any problems are encountered and the procedure or command output does not provide relevant guidance, see
 >   [Relevant troubleshooting links for upgrade-related issues](README.md#relevant-troubleshooting-links-for-upgrade-related-issues).
 
@@ -27,7 +27,7 @@ backup of Workload Manager configuration data and files is created. Once complet
 1. Set the `CSM_RELEASE` variable to the **target** CSM version of this upgrade.
 
    ```bash
-   ncn-m001# CSM_RELEASE=csm-1.2.2
+   ncn-m001# CSM_RELEASE=csm-1.2.1
    ```
 
 1. If there are space concerns on the node, then add an `rbd` device on the node for the CSM tarball.

--- a/upgrade/1.2/Stage_2.md
+++ b/upgrade/1.2/Stage_2.md
@@ -99,7 +99,7 @@ upgrade procedure pivots to use `ncn-m002` as the new "stable node", in order to
 1. Set the `CSM_RELEASE` variable to the **target** CSM version of this upgrade.
 
    ```bash
-   ncn-m002# CSM_RELEASE=csm-1.2.2
+   ncn-m002# CSM_RELEASE=csm-1.2.1
    ```
 
 1. Copy artifacts from `ncn-m001`.


### PR DESCRIPTION
I jumped the gun a bit with the CSM 1.2.2 patch instructions when I went ahead and updated the references in the csm-1.2 upgrade and fresh install docs to point to the 1.2.2 patch.   This PR will set it back to point to 1.2.1 until we are ready to ship 1.2.2, at which point, we'll need to change them back to point to 1.2.2.