### PR TITLE
CASMPET-6010 Add IUF support for Nexus setup

### DIFF
--- a/workflows/iuf/nexus-setup/README.md
+++ b/workflows/iuf/nexus-setup/README.md
@@ -2,7 +2,7 @@
 
 ## ```nexus-setup-template.yaml```
 
-This template will perform Nexus blobstore and repository setup. In its current form, the template requires a few parameters. These parameters should be automatically obtained from the product installer's IUF manifest file, but that functionality is not in place yet. The template leverages the cray-nexus-setup container. Since this template is still in development, it is using a specific non-production version of that image to support the IUF.
+This template will perform Nexus blobstore and repository setup. In its current form, the template requires a few parameters. Most parameters should be automatically obtained from the product installer's IUF manifest file, but that functionality is not in place yet. The template leverages the cray-nexus-setup container. Since this template is still in development, it is using a specific non-production version of that image to support the IUF.
 
 ### Developer usage
 Argo will need to be told about the template. This can be done using ```argo template create``` as in the example below:
@@ -14,14 +14,13 @@ Namespace:           argo
 Created:             Wed Oct 12 18:18:46 +0000 (now)
 ```
 
-The example below shows how to run the template using the current required parameters. The workflow will attempt to process the ```nexus_blob_stores``` and ```nexus_repositories``` files relative to the host mounted ```product_host_path```/```product``` directory. Again, this should come from the IUF manifest file in the future. This example will execute the template and requires a directory matching ```product_host_path``` which contains the product directory ```foo```.
+The example below shows how to run the template using the current required parameters. The workflow will attempt to process the ```nexus_blob_stores``` and ```nexus_repositories``` files (named in iuf-manifest.yaml) relative to the host mounted ```product_host_path```/```product``` directory. This example will execute the template and requires a directory matching ```product_host_path``` which contains the product directory ```foo```.
 
 ```bash
 argo -n argo submit --from workflowtemplate/nexus-setup-template \
-  -p 'nexus_blob_stores=nexus-blobstores.yaml' \
-  -p 'nexus_repositories=nexus-repositories.yaml' \
   -p 'product=foo' \
   -p 'product_host_path=/root/rnoska/argo-nexus/products' \
+  --parameter-file /root/rnoska/argo-nexus/products/foo/iuf-manifest.yaml \
   --watch 
 ```
 
@@ -37,4 +36,4 @@ argo -n argo template create nexus-setup-template.yaml
 ```
 
 ### Planned Work
-Determine how to best obtain values from the IUF manifest file. I have looked at using the ```--parameter-file``` argument to ```argo``` but this method does not return parameter nested values but rather the entire yaml block as a string. Using a DAG to obtain the values should be investigated next (details TBD).
+Provide a way to obtain a default values for items read from iuf-manifest.yaml (by ```jsonpath```) that may have not been set. Examples are ```nexus_blob_stores``` and ```nexus_repositories```.

--- a/workflows/iuf/nexus-setup/README.md
+++ b/workflows/iuf/nexus-setup/README.md
@@ -36,4 +36,6 @@ argo -n argo template create nexus-setup-template.yaml
 ```
 
 ### Planned Work
-Provide a way to obtain a default values for items read from iuf-manifest.yaml (by ```jsonpath```) that may have not been set. Examples are ```nexus_blob_stores``` and ```nexus_repositories```.
+- Provide a way to obtain a default values for items read from iuf-manifest.yaml (by ```jsonpath```) that may have not been set. Examples are ```nexus_blob_stores``` and ```nexus_repositories```.
+
+- Obtain the ```nexus-admin-credential``` secret from the ```nexus``` namespace. The secret is currently manually copied into the ```argo``` namespace.

--- a/workflows/iuf/nexus-setup/README.md
+++ b/workflows/iuf/nexus-setup/README.md
@@ -20,6 +20,7 @@ The example below shows how to run the template using the current required param
 argo -n argo submit --from workflowtemplate/nexus-setup-template \
   -p 'product=foo' \
   -p 'product_host_path=/root/rnoska/argo-nexus/products' \
+  -p 'nexus_setup_image=artifactory.algol60.net/csm-docker/unstable/cray-nexus-setup:0.8.0-20221021164623_e8d3d3d' \
   --parameter-file /root/rnoska/argo-nexus/products/foo/iuf-manifest.yaml \
   --watch 
 ```

--- a/workflows/iuf/nexus-setup/README.md
+++ b/workflows/iuf/nexus-setup/README.md
@@ -34,8 +34,3 @@ If you wish to make changes, edit the template and then update the template in A
 argo -n argo template delete nexus-setup-template
 argo -n argo template create nexus-setup-template.yaml
 ```
-
-### Planned Work
-- Provide a way to obtain a default values for items read from iuf-manifest.yaml (by ```jsonpath```) that may have not been set. Examples are ```nexus_blob_stores``` and ```nexus_repositories```.
-
-- Obtain the ```nexus-admin-credential``` secret from the ```nexus``` namespace. The secret is currently manually copied into the ```argo``` namespace.

--- a/workflows/iuf/nexus-setup/README.md
+++ b/workflows/iuf/nexus-setup/README.md
@@ -1,0 +1,40 @@
+# Argo Templates
+
+## ```nexus-setup-template.yaml```
+
+This template will perform Nexus blobstore and repository setup. In its current form, the template requires a few parameters. These parameters should be automatically obtained from the product installer's IUF manifest file, but that functionality is not in place yet. The template leverages the cray-nexus-setup container. Since this template is still in development, it is using a specific non-production version of that image to support the IUF.
+
+### Developer usage
+Argo will need to be told about the template. This can be done using ```argo template create``` as in the example below:
+
+```bash
+ncn-m001:~/rnoska/argo-nexus/test # argo -n argo template create nexus-setup-template.yaml
+Name:                nexus-setup-template
+Namespace:           argo
+Created:             Wed Oct 12 18:18:46 +0000 (now)
+```
+
+The example below shows how to run the template using the current required parameters. The workflow will attempt to process the ```nexus_blob_stores``` and ```nexus_repositories``` files relative to the host mounted ```product_host_path```/```product``` directory. Again, this should come from the IUF manifest file in the future. This example will execute the template and requires a directory matching ```product_host_path``` which contains the product directory ```foo```.
+
+```bash
+argo -n argo submit --from workflowtemplate/nexus-setup-template \
+  -p 'nexus_blob_stores=nexus-blobstores.yaml' \
+  -p 'nexus_repositories=nexus-repositories.yaml' \
+  -p 'product=foo' \
+  -p 'product_host_path=/root/rnoska/argo-nexus/products' \
+  --watch 
+```
+
+You can view the current template by running:
+```bash
+argo -n argo template get nexus-setup-template -o yaml
+```
+
+If you wish to make changes, edit the template and then update the template in Argo by running:
+```bash
+argo -n argo template delete nexus-setup-template
+argo -n argo template create nexus-setup-template.yaml
+```
+
+### Planned Work
+Determine how to best obtain values from the IUF manifest file. I have looked at using the ```--parameter-file``` argument to ```argo``` but this method does not return parameter nested values but rather the entire yaml block as a string. Using a DAG to obtain the values should be investigated next (details TBD).

--- a/workflows/iuf/nexus-setup/README.md
+++ b/workflows/iuf/nexus-setup/README.md
@@ -1,15 +1,15 @@
 # Argo Templates
 
-## ```nexus-setup-template.yaml```
+## `nexus-setup-template.yaml`
 
-This template will perform Nexus blobstore and repository setup. In its current form, the template requires a few parameters.
-Most parameters should be automatically obtained from the product installer's IUF manifest file, but that functionality is not 
-in place yet. The template leverages the cray-nexus-setup container. Since this template is still in development, it is using a 
+This template will perform Nexus `blobstore` and `repository` setup. In its current form, the template requires a few parameters.
+Most parameters should be automatically obtained from the product installer's IUF manifest file, but that functionality is not
+in place yet. The template leverages the `cray-nexus-setup` container. Since this template is still in development, it is using a
 specific non-production version of that image to support the IUF.
 
 ### Developer usage
 
-Argo will need to be told about the template. This can be done using ```argo template create``` as in the example below:
+Argo will need to be told about the template. This can be done using `argo template create` as in the example below:
 
 ```bash
 ncn-m001:~/rnoska/argo-nexus/test # argo -n argo template create nexus-setup-template.yaml
@@ -19,15 +19,16 @@ Created:             Wed Oct 12 18:18:46 +0000 (now)
 ```
 
 The example below shows how to run the template using the current required parameters. The workflow will attempt to process the
-```nexus_blob_stores``` and ```nexus_repositories``` files (named in iuf-manifest.yaml) relative to the host mounted
-```product_host_path```/```product``` directory. This example will execute the template and requires a directory matching
-```product_host_path``` which contains the product directory ```foo```.
+`nexus_blob_stores` and `nexus_repositories` files (named in `iuf-manifest.yaml`) relative to the host mounted
+`product_host_path`/`product` directory. This example will execute the workflow and requires a directory matching
+`product_host_path` which contains the product directory `foo`. The `nexus_setup_image` parameter specifies the current image and
+tag that is used to perform the underlying Nexus functions.
 
 ```bash
 argo -n argo submit --from workflowtemplate/nexus-setup-template \
-  -p 'product=foo' \
-  -p 'product_host_path=/root/rnoska/argo-nexus/products' \
-  -p 'nexus_setup_image=artifactory.algol60.net/csm-docker/unstable/cray-nexus-setup:0.8.0-20221021164623_e8d3d3d' \
+  -p product=foo \
+  -p product_host_path=/root/rnoska/argo-nexus/products \
+  -p nexus_setup_image=artifactory.algol60.net/csm-docker/unstable/cray-nexus-setup:0.8.0-20221021164623_e8d3d3d \
   --parameter-file /root/rnoska/argo-nexus/products/foo/iuf-manifest.yaml \
   --watch 
 ```

--- a/workflows/iuf/nexus-setup/README.md
+++ b/workflows/iuf/nexus-setup/README.md
@@ -2,9 +2,13 @@
 
 ## ```nexus-setup-template.yaml```
 
-This template will perform Nexus blobstore and repository setup. In its current form, the template requires a few parameters. Most parameters should be automatically obtained from the product installer's IUF manifest file, but that functionality is not in place yet. The template leverages the cray-nexus-setup container. Since this template is still in development, it is using a specific non-production version of that image to support the IUF.
+This template will perform Nexus blobstore and repository setup. In its current form, the template requires a few parameters.
+Most parameters should be automatically obtained from the product installer's IUF manifest file, but that functionality is not 
+in place yet. The template leverages the cray-nexus-setup container. Since this template is still in development, it is using a 
+specific non-production version of that image to support the IUF.
 
 ### Developer usage
+
 Argo will need to be told about the template. This can be done using ```argo template create``` as in the example below:
 
 ```bash
@@ -14,7 +18,10 @@ Namespace:           argo
 Created:             Wed Oct 12 18:18:46 +0000 (now)
 ```
 
-The example below shows how to run the template using the current required parameters. The workflow will attempt to process the ```nexus_blob_stores``` and ```nexus_repositories``` files (named in iuf-manifest.yaml) relative to the host mounted ```product_host_path```/```product``` directory. This example will execute the template and requires a directory matching ```product_host_path``` which contains the product directory ```foo```.
+The example below shows how to run the template using the current required parameters. The workflow will attempt to process the
+```nexus_blob_stores``` and ```nexus_repositories``` files (named in iuf-manifest.yaml) relative to the host mounted
+```product_host_path```/```product``` directory. This example will execute the template and requires a directory matching
+```product_host_path``` which contains the product directory ```foo```.
 
 ```bash
 argo -n argo submit --from workflowtemplate/nexus-setup-template \
@@ -26,11 +33,13 @@ argo -n argo submit --from workflowtemplate/nexus-setup-template \
 ```
 
 You can view the current template by running:
+
 ```bash
 argo -n argo template get nexus-setup-template -o yaml
 ```
 
 If you wish to make changes, edit the template and then update the template in Argo by running:
+
 ```bash
 argo -n argo template delete nexus-setup-template
 argo -n argo template create nexus-setup-template.yaml

--- a/workflows/iuf/nexus-setup/nexus-setup-template.yaml
+++ b/workflows/iuf/nexus-setup/nexus-setup-template.yaml
@@ -34,11 +34,90 @@ spec:
     # The value for content is set to the json string value for 'content' in the manifest when --parameter-file is
     # set to the path of the IUF manifest yaml file.
     - name: content
-  entrypoint: nexus-setup
+  entrypoint: main
   templates:
-  - name: nexus-setup
+### Main Steps ###
+  - name: main
+    steps:
+    - - name: nexus-get-admin-credential
+        template: nexus-get-admin-credential-template
+    - - name: nexus-setup
+        template: nexus-setup-template
+        arguments:
+          parameters:
+          - name: nexus_admin_credential_secret_name
+            value: "{{steps.nexus-get-admin-credential.outputs.parameters.secret_name}}"
+          - name: content
+            value: "{{workflow.parameters.content}}"
+          - name: product
+            value: "{{workflow.parameters.product}}"
+          - name: product_host_path
+            value: "{{workflow.parameters.product_host_path}}"
+    - - name: cleanup
+        template: cleanup-template
+        arguments:
+          parameters:
+          - name: nexus_admin_credential_secret_name
+            value: "{{steps.nexus-get-admin-credential.outputs.parameters.secret_name}}"
+### Templates ###
+## nexus-get-secret-template ##
+  - name: nexus-get-admin-credential-template
+    nodeSelector:   
+      kubernetes.io/hostname: ncn-m001
+    tolerations:
+    - key: node-role.kubernetes.io/master
+      effect: NoSchedule
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+    outputs:
+      parameters:
+        - name: secret_name
+          valueFrom:
+            path: /tmp/secret_name
+    retryStrategy:
+        limit: "2"
+        retryPolicy: "Always"
+        backoff:
+          duration: "10s" # Must be a string. Default unit is seconds. Could also be a Duration, e.g.: "2m", "6h", "1d"
+          factor: "2"
+          maxDuration: "1m"
+    script:
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:latest-v1.21.1-amd64
+      command: [bash]
+      source: |
+        function sync_item() {
+          item_name="$1"
+          source_ns="$2"
+          destination_name="$3-$RANDOM"
+          destination_ns="$4"
+          if kubectl get $item_name -n $source_ns &> /dev/null; then
+            echo "Syncing $item_name from $source_ns to $destination_ns as $destination_name"
+            kubectl get $item_name -n $source_ns -o json | \
+              jq 'del(.metadata.namespace)' | \
+              jq 'del(.metadata.creationTimestamp)' | \
+              jq 'del(.metadata.resourceVersion)' | \
+              jq 'del(.metadata.selfLink)' | \
+              jq 'del(.metadata.uid)' | \
+              jq 'del(.metadata.ownerReferences)' | \
+              jq 'del(.metadata.name)' | \
+              jq '.metadata |= . + {"name":"'$destination_name'"}' | \
+              kubectl apply -n $destination_ns -f -
+              return $?
+          else
+            echo "Didn't find $item_name in the $source_ns namespace"
+            return 1
+          fi
+        }
+        sync_item secret/nexus-admin-credential nexus nexus-admin-credential-argo argo
+        rc=$?
+        echo $destination_name >> /tmp/secret_name
+        exit $rc
+## nexus-setup-template ##
+  - name: nexus-setup-template
     inputs:
       parameters:
+      - name: nexus_admin_credential_secret_name
       - name: content
         value: "{{workflow.parameters.content}}"
       - name: product
@@ -63,12 +142,12 @@ spec:
       - name: NEXUS_USERNAME
         valueFrom:
           secretKeyRef:
-            name: nexus-admin-credential
+            name: "{{inputs.parameters.nexus_admin_credential_secret_name}}"
             key: username
       - name: NEXUS_PASSWORD
         valueFrom:
           secretKeyRef:
-            name: nexus-admin-credential
+            name: "{{inputs.parameters.nexus_admin_credential_secret_name}}"
             key: password
       volumeMounts:
       - name: products
@@ -78,3 +157,23 @@ spec:
     - name: products
       hostPath:
         path: "{{workflow.parameters.product_host_path}}"
+## cleanup-template ##
+## Remove the secret created earlier.
+  - name: cleanup-template
+    inputs:
+      parameters:
+      - name: nexus_admin_credential_secret_name
+        value: "{{steps.nexus-get-admin-credential.outputs.parameters.secret_name}}"
+    nodeSelector:
+      kubernetes.io/hostname: ncn-m001
+    tolerations:
+    - key: node-role.kubernetes.io/master
+      effect: NoSchedule
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+    script:
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:latest-v1.21.1-amd64
+      command: [bash]
+      source: |
+        kubectl -n argo delete secret/{{inputs.parameters.nexus_admin_credential_secret_name}}

--- a/workflows/iuf/nexus-setup/nexus-setup-template.yaml
+++ b/workflows/iuf/nexus-setup/nexus-setup-template.yaml
@@ -29,19 +29,18 @@ metadata:
 spec:
   arguments:
     parameters:
-    - name: nexus_blob_stores
-    - name: nexus_repositories
     - name: product
     - name: product_host_path
+    # The value for content is set to the json string value for 'content' in the manifest when --parameter-file is
+    # set to the path of the IUF manifest yaml file.
+    - name: content
   entrypoint: nexus-setup
   templates:
   - name: nexus-setup
     inputs:
       parameters:
-      - name: nexus_blob_stores
-        value: "{{workflow.parameters.nexus_blob_stores}}"
-      - name: nexus_repositories
-        value: "{{workflow.parameters.nexus_repositories}}"
+      - name: content
+        value: "{{workflow.parameters.content}}"
       - name: product
         value: "{{workflow.parameters.product}}"
       - name: product_host_path
@@ -57,7 +56,7 @@ spec:
     container:
       image: artifactory.algol60.net/csm-docker/unstable/cray-nexus-setup:0.8.0-20221006225615_49737fe
       command: [iuf-nexus-setup]
-      args: ["--blobstores","/products/{{workflow.parameters.product}}/{{workflow.parameters.nexus_blob_stores}}","--repositories","/products/{{workflow.parameters.product}}/{{workflow.parameters.nexus_repositories}}"]
+      args: ["--blobstores","/products/{{workflow.parameters.product}}/{{=jsonpath(workflow.parameters.content,'$.nexus_blob_stores.yaml_path')}}","--repositories","/products/{{workflow.parameters.product}}/{{=jsonpath(workflow.parameters.content,'$.nexus_repositories.yaml_path')}}"]
       env:
       - name: NEXUS_URL
         value: "https://packages.local"

--- a/workflows/iuf/nexus-setup/nexus-setup-template.yaml
+++ b/workflows/iuf/nexus-setup/nexus-setup-template.yaml
@@ -29,6 +29,7 @@ metadata:
 spec:
   arguments:
     parameters:
+    - name: nexus-setup-image
     - name: product
     - name: product_host_path
     # The value for content is set to the json string value for 'content' in the manifest when --parameter-file is
@@ -45,6 +46,8 @@ spec:
         template: nexus-setup-template
         arguments:
           parameters:
+          - name: nexus-setup-image
+            value: "{{workflow.parameters.nexus-setup-image}}"
           - name: nexus_admin_credential_secret_name
             value: "{{steps.nexus-get-admin-credential.outputs.parameters.secret_name}}"
           - name: content
@@ -117,6 +120,8 @@ spec:
   - name: nexus-setup-template
     inputs:
       parameters:
+      - name: nexus_setup_image
+        value: "{{workflow.parameters.nexus-setup-image}}"
       - name: nexus_admin_credential_secret_name
       - name: content
         value: "{{workflow.parameters.content}}"
@@ -133,7 +138,7 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
     container:
-      image: artifactory.algol60.net/csm-docker/unstable/cray-nexus-setup:0.8.0-20221006225615_49737fe
+      image: {{inputs.parameters.nexus_setup_image}}
       command: [iuf-nexus-setup]
       args: ["--blobstores","/products/{{workflow.parameters.product}}/{{=jsonpath(workflow.parameters.content,'$.nexus_blob_stores.yaml_path')}}","--repositories","/products/{{workflow.parameters.product}}/{{=jsonpath(workflow.parameters.content,'$.nexus_repositories.yaml_path')}}"]
       env:

--- a/workflows/iuf/nexus-setup/nexus-setup-template.yaml
+++ b/workflows/iuf/nexus-setup/nexus-setup-template.yaml
@@ -1,0 +1,81 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: nexus-setup-template
+  namespace: argo
+spec:
+  arguments:
+    parameters:
+    - name: nexus_blob_stores
+    - name: nexus_repositories
+    - name: product
+    - name: product_host_path
+  entrypoint: nexus-setup
+  templates:
+  - name: nexus-setup
+    inputs:
+      parameters:
+      - name: nexus_blob_stores
+        value: "{{workflow.parameters.nexus_blob_stores}}"
+      - name: nexus_repositories
+        value: "{{workflow.parameters.nexus_repositories}}"
+      - name: product
+        value: "{{workflow.parameters.product}}"
+      - name: product_host_path
+        value: "{{workflow.parameters.product_host_path}}"
+    nodeSelector:
+      kubernetes.io/hostname: ncn-m001
+    tolerations:
+    - key: node-role.kubernetes.io/master
+      effect: NoSchedule
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+    container:
+      image: artifactory.algol60.net/csm-docker/unstable/cray-nexus-setup:0.8.0-20221006225615_49737fe
+      command: [iuf-nexus-setup]
+      args: ["--blobstores","/products/{{workflow.parameters.product}}/{{workflow.parameters.nexus_blob_stores}}","--repositories","/products/{{workflow.parameters.product}}/{{workflow.parameters.nexus_repositories}}"]
+      env:
+      - name: NEXUS_URL
+        value: "https://packages.local"
+      - name: NEXUS_USERNAME
+        valueFrom:
+          secretKeyRef:
+            name: nexus-admin-credential
+            key: username
+      - name: NEXUS_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: nexus-admin-credential
+            key: password
+      volumeMounts:
+      - name: products
+        mountPath: /products
+    # This will be an RBD mount.
+    volumes:
+    - name: products
+      hostPath:
+        path: "{{workflow.parameters.product_host_path}}"


### PR DESCRIPTION
# Description

This adds a new Argo workflow template to support the Install and Upgrade Framework (IUF) ability to create Nexus blob stores and repositories as required.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
