### PR TITLE
CASMTRIAGE-4577 - DNS hangs seen on airgapped system when host lookups fail

### DIFF
--- a/install/prepare_site_init.md
+++ b/install/prepare_site_init.md
@@ -352,13 +352,20 @@ with system-specific customizations.
     172.30.84.40
     ```
 
-    If there is **no requirement to resolve external hostnames or no upstream DNS server**,
-    then remove the DNS forwarding configuration from the `cray-dns-unbound` service.
+    If there is **no requirement to resolve external hostnames (including other services on the site network) or no upstream DNS server**,
+    then the `cray-dns-unbound` service should be configured to forward to the `cray-dns-powerdns` service.
 
-    1. (`pit#`) Remove the `forwardZones` configuration for the `cray-dns-unbound` service.
+    1. (`pit#`) Update the `forwardZones` configuration for the `cray-dns-unbound` service to point to the `cray-dns-powerdns` service.
 
         ```bash
-        yq delete -i "${SITE_INIT}/customizations.yaml" spec.kubernetes.services.cray-dns-unbound.forwardZones
+        yq write -s - -i ${SITE_INIT}/customizations.yaml <<EOF
+        - command: update
+          path: spec.kubernetes.services.cray-dns-unbound.forwardZones
+          value:
+          - name: "."
+            forwardIps:
+            - "10.92.100.85"
+        EOF
         ```
 
     1. (`pit#`) Review the `cray-dns-unbound` values.
@@ -368,6 +375,20 @@ with system-specific customizations.
         ```bash
         yq read "${SITE_INIT}/customizations.yaml" spec.kubernetes.services.cray-dns-unbound
         ```
+
+        Expected Output:
+
+        ```text
+        domain_name: '{{ network.dns.external }}'
+        forwardZones:
+          - name: "."
+            forwardIps:
+              - "10.92.100.85"
+        ```
+
+    See the following documentation regarding known issues when operating with no upstream DNS server.
+    - [Spire Database Cluster DNS Lookup Failure](../troubleshooting/known_issues/spire_database_lookup_error.md)
+    - [Spire database connection pool configuration in an air-gapped environment](../troubleshooting/known_issues/spire_database_airgap_configuration.md)
 
 1. (Optional) Configure PowerDNS zone transfer and DNSSEC. See the [PowerDNS Configuration Guide](../operations/network/dns/PowerDNS_Configuration.md) for more information.
 

--- a/troubleshooting/known_issues/spire_database_airgap_configuration.md
+++ b/troubleshooting/known_issues/spire_database_airgap_configuration.md
@@ -37,7 +37,7 @@ Due to the way the resolver code works in certain versions of Alpine Linux, it m
 
    Example output:
 
-   ```text
+   ```yaml
    containers:
    - env:
      - name: PGHOST
@@ -46,7 +46,7 @@ Due to the way the resolver code works in certain versions of Alpine Linux, it m
 
    Change `PGHOST` to:
 
-   ```text
+   ```yaml
    containers:
    - env:
      - name: PGHOST

--- a/troubleshooting/known_issues/spire_database_airgap_configuration.md
+++ b/troubleshooting/known_issues/spire_database_airgap_configuration.md
@@ -1,0 +1,60 @@
+# Spire database connection pool configuration in an air-gapped environment
+
+## Description
+
+Due to the way the resolver code works in certain versions of Alpine Linux, it may be necessary to reconfigure the `spire-postgres-pooler` to use the fully qualified domain name of the database in order to prevent DNS lookup errors.
+
+## Symptoms
+
+* The `spire-server` pods are logging `query_wait_timeout` errors.
+
+  ```text
+  time="2022-11-15T09:39:38Z" level=error msg="Fatal run error" error="datastore-sql: pq: query_wait_timeout"
+  time="2022-11-15T09:39:38Z" level=error msg="Server crashed" error="datastore-sql: pq: query_wait_timeout"
+  ```
+
+* The `spire-postgres-pooler` pods are logging DNS lookup failure errors.
+
+  ```text
+  2022-11-15 09:38:40.290 UTC [1] WARNING DNS lookup failed: spire-postgres: result=0
+  2022-11-15 09:38:56.211 UTC [1] WARNING DNS lookup failed: spire-postgres: result=0
+  2022-11-15 09:39:11.881 UTC [1] WARNING DNS lookup failed: spire-postgres: result=0
+  2022-11-15 09:39:27.879 UTC [1] WARNING DNS lookup failed: spire-postgres: result=0
+  2022-11-15 09:39:38.541 UTC [1] WARNING C-0x55729bbc56c0: spire/(nouser)@127.0.0.6:56151 pooler error: query_wait_timeout
+  ```
+
+## Solution
+
+1. (`ncn-mw#`) Edit the `spire-postgres-pooler` Deployment.
+
+   Command:
+
+   ```bash
+   kubectl -n spire edit deployment spire-postgres-pooler
+   ```
+
+1. Update the `PGHOST` environment variable to use the fully qualified domain name.
+
+   Example output:
+
+   ```text
+   containers:
+   - env:
+     - name: PGHOST
+       value: spire-postgres
+   ```
+
+   Change `PGHOST` to:
+
+   ```text
+   containers:
+   - env:
+     - name: PGHOST
+       value: spire-postgres.spire.svc.cluster.local
+   ```
+
+   The `spire-postgres-pooler` pods will automatically restart to pick up the new value.
+
+**IMPORTANT:** This change will need to be reapplied if the `spire` Helm chart is re-installed.
+
+This will be resolved in a future CSM release when the PostgreSQL operator is upgraded to a newer version.


### PR DESCRIPTION
# Description

Modify air-gapped DNS procedure to forward the `"."` zone to PowerDNS so queries don't hang and timeout and apply required workaround to `spire-postgres-pooler` to prevent spire database lookup failures.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
