### PR TITLE
CASMTRIAGE-4499 Add notice about UAIs if CHN is set but not installed and configured

### DIFF
--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -594,6 +594,9 @@ This section can be run on any NCN or the PIT node.
    > from incorrect or incomplete installation of these products will generally take the form of UAIs stuck in
    > waiting state trying to set up volume mounts. See the
    > [UAI Troubleshooting](#64-uasuai-troubleshooting) section for more information.
+   > **IMPORTANT:** If the site is configured to use the CHN, and the high speed network has not been
+   > installed and configured, this procedure can not be completed. The UAI that is created will be inaccessible
+   > until the high speed network is available.
 
 This procedure must run on a master or worker node (**not the PIT node**).
 


### PR DESCRIPTION
# Description

Document that UAIs will not be accessible if the CHN is set in SLS, but the CHN has not been installed and configured.
https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4499

# Checklist Before Merging

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
