### PR TITLE
CASMINST-5577: Linting of upgrade stage 0 and CSM RBD Tool info page

### DIFF
--- a/operations/utility_storage/CSM_rbd_tool_Usage.md
+++ b/operations/utility_storage/CSM_rbd_tool_Usage.md
@@ -1,6 +1,55 @@
 # CSM RBD Tool Usage
 
-## Introduction
+- [Prerequisites](#prerequisites)
+  - [Preparing the Python environment](#preparing-the-python-environment)
+  - [Restoring the Python environment](#restoring-the-python-environment)
+- [Usage](#usage)
+- [Examples](#examples)
+  - [Checking device status](#checking-device-status)
+  - [Moving device to different node](#moving-device-to-different-node)
+- [Troubleshooting](#troubleshooting)
+  - [mount system call fails when moving `rbd` device](#mount-system-call-fails-when-moving-rbd-device)
+
+## Prerequisites
+
+- The tool must be run on a Kubernetes master NCN or one of the Ceph storage NCNs.
+  - The Ceph storage NCNs are typically the first three storage NCNs: `ncn-s001`, `ncn-s002`, and `ncn-s003`.
+- The latest CSM documentation RPM is installed on the node where the script is being run.
+  - See [Check for latest documentation](../../update_product_stream/README.md#check-for-latest-documentation).
+- Before running the tool, the Python environment must be prepared.
+  - See [Preparing the Python environment](#preparing-the-python-environment).
+
+### Preparing the Python environment
+
+Before running the tool, the Python environment must be prepared using the following procedure on the node where the tool is going to be run.
+
+1. Verify that the latest CSM documentation RPM is installed.
+
+    See [Check for latest documentation](../../update_product_stream/README.md#check-for-latest-documentation).
+
+1. (`ncn-ms#`) Extract the necessary files.
+
+    > This only needs to be done once after the latest documentation RPM is installed on the node, but there is no harm in running it multiple times.
+
+    ```bash
+    tar xvf /usr/share/doc/csm/scripts/csm_rbd_tool.tar.gz -C /opt/cray/csm/scripts/
+    ```
+
+1. (`ncn-ms#`) Initialize the Python environment.
+
+    ```bash
+    source /opt/cray/csm/scripts/csm_rbd_tool/bin/activate
+    ```
+
+After the tool has been run, restore the original Python environment in the shell. See [Restoring the Python environment](#restoring-the-python-environment).
+
+### Restoring the Python environment
+
+(`ncn-ms#`) After the tool has been run, restore the original Python environment in the shell by running the following command:
+
+```bash
+deactivate
+```
 
 ## Usage
 
@@ -31,85 +80,103 @@ optional arguments:
 
 ## Examples
 
-1. (`ncn-m#`) Check the status of the `rbd` device.
+- [Checking device status](#checking-device-status)
+- [Moving device to different node](#moving-device-to-different-node)
 
-   ```bash
-   /usr/share/doc/csm/scripts/csm_rbd_tool.py --status
-   ```
+### Checking device status
 
-   Output:
-
-   ```text
-   [{"id":"0","pool":"csm_admin_pool","namespace":"","name":"csm_scratch_img","snap":"-","device":"/dev/rbd0"}]
-   Pool csm_admin_pool exists: True
-   RBD device exists True
-   RBD device mounted at - ncn-m001.nmn:/etc/cray/upgrade/csm
-   ```
-
-2. (`ncn-s001`) Move the `rbd` device.
-
-   ```bash
-   /usr/share/doc/csm/scripts/csm_rbd_tool.py --rbd_action move --target_host ncn-m002
-   ```
-
-   Output:
-
-   ```text
-   [{"id":"0","pool":"csm_admin_pool","namespace":"","name":"csm_scratch_img","snap":"-","device":"/dev/rbd0"}]
-   /dev/rbd0
-   RBD device mounted at - ncn-m002.nmn:/etc/cray/upgrade/csm
-   ```
-
-## Troubleshooting the RBD Tool
-
-### Issue
-
-Moving the `rbd` device can fail with the error message:
-
- `mount: /etc/cray/upgrade/csm: mount(2) system call failed: Structure needs cleaning.`
-
-### Fix
-
-To clean the device, first get the `rbd` device name and location.
-This can be found in the information outputted by the status check shown above. The device name is likely `/dev/rbd0` or similar and it should be located on `ncn-m001` or `ncn-m002`.
-Run the following command on the node that the device is located on.
-
-(`ncn-m#`) Clean the device. This may have multiple prompts. 
+(`ncn-ms#`) Check the status of the `rbd` device.
 
 ```bash
-   fsck.ext4 <device_name>
+/usr/share/doc/csm/scripts/csm_rbd_tool.py --status
 ```
 
 Example output:
 
 ```text
-e2fsck 1.43.8 (1-Jan-2018)
-One or more block group descriptor checksums are invalid.  Fix<y>?
-
-Group descriptor 7999 checksum is 0x6f65, should be 0x6971.  FIXED.
-Pass 1: Checking inodes, blocks, and sizes
-
-Pass 2: Checking directory structure
-Pass 3: Checking directory connectivity
-Pass 4: Checking reference counts
-Pass 5: Checking group summary information
-Block bitmap differences:  +(32768--33917) +(98304--99453) + ...
-Fix<y>? yes
-Free blocks count wrong (246632145, counted=257747999).
-Fix<y>? yes
-Free inodes count wrong (65529942, counted=65535989).
-Fix<y>? yes
-Padding at end of inode bitmap is not set. Fix<y>? yes
-
-/dev/rbd0: ***** FILE SYSTEM WAS MODIFIED *****
-/dev/rbd0: 11/65536000 files (0.0% non-contiguous), 4396001/262144000 blocks
+[{"id":"0","pool":"csm_admin_pool","namespace":"","name":"csm_scratch_img","snap":"-","device":"/dev/rbd0"}]
+Pool csm_admin_pool exists: True
+RBD device exists True
+RBD device mounted at - ncn-m001.nmn:/etc/cray/upgrade/csm
 ```
 
-Example output if the `rbd` device is already clean:
+### Moving device to different node
+
+(`ncn-ms#`) Move the `rbd` device.
+
+```bash
+/usr/share/doc/csm/scripts/csm_rbd_tool.py --rbd_action move --target_host ncn-m002
+```
+
+Example output:
 
 ```text
-e2fsck 1.43.8 (1-Jan-2018)
-/dev/rbd0: clean, 11/65536000 files, 4396001/262144000 blocks
+[{"id":"0","pool":"csm_admin_pool","namespace":"","name":"csm_scratch_img","snap":"-","device":"/dev/rbd0"}]
+/dev/rbd0
+RBD device mounted at - ncn-m002.nmn:/etc/cray/upgrade/csm
 ```
 
-Once this is completed, retry moving the `rbd` device.
+## Troubleshooting
+
+### mount system call fails when moving `rbd` device
+
+The symptom of this issue is that moving the `rbd` device fails with the error message:
+
+ `mount: /etc/cray/upgrade/csm: mount(2) system call failed: Structure needs cleaning.`
+
+The fix for this issue is to clean the device using the following procedure.
+
+1. Get the `rbd` device name and location.
+
+    1. Check the device status.
+
+        See [Checking device status](#checking-device-status).
+
+    1. Examine the output of the status check for the device name and location.
+
+        The device name is likely `/dev/rbd0` or similar and it usually is located on `ncn-m001` or `ncn-m002`.
+
+1. (`ncn-m#`) Clean the device.
+
+    Run the following command on the node that the device is located on. Modify the command to use the
+    device name identified in the previous step.
+
+    This command may have multiple prompts.
+
+    ```bash
+    fsck.ext4 <device_name>
+    ```
+
+    - Example output of a successful clean:
+
+        ```text
+        e2fsck 1.43.8 (1-Jan-2018)
+        One or more block group descriptor checksums are invalid.  Fix<y>?
+
+        Group descriptor 7999 checksum is 0x6f65, should be 0x6971.  FIXED.
+        Pass 1: Checking inodes, blocks, and sizes
+
+        Pass 2: Checking directory structure
+        Pass 3: Checking directory connectivity
+        Pass 4: Checking reference counts
+        Pass 5: Checking group summary information
+        Block bitmap differences:  +(32768--33917) +(98304--99453) + ...
+        Fix<y>? yes
+        Free blocks count wrong (246632145, counted=257747999).
+        Fix<y>? yes
+        Free inodes count wrong (65529942, counted=65535989).
+        Fix<y>? yes
+        Padding at end of inode bitmap is not set. Fix<y>? yes
+
+        /dev/rbd0: ***** FILE SYSTEM WAS MODIFIED *****
+        /dev/rbd0: 11/65536000 files (0.0% non-contiguous), 4396001/262144000 blocks
+        ```
+
+    - Example output if the `rbd` device is already clean:
+
+        ```text
+        e2fsck 1.43.8 (1-Jan-2018)
+        /dev/rbd0: clean, 11/65536000 files, 4396001/262144000 blocks
+        ```
+
+1. Retry the original attempt to move the device.

--- a/upgrade/Stage_0_Prerequisites.md
+++ b/upgrade/Stage_0_Prerequisites.md
@@ -76,54 +76,71 @@ after a break, always be sure that a typescript is running before proceeding.
 
 1. (`ncn-m001#`) Create and mount an `rbd` device where the CSM release tarball can be stored.
 
+   This mounts the `rbd` device at `/etc/cray/upgrade/csm` on `ncn-m001`. This mount is available to stage content for the install/upgrade process.
+
+   > For more information about the tool used in this procedure, including troubleshooting information, see
+   > [CSM RBD Tool Usage](../operations/utility_storage/CSM_rbd_tool_Usage.md).
+
    1. Initialize the Python virtual environment.
 
       ```bash
       tar xvf /usr/share/doc/csm/scripts/csm_rbd_tool.tar.gz -C /opt/cray/csm/scripts/
       ```
 
-   1. Create and map the `rbd` device.
-
-      **IMPORTANT:** This mounts the `rbd` device at `/etc/cray/upgrade/csm` on `ncn-m001`. This mount is available to stage content for the install/upgrade process. First, check if this device already exists.
+   1. Check if the `rbd` device already exists.
 
       ```bash
       source /opt/cray/csm/scripts/csm_rbd_tool/bin/activate
       /usr/share/doc/csm/scripts/csm_rbd_tool.py --status
       ```
 
-      >Expected output if `rbd` device does not exist:
-      >
-      >```text
-      >Pool csm_admin_pool does not exist
-      >Pool csm_admin_pool exists: False
-      >RBD device exists None
-      >```
-      >
-      >Example output if `rbd` device already exist:
-      >
-      >```text
-      >[{"id":"0","pool":"csm_admin_pool","namespace":"","name":"csm_scratch_img","snap":"-","device":"/dev/rbd0"}]
-      >Pool csm_admin_pool exists: True
-      >RBD device exists True
-      >RBD device mounted at - ncn-m002.nmn:/etc/cray/upgrade/csm
-      >```
+      - Expected output if `rbd` device does not exist:
 
-      If the `rbd` device already exists and is mounted, it can be moved to the desired node, if not already mounted there.
-      **IMPORTANT:** *If upgrading from a CSM version that had previously mounted this rbd device, the `/etc/cray/upgrade/csm/myenv` file will need to be removed before proceeding with this upgrade as it will contain information from the previous install.*
+         ```text
+         Pool csm_admin_pool does not exist
+         Pool csm_admin_pool exists: False
+         RBD device exists None
+         ```
 
-      ```bash
-      /usr/share/doc/csm/scripts/csm_rbd_tool.py --rbd_action move --target_host ncn-m001
-      deactivate
-      ```
+      - Example output if `rbd` device already exists and is mounted on `ncn-m002`:
 
-      If the `rbd` device does not exists, create it.
+         ```text
+         [{"id":"0","pool":"csm_admin_pool","namespace":"","name":"csm_scratch_img","snap":"-","device":"/dev/rbd0"}]
+         Pool csm_admin_pool exists: True
+         RBD device exists True
+         RBD device mounted at - ncn-m002.nmn:/etc/cray/upgrade/csm
+         ```
 
-      ```bash
-      /usr/share/doc/csm/scripts/csm_rbd_tool.py --pool_action create --rbd_action create --target_host ncn-m001
-      deactivate
-      ```
+   1. Perform one of the following options based on the output of the status check.
 
-      For more information or usage on the csm_rbd_tool utility please see [csm_rbd_tool Usage](../operations/utility_storage/CSM_rbd_tool_Usage.md)
+      - The `rbd` device does not exist.
+
+         1. Create and map the `rbd` device.
+
+            ```bash
+            /usr/share/doc/csm/scripts/csm_rbd_tool.py --pool_action create --rbd_action create --target_host ncn-m001
+            deactivate
+            ```
+
+      - The `rbd` device exists.
+
+         1. Move the device to `ncn-m001`, if necessary.
+
+            This step is not necessary if the status output indicated that the device is already mounted on `ncn-m001`.
+
+            ```bash
+            /usr/share/doc/csm/scripts/csm_rbd_tool.py --rbd_action move --target_host ncn-m001
+            deactivate
+            ```
+
+         1. Remove leftover state file from a previous CSM upgrade, if necessary.
+
+            **IMPORTANT:** If upgrading from a CSM version that had previously mounted this `rbd` device, then the `/etc/cray/upgrade/csm/myenv`
+            file must be removed before proceeding with this upgrade, because it contains information from the previous upgrade.
+
+            ```bash
+            [[ -f /etc/cray/upgrade/csm/myenv ]] && rm -f /etc/cray/upgrade/csm/myenv
+            ```
 
 1. Follow either the [Direct download](#direct-download) or [Manual copy](#manual-copy) procedure.
 


### PR DESCRIPTION
# Description

Linting, but fairly extensive in terms of reorganizing and rewording content. No real content changes, but should still receive SME review from Craig or Lindsay, I think. Would be good to also get someone from SSI or an internal upgrader to take a gander, to make sure the changes to the stage 0 page in particular look okay to them.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
