### PR TITLE
CASMNET-1939 - Unbound forward to PowerDNS does not work in an air-gapped configuration.

### DIFF
--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -41,6 +41,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 * [SSL Certificate Validation Issues](known_issues/ssl_certificate_validation_issues.md)
 * [SLS Not Working During Node Rebuild](known_issues/SLS_Not_Working_During_Node_Rebuild.md)
 * [Antero node NID allocation](known_issues/antero_node_NID_allocation.md)
+* [Unbound forwarding to PowerDNS in an air-gapped environment](known_issues/unbound_airgap_forwarding.md)
 
 ## Booting
 

--- a/troubleshooting/dns_runbook.md
+++ b/troubleshooting/dns_runbook.md
@@ -136,7 +136,6 @@ to
         local-zone: "nmn." static
         local-zone: "hmn." static
         local-zone: "10.in-addr.arpa." nodefault
-        local-zone: "."
 ```
 
 ## 3. Checking Hostname in DNS

--- a/troubleshooting/known_issues/unbound_airgap_forwarding.md
+++ b/troubleshooting/known_issues/unbound_airgap_forwarding.md
@@ -1,0 +1,57 @@
+# Unbound forwarding to PowerDNS in and air-gapped environment
+
+## Description
+
+If Unbound is configured with no upstream DNS server to forward requests to, the forwarding of fully qualified domain name queries system components and services to PowerDNS does not work.
+
+## Symptoms
+
+* DNS resolution of short names (e.g. `api-gw-server-nmn.local`) works.
+* DNS resolution of fully qualified domain names (e.g. `api.nmnlb.SYSTEM_DOMAIN`) does not work.
+
+## Solution
+
+1. (`ncn-mw#`) Edit the `cray-dns-unbound` ConfigMap.
+
+   Command:
+
+   ```bash
+   kubectl -n services edit cm cray-dns-unbound
+   ```
+
+1. Add the following to `unbound.conf`.
+
+   ```text
+   local-zone: "mtl." static
+   ```
+
+   Example output:
+
+   ```text
+   data:
+     unbound.conf: |-
+       server:
+       ...
+        local-zone: "local" static
+        local-zone: "nmn." static
+        local-zone: "hmn." static
+        local-zone: "mtl." static
+        local-zone: "10.in-addr.arpa." nodefault
+        local-zone: "." static
+   ```
+
+1. Remove the following from `unbound.conf`.
+
+   ```text
+   local-zone: "." static
+   ```
+
+1. (`ncn-mw#`) Restart the `cray-dns-unbound` service.
+
+   ```bash
+   kubectl -n services rollout restart deployment cray-dns-unbound
+   ```
+
+**IMPORTANT:** This change will need to be reapplied if the `cray-dns-unbound` helm chart is re-installed.
+
+This will be resolved in CSM 1.3.1 and above.


### PR DESCRIPTION
# Description

Document workaround for known issue where air-gapped Unbound DNS configuration causes forwarding of requests to PowerDNS to stop working.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.


