### PR TITLE
CASMINST-5647 | 1.4 | CHN gw test removal

### DIFF
--- a/scripts/operations/gateway-test/gateway-test.py
+++ b/scripts/operations/gateway-test/gateway-test.py
@@ -230,9 +230,10 @@ if __name__ == '__main__':
       slsnetworks = get_sls_networks(ADMIN_SECRET, SYSTEM_DOMAIN, svcs['test-networks'])
       if "can" in slsnetworks:
         USER_NET = "can"
-      if "chn" in slsnetworks:
-        USER_NET = "chn"
-    reachnets.append(USER_NET)
+#      CASMINST-5647: removing CHN test from 1.3 until test case can be redesigned.
+#      if "chn" in slsnetworks:
+#        USER_NET = "chn"
+    	reachnets.append(USER_NET)
 
     if NODE_TYPE == "ncn":
       reachnets.append("nmnlb")


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->

Removes CHN test to avoid failure during install. Needs to be reworked in the future. 
# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
