### PR TITLE
CASMHMS-5839 HPE RF event WAR

### DIFF
--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -42,6 +42,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 * [SLS Not Working During Node Rebuild](known_issues/SLS_Not_Working_During_Node_Rebuild.md)
 * [Antero node NID allocation](known_issues/antero_node_NID_allocation.md)
 * [Unbound forwarding to PowerDNS in an air-gapped environment](known_issues/unbound_airgap_forwarding.md)
+* [HPE nodes not properly transitioning power state](known_issues/hpe_systems_not_transitioning_power_state.md)
 
 ## Booting
 

--- a/troubleshooting/known_issues/hpe_systems_not_transitioning_power_state.md
+++ b/troubleshooting/known_issues/hpe_systems_not_transitioning_power_state.md
@@ -2,6 +2,7 @@
 
 HPE Systems impacted:
 
+* DL325
 * DL385
 * Apollo 6500
 

--- a/troubleshooting/known_issues/hpe_systems_not_transitioning_power_state.md
+++ b/troubleshooting/known_issues/hpe_systems_not_transitioning_power_state.md
@@ -1,0 +1,33 @@
+# HPE iLO dropping event subscriptions and not properly transitioning power state in CSM software
+
+HPE Systems impacted:
+
+* DL385
+* Apollo 6500
+
+When HPE iLO systems are not properly transitioning power state in HMS/SAT this
+could indicate that Redfish events are not being received by the HMS
+HM-Collector. When this occurs, the HPE iLO receives an error back from its
+attempt to send events and will delete the subscription if there are enough
+failures. To detect this state, look at the subscription numbers under
+`/redfish/v1/EventService/Subscriptions`. If subscriptions are missing or are
+extremely large and increasing, this would indicate the iLO is receiving an
+error when trying to send Redfish events.
+
+(`ncn-m#`) Check subscriptions on affected BMC
+
+```bash
+curl -sk -u root:$PASSWD https://${BMC}/redfish/v1/EventService/Subscriptions | jq -c '.Members[]'
+```
+
+* If there is at least one subscription and it is a low number, everything is OK. No action is needed.
+* If there is at least one subscription and it is large number, verify it is not increasing by executing the above command several times over ~10 minutes.
+* If the subscription number is not increasing, everything is OK. No action is needed.
+* If the subscription number is increasing, the BMC will need to be reset.
+* If there are no subscriptions, the BMC will need to be reset.
+
+(`ncn-m#`) Reset BMC with `ipmitool`
+
+```bash
+ipmitool -H $BMC -U root -P $PASSWD -I lanplus mc reset cold
+```


### PR DESCRIPTION
# Description

HPE Systems impacted:
- DL385
- Apollo 6500

When HPE iLO systems are not properly transitioning power state in HMS/SAT this could indicate that Redfish events are not being received by the HMS HM-Collector. When this occurs, the HPE iLO receives an error back from its attempt to send events and will delete the subscription if there are enough failures.

This WAR provides a resolution until firmware updates are available.

# Checklist Before Merging

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
