### PR TITLE
CASMCMS-8311 - add console services troubleshooting page for stuck pods.

### DIFF
--- a/operations/conman/ConMan.md
+++ b/operations/conman/ConMan.md
@@ -10,4 +10,16 @@ There are multiple `cray-console-node` pods, scaled to the size of the system.
 
 ## How To Use
 
-See [Log in to a Node Using ConMan](Log_in_to_a_Node_Using_ConMan.md) for more information.
+[Log in to a Node Using ConMan](Log_in_to_a_Node_Using_ConMan.md)
+[Access Compute Node Logs](Access_Compute_Node_Logs.md)
+[Manage Node Consoles](Manage_Node_Consoles.md)
+[Establish a Serial Connection to an NCN](Establish_a_Serial_Connection_to_NCNs.md)
+[Disable ConMan After System Software Installation](Disable_ConMan_After_System_Software_Installation.md)
+[Access Console Log Data Via the System Monitoring Framework (SMF)](Access_Console_Log_Data_Via_the_System_Monitoring_Framework_SMF.md)
+
+## Troubleshooting
+
+[Troubleshoot ConMan Asking for Password on SSH Connection](Troubleshoot_ConMan_Asking_for_Password_on_SSH_Connection.md)
+[Troubleshoot ConMan Blocking Access to a Node BMC](Troubleshoot_ConMan_Blocking_Access_to_a_Node_BMC.md)
+[Troubleshoot ConMan Failing to Connect to a Console](Troubleshoot_ConMan_Failing_to_Connect_to_a_Console.md)
+[Troubleshoot ConMan Node Pod Stuck in Terminating](Troubleshoot_ConMan_Node_Pod_Stuck_Terminating.md)

--- a/operations/conman/ConMan.md
+++ b/operations/conman/ConMan.md
@@ -8,18 +8,18 @@ Node console logs are stored locally within the `cray-console-node` pods in the 
 In CSM versions 1.0 and later, the ConMan logs and interactive consoles are accessible through one of the `cray-console-node` pods.
 There are multiple `cray-console-node` pods, scaled to the size of the system.
 
-## How To Use
+## How to use
 
-[Log in to a Node Using ConMan](Log_in_to_a_Node_Using_ConMan.md)
-[Access Compute Node Logs](Access_Compute_Node_Logs.md)
-[Manage Node Consoles](Manage_Node_Consoles.md)
-[Establish a Serial Connection to an NCN](Establish_a_Serial_Connection_to_NCNs.md)
-[Disable ConMan After System Software Installation](Disable_ConMan_After_System_Software_Installation.md)
-[Access Console Log Data Via the System Monitoring Framework (SMF)](Access_Console_Log_Data_Via_the_System_Monitoring_Framework_SMF.md)
+- [Log in to a Node Using ConMan](Log_in_to_a_Node_Using_ConMan.md)
+- [Access Compute Node Logs](Access_Compute_Node_Logs.md)
+- [Manage Node Consoles](Manage_Node_Consoles.md)
+- [Establish a Serial Connection to an NCN](Establish_a_Serial_Connection_to_NCNs.md)
+- [Disable ConMan After System Software Installation](Disable_ConMan_After_System_Software_Installation.md)
+- [Access Console Log Data Via the System Monitoring Framework (SMF)](Access_Console_Log_Data_Via_the_System_Monitoring_Framework_SMF.md)
 
 ## Troubleshooting
 
-[Troubleshoot ConMan Asking for Password on SSH Connection](Troubleshoot_ConMan_Asking_for_Password_on_SSH_Connection.md)
-[Troubleshoot ConMan Blocking Access to a Node BMC](Troubleshoot_ConMan_Blocking_Access_to_a_Node_BMC.md)
-[Troubleshoot ConMan Failing to Connect to a Console](Troubleshoot_ConMan_Failing_to_Connect_to_a_Console.md)
-[Troubleshoot ConMan Node Pod Stuck in Terminating](Troubleshoot_ConMan_Node_Pod_Stuck_Terminating.md)
+- [Troubleshoot ConMan Asking for Password on SSH Connection](Troubleshoot_ConMan_Asking_for_Password_on_SSH_Connection.md)
+- [Troubleshoot ConMan Blocking Access to a Node BMC](Troubleshoot_ConMan_Blocking_Access_to_a_Node_BMC.md)
+- [Troubleshoot ConMan Failing to Connect to a Console](Troubleshoot_ConMan_Failing_to_Connect_to_a_Console.md)
+- [Troubleshoot ConMan Node Pod Stuck in Terminating](Troubleshoot_ConMan_Node_Pod_Stuck_Terminating.md)

--- a/operations/conman/Troubleshoot_ConMan_Node_Pod_Stuck_Terminating.md
+++ b/operations/conman/Troubleshoot_ConMan_Node_Pod_Stuck_Terminating.md
@@ -1,0 +1,99 @@
+# Troubleshoot Console Node Pod Stuck in Terminating State
+
+When a worker node goes down unexpectedly, a `cray-console-node` pod running on that worker
+may get stuck in a `Terminating` state that prevents it moving to a healthy worker. This can
+leave consoles unmonitored and not available for interactive access.
+
+## Prerequisite
+
+Determine if this is a scenario where the `cray-console-node` pod is stuck in `Terminating` due
+to the failure of the worker node it is running on or some other cause. This fix should only
+be applied to the case where the worker node did not properly drain before being shut down.
+
+1. (`ncn-mw#`) Find which worker the `Terminating` pod is running on.
+
+```bash
+kubectl -n services get pods | grep console
+```
+
+Example output:
+
+```text
+cray-console-data-6ff47b7454-ch5dj             2/2     Running        0      4d3h   ncn-w003
+cray-console-data-postgres-0                   3/3     Running        0      5h50m  ncn-w002
+cray-console-data-postgres-1                   3/3     Terminating    0      3d22h  ncn-w001
+cray-console-data-postgres-2                   3/3     Running        0      4d1h   ncn-w003
+cray-console-node-0                            3/3     Terminating    0      16h    ncn-w001
+cray-console-node-1                            3/3     Running        0      4d22h  ncn-w002
+cray-console-operator-575d8b9f9d-s95v9         2/2     Running        0      30m    ncn-w002
+cray-console-operator-575d8b9f9d-x2bvm         2/2     Terminating    0      16h    ncn-w001
+```
+
+In this example `cray-console-node-0` is stuck in `Terminating` and running on `ncn-w001`.
+
+**`NOTE`** Other pods are also stuck in `Terminating`, but only the `cray-console-node` pods
+need to be manually terminated and forced to a different worker node.
+
+1. (`ncn-mw#`) Find the state of the worker node.
+
+```bash
+kubectl get nodes
+```
+
+Example output:
+
+```text
+NAME       STATUS     ROLES                  AGE   VERSION
+ncn-m001   Ready      control-plane,master   34d   v1.21.12
+ncn-m002   Ready      control-plane,master   35d   v1.21.12
+ncn-m003   Ready      control-plane,master   35d   v1.21.12
+ncn-w001   NotReady   <none>                 35d   v1.21.12
+ncn-w002   Ready      <none>                 35d   v1.21.12
+ncn-w003   Ready      <none>                 35d   v1.21.12
+```
+
+In this example the worker node `ncn-w001` is not reporting to the cluster.
+
+1. Wait some time to see if the worker node rejoins the cluster.
+
+If the node rejoins the cluster the issue will sort itself out with no further manual
+intervention. If too much time has passed and the node is not resolving the problem
+continue on to the below procedure to force the `cray-console-node` pod to move to a
+different worker.
+
+## Procedure
+
+A force terminate will remove the old pod and it will start up on a healthy worker. There
+is a slight chance that if the old pod is really still working despite the node being
+unhealthy, the new and old pods will conflict. Only do the following if the worker node is
+down.
+
+1. (`ncn-mw#`) Force terminate the `cray-console-node` pod.
+
+In the above example the `cray-console-node-0` pod was on the worker node that shut down
+unexpectedly. The following commands assume that is the pod being worked with.
+
+```bash
+kubectl -n services delete pod cray-console-node-0 --grace-period=0 --force
+```
+
+1. (`ncn-mw#`) Wait for the new pod to restart on a healthy worker.
+
+```bash
+kubectl -n services get pods | grep console
+```
+
+Expected output when healthy:
+
+```text
+cray-console-data-6ff47b7454-ch5dj             2/2     Running        0      4d3h   ncn-w003
+cray-console-data-postgres-0                   3/3     Running        0      5h50m  ncn-w002
+cray-console-data-postgres-1                   3/3     Terminating    0      3d22h  ncn-w001
+cray-console-data-postgres-2                   3/3     Running        0      4d1h   ncn-w003
+cray-console-node-0                            3/3     Running        0      2m     ncn-w003
+cray-console-node-1                            3/3     Running        0      4d22h  ncn-w002
+cray-console-operator-575d8b9f9d-s95v9         2/2     Running        0      30m    ncn-w002
+cray-console-operator-575d8b9f9d-x2bvm         2/2     Terminating    0      16h    ncn-w001
+```
+
+It will take a few minutes for the new pod to resume console interactions.

--- a/operations/conman/Troubleshoot_ConMan_Node_Pod_Stuck_Terminating.md
+++ b/operations/conman/Troubleshoot_ConMan_Node_Pod_Stuck_Terminating.md
@@ -6,94 +6,95 @@ leave consoles unmonitored and not available for interactive access.
 
 ## Prerequisite
 
-Determine if this is a scenario where the `cray-console-node` pod is stuck in `Terminating` due
-to the failure of the worker node it is running on or some other cause. This fix should only
-be applied to the case where the worker node did not properly drain before being shut down.
+Determine if this is a scenario where the `cray-console-node` pod is stuck in `Terminating` because
+of the failure of the worker node it is running on, or for some other reason. This fix should only
+be applied in the case where the worker node did not properly drain before being shut down.
 
 1. (`ncn-mw#`) Find which worker the `Terminating` pod is running on.
 
-```bash
-kubectl -n services get pods | grep console
-```
+    ```bash
+    kubectl -n services get pods | grep console
+    ```
 
-Example output:
+    Example output:
 
-```text
-cray-console-data-6ff47b7454-ch5dj             2/2     Running        0      4d3h   ncn-w003
-cray-console-data-postgres-0                   3/3     Running        0      5h50m  ncn-w002
-cray-console-data-postgres-1                   3/3     Terminating    0      3d22h  ncn-w001
-cray-console-data-postgres-2                   3/3     Running        0      4d1h   ncn-w003
-cray-console-node-0                            3/3     Terminating    0      16h    ncn-w001
-cray-console-node-1                            3/3     Running        0      4d22h  ncn-w002
-cray-console-operator-575d8b9f9d-s95v9         2/2     Running        0      30m    ncn-w002
-cray-console-operator-575d8b9f9d-x2bvm         2/2     Terminating    0      16h    ncn-w001
-```
+    ```text
+    cray-console-data-6ff47b7454-ch5dj             2/2     Running        0      4d3h   ncn-w003
+    cray-console-data-postgres-0                   3/3     Running        0      5h50m  ncn-w002
+    cray-console-data-postgres-1                   3/3     Terminating    0      3d22h  ncn-w001
+    cray-console-data-postgres-2                   3/3     Running        0      4d1h   ncn-w003
+    cray-console-node-0                            3/3     Terminating    0      16h    ncn-w001
+    cray-console-node-1                            3/3     Running        0      4d22h  ncn-w002
+    cray-console-operator-575d8b9f9d-s95v9         2/2     Running        0      30m    ncn-w002
+    cray-console-operator-575d8b9f9d-x2bvm         2/2     Terminating    0      16h    ncn-w001
+    ```
 
-In this example `cray-console-node-0` is stuck in `Terminating` and running on `ncn-w001`.
+    In this example, `cray-console-node-0` is stuck in `Terminating` and running on `ncn-w001`.
 
-**`NOTE`** Other pods are also stuck in `Terminating`, but only the `cray-console-node` pods
-need to be manually terminated and forced to a different worker node.
+    **NOTE** Other pods are also stuck in `Terminating`, but only the `cray-console-node` pods
+    need to be manually terminated and forced to a different worker node.
 
 1. (`ncn-mw#`) Find the state of the worker node.
 
-```bash
-kubectl get nodes
-```
+    ```bash
+    kubectl get nodes
+    ```
 
-Example output:
+    Example output:
 
-```text
-NAME       STATUS     ROLES                  AGE   VERSION
-ncn-m001   Ready      control-plane,master   34d   v1.21.12
-ncn-m002   Ready      control-plane,master   35d   v1.21.12
-ncn-m003   Ready      control-plane,master   35d   v1.21.12
-ncn-w001   NotReady   <none>                 35d   v1.21.12
-ncn-w002   Ready      <none>                 35d   v1.21.12
-ncn-w003   Ready      <none>                 35d   v1.21.12
-```
+    ```text
+    NAME       STATUS     ROLES                  AGE   VERSION
+    ncn-m001   Ready      control-plane,master   34d   v1.21.12
+    ncn-m002   Ready      control-plane,master   35d   v1.21.12
+    ncn-m003   Ready      control-plane,master   35d   v1.21.12
+    ncn-w001   NotReady   <none>                 35d   v1.21.12
+    ncn-w002   Ready      <none>                 35d   v1.21.12
+    ncn-w003   Ready      <none>                 35d   v1.21.12
+    ```
 
-In this example the worker node `ncn-w001` is not reporting to the cluster.
+    In this example, the worker node `ncn-w001` is not reporting to the cluster.
 
 1. Wait some time to see if the worker node rejoins the cluster.
 
-If the node rejoins the cluster the issue will sort itself out with no further manual
-intervention. If too much time has passed and the node is not resolving the problem
-continue on to the below procedure to force the `cray-console-node` pod to move to a
-different worker.
+    If the node rejoins the cluster, then the issue will sort itself out with no further manual
+    intervention. If too much time has passed and the node is not resolving the problem on its
+    own, then perform the following procedure in order to force the `cray-console-node` pod to
+    move to a different worker.
 
 ## Procedure
 
 A force terminate will remove the old pod and it will start up on a healthy worker. There
 is a slight chance that if the old pod is really still working despite the node being
-unhealthy, the new and old pods will conflict. Only do the following if the worker node is
+unhealthy, then the new and old pods will conflict. Only do the following if the worker node is
 down.
 
 1. (`ncn-mw#`) Force terminate the `cray-console-node` pod.
 
-In the above example the `cray-console-node-0` pod was on the worker node that shut down
-unexpectedly. The following commands assume that is the pod being worked with.
+    In the above example the `cray-console-node-0` pod was on the worker node that shut down
+    unexpectedly. The following command example uses that pod name. Be sure to modify the example
+    command with the actual pod name before running it.
 
-```bash
-kubectl -n services delete pod cray-console-node-0 --grace-period=0 --force
-```
+    ```bash
+    kubectl -n services delete pod cray-console-node-0 --grace-period=0 --force
+    ```
 
 1. (`ncn-mw#`) Wait for the new pod to restart on a healthy worker.
 
-```bash
-kubectl -n services get pods | grep console
-```
+    ```bash
+    kubectl -n services get pods | grep console
+    ```
 
-Expected output when healthy:
+    Example output when healthy:
 
-```text
-cray-console-data-6ff47b7454-ch5dj             2/2     Running        0      4d3h   ncn-w003
-cray-console-data-postgres-0                   3/3     Running        0      5h50m  ncn-w002
-cray-console-data-postgres-1                   3/3     Terminating    0      3d22h  ncn-w001
-cray-console-data-postgres-2                   3/3     Running        0      4d1h   ncn-w003
-cray-console-node-0                            3/3     Running        0      2m     ncn-w003
-cray-console-node-1                            3/3     Running        0      4d22h  ncn-w002
-cray-console-operator-575d8b9f9d-s95v9         2/2     Running        0      30m    ncn-w002
-cray-console-operator-575d8b9f9d-x2bvm         2/2     Terminating    0      16h    ncn-w001
-```
+    ```text
+    cray-console-data-6ff47b7454-ch5dj             2/2     Running        0      4d3h   ncn-w003
+    cray-console-data-postgres-0                   3/3     Running        0      5h50m  ncn-w002
+    cray-console-data-postgres-1                   3/3     Terminating    0      3d22h  ncn-w001
+    cray-console-data-postgres-2                   3/3     Running        0      4d1h   ncn-w003
+    cray-console-node-0                            3/3     Running        0      2m     ncn-w003
+    cray-console-node-1                            3/3     Running        0      4d22h  ncn-w002
+    cray-console-operator-575d8b9f9d-s95v9         2/2     Running        0      30m    ncn-w002
+    cray-console-operator-575d8b9f9d-x2bvm         2/2     Terminating    0      16h    ncn-w001
+    ```
 
-It will take a few minutes for the new pod to resume console interactions.
+    It will take a few minutes for the new pod to resume console interactions.


### PR DESCRIPTION
# Description

Add a console services troubleshooting page for how to manually move a cray-console-node pod that is stuck in 'Terminating' due to a worker node being shut down unexpectedly. Since this is a stateful set instead of a deployment it needs to be manually killed before it will move to another (healthy) worker.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
