### PR TITLE
Additional memory tuning for ceph latency script (CASMPET-6157)

### DIFF
--- a/scripts/repair-ceph-latency.sh
+++ b/scripts/repair-ceph-latency.sh
@@ -143,7 +143,8 @@ function restart_osds() {
 }
 
 function set_memory_target_settings() {
-  ceph config set osd osd_memory_target_autotune false
+  ceph config rm osd bluestore_rocksdb_options
+  ceph config set osd osd_memory_target_autotune true
   ceph config set osd osd_memory_target ${osd_memory_target_bytes}
 }
 


### PR DESCRIPTION
# Description

After some soak testing, additional memory tuning to prevent ceph latency.  Tested on loki/shandy.

# Checklist Before Merging

- [ x If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
