### PR TITLE
CASMPET-6031 Document encryption should be off during an upgrade

### DIFF
--- a/operations/kubernetes/encryption/README.md
+++ b/operations/kubernetes/encryption/README.md
@@ -25,7 +25,7 @@ The current implementation has a known limitation in regards to upgrades. While 
 boot and operational issues it is recommended to disable encryption prior to any upgrades. Failure to disable encryption will cause each control plane node to fail
 to complete `cloud-init` as the default Kubernetes configuration lacks the necessary keys to decrypt etcd data.
 
-Once upgraded you may re-enable encryption
+Once upgraded, encryption can be re-enabled.
 
 ## Implementation details
 
@@ -250,7 +250,7 @@ All subsequent ciphers provided allow for any secrets encrypted with that cipher
 
 * (`ncn-m#`) The `encryption.sh` script needs to be run with the new key as the first switch and the existing key as a subsequent switch.
 
-    As shown in the following command example, always run `encryption.sh` with a leading space on the command line. This will cause Bash to not record the command in the `.bash_history` file.
+    **`NOTE`**: As shown in the following command example, always run `encryption.sh` with a leading space on the command line. This will cause Bash to not record the command in the `.bash_history` file.
 
     ```bash
      /usr/share/doc/csm/scripts/operations/kubernetes/encryption.sh --enable --aescbc NEWKEYVALUE --aescbc EXISTINGKEYVALUE
@@ -262,12 +262,12 @@ All subsequent ciphers provided allow for any secrets encrypted with that cipher
     ncn-m001 configuration updated ensure all control plane nodes run this same command
     ```
 
-Once completed, reference Encryption status for details, you may optionally remove the old key from all control plane nodes. Note that removing the old key will mean you will be unable to
-use etcd backups that contain data with that encryption key.
+Once completed, reference the Encryption status for details. Optionally, the old key can be removed from all control plane nodes. Note that removing the old key will make
+the etcd backups that contain data with that encryption key unusable.
 
 * (`ncn-m#`) The `encryption.sh` script needs to be run again with just the new key.
 
-    As shown in the following command example, always run `encryption.sh` with a leading space on the command line. This will cause Bash to not record the command in the `.bash_history` file.
+    **`NOTE`**: As shown in the following command example, always run `encryption.sh` with a leading space on the command line. This will cause Bash to not record the command in the `.bash_history` file.
 
     ```bash
      /usr/share/doc/csm/scripts/operations/kubernetes/encryption.sh --enable --aescbc NEWKEYVALUE

--- a/operations/kubernetes/encryption/README.md
+++ b/operations/kubernetes/encryption/README.md
@@ -10,12 +10,22 @@ Note that control plane is used in this document elsewhere master or management 
 
 ## Table of contents
 
+* [Upgrade limitation](#upgrade-limitation)
 * [Implementation details](#implementation-details)
 * [Setup](#setup)
 * [Enabling encryption](#enabling-encryption)
 * [Disabling encryption](#disabling-encryption)
 * [Encryption status](#encryption-status)
 * [Force rewrite](#force-rewrite)
+* [Key rotation](#key-rotation)
+
+## Upgrade limitation
+
+The current implementation has a known limitation in regards to upgrades. While it is technically feasible to upgrade a cluster with encryption enabled, to minimize
+boot and operational issues it is recommended to disable encryption prior to any upgrades. Failure to disable encryption will cause each control plane node to fail
+to complete `cloud-init` as the default Kubernetes configuration lacks the necessary keys to decrypt etcd data.
+
+Once upgraded you may re-enable encryption
 
 ## Implementation details
 
@@ -230,4 +240,41 @@ If necessary, a forced rewrite of secret data can be performed. Generally unnece
     Waiting for daemon set "cray-k8s-encryption" rollout to finish: 2 out of 3 new pods have been updated...
     Waiting for daemon set "cray-k8s-encryption" rollout to finish: 2 of 3 updated pods are available...
     daemon set "cray-k8s-encryption" successfully rolled out
+    ```
+
+## Key rotation
+
+Rotation of the encryption keys is similar to disabling encryption. The first cipher passed to `encryption.sh` is the cipher that will be used to encrypt secrets.
+
+All subsequent ciphers provided allow for any secrets encrypted with that cipher to be read but will not be used for new secrets.
+
+* (`ncn-m#`) The `encryption.sh` script needs to be run with the new key as the first switch and the existing key as a subsequent switch.
+
+    As shown in the following command example, always run `encryption.sh` with a leading space on the command line. This will cause Bash to not record the command in the `.bash_history` file.
+
+    ```bash
+     /usr/share/doc/csm/scripts/operations/kubernetes/encryption.sh --enable --aescbc NEWKEYVALUE --aescbc EXISTINGKEYVALUE
+    ```
+
+    Example output:
+
+    ```text
+    ncn-m001 configuration updated ensure all control plane nodes run this same command
+    ```
+
+Once completed, reference Encryption status for details, you may optionally remove the old key from all control plane nodes. Note that removing the old key will mean you will be unable to
+use etcd backups that contain data with that encryption key.
+
+* (`ncn-m#`) The `encryption.sh` script needs to be run again with just the new key.
+
+    As shown in the following command example, always run `encryption.sh` with a leading space on the command line. This will cause Bash to not record the command in the `.bash_history` file.
+
+    ```bash
+     /usr/share/doc/csm/scripts/operations/kubernetes/encryption.sh --enable --aescbc NEWKEYVALUE
+    ```
+
+    Example output:
+
+    ```text
+    ncn-m001 configuration updated ensure all control plane nodes run this same command
     ```

--- a/upgrade/prepare_for_upgrade.md
+++ b/upgrade/prepare_for_upgrade.md
@@ -20,6 +20,14 @@ there may be a degraded system. For example, if there are three Kubernetes maste
 maintained by the remaining two nodes. If one of those two nodes has a fault before the third node completes its upgrade,
 then quorum would be lost.
 
+## Disable encryption for upgrade if enabled
+
+While it is possible to upgrade with Kubernetes encryption enabled, we recommend disabling encryption for the duration of the upgrade if it has been enabled.
+
+Reference the [Kubernetes Encryption](../operations/kubernetes/encryption/README.md) for details.
+
+Once the upgrade is complete encryption can be turned back on.
+
 ## Start typescript
 
 1. (`ncn-m001#`) If a typescript session is already running in the shell, then first stop it with the `exit` command.

--- a/upgrade/prepare_for_upgrade.md
+++ b/upgrade/prepare_for_upgrade.md
@@ -22,7 +22,7 @@ then quorum would be lost.
 
 ## Disable encryption for upgrade if enabled
 
-While it is possible to upgrade with Kubernetes encryption enabled, we recommend disabling encryption for the duration of the upgrade if it has been enabled.
+While it is possible to upgrade with Kubernetes encryption enabled, disabling encryption is recommended for the duration of the upgrade if it has been enabled.
 
 Reference the [Kubernetes Encryption](../operations/kubernetes/encryption/README.md) for details.
 


### PR DESCRIPTION
# Description

Document and note that upgrades should be done with encryption off for 1.3.

While here note how to rotate encryption keys.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
