### PR TITLE
CASMINST-5625 remove retryStrategy from preflight-checks-for-services.yaml

### DIFF
--- a/workflows/iuf/operations/preflight-checks-for-services.yaml
+++ b/workflows/iuf/operations/preflight-checks-for-services.yaml
@@ -44,13 +44,6 @@ spec:
             templateRef: 
               name: iuf-base-template
               template: shell-script
-            retryStrategy:
-              limit: "2"
-              retryPolicy: "Always"
-              backoff:
-                duration: "10s"       # Must be a string. Default unit is seconds. Could also be a Duration, e.g.: "2m", "6h", "1d"
-                factor: "2"
-                maxDuration: "1m"
             arguments:
               parameters:
                 - name: dryRun


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->

Remove retryStrategy from preflight-checks-for-services.yaml. This can be removed because this stage references a different template that specifies the retryStrategy. 

Tested on Frigg.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
