### PR TITLE
CASM-3665 IUF: Nexus operations paths are not correct in stages.yaml

### DIFF
--- a/workflows/iuf/stages.yaml
+++ b/workflows/iuf/stages.yaml
@@ -48,17 +48,17 @@ stages:
           local-path: operations/s3-upload.yaml # this is relative to stages.yaml, which is contained in workflows/iuf/ in docs-csm
           static-parameters: {} # any parameters that will be supplied statically to this operation.
         - name: nexus-setup
-          local-path: nexus-setup/nexus-setup-template.yaml # this is relative to stages.yaml, which is contained in workflows/iuf/ in docs-csm
+          local-path: operations/nexus-setup/nexus-setup-template.yaml # this is relative to stages.yaml, which is contained in workflows/iuf/ in docs-csm
           static-parameters: # any parameters that will be supplied statically to this operation.
             nexus-setup-image: artifactory.algol60.net/csm-docker/unstable/cray-nexus-setup:0.8.0-20221021164623-e8d3d3d
         - name: nexus-rpm-upload
-          local-path: operations/nexus-rpm-upload.yaml # this is relative to stages.yaml, which is contained in workflows/iuf/ in docs-csm
+          local-path: operations/nexus-setup/nexus-rpm-upload.yaml # this is relative to stages.yaml, which is contained in workflows/iuf/ in docs-csm
           static-parameters: {} # any parameters that will be supplied statically to this operation.
         - name: nexus-docker-upload
-          local-path: operations/nexus-docker-upload.yaml # this is relative to stages.yaml, which is contained in workflows/iuf/ in docs-csm
+          local-path: operations/nexus-setup/nexus-docker-upload.yaml # this is relative to stages.yaml, which is contained in workflows/iuf/ in docs-csm
           static-parameters: {} # any parameters that will be supplied statically to this operation.
         - name: nexus-helm-upload
-          local-path: operations/nexus-helm-upload.yaml # this is relative to stages.yaml, which is contained in workflows/iuf/ in docs-csm
+          local-path: operations/nexus-setup/nexus-helm-upload.yaml # this is relative to stages.yaml, which is contained in workflows/iuf/ in docs-csm
           static-parameters: {} # any parameters that will be supplied statically to this operation.
         - name: vcs-upload
           local-path: operations/vcs-upload.yaml # this is relative to stages.yaml, which is contained in workflows/iuf/ in docs-csm


### PR DESCRIPTION
CASM-3665 IUF: Nexus operations paths are not correct in stages.yaml


# Description

<!--- Describe what this change is and what it is for. -->

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
