### PR TITLE
CASMINST-5366 Add reference to SNMP configuration to `validate_csm_health.md`

### DIFF
--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -340,6 +340,7 @@ If it was determined that the mismatch can not be ignored, then proceed onto the
 
 Known issues that may prevent hardware from getting discovered by Hardware State Manager:
 
+- Switches with river cabinets require SNMP to be enabled for discovery to work. For configuring SNMP, see [Configure SNMP](./network/management_network/configure_snmp.md)
 - [HMS Discovery job not creating Redfish Endpoints in Hardware State Manager](../troubleshooting/known_issues/discovery_job_not_creating_redfish_endpoints.md)
 
 ## 3 Software Management Services (SMS) health checks


### PR DESCRIPTION
# Description

This adds a reference to SNMP configuration documentation in validate_csm_health.md for troubleshooting river discovery issues.

# Checklist Before Merging

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
