### PR TITLE
Add troubleshooting known issue for kubectl logs indicating no space left on device (CASMPET-6140)

### DIFF
--- a/troubleshooting/known_issues/kubectl_logs_no_space_left_on_device.md
+++ b/troubleshooting/known_issues/kubectl_logs_no_space_left_on_device.md
@@ -1,0 +1,15 @@
+# Known Issue: `kubectl logs -f` returns no space left on device
+
+On some systems, running `kubectl logs -n <NAMESPACE> <PODNAME> -f` returns `no space left on device`.
+This can be caused by a lower limit for the `sysctl` setting `fs.inotify.max_user_watches` (defaults to `65536`) in some kernel releases.
+This can be fixed by increasing this setting.  Note that later versions of the kernel increase this setting by default.
+
+## Fix
+
+Run the following command from a master node. Be sure to change the `-w ncn-w[001-0..]` argument reflects all the worker nodes for the system:
+
+```bash
+pdsh -w ncn-w[001-0..] 'sysctl -w fs.inotify.max_user_watches=524288'
+```
+
+Once the `sysctl` command is complete, the `kubectl logs` command should again follow the log for that pod.

--- a/troubleshooting/known_issues/kubectl_logs_no_space_left_on_device.md
+++ b/troubleshooting/known_issues/kubectl_logs_no_space_left_on_device.md
@@ -1,12 +1,12 @@
-# Known Issue: `kubectl logs -f` returns no space left on device
+# Known issue: `kubectl logs -f` returns no space left on device
 
 On some systems, running `kubectl logs -n <NAMESPACE> <PODNAME> -f` returns `no space left on device`.
 This can be caused by a lower limit for the `sysctl` setting `fs.inotify.max_user_watches` (defaults to `65536`) in some kernel releases.
-This can be fixed by increasing this setting.  Note that later versions of the kernel increase this setting by default.
+This can be fixed by increasing this setting. Note that later versions of the kernel increase this setting by default.
 
 ## Fix
 
-Run the following command from a master node. Be sure to change the `-w ncn-w[001-0..]` argument reflects all the worker nodes for the system:
+Run the following command from a master node. Be sure to change the `-w ncn-w[001-0..]` argument to reflect all of the worker nodes for the system:
 
 ```bash
 pdsh -w ncn-w[001-0..] 'sysctl -w fs.inotify.max_user_watches=524288'


### PR DESCRIPTION
# Description

Fix for https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6140 -- indicate how to increase fs.inotify.max_user_watches if kubectl logs -f indicates no space left on device.

# Checklist Before Merging

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
