### PR TITLE
CASMTRIAGE-4424: Incorrect default container called in docs for vault

### DIFF
--- a/operations/security_and_authentication/Update_NCN_Passwords.md
+++ b/operations/security_and_authentication/Update_NCN_Passwords.md
@@ -63,7 +63,7 @@ for it to be applied to the NCNs.
    any special characters.
 
    ```bash
-   kubectl exec -itn vault cray-vault-0 -- sh
+   kubectl exec -itn vault cray-vault-0 -c vault -- sh
    export VAULT_ADDR=http://cray-vault:8200
    vault login
    vault write secret/csm/users/root password='<INSERT HASH HERE>' [... other fields (see warning below) ...]


### PR DESCRIPTION
# Description

Changes a command to set the root password in vault because it was missing the container name in the exec command.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
