### PR TITLE
CASMTRIAGE-4475

### DIFF
--- a/install/prepare_site_init.md
+++ b/install/prepare_site_init.md
@@ -191,11 +191,19 @@ with system-specific customizations.
         openssl s_client -showcerts -nameopt RFC2253 -connect "${LDAP}:${PORT}" </dev/null 2>/dev/null | grep issuer= | sed -e 's/^issuer=//'
         ```
 
-        Expected output includes a line similar to this:
+        Expected output includes a line similar to one of the below examples:
+
+        Self-signed Certificate:
 
         ```text
         emailAddress=dcops@hpe.com,CN=Data Center,OU=HPC/MCS,O=HPE,ST=WI,C=US
         ```
+
+        Signed Certificate:
+
+        ```text
+         CN=DigiCert Global G2 TLS RSA SHA256 2020 CA1,O=DigiCert Inc,C=US
+         ```
 
     1. (`pit#`) Extract the issuer's certificate using `awk`.
 

--- a/operations/security_and_authentication/Add_LDAP_User_Federation.md
+++ b/operations/security_and_authentication/Add_LDAP_User_Federation.md
@@ -356,7 +356,7 @@ LDAP user federation is not currently configured in Keycloak. For example, if it
          Example output:
 
          ```text
-         emailAddress=dcops@hpe.com,CN=Data Center,OU=HPC/MCS,O=HPE,ST=WI,C=US
+         CN=DigiCert Global G2 TLS RSA SHA256 2020 CA1,O=DigiCert Inc,C=US
          ```
 
       1. Extract the issuer's certificate using the `awk` command.
@@ -367,7 +367,7 @@ LDAP user federation is not currently configured in Keycloak. For example, if it
 
          ```bash
          openssl s_client -showcerts -nameopt RFC2253 -connect $LDAP:${PORT} </dev/null 2>/dev/null |
-            awk '/s:emailAddress=dcops@hpe.com,CN=Data Center,OU=HPC\/MCS,O=HPE,ST=WI,C=US/,/END CERTIFICATE/' |
+            awk '/s:CN=DigiCert Global G2 TLS RSA SHA256 2020 CA1,O=DigiCert Inc,C=US/,/END CERTIFICATE/' |
             awk '/BEGIN CERTIFICATE/,/END CERTIFICATE/' > cacert.pem
          ```
 


### PR DESCRIPTION
# Description

Fix for the new dcldap cert.  The cert format changed so the older command would not result in fetching the cert

<!--- Describe what this change is and what it is for. -->

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
