### PR TITLE
Add note about resetting cfs component state prior to worker upgrade if in error state (CASMTRIAGE-4500)

### DIFF
--- a/upgrade/Stage_2.md
+++ b/upgrade/Stage_2.md
@@ -60,6 +60,14 @@ Note that the progress for the current stage will not show up in Argo before the
 
 For more information, see [Using the Argo UI](../operations/argo/Using_the_Argo_UI.md) and [Using Argo Workflows](../operations/argo/Using_Argo_Workflows.md).
 
+> **`NOTE`** One of the Argo steps (`wait-for-cfs`) will prevent the upgrade of a worker node from proceeding if the CFS component status for that worker is in an `Error` state, and this must be fixed in order for the upgrade to continue.
+The following steps can be used to reset the component state in CFS (replace `XNAME` below with the `XNAME` for the worker node:
+
+```text
+cray cfs components update --error-count 0 <XNAME>
+cray cfs components update --state '[]' <XNAME>
+```
+
 ## Stage 2.2 - Worker node image upgrade
 
 There are two options available for upgrading worker nodes.


### PR DESCRIPTION
# Description

Add note about how to reset cfs component state prior to worker upgrade if in error state.

# Checklist Before Merging

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
