### PR TITLE
CASMTRIAGE-4424: Incorrect default container called in docs for vault

### DIFF
--- a/operations/security_and_authentication/Update_NCN_Passwords.md
+++ b/operations/security_and_authentication/Update_NCN_Passwords.md
@@ -65,7 +65,7 @@ for it to be applied to the NCNs.
    any special characters.
 
    ```bash
-   ncn-mw# kubectl exec -itn vault cray-vault-0 -- sh
+   ncn-mw# kubectl exec -itn vault cray-vault-0 -c vault -- sh
    cray-vault-0# export VAULT_ADDR=http://cray-vault:8200
    cray-vault-0# vault login
    cray-vault-0# vault write secret/csm/users/root password='<INSERT HASH HERE>' [... other fields (see warning below) ...]


### PR DESCRIPTION
# Description

Backport of https://github.com/Cray-HPE/docs-csm/pull/2698

This fix is not necessary for this release (because the container defaulted to the correct value), but it is still better practice to explicitly specify it. And keeping the docs common reduces maintenance issues.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
