### PR TITLE
Add troubleshooting doc for helm charts that timeout (CASMPET-6114)

### DIFF
--- a/install/install_csm_services.md
+++ b/install/install_csm_services.md
@@ -11,6 +11,7 @@ This procedure will install CSM applications and services into the CSM Kubernete
 * [Known issues](#known-issues)
   * [`Deploy CSM Applications and Services` known issues](#deploy-csm-applications-and-services-known-issues)
   * [`Setup Nexus` known issues](#setup-nexus-known-issues)
+  * [`Helm Chart Timeouts` known issues](../troubleshooting/known_issues/helm_chart_deploy_timeouts.md)
 
 ## 1. Install CSM services
 

--- a/troubleshooting/known_issues/helm_chart_deploy_timeouts.md
+++ b/troubleshooting/known_issues/helm_chart_deploy_timeouts.md
@@ -1,0 +1,20 @@
+# Helm Chart Deploy Timeouts
+
+There are times when installing CSM Services (either during fresh install or upgrade) when some helm charts may take longer than five minutes (default) to deploy.
+Several charts known to take longer than five minutes have been modified to allow more time, but this page can be used to manually increase this timeout if needed.
+
+## Edit the manifest used by Loftsman
+
+Locate the chart which is taking too long to deploy in the manifest (typically `platform.yaml` or `sysmgmt.yaml`), and add the `timeout` field at the same level as `name` in the manifest:
+
+```text
+  - name: cray-precache-images
+    source: csm-algol60
+    version: 0.5.2
+    namespace: nexus
+    timeout: 20m0s     <-------------
+```
+
+## Continue with the CSM Services install
+
+After having changed this setting in the manifest, re-running the install (or upgrade script) should successfully deploy the chart(s).

--- a/upgrade/Upgrade_Management_Nodes_and_CSM_Services.md
+++ b/upgrade/Upgrade_Management_Nodes_and_CSM_Services.md
@@ -111,3 +111,7 @@ mentioned explicitly on this page, see [resource material](resource_material/REA
 
   - See the inline comment above on how to rerun a single step.
   - In order to rerun the whole upgrade of a node, delete its state file.
+
+- Helm Chart Timeouts
+
+  See [`Helm Chart Timeouts` known issues](../troubleshooting/known_issues/helm_chart_deploy_timeouts.md) for steps to increase the timeout for a chart that is taking longer than five minutes to deploy.


### PR DESCRIPTION
# Description

Add note instructing users on how to increase a helm deploy timeout.

# Checklist Before Merging

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

