### PR TITLE
CASMTRIAGE-4427 - Moved Upload of BMC Recovery images

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -162,22 +162,30 @@ types include Slack, Pager Duty, email, or a custom integration via a generic we
 See [Configure Prometheus Email Alert Notifications](../operations/system_management_health/Configure_Prometheus_Email_Alert_Notifications.md) for an example
 configuration of an email alert notification for the Postgres replication alerts that are defined on the system.
 
-### 8. Update firmware with FAS
+### 8. Upload Olympus BMC recovery firmware into TFTP server
+
+> **IMPORTANT:**
+> Before Firmware can be updated the HPC Firmware Pack (HFP) must be installed  refer to the
+> [HPE Cray EX System Software Getting Started Guide S-8000](https://www.hpe.com/support/ex-S-8000)
+> on the HPE Customer Support Center for more information about how to install
+> the HPE Cray EX HPC Firmware Pack (HFP) product.
+
+The Olympus hardware needs to have recovery firmware loaded to the `cray-tftp` server in case the BMC loses its firmware.
+The BMCs are configured to load a recovery firmware from a TFTP server.
+This procedure does not modify any BMC firmware, but only stages the firmware on the TFTP server for download in the event it is needed.
+
+See [Load Olympus BMC Recovery Firmware into TFTP server](../operations/firmware/Upload_Olympus_BMC_Recovery_Firmware_into_TFTP_Server.md).
+
+## 9. Update firmware with FAS
 
 Now that all management nodes and CSM services have been validated as healthy, the firmware on other
 components in the system can be checked and updated. The Firmware Action Service (FAS) communicates
 with many devices on the system. FAS can be used to update the firmware for all of the devices it
 communicates with at once, or specific devices can be targeted for a firmware update.
 
-> **IMPORTANT:**
-> Before FAS can be used to update firmware, refer to the
-> [HPE Cray EX System Software Getting Started Guide S-8000](https://www.hpe.com/support/ex-S-8000)
-> on the HPE Customer Support Center for more information about how to install
-> the HPE Cray EX HPC Firmware Pack (HFP) product. The installation of HFP will inform FAS of the newest firmware
-> available. Once FAS is aware that new firmware is available, then see
-> [Update Firmware with FAS](../operations/firmware/Update_Firmware_with_FAS.md).
+See [Update Firmware with FAS](../operations/firmware/Update_Firmware_with_FAS.md)
 
-### 9. Prepare compute nodes
+### 10. Prepare compute nodes
 
 After completion of the firmware update with FAS, compute nodes can be prepared. Some compute node
 types have special preparation steps, but most compute nodes are ready to be used now.
@@ -189,7 +197,7 @@ These compute node types require preparation:
 
 See [Prepare Compute Nodes](prepare_compute_nodes.md).
 
-### 10. Next topic
+### 11. Next topic
 
 After completion of the firmware update with FAS and the preparation of compute nodes, the CSM product stream has
 been fully installed and configured.
@@ -205,7 +213,7 @@ for additional information on system hardware, troubleshooting, and administrati
 
 See [Troubleshooting Installation Problems](troubleshooting_installation.md).
 
-### 11. Kubernetes encryption
+### 12. Kubernetes encryption
 
 As an optional post installation task, encryption of Kubernetes secrets may be enabled. This enables
 at rest encryption of data in the `etcd` database used by Kubernetes.

--- a/install/README.md
+++ b/install/README.md
@@ -39,12 +39,13 @@ shown here with numbered topics.
     1. [Configure administrative access](#5-configure-administrative-access)
     1. [Validate CSM health](#6-validate-csm-health)
     1. [Configure Prometheus alert notifications](#7-configure-prometheus-alert-notifications)
-    1. [Update firmware with FAS](#8-update-firmware-with-fas)
-    1. [Prepare compute nodes](#9-prepare-compute-nodes)
-    1. [Next topic](#10-next-topic)
+    1. [Upload Olympus BMC recovery firmware into TFTP server](#8-upload-olympus-bmc-recovery-firmware-into-tftp-server)
+    1. [Update firmware with FAS](#9-update-firmware-with-fas)
+    1. [Prepare compute nodes](#10-prepare-compute-nodes)
+    1. [Next topic](#11-next-topic)
     - [Troubleshooting installation problems](#troubleshooting-installation-problems)
 1. [Post-installation](#post-installation)
-    1. [Kubernetes encryption](#11-encryption)
+    1. [Kubernetes encryption](#12-encryption)
 
 > **`NOTE`** If problems are encountered during the installation,
 > [Troubleshooting installation problems](#troubleshooting-installation-problems) and

--- a/install/configure_administrative_access.md
+++ b/install/configure_administrative_access.md
@@ -111,18 +111,7 @@ CSM provide one or more layers of configuration in a process called "NCN persona
 
 See [Configure Non-Compute Nodes with CFS](../operations/CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md).
 
-## 6. Upload Olympus BMC recovery firmware into TFTP server
-
-> **`NOTE`** This step requires the CSM software, Cray CLI, and HPC Firmware Pack (HFP) to be installed.
-> If these are not currently installed, then skip this step and perform it later.
-
-The Olympus hardware needs to have recovery firmware loaded to the `cray-tftp` server in case the BMC loses its firmware.
-The BMCs are configured to load a recovery firmware from a TFTP server.
-This procedure does not modify any BMC firmware, but only stages the firmware on the TFTP server for download in the event it is needed.
-
-See [Load Olympus BMC Recovery Firmware into TFTP server](../operations/firmware/Upload_Olympus_BMC_Recovery_Firmware_into_TFTP_Server.md).
-
-## 7. Proceed to next topic
+## 6. Proceed to next topic
 
 After completing the operational procedures above which configure administrative access, the next step is to validate the health of management nodes and CSM services.
 

--- a/install/configure_administrative_access.md
+++ b/install/configure_administrative_access.md
@@ -14,8 +14,7 @@ BMC/controller passwords.
 1. [Lock management nodes](#3-lock-management-nodes)
 1. [Configure BMC and controller parameters with SCSD](#4-configure-bmc-and-controller-parameters-with-scsd)
 1. [Configure non-compute nodes with CFS](#5-configure-non-compute-nodes-with-cfs)
-1. [Upload Olympus BMC recovery firmware into TFTP server](#6-upload-olympus-bmc-recovery-firmware-into-tftp-server)
-1. [Proceed to next topic](#7-proceed-to-next-topic)
+1. [Proceed to next topic](#6-proceed-to-next-topic)
 
 > **`NOTE`** The procedures in this section of installation documentation are intended to be done in order, even though the topics are
 > administrative or operational procedures. The topics themselves do not have navigational links to the next topic in the sequence.

--- a/operations/firmware/Update_Firmware_with_FAS.md
+++ b/operations/firmware/Update_Firmware_with_FAS.md
@@ -4,7 +4,7 @@ If FAS has not yet been installed, firmware for NCNs can be updated manually wit
 
 The Firmware Action Service (FAS) provides an interface for managing firmware versions of Redfish-enabled hardware in the system. FAS interacts with the Hardware State Managers (HSM), device data, and image data in order to update firmware.
 
-Reset Gigabyte node BMC to factory defaults if having problems with `ipmitool`, problems using Redfish, or when flashing procedures fail.
+Gigabyte nodes that are having issues with `ipmitool`, Redfish, or flashing firmware may need to be reset to factory defaults.
 See [Set Gigabyte Node BMC to Factory Defaults](../../operations/node_management/Set_Gigabyte_Node_BMC_to_Factory_Defaults.md).
 
 FAS images contain the following information that is needed for a hardware device to update firmware versions:
@@ -59,7 +59,7 @@ Table 1. Upgradable Firmware Items
 | Cray             | `chassisBMC` | `BMC`, `Recovery`                                                                   |
 | Cray             | `routerBMC`  | `BMC`, `Recovery`                                                                   |
 | Gigabyte         | `nodeBMC`    | `BMC`, `BIOS`                                                                       |
-| HPE              | `nodeBMC`    | `iLO 5` (`BMC` or `1` ), `System ROM` ,`Redundant System ROM` (`BIOS` or `2`)       |
+| HPE              | `nodeBMC`    | `iLO 5`, `System ROM` ,`Redundant System ROM`                                       |
 
 ## Order of operations
 


### PR DESCRIPTION
# Description

Move the section on Uploading Olympus BMC Recovery Firmware into TFTP Server to after HFP has been loaded on the system.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
