### PR TITLE
CASMINST 5539: add troubleshooting for ceph.ro.keyring file not existing during storage upgrade

### DIFF
--- a/upgrade/Stage_1.md
+++ b/upgrade/Stage_1.md
@@ -77,14 +77,14 @@ It is possible to upgrade a single storage node at a time using the following co
 > - If the upgrade is 'waiting for ceph HEALTH_OK', the output from commands `ceph -s` and `ceph health detail` should provide information.
 > - If a crash has occurred, [dumping the ceph crash data](../operations/utility_storage/Dump_Ceph_Crash_Data.md) will return Ceph to healthy state and allow the upgrade to continue.
 >   The crash should be evaluated to determine if there is an issue that should be addressed.
-> - If the following error occurs during the `check-ceph-ro-key` phase, "Can't open input file /etc/ceph/ceph.client.ro.keyring: [Errno 2] No such file or directory: '/etc/ceph/ceph.client.ro.keyring'", 
+> - If the following error occurs during the `check-ceph-ro-key` phase, "Can't open input file /etc/ceph/ceph.client.ro.keyring: [Errno 2] No such file or directory: '/etc/ceph/ceph.client.ro.keyring'",
 >then export the keyring in a separate terminal. The workflow will continue on its own.
 >
 >   (`ncn-m001#`) Export keyring.
 >
 >   ```bash
 >   ceph auth get client.ro -o /etc/ceph/ceph.client.ro.keyring
->   ``` 
+>   ```
 >
 > - Refer to [storage troubleshooting documentation](../operations/utility_storage/Utility_Storage.md#storage-troubleshooting-references) for Ceph related issues.
 

--- a/upgrade/Stage_1.md
+++ b/upgrade/Stage_1.md
@@ -77,6 +77,15 @@ It is possible to upgrade a single storage node at a time using the following co
 > - If the upgrade is 'waiting for ceph HEALTH_OK', the output from commands `ceph -s` and `ceph health detail` should provide information.
 > - If a crash has occurred, [dumping the ceph crash data](../operations/utility_storage/Dump_Ceph_Crash_Data.md) will return Ceph to healthy state and allow the upgrade to continue.
 >   The crash should be evaluated to determine if there is an issue that should be addressed.
+> - If the following error occurs during the `check-ceph-ro-key` phase, "Can't open input file /etc/ceph/ceph.client.ro.keyring: [Errno 2] No such file or directory: '/etc/ceph/ceph.client.ro.keyring'", 
+>then export the keyring in a seperate terminal. The workflow will continue on its own.
+>
+>   (`ncn-m001#`) Export keyring.
+>
+>   ```bash
+>   ceph auth get client.ro -o /etc/ceph/ceph.client.ro.keyring
+>   ``` 
+>
 > - Refer to [storage troubleshooting documentation](../operations/utility_storage/Utility_Storage.md#storage-troubleshooting-references) for Ceph related issues.
 
 ## Ensure that `rbd` stats monitoring is enabled

--- a/upgrade/Stage_1.md
+++ b/upgrade/Stage_1.md
@@ -78,7 +78,7 @@ It is possible to upgrade a single storage node at a time using the following co
 > - If a crash has occurred, [dumping the ceph crash data](../operations/utility_storage/Dump_Ceph_Crash_Data.md) will return Ceph to healthy state and allow the upgrade to continue.
 >   The crash should be evaluated to determine if there is an issue that should be addressed.
 > - If the following error occurs during the `check-ceph-ro-key` phase, "Can't open input file /etc/ceph/ceph.client.ro.keyring: [Errno 2] No such file or directory: '/etc/ceph/ceph.client.ro.keyring'", 
->then export the keyring in a seperate terminal. The workflow will continue on its own.
+>then export the keyring in a separate terminal. The workflow will continue on its own.
 >
 >   (`ncn-m001#`) Export keyring.
 >


### PR DESCRIPTION
# Description

DOCs change: add troubleshooting for ceph.ro.keyring file not existing during storage upgrade

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
