### PR TITLE
CASMINST-5591: Elaborate on CFS image customization session procedure

### DIFF
--- a/operations/configuration_management/Create_an_Image_Customization_CFS_Session.md
+++ b/operations/configuration_management/Create_an_Image_Customization_CFS_Session.md
@@ -12,13 +12,22 @@ that are not specified will not be included, even if they appear in other CFS in
 Users can expect that staging the image and generating an inventory will be a longer process than creating a session with other target definitions \(for example, inventories\). Tearing down the
 configuration session will also require additional time while IMS packages up the image build artifacts and uploads them to the artifact repository.
 
-- [Check if image is registered with IMS](#check-if-image-is-registered-with-ims)
-- [Create CFS image customization session](#create-cfs-image-customization-session)
-- [Retrieve the resultant image ID](#retrieve-the-resultant-image-id)
+- [Prerequisites](#prerequisites)
+- [1. Check if image is registered with IMS](#1-check-if-image-is-registered-with-ims)
+- [2. Create CFS image customization session](#2-create-cfs-image-customization-session)
+- [3. Wait for CFS session to complete successfully](#3-wait-for-cfs-session-to-complete-successfully)
+- [4. Retrieve the resultant image ID](#4-retrieve-the-resultant-image-id)
 
-## Check if image is registered with IMS
+## Prerequisites
 
-In order to use the `image` target definition, an image must be registered with the IMS.
+- The Cray CLI must be configured on the node where the commands are being run.
+  - See [Configure the Cray CLI](../configure_cray_cli.md).
+- The image being customized must be registered in IMS.
+  - See [Check if image is registered with IMS](#1-check-if-image-is-registered-with-ims).
+
+## 1. Check if image is registered with IMS
+
+In order to use the `image` target definition, an image must be registered with IMS.
 
 (`ncn-mw#`) For example, if the image ID is `5d64c8b2-4f0e-4b2e-b334-51daba16b7fb`, then use `jq` along with the CLI `--format json` output option to determine if the image ID is known to IMS:
 
@@ -32,7 +41,7 @@ Example output:
 true
 ```
 
-## Create CFS image customization session
+## 2. Create CFS image customization session
 
 (`ncn-mw#`) To create a CFS session for image customization, provide a session name, the name of the configuration to apply, and the group/image ID mapping:
 
@@ -81,7 +90,11 @@ Example output:
 }
 ```
 
-## Retrieve the resultant image ID
+## 3. Wait for CFS session to complete successfully
+
+See [Track the Status of a Session](Track_the_Status_of_a_Session.md).
+
+## 4. Retrieve the resultant image ID
 
 (`ncn-mw#`) When an image customization CFS session is complete, use the CFS `describe` command to show the IMS image ID that results from the applied configuration:
 

--- a/operations/configuration_management/Management_Node_Image_Customization.md
+++ b/operations/configuration_management/Management_Node_Image_Customization.md
@@ -6,6 +6,23 @@ is only relevant for booting compute nodes and can be ignored when working with 
 This document describes the configuration of a Kubernetes NCN image. The same steps could be used to modify a Ceph NCN image
 with minor command modifications.
 
+* [Prerequisites](#prerequisites)
+* [Procedure](#procedure)
+    1. [Obtain NCN image artifacts](#1-obtain-ncn-image-artifacts)
+    1. [Import the NCN image into IMS](#2-import-the-ncn-image-into-ims)
+    1. [Create a CFS configuration, if needed](#3-create-a-cfs-configuration-if-needed)
+    1. [Run the CFS image customization session](#4-run-the-cfs-image-customization-session)
+    1. [Update NCN boot parameters](#5-update-ncn-boot-parameters)
+* [Next steps](#next-steps)
+
+## Prerequisites
+
+The Cray CLI must be configured on the node where the commands are being run. See [Configure the Cray CLI](../configure_cray_cli.md).
+
+## Procedure
+
+### 1. Obtain NCN image artifacts
+
 1. (`ncn-mw#`) Identify the NCN image to be modified.
 
     If this procedure is being done as part of a CSM upgrade, then the documentation which linked to this procedure will have
@@ -38,55 +55,75 @@ with minor command modifications.
     export IMS_INITRD_FILENAME="${ARTIFACT_VERSION}-initrd"
     ```
 
-1. Import the NCN image into IMS.
+### 2. Import the NCN image into IMS
 
-    Perform the [Import External Image to IMS](../image_management/Import_External_Image_to_IMS.md) procedure, except
-    skip the following sections:
+Perform the [Import External Image to IMS](../image_management/Import_External_Image_to_IMS.md) procedure, except
+skip the following sections:
 
-    * [Set helper variables](../image_management/Import_External_Image_to_IMS.md#2-set-helper-variables)
-      * Skip this section because the variables have already been set above, in the previous step.
-    * [Upload artifacts to S3](../image_management/Import_External_Image_to_IMS.md#5-upload-artifacts-to-s3)
-      * Skip this section because the artifacts are already in S3.
+* [Set helper variables](../image_management/Import_External_Image_to_IMS.md#2-set-helper-variables)
+  * Skip this section because the variables have already been set above, in the previous step.
+* [Upload artifacts to S3](../image_management/Import_External_Image_to_IMS.md#5-upload-artifacts-to-s3)
+  * Skip this section because the artifacts are already in S3.
 
-1. (`ncn-m001#`) If `sat bootprep` was not used in [Worker Image Customization](Worker_Image_Customization.md) to create a CFS
-   configuration for management node image customization, then execute the following two substeps:
+### 3. Create a CFS configuration, if needed
 
-    1. Clone the `csm-config-management` repository.
+If `sat bootprep` was used to create a CFS configuration for management node image customization, then one does not
+need to be created now. For example. this will be the case if this procedure is being followed as part of
+[Worker Image Customization](Worker_Image_Customization.md). If `sat bootprep` was used to create the CFS configuration,
+then skip this step and proceed to [Run the CFS image customization session](#4-run-the-cfs-image-customization-session).
 
-        ```bash
-        VCS_USER=$(kubectl get secret -n services vcs-user-credentials --template={{.data.vcs_username}} | base64 --decode)
-        VCS_PASS=$(kubectl get secret -n services vcs-user-credentials --template={{.data.vcs_password}} | base64 --decode)
-        git clone "https://${VCS_USER}:${VCS_PASS}@api-gw-service-nmn.local/vcs/cray/csm-config-management.git"
-        ```
+1. (`ncn-mw#`) Clone the `csm-config-management` repository.
 
-        A Git commit hash from this repository is needed in the following step.
+    ```bash
+    VCS_USER=$(kubectl get secret -n services vcs-user-credentials --template={{.data.vcs_username}} | base64 --decode)
+    VCS_PASS=$(kubectl get secret -n services vcs-user-credentials --template={{.data.vcs_password}} | base64 --decode)
+    git clone "https://${VCS_USER}:${VCS_PASS}@api-gw-service-nmn.local/vcs/cray/csm-config-management.git"
+    ```
 
-    1. [Create a CFS Configuration](Create_a_CFS_Configuration.md).
+    A Git commit hash from this repository is needed in the following step.
 
-        The first layer in the CFS configuration should be similar to this:
+1. (`ncn-mw#`) Create the CFS configuration to use for image customization.
 
-        ```json
-        {
-          "name": "csm-ncn-workers",
-          "cloneUrl": "https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git",
-          "playbook": "ncn-worker_nodes.yml",
-          "commit": "<git commit hash>"
-        }
-        ```
+    See [Create a CFS Configuration](Create_a_CFS_Configuration.md).
 
-        The last layer in the CFS configuration should be similar to this:
+    The first layer in the CFS configuration should be similar to this:
 
-        ```json
-        {
-          "name": "csm-ncn-initrd",
-          "cloneUrl": "https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git",
-          "playbook": "ncn-initrd.yml",
-          "commit": "<git commit hash>"
-        }
-        ```
+    ```json
+    {
+      "name": "csm-ncn-workers",
+      "cloneUrl": "https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git",
+      "playbook": "ncn-worker_nodes.yml",
+      "commit": "<git commit hash>"
+    }
+    ```
 
-1. (`ncn-mw#`) Ensure that the environment variable `$IMS_IMAGE_ID` was set during
-   [Import an External Image to IMS](../image_management/Import_External_Image_to_IMS.md).
+    The last layer in the CFS configuration should be similar to this:
+
+    ```json
+    {
+      "name": "csm-ncn-initrd",
+      "cloneUrl": "https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git",
+      "playbook": "ncn-initrd.yml",
+      "commit": "<git commit hash>"
+    }
+    ```
+
+### 4. Run the CFS image customization session
+
+1. (`ncn-mw#`) Record the name of the CFS configuration to use for image customization.
+
+    If the CFS configuration was created in the previous section, then set the `CFS_CONFIG_NAME` variable to the
+    name of that CFS configuration. If the CFS configuration was created by `sat bootprep` (for example, as part
+    of [Worker Image Customization](Worker_Image_Customization.md)), then set the `CFS_CONFIG_NAME` variable to the
+    CFS configuration name specified in that procedure.
+
+    ```bash
+    CFS_CONFIG_NAME=ncn-image-customization
+    ```
+
+1. (`ncn-mw#`) Ensure that the environment variable `IMS_IMAGE_ID` is set.
+
+    It should have been set as part of [Import an External Image to IMS](../image_management/Import_External_Image_to_IMS.md).
 
     ```bash
     echo "${IMS_IMAGE_ID}"
@@ -108,10 +145,32 @@ with minor command modifications.
         ```bash
         cray cfs sessions create \
             --name "${CFS_SESSION_NAME}" \
-            --configuration-name ncn-image-customization \
+            --configuration-name "${CFS_CONFIG_NAME}" \
             --target-definition image --format json \
             --target-group Management_Worker "${IMS_IMAGE_ID}"
         ```
+
+    1. Monitor the CFS session until it completes successfully.
+
+        See [Track the Status of a Session](Track_the_Status_of_a_Session.md).
+
+    1. Obtain the IMS resultant image ID.
+
+        ```bash
+        IMS_RESULTANT_IMAGE_ID=$(cray cfs sessions describe "${CFS_SESSION_NAME}" --format json |
+                                   jq -r '.status.artifacts[] | select(.type == "ims_customized_image") | .result_id')
+        echo "${IMS_RESULTANT_IMAGE_ID}"
+        ```
+
+        Example output:
+
+        ```text
+        a44ff301-6232-46b4-9ba6-88ee1d19e2c2
+        ```
+
+### 5. Update NCN boot parameters
+
+Every NCN which will be booting from the customized image must have its boot parameters updated in BSS to use the artifacts of the customized image.
 
 1. (`ncn-mw#`) Determine the component names (xnames) for the NCNs which will boot from the new image.
 
@@ -148,14 +207,14 @@ with minor command modifications.
         ssh ncn-w001 cat /etc/cray/xname
         ```
 
-1. (`ncn-mw#`) Update boot parameters for a Kubernetes NCN.
+1. (`ncn-mw#`) Update boot parameters for an NCN.
 
     > If being done as part of a CSM upgrade, then update the boot parameters for the NCN worker nodes.
     > Master and storage NCNs are managed automatically in later stages of the CSM upgrade.
 
-    Perform the following procedure for each xname identified in the previous step.
+    Perform the following procedure **for each xname** identified in the previous step.
 
-    1. Get the existing `metal.server` setting for the component name (xname) of the node of interest:
+    1. Get the existing `metal.server` setting for the component name (xname) of the node of interest.
 
         ```bash
         XNAME=<node-xname>
@@ -165,27 +224,35 @@ with minor command modifications.
         echo "${METAL_SERVER}"
         ```
 
-    1. Update the kernel, `initrd`, and metal server to point to the new artifacts.
+    1. Create updated boot parameters that point to the new artifacts.
 
-        **NOTE:** `${IMS_RESULTANT_IMAGE_ID}` is the `result_id` returned in the output of the last command
-        in the "Create an Image Customization CFS Session" procedure, repeated here for convenience:
+        1. Set the path to the artifacts in S3.
 
-        ```bash
-        cray cfs sessions describe "${CFS_SESSION_NAME}" --format json | jq .status.artifacts
-        ```
+            **NOTE:** This uses the `IMS_RESULTANT_IMAGE_ID` variable set in an earlier step.
 
-        ```bash
-        S3_ARTIFACT_PATH="boot-images/${IMS_RESULTANT_IMAGE_ID}"
-        NEW_METAL_SERVER="s3://${S3_ARTIFACT_PATH}/rootfs"
+            ```bash
+            S3_ARTIFACT_PATH="boot-images/${IMS_RESULTANT_IMAGE_ID}"
+            echo "${S3_ARTIFACT_PATH}"
+            ```
 
-        PARAMS=$(cray bss bootparameters list --hosts "${XNAME}" --format json | jq '.[] |."params"' | \
-            sed "/metal.server/ s|${METAL_SERVER}|${NEW_METAL_SERVER}|" | \
-            sed "s/metal.no-wipe=1/metal.no-wipe=0/" | \
-            tr -d \")
-        echo "${PARAMS}"
-        ```
+        1. Set the new `metal.server` value.
 
-        In the output of the final `echo` command, verify that the value of `metal.server` was correctly set to `${NEW_METAL_SERVER}`.
+            ```bash
+            NEW_METAL_SERVER="s3://${S3_ARTIFACT_PATH}/rootfs"
+            echo "${NEW_METAL_SERVER}"
+            ```
+
+        1. Determine the modified boot parameters for the node.
+
+            ```bash
+            PARAMS=$(cray bss bootparameters list --hosts "${XNAME}" --format json | jq '.[] |."params"' | \
+                sed "/metal.server/ s|${METAL_SERVER}|${NEW_METAL_SERVER}|" | \
+                sed "s/metal.no-wipe=1/metal.no-wipe=0/" | \
+                tr -d \")
+            echo "${PARAMS}"
+            ```
+
+            In the output of the `echo` command, verify that the value of `metal.server` is correctly set to the value of `${NEW_METAL_SERVER}`.
 
     1. Update BSS with the new boot parameters.
 
@@ -196,7 +263,9 @@ with minor command modifications.
             --params "${PARAMS}"
         ```
 
-   **NOTE**: If the worker node image is being customized as part of a Cray EX initial install or upgrade involving multiple products,
-   then refer to the `HPE Cray EX System Software Getting Started Guide (S-8000)` for details on when to reboot the worker nodes to the new image.
+## Next steps
 
-   If this procedure is being followed outside of the `S-8000` document, then proceed to [rebuild the NCN](../node_management/Rebuild_NCNs/Rebuild_NCNs.md).
+If the worker node image is being customized as part of a Cray EX initial install or upgrade involving multiple products,
+then refer to the `HPE Cray EX System Software Getting Started Guide (S-8000)` for details on when to reboot the worker nodes to the new image.
+
+If this procedure is being followed outside of the `S-8000` document, then proceed to [rebuild the NCN](../node_management/Rebuild_NCNs/Rebuild_NCNs.md).

--- a/operations/configuration_management/Track_the_Status_of_a_Session.md
+++ b/operations/configuration_management/Track_the_Status_of_a_Session.md
@@ -1,8 +1,22 @@
 # Track the Status of a Session
 
-A configuration session can be a long-running process, and depends on many system factors, as well as the number of configuration layers and Ansible tasks that are run in each layer. The Configuration Framework Service \(CFS\) provides the session status through the session metadata to allow for tracking progress and session state.
+A configuration session can be a long-running process, and depends on many system factors, as well as the number of configuration layers and Ansible
+tasks that are run in each layer. The Configuration Framework Service \(CFS\) provides the session status through the session metadata to allow for
+tracking progress and session state.
 
-To view the session status of a session named *example*, use the following command:
+- [Prerequisites](#prerequisites)
+- [View session status](#view-session-status)
+- [Troubleshooting](#troubleshooting)
+
+## Prerequisites
+
+- A configuration session exists in CFS.
+- The Cray CLI must be configured on the node where the commands are being run.
+  - See [Configure the Cray CLI](../configure_cray_cli.md).
+
+## View session status
+
+(`ncn-mw#`) To view the session status of a session named `example`, use the following command:
 
 ```bash
 cray cfs sessions describe example --format json
@@ -43,8 +57,7 @@ Example output:
 The `jq` tool, along with the `--format json` output option of the CLI, are helpful for filtering the session data to view just the session status:
 
 ```bash
-cray cfs sessions describe example \
---format json | jq .status.session
+cray cfs sessions describe example --format json | jq .status.session
 ```
 
 Example output:
@@ -59,11 +72,20 @@ Example output:
 }
 ```
 
-The `status` section of the cray cfs session describe command output will not be populated until the CFS session Kubernetes job has started.
+The `status` section of the `cray cfs session describe` command output will not be populated until the CFS session Kubernetes job has started.
 
-The `.status.session` mapping shows the overall status of the configuration session. The `.succeeded` key within this mapping is a string with values of either `"true"`, `"false"`, `"unknown"`, or `"none"`.
+The `.status.session` mapping shows the overall status of the configuration session. The `.succeeded` key within this mapping is a string with
+values of either `"true"`, `"false"`, `"unknown"`, or `"none"`.
 
-`"none"` occurs if the session has not yet completed, and `"unknown"` occurs when the session is deleted mid-run, there is an error creating the session and it never starts, or any similar case where checking the session status would fail to find the underlying Kubernetes job running the CFS session.
+`"none"` occurs if the session has not yet completed, and `"unknown"` occurs when the session is deleted mid-run, there is an error creating the session
+and it never starts, or any similar case where checking the session status would fail to find the underlying Kubernetes job running the CFS session.
 
 Values of `.status` can be `"pending"`, `"running"`, or `"complete"`.
 
+## Troubleshooting
+
+If a session is not starting, then see [Troubleshoot CFS Sessions Failing to Start](Troubleshoot_CFS_Sessions_Failing_to_Start.md).
+
+If a session is starting but not completing, then see [Troubleshoot CFS Session Failing to Complete](Troubleshoot_CFS_Session_Failing_to_Complete.md).
+
+If a session completed but did not succeed, then see [Troubleshoot Ansible Play Failures in CFS Sessions](#Troubleshoot_Ansible_Play_Failures_in_CFS_Sessions.md).

--- a/scripts/operations/configuration/backup_cfs_config_comp.sh
+++ b/scripts/operations/configuration/backup_cfs_config_comp.sh
@@ -55,7 +55,7 @@ usage()
    echo "All parameters are optional and the values will be determined automatically if not set."
    echo
    echo "Usage: backup_cfs_config_comp.sh [ -b base_directory | -d target_directory ]"
-   echo "                                 [--comp-only | --cnfg-only]"
+   echo "                                 [--components-only | --configs-only]"
    echo
    echo "By default, a backup directory will be created as a subdirectory of /root."
    echo


### PR DESCRIPTION
# Description

The NCN image customization procedure is somewhat vague about the step where the CFS session is run. The command is given for how to run it, but no mention is made of how to monitor it while it runs, how to know when it is done, how to know if it was successful, and how to troubleshoot problems if they occur.

This PR modifies several documents to try and clarify that process. Other minor linting and reorganization is done around the image customization procedure.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
