### PR TITLE
CASMHMS-5676 Changed the validation step for SLS backup restore

### DIFF
--- a/operations/system_layout_service/Restore_SLS_Postgres_Database_from_Backup.md
+++ b/operations/system_layout_service/Restore_SLS_Postgres_Database_from_Backup.md
@@ -167,7 +167,15 @@ by the `cray-sls-postgresql-db-backup` Kubernetes cronjob.
     ncn# /usr/share/doc/csm/scripts/operations/system_layout_service/restore_sls_postgres_from_backup.sh
     ```
 
-7. Verify the health of the SLS Postgres cluster by running the `ncnPostgresHealthChecks.sh` script. Follow the [`ncnPostgresHealthChecks` topic in Validate CSM Health document](../validate_csm_health.md#pet-ncnpostgreshealthchecks).
+7. Verify the health of the SLS Postgres cluster by running the following scripts.
+    If there are issues with `run_hms_ct_tests.sh`, then follow [Interpreting HMS Health Check Results](../../troubleshooting/interpreting_hms_health_check_results.md).
+    If there are issues with `verify_hsm_discovery.py`, then follow the "Interpreting HSM discovery results" section of the [Validate CSM Health document](../validate_csm_health.md#221-interpreting-hsm-discovery-results).
+
+    ```bash
+    ncn# /opt/cray/csm/scripts/hms_verification/run_hms_ct_tests.sh -t sls
+    ncn# /opt/cray/platform-utils/ncnPostgresHealthChecks.sh
+    ncn# /opt/cray/csm/scripts/hms_verification/verify_hsm_discovery.py
+    ```
 
 8. Verify that the service is functional:
 


### PR DESCRIPTION
Jira: CASMHMS-5676

# Description

<!--- Describe what this change is and what it is for. -->

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
