### PR TITLE
CASMINST-5590: Use legal CFS session name during NCN image customization

### DIFF
--- a/operations/configuration_management/Management_Node_Image_Customization.md
+++ b/operations/configuration_management/Management_Node_Image_Customization.md
@@ -94,16 +94,24 @@ with minor command modifications.
 
 1. (`ncn-mw#`) Create an image customization CFS session.
 
-    See [Create an Image Customization CFS Session](Create_an_Image_Customization_CFS_Session.md) for additional information
-    on creating an image customization CFS session.
+    See [Create an Image Customization CFS Session](Create_an_Image_Customization_CFS_Session.md) for additional information.
 
-    ```bash
-    cray cfs sessions create \
-        --name "ncn-image-customization-session-$(date +%Y%m%d_%H%M%S)" \
-        --configuration-name ncn-image-customization \
-        --target-definition image --format json \
-        --target-group Management_Worker "${IMS_IMAGE_ID}"
-    ```
+    1. Set a name for the session.
+
+        ```bash
+        CFS_SESSION_NAME="ncn-image-customization-session-$(date +%y%m%d%H%M%S)"
+        echo "${CFS_SESSION_NAME}"
+        ```
+
+    1. Create the session.
+
+        ```bash
+        cray cfs sessions create \
+            --name "${CFS_SESSION_NAME}" \
+            --configuration-name ncn-image-customization \
+            --target-definition image --format json \
+            --target-group Management_Worker "${IMS_IMAGE_ID}"
+        ```
 
 1. (`ncn-mw#`) Determine the component names (xnames) for the NCNs which will boot from the new image.
 
@@ -163,7 +171,7 @@ with minor command modifications.
         in the "Create an Image Customization CFS Session" procedure, repeated here for convenience:
 
         ```bash
-        cray cfs sessions describe ncn-image-customization-session --format json | jq .status.artifacts
+        cray cfs sessions describe "${CFS_SESSION_NAME}" --format json | jq .status.artifacts
         ```
 
         ```bash


### PR DESCRIPTION
# Description

Fix a command in the NCN image customization procedure so that it uses a legal CFS session name. The command currently uses a name which is illegal for two reasons -- too long (45 characters is the maximum) and containing an invalid character (underscores are verboten).

This PR:
- removes the invalid character and reduces the name length
- removes a redundant bit of text in the description of the command itself. 
- updates a later command in the procedure to use the correct CFS session name, rather than the old hardcoded one

If interested in the full details, see the description of [CASMINST-5590](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5590).

This should merge as soon as it gets approvals, to avoid more people hitting this problem when following the procedure.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
