### PR TITLE
CASMHMS-5840 Add documentation for test failures due to unexpected BMC states Main

### DIFF
--- a/troubleshooting/interpreting_hms_health_check_results.md
+++ b/troubleshooting/interpreting_hms_health_check_results.md
@@ -423,6 +423,47 @@ ssh: connect to host sw-leaf-bmc-001 port 22: Connection timed out
 
 Restoring connectivity, resolving configuration issues, or restarting the relevant ports on the `leaf-bmc` switch should allow the compute hardware to issue DHCP requests and be discovered successfully.
 
+##### `test_components.tavern.yaml`
+
+These tests include checks for healthy BMC states in HSM.
+
+The following is an example of a failed test execution due to an unexpected BMC state in HSM:
+
+```text
+Running functional tests...
+============================= test session starts ==============================
+platform linux -- Python 3.9.13, pytest-7.1.2, pluggy-1.0.0 -- /usr/bin/python3
+cachedir: .pytest_cache
+rootdir: /src/app, configfile: pytest.ini
+plugins: tavern-1.23.1
+collecting ... collected 38 items
+
+...
+
+test_components.tavern.yaml::Ensure that we can conduct a query for all Node BMCs in the Component collection FAILED [ 26%]
+
+...
+
+Errors:
+E   tavern.util.exceptions.TestFailError: Test 'Verify the expected response fields for all NodeBMCs' failed:
+    - Error calling validate function '<function validate_pykwalify at 0x7f22cbaf0700>':
+        Traceback (most recent call last):
+          File "/usr/lib/python3.9/site-packages/tavern/schemas/files.py", line 106, in verify_generic
+            verifier.validate()
+          File "/usr/lib/python3.9/site-packages/pykwalify/core.py", line 194, in validate
+            raise SchemaError(u"Schema validation failed:\n - {error_msg}.".format(
+        pykwalify.errors.SchemaError: <SchemaError: error code 2: Schema validation failed:
+         - Enum 'Off' does not exist. Path: '/Components/1/State' Enum: ['Ready'].
+
+...
+
+=========================== short test summary info ============================
+FAILED test_components.tavern.yaml::Ensure that we can conduct a query for all Node BMCs in the Component collection
+=================== 1 failed, 37 passed in 214.09s (0:03:34) ===================
+```
+
+Test failures due to unexpected BMC states in HSM can be safely ignored if there are BMCs in the system that are intentionally powered off, such as during system shutdown and power off testing.
+
 ### `hsm_discovery_status_test.sh`
 
 This test verifies that the system hardware has been discovered successfully.

--- a/troubleshooting/interpreting_hms_health_check_results.md
+++ b/troubleshooting/interpreting_hms_health_check_results.md
@@ -364,7 +364,7 @@ FAILED test_hardware.tavern.yaml::Query the Hardware collection for Node informa
 (`ncn-mw#`) If these failures occur, confirm that there are no discovered compute nodes in HSM.
 
 ```bash
-cray hsm state components list --type=Node --role=compute --format=json
+cray hsm state components list --type Node --role compute --format json
 ```
 
 Example output:

--- a/troubleshooting/interpreting_hms_health_check_results.md
+++ b/troubleshooting/interpreting_hms_health_check_results.md
@@ -471,7 +471,7 @@ This job executes the tests for the Firmware Action Service (FAS).
 
 ##### `test_actions.tavern.yaml`
 
-These tests require at least one healthy (State=Ready, Flag=OK) BMC in HSM.
+These tests require at least one healthy BMC (State=Ready, Flag=OK) in HSM.
 
 The following is an example of a failed test execution due to no healthy BMCs in HSM:
 

--- a/troubleshooting/interpreting_hms_health_check_results.md
+++ b/troubleshooting/interpreting_hms_health_check_results.md
@@ -12,6 +12,7 @@
 - [Additional troubleshooting](#additional-troubleshooting)
   - [`run_hms_ct_tests.sh`](#run_hms_ct_testssh)
     - [`cray-hms-smd-test-functional`](#cray-hms-smd-test-functional)
+    - [`cray-hms-firmware-action-test-functional`](#cray-hms-firmware-action-test-functional)
   - [`hsm_discovery_status_test.sh`](#hsm_discovery_status_testsh)
     - [`HTTPsGetFailed`](#httpsgetfailed)
     - [`ChildVerificationFailed`](#childverificationfailed)
@@ -463,6 +464,44 @@ FAILED test_components.tavern.yaml::Ensure that we can conduct a query for all N
 ```
 
 Test failures due to unexpected BMC states in HSM can be safely ignored if there are BMCs in the system that are intentionally powered off, such as during system shutdown and power off testing.
+
+#### `cray-hms-firmware-action-test-functional`
+
+This job executes the tests for the Firmware Action Service (FAS).
+
+##### `test_actions.tavern.yaml`
+
+These tests require at least one healthy (State=Ready, Flag=OK) BMC in HSM.
+
+The following is an example of a failed test execution due to no healthy BMCs in HSM:
+
+```text
+Running functional tests...
+============================= test session starts ==============================
+platform darwin -- Python 3.9.13, pytest-7.1.2, pluggy-1.0.0
+rootdir: /Users/schooler/Git/GitHub/hms-firmware-action/test/ct/api/1-non-disruptive, configfile: pytest.ini
+plugins: tavern-1.23.3
+collected 6 items
+
+...
+
+test_actions.tavern.yaml::Ensure that the BMC firmware can be updated with a FAS action FAILED [ 16%]
+
+...
+
+Errors:
+E   tavern.util.exceptions.TestFailError: Test 'Ensure that the BMC firmware can be updated with a FAS action' failed:
+    - Status code was 400, expected 202:
+        {"type": "about:blank", "detail": "invalid/duplicate xnames: [None]", "status": 400, "title": "Bad Request"}
+
+...
+
+=========================== short test summary info ============================
+FAILED test_actions.tavern.yaml::Ensure that the BMC firmware can be updated with a FAS action
+=================== 1 failed, 5 passed in 21.22s ===============================
+```
+
+Test failures due to no healthy BMCs in HSM can be safely ignored if the BMCs in the system are intentionally powered off, such as during system shutdown and power off testing.
 
 ### `hsm_discovery_status_test.sh`
 


### PR DESCRIPTION
### Summary and Scope

This change adds troubleshooting documentation about handling test failures due to BMCs in unexpected states such as during system shutdown and power off testing.

### Issues and Related PRs

* Partially resolves CASMHMS-5840 in Main.

### Testing

Was a fresh Install tested? N/A
Was an Upgrade tested? N/A
Was a Downgrade tested? N/A

### Risks and Mitigations

No risks.