### PR TITLE
Remove Redundant LiveCD Definition

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -31,8 +31,6 @@ Glossary of terms used in CSM documentation.
 * [Heartbeat Tracker Daemon (HBTD)](#heartbeat-tracker-daemon-hbtd)
 * [High Speed Network (HSN)](#high-speed-network-hsn)
 * [Image Management Service (IMS)](#image-management-service-ims)
-* [Kubernetes NCNs](#kubernetes-ncns)
-* [Management Cabinet](#management-cabinet)
 * [Management Nodes](#management-nodes)
 * [Mountain Endpoint Discovery Service (MEDS)](#mountain-endpoint-discovery-service-meds)
 * [NIC Mezzanine Card (NMC)](#nic-mezzanine-card-nmc)
@@ -298,28 +296,16 @@ It tracks changes in heartbeats and conveys changes to HSM.
 
 The High Speed Network (HSN) in an HPE Cray EX system is based on the Slingshot switches.
 
-## Kubernetes NCNs
-
-The Kubernetes NCNs are the management nodes which are known as Kubernetes master nodes
-(`ncn-mXXX`) or Kubernetes worker nodes (`ncn-wXXX`). The only type of management node which is
-excluded from this is the utility storage node (`ncn-sXXX`).
-
-## Management Cabinet
-
-At least one 19 inch IEA management cabinet is required for every HPE Cray EX system to
-support the management non-compute nodes (NCN), system management network, utility
-storage, and other support equipment. This cabinet serves as the primary customer access
-point for managing the system.
-
 ## Management Nodes
 
-The management nodes are one grouping of NCNs. The management nodes include the master nodes
-with hostnames of the form of `ncn-mXXX`, the worker nodes with hostnames of the form `ncn-wXXX`,
-and utility storage nodes, with hostnames of the form `ncn-sXXX`, where the `XXX` is a three
-digit number starting with zero padding. The utility storage nodes provide Ceph storage for use
-by the management nodes. The master nodes provide Kubernetes master functions and have the
-etcd cluster which provides a datastore for Kubernetes. The worker nodes provide Kubernetes
-worker functions where most of the containerized workload is scheduled by Kubernetes.
+The management nodes refer to [non-compute nodes (NCNs)](#non-compute-node-ncn). Management nodes
+provide containerization services as well as storage classes.
+
+The management nodes have various roles:
+
+- masters nodes are Kubernetes masters 
+- worker nodes are Kubernetes workers and have physical connections to the [high-speed network](#high-speed-network-hsn)
+- storage nodes physically have more local storage for providing storage classes to Kubernetes
 
 ## Mountain Cabinet
 
@@ -355,8 +341,8 @@ general access to management REST APIs.
 
 ## Non-Compute Node (NCN)
 
-Any node which is not a compute node may be called a Non-Compute Node (NCN). The NCNs include
-management nodes and application nodes.
+The non-compute nodes are in the management-plane, these nodes serve infrastructure for microservices
+(e.g. Kubernetes and storage classes).
 
 ## Olympus Cabinet
 
@@ -376,12 +362,14 @@ not connect to the SMNet.
 
 ## Pre-Install Toolkit (PIT)
 
-The Pre-Install Toolkit (PIT) provides a framework for bare-metal discovery, recovery, and for starting a [CSM](#cray-system-management-csm) installation.
-The PIT can be used on any node in the system for recovery, for installations and bare-metal discovery it is commonly
-used from a node that has a site-link (such as a Kubernetes master).
+The Pre-Install Toolkit (PIT), also known as the *Cray Pre-Install Toolkit"*, provides a framework installing [Cray Systems Management](#cray-system-management-csm).
+The PIT can be used on any node in the system for recovery and bare-metal discovery, the PIT includes tooling
+for recovering any [non-compute nodes](#non-compute-node-ncn), and can remotely recover other [NCNs](#non-compute-node-ncn).
 
-Typically, the first Kubernetes master (`ncn-m001`) is chosen for running the PIT during a [CSM](#cray-system-management-csm) installation. After [CSM](#cray-system-management-csm) is installed,
-the node running the PIT will be rebooted and deployed via [CSM](#cray-system-management-csm) services before finally joining the running Kubernetes cluster.
+Regarding [CSM](#cray-system-management-csm) installations, typically the first Kubernetes master (`ncn-m001`) is chosen for
+running the PIT during a [CSM](#cray-system-management-csm) installation. After [CSM](#cray-system-management-csm) is installed,
+the node running the PIT will be rebooted and deployed via [CSM](#cray-system-management-csm) services before finally joining
+the running Kubernetes cluster.
 
 The PIT is delivered as a [LiveCD](#livecd), a disk image that can be used to remotely boot a node (e.g. a [RemoteISO](#remoteiso)) or by a USB stick.
 
@@ -412,9 +400,9 @@ Redfish, such as a ServerTech PDU in a River Cabinet.
 ## River Cabinet
 
 At least one 19 inch IEA management cabinet is required for every HPE Cray EX system to
-support the management non-compute nodes (NCN), system management network, utility
-storage, and other support equipment. Additional River cabinets may be included to
-house storage storage or compute nodes which are not in an Olympus liquid-cooled cabinet.
+support the [management nodes](#management-nodes), system management network, utility
+storage, and other support equipment. This cabinet serves as the primary customer access
+point for managing the system.
 
 ## River Endpoint Discovery Service (REDS)
 

--- a/glossary.md
+++ b/glossary.md
@@ -32,7 +32,6 @@ Glossary of terms used in CSM documentation.
 * [High Speed Network (HSN)](#high-speed-network-hsn)
 * [Image Management Service (IMS)](#image-management-service-ims)
 * [Kubernetes NCNs](#kubernetes-ncns)
-* [LiveCD](#livecd)
 * [Management Cabinet](#management-cabinet)
 * [Management Nodes](#management-nodes)
 * [Mountain Endpoint Discovery Service (MEDS)](#mountain-endpoint-discovery-service-meds)
@@ -43,6 +42,8 @@ Glossary of terms used in CSM documentation.
 * [Olympus Cabinet](#olympus-cabinet)
 * [Power Distribution Unit (PDU)](#power-distribution-unit-pdu)
 * [Pre-Install Toolkit (PIT) node](#pre-install-toolkit-pit)
+  * [LiveCD](#livecd)
+  * [RemoteISO](#remoteiso)
 * [Rack-Mounted CDU](#rack-mounted-cdu)
 * [Rack System Compute Cabinet](#rack-system-compute-cabinet)
 * [Redfish Translation Service (RTS)](#redfish-translation-service-rts)
@@ -303,13 +304,6 @@ The Kubernetes NCNs are the management nodes which are known as Kubernetes maste
 (`ncn-mXXX`) or Kubernetes worker nodes (`ncn-wXXX`). The only type of management node which is
 excluded from this is the utility storage node (`ncn-sXXX`).
 
-## LiveCD
-
-The LiveCD has a complete bootable Linux operating system that can be run from a read-only CD or
-DVD, a writable USB flash drive, or a hard disk. It is used to bootstrap the installation
-process for CSM software. It contains the Pre-Install Toolkit (PIT). The node which boots
-from it during the install is known as the [PIT node](#pre-install-toolkit-pit).
-
 ## Management Cabinet
 
 At least one 19 inch IEA management cabinet is required for every HPE Cray EX system to
@@ -382,21 +376,22 @@ not connect to the SMNet.
 
 ## Pre-Install Toolkit (PIT)
 
-The Pre-Install Toolkit is installed onto the initial node used as the inception node during software
-installation which is booted from a [LiveCD](#livecd). This is the node that will eventually become `ncn-m001`.
-The node running the Pre-Install Toolkit is known as the PIT node during the installation process
-until it reboots from a normal management node image like the other master nodes.
+The Pre-Install Toolkit (PIT) provides a framework for bare-metal discovery, recovery, and for starting a CSM installation.
+The PIT can be used on any node in the system for recovery, for installations and bare-metal discovery it is commonly
+used from a node that has a site-link (such as a Kubernetes master).
 
-Early in the install process, before the Pre-Install Toolkit has been installed or booted, the
-documents may still refer to the PIT node. In this case, they are referring to the node which
-will eventually become the PIT node.
+Typically the first Kubernetes master (`ncn-m001`) is chosen for running the PIT during a CSM installation. After CSM is installed,
+the node running the PIT will be rebooted and deployed via CSM services before finally joining the running Kubernetes cluster.
 
-In this documentation, PIT node, RemoteISO, and LiveCD are sometimes used interchangeably to refer to various contexts:
+The PIT is ephemeral, it runs in either in memory or it can be written to a USB stick for persistence.
 
-* The pre-install-toolkit (PIT) refers to the running environment used for CSM installations and recovery. Example: "Once in the PIT, proceed with the pre-installation,"
-  means once the user is in the environment provided by the LiveCD they can proceed with their procedure.
-* The LiveCD refers to the artifact (e.g. the `.iso` file) providing the PIT. Example: "A new LiveCD is needed," means a new artifact is needed.
-* The term RemoteISO is used to refer to the LiveCD (e.g the `.iso`) when it is remotely mounted on a server's BMC). Example: "The RemoteISO failed," means that the remotely connected LiveCD is having an issue.
+### LiveCD
+
+The **LiveCD** refers to the artifact (e.g. the `.iso` file) providing the PIT. Example: "A new LiveCD is needed," means a new artifact is needed.
+
+### RemoteISO
+
+The term **RemoteISO** is used to refer to the LiveCD (e.g the `.iso`) when it is remotely mounted on a server's BMC). Example: "The RemoteISO failed," means that the remotely connected LiveCD is having an issue.
 
 ## Rack-Mounted CDU
 

--- a/glossary.md
+++ b/glossary.md
@@ -383,15 +383,15 @@ used from a node that has a site-link (such as a Kubernetes master).
 Typically the first Kubernetes master (`ncn-m001`) is chosen for running the PIT during a CSM installation. After CSM is installed,
 the node running the PIT will be rebooted and deployed via CSM services before finally joining the running Kubernetes cluster.
 
-The PIT is ephemeral, it runs in either in memory or it can be written to a USB stick for persistence.
+The PIT is delivered as a [LiveCD](#livecd), a disk image that can be used to remotely boot a node (e.g. a [RemoteISO](#remoteiso)) or by a USB stick.
 
 ### LiveCD
 
-The **LiveCD** refers to the artifact (e.g. the `.iso` file) providing the PIT. Example: "A new LiveCD is needed," means a new artifact is needed.
+The **LiveCD** refers to the artifact, the literal image file that contains the pre-install toolkit.
 
 ### RemoteISO
 
-The term **RemoteISO** is used to refer to the LiveCD (e.g the `.iso`) when it is remotely mounted on a server's BMC). Example: "The RemoteISO failed," means that the remotely connected LiveCD is having an issue.
+The term **RemoteISO** is used to refer to a remotely mounted the LiveCD. A remotely mounted LiveCD has no persistence.
 
 ## Rack-Mounted CDU
 

--- a/glossary.md
+++ b/glossary.md
@@ -376,22 +376,23 @@ not connect to the SMNet.
 
 ## Pre-Install Toolkit (PIT)
 
-The Pre-Install Toolkit (PIT) provides a framework for bare-metal discovery, recovery, and for starting a CSM installation.
+The Pre-Install Toolkit (PIT) provides a framework for bare-metal discovery, recovery, and for starting a [CSM](#cray-system-management-csm) installation.
 The PIT can be used on any node in the system for recovery, for installations and bare-metal discovery it is commonly
 used from a node that has a site-link (such as a Kubernetes master).
 
-Typically the first Kubernetes master (`ncn-m001`) is chosen for running the PIT during a CSM installation. After CSM is installed,
-the node running the PIT will be rebooted and deployed via CSM services before finally joining the running Kubernetes cluster.
+Typically, the first Kubernetes master (`ncn-m001`) is chosen for running the PIT during a [CSM](#cray-system-management-csm) installation. After [CSM](#cray-system-management-csm) is installed,
+the node running the PIT will be rebooted and deployed via [CSM](#cray-system-management-csm) services before finally joining the running Kubernetes cluster.
 
 The PIT is delivered as a [LiveCD](#livecd), a disk image that can be used to remotely boot a node (e.g. a [RemoteISO](#remoteiso)) or by a USB stick.
 
 ### LiveCD
 
-The **LiveCD** refers to the artifact, the literal image file that contains the pre-install toolkit.
+The term *LiveCD* refers to the artifact, the literal image file that contains the pre-install toolkit.
 
 ### RemoteISO
 
-The term **RemoteISO** is used to refer to a remotely mounted the LiveCD. A remotely mounted LiveCD has no persistence.
+The term *RemoteISO* refers to a [LiveCD](#livecd) that is remotely mounted on a server. A remotely mounted LiveCD has no persistence,
+a reboot of a RemoteISO will lose all data/information from the running session.
 
 ## Rack-Mounted CDU
 


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
Removes the redundant LiveCD definition, and adds emphasis to the PIT's aliases.

Signed-off-by: Russell Bunch <doomslayer@hpe.com>

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
