### PR TITLE
CASMCMS-8255: Create an Argo template for VCS/gitea uploads

### DIFF
--- a/workflows/iuf/operations/vcs-upload-content.yaml
+++ b/workflows/iuf/operations/vcs-upload-content.yaml
@@ -1,0 +1,203 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: vcs-upload-content
+spec:
+  entrypoint: main
+  templates:
+    ### Main Steps ###
+    - name: main
+      inputs:
+        parameters:
+          - name: auth_token
+          - name: global_params
+      steps:
+        - - name: get-vcs-secrets
+            template: get-vcs-secrets-template
+        - - name: gitea-upload-content
+            template: gitea-upload-content
+            arguments:
+              parameters:
+                - name: vcs_user_credentials_secret_name
+                  value: "{{steps.get-vcs-secrets.outputs.parameters.secret_name}}"
+                - name: cf_import_product_name
+                  value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.name')}}"
+                - name: cf_import_product_version
+                  value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.version')}}"
+                - name: cf_import_content_hostpath # parent path + content.vcs.path from manifest
+                  value: "{{=jsonpath(inputs.parameters.global_params, '$.stage_params.process_media.current_product.parent_directory')}}/{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.content.vcs.path')}}"
+                - name: cf_import_gitea_org
+                  value: cray
+                - name: cf_import_gitea_url
+                  value: "https://api-gw-service-nmn.local/vcs"
+        - - name: cleanup
+            template: cleanup-template
+            arguments:
+              parameters:
+                - name: vcs_user_credentials_secret_name
+                  value: "{{steps.get-vcs-secrets.outputs.parameters.secret_name}}"
+    ### Templates ###
+    ## get-vcs-secrets-template ##
+    - name: get-vcs-secrets-template
+      nodeSelector:
+        kubernetes.io/hostname: ncn-m001
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+      metadata:
+        annotations:
+          sidecar.istio.io/inject: "false"
+      outputs:
+        parameters:
+          - name: secret_name
+            valueFrom:
+              path: /tmp/secret_name
+      retryStrategy:
+        limit: "2"
+        retryPolicy: "Always"
+        backoff:
+          duration: "10s" # Must be a string. Default unit is seconds. Could also be a Duration, e.g.: "2m", "6h", "1d"
+          factor: "2"
+          maxDuration: "1m"
+      script:
+        image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:latest-v1.21.1-amd64
+        command: [bash]
+        source: |
+          function sync_item() {
+            item_name="$1"
+            source_ns="$2"
+            destination_name="$3-$RANDOM"
+            destination_ns="$4"
+            if kubectl get $item_name -n $source_ns &> /dev/null; then
+              echo "Syncing $item_name from $source_ns to $destination_ns as $destination_name"
+              kubectl get $item_name -n $source_ns -o json | \
+                jq 'del(.metadata.namespace)' | \
+                jq 'del(.metadata.creationTimestamp)' | \
+                jq 'del(.metadata.resourceVersion)' | \
+                jq 'del(.metadata.selfLink)' | \
+                jq 'del(.metadata.uid)' | \
+                jq 'del(.metadata.ownerReferences)' | \
+                jq 'del(.metadata.name)' | \
+                jq '.metadata |= . + {"name":"'$destination_name'"}' | \
+                kubectl apply -n $destination_ns -f -
+                return $?
+            else
+              echo "Didn't find $item_name in the $source_ns namespace"
+              return 1
+            fi
+          }
+          sync_item secret/vcs-user-credentials services vcs-user-credentials-argo argo
+          rc=$?
+          echo $destination_name >> /tmp/secret_name
+          exit $rc
+    ## gitea-upload-content ##
+    - name: gitea-upload-content
+      nodeSelector:
+        kubernetes.io/hostname: ncn-m001
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+      metadata:
+        annotations:
+          sidecar.istio.io/inject: "false"
+      inputs:
+        parameters:
+          - name: vcs_user_credentials_secret_name
+          - name: cf_import_gitea_url
+          - name: cf_import_product_name
+          - name: cf_import_product_version
+          - name: cf_import_gitea_org
+          - name: cf_import_content_hostpath
+      outputs:
+        parameters:
+          - name: vcs-upload-content-results
+            valueFrom:
+              path: /results/records.yaml
+            default: ""
+      container:
+        image: registry.local/artifactory.algol60.net/csm-docker/stable/cf-gitea-import:1.8.0-alpha.16_a2674cd
+        command:
+          - "/bin/sh"
+        args: ["-c", "/opt/csm/cf-gitea-import/argo_entrypoint.sh"]
+        env:
+          - name: CF_IMPORT_GITEA_USER
+            valueFrom:
+              secretKeyRef:
+                name: "{{inputs.parameters.vcs_user_credentials_secret_name}}"
+                key: vcs_username
+          - name: CF_IMPORT_GITEA_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: "{{inputs.parameters.vcs_user_credentials_secret_name}}"
+                key: vcs_password
+          - name: CF_IMPORT_GITEA_URL
+            value: "{{inputs.parameters.cf_import_gitea_url}}"
+          - name: CF_IMPORT_PRODUCT_NAME
+            value: "{{inputs.parameters.cf_import_product_name}}"
+          - name: CF_IMPORT_PRODUCT_VERSION
+            value: "{{inputs.parameters.cf_import_product_version}}"
+          - name: CF_IMPORT_GITEA_ORG
+            value: "{{inputs.parameters.cf_import_gitea_org}}"
+          - name: CF_IMPORT_CONTENT
+            value: /content
+        volumeMounts:
+          - name: content
+            mountPath: "{{inputs.parameters.cf_import_content}}"
+          - name: results
+            mountPath: /results
+          - name: certs # mount cluster certs to ca-certificates.crt for curl/http libraries
+            mountPath: /etc/ssl/certs/ca-certificates.crt
+            subPath: platform-ca-certs.crt
+      volumes:
+        - name: content
+          hostPath:
+            # /opt/cray/iuf/
+            path: "{{inputs.parameters.cf_import_content_hostpath}}"
+        - name: results
+          emptyDir: {}
+        - name: certs
+          hostPath:
+            path: /etc/pki/trust/anchors
+    ## cleanup-template ##
+    ## Remove the secret created earlier.
+    - name: cleanup-template
+      inputs:
+        parameters:
+          - name: vcs_user_credentials_secret_name
+            value: "{{steps.get-vcs-secrets.outputs.parameters.secret_name}}"
+      nodeSelector:
+        kubernetes.io/hostname: ncn-m001
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+      metadata:
+        annotations:
+          sidecar.istio.io/inject: "false"
+      script:
+        image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:latest-v1.21.1-amd64
+        command: [bash]
+        source: |
+          kubectl -n argo delete secret/{{inputs.parameters.vcs_user_credentials_secret_name}}

--- a/workflows/iuf/operations/vcs-upload/README.md
+++ b/workflows/iuf/operations/vcs-upload/README.md
@@ -1,0 +1,23 @@
+# Argo Templates
+
+## `vcs-upload-content.yaml`
+
+This template will upload the current product's git content to the `gitea` server. This operation is calling containerized code living here [cf-gitea-import](https://github.com/Cray-HPE/cf-gitea-import).
+In the current state of this template, there are a few required parameters:
+
+All of these parameters may be overridden by passing them through argo with:
+> -p parameter=foo
+
+- `cf_import_gitea_org` - Defaults to 'cray'
+- `cf_import_content_hostpath` - Defaults to /content
+- `cf_import_results_hostpath` - Defaults to /results
+  - This is the path on the management node where the product's content and results will be stored so it will be used as a `volumeMount` in the template.
+
+### Manifest parameters
+
+Several parameters are being provided to the template through the product manifest json file. This will be abstracted through the CLI API. For clarity, here are the explicit parameters:
+
+To see the exact jsonpath examine the yaml.
+
+- `cf_import_product_name`
+- `cf_import_product_version`

--- a/workflows/iuf/operations/vcs-upload/vcs-upload-content.yaml
+++ b/workflows/iuf/operations/vcs-upload/vcs-upload-content.yaml
@@ -1,0 +1,203 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: vcs-upload-content
+spec:
+  entrypoint: main
+  templates:
+    ### Main Steps ###
+    - name: main
+      inputs:
+        parameters:
+          - name: auth_token
+          - name: global_params
+      steps:
+        - - name: get-vcs-secrets
+            template: get-vcs-secrets-template
+        - - name: gitea-upload-content
+            template: gitea-upload-content
+            arguments:
+              parameters:
+                - name: vcs_user_credentials_secret_name
+                  value: "{{steps.get-vcs-secrets.outputs.parameters.secret_name}}"
+                - name: cf_import_product_name
+                  value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.name')}}"
+                - name: cf_import_product_version
+                  value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.version')}}"
+                - name: cf_import_content_hostpath # parent path + content.vcs.path from manifest
+                  value: "{{=jsonpath(inputs.parameters.global_params, '$.stage_params.process_media.current_product.parent_directory')}}/{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.content.vcs.path')}}"
+                - name: cf_import_gitea_org
+                  value: cray
+                - name: cf_import_gitea_url
+                  value: "https://api-gw-service-nmn.local/vcs"
+        - - name: cleanup
+            template: cleanup-template
+            arguments:
+              parameters:
+                - name: vcs_user_credentials_secret_name
+                  value: "{{steps.get-vcs-secrets.outputs.parameters.secret_name}}"
+    ### Templates ###
+    ## get-vcs-secrets-template ##
+    - name: get-vcs-secrets-template
+      nodeSelector:
+        kubernetes.io/hostname: ncn-m001
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+      metadata:
+        annotations:
+          sidecar.istio.io/inject: "false"
+      outputs:
+        parameters:
+          - name: secret_name
+            valueFrom:
+              path: /tmp/secret_name
+      retryStrategy:
+        limit: "2"
+        retryPolicy: "Always"
+        backoff:
+          duration: "10s" # Must be a string. Default unit is seconds. Could also be a Duration, e.g.: "2m", "6h", "1d"
+          factor: "2"
+          maxDuration: "1m"
+      script:
+        image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:latest-v1.21.1-amd64
+        command: [bash]
+        source: |
+          function sync_item() {
+            item_name="$1"
+            source_ns="$2"
+            destination_name="$3-$RANDOM"
+            destination_ns="$4"
+            if kubectl get $item_name -n $source_ns &> /dev/null; then
+              echo "Syncing $item_name from $source_ns to $destination_ns as $destination_name"
+              kubectl get $item_name -n $source_ns -o json | \
+                jq 'del(.metadata.namespace)' | \
+                jq 'del(.metadata.creationTimestamp)' | \
+                jq 'del(.metadata.resourceVersion)' | \
+                jq 'del(.metadata.selfLink)' | \
+                jq 'del(.metadata.uid)' | \
+                jq 'del(.metadata.ownerReferences)' | \
+                jq 'del(.metadata.name)' | \
+                jq '.metadata |= . + {"name":"'$destination_name'"}' | \
+                kubectl apply -n $destination_ns -f -
+                return $?
+            else
+              echo "Didn't find $item_name in the $source_ns namespace"
+              return 1
+            fi
+          }
+          sync_item secret/vcs-user-credentials services vcs-user-credentials-argo argo
+          rc=$?
+          echo $destination_name >> /tmp/secret_name
+          exit $rc
+    ## gitea-upload-content ##
+    - name: gitea-upload-content
+      nodeSelector:
+        kubernetes.io/hostname: ncn-m001
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+      metadata:
+        annotations:
+          sidecar.istio.io/inject: "false"
+      inputs:
+        parameters:
+          - name: vcs_user_credentials_secret_name
+          - name: cf_import_gitea_url
+          - name: cf_import_product_name
+          - name: cf_import_product_version
+          - name: cf_import_gitea_org
+          - name: cf_import_content_hostpath
+      outputs:
+        parameters:
+          - name: vcs-upload-content-results
+            valueFrom:
+              path: /results/records.yaml
+            default: ""
+      container:
+        image: registry.local/artifactory.algol60.net/csm-docker/stable/cf-gitea-import:1.8.0-alpha.16_a2674cd
+        command:
+          - "/bin/sh"
+        args: ["-c", "/opt/csm/cf-gitea-import/argo_entrypoint.sh"]
+        env:
+          - name: CF_IMPORT_GITEA_USER
+            valueFrom:
+              secretKeyRef:
+                name: "{{inputs.parameters.vcs_user_credentials_secret_name}}"
+                key: vcs_username
+          - name: CF_IMPORT_GITEA_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: "{{inputs.parameters.vcs_user_credentials_secret_name}}"
+                key: vcs_password
+          - name: CF_IMPORT_GITEA_URL
+            value: "{{inputs.parameters.cf_import_gitea_url}}"
+          - name: CF_IMPORT_PRODUCT_NAME
+            value: "{{inputs.parameters.cf_import_product_name}}"
+          - name: CF_IMPORT_PRODUCT_VERSION
+            value: "{{inputs.parameters.cf_import_product_version}}"
+          - name: CF_IMPORT_GITEA_ORG
+            value: "{{inputs.parameters.cf_import_gitea_org}}"
+          - name: CF_IMPORT_CONTENT
+            value: /content
+        volumeMounts:
+          - name: content
+            mountPath: "{{inputs.parameters.cf_import_content}}"
+          - name: results
+            mountPath: /results
+          - name: certs # mount cluster certs to ca-certificates.crt for curl/http libraries
+            mountPath: /etc/ssl/certs/ca-certificates.crt
+            subPath: platform-ca-certs.crt
+      volumes:
+        - name: content
+          hostPath:
+            # /opt/cray/iuf/
+            path: "{{inputs.parameters.cf_import_content_hostpath}}"
+        - name: results
+          emptyDir: {}
+        - name: certs
+          hostPath:
+            path: /etc/pki/trust/anchors
+    ## cleanup-template ##
+    ## Remove the secret created earlier.
+    - name: cleanup-template
+      inputs:
+        parameters:
+          - name: vcs_user_credentials_secret_name
+            value: "{{steps.get-vcs-secrets.outputs.parameters.secret_name}}"
+      nodeSelector:
+        kubernetes.io/hostname: ncn-m001
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+      metadata:
+        annotations:
+          sidecar.istio.io/inject: "false"
+      script:
+        image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:latest-v1.21.1-amd64
+        command: [bash]
+        source: |
+          kubectl -n argo delete secret/{{inputs.parameters.vcs_user_credentials_secret_name}}

--- a/workflows/iuf/stages.yaml
+++ b/workflows/iuf/stages.yaml
@@ -61,7 +61,7 @@ stages:
         local-path: operations/nexus-setup/nexus-helm-upload.yaml # this is relative to stages.yaml, which is contained in workflows/iuf/ in docs-csm
         static-parameters: {} # any parameters that will be supplied statically to this operation.
       - name: vcs-upload
-        local-path: operations/vcs-upload.yaml # this is relative to stages.yaml, which is contained in workflows/iuf/ in docs-csm
+        local-path: operations/vcs-upload/vcs-upload-content.yaml # this is relative to stages.yaml, which is contained in workflows/iuf/ in docs-csm
         static-parameters: {} # any parameters that will be supplied statically to this operation.
       - name: ims-upload
         local-path: operations/ims-upload.yaml # this is relative to stages.yaml, which is contained in workflows/iuf/ in docs-csm


### PR DESCRIPTION
# Description
Argo Workflow template following global_params.json example.
https://github.com/Cray-HPE/docs-csm/blob/a9ae6778ae529fe96cba9cb0a293ef9731e1351d/workflows/iuf/samples/example%20of%20global_params.json

<!--- Describe what this change is and what it is for. -->
Argo workflow template for VCS upload gitea operation. There are a few caveats with unknowns.
1. Clarification around the various products manifests `vcs.path`
2. Stable docker image for cf-gitea-import with argo entrypoint
# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
