### PR TITLE
CASMPET-6089: DOCS: Fix broken Force rewrite link in Kubernetes Encry…

### DIFF
--- a/operations/kubernetes/encryption/README.md
+++ b/operations/kubernetes/encryption/README.md
@@ -203,7 +203,7 @@ Encryption status is obtained through the `--status` switch of the `encryption.s
     The output shows that the `current` key and `goal` keys are in agreement. This indicates that all secret data in `etcd`
     is now encrypted with this key provider's name. This indicates that all secret data in etcd is now encrypted with this key provider's name.
 
-## Forcing encryption
+## Force rewrite
 
 If necessary, a forced rewrite of secret data can be performed. Generally unnecessary but can be used to reduce the time for nodes to synchronize status.
 


### PR DESCRIPTION
### Summary and Scope
Main - CASMPET-6089: DOCS: Fix broken Force rewrite link in Kubernetes Encryption document.

Fix broken **Force rewrite** link in Kubernetes Encryption document by updating section title. 

### Issues and Related PRs
CASMPET-6089

### Testing
Viewed updated document and tested link.

Was a fresh Install tested? N - N/A
Was an Upgrade tested? N - N/A
Was a Downgrade tested? N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations
Low

### Requires:
N/A