### PR TITLE
CASMINST-5485/CASMINST-5487: Clarify NCN personalization & image customization

### DIFF
--- a/operations/configuration_management/NCN_Node_Personalization.md
+++ b/operations/configuration_management/NCN_Node_Personalization.md
@@ -2,6 +2,8 @@
 
 When performing an upgrade or fresh install, NCN node personalization must be performed on the NCN management nodes to ensure the appropriate CFS layers are applied post-boot.
 This step involves configuring CFS to use the default `sat bootprep` files from the `hpc-csm-software-recipe` repository and applying the resulting configuration to the NCN management nodes.
+The same CFS configuration is used for post-boot personalization of master, storage, and worker NCNs. However, some individual parts of that configuration will only be applied to
+appropriate node types.
 
 The definition of the CFS configuration used for node personalization is provided in the `hpc-csm-software-recipe` repository in VCS.
 The following procedure describes how to correctly edit the `sat bootprep` files to be able to use them to perform node personalization.

--- a/operations/configuration_management/Worker_Image_Customization.md
+++ b/operations/configuration_management/Worker_Image_Customization.md
@@ -33,8 +33,13 @@ The following procedure describes how to correctly edit the `bootprep` files to 
     sat bootprep run management-bootprep-image-customization.yaml
     ```
 
-1. (`ncn-m#`) Perform the steps in [Management Node Image Customization](Management_Node_Image_Customization.md). Use the CFS configuration created in the previous step when
-    customizing the image.
+1. Customize the worker NCN image and update BSS to use the new image.
+
+    Perform the steps in [Management Node Image Customization](Management_Node_Image_Customization.md), with the following notes:
+
+    - Skip the steps in the linked procedure to create the CFS configuration, because the CFS configuration was already created in the previous step.
+    - When creating the CFS session to customize the image, use the CFS configuration created in the previous step.
+    - When updating the boot parameters, update them for every NCN worker node in the system.
 
 1. (`ncn-m#`) Optionally, delete `management-bootprep-image-customization.yaml`, which is no longer needed.
 

--- a/upgrade/Stage_0_Prerequisites.md
+++ b/upgrade/Stage_0_Prerequisites.md
@@ -263,7 +263,8 @@ microservices to personalize a node after it has booted.
 
 ### Standard upgrade
 
-In most cases, administrators will be performing a standard upgrade and not a CSM-only system upgrade. In the standard upgrade, worker NCN image customization and node personalization steps are required.
+In most cases, administrators will be performing a standard upgrade and not a CSM-only system upgrade.
+In the standard upgrade, the new worker NCN images must be customized, and all NCNs must have their personalization configurations updated in CFS.
 
 **NOTE:** For the standard upgrade, it will not be possible to rebuild NCNs on the current, pre-upgraded CSM version after performing these steps. Rebuilding NCNs will become the same thing as upgrading them.
 
@@ -277,9 +278,9 @@ In most cases, administrators will be performing a standard upgrade and not a CS
     This will ensure that the CFS configuration layers are applied to perform image customization for the worker NCNs.
     See [Worker Image Customization](../operations/configuration_management/Worker_Image_Customization.md).
 
-1. Prepare the post-boot worker NCN personalizations.
+1. Prepare the post-boot NCN personalizations.
 
-    This will ensure that the appropriate CFS configuration layers are applied when performing post-boot node personalization of the worker NCNs.
+    This will ensure that the appropriate CFS configuration layers are applied when performing post-boot node personalization of the NCNs.
     See [NCN Node Personalization](../operations/configuration_management/NCN_Node_Personalization.md).
 
 Continue on to [Stage 0.4](#stage-04---backup-workload-manager-data), skipping the [CSM-only system upgrade](#csm-only-system-upgrade) subsection below.

--- a/upgrade/Stage_0_Prerequisites.md
+++ b/upgrade/Stage_0_Prerequisites.md
@@ -280,7 +280,7 @@ In the standard upgrade, the new worker NCN images must be customized, and all N
 
 1. Prepare the post-boot NCN personalizations.
 
-    This will ensure that the appropriate CFS configuration layers are applied when performing post-boot node personalization of the NCNs.
+    This will ensure that the appropriate CFS configuration layers are applied when performing post-boot node personalization of the master, storage, and worker NCNs.
     See [NCN Node Personalization](../operations/configuration_management/NCN_Node_Personalization.md).
 
 Continue on to [Stage 0.4](#stage-04---backup-workload-manager-data), skipping the [CSM-only system upgrade](#csm-only-system-upgrade) subsection below.


### PR DESCRIPTION
# Description

Clarify that during upgrades, NCN image customizations is worker only, but personalization is for all management NCNs.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
