### PR TITLE
CASMINST-5595 - Clarify usage of --no-cache flag when resuming CSM services install

### DIFF
--- a/install/install_csm_services.md
+++ b/install/install_csm_services.md
@@ -46,6 +46,7 @@ This procedure will install CSM applications and services into the CSM Kubernete
 >   the `--console-output execute` argument to the `yapl` command.
 > * The `yapl` command can safely be rerun. By default, it will skip any steps which were previously completed successfully. To force it to
 >   rerun all steps regardless of what was previously completed, append the `--no-cache` argument to the `yapl` command.
+> * The order of the `yapl` command arguments is important. The syntax is `yapl -f install.yaml [--console-output] execute [--no-cache]`.
 
 ## 2. Create base BSS global boot parameters
 


### PR DESCRIPTION
# Description

The order in which the `yapl` command line arguments must be specified is important and not entirely clear in the documentation.

The `--console-output` is a global option which must be specified before the `execute` command whereas the `--no-cache` option is a `execute` command argument and must be specified after it.

Added a note to clarify the order in which the options must be specified.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
