### PR TITLE
CASMINST-5544: Be more precise in setting postgres leader pod variable

### DIFF
--- a/upgrade/1.2/scripts/upgrade/prerequisites.sh
+++ b/upgrade/1.2/scripts/upgrade/prerequisites.sh
@@ -921,9 +921,9 @@ state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
 if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
     echo "====> ${state_name} ..."
     {
-    
-    pgLeaderPod=$(kubectl exec gitea-vcs-postgres-0 -n services -c postgres -it -- patronictl list | grep Leader | awk -F'|' '{print $2}')
-    kubectl exec -it ${pgLeaderPod} -n services -c postgres -- pg_dumpall -c -U postgres > gitea-vcs-postgres.sql
+
+    pgLeaderPod=$(kubectl exec gitea-vcs-postgres-0 -n services -c postgres -it -- patronictl list -f json | jq -r '.[] | select(.Role == "Leader").Member')
+    kubectl exec -it "${pgLeaderPod}" -n services -c postgres -- pg_dumpall -c -U postgres > gitea-vcs-postgres.sql
 
     SECRETS="postgres service-account standby"
     echo "---" > gitea-vcs-postgres.manifest


### PR DESCRIPTION
(cherry picked from commit 58d5a5c1c0f952e6d5d9267726cf7cdd54fec83a)

# Description

Backport of https://github.com/Cray-HPE/docs-csm/pull/2708

The failure reported in CASMINST-5544 does not happen in csm-1.2, but that is just due to the fact that the variable is only dereferenced without double quotes. The variable itself still contains the extraneous whitespace. Therefore, it still makes sense to backport this fix so that the variable gets the correct value.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
