### PR TITLE
CASMINST-5578: Linting

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -638,7 +638,7 @@ Zypper
 # Per-file spelling exceptions. Please keep this section sorted in order by filepath, to help make it easier to
 # see if a file already is listed.
 
-- background/README.md
+- background/ncn_kernel.md
 initramFS
 
 - glossary.md

--- a/background/ncn_kdump.md
+++ b/background/ncn_kdump.md
@@ -118,7 +118,7 @@ to be installed; the `crash` command can not thoroughly analyze a dump without t
 
     1. Change to the desired crash dump directory.
 
-        For exmaple, if `2022-09-07-14:31` was the crash to be examined:
+        For example, if `2022-09-07-14:31` was the crash to be examined:
 
         ```bash
         cd /var/crash/2022-09-07-14\:31

--- a/background/ncn_kernel.md
+++ b/background/ncn_kernel.md
@@ -75,7 +75,7 @@ Certain kernel modules are blacklisted from loading on the non-compute node.
 
 ## Parameters
 
-Below are a list of kernel parameters used on an NCN, each will denote it's default value(s). If more
+Below are a list of kernel parameters used on an NCN, each will denote its default values. If more
 than one default value is listed, that means the parameter itself is listed on the command line
 multiple times.
 
@@ -155,7 +155,7 @@ not created for devices unless they had a corresponding `ip` parameter set. The 
 safest value to set here that did not disrupt the state of the NCN.
 
 > ***NOTE*** When an NCN boots using a disk this parameter is not set (`ip` is removed), disk boots
-> will use the already stored image found in the squashFS storage.
+> will use the already stored image found in the SquashFS storage.
 
 For more information, see [dracut command line's network parameter definition][13].
 
@@ -226,7 +226,7 @@ for host-only devices (e.g. devices created via SR-IOV).
 
 ### `metal.server`
 
-This parameter's value tells the initramFS where to download the kernel, initrd, and squashFS from.
+This parameter's value tells the initramFS where to download the kernel, `initrd`, and SquashFS from.
 
 | NCN Type | Default Value(s) | Context |
 | :------: | :------------ | :------ |
@@ -310,7 +310,7 @@ For more information, see [the Linux kernel user's administrator's guide][5].
 This parameter tells dracut two things:
 
 1. We are using the [`live` module][10] for booting images.
-1. Our squashFS image is on a filesystem with the `FSLabel` of `SQFSRAID`
+1. Our SquashFS image is on a filesystem with the `FSLabel` of `SQFSRAID`
 
 For more information, see [dracut command line's standard parameter definition][7], and
 [`dracut-metal-mdsquash` usage][2].
@@ -321,7 +321,7 @@ For more information, see [dracut command line's standard parameter definition][
 | :------: | :------------: |
 | All | `0` |
 
-This parameter determines whether or not to copy the entire squashFS image into RAM or not. This is
+This parameter determines whether or not to copy the entire SquashFS image into RAM or not. This is
 useful when the media resides on a slow I/O device such as a DVD.
 
 For more information, see [dracut command line's booting live images definitions][14].
@@ -332,9 +332,9 @@ For more information, see [dracut command line's booting live images definitions
 | :------: | :------------: |
 | All | `0` |
 
-This enables writing to the squashFS image, this is not always supported nor desired. CSM does not
+This enables writing to the SquashFS image, this is not always supported nor desired. CSM does not
 want to enable writing to the image in order to preserve the original image. All changes are written
-to a persistent overlayFS instead.
+to a persistent OverlayFS instead.
 
 For more information, see [dracut command line's booting live images definitions][14].
 
@@ -480,7 +480,7 @@ This parameter enables or disables `dmraid` in the initramFS.
 Whether or not the network is necessary for boot.
 
 > ***NOTE*** This is useful for booting over an NFS or other network share, NCNs set this to `0`
-> because despite downloading a squashFS the `root` parameter is set to a disk `FSLabel`. As such, `root`
+> because despite downloading a SquashFS the `root` parameter is set to a disk `FSLabel`. As such, `root`
 > is *not* dependent on the network to come up.
 
 ### `rd.peerdns`
@@ -635,7 +635,7 @@ Minimize the output from the initramFS to only `stderr`.
 
 The amount of memory reserved in the event of a crash to run dump tools.
 
-This must be larger than the size of the `kdump` initrd located in `/boot`.
+This must be larger than the size of the `kdump` `initrd` located in `/boot`.
 
 ### `log_buf_len`
 

--- a/operations/configuration_management/Management_Node_Image_Customization.md
+++ b/operations/configuration_management/Management_Node_Image_Customization.md
@@ -107,43 +107,45 @@ with minor command modifications.
 
 1. (`ncn-mw#`) Determine the component names (xnames) for the NCNs which will boot from the new image.
 
-   > If being done as part of a CSM upgrade, this will be the NCN worker nodes.  
+    > If being done as part of a CSM upgrade, then this will be the NCN worker nodes.
 
-   Options to determine node xnames:
+    Options to determine node xnames:
 
-   * Get a comma-separated list of all worker NCN xnames:
+    * Get a comma-separated list of all worker NCN xnames:
 
-      ```bash
-      cray hsm state components list --role Management --subrole Worker --type Node --format json |
+        ```bash
+        cray hsm state components list --role Management --subrole Worker --type Node --format json |
           jq -r '.Components | map(.ID) | join(",")'
-      ```
+        ```
 
-   * Get a comma-separated list of all master NCN xnames:
+    * Get a comma-separated list of all master NCN xnames:
 
-      ```bash
-      cray hsm state components list --role Management --subrole Master --type Node --format json |
+        ```bash
+        cray hsm state components list --role Management --subrole Master --type Node --format json |
           jq -r '.Components | map(.ID) | join(",")'
-      ```
+        ```
 
-   * Get a comma-separated list of all storage NCN xnames:
+    * Get a comma-separated list of all storage NCN xnames:
 
-      ```bash
-      cray hsm state components list --role Management --subrole Storage --type Node --format json |
+        ```bash
+        cray hsm state components list --role Management --subrole Storage --type Node --format json |
           jq -r '.Components | map(.ID) | join(",")'
-      ```
+        ```
 
-   * Get the xname for a specific NCN:
+    * Get the xname for a specific NCN:
 
-      > In this example, the xname for `ncn-w001` is being found.
+        > In this example, the xname for `ncn-w001` is being found.
 
-      ```bash
-      ssh ncn-w001 cat /etc/cray/xname
-      ```
+        ```bash
+        ssh ncn-w001 cat /etc/cray/xname
+        ```
 
 1. (`ncn-mw#`) Update boot parameters for a Kubernetes NCN.
 
-   **NOTE:** If you are following this procedure as part of the multi-product recipe upgrade, you should only modify NCN worker boot parameters.
-   Master and storage NCNs are managed automatically in later stages of the CSM upgrade.
+    > If being done as part of a CSM upgrade, then update the boot parameters for the NCN worker nodes.
+    > Master and storage NCNs are managed automatically in later stages of the CSM upgrade.
+
+    Perform the following procedure for each xname identified in the previous step.
 
     1. Get the existing `metal.server` setting for the component name (xname) of the node of interest:
 

--- a/operations/configuration_management/Management_Node_Image_Customization.md
+++ b/operations/configuration_management/Management_Node_Image_Customization.md
@@ -142,6 +142,9 @@ with minor command modifications.
 
 1. (`ncn-mw#`) Update boot parameters for a Kubernetes NCN.
 
+   **NOTE:** If you are following this procedure as part of the multi-product recipe upgrade, you should only modify NCN worker boot parameters.
+   Master and storage NCNs are managed automatically in later stages of the CSM upgrade.
+
     1. Get the existing `metal.server` setting for the component name (xname) of the node of interest:
 
         ```bash

--- a/operations/configure_cray_cli.md
+++ b/operations/configure_cray_cli.md
@@ -400,7 +400,7 @@ debug level log messages to be displayed. Alternatively, each failing node may b
             ceph mgr dump | jq -r .active_name
             ```
 
-            Expect the output to be a different manager than was prevoiusly reported:
+            Expect the output to be a different manager than was previously reported:
 
             ```text
             ncn-s001.qucrpr

--- a/operations/firmware/FASUpdate_Script.md
+++ b/operations/firmware/FASUpdate_Script.md
@@ -42,7 +42,7 @@ Set `overrideDryrun` to true to do an actual update instead of a dryrun.
 * `--list` : List the available action recipe files in the default or specified directory.
 * `--recipedir dir` : Directory containing the action recipe file (if not using the default directory).
 * `--xnames xname1,xname2` : List of xnames to be updated.  If not present, FAS will check all xnames.
-* `--overredDryrun {true/false}` : Default false - Set to true to do an actual update run instead of a dryrun.
+* `--overrideDryrun {true/false}` : Default false - Set to true to do an actual update run instead of a dryrun.
 * `--watchtime sec` : Number of seconds to wait before outputting the summary status (default 30).
 * `--description des` : Overwrite the description field in the recipe file.
 * `--url-fas url` : URL to access FAS (usually not needed).

--- a/operations/node_management/Add_a_Standard_Rack_Node.md
+++ b/operations/node_management/Add_a_Standard_Rack_Node.md
@@ -575,7 +575,7 @@ Usually there are two `cray-cps-cm-pm` pods, one on `ncn-w002` and one on `ncn-w
         DESIRED_IP_ADDRESS=10.252.0.26
         ```
 
-    1. Determine the HSM EthenretInterface entry holding onto the desired IP address.
+    1. Determine the HSM EthernetInterface entry holding onto the desired IP address.
 
         ```bash
         cray hsm inventory ethernetInterfaces list --ip-address "${DESIRED_IP_ADDRESS}" --output toml

--- a/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System.md
+++ b/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System.md
@@ -558,7 +558,7 @@ Usually there are two `cray-cps-cm-pm` pods, one on `ncn-w002` and one on `ncn-w
         DESIRED_IP_ADDRESS=10.252.0.26
         ```
 
-    1. Determine the HSM EthenretInterface entry holding onto the desired IP address.
+    1. Determine the HSM EthernetInterface entry holding onto the desired IP address.
 
         ```bash
         cray hsm inventory ethernetInterfaces list --ip-address "${DESIRED_IP_ADDRESS}" --output toml

--- a/scripts/operations/configuration/apply_csm_configuration.sh
+++ b/scripts/operations/configuration/apply_csm_configuration.sh
@@ -53,14 +53,14 @@ run_mktemp()
 
 usage()
 {
-   # Display Help
+   # Display help
    echo "Updates CFS configurations"
    echo "All parameters are optional and the values will be determined automatically if not set."
    echo
-   echo "Usage: deploy_ssh_keys.sh [ --csm-release version ] [ --git-commit hash ]"
-   echo "                          [ --git-clone-url url ] [ --ncn-config-file file ]"
-   echo "                          [ --clear-state ] [ --no-enable ]"
-   echo "                          [ --xnames xname1,xname2... ]"
+   echo "Usage: apply_csm_configuration.sh [ --csm-release version ] [ --git-commit hash ]"
+   echo "                                  [ --git-clone-url url ] [ --ncn-config-file file ]"
+   echo "                                  [ --clear-state ] [ --no-enable ]"
+   echo "                                  [ --xnames xname1,xname2... ]"
    echo
    echo "Options:"
    echo "csm-release          The version of the CSM release to use. (e.g. 1.6.11)"

--- a/scripts/operations/firmware/FASUpdate.py
+++ b/scripts/operations/firmware/FASUpdate.py
@@ -124,7 +124,7 @@ def main():
 
     parser.add_argument("--file", type=str, required=False, help="Filename of the .json action recipe file to use", default="")
     parser.add_argument("--list", required=False, help="List files available in the recipes directory", action="store_true")
-    parser.add_argument("--recipedir", type=str, required=False, help="Specify the directory to find the recipies", default="")
+    parser.add_argument("--recipedir", type=str, required=False, help="Specify the directory to find the recipes", default="")
     parser.add_argument("--xnames", type=str, required=False, help="List of xnames to update", default="")
     parser.add_argument("--overrideDryrun", type=str2bool, required=False, help="Perform Dry or Real update", default=False)
     parser.add_argument("--watchtime", type=int, required=False, help="Time between actions status", default=30)

--- a/scripts/operations/kubernetes/encryption.sh
+++ b/scripts/operations/kubernetes/encryption.sh
@@ -247,7 +247,7 @@ updatek8sconfig() {
 # So instead of kubeadm upgrade .. to restart the kubeadm containers, we simply
 # kubectl delete the local nodes kubeapi pod. Then validate that we have the
 # encryption config file passed into kubeapi's process args list. If yes, yatta,
-# we can then symlink curren.yaml to that file, if not we abort something is
+# we can then symlink current.yaml to that file; if not, we abort because something is
 # amiss.
 #
 # Arg is simply the full encryption filename path that we'll pass to pgrep -lif
@@ -274,7 +274,7 @@ restartk8s() {
 # Glorified wrapper functions for unit tests.
 
 # Simply wrapping around:
-# pgrep -lif proces.*something in the arg list
+# pgrep -lif process.*something in the arg list
 sutpgrep() {
   pgrep -lif "kube-apiserver.*${1:-invalid}" > /dev/null 2>&1
 }

--- a/spec/encryption_spec.sh
+++ b/spec/encryption_spec.sh
@@ -276,7 +276,7 @@ Describe 'encryption.sh logic'
         The status should equal 1
       End
 
-      It 'returns ok when pgrep returns a kubeapi proces that matches'
+      It 'returns ok when pgrep returns a kubeapi process that matches'
         sutpgrep() {
           printf '12345 kube-api\n'
           return 0


### PR DESCRIPTION
# Description

Just linting. No content changes.

The changes to script files are only to comments or printed messages -- none to the code itself.

I don't know why the diff for operations/firmware/FASUpdate_Script.md shows so many changes, when only one string in the file was changed. It may be that it was checked in with weird line endings, and my PR stripped them. You can see that only one typoed string is actually changed.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
