### PR TITLE
CASMTRIAGE-4425: Incorrect node command - Update the desired configuration for all NCNs.

### DIFF
--- a/operations/CSM_product_management/Perform_NCN_Personalization.md
+++ b/operations/CSM_product_management/Perform_NCN_Personalization.md
@@ -105,7 +105,7 @@ configuration layer requires special placement in the layer list.
 1. Update the desired configuration for all NCNs.
 
    ```bash
-   for xname in $(cray hsm state components list --role Management --type node --format json | jq -r .Components[].ID)
+   for xname in $(cray hsm state components list --role Management --type Node --format json | jq -r .Components[].ID)
    do
        cray cfs components update --desired-config ncn-personalization --enabled true --format json $xname
    done


### PR DESCRIPTION
# Description

Mistyped option in command needed a capitlization.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
