### PR TITLE
CASMTRIAGE-4504 Add known issue for IMS image creation failures

### DIFF
--- a/troubleshooting/known_issues/ims_image_creation_failure.md
+++ b/troubleshooting/known_issues/ims_image_creation_failure.md
@@ -1,0 +1,39 @@
+# Known Issue: IMS image creation failure
+
+On some systems, IMS image creation will fail with the following error in the CFS pod log:
+
+```text
+Traceback (most recent call last):
+  File "/usr/lib/python3.9/multiprocessing/process.py", line 315, in _bootstrap
+    self.run()
+  File "/usr/lib/python3.9/multiprocessing/process.py", line 108, in run
+    self._target(*self._args, **self._kwargs)
+  File "/usr/lib/python3.9/site-packages/cray/cfs/inventory/image/__init__.py", line 239, in _request_ims_ssh
+    mpq.put(ImageRootInventory._wait_for_ssh_container(ims_id, job_id, cfs_session))
+  File "/usr/lib/python3.9/site-packages/cray/cfs/inventory/image/__init__.py", line 290, in _wait_for_ssh_container
+    raise CFSInventoryError(
+cray.cfs.inventory.CFSInventoryError: ('IMS status=error for IMS image=%r job=%r, SSH container was not created.', 'b72ca306-965c-4139-a8db-fb84233b2c1f', '68d681ca-cf5e-44f8-b089-8b482e009ea1')
+2022-11-02 16:53:21,764 - INFO    - cray.cfs.inventory.image - Removing public key from IMS.
+2022-11-02 16:53:21,822 - ERROR   - cray.cfs.inventory - An error occurred while attempting to generate the inventory. Error: One or more IMS jobs failed to launch.
+ 
+```
+
+When this happens, the IMS pod creating the image may contain this error:
+
+```text
+  File "/scripts/fetch.py", line 221, in download_file
+    for chunk in response.iter_content(chunk_size=1024*1024):
+  File "/scripts/venv/lib/python3.9/site-packages/requests/models.py", line 754, in generate
+    raise ChunkedEncodingError(e)
+requests.exceptions.ChunkedEncodingError: ("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
+```
+
+## Fix
+
+Run the following command from a master node. Be sure to change the `-w ncn-w[0-n]` argument reflects all the worker nodes for the system (`pdsh` supports multiple `-w` arguments):
+
+```bash
+pdsh -w ncn-w00[1-n] 'sysctl -w net.netfilter.nf_conntrack_tcp_be_liberal=1'
+```
+
+Once the `sysctl` command is complete, the `Connection reset by peer` errors in the IMS pod should no longer appear and the CFS job should complete successfully.

--- a/upgrade/README.md
+++ b/upgrade/README.md
@@ -14,6 +14,8 @@ product streams for the HPE Cray EX system can be installed or upgraded.
 Note: If problems are encountered during the upgrade, some of the topics do have their own troubleshooting
 sections, but there is also a general troubleshooting topic.
 
+- If IMS image creation CFS jobs fail, see [Known Issue: IMS image creation failure](../troubleshooting/known_issues/ims_image_creation_failure.md) for a possible workaround.
+
 ## 1. Prepare for upgrade
 
 See [Prepare for Upgrade](prepare_for_upgrade.md).


### PR DESCRIPTION
# Description

Fix for https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4504 -- add troubleshooting for ims image creation failure.

# Checklist Before Merging

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

