### PR TITLE
CASMINST-5482: Specify where to obtain artifact version for NCN image customization during CSM upgrades

### DIFF
--- a/operations/configuration_management/Management_Node_Image_Customization.md
+++ b/operations/configuration_management/Management_Node_Image_Customization.md
@@ -21,7 +21,7 @@ This document describes the configuration of a Kubernetes NCN image. The same st
 1. (`ncn-mw#`) Obtain the NCN image's associated artifacts (SquashFS, kernel, and `initrd`).
 
     These example commands show how to download these artifacts from S3, which is where the NCN image artifacts are stored.
-    If customizing a Ceph image, the `k8s` string in these examples would be replaced by `ceph`.
+    If customizing a Ceph image, then replace the `k8s` string in these examples with `ceph`.
 
     ```bash
     cray artifacts get boot-images "k8s/${ARTIFACT_VERSION}/rootfs" "./${ARTIFACT_VERSION}-rootfs"

--- a/operations/configuration_management/Management_Node_Image_Customization.md
+++ b/operations/configuration_management/Management_Node_Image_Customization.md
@@ -5,22 +5,25 @@ is only relevant for booting compute nodes and can be ignored when working with 
 
 This document describes the configuration of a Kubernetes NCN image. The same steps could be used to modify a Ceph NCN image.
 
-1. Identify the NCN image to be modified.
+1. (`ncn-mw#`) Identify the NCN image to be modified.
 
-    This example assumes that the administrator wants to modify the Kubernetes image that is currently in use by Kubernetes NCNs.
-    However, the steps are the same for any Management NCN SquashFS image.
+    If this procedure is being done as part of a CSM upgrade, then the documentation which linked to this procedure will have
+    provided instructions for how to set the `ARTIFACT_VERSION` variable.
 
-    If the image to be modified is the image currently booted on a Kubernetes NCN, the value for `ARTIFACT_VERSION` can be found by looking
-    at the boot parameters for the NCNs, or from `/proc/cmdline` on a booted Kubernetes NCN. The version has the form of `X.Y.Z`.
+    Otherwise, if the image to be modified is the image currently booted on a Kubernetes NCN, then find the value for `ARTIFACT_VERSION`
+    by looking at the boot parameters for the NCNs, or by reading  `/proc/cmdline` on a booted Kubernetes NCN. The version has the form of `X.Y.Z`.
     See: [boot parameters](../../background#metalserver)
+
+    ```bash
+    ARTIFACT_VERSION=<artifact-version>
+    ```
 
 1. (`ncn-mw#`) Obtain the NCN image's associated artifacts (SquashFS, kernel, and `initrd`).
 
     These example commands show how to download these artifacts from S3, which is where the NCN image artifacts are stored.
+    If customizing a Ceph image, the `k8s` string in these examples would be replaced by `ceph`.
 
     ```bash
-    ARTIFACT_VERSION=<artifact-version>
-
     cray artifacts get boot-images "k8s/${ARTIFACT_VERSION}/rootfs" "./${ARTIFACT_VERSION}-rootfs"
 
     cray artifacts get boot-images "k8s/${ARTIFACT_VERSION}/kernel" "./${ARTIFACT_VERSION}-kernel"

--- a/operations/configuration_management/Worker_Image_Customization.md
+++ b/operations/configuration_management/Worker_Image_Customization.md
@@ -69,7 +69,7 @@ to the NCN worker image before the workers are booted.
         ```
 
     - Skip the steps in the linked procedure to create the CFS configuration, because the CFS configuration was already created in the previous step.
-    - When creating the CFS session to customize the image, use the CFS configuration created in the previous step.
+    - When creating the CFS session to customize the image, use the `ncn-image-customization` CFS configuration created earlier in this procedure.
     - When updating the boot parameters, update them for every NCN worker node in the system.
 
 1. (`ncn-m#`) Optionally, delete `management-bootprep-image-customization.yaml`, which is no longer needed.

--- a/operations/configuration_management/Worker_Image_Customization.md
+++ b/operations/configuration_management/Worker_Image_Customization.md
@@ -35,7 +35,7 @@ to the NCN worker image before the workers are booted.
     cp management-bootprep.yaml management-bootprep-image-customization.yaml
     ```
 
-1. (`ncn-m#`) Delete the `ncn-personalization` configuration in the `management-bootprep-node-personalization.yaml` file.
+1. (`ncn-m#`) Delete the `ncn-personalization` configuration in the `management-bootprep-image-customization.yaml` file.
 
     After editing, the `ncn-image-customization` configuration should be the only entry remaining in the file, and
     the file should begin with the following lines:

--- a/operations/configuration_management/Worker_Image_Customization.md
+++ b/operations/configuration_management/Worker_Image_Customization.md
@@ -1,25 +1,46 @@
 # Worker Image Customization
 
-When performing an upgrade or fresh install, NCN image customization must be performed with the NCN worker node image to ensure the appropriate CFS layers are applied.
-This step involves configuring CFS to use the default `sat bootprep` files from the `hpc-csm-software-recipe` repository and rebuilding the NCN worker nodes so they boot the newly customized image.
+- [Background](#background)
+- [Procedure](#procedure)
 
-The definition of the CFS configuration used for NCN worker node image customization is provided in the `hpc-csm-software-recipe` repository in VCS.
-The following procedure describes how to correctly edit the `bootprep` files to be able to use them to perform image customization.
+## Background
 
-1. (`ncn-m#`) Perform the steps in the [Accessing `sat bootprep` Files](Accessing_Sat_Bootprep_Files.md) procedure to gather a copy of the `sat bootprep` files.
+NCN image customization refers to the process of CFS applying a configuration directly to an unbooted NCN image.
+During CSM upgrades, NCN image customization must be performed on the NCN worker node image, and the worker NCNs must
+then be configured to boot from the customized image. The purpose is to ensure that the appropriate CFS layers are applied
+to the NCN worker image before the workers are booted.
 
-1. (`ncn-m#`) Create a local copy of the `management-bootprep.yaml` file and delete the `ncn-personalization` configuration. The `ncn-image-customization` configuration will be the only entry remaining in the file.
+## Procedure
+
+1. (`ncn-m#`) Back up the current CFS state.
+
+    For the CSM 1.3 release, the NCN image customization configuration is named `ncn-image-customization`.
+    If a CFS configuration with this name already exists, the procedure on this page will overwrite it.
+
+    Because this procedure will create/update a CFS configuration, take a snapshot of the current state of CFS.
+
+    ```bash
+    /usr/share/doc/csm/scripts/operations/configuration/backup_cfs_config_comp.sh
+    ```
+
+1. Gather a copy of the `sat bootprep` files.
+
+    This procedure uses the default `sat bootprep` files from the `hpc-csm-software-recipe` repository in VCS.
+
+    See [Accessing `sat bootprep` Files](Accessing_Sat_Bootprep_Files.md).
+
+1. (`ncn-m#`) Create a local copy of the `management-bootprep.yaml` file.
 
     ```bash
     cp management-bootprep.yaml management-bootprep-image-customization.yaml
-    vi management-bootprep-image-customization.yaml
     ```
 
-    Edit the `management-bootprep-image-customization.yaml` file to delete the ncn-personalization configuration definition.
+1. (`ncn-m#`) Delete the `ncn-personalization` configuration in the `management-bootprep-node-personalization.yaml` file.
 
-    Verify the content now starts with just the image customization section.
+    After editing, the `ncn-image-customization` configuration should be the only entry remaining in the file, and
+    the file should begin with the following lines:
 
-    ```bash
+    ```yaml
     # (C) Copyright 2022 Hewlett Packard Enterprise Development LP
     ---
     schema_version: 1.0.2
@@ -27,7 +48,9 @@ The following procedure describes how to correctly edit the `bootprep` files to 
     - name: ncn-image-customization
     ```
 
-1. (`ncn-m#`) Run `sat bootprep` against the `management-bootprep-image-customization.yaml` file to create CFS configuration that will be used to customize the worker image.
+1. (`ncn-m#`) Create the `ncn-image-customization` CFS configuration.
+
+    Run `sat bootprep` against the `management-bootprep-image-customization.yaml` file to create the CFS configuration that will be used for image customization on the worker NCN image.
 
     ```bash
     sat bootprep run management-bootprep-image-customization.yaml
@@ -36,6 +59,14 @@ The following procedure describes how to correctly edit the `bootprep` files to 
 1. Customize the worker NCN image and update BSS to use the new image.
 
     Perform the steps in [Management Node Image Customization](Management_Node_Image_Customization.md), with the following notes:
+
+    - The linked procedure gives examples of customizing a Kubernetes NCN image, which is what needs to be done in this case.
+    - (`ncn-m001#`) In the steps to identify the NCN image and obtain its artifacts, use the following command to set the `ARTIFACT_VERSION` variable.
+
+        ```bash
+        ARTIFACT_VERSION=$(grep "^export KUBERNETES_VERSION=" /etc/cray/upgrade/csm/myenv | tail -1 | cut -d= -f2)
+        echo "${ARTIFACT_VERSION}"
+        ```
 
     - Skip the steps in the linked procedure to create the CFS configuration, because the CFS configuration was already created in the previous step.
     - When creating the CFS session to customize the image, use the CFS configuration created in the previous step.


### PR DESCRIPTION
# Description

This PR does some minor linting and reorganization, as well as including the detail on where to obtain the worker NCN artifact version that is needed during CSM upgrades.

No backports for this are needed. This procedure is changing in 1.4 and will be handled by [MTL-1949](https://jira-pro.its.hpecorp.net:8443/browse/MTL-1949)

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
