### PR TITLE
CASM-3653: write_root_secrets_to_vault: Add logging, split into modules

### DIFF
--- a/scripts/operations/configuration/python_lib/k8s.py
+++ b/scripts/operations/configuration/python_lib/k8s.py
@@ -1,0 +1,121 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""Shared Python function library: Kubernetes"""
+
+import logging
+import traceback
+
+import kubernetes
+import kubernetes.client
+import kubernetes.client.api
+import kubernetes.config
+
+from . import common
+
+K8S_CONFIGURATION = None
+K8S_API_CLIENT = None
+
+
+def log_error_raise_exception(msg: str, parent_exception: Exception = None) -> None:
+    """
+    1) If a parent exception is passed in, make a debug log entry with its stack trace.
+    2) Log an error with the specified message.
+    3) Raise a ScriptException with the specified message (from the parent exception, if
+       specified)
+    """
+    if parent_exception is not None:
+        logging.debug(traceback.format_exc())
+    logging.error(msg)
+    if parent_exception is None:
+        raise common.ScriptException(msg)
+    raise common.ScriptException(msg) from parent_exception
+
+
+def get_configuration() -> kubernetes.client.configuration.Configuration:
+    """
+    Creates a default Kubernetes configuration and returns it.
+    """
+    global K8S_CONFIGURATION
+    if K8S_CONFIGURATION is None:
+        logging.debug("Loading Kubernetes configuration")
+        try:
+            kubernetes.config.load_kube_config()
+        except Exception as e:
+            log_error_raise_exception(
+                "Error loading Kubernetes configuration", e)
+        logging.debug("Getting default copy of Kubernetes configuration")
+        try:
+            K8S_CONFIGURATION = kubernetes.client.Configuration().get_default_copy()
+        except Exception as e:
+            log_error_raise_exception(
+                "Error getting default copy of Kubernetes configuration", e)
+    return K8S_CONFIGURATION
+
+
+def get_api_client() -> kubernetes.client.api.core_v1_api.CoreV1Api:
+    """
+    Creates a Kubernetes API client and returns it.
+    """
+    global K8S_API_CLIENT
+    if K8S_API_CLIENT is None:
+        logging.info("Initializing Kubernetes client")
+        k8s_config = get_configuration()
+        logging.debug("Setting client default Kubernetes configuration")
+        try:
+            kubernetes.client.Configuration.set_default(k8s_config)
+        except Exception as e:
+            log_error_raise_exception(
+                "Error setting default Kubernetes configuration", e)
+        try:
+            K8S_API_CLIENT = kubernetes.client.api.core_v1_api.CoreV1Api()
+        except Exception as e:
+            log_error_raise_exception(
+                "Error obtaining Kubernetes API client", e)
+    return K8S_API_CLIENT
+
+
+def get_secret(name: str, namespace: str) -> kubernetes.client.models.v1_secret.V1Secret:
+    """
+    Wrapper for read_namespaced_secret function
+    """
+    api_client = get_api_client()
+    secret_label = f"{namespace}/{name} Kubernetes secret"
+    logging.debug(f"Getting {secret_label}")
+    try:
+        return api_client.read_namespaced_secret(name=name, namespace=namespace)
+    except Exception as e:
+        log_error_raise_exception(f"Error retrieving {secret_label}", e)
+
+
+def get_service(name: str, namespace: str) -> kubernetes.client.models.v1_service.V1Service:
+    """
+    Wrapper for read_namespaced_service function
+    """
+    api_client = get_api_client()
+    service_label = f"{namespace}/{name} Kubernetes service"
+    logging.debug(f"Getting {service_label}")
+    try:
+        return api_client.read_namespaced_service(name=name, namespace=namespace)
+    except Exception as e:
+        log_error_raise_exception(f"Error retrieving {service_label}", e)

--- a/scripts/operations/configuration/python_lib/logger.py
+++ b/scripts/operations/configuration/python_lib/logger.py
@@ -1,0 +1,90 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""Shared Python function library: logging"""
+
+import logging
+import logging.config
+import sys
+
+
+class _ExcludeErrorsFilter(logging.Filter):
+    def filter(self, record):
+        """Allow through the filter if the log level is less than ERROR"""
+        return record.levelno < logging.ERROR
+
+
+def configure_logging(filename):
+    """
+    Configures logging, with file logging going to the specified filename
+    """
+    config = {
+        'version': 1,
+        'filters': {
+            'exclude_errors': {
+                '()': _ExcludeErrorsFilter
+            }
+        },
+        'formatters': {
+            'file_formatter': {
+                'format': ('%(asctime)s.%(msecs)03d | %(process)d | %(name)s | %(pathname)s |'
+                           ' %(lineno)s | %(funcName)s | %(levelname)s | %(message)s'),
+                'datefmt': '%Y%m%d_%H%M%S'
+            },
+            'stream_formatter': {
+                'format': '%(message)s'
+            }
+        },
+        'handlers': {
+            'console_stderr': {
+                # Sends log messages with log level ERROR or higher to stderr
+                'class': 'logging.StreamHandler',
+                'level': 'ERROR',
+                'formatter': 'stream_formatter',
+                'stream': sys.stderr
+            },
+            'console_stdout': {
+                # Sends log messages with log level INFO or higher, but lower than ERROR, to stdout
+                'class': 'logging.StreamHandler',
+                'level': 'INFO',
+                'formatter': 'stream_formatter',
+                'filters': ['exclude_errors'],
+                'stream': sys.stdout
+            },
+            'file': {
+                # Sends all log messages to a file
+                'class': 'logging.FileHandler',
+                'level': 'DEBUG',
+                'formatter': 'file_formatter',
+                'filename': filename,
+                'encoding': 'utf8'
+            }
+        },
+        'root': {
+            # In general, this should be kept at 'NOTSET'.
+            # Otherwise it would interfere with the log levels set for each handler.
+            'level': 'NOTSET',
+            'handlers': ['console_stderr', 'console_stdout', 'file']
+        },
+    }
+    logging.config.dictConfig(config)

--- a/scripts/operations/configuration/python_lib/vault.py
+++ b/scripts/operations/configuration/python_lib/vault.py
@@ -1,0 +1,210 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""Shared Python function library: Vault"""
+
+import traceback
+
+import base64
+import logging
+import requests
+
+from . import api_requests
+from . import common
+from . import k8s
+
+SECRET_FIELD_NAMES = ["password", "ssh_private_key", "ssh_public_key"]
+
+K8S_NAMESPACE = "vault"
+K8S_SECRET_NAME = "cray-vault-unseal-keys"
+K8S_SERVICE_NAME = "cray-vault"
+
+TOKEN_STRING = None
+API_URL = None
+
+
+def log_error_raise_exception(msg: str, parent_exception: Exception = None) -> None:
+    """
+    1) If a parent exception is passed in, make a debug log entry with its stack trace.
+    2) Log an error with the specified message.
+    3) Raise a ScriptException with the specified message (from the parent exception, if
+       specified)
+    """
+    if parent_exception is not None:
+        logging.debug(traceback.format_exc())
+    logging.error(msg)
+    if parent_exception is None:
+        raise common.ScriptException(msg)
+    raise common.ScriptException(msg) from parent_exception
+
+
+def get_token_string() -> str:
+    """
+    Retrieve the Vault Kubernetes secret, extract the token string from it,
+    decode it from base-64, and return it as a string.
+    """
+    global TOKEN_STRING
+    if TOKEN_STRING is None:
+        # Obtain Vault token string from Kubernetes secret
+        secret_label = f"{K8S_NAMESPACE}/{K8S_SECRET_NAME} Kubernetes secret"
+        logging.info(f"Getting Vault token from {secret_label}")
+        vault_secret = k8s.get_secret(
+            name=K8S_SECRET_NAME, namespace=K8S_NAMESPACE)
+        try:
+            encoded_vault_token = vault_secret.data["vault-root"]
+        except (AttributeError, KeyError, TypeError) as e:
+            log_error_raise_exception(
+                f"{secret_label} has an unexpected format", e)
+        # return decoded bytes as a string
+        try:
+            TOKEN_STRING = base64.standard_b64decode(
+                encoded_vault_token).decode()
+        except Exception as e:
+            log_error_raise_exception(
+                f"Error decoding token in {secret_label}", e)
+    return TOKEN_STRING
+
+
+def get_api_url() -> str:
+    """
+    1. Looks up the vault/cray-vault service in Kubernetes
+    2. Retrieves the cluster IP address of the service
+    3. Retrieves the port list of the service
+    4. Finds the API port.
+    5. Assembles the base URL for the Vault API
+    """
+    global API_URL
+    if API_URL is None:
+        logging.debug("Finding Vault API URL")
+        service_label = f"{K8S_NAMESPACE}/{K8S_SERVICE_NAME} Kubernetes service"
+        vault_service = k8s.get_service(
+            name=K8S_SERVICE_NAME, namespace=K8S_NAMESPACE)
+
+        try:
+            vault_ip = vault_service.spec.cluster_ip
+            for vault_port in vault_service.spec.ports:
+                if vault_port.name == 'http-api-port':
+                    API_URL = f"http://{vault_ip}:{vault_port.port}"
+                    break
+        except (AttributeError, KeyError, TypeError) as e:
+            log_error_raise_exception(
+                f"{service_label} has an unexpected format", e)
+
+        if API_URL is None:
+            log_error_raise_exception(
+                f"No 'http-api-port' port found for {service_label}")
+        logging.debug(f"API_URL = {API_URL}")
+    return API_URL
+
+
+def get_csm_root_secret_api_url() -> str:
+    """
+    Returns the Vault API endpoint URL for the secret/csm/users/root Vault entry
+    """
+    api_url_base = get_api_url()
+    return f"{api_url_base}/v1/secret/csm/users/root"
+
+
+def write_root_secrets(ssh_private_key: str,
+                       ssh_public_key: str,
+                       password_hash: str,
+                       verify: bool = True) -> None:
+    """
+    Write the SSH keys and passwords to the csm root secret in Vault.
+    If verify is true, read them back to verify that they were set to the desired values.
+    """
+
+    secrets_to_write = {
+        "ssh_private_key": ssh_private_key,
+        "ssh_public_key": ssh_public_key,
+        "password": password_hash}
+
+    csm_root_secret_url = get_csm_root_secret_api_url()
+    logging.debug(f"csm_root_secret_url = {csm_root_secret_url}")
+    request_headers = {
+        "X-Vault-Request": "true",
+        "X-Vault-Token": get_token_string()}
+
+    # Create API request session
+    with requests.Session() as session:
+        # The same headers are used for all requests we'll be making
+        session.headers.update(request_headers)
+
+        # Write secrets to Vault
+        logging.info(
+            "Writing SSH keys and root password hash to secret/csm/users/root in Vault")
+        # We do not expect or care about any output of the write request,
+        # so no need to save the function return
+        try:
+            api_requests.make_api_request_with_retries(request_method=session.post,
+                                                       url=csm_root_secret_url,
+                                                       expected_status_code=204,
+                                                       json=secrets_to_write)
+        except Exception as e:
+            log_error_raise_exception(
+                f"Error making POST request to {csm_root_secret_url}", e)
+
+        if not verify:
+            logging.info("Vault write completed successfully")
+            return
+
+        # Read secrets back from Vault
+        logging.info(
+            "Read back secrets from Vault to verify that the values were correctly saved")
+        try:
+            resp_body = api_requests.make_api_request_with_retries(request_method=session.get,
+                                                                   url=csm_root_secret_url,
+                                                                   expected_status_code=200)
+        except Exception as e:
+            log_error_raise_exception(
+                f"Error making GET request to {csm_root_secret_url}", e)
+
+        if resp_body is None:
+            log_error_raise_exception(
+                "Empty body in response to Vault API read request")
+
+        try:
+            retrieved_vault_secrets = {
+                field: resp_body["data"][field] for field in SECRET_FIELD_NAMES}
+        except (KeyError, TypeError) as e:
+            log_error_raise_exception(
+                "Vault API read response has unexpected format", e)
+
+    # Validate that Vault values match what we wrote
+    logging.debug(
+        "Validating that Vault contents match what was written to it")
+    if retrieved_vault_secrets == secrets_to_write:
+        logging.info(
+            "Secrets read back from Vault match desired values -- "
+            "all secrets successfully written to Vault")
+        return
+
+    # Print summary of differences
+    for field in SECRET_FIELD_NAMES:
+        if secrets_to_write[field] == retrieved_vault_secrets[field]:
+            logging.debug(f"Vault value for {field} matches what was written")
+        else:
+            logging.error(
+                f"Vault value for {field} DOES NOT MATCH what was written")
+    raise common.ScriptException(
+        "Secrets read back from Vault do not all match what was written")

--- a/scripts/operations/configuration/write_root_secrets_to_vault.py
+++ b/scripts/operations/configuration/write_root_secrets_to_vault.py
@@ -23,120 +23,66 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-# Reads in:
-# - the hashed root user password from /etc/shadow
-# - the root user SSH private key from /root/.ssh/id_rsa
-# - the root user SSH public key from /root/.ssh/id_rsa.pub
-#
-# Writes these to the secret/csm/users/root in Vault, and then
-# reads them back to verify that they match what was written.
-#
-# Beyond validating the inputs, currently this script does minimal error-checking.
-# This is because it is desirable for any errors to be fatal, so catching the
-# Python exceptions is only useful inasmuch as it gives the opportunity to translate
-# the error into a more user-friendly format. This is certainly something that should
-# eventually be implemented, but for the initial version of this tool, it is not
-# necessary.
+"""
+Reads in:
+- the hashed root user password from /etc/shadow
+- the root user SSH private key from /root/.ssh/id_rsa
+- the root user SSH public key from /root/.ssh/id_rsa.pub
 
-import base64
-import kubernetes
-import kubernetes.client
-import kubernetes.client.api
-import kubernetes.config
-import requests
-import sys
-import time
+Writes these to the secret/csm/users/root in Vault, and then
+reads them back to verify that they match what was written.
+"""
 
-from python_lib.common import err, err_exit, stdout_write_flush
+import logging
+import traceback
 
-VAULT_SECRET_FIELD_NAMES = [ "password", "ssh_private_key", "ssh_public_key" ]
+from python_lib import common
+from python_lib import logger
+from python_lib import vault
 
-def read_file(filename):
+
+def log_error_raise_exception(msg: str, parent_exception: Exception = None) -> None:
     """
-    Reads contents of text file, verifies it is more than a few characters long,
-    and returns it as a string. The length check could be refined to be
-    more precise, but this will suffice.
+    1) If a parent exception is passed in, make a debug log entry with its stack trace.
+    2) Log an error with the specified message.
+    3) Raise a ScriptException with the specified message (from the parent exception, if
+       specified)
     """
+    if parent_exception is not None:
+        logging.debug(traceback.format_exc())
+    logging.error(msg)
+    if parent_exception is None:
+        raise common.ScriptException(msg)
+    raise common.ScriptException(msg) from parent_exception
 
-    print("Reading in file '%s'" % filename, flush=True)
-    try:
-        with open(filename, "rt") as textfile:
-            contents = textfile.read()
-    except FileNotFoundError:
-        err_exit("File '%s' does not exist" % filename)
-    if len(contents) < 4:
-        err_exit("File '%s' only contains %d characters" % (filename, len(contents)))
-    return contents
 
-def get_root_hash_from_etc_shadow():
+def get_root_hash_from_etc_shadow() -> str:
     """
     Find the line in /etc/shadow for the root user and return the
     hashed password field from that line.
     """
 
-    for etc_shadow_line in read_file("/etc/shadow").splitlines():
-        line_fields = etc_shadow_line.split(":")
-        if line_fields[0] != "root":
-            continue
-        print("Found root user line in /etc/shadow", flush=True)
-        # Hash is in the second field of this line
-        root_password_hash = line_fields[1]
-        if not root_password_hash:
-            err_exit("No password hash found on root user line")
-        return root_password_hash
-    err_exit("No root user line found in /etc/shadow file")
+    etc_shadow_lines = common.read_file("/etc/shadow")
 
-def get_vault_api_endpoint_url(k8s_core_v1_api):
-    """
-    1. Looks up the vault/cray-vault service in Kubernetes
-    2. Retrieves the cluster IP address of the service
-    3. Retrieves the port list of the service
-    4. Finds the API port.
-    5. Assembles the URL for the Vault API endpoint URL for the secret/csm/users/root Vault entry
-       and returns it as a string.
-    """
-    vault_service = k8s_core_v1_api.read_namespaced_service(name="cray-vault", namespace="vault")
-    vault_ip = vault_service.spec.cluster_ip
-    for vault_port in vault_service.spec.ports:
-        if vault_port.name == 'http-api-port':
-            return "http://{ip}:{port}/v1/secret/csm/users/root".format(ip=vault_ip, port=vault_port.port)
-    err_exit("No 'http-api-port' port found for vault/cray-vault Kubernetes service")
+    try:
+        for etc_shadow_line in etc_shadow_lines.splitlines():
+            line_fields = etc_shadow_line.split(":")
+            if line_fields[0] != "root":
+                continue
+            logging.info("Found root user line in /etc/shadow")
+            # Hash is in the second field of this line
+            root_password_hash = line_fields[1]
+            if not root_password_hash:
+                common.print_err_exit(
+                    "No password hash found on root user line")
+            return root_password_hash
+    except Exception as e:
+        common.log_error_raise_exception(
+            "Unexpected error parsing /etc/shadow file contents", e)
+    common.print_err_exit("No root user line found in /etc/shadow file")
 
-def make_api_request_with_retries(request_method, url, expected_status_code, **request_kwargs):
-    """
-    Makes request with specified method to specified URL with specified keyword arguments (if any).
-    If the expected status code is returned, then the response body is returned (or None, if empty).
-    If a 5xx status code is returned, the request will be retried after a brief wait, a limited number
-    of times.
-    If the expected status code is never returned (or an unexpected and non-5xx status code is
-    ever returned), then exit in error.
-    """
-    count=0
-    max_attempts=6
-    while count < max_attempts:
-        count+=1
-        print("Making {method} request to {url}".format(method=request_method.__name__.upper(), url=url), flush=True)
-        resp = request_method(url, **request_kwargs)
-        print("Response status code = {}".format(resp.status_code), flush=True)
-        if resp.status_code == expected_status_code:
-            if resp.text:
-                return resp.json()
-            else:
-                return None
-        print("Response reason = {}".format(resp.reason), flush=True)
-        print("Response text = {}".format(resp.text), flush=True)
-        if not 500 <= resp.status_code <= 599:
-            err_exit("Unexpect status code received in response to API request")
-        elif count >= max_attempts:
-            err_exit("API request unsuccessful even after {} attempts".format(max_attempts))
-        stdout_write_flush("Sleeping 3 seconds before retrying..")
-        for x in range(3):
-            stdout_write_flush(".")
-            time.sleep(1)
-        stdout_write_flush("\n\n")
-    err_exit("PROGRAMMING LOGIC ERROR: Should never reach this point in the make_api_request_with_retries function")
 
-def main():
+def main() -> None:
     """
     1. Read in the SSH keys and hashed root password from the system.
     2. Initialize the Kubernetes API client.
@@ -147,63 +93,21 @@ def main():
     """
 
     # Read in secrets from the system
-    system_secrets = {
-        "ssh_private_key": read_file("/root/.ssh/id_rsa"),
-        "ssh_public_key": read_file("/root/.ssh/id_rsa.pub"),
-        "password": get_root_hash_from_etc_shadow() }
+    try:
+        ssh_private_key = common.read_file("/root/.ssh/id_rsa")
+        ssh_public_key = common.read_file("/root/.ssh/id_rsa.pub")
+        password_hash = get_root_hash_from_etc_shadow()
+        vault.write_root_secrets(ssh_private_key=ssh_private_key,
+                                 ssh_public_key=ssh_public_key,
+                                 password_hash=password_hash,
+                                 verify=True)
+    except common.ScriptException as e:
+        common.print_err_exit(f"{e}")
 
-    # Initialize our Kubernetes API client
-    print("\nInitializing Kubernetes client", flush=True)
-    kubernetes.config.load_kube_config()
-    k8s_configuration = kubernetes.client.Configuration().get_default_copy()
-    kubernetes.client.Configuration.set_default(k8s_configuration)
-    k8s_core_v1_api = kubernetes.client.api.core_v1_api.CoreV1Api()
+    print("SUCCESS", flush=True)
 
-    # Obtain Vault token string from Kubernetes secret
-    print("\nGetting Vault token from vault/cray-vault-unseal-keys Kubernetes secret", flush=True)
-    vault_secret = k8s_core_v1_api.read_namespaced_secret(name="cray-vault-unseal-keys", namespace="vault")
-    encoded_vault_token = vault_secret.data["vault-root"]
-    decoded_token_bytes = base64.standard_b64decode(encoded_vault_token)
-    # Convert from bytes to string for API request header
-    vault_api_request_headers = { 
-        "X-Vault-Request": "true", 
-        "X-Vault-Token": decoded_token_bytes.decode() }
-
-    # Obtain Vault API IP address and port from Kubernetes cray-vault service
-    print("\nExamining Kubernetes cray-vault service to determine URL for Vault API endpoint of secret/csm/users/root", flush=True)
-    vault_api_url = get_vault_api_endpoint_url(k8s_core_v1_api)
-
-    # Create API request session
-    with requests.Session() as session:
-        # The same headers are used for all requests we'll be making
-        session.headers.update(vault_api_request_headers)
-
-        # Write secrets to Vault
-        print("\nWriting SSH keys and root password hash to secret/csm/users/root in Vault", flush=True)
-        # We do not expect or care about any output of the write request, so no need to save the function return
-        make_api_request_with_retries(request_method=session.post, url=vault_api_url, expected_status_code=204, json=system_secrets)
-
-        # Read secrets back from Vault
-        print("\nRead back secrets from Vault to verify that the values were correctly saved", flush=True)
-        resp_body = make_api_request_with_retries(request_method=session.get, url=vault_api_url, expected_status_code=200)
-        if resp_body == None:
-            err_exit("Empty body in response to Vault API request")
-        vault_secrets = { field: resp_body["data"][field] for field in VAULT_SECRET_FIELD_NAMES }
-
-    # Validate that Vault values match what we wrote
-    print("\nValidating that Vault contents match what was written to it", flush=True)
-    if vault_secrets == system_secrets:
-        print("All secrets successfully written to Vault\n", flush=True)
-        print("SUCCESS", flush=True)
-        sys.exit(0)
-
-    # Print summary of differences
-    for field in VAULT_SECRET_FIELD_NAMES:
-        if system_secrets[field] == vault_secrets[field]:
-            print("Vault value for {} matches what was written".format(field), flush=True)
-        else:
-            err("Vault value for {} DOES NOT MATCH what was written".format(field))
-    err_exit("Not all secrets successfully written to Vault")
 
 if __name__ == '__main__':
+    logger.configure_logging(
+        filename='/var/log/write_root_secrets_to_vault.log')
     main()


### PR DESCRIPTION
# Description

This PR modifies the write_root_secrets_to_vault.py script.

From a user perspective, the script is unchanged (beyond some minor changes to the printed output). The changes are primarily splitting it into a few library modules, adding logging, and adding type hinting. This is to enable upcoming work as part of [CASM-3367](https://jira-pro.its.hpecorp.net:8443/browse/CASM-3367).

I tested the updated script on fanta and verified that it still works as it did prior to the changes.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
