### PR TITLE
CASMINST-5552 Enable boot-order WAR for Upgrades from 1.0.X

### DIFF
--- a/scripts/workarounds/boot-order/lib.sh
+++ b/scripts/workarounds/boot-order/lib.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+function mprint {
+    printf '[% -25s] %s\n' "$0" "$1"
+}

--- a/scripts/workarounds/boot-order/run.sh
+++ b/scripts/workarounds/boot-order/run.sh
@@ -55,6 +55,8 @@ done
 for ncn in "${NCNS[@]}"; do
     printf "Uploading new metal-lib.sh to $ncn:/srv/cray/scripts/metal/ ... "
     scp ${workdir}/metal-lib.sh ${ncn}:/srv/cray/scripts/metal/metal-lib.sh >/dev/null
+    printf "Uploading lib.sh to $ncn:/srv/cray/scripts/common/ ... "
+    scp ${workdir}/lib.sh ${ncn}:/srv/cray/scripts/common/lib.sh >/dev/null
     echo "Done" 
 done
 


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
Systems upgrading from CSM 1.0.X to 1.2.2+ do not have the `lib.sh` dependency needed by the WAR `metal-lib.sh` library. This adds that dependency, enabling the WAR to be ran on CSM 1.0.X images.

When this WAR was originally added, it was intended to run on CSM 1.2.0 or CSM 1.2.1 systems upgrading to CSM 1.2.2 - CSM 1.2.X images include `lib.sh`, whereas CSM 1.0.X images do not have this file.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
