### PR TITLE
CASM-3633/CASM-3635: write_root_secrets_to_vault.py: Additional options added

### DIFF
--- a/scripts/operations/configuration/python_lib/api_requests.py
+++ b/scripts/operations/configuration/python_lib/api_requests.py
@@ -26,7 +26,9 @@
 import logging
 import time
 import traceback
-from typing import Callable
+from typing import Callable, Container, Union
+
+import requests
 
 from . import common
 
@@ -48,21 +50,17 @@ def log_error_raise_exception(msg: str, parent_exception: Exception = None) -> N
 
 def make_api_request_with_retries(request_method: Callable,
                                   url: str,
-                                  expected_status_code: int,
-                                  **request_kwargs):
+                                  **request_kwargs) -> requests.models.Response:
     """
     Makes request with specified method to specified URL with specified keyword arguments (if any).
-    If the expected status code is returned, then the response body is returned (or None, if empty).
     If a 5xx status code is returned, the request will be retried after a brief wait, a limited
-    number of times.
-    If the expected status code is never returned (or an unexpected and non-5xx status code is
-    ever returned), then raise an exception
+    number of times. If this persists, an exception is raised. Otherwise, the response is returned.
     """
     try:
         method_name = request_method.__name__.upper()
-    except Exception as e:
+    except Exception as exc:
         log_error_raise_exception(
-            "Unexpected error determining API request method name", e)
+            "Unexpected error determining API request method name", exc)
 
     count = 0
     max_attempts = 6
@@ -71,31 +69,38 @@ def make_api_request_with_retries(request_method: Callable,
         logging.info(f"Making {method_name} request to {url}")
         try:
             resp = request_method(url, **request_kwargs)
-        except Exception as e:
+        except Exception as exc:
             log_error_raise_exception(
-                f"Error making {method_name} request to {url}", e)
+                f"Error making {method_name} request to {url}", exc)
         logging.debug(f"Response status code = {resp.status_code}")
-        if resp.status_code == expected_status_code:
-            if resp.text:
-                try:
-                    return resp.json()
-                except Exception as e:
-                    logging.debug(f"Response reason = {resp.reason}")
-                    logging.debug(f"Response text = {resp.text}")
-                    log_error_raise_exception(
-                        f"Error parsing {url} {method_name} response as JSON", e)
-            else:
-                return None
+        if not 500 <= resp.status_code <= 599:
+            return resp
         logging.debug(f"Response reason = {resp.reason}")
         logging.debug(f"Response text = {resp.text}")
-        if not 500 <= resp.status_code <= 599:
-            log_error_raise_exception(
-                "Unexpected status code received in response to API request."
-                f"Received {resp.status_code}, expecting {expected_status_code}")
-        elif count >= max_attempts:
+        if count >= max_attempts:
             log_error_raise_exception(
                 f"API request unsuccessful even after {max_attempts} attempts")
         logging.info("Sleeping 3 seconds before retrying..")
         time.sleep(3)
     log_error_raise_exception(
         "PROGRAMMING LOGIC ERROR: make_api_request_with_retries function should get here")
+
+
+def retry_request_validate_status(expected_status_codes: Union[int, Container[int]],
+                                  **kwargs_to_make_api_request_with_retries
+                                 ) -> requests.models.Response:
+    """
+    Wrapper function for make_api_request_with_retries that validates the status code of the
+    response.
+    expected_status_codes specifies the expected status code(s) for the API request.
+    It can be a single int, or a collection of ints. If the response status code does not match,
+    an exception is raised. Otherwise, the response is returned.
+    """
+    if isinstance(expected_status_codes, int):
+        expected_status_codes = {expected_status_codes}
+    response = make_api_request_with_retries(
+        **kwargs_to_make_api_request_with_retries)
+    if response.status_code not in expected_status_codes:
+        log_error_raise_exception(f"Response status code ({response.status_code}) does not match"
+                                  f" any expected status codes ({expected_status_codes})")
+    return response

--- a/scripts/operations/configuration/python_lib/args.py
+++ b/scripts/operations/configuration/python_lib/args.py
@@ -31,7 +31,7 @@ import os
 from typing import Callable, List
 
 
-text_file_type = argparse.FileType('rt', encoding="utf-8")
+TEXT_FILE_TYPE = argparse.FileType('rt', encoding="utf-8")
 
 
 def get_text_file_contents(file_name: str,
@@ -47,7 +47,7 @@ def get_text_file_contents(file_name: str,
     """
     # Use the built-in argparse FileType to open the file for reading.
     # This will automatically raise appropriate errors if there are any issues.
-    file_contents = text_file_type(file_name).read()
+    file_contents = TEXT_FILE_TYPE(file_name).read()
 
     if value_validator is not None:
         try:
@@ -126,7 +126,7 @@ class PasswordPromptAction(argparse.Action):
     and then validate that it meets the minimum and maximum length requirements (if any).
     """
 
-    def __init__(self, option_strings: List, dest: str, nargs = 0,
+    def __init__(self, option_strings: List, dest: str, nargs=0,
                  min_length: int = None, max_length: int = None, **kwargs):
         """
         Initialize the custom action, storing the length requirements for later use

--- a/scripts/operations/configuration/python_lib/args.py
+++ b/scripts/operations/configuration/python_lib/args.py
@@ -1,0 +1,156 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""Shared Python function library: argument parsing"""
+
+import argparse
+import getpass
+import logging
+import os
+
+from typing import Callable, List
+
+
+text_file_type = argparse.FileType('rt', encoding="utf-8")
+
+
+def get_text_file_contents(file_name: str,
+                           value_validator: Callable = None) -> str:
+    """
+    Reads in the contents of the specified file as a string.
+
+    If value_validator is set, it is called with the file contents string as the only argument.
+    The return of the call is not examined -- the expectation is that the call will raise an
+    ArgumentTypeError if there is a problem.
+
+    Returns the file contents string if there are no errors.
+    """
+    # Use the built-in argparse FileType to open the file for reading.
+    # This will automatically raise appropriate errors if there are any issues.
+    file_contents = text_file_type(file_name).read()
+
+    if value_validator is not None:
+        try:
+            value_validator(file_contents)
+        except argparse.ArgumentTypeError as exc:
+            raise argparse.ArgumentTypeError(
+                f"Contents of '{file_name}' file failed validation: {exc}") from exc
+
+    return file_contents
+
+
+def get_env_var_value(env_var_name: str,
+                      value_validator: Callable = None,
+                      unset_ok: bool = False) -> str:
+    """
+    Looks up the value of the specified environment variable.
+
+    If unset_ok is False and the variable is not set, an ArgumentTypeError is raised.
+
+    NOTE that the variable may be set to an empty string, which is not the same as being unset.
+    If that condition needs to be caught, then the value_validator parameter must be used.
+
+    If value_validator is set, it is called with the variable value as the only argument.
+    The return of the call is not examined -- the expectation is that the call will raise an
+    ArgumentTypeError if there is a problem.
+
+    If there are no errors, the value of the variable is returned (or an empty string, if
+    the variable is unset and unset_ok is True).
+    """
+    env_var_value = os.getenv(env_var_name)
+    if env_var_value is None:
+        msg = f"Environment variable {env_var_name} is not set"
+        if unset_ok:
+            logging.debug(f"{msg}; unset_ok is True")
+            env_var_value = ""
+        else:
+            logging.error(msg)
+            raise argparse.ArgumentTypeError(msg)
+
+    if value_validator is not None:
+        try:
+            value_validator(env_var_value)
+        except argparse.ArgumentTypeError as exc:
+            raise argparse.ArgumentTypeError(
+                f"Value of environment variable {env_var_name} failed validation: {exc}") from exc
+
+    return env_var_value
+
+
+def validate_string(string_to_validate: str,
+                    min_length: int = None,
+                    max_length: int = None,
+                    required_prefix: str = None) -> None:
+    """
+    If the specified string fails to meet any of the requirements, raise an
+    argparse.ArgumentTypeError.
+    """
+    string_length = len(string_to_validate)
+
+    if min_length is not None and string_length < min_length:
+        raise argparse.ArgumentTypeError(
+            f"Length {string_length} is less than minimum permitted length {min_length}")
+
+    if max_length is not None and string_length > max_length:
+        raise argparse.ArgumentTypeError(
+            f"Length {string_length} is greater than maximum permitted length {max_length}")
+
+    if required_prefix is not None and string_to_validate.find(required_prefix) != 0:
+        raise argparse.ArgumentTypeError(
+            f"Does not begin with required prefix: '{required_prefix}'")
+
+
+class PasswordPromptAction(argparse.Action):
+    """
+    Custom argparse action to prompt user for a password, have them re-enter it to verify,
+    and then validate that it meets the minimum and maximum length requirements (if any).
+    """
+
+    def __init__(self, option_strings: List, dest: str, nargs = 0,
+                 min_length: int = None, max_length: int = None, **kwargs):
+        """
+        Initialize the custom action, storing the length requirements for later use
+        """
+        if nargs != 0:
+            raise ValueError("nargs must be 0")
+        self.min_length, self.max_length = min_length, max_length
+        super().__init__(option_strings, dest, nargs=nargs, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        """
+        Prompt the user for the password, making sure that it meets the length requirements (if any)
+        and that it is entered correctly a second time
+        """
+        logging.debug("Prompting user for password")
+        while True:
+            pw_text = getpass.getpass("Enter desired password: ")
+            try:
+                validate_string(pw_text, min_length=self.min_length,
+                                max_length=self.max_length)
+            except argparse.ArgumentTypeError as exc:
+                logging.error(exc)
+                continue
+            if pw_text == getpass.getpass("Verify password: "):
+                break
+            logging.error("Passwords do not match. Please try again.")
+        setattr(namespace, self.dest, pw_text)

--- a/scripts/operations/configuration/python_lib/k8s.py
+++ b/scripts/operations/configuration/python_lib/k8s.py
@@ -61,15 +61,15 @@ def get_configuration() -> kubernetes.client.configuration.Configuration:
         logging.debug("Loading Kubernetes configuration")
         try:
             kubernetes.config.load_kube_config()
-        except Exception as e:
+        except Exception as exc:
             log_error_raise_exception(
-                "Error loading Kubernetes configuration", e)
+                "Error loading Kubernetes configuration", exc)
         logging.debug("Getting default copy of Kubernetes configuration")
         try:
             K8S_CONFIGURATION = kubernetes.client.Configuration().get_default_copy()
-        except Exception as e:
+        except Exception as exc:
             log_error_raise_exception(
-                "Error getting default copy of Kubernetes configuration", e)
+                "Error getting default copy of Kubernetes configuration", exc)
     return K8S_CONFIGURATION
 
 
@@ -84,14 +84,14 @@ def get_api_client() -> kubernetes.client.api.core_v1_api.CoreV1Api:
         logging.debug("Setting client default Kubernetes configuration")
         try:
             kubernetes.client.Configuration.set_default(k8s_config)
-        except Exception as e:
+        except Exception as exc:
             log_error_raise_exception(
-                "Error setting default Kubernetes configuration", e)
+                "Error setting default Kubernetes configuration", exc)
         try:
             K8S_API_CLIENT = kubernetes.client.api.core_v1_api.CoreV1Api()
-        except Exception as e:
+        except Exception as exc:
             log_error_raise_exception(
-                "Error obtaining Kubernetes API client", e)
+                "Error obtaining Kubernetes API client", exc)
     return K8S_API_CLIENT
 
 
@@ -104,8 +104,8 @@ def get_secret(name: str, namespace: str) -> kubernetes.client.models.v1_secret.
     logging.debug(f"Getting {secret_label}")
     try:
         return api_client.read_namespaced_secret(name=name, namespace=namespace)
-    except Exception as e:
-        log_error_raise_exception(f"Error retrieving {secret_label}", e)
+    except Exception as exc:
+        log_error_raise_exception(f"Error retrieving {secret_label}", exc)
 
 
 def get_service(name: str, namespace: str) -> kubernetes.client.models.v1_service.V1Service:
@@ -117,5 +117,5 @@ def get_service(name: str, namespace: str) -> kubernetes.client.models.v1_servic
     logging.debug(f"Getting {service_label}")
     try:
         return api_client.read_namespaced_service(name=name, namespace=namespace)
-    except Exception as e:
-        log_error_raise_exception(f"Error retrieving {service_label}", e)
+    except Exception as exc:
+        log_error_raise_exception(f"Error retrieving {service_label}", exc)

--- a/scripts/operations/configuration/python_lib/types.py
+++ b/scripts/operations/configuration/python_lib/types.py
@@ -1,0 +1,29 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""Shared Python function library: Type hints"""
+
+from typing import Any, Dict
+
+# A simplified type hint to use for JSON objects
+JSONObject = Dict[str, Any]


### PR DESCRIPTION
# Description

This PR continues the modifications to the write_root_secrets_to_vault script. This PR contains changes for two tickets.

## [CASM-3633](https://jira-pro.its.hpecorp.net:8443/browse/CASM-3633)

Until now, that script did not provide the user any options to govern how it behaved. Instead it would always read in the root password hash from the /etc/shadow file and it would read in the SSH keys from the /root/.ssh/id_rsa* files.

This PR adds options to:

1. Allow the user to specify the source file for the private SSH key
2. Allow the user to specify the source file for the public SSH key
3. Give the user other options to specify the root password -- provide the plaintext root password via environment variable, provide the hashed password string via environment variable, or be prompted to enter the plaintext root password.

In the case where a root password is provided in plaintext, a shadow file-style SHA512 hash string is generated (just as we do in a number of procedures in the CSM documentation: [example1](https://github.com/Cray-HPE/docs-csm/blob/release/1.3/operations/security_and_authentication/Change_Root_Passwords_for_Compute_Nodes.md) [example2](https://github.com/Cray-HPE/docs-csm/blob/release/1.3/operations/security_and_authentication/Update_NCN_Passwords.md)) from it.

If no arguments are specified, the script behaves as it always has. Thus, because there are no accompanying documentation changes in this PR, to the end user there will not yet be any visible change. Future PRs will address this.

I tested the script on surtur, testing the default path, good path for the other options, as well as bad paths. I also made sure that the hash strings being generated by the script work as intended (as in, when I put them in the shadow file, I am able to authenticate using the password).

None of the code that deals with Vault has changed, so I do not believe anyone with particular Vault knowledge is required to review this part of the PR.

## [CASM-3635](https://jira-pro.its.hpecorp.net:8443/browse/CASM-3635)

The primary change is the addition of arguments to the write_root_secrets_to_vault.py script. Previously the script always set values for the password and both SSH keys. These new arguments add the following options:

- Delete field from root secret in Vault
- Retain current value (if any) from root secret in Vault
- 
Each of those options can be specified independently for either SSH key or the root password hash, in addition to the previous options.

This now allows users to use the tool to make changes to just one of the fields, or to remove the field from Vault (which is a supported option for admins who do not want to enable passwordless SSH or do not want the root password kept in Vault).

The default behavior of the tool remains unchanged.

I also did some refactoring of the tool and its libraries as part of this.

I tested the changes on fanta, both the new options and the previous ones.

The new tool options are not yet being documented. They are being added as part of larger work for [CASM-3367](https://jira-pro.its.hpecorp.net:8443/browse/CASM-3367).

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
