### PR TITLE
CASMINST-5609: Refine and clarify NCN personalization procedures

### DIFF
--- a/install/configure_administrative_access.md
+++ b/install/configure_administrative_access.md
@@ -63,7 +63,7 @@ completely restarted.
 
 **Lock the management nodes now!**
 
-Run the `lock_management_nodes.py` script to lock all management nodes and their BMCs that are not already locked:
+(`ncn-mw#`) Run the `lock_management_nodes.py` script to lock all management nodes and their BMCs that are not already locked:
 
 ```bash
 /opt/cray/csm/scripts/admin_access/lock_management_nodes.py

--- a/operations/CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md
+++ b/operations/CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md
@@ -27,9 +27,9 @@ personalization. Review the upgrade documentation for more information.
    - [Option 1: Automatic configuration](#option-1-automatic-configuration)
      - [Automatic configuration: CSM fresh install](#automatic-configuration-csm-fresh-install)
      - [Automatic configuration: Apply changes](#automatic-configuration-apply-changes)
-     - [Automatic configuration: Modes of operation](#automatic-configuration-modes-of-operation).
-     - [Automatic configuration: Usage](#automatic-configuration-usage).
-     - [Automatic configuration: Parameters](#automatic-configuration-parameters).
+     - [Automatic configuration: Modes of operation](#automatic-configuration-modes-of-operation)
+     - [Automatic configuration: Usage](#automatic-configuration-usage)
+     - [Automatic configuration: Parameters](#automatic-configuration-parameters)
    - [Option 2: Manual configuration](#option-2-manual-configuration)
 
 ## 1. Set up passwordless SSH
@@ -320,9 +320,9 @@ The options used with the script depend on the context in which this procedure i
 In either case, although it is not usually required, it is possible to further customize the behavior of the script.
 For more information, see:
 
-- [Automatic configuration: Modes of operation](#automatic-configuration-modes-of-operation).
-- [Automatic configuration: Usage](#automatic-configuration-usage).
-- [Automatic configuration: Parameters](#automatic-configuration-parameters).
+- [Automatic configuration: Modes of operation](#automatic-configuration-modes-of-operation)
+- [Automatic configuration: Usage](#automatic-configuration-usage)
+- [Automatic configuration: Parameters](#automatic-configuration-parameters)
 
 #### Automatic configuration: CSM fresh install
 

--- a/operations/README.md
+++ b/operations/README.md
@@ -234,7 +234,10 @@ The Configuration Framework Service \(CFS\) is available on systems for remote e
 - [Write Ansible Code for CFS](configuration_management/Write_Ansible_Code_for_CFS.md)
   - [Target Ansible Tasks for Image Customization](configuration_management/Target_Ansible_Tasks_for_Image_Customization.md)
 - [CFS Key Management](configuration_management/CFS_Key_Management.md)
-- [Management Node Image Customization](configuration_management/Management_Node_Image_Customization.md)
+- Management NCN personalization and image customization
+  - [NCN Node Personalization](configuration_management/NCN_Node_Personalization.md)
+  - [Management Node Image Customization](configuration_management/Management_Node_Image_Customization.md)
+  - [Worker Image Customization](configuration_management/Worker_Image_Customization.md)
 
 ## Kubernetes
 

--- a/scripts/operations/configuration/apply_csm_configuration.sh
+++ b/scripts/operations/configuration/apply_csm_configuration.sh
@@ -39,6 +39,19 @@ run_cmd()
     "$@" || err_exit "Command failed with rc $?: $*"
 }
 
+DEFAULT_CONFIG_NAME="ncn-personalization"
+CONFIG_NAME=""
+CONFIG_CHANGE=""
+RELEASE=""
+VERSION=""
+COMMIT=""
+CLONE_URL=""
+OLD_NCN_CONFIG_FILE=""
+XNAMES=""
+CLEAR_STATE=""
+NO_ENABLE=""
+NO_CLEAR_ERR=""
+
 run_mktemp()
 {
     tmpfile=$(mktemp "$@") || err_exit "Command failed with rc $?: mktemp $*"
@@ -57,20 +70,34 @@ usage()
    echo "Updates CFS configurations"
    echo "All parameters are optional and the values will be determined automatically if not set."
    echo
-   echo "Usage: apply_csm_configuration.sh [ --csm-release version ] [ --git-commit hash ]"
-   echo "                                  [ --git-clone-url url ] [ --ncn-config-file file ]"
-   echo "                                  [ --clear-state ] [ --no-enable ]"
-   echo "                                  [ --xnames xname1,xname2... ]"
+   echo "Usage 1: apply_csm_configuration.sh [ --config-change ] [ --config-name name ]"
+   echo "                                    [ --csm-release version ] [ --git-commit hash ]"
+   echo "                                    [ --git-clone-url url ] [ --ncn-config-file file ]"
+   echo "                                    [ --clear-state ] [ --no-enable ] [ --no-clear-err ]"
+   echo "                                    [ --xnames xname1,xname2... ]"
+   echo
+   echo "Usage 2: apply_csm_configuration.sh --no-config-change [ --config-name name ]"
+   echo "                                    [ --clear-state ] [ --no-enable ] [ --no-clear-err ]"
+   echo "                                    [ --xnames xname1,xname2... ]"
+   echo
+   echo "In usage 1, either a new CFS configuration is created or an existing CFS configuration is updated."
+   echo "In usage 2, an existing CFS configuration is used without modification."
    echo
    echo "Options:"
-   echo "csm-release          The version of the CSM release to use. (e.g. 1.6.11)"
-   echo "git-commit           The git commit hash for CFS to use."
-   echo "git-clone-url        The git clone url for CFS to use."
-   echo "ncn-config-file      A file containing the NCN CFS configuration."
+   echo "config-name          Usage 1: name to use for the new/updated CFS configuration."
+   echo "                     Usage 2: name of existing CFS configuration to use"
+   echo "                     Default: ${DEFAULT_CONFIG_NAME}"
+   echo "config-change        Specifies usage 1. (default)"
+   echo "no-config-change     Specifies usage 2."
+   echo "csm-release          The version of the CSM release to use. (e.g. 1.6.11). Only valid with usage 1."
+   echo "git-commit           The git commit hash for CFS to use. Only valid with usage 1."
+   echo "git-clone-url        The git clone url for CFS to use. Only valid with usage 1."
+   echo "ncn-config-file      A file containing the NCN CFS configuration. Only valid with usage 1."
    echo "xnames               A comma-separated list of component names (xnames) to deploy to. All management nodes will be included if not set."
    echo "clear-state          Clears existing state from components to ensure CFS runs."
    echo "no-enable            By default, the script enables all of the NCNs and waits for them to complete configuration. If this flag is set,"
    echo "                     however, it updates their desired configurations but leaves them disabled."
+   echo "no-clear-err         By default, the script clears the error count of all NCNs in CFS. If this flag is set, it does not."
    echo
 }
 
@@ -85,34 +112,60 @@ while [[ $# -gt 0 ]]; do
 
   # Make sure that flags which require arguments get them
   case "${key}" in
-    --csm-release|--csm-config-version|--git-commit|--git-clone-url|--ncn-config-file|--xnames)
+    --csm-release|--csm-config-version|--git-commit|--git-clone-url|--ncn-config-file|--xnames|--config-name)
       [[ $# -lt 2 ]] && usage_err_exit "${key} requires an argument"
       [[ -z "$2" ]] && usage_err_exit "Argument to ${key} may not be blank"
       ;;
   esac
 
   case "${key}" in
+    --config-change)
+      [[ ${CONFIG_CHANGE} == false ]] && usage_err_exit "--config-change and --no-config-change are mutually exclusive"
+      CONFIG_CHANGE="true"
+      shift # past argument
+      ;;
+    --no-config-change)
+      [[ ${CONFIG_CHANGE} == true ]] && usage_err_exit "--config-change and --no-config-change are mutually exclusive"
+      # This argument conflicts with several others
+      [[ -n ${RELEASE} ]] && usage_err_exit "--csm-release and --no-config-change are mutually exclusive"
+      [[ -n ${VERSION} ]] && usage_err_exit "--csm-config-version and --no-config-change are mutually exclusive"
+      [[ -n ${COMMIT} ]] && usage_err_exit "--git-commit and --no-config-change are mutually exclusive"
+      [[ -n ${CLONE_URL} ]] && usage_err_exit "--git-clone-url and --no-config-change are mutually exclusive"
+      [[ -n ${OLD_NCN_CONFIG_FILE} ]] && usage_err_exit "--ncn-config-file and --no-config-change are mutually exclusive"
+      CONFIG_CHANGE="false"
+      shift # past argument
+      ;;
+    --config-name)
+      CONFIG_NAME="$2"
+      shift # past argument
+      shift # past value
+      ;;
     --csm-release)
+      [[ ${CONFIG_CHANGE} == false ]] && usage_err_exit "--csm-release and --no-config-change are mutually exclusive"
       RELEASE="$2"
       shift # past argument
       shift # past value
       ;;
     --csm-config-version)
+      [[ ${CONFIG_CHANGE} == false ]] && usage_err_exit "--csm-config-version and --no-config-change are mutually exclusive"
       VERSION="$2"
       shift # past argument
       shift # past value
       ;;
     --git-commit)
+      [[ ${CONFIG_CHANGE} == false ]] && usage_err_exit "--git-commit and --no-config-change are mutually exclusive"
       COMMIT="$2"
       shift # past argument
       shift # past value
       ;;
     --git-clone-url)
+      [[ ${CONFIG_CHANGE} == false ]] && usage_err_exit "--git-clone-url and --no-config-change are mutually exclusive"
       CLONE_URL="$2"
       shift # past argument
       shift # past value
       ;;
     --ncn-config-file)
+      [[ ${CONFIG_CHANGE} == false ]] && usage_err_exit "--ncn-config-file and --no-config-change are mutually exclusive"
       # Make sure the file exists, is a regular file, is not empty, and 
       # contains valid JSON data
       [[ -e "$2" ]] || usage_err_exit "NCN config file ($2) does not exist"
@@ -133,6 +186,10 @@ while [[ $# -gt 0 ]]; do
       CLEAR_STATE="true"
       shift # past argument
       ;;
+    --no-clear-err)
+      NO_CLEAR_ERR="true"
+      shift # past argument
+      ;;      
     --no-enable)
       NO_ENABLE="true"
       shift # past argument
@@ -148,21 +205,9 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-## CONFIGURATION SETUP ##
-if [[ -z "${RELEASE}" && -z "${VERSION}" ]]; then
-    RELEASE=$(kubectl -n services get cm cray-product-catalog -o jsonpath='{.data.csm}' 2>/dev/null\
-        | yq r -j - 2>/dev/null | jq -r ' to_entries | max_by(.key) | .key' 2>/dev/null)
-    [[ -n "${RELEASE}" ]] || err_exit "Unable to determine CSM release version"
-    echo "Using latest release ${RELEASE}"
-fi
-
-if [[ -z "${VERSION}" ]]; then
-    VERSION=$(kubectl -n services get cm cray-product-catalog -o jsonpath='{.data.csm}' 2>/dev/null\
-        | yq r -j - 2>/dev/null | jq -r ".[\"$RELEASE\"].configuration.import_branch" 2>/dev/null\
-        | awk -F'/' '{ print $NF }')
-    [[ -n "${VERSION}" ]] || err_exit "Unable to determine CSM configuration version"
-    echo "Using CSM configuration version ${VERSION}"
-fi
+## Set defaults
+[[ -z ${CONFIG_NAME} ]] && CONFIG_NAME=${DEFAULT_CONFIG_NAME}
+[[ -z ${CONFIG_CHANGE} ]] && CONFIG_CHANGE="true"
 
 # The script will keep all relevant files in a temporary directory. During
 # CSM upgrades, this directory will be backed up, in case it is needed for
@@ -170,72 +215,8 @@ fi
 run_mktemp -d "${HOME}/apply_csm_configuration.$(date +%Y%m%d_%H%M%S).XXXXXX"
 TMPDIR=${tmpfile}
 
-# If a file is passed in as input, keep a copy in the temporary directory
-if [[ -n ${OLD_NCN_CONFIG_FILE} && -f ${OLD_NCN_CONFIG_FILE} ]]; then
-    run_cmd cp "${OLD_NCN_CONFIG_FILE}" "${TMPDIR}"
-fi
-
-run_mktemp --tmpdir="${TMPDIR}" "csm-config-$VERSION-XXXXXX.json"
-CSM_CONFIG_FILE=${tmpfile}
-
-run_mktemp --tmpdir="${TMPDIR}" "new-ncn-personalization-XXXXXX.json"
-NCN_CONFIG_FILE=${tmpfile}
-
-run_mktemp --tmpdir="${TMPDIR}" "backup-ncn-personalization-XXXXXX.json"
+run_mktemp --tmpdir="${TMPDIR}" "backup-${CONFIG_NAME}-XXXXXX.json"
 BACKUP_NCN_CONFIG_FILE=${tmpfile}
-
-if [[ -z "${CLONE_URL}" ]]; then
-    CLONE_URL="https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git"
-fi
-
-if [[ -z "${COMMIT}" ]]; then
-    VCS_USER=$(kubectl get secret -n services vcs-user-credentials --template='{{.data.vcs_username}}' | base64 --decode)
-    [[ -n "${VCS_USER}" ]] || err_exit "Unable to obtain VCS username"
-    VCS_PASSWORD=$(kubectl get secret -n services vcs-user-credentials --template='{{.data.vcs_password}}' | base64 --decode)
-    [[ -n "${VCS_PASSWORD}" ]] || err_exit "Unable to obtain VCS password"
-    run_mktemp -d
-    TEMP_DIR=${tmpfile}
-    TEMP_HOME=${HOME}
-    HOME=${TEMP_DIR}
-    cd "${TEMP_DIR}" || err_exit "Unable to change directory to '${TEMP_DIR}'"
-    echo "${CLONE_URL/\/\//\/\/${VCS_USER}:${VCS_PASSWORD}@}" > .git-credentials
-    run_cmd git config --file .gitconfig credential.helper store
-    COMMIT=$(git ls-remote ${CLONE_URL} refs/heads/cray/csm/${VERSION} | awk '{print $1}')
-    if [[ -n ${COMMIT} ]]; then
-        echo "Found git commit ${COMMIT}"
-    else
-        echo "No git commit found"
-        exit 1
-    fi
-    cd - >/dev/null || err_exit "Unable to change directory back to previous directory"
-    HOME=${TEMP_HOME}
-    rm -r "${TEMP_DIR}" || echo "WARNING: Unable to delete temporary directory '${TEMP_DIR}'" 1>&2
-fi
-
-#shellcheck disable=SC2089
-CONFIG="{
-  \"layers\": [
-    {
-      \"name\": \"csm-${VERSION}\",
-      \"cloneUrl\": \"${CLONE_URL}\",
-      \"commit\": \"${COMMIT}\",
-      \"playbook\": \"site.yml\"
-    }
-  ]
-}"
-
-echo "Creating the configuration file ${CSM_CONFIG_FILE}"
-echo "${CONFIG}" | jq > "${CSM_CONFIG_FILE}" || err_exit "Unexpected error parsing JSON or writing to '${CSM_CONFIG_FILE}'"
-
-if [[ -n ${OLD_NCN_CONFIG_FILE} && -f ${OLD_NCN_CONFIG_FILE} ]]; then
-    echo "Combining new CSM configuration '${CSM_CONFIG_FILE}' with contents of '${OLD_NCN_CONFIG_FILE}' to generate '${NCN_CONFIG_FILE}'"
-    jq -n --slurpfile new "${CSM_CONFIG_FILE}" --slurpfile old "${OLD_NCN_CONFIG_FILE}" \
-        '{"layers": ($new[0].layers + ($old[0].layers | del(.[] | select(.cloneUrl == $new[0].layers[0].cloneUrl and .playbook == $new[0].layers[0].playbook))))}'\
-        > "${NCN_CONFIG_FILE}" || err_exit "Unexpected error combining JSON or writing to '${NCN_CONFIG_FILE}'"
-else
-    echo "Creating new NCN configuration file ${NCN_CONFIG_FILE}"
-    run_cmd cp -p "${CSM_CONFIG_FILE}" "${NCN_CONFIG_FILE}"
-fi
 
 if [[ -z ${XNAMES} ]]; then
     echo "Retrieving a list of all management node component names (xnames)"
@@ -244,37 +225,124 @@ if [[ -z ${XNAMES} ]]; then
 fi
 XNAME_LIST=${XNAMES//,/ }
 
-## UPDATING CFS ##
+## CONFIGURATION SETUP ##
+if [[ ${CONFIG_CHANGE} == true ]]; then
 
-echo "Disabling configuration for all listed components"
-for xname in ${XNAME_LIST}; do
-    run_cmd cray cfs components update ${xname} --enabled false
-done
+    if [[ -z "${RELEASE}" && -z "${VERSION}" ]]; then
+        RELEASE=$(kubectl -n services get cm cray-product-catalog -o jsonpath='{.data.csm}' 2>/dev/null\
+            | yq r -j - 2>/dev/null | jq -r ' to_entries | max_by(.key) | .key' 2>/dev/null)
+        [[ -n "${RELEASE}" ]] || err_exit "Unable to determine CSM release version"
+        echo "Using latest release ${RELEASE}"
+    fi
 
-# Before updating the configuration, make a backup of the existing configuration (if it exists)
-echo "Backing up existing ncn-personalization configuration (if any) to ${BACKUP_NCN_CONFIG_FILE}"
-# Do not use run_cmd for this call because if it fails, that's okay -- it most likely means that the CFS configuration does not exist.
-cray cfs configurations describe ncn-personalization --format json > "${BACKUP_NCN_CONFIG_FILE}" 2>&1
+    if [[ -z "${VERSION}" ]]; then
+        VERSION=$(kubectl -n services get cm cray-product-catalog -o jsonpath='{.data.csm}' 2>/dev/null\
+            | yq r -j - 2>/dev/null | jq -r ".[\"$RELEASE\"].configuration.import_branch" 2>/dev/null\
+            | awk -F'/' '{ print $NF }')
+        [[ -n "${VERSION}" ]] || err_exit "Unable to determine CSM configuration version"
+        echo "Using CSM configuration version ${VERSION}"
+    fi
 
-echo "Updating ncn-personalization configuration"
-run_cmd cray cfs configurations update ncn-personalization --file "${NCN_CONFIG_FILE}"
+    # If a file is passed in as input, keep a copy in the temporary directory
+    if [[ -n ${OLD_NCN_CONFIG_FILE} && -f ${OLD_NCN_CONFIG_FILE} ]]; then
+        run_cmd cp "${OLD_NCN_CONFIG_FILE}" "${TMPDIR}"
+    fi
+
+    run_mktemp --tmpdir="${TMPDIR}" "csm-config-$VERSION-XXXXXX.json"
+    CSM_CONFIG_FILE=${tmpfile}
+
+    run_mktemp --tmpdir="${TMPDIR}" "new-${CONFIG_NAME}-XXXXXX.json"
+    NCN_CONFIG_FILE=${tmpfile}
+
+    if [[ -z "${CLONE_URL}" ]]; then
+        CLONE_URL="https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git"
+    fi
+
+    if [[ -z "${COMMIT}" ]]; then
+        VCS_USER=$(kubectl get secret -n services vcs-user-credentials --template='{{.data.vcs_username}}' | base64 --decode)
+        [[ -n "${VCS_USER}" ]] || err_exit "Unable to obtain VCS username"
+        VCS_PASSWORD=$(kubectl get secret -n services vcs-user-credentials --template='{{.data.vcs_password}}' | base64 --decode)
+        [[ -n "${VCS_PASSWORD}" ]] || err_exit "Unable to obtain VCS password"
+        run_mktemp -d
+        TEMP_DIR=${tmpfile}
+        TEMP_HOME=${HOME}
+        HOME=${TEMP_DIR}
+        cd "${TEMP_DIR}" || err_exit "Unable to change directory to '${TEMP_DIR}'"
+        echo "${CLONE_URL/\/\//\/\/${VCS_USER}:${VCS_PASSWORD}@}" > .git-credentials
+        run_cmd git config --file .gitconfig credential.helper store
+        COMMIT=$(git ls-remote ${CLONE_URL} refs/heads/cray/csm/${VERSION} | awk '{print $1}')
+        if [[ -n ${COMMIT} ]]; then
+            echo "Found git commit ${COMMIT}"
+        else
+            echo "No git commit found"
+            exit 1
+        fi
+        cd - >/dev/null || err_exit "Unable to change directory back to previous directory"
+        HOME=${TEMP_HOME}
+        rm -r "${TEMP_DIR}" || echo "WARNING: Unable to delete temporary directory '${TEMP_DIR}'" 1>&2
+    fi
+
+    CONFIG="{ \"layers\": [ { \"name\": \"csm-${VERSION}\", \"cloneUrl\": \"${CLONE_URL}\", \"commit\": \"${COMMIT}\", \"playbook\": \"site.yml\" } ] }"
+
+    echo "Creating the configuration file ${CSM_CONFIG_FILE}"
+    echo "${CONFIG}" | jq > "${CSM_CONFIG_FILE}" || err_exit "Unexpected error parsing JSON or writing to '${CSM_CONFIG_FILE}'"
+
+    if [[ -n ${OLD_NCN_CONFIG_FILE} && -f ${OLD_NCN_CONFIG_FILE} ]]; then
+        echo "Combining new CSM configuration '${CSM_CONFIG_FILE}' with contents of '${OLD_NCN_CONFIG_FILE}' to generate '${NCN_CONFIG_FILE}'"
+        jq -n --slurpfile new "${CSM_CONFIG_FILE}" --slurpfile old "${OLD_NCN_CONFIG_FILE}" \
+            '{"layers": ($new[0].layers + ($old[0].layers | del(.[] | select(.cloneUrl == $new[0].layers[0].cloneUrl and .playbook == $new[0].layers[0].playbook))))}'\
+            > "${NCN_CONFIG_FILE}" || err_exit "Unexpected error combining JSON or writing to '${NCN_CONFIG_FILE}'"
+    else
+        echo "Creating new NCN configuration file ${NCN_CONFIG_FILE}"
+        run_cmd cp -p "${CSM_CONFIG_FILE}" "${NCN_CONFIG_FILE}"
+    fi
+
+    ## UPDATING CFS ##
+
+    echo "Disabling configuration for all listed components"
+    for xname in ${XNAME_LIST}; do
+        run_cmd cray cfs components update ${xname} --enabled false
+    done
+
+    # Before updating the configuration, make a backup of the existing configuration (if it exists)
+    echo "Backing up existing ${CONFIG_NAME} configuration (if any) to ${BACKUP_NCN_CONFIG_FILE}"
+    # Do not use run_cmd for this call because if it fails, that's okay -- it most likely means that the CFS configuration does not exist.
+    cray cfs configurations describe "${CONFIG_NAME}" --format json > "${BACKUP_NCN_CONFIG_FILE}" 2>&1
+
+    echo "Updating ${CONFIG_NAME} configuration"
+    run_cmd cray cfs configurations update "${CONFIG_NAME}" --file "${NCN_CONFIG_FILE}"
+
+else
+
+    # In this case, we are using an existing configuration. We will take a snapshot of it, and unlike above, we will
+    # fail if it does not exist
+    echo "Taking snapshot of existing ${CONFIG_NAME} configuration to ${BACKUP_NCN_CONFIG_FILE}"
+    run_cmd cray cfs configurations describe "${CONFIG_NAME}" --format json > "${BACKUP_NCN_CONFIG_FILE}"
+
+fi
+
+CFS_COMP_UPDATE_MSG="Setting desired configuration"
+CFS_COMP_UPDATE_ARGS=""
 
 if [[ -n ${CLEAR_STATE} ]]; then
-    echo "Clearing state from all listed components"
-    for xname in ${XNAME_LIST}; do
-        run_cmd cray cfs components update ${xname} --state []
-    done
+    CFS_COMP_UPDATE_MSG+=", clearing state"
+    CFS_COMP_UPDATE_ARGS+=" --state []"
+fi
+
+if [[ -z ${NO_CLEAR_ERR} ]]; then
+    CFS_COMP_UPDATE_MSG+=", clearing error count"
+    CFS_COMP_UPDATE_ARGS+=" --error-count 0"
 fi
 
 if [[ -z ${NO_ENABLE} ]]; then
-    echo "Setting desired configuration, clearing error count, and enabling all listed components"
+    echo "${CFS_COMP_UPDATE_MSG}, enabling components in CFS"
     for xname in ${XNAME_LIST}; do
-        run_cmd cray cfs components update ${xname} --enabled true --error-count 0 --desired-config ncn-personalization
+        run_cmd cray cfs components update ${xname} --enabled true ${CFS_COMP_UPDATE_ARGS} --desired-config "${CONFIG_NAME}"
     done
 else
-    echo "Setting desired configuration and clearing error count for all listed components"
+    echo "${CFS_COMP_UPDATE_MSG} components in CFS"
     for xname in ${XNAME_LIST}; do
-        run_cmd cray cfs components update ${xname} --enabled false --error-count 0 --desired-config ncn-personalization
+        run_cmd cray cfs components update ${xname} --enabled false ${CFS_COMP_UPDATE_ARGS} --desired-config "${CONFIG_NAME}"
     done
     echo "All components updated successfully."
     exit 0

--- a/upgrade/Stage_0_Prerequisites.md
+++ b/upgrade/Stage_0_Prerequisites.md
@@ -285,11 +285,6 @@ In the standard upgrade, the new worker NCN images must be customized, and all N
 
 **NOTE:** For the standard upgrade, it will not be possible to rebuild NCNs on the current, pre-upgraded CSM version after performing these steps. Rebuilding NCNs will become the same thing as upgrading them.
 
-1. If not already done, consult the `HPE Cray EX System Software Getting Started Guide`.
-
-    Read the `HPE Cray EX software upgrade workflow` section. Pay particular attention to the `HPC CSM Software Recipe` and `Cray System Management (CSM)` subsections,
-    as well as any `NCN Personalization` subsections.
-
 1. Prepare the pre-boot worker NCN image customizations.
 
     This will ensure that the CFS configuration layers are applied to perform image customization for the worker NCNs.


### PR DESCRIPTION
# Description

[CASMINST-5609](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5609) was opened because for the CSM install case, the Getting Started Guide and the CSM docs were not synched up when it came to NCN personalization. There are some gaps and also some needless duplications. Other than some minor housekeeping tasks, this PR primarily does the following:

- Updates the Configure NCNs with CFS procedure to add language to cover both the install and upgrade cases, to make it clearer the different paths that may be followed.
- Same for NCN Node Personalization procedure.
- Removes a confusing callback to the GSG from stage 0.3 of the upgrade path, because there is nothing in the GSG that needs to be done at that point. The mention just adds confusion for no benefit.

This is not a thing of beauty. I had to restrain myself from more drastic reorganization and editing, because of the urgency of this and the lateness in the release. And because some of this content is going to be changing anyway because of IUF and other work. Please keep this in mind when reviewing this PR. The goal is to improve what we have without requiring a massive re-write that risks breaking links or introducing other issues. More significant suggestions will likely be documented in new tickets, rather than addressed in this one.

# Testing

I tested the changes made to apply_csm_configuration.sh on surtur.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
