### PR TITLE
CASMTRIAGE-4473-1.0 : DOCS: The "Alpha Framework to Add, Remove, Repl…

### DIFF
--- a/operations/node_management/Add_Remove_Replace_NCNs/Add_NCN_Data.md
+++ b/operations/node_management/Add_Remove_Replace_NCNs/Add_NCN_Data.md
@@ -477,4 +477,4 @@ Scenarios where this procedure is applicable:
 ## Next step
 
 Proceed to [Update Firmware](Update_Firmware.md) or return to the main
-[Add, Remove, Replace, or Move NCNs](../Add_Remove_Replace_NCNs.md) page.
+[Add, Remove, Replace, or Move NCNs](Add_Remove_Replace_NCNs.md) page.

--- a/operations/node_management/Add_Remove_Replace_NCNs/Add_Remove_Replace_NCNs.md
+++ b/operations/node_management/Add_Remove_Replace_NCNs/Add_Remove_Replace_NCNs.md
@@ -28,7 +28,7 @@ The system is fully installed and has transitioned off of the LiveCD.
 
 All activities required for site maintenance are complete.
 
-The latest CSM documentation has been installed on the master nodes. See [Update CSM Product Stream](../../update_product_stream/index.md).
+The latest CSM documentation has been installed on the master nodes. See [Update CSM Product Stream](../../../update_product_stream/index.md).
 
 1. Run `ncn_add_pre-req.py` to adjust the network.
 
@@ -213,11 +213,11 @@ ncn-m# XNAME=<xname>
    ```
 
 * If adding an NCN that was not previously in the system, follow the
-  [Access and Update the Settings for Replacement NCNs](Access_and_Update_the_Settings_for_Replacement_NCNs.md) procedure.
+  [Access and Update the Settings for Replacement NCNs](../Access_and_Update_the_Settings_for_Replacement_NCNs.md) procedure.
 * Ensure the NCN BMC is configured to use DHCP.
   * This does not apply to the BMC for `ncn-m001`, because it is statically configured for the site.
 * Ensure that the NCN is configured to boot over the PCIe NICs instead of the Onboard 1 Gig NICs.
-  * See the [Switch PXE Boot from Onboard NIC to PCIe](../../install/switch_pxe_boot_from_onboard_nic_to_pcie.md) procedure.
+  * See the [Switch PXE Boot from Onboard NIC to PCIe](../../../install/switch_pxe_boot_from_onboard_nic_to_pcie.md) procedure.
 
 * If adding an HPE NCN, then ensure that IPMI is enabled.
 
@@ -297,14 +297,14 @@ ncn-m# XNAME=<xname>
 
 The following is a high-level overview of the add NCN workflow:
 
-1. [Allocate NCN IP Addresses](Add_Remove_Replace_NCNs/Allocate_NCN_IP_Addresses.md).
-1. [Add Switch Configuration](Add_Remove_Replace_NCNs/Add_Switch_Config.md).
-1. [Add NCN data](Add_Remove_Replace_NCNs/Add_NCN_Data.md) for SLS, BSS and HSM.
-1. [Update Firmware](Add_Remove_Replace_NCNs/Update_Firmware.md) via FAS.
-1. [Boot NCN and Configure](Add_Remove_Replace_NCNs/Boot_NCN.md).
-1. [Redeploy Services](Add_Remove_Replace_NCNs/Redeploy_Services.md).
-1. [Validate NCN](Add_Remove_Replace_NCNs/Validate_NCN.md).
-1. [Validate Health](Add_Remove_Replace_NCNs/Validate_Health.md).
+1. [Allocate NCN IP Addresses](Allocate_NCN_IP_Addresses.md).
+1. [Add Switch Configuration](Add_Switch_Config.md).
+1. [Add NCN data](Add_NCN_Data.md) for SLS, BSS and HSM.
+1. [Update Firmware](Update_Firmware.md) via FAS.
+1. [Boot NCN and Configure](Boot_NCN.md).
+1. [Redeploy Services](Redeploy_Services.md).
+1. [Validate NCN](Validate_NCN.md).
+1. [Validate Health](Validate_Health.md).
 
 <a name="remove-worker-storage-master"></a>
 
@@ -330,11 +330,11 @@ ncn# echo "${XNAME}"
 
 The following is a high-level overview of the remove NCN workflow:
 
-1. [Remove NCN from Role, Wipe the Disks, and Power Down](Add_Remove_Replace_NCNs/Remove_NCN_from_Role.md).
-1. [Remove NCN data](Add_Remove_Replace_NCNs/Remove_NCN_Data.md) from SLS, BSS and HSM.
-1. [Remove Switch Configuration](Add_Remove_Replace_NCNs/Remove_Switch_Config.md).
-1. [Redeploy Services](Add_Remove_Replace_NCNs/Redeploy_Services.md).
-1. [Validate Health](Add_Remove_Replace_NCNs/Validate_Health.md).
+1. [Remove NCN from Role, Wipe the Disks, and Power Down](Remove_NCN_from_Role.md).
+1. [Remove NCN data](Remove_NCN_Data.md) from SLS, BSS and HSM.
+1. [Remove Switch Configuration](Remove_Switch_Config.md).
+1. [Redeploy Services](Redeploy_Services.md).
+1. [Validate Health](Validate_Health.md).
 
 **IMPORTANT:** Update the SHCD to remove the device. This is only needed if no NCN device will be added back to same location with the same cabling.
 

--- a/operations/node_management/Add_Remove_Replace_NCNs/Add_Switch_Config.md
+++ b/operations/node_management/Add_Remove_Replace_NCNs/Add_Switch_Config.md
@@ -1,4 +1,4 @@
-# Add Switch Config for NCN
+# Add Switch Configuration for NCN
 
 ## Description
 
@@ -22,11 +22,11 @@ Update the network switches for the NCN that is being added.
 
 ## Mellanox and Dell
 
-### Spine/Agg Switch Updates
+### Mellanox and Dell `Spine/Agg` Switch Updates
 
-[spine/agg edge port configuration](../../../install/configure_mellanox_spine_switch.md#Configure-MLAG)
+[`Spine/Agg` edge port configuration](../../../install/configure_mellanox_spine_switch.md#Configure-MLAG)
 
-### Spine BGP Updates
+### Mellanox and Dell Spine BGP Updates
 
 The configuration will be the same across both switches.
 
@@ -47,17 +47,17 @@ router bgp 65533 vrf default neighbor 10.252.1.13 timers 1 3
 router bgp 65533 vrf default neighbor 10.252.1.13 transport connection-mode passive
 ```
 
-### BMC Port Configuration
+### Mellanox and Dell BMC Port Configuration
 
 [Dell edge port configuration](../../../install/configure_dell_leaf_switch.md#Configure-Edge-Port)
 
 ## Aruba
 
-### Spine/Agg Switch Updates
+### Aruba `Spine/Agg` Switch Updates
 
-[spine/agg edge port configuration](../../../install/configure_aruba_spine_switch.md#Configure-Edge-Port)
+[`Spine/Agg` edge port configuration](../../../install/configure_aruba_spine_switch.md#Configure-Edge-Port)
 
-### Spine BGP Updates
+### Aruba Spine BGP Updates
 
 The configuration will be the same across both switches.
 
@@ -67,7 +67,7 @@ For more information, see [Update BGP Neighbors](../../network/metallb_bgp/Updat
 
 - The `tftp` route maps will only include the first 3 workers.
 
-```
+```text
 route-map ncn-w004 permit seq 10
      match ip address prefix-list tftp
      match ip next-hop $worker1.nmn.ip
@@ -97,8 +97,8 @@ router bgp 65533
         neighbor 10.252.1.13 ($worker4.nmn.ip) route-map ncn-w004 in
 ```
 
-### BMC Port Configuration
+### Aruba BMC Port Configuration
 
 Refer to [Aruba edge port configuration](../../../install/configure_aruba_leaf_switch.md#Configure-Edge-Port) for more information.
 
-Proceed to the next step to [Add NCN Data](Add_NCN_Data.md) or return to the main [Add, Remove, Replace, or Move NCNs](../Add_Remove_Replace_NCNs.md) page.
+Proceed to the next step to [Add NCN Data](Add_NCN_Data.md) or return to the main [Add, Remove, Replace, or Move NCNs](Add_Remove_Replace_NCNs.md) page.

--- a/operations/node_management/Add_Remove_Replace_NCNs/Allocate_NCN_IP_Addresses.md
+++ b/operations/node_management/Add_Remove_Replace_NCNs/Allocate_NCN_IP_Addresses.md
@@ -113,4 +113,4 @@ This procedure will perform and verify the following:
 
 ## Next step
 
-Proceed to the next step to [Add Switch Configuration](Add_Switch_Config.md) or return to the main [Add, Remove, Replace, or Move NCNs](../Add_Remove_Replace_NCNs.md) page.
+Proceed to the next step to [Add Switch Configuration](Add_Switch_Config.md) or return to the main [Add, Remove, Replace, or Move NCNs](Add_Remove_Replace_NCNs.md) page.

--- a/operations/node_management/Add_Remove_Replace_NCNs/Boot_NCN.md
+++ b/operations/node_management/Add_Remove_Replace_NCNs/Boot_NCN.md
@@ -16,7 +16,7 @@ Boot a master, worker, or storage non-compute node (NCN) that is to be added to 
 
 ### Set the PXE boot option and power on the node
 
-**IMPORTANT:** These commands assume the variables from [the prerequisites section](../Add_Remove_Replace_NCNs.md#add-ncn-prerequisites) have been set.
+**IMPORTANT:** These commands assume the variables from [the prerequisites section](Add_Remove_Replace_NCNs.md#add-ncn-prerequisites) have been set.
 
 1. Set the `BMC` variable to the hostname of the BMC of the node being rebuilt.
 
@@ -294,4 +294,4 @@ Follow [Add Ceph Node](../../utility_storage/Add_Ceph_Node.md) to join the added
 ### Next step
 
 Proceed to [Redeploy Services](Redeploy_Services.md) or return to the main
-[Add, Remove, Replace, or Move NCNs](../Add_Remove_Replace_NCNs.md) page.
+[Add, Remove, Replace, or Move NCNs](Add_Remove_Replace_NCNs.md) page.

--- a/operations/node_management/Add_Remove_Replace_NCNs/Redeploy_Services.md
+++ b/operations/node_management/Add_Remove_Replace_NCNs/Redeploy_Services.md
@@ -2,15 +2,15 @@
 
 This procedure redeploys S3 and `sysmgmt-health` services to add or remove storage node endpoints.
 
-**This procedure can be skipped if a worker or master node has been added.** In that case, proceed to the next step to [Validate NCN](Validate_NCN.md) or return to the main [Add, Remove, Replace, or Move NCNs](../Add_Remove_Replace_NCNs.md) page.
+**This procedure can be skipped if a worker or master node has been added.** In that case, proceed to the next step to [Validate NCN](Validate_NCN.md) or return to the main [Add, Remove, Replace, or Move NCNs](Add_Remove_Replace_NCNs.md) page.
 
-**This procedure can be skipped if a worker or master node have been removed.** In that case, proceed to the next step to [Validate Health](Validate_Health.md) or return to the main [Add, Remove, Replace, or Move NCNs](../Add_Remove_Replace_NCNs.md) page.
+**This procedure can be skipped if a worker or master node have been removed.** In that case, proceed to the next step to [Validate Health](Validate_Health.md) or return to the main [Add, Remove, Replace, or Move NCNs](Add_Remove_Replace_NCNs.md) page.
 
 Otherwise, if a storage node has been added or removed, proceed with the following steps.
 
 ## Prerequisite
 
-The docs-csm RPM has been installed on the NCN. Verify that the following file exists:
+The `docs-csm` RPM has been installed on the NCN. Verify that the following file exists:
 
 ```bash
 ncn-m# ls /usr/share/docs/csm/scripts/operations/node_management/Add_Remove_Replace_NCNs/update_customizations.sh
@@ -77,7 +77,7 @@ Before redeploying the desired charts, update the `customizations.yaml` file in 
 
    Example output:
 
-   ```
+   ```text
    10.252.1.13
    ```
 
@@ -151,7 +151,7 @@ Before redeploying the desired charts, update the `customizations.yaml` file in 
 
     Example output:
 
-    ```
+    ```text
     10.252.1.13
     10.252.1.4
     10.252.1.5
@@ -194,7 +194,7 @@ Before redeploying the desired charts, update the `customizations.yaml` file in 
 
     Example Output:
 
-    ```
+    ```text
     48h
     ```
 
@@ -248,7 +248,7 @@ Before redeploying the desired charts, update the `customizations.yaml` file in 
 
     Example output:
 
-    ```
+    ```text
     10.252.1.13
     10.252.1.4
     10.252.1.5
@@ -267,5 +267,5 @@ ncn-m# rm /tmp/customizations.yaml /tmp/customizations.original.yaml /tmp/custom
 
 Proceed to the next step:
 
-- If a storage NCN was added, proceed to [Validate NCN](Validate_NCN.md) or return to the main [Add, Remove, Replace, or Move NCNs](../Add_Remove_Replace_NCNs.md) page.
-- If a storage NCN was removed, proceed to [Validate Health](Validate_Health.md) or return to the main [Add, Remove, Replace, or Move NCNs](../Add_Remove_Replace_NCNs.md) page.
+- If a storage NCN was added, proceed to [Validate NCN](Validate_NCN.md) or return to the main [Add, Remove, Replace, or Move NCNs](Add_Remove_Replace_NCNs.md) page.
+- If a storage NCN was removed, proceed to [Validate Health](Validate_Health.md) or return to the main [Add, Remove, Replace, or Move NCNs](Add_Remove_Replace_NCNs.md) page.

--- a/operations/node_management/Add_Remove_Replace_NCNs/Remove_NCN_Data.md
+++ b/operations/node_management/Add_Remove_Replace_NCNs/Remove_NCN_Data.md
@@ -6,7 +6,7 @@ Remove NCN data to System Layout Service (SLS), Boot Script Service (BSS) and Ha
 
 ## Procedure
 
-**IMPORTANT:** The following procedures assume you have set the variables from [the prerequisites section](../Add_Remove_Replace_NCNs.md#remove-ncn-prerequisites)
+**IMPORTANT:** The following procedures assume you have set the variables from [the prerequisites section](Add_Remove_Replace_NCNs.md#remove-ncn-prerequisites)
 
 1. Prepare for the procedure.
 
@@ -175,4 +175,4 @@ Remove NCN data to System Layout Service (SLS), Boot Script Service (BSS) and Ha
     ```
 
 Proceed to [Remove Switch Configuration](Remove_Switch_Config.md) or return to the main
-[Add, Remove, Replace, or Move NCNs](../Add_Remove_Replace_NCNs.md) page.
+[Add, Remove, Replace, or Move NCNs](Add_Remove_Replace_NCNs.md) page.

--- a/operations/node_management/Add_Remove_Replace_NCNs/Remove_NCN_from_Role.md
+++ b/operations/node_management/Add_Remove_Replace_NCNs/Remove_NCN_from_Role.md
@@ -6,7 +6,7 @@ Remove master, worker, or storage NCN from current roles. Select the procedure b
 
 ## Procedure
 
-**IMPORTANT:** The following procedures assume you have set the variables from [the prerequisites section](../Add_Remove_Replace_NCNs.md#remove-ncn-prerequisites)
+**IMPORTANT:** The following procedures assume you have set the variables from [the prerequisites section](Add_Remove_Replace_NCNs.md#remove-ncn-prerequisites)
 
 1. [Remove roles](#1-remove-roles)
     - [Master node](#master-node-remove-roles)
@@ -500,4 +500,4 @@ Once the wipe of the drives is complete, proceed to [Power off the node](#3-powe
 ## Next step
 
 Proceed to [Remove NCN Data](Remove_NCN_Data.md) or return to the main
-[Add, Remove, Replace, or Move NCNs](../Add_Remove_Replace_NCNs.md) page.
+[Add, Remove, Replace, or Move NCNs](Add_Remove_Replace_NCNs.md) page.

--- a/operations/node_management/Add_Remove_Replace_NCNs/Remove_Switch_Config.md
+++ b/operations/node_management/Add_Remove_Replace_NCNs/Remove_Switch_Config.md
@@ -1,11 +1,12 @@
-# Remove Switch Config for NCN
+# Remove Switch Configuration for NCN
 
 Update the network switches for the NCN that was removed.
 
 ## Update Networking to Remove NCN
 
-### `ncn-w004` IP data:
-```
+### `ncn-w004` IP data
+
+```text
 10.102.4.15     ncn-w004.can
 10.254.1.22     ncn-w004.hmn
 10.1.1.11       ncn-w004.mtl
@@ -13,8 +14,9 @@ Update the network switches for the NCN that was removed.
 10.254.1.21     ncn-w004-mgmt
 ```
 
-### spine-01 switch updates
-```
+### `spine-01` switch updates
+
+```text
 no route-map ncn-w004 permit 10 match ip address pl-can
 no route-map ncn-w004 permit 10 set ip next-hop 10.102.4.15
 no route-map ncn-w004 permit 20 match ip address pl-hmn
@@ -32,8 +34,9 @@ no interface mlag-port-channel 12 description "sw-spine-001:12==>ncn-w004:pcie-s
 no interface mlag-port-channel 12 no shutdown
 ```
 
-### spine-02 switch updates
-```
+### `spine-02` switch updates
+
+```text
 no route-map ncn-w004 permit 10 match ip address pl-can
 no route-map ncn-w004 permit 10 set ip next-hop 10.102.4.15
 no route-map ncn-w004 permit 20 match ip address pl-hmn
@@ -55,16 +58,18 @@ no interface mlag-port-channel 12 no shutdown
 
 **These steps only need to be performed when the node removed was a worker node.**
 
-### spine-01 switch updates
-```
+### `spine-01` switch updates for worker node
+
+```text
 no router bgp 65533 vrf default neighbor 10.252.1.13 remote-as 65533
 no router bgp 65533 vrf default neighbor 10.252.1.13 route-map ncn-w004
 no router bgp 65533 vrf default neighbor 10.252.1.13 timers 1 3
 no router bgp 65533 vrf default neighbor 10.252.1.13 transport connection-mode passive
 ```
 
-### spine-02 switch updates
-```
+### `spine-02` switch updates for worker node
+
+```text
 no router bgp 65533 vrf default neighbor 10.252.1.13 remote-as 65533
 no router bgp 65533 vrf default neighbor 10.252.1.13 route-map ncn-w004
 no router bgp 65533 vrf default neighbor 10.252.1.13 timers 1 3
@@ -73,4 +78,4 @@ no router bgp 65533 vrf default neighbor 10.252.1.13 transport connection-mode p
 
 ## Next Step
 
-Proceed to the next step to [Redeploy Services](Redeploy_Services.md) or return to the main [Add, Remove, Replace, or Move NCNs](../Add_Remove_Replace_NCNs.md) page.
+Proceed to the next step to [Redeploy Services](Redeploy_Services.md) or return to the main [Add, Remove, Replace, or Move NCNs](Add_Remove_Replace_NCNs.md) page.

--- a/operations/node_management/Add_Remove_Replace_NCNs/Update_Firmware.md
+++ b/operations/node_management/Add_Remove_Replace_NCNs/Update_Firmware.md
@@ -8,4 +8,4 @@ Use FAS to update the firmware and set the BMC password.
 
 Open a new tab and follow [Update Firmware](../../firmware/Update_Firmware_with_FAS.md).
 
-Proceed to the next step to [Boot NCN and Configure](Boot_NCN.md) or return to the main [Add, Remove, Replace, or Move NCNs](../Add_Remove_Replace_NCNs.md) page.
+Proceed to the next step to [Boot NCN and Configure](Boot_NCN.md) or return to the main [Add, Remove, Replace, or Move NCNs](Add_Remove_Replace_NCNs.md) page.

--- a/operations/node_management/Add_Remove_Replace_NCNs/Validate_Health.md
+++ b/operations/node_management/Add_Remove_Replace_NCNs/Validate_Health.md
@@ -53,4 +53,4 @@ The following procedures can be run from any master or worker node.
    If a storage node has been added, `ncn-healthcheck-storage` failures for the following test may need to be remediated based on the test description information and the `ncn-healthcheck-storage` tests should then be re-run to verify all tests pass.
    - `Spire Health Check`
 
-The procedure is complete. [Return to Main Page](../Add_Remove_Replace_NCNs.md).
+The procedure is complete. [Return to Main Page](Add_Remove_Replace_NCNs.md).

--- a/operations/node_management/Add_Remove_Replace_NCNs/Validate_NCN.md
+++ b/operations/node_management/Add_Remove_Replace_NCNs/Validate_NCN.md
@@ -100,7 +100,7 @@ Validate the worker node added successfully.
 
 1. Confirm the pods are beginning to get scheduled and reach a `Running` state on the worker node.
 
-    Run this command on any master or worker node. This command assumes you have set the variables from [the prerequisites section](../Add_Remove_Replace_NCNs.md#add-ncn-prerequisites).
+    Run this command on any master or worker node. This command assumes you have set the variables from [the prerequisites section](Add_Remove_Replace_NCNs.md#add-ncn-prerequisites).
 
     ```bash
     ncn# kubectl get po -A -o wide | grep $NODE
@@ -208,4 +208,4 @@ Validate the storage node added successfully. The following examples are based o
 
 ## Next Step
 
-Proceed to the next step to [Validate Health](Validate_Health.md) or return to the main [Add, Remove, Replace, or Move NCNs](../Add_Remove_Replace_NCNs.md) page.
+Proceed to the next step to [Validate Health](Validate_Health.md) or return to the main [Add, Remove, Replace, or Move NCNs](Add_Remove_Replace_NCNs.md) page.


### PR DESCRIPTION
# Description

DOCS: The "Alpha Framework to Add, Remove, Replace, or Move NCNs" top level procedure is missing from the generated HMTL docs

Move the .md under the directory so as not to cause issues overwriting the index.

# Checklist Before Merging

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
