### PR TITLE
CASMTRIAGE-4413: export ceph.client.ro.keyring if file not present

### DIFF
--- a/workflows/ncn/storage/storage.rebuild.yaml
+++ b/workflows/ncn/storage/storage.rebuild.yaml
@@ -102,8 +102,15 @@ spec:
                   value: "{{$.DryRun}}"  
                 - name: scriptContent
                   value: |
-                    ceph auth get client.ro >/dev/null 2>/dev/null || ceph-authtool -C /etc/ceph/ceph.client.ro.keyring -n client.ro --cap mon 'allow r' --cap mds 'allow r' --cap osd 'allow r' --cap mgr 'allow r' --gen-key
-                    ceph auth import -i /etc/ceph/ceph.client.ro.keyring
+                    if ! $(ceph auth get client.ro >/dev/null 2>/dev/null); then
+                      ceph-authtool -C /etc/ceph/ceph.client.ro.keyring -n client.ro --cap mon 'allow r' --cap mds 'allow r' --cap osd 'allow r' --cap mgr 'allow r' --gen-key
+                    fi
+                    if [ -f "/etc/ceph/ceph.client.ro.keyring" ]; then
+                      ceph auth import -i /etc/ceph/ceph.client.ro.keyring
+                    else
+                      ceph auth get client.ro -o /etc/ceph/ceph.client.ro.keyring
+                      ceph auth import -i /etc/ceph/ceph.client.ro.keyring
+                    fi
                     for node in $(ceph orch host ls --format=json|jq -r '.[].hostname'); do scp /etc/ceph/ceph.client.ro.keyring $node:/etc/ceph/ceph.client.ro.keyring; done
           - name: pre-upgrade-ceph-health-check
             templateRef:


### PR DESCRIPTION
# Description

Export ceph.client.ro.keyring if file not present. This is done before storage upgrade starts.
Tested on surtur.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
