### PR TITLE
CASMINST-5545 1.3 to 1.4 Refactor

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -504,6 +504,10 @@ singlemode
 site-routable
 Skopeo
 SLES-based
+SLES-15-SP2
+SLES-15-SP3
+SLES-15-SP4
+SLES-15-SP5
 SLS
 Slurm
 SMNet

--- a/background/ncn_kernel.md
+++ b/background/ncn_kernel.md
@@ -673,22 +673,25 @@ This value sets the `xname` for the node, detailing the geolocation of the node.
 
 ## Versioning
 
-| CSM Release               | Kernel Version            | Kernel Change Rationale  |
-| :------------------------ | :------------------------ | ------------------------ |
-| CSM 0.9.0 (Shasta v1.4.0) | 5.3.18-24.49.2            | Initial                  |
-| CSM 0.9.2 (Shasta v1.4.1) | 5.3.18-24.49.2            |                          |
-| CSM 0.9.3 (Shasta v1.4.2) | 5.3.18-24.49.2            |                          |
-| CSM 0.9.3                 | 5.3.18-24.**75.3**        | Proactive update         |
-| CSM 0.9.4                 | 5.3.18-24.75.3            |                          |
-| CSM 0.9.5                 | 5.3.18-24.75.3            |                          |
-| CSM 0.9.6                 | 5.3.18-24.75.3            |                          |
-| CSM 1.0.0                 | 5.3.18-24.75.3            |                          |
-| CSM 1.0.1 (Shasta v1.5.0) | 5.3.18-24.75.3            |                          |
-| CSM 1.0.10                | 5.3.18-24.75.3            |                          |
-| CSM 1.0.11                | 5.3.18-24.**99.1**        | [`CVE-2021-4034`][21]    |
-| CSM 1.2.0                 | 5.3.18-**150300.59.43.1** | [`CVE-2022-0185`][22]    |
-| CSM 1.2.1                 | 5.3.18-150300.59.43.1     | [`CVE-2022-0185`][22]    |
-| CSM 1.3.0                 | 5.3.18-150300.59.**87.1** | [`CVE-2022-33981`][23]   |
+| CSM Release               | Kernel Version             | Kernel Change Rationale  |
+| :------------------------ | :------------------------- | ------------------------ |
+| CSM 0.9.0 (Shasta v1.4.0) | 5.3.18-24.49.2             | Initial                  |
+| CSM 0.9.2 (Shasta v1.4.1) | 5.3.18-24.49.2             |                          |
+| CSM 0.9.3 (Shasta v1.4.2) | 5.3.18-24.49.2             |                          |
+| CSM 0.9.3                 | 5.3.18-24.**75.3**         | Proactive update         |
+| CSM 0.9.4                 | 5.3.18-24.75.3             |                          |
+| CSM 0.9.5                 | 5.3.18-24.75.3             |                          |
+| CSM 0.9.6                 | 5.3.18-24.75.3             |                          |
+| CSM 1.0.0                 | 5.3.18-24.75.3             |                          |
+| CSM 1.0.1 (Shasta v1.5.0) | 5.3.18-24.75.3             |                          |
+| CSM 1.0.10                | 5.3.18-24.75.3             |                          |
+| CSM 1.0.11                | 5.3.18-24.**99.1**         | [`CVE-2021-4034`][21]    |
+| CSM 1.2.0                 | 5.3.18-**150300.59.43.1**  | [`CVE-2022-0185`][22]    |
+| CSM 1.2.1                 | 5.3.18-150300.59.43.1      | [`CVE-2022-0185`][22]    |
+| CSM 1.2.2                 | 5.3.18-150300.59.43.1      |                          |
+| CSM 1.3.0                 | 5.3.18-150300.59.**87.1**  | [`CVE-2022-33981`][23]   |
+| CSM 1.3.1                 | 5.3.18-150300.59.87.1      |                          |
+| CSM 1.4.0                 | 5.**14.21-150400.24.21.2** | SLES-15-SP4 Upgrade      |
 
 [1]:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/networking_guide/sec-consistent_network_device_naming_using_biosdevname
 [2]:https://github.com/Cray-HPE/dracut-metal-mdsquash/blob/main/README.md#usage

--- a/install/pre-installation.md
+++ b/install/pre-installation.md
@@ -51,7 +51,7 @@ Any steps run on an `external` server require that server to have the following 
    # e.g. an alpha : CSM_RELEASE=1.4.0-alpha.99
    # e.g. an RC    : CSM_RELEASE=1.4.0-rc.1
    # e.g. a stable : CSM_RELEASE=1.4.0  
-   CSM_RELEASE=1.3.0-alpha.9
+   CSM_RELEASE=1.4.0-alpha.9
    ```
 
    ```bash

--- a/operations/package_repository_management/Repair_Yum_Repository_Metadata.md
+++ b/operations/package_repository_management/Repair_Yum_Repository_Metadata.md
@@ -2,7 +2,7 @@
 
 Nexus may have trouble \(re\)generating repository metadata \(for example, repodata/repomd.xml\), especially for larger repositories. Configure the `Repair - Rebuild Yum repository metadata (repodata)` task in Nexus to create the metadata if the standard generation fails. This is not typically needed, which makes it a repair task.
 
-The example in this procedure is for creating a repair task to rebuild Yum metadata for the `mirror-1.3.0-opensuse-leap-15` repository.
+The example in this procedure is for creating a repair task to rebuild Yum metadata for the `mirror-1.4.0-opensuse-leap-15` repository.
 
 See the Nexus documentation on Tasks for more details: [https://help.sonatype.com/repomanager3/system-configuration/tasks](https://help.sonatype.com/repomanager3/system-configuration/tasks)
 
@@ -74,7 +74,7 @@ The system is fully installed.
 
 9.  Track down the name of the repository being repaired.
 
-    In this example, `mirror-1.3.0-opensuse-leap-15` is used.
+    In this example, `mirror-1.4.0-opensuse-leap-15` is used.
 
 10. View the repodata for the repository.
 
@@ -113,18 +113,18 @@ The system is fully installed.
         -rw-r--r-- 1 nexus nexus 1525 Aug 23 01:00 repository.cleanup-20200823010000013.log
         ```
 
-        If multiple repositories are being rebuilt, search the logs for the specific repository to find the latest corresponding log file. The example below is for `mirror-1.3.0-opensuse-leap-15`:
+        If multiple repositories are being rebuilt, search the logs for the specific repository to find the latest corresponding log file. The example below is for `mirror-1.4.0-opensuse-leap-15`:
 
         ```bash
         kubectl -n nexus exec -ti nexus-55d8c77547-65k6q \
-        -c nexus -- grep -R 'Rebuilding yum metadata for repository mirror-1.3.0-opensuse-leap-15' \
+        -c nexus -- grep -R 'Rebuilding yum metadata for repository mirror-1.4.0-opensuse-leap-15' \
         /nexus-data/log/tasks
         ```
 
         Example output:
 
         ```
-        /nexus-data/log/tasks/repository.yum.rebuild.metadata-20200822235306934.log:2020-08-22 23:53:06,936+0000 INFO  [event-12-thread-797]  *SYSTEM org.sonatype.nexus.repository.yum.internal.createrepo.CreateRepoFacetImpl - Rebuilding yum metadata for repository mirror-1.3.0-opensuse-leap-15
+        /nexus-data/log/tasks/repository.yum.rebuild.metadata-20200822235306934.log:2020-08-22 23:53:06,936+0000 INFO  [event-12-thread-797]  *SYSTEM org.sonatype.nexus.repository.yum.internal.createrepo.CreateRepoFacetImpl - Rebuilding yum metadata for repository mirror-1.4.0-opensuse-leap-15
         ```
 
     3.  View the log file for the rebuild.
@@ -142,12 +142,12 @@ The system is fully installed.
         2020-08-22 23:53:06,934+0000 INFO  [quartz-9-thread-20]  *SYSTEM org.sonatype.nexus.repository.yum.internal.createrepo.task.YumCreateRepoTask - Task information:
         2020-08-22 23:53:06,935+0000 INFO  [quartz-9-thread-20]  *SYSTEM org.sonatype.nexus.repository.yum.internal.createrepo.task.YumCreateRepoTask -  ID: 35536bcd-3947-4ba9-8d6d-43dcadbb87ad
         2020-08-22 23:53:06,935+0000 INFO  [quartz-9-thread-20]  *SYSTEM org.sonatype.nexus.repository.yum.internal.createrepo.task.YumCreateRepoTask -  Type: repository.yum.rebuild.metadata
-        2020-08-22 23:53:06,935+0000 INFO  [quartz-9-thread-20]  *SYSTEM org.sonatype.nexus.repository.yum.internal.createrepo.task.YumCreateRepoTask -  Name: Rebuild Yum metadata - mirror-1.3.0-opensuse-leap-15
-        2020-08-22 23:53:06,935+0000 INFO  [quartz-9-thread-20]  *SYSTEM org.sonatype.nexus.repository.yum.internal.createrepo.task.YumCreateRepoTask -  Description: Rebuild metadata for mirror-1.3.0-opensuse-leap-15
+        2020-08-22 23:53:06,935+0000 INFO  [quartz-9-thread-20]  *SYSTEM org.sonatype.nexus.repository.yum.internal.createrepo.task.YumCreateRepoTask -  Name: Rebuild Yum metadata - mirror-1.4.0-opensuse-leap-15
+        2020-08-22 23:53:06,935+0000 INFO  [quartz-9-thread-20]  *SYSTEM org.sonatype.nexus.repository.yum.internal.createrepo.task.YumCreateRepoTask -  Description: Rebuild metadata for mirror-1.4.0-opensuse-leap-15
         2020-08-22 23:53:06,936+0000 INFO  [quartz-9-thread-20]  *SYSTEM org.sonatype.nexus.repository.yum.internal.createrepo.task.YumCreateRepoTask - Task log: /nexus-data/log/tasks/repository.yum.rebuild.metadata-20200822235306934.log
-        2020-08-22 23:53:06,936+0000 INFO  [event-12-thread-797]  *SYSTEM org.sonatype.nexus.repository.yum.internal.createrepo.CreateRepoFacetImpl - Rebuilding yum metadata for repository mirror-1.3.0-opensuse-leap-15
+        2020-08-22 23:53:06,936+0000 INFO  [event-12-thread-797]  *SYSTEM org.sonatype.nexus.repository.yum.internal.createrepo.CreateRepoFacetImpl - Rebuilding yum metadata for repository mirror-1.4.0-opensuse-leap-15
         2020-08-22 23:53:06,936+0000 INFO  [quartz-9-thread-20]  *SYSTEM org.sonatype.nexus.repository.yum.internal.createrepo.task.YumCreateRepoTask - Task complete
-        2020-08-23 00:50:47,468+0000 INFO  [event-12-thread-797]  *SYSTEM org.sonatype.nexus.repository.yum.internal.createrepo.CreateRepoFacetImpl - Finished rebuilding yum metadata for repository mirror-1.3.0-opensuse-leap-15
+        2020-08-23 00:50:47,468+0000 INFO  [event-12-thread-797]  *SYSTEM org.sonatype.nexus.repository.yum.internal.createrepo.CreateRepoFacetImpl - Finished rebuilding yum metadata for repository mirror-1.4.0-opensuse-leap-15
         ```
 
         The returned `Finished rebuilding yum metadata for repository` without any other `ERROR` or `WARN` messages indicates the rebuild has completed successfully.
@@ -160,7 +160,7 @@ The system is fully installed.
 
     ![Repodata Attributes](../../img/operations/Nexus_Repodata_Attributes_After.png "Repodata Attributes")
 
-**Troubleshooting:** When a rebuild fails, expect to see `ERROR` and `WARN` messages around the same time as the `Finished rebuilding yum metadata for repository` message. For example, consider the log from a failed rebuild of `mirror-1.3.0-opensuse-leap-15`:
+**Troubleshooting:** When a rebuild fails, expect to see `ERROR` and `WARN` messages around the same time as the `Finished rebuilding yum metadata for repository` message. For example, consider the log from a failed rebuild of `mirror-1.4.0-opensuse-leap-15`:
 
 ```bash
 kubectl -n nexus exec -ti nexus-55d8c77547-65k6q -c nexus -- \
@@ -173,13 +173,13 @@ Example output:
 2020-08-22 23:12:59,523+0000 INFO  [quartz-9-thread-20]  *SYSTEM org.sonatype.nexus.repository.yum.internal.createrepo.task.YumCreateRepoTask - Task information:
 2020-08-22 23:12:59,526+0000 INFO  [quartz-9-thread-20]  *SYSTEM org.sonatype.nexus.repository.yum.internal.createrepo.task.YumCreateRepoTask -  ID: 35536bcd-3947-4ba9-8d6d-43dcadbb87ad
 2020-08-22 23:12:59,526+0000 INFO  [quartz-9-thread-20]  *SYSTEM org.sonatype.nexus.repository.yum.internal.createrepo.task.YumCreateRepoTask -  Type: repository.yum.rebuild.metadata
-2020-08-22 23:12:59,526+0000 INFO  [quartz-9-thread-20]  *SYSTEM org.sonatype.nexus.repository.yum.internal.createrepo.task.YumCreateRepoTask -  Name: Rebuild Yum metadata - mirror-1.3.0-opensuse-leap-15
-2020-08-22 23:12:59,527+0000 INFO  [quartz-9-thread-20]  *SYSTEM org.sonatype.nexus.repository.yum.internal.createrepo.task.YumCreateRepoTask -  Description: Rebuild metadata for mirror-1.3.0-opensuse-leap-15
+2020-08-22 23:12:59,526+0000 INFO  [quartz-9-thread-20]  *SYSTEM org.sonatype.nexus.repository.yum.internal.createrepo.task.YumCreateRepoTask -  Name: Rebuild Yum metadata - mirror-1.4.0-opensuse-leap-15
+2020-08-22 23:12:59,527+0000 INFO  [quartz-9-thread-20]  *SYSTEM org.sonatype.nexus.repository.yum.internal.createrepo.task.YumCreateRepoTask -  Description: Rebuild metadata for mirror-1.4.0-opensuse-leap-15
 2020-08-22 23:12:59,529+0000 INFO  [quartz-9-thread-20]  *SYSTEM org.sonatype.nexus.repository.yum.internal.createrepo.task.YumCreateRepoTask - Task log: /nexus-data/log/tasks/repository.yum.rebuild.metadata-20200822231259523.log
-2020-08-22 23:12:59,529+0000 INFO  [event-12-thread-780]  *SYSTEM org.sonatype.nexus.repository.yum.internal.createrepo.CreateRepoFacetImpl - Rebuilding yum metadata for repository mirror-1.3.0-opensuse-leap-15
+2020-08-22 23:12:59,529+0000 INFO  [event-12-thread-780]  *SYSTEM org.sonatype.nexus.repository.yum.internal.createrepo.CreateRepoFacetImpl - Rebuilding yum metadata for repository mirror-1.4.0-opensuse-leap-15
 2020-08-22 23:12:59,531+0000 INFO  [quartz-9-thread-20]  *SYSTEM org.sonatype.nexus.repository.yum.internal.createrepo.task.YumCreateRepoTask - Task complete
 2020-08-22 23:24:16,974+0000 INFO  [Thread-1948 <command>sql.select from asset where (component IS NOT NULL  AND attributes.yum.asset_kind = :p0) and (bucket=#59:1)</command>]  *SYSTEM com.orientechnologies.common.profiler.OProfilerStub - $ANSI{green {db=component}} [TIP] Query 'SELECT FROM asset WHERE (component IS NOT NULL AND attributes.yum.asset_kind = "RPM" ) AND (bucket = #59:1 )' returned a result set with more than 10000 records. Check if you really need all these records, or reduce the resultset by using a LIMIT to improve both performance and used RAM
-2020-08-22 23:29:57,700+0000 INFO  [event-12-thread-780]  *SYSTEM org.sonatype.nexus.repository.yum.internal.createrepo.CreateRepoFacetImpl - Finished rebuilding yum metadata for repository mirror-1.3.0-opensuse-leap-15
+2020-08-22 23:29:57,700+0000 INFO  [event-12-thread-780]  *SYSTEM org.sonatype.nexus.repository.yum.internal.createrepo.CreateRepoFacetImpl - Finished rebuilding yum metadata for repository mirror-1.4.0-opensuse-leap-15
 2020-08-22 23:29:57,701+0000 ERROR [event-12-thread-780]  *SYSTEM com.google.common.eventbus.EventBus.nexus.async - Could not dispatch event org.sonatype.nexus.repository.yum.internal.createrepo.YumMetadataInvalidationEvent@75b487e7 to subscriber org.sonatype.nexus.repository.yum.internal.createrepo.CreateRepoFacetImpl$$EnhancerByGuice$$9db995@93053b8 method [public void org.sonatype.nexus.repository.yum.internal.createrepo.CreateRepoFacetImpl.on(org.sonatype.nexus.repository.yum.internal.createrepo.YumMetadataInvalidationEvent)]
 org.sonatype.nexus.repository.InvalidContentException: Invalid RPM: external/noarch/redeclipse-data-1.5.6-lp151.2.5.noarch.rpm
     at org.sonatype.nexus.repository.yum.internal.rpm.YumRpmParser.parse(YumRpmParser.java:108)

--- a/upgrade/Stage_0_Prerequisites.md
+++ b/upgrade/Stage_0_Prerequisites.md
@@ -2,7 +2,7 @@
 
 > **Reminders:**
 >
-> - CSM 1.2.0 or higher is required in order to upgrade to CSM 1.3.0.
+> - CSM 1.3.0 or higher is required in order to upgrade to CSM 1.4.0.
 > - If any problems are encountered and the procedure or command output does not provide relevant guidance, see
 >   [Relevant troubleshooting links for upgrade-related issues](Upgrade_Management_Nodes_and_CSM_Services.md#relevant-troubleshooting-links-for-upgrade-related-issues).
 
@@ -40,7 +40,7 @@ after a break, always be sure that a typescript is running before proceeding.
 1. (`ncn-m001#`) Set the `CSM_RELEASE` variable to the **target** CSM version of this upgrade.
 
    ```bash
-   CSM_RELEASE=1.3.0
+   CSM_RELEASE=1.4.0
    CSM_REL_NAME=csm-${CSM_RELEASE}
    ```
 
@@ -51,7 +51,7 @@ after a break, always be sure that a typescript is running before proceeding.
       > **Important:** The upgrade scripts expect the `docs-csm` RPM to be located at `/root/docs-csm-latest.noarch.rpm`; that is why these commands copy it there.
 
       ```bash
-      wget https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/docs-csm/1.3/noarch/docs-csm-latest.noarch.rpm \
+      wget https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/docs-csm/1.4/noarch/docs-csm-latest.noarch.rpm \
           -O /root/docs-csm-latest.noarch.rpm &&
       rpm -Uvh --force /root/docs-csm-latest.noarch.rpm
       ```

--- a/upgrade/Stage_1.md
+++ b/upgrade/Stage_1.md
@@ -5,7 +5,6 @@
 
 - [Stage 1 - Ceph image upgrade](#stage-1---ceph-image-upgrade)
   - [Start typescript](#start-typescript)
-  - [Apply boot order workaround](#apply-boot-order-workaround)
   - [Argo workflows](#argo-workflows)
   - [CSM Upgrade requirement for upgrades staying within a CSM release version](#csm-upgrade-requirement-for-upgrades-staying-within-a-csm-release-version)
   - [Storage node image upgrade](#storage-node-image-upgrade)
@@ -26,14 +25,6 @@
 
 If additional shells are opened during this procedure, then record those with typescripts as well. When resuming a procedure
 after a break, always be sure that a typescript is running before proceeding.
-
-## Apply boot order workaround
-
-(`ncn-m001#`) Apply a workaround for the boot order:
-
-```bash
-/usr/share/doc/csm/scripts/workarounds/boot-order/run.sh
-```
 
 ## Argo workflows
 

--- a/upgrade/Stage_1.md
+++ b/upgrade/Stage_1.md
@@ -37,7 +37,7 @@ For more information, see [Using the Argo UI](../operations/argo/Using_the_Argo_
 
 **IMPORTANT:**
 
-> If the upgrade is staying with a CSM release, e.g. `CSM-1.3.0-rc1` to `CSM-1.3.0-rc2`, then you will need to run the following to point the Ceph cluster to use the Ceph container image stored in Nexus.
+> If the upgrade is staying with a CSM release, e.g. `CSM-1.4.0-rc1` to `CSM-1.4.0-rc2`, then you will need to run the following to point the Ceph cluster to use the Ceph container image stored in Nexus.
 > The issue stems from slightly different `sha` values for the Ceph containers for in-family CSM storage node images which will prevent the Ceph containers from starting.
 > This will utilize the upgrade procedure to accomplish this as it has built in checks and health monitoring to better manage this rolling restart of the Ceph containers with the image stored in Nexus.  Please see [cubs_tool usage for further information](../operations/utility_storage/Cubs_tool_Usage.md)
 

--- a/upgrade/Stage_1.md
+++ b/upgrade/Stage_1.md
@@ -39,7 +39,7 @@ For more information, see [Using the Argo UI](../operations/argo/Using_the_Argo_
 
 > If the upgrade is staying with a CSM release, e.g. `CSM-1.4.0-rc1` to `CSM-1.4.0-rc2`, then you will need to run the following to point the Ceph cluster to use the Ceph container image stored in Nexus.
 > The issue stems from slightly different `sha` values for the Ceph containers for in-family CSM storage node images which will prevent the Ceph containers from starting.
-> This will utilize the upgrade procedure to accomplish this as it has built in checks and health monitoring to better manage this rolling restart of the Ceph containers with the image stored in Nexus.  Please see [cubs_tool usage for further information](../operations/utility_storage/Cubs_tool_Usage.md)
+> This will utilize the upgrade procedure to accomplish this as it has built in checks and health monitoring to better manage this rolling restart of the Ceph containers with the image stored in Nexus.  Please see [`cubs_tool` usage for further information](../operations/utility_storage/Cubs_tool_Usage.md)
 
 (`ncn-s001#`) In family upgrade to a new container with the same Ceph version:
 
@@ -65,8 +65,8 @@ It is possible to upgrade a single storage node at a time using the following co
 >**Storage node image upgrade troubleshooting**
 >
 > - The best troubleshooting tool for this stage is the Argo UI. Information about accessing this UI and about using Argo Workflows is above.
-> - If the upgrade is 'waiting for ceph HEALTH_OK', the output from commands `ceph -s` and `ceph health detail` should provide information.
-> - If a crash has occurred, [dumping the ceph crash data](../operations/utility_storage/Dump_Ceph_Crash_Data.md) will return Ceph to healthy state and allow the upgrade to continue.
+> - If the upgrade is 'waiting for Ceph `HEALTH_OK`', the output from commands `ceph -s` and `ceph health detail` should provide information.
+> - If a crash has occurred, [dumping the Ceph crash data](../operations/utility_storage/Dump_Ceph_Crash_Data.md) will return Ceph to healthy state and allow the upgrade to continue.
 >   The crash should be evaluated to determine if there is an issue that should be addressed.
 > - Refer to [storage troubleshooting documentation](../operations/utility_storage/Utility_Storage.md#storage-troubleshooting-references) for Ceph related issues.
 

--- a/upgrade/Upgrade_Management_Nodes_and_CSM_Services.md
+++ b/upgrade/Upgrade_Management_Nodes_and_CSM_Services.md
@@ -1,8 +1,8 @@
-# CSM 1.2.0 or later to 1.3.0 Upgrade Process
+# CSM 1.3.0 or later to 1.4.0 Upgrade Process
 
 ## Introduction
 
-This document guides an administrator through the upgrade of Cray Systems Management from v1.0 to v1.2. When upgrading a system, follow this top-level file
+This document guides an administrator through the upgrade of Cray Systems Management from v1.3 to v1.4. When upgrading a system, follow this top-level file
 from top to bottom. The content on this top-level page is meant to be terse. For additional reference material on the upgrade processes and scripts
 mentioned explicitly on this page, see [resource material](resource_material/README.md).
 

--- a/upgrade/scripts/upgrade/prepare-assets.sh
+++ b/upgrade/scripts/upgrade/prepare-assets.sh
@@ -90,7 +90,7 @@ if [[ -z ${TARBALL_FILE} ]]; then
 
     if [[ -z ${ENDPOINT} ]]; then
         # default endpoint to internal artifactory
-        ENDPOINT=https://artifactory.algol60.net/artifactory/csm-releases/csm/1.3/
+        ENDPOINT=https://artifactory.algol60.net/artifactory/csm-releases/csm/1.4/
         echo "Use internal endpoint: ${ENDPOINT}"
     fi
 


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
This refactors all references with exception to a few (see exceptions below) of 1.3 and 1.3.0 to 1.4 and 1.4.0 (respectively). This also removes the boot-order workaround from the upgrade directions as it is already fixed, upgrades from 1.3 already have the fix in their 1.3 images and the fix also exists in the 1.4 images being upgraded to.

Exceptions:
- BOS/BOA references to cle-1.3.0 were left alone
- `canu` references to 1.3 were left alone, since `canu` does not support `1.4` CSM switch configs yet


# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
