### PR TITLE
CASMHMS-5839 HPE RF event WAR

### DIFF
--- a/troubleshooting/index.md
+++ b/troubleshooting/index.md
@@ -30,6 +30,7 @@ This document provides links to troubleshooting information for services and fun
 * [Kafka Failure after CSM 1.2 Upgrade](known_issues/kafka_upgrade_failure.md)
 * [SLS Not Working During Node Rebuild](known_issues/SLS_Not_Working_During_Node_Rebuild.md)
 * [Multiple Console Node Pods on the Same Worker](known_issues/Multiple_Console_Node_Pods_on_the_Same_Worker.md)
+* [HPE nodes not properly transitioning power state](known_issues/hpe_systems_not_transitioning_power_state.md)
 
 ## Kubernetes
 

--- a/troubleshooting/known_issues/hpe_systems_not_transitioning_power_state.md
+++ b/troubleshooting/known_issues/hpe_systems_not_transitioning_power_state.md
@@ -13,8 +13,9 @@ failures. To detect this state, look at the subscription numbers under
 extremely large and increasing, this would indicate the iLO is receiving an
 error when trying to send Redfish events.
 
+Check subscriptions on affected BMC
 ```bash
-# curl -sk -u root:$PASSWD https://${BMC}/redfish/v1/EventService/Subscriptions | jq -c '.Members[]'
+ncn-m# curl -sk -u root:$PASSWD https://${BMC}/redfish/v1/EventService/Subscriptions | jq -c '.Members[]'
 ```
 * If there is at least one subscription and it is a low number, everything is OK. No action is needed.
 * If there is at least one subscription and it is large number, verify it is not increasing by executing the above command several times over ~10 minutes.
@@ -22,8 +23,7 @@ error when trying to send Redfish events.
 * If the subscription number is increasing, the BMC will need to be reset.
 * If there are no subscriptions, the BMC will need to be reset.
 
-Reset the BMC with ipmitool
-
+Reset BMC with ipmitool
 ```bash
-# ipmitool -H $BMC -U root -P $PASSWD -I lanplus mc reset cold
+ncn-m# ipmitool -H $BMC -U root -P $PASSWD -I lanplus mc reset cold
 ```

--- a/troubleshooting/known_issues/hpe_systems_not_transitioning_power_state.md
+++ b/troubleshooting/known_issues/hpe_systems_not_transitioning_power_state.md
@@ -1,0 +1,29 @@
+# HPE iLO dropping event subscriptions and not properly transitioning power state in CSM software.
+
+HPE Systems impacted:
+* DL385
+* Apollo 6500
+
+When HPE iLO systems are not properly transitioning power state in HMS/SAT this
+could indicate that Redfish events are not being received by the HMS
+HM-Collector. When this occurs, the HPE iLO receives an error back from its
+attempt to send events and will delete the subscription if there are enough
+failures. To detect this state, look at the subscription numbers under
+`/redfish/v1/EventService/Subscriptions`. If subscriptions are missing or are
+extremely large and increasing, this would indicate the iLO is receiving an
+error when trying to send Redfish events.
+
+```bash
+# curl -sk -u root:$PASSWD https://${BMC}/redfish/v1/EventService/Subscriptions | jq -c '.Members[]'
+```
+* If there is at least one subscription and it is a low number, everything is OK. No action is needed.
+* If there is at least one subscription and it is large number, verify it is not increasing by executing the above command several times over ~10 minutes.
+* If the subscription number is not increasing, everything is OK. No action is needed.
+* If the subscription number is increasing, the BMC will need to be reset.
+* If there are no subscriptions, the BMC will need to be reset.
+
+Reset the BMC with ipmitool
+
+```bash
+# ipmitool -H $BMC -U root -P $PASSWD -I lanplus mc reset cold
+```

--- a/troubleshooting/known_issues/hpe_systems_not_transitioning_power_state.md
+++ b/troubleshooting/known_issues/hpe_systems_not_transitioning_power_state.md
@@ -1,6 +1,7 @@
-# HPE iLO dropping event subscriptions and not properly transitioning power state in CSM software.
+# HPE iLO dropping event subscriptions and not properly transitioning power state in CSM software
 
 HPE Systems impacted:
+
 * DL385
 * Apollo 6500
 
@@ -14,9 +15,11 @@ extremely large and increasing, this would indicate the iLO is receiving an
 error when trying to send Redfish events.
 
 Check subscriptions on affected BMC
+
 ```bash
 ncn-m# curl -sk -u root:$PASSWD https://${BMC}/redfish/v1/EventService/Subscriptions | jq -c '.Members[]'
 ```
+
 * If there is at least one subscription and it is a low number, everything is OK. No action is needed.
 * If there is at least one subscription and it is large number, verify it is not increasing by executing the above command several times over ~10 minutes.
 * If the subscription number is not increasing, everything is OK. No action is needed.
@@ -24,6 +27,7 @@ ncn-m# curl -sk -u root:$PASSWD https://${BMC}/redfish/v1/EventService/Subscript
 * If there are no subscriptions, the BMC will need to be reset.
 
 Reset BMC with `ipmitool`
+
 ```bash
 ncn-m# ipmitool -H $BMC -U root -P $PASSWD -I lanplus mc reset cold
 ```

--- a/troubleshooting/known_issues/hpe_systems_not_transitioning_power_state.md
+++ b/troubleshooting/known_issues/hpe_systems_not_transitioning_power_state.md
@@ -23,7 +23,7 @@ ncn-m# curl -sk -u root:$PASSWD https://${BMC}/redfish/v1/EventService/Subscript
 * If the subscription number is increasing, the BMC will need to be reset.
 * If there are no subscriptions, the BMC will need to be reset.
 
-Reset BMC with ipmitool
+Reset BMC with `ipmitool`
 ```bash
 ncn-m# ipmitool -H $BMC -U root -P $PASSWD -I lanplus mc reset cold
 ```

--- a/troubleshooting/known_issues/hpe_systems_not_transitioning_power_state.md
+++ b/troubleshooting/known_issues/hpe_systems_not_transitioning_power_state.md
@@ -2,6 +2,7 @@
 
 HPE Systems impacted:
 
+* DL325
 * DL385
 * Apollo 6500
 


### PR DESCRIPTION
# Description

HPE Systems impacted:
- DL385
- Apollo 6500

When HPE iLO systems are not properly transitioning power state in HMS/SAT this could indicate that Redfish events are not being received by the HMS HM-Collector. When this occurs, the HPE iLO receives an error back from its attempt to send events and will delete the subscription if there are enough failures.

This WAR provides a resolution until firmware updates are available.

# Checklist Before Merging

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
