### PR TITLE
CASMTRIAGE-4526 : DOCS: sls postgresql db backup error: schema wi…

### DIFF
--- a/upgrade/Upgrade_Management_Nodes_and_CSM_Services.md
+++ b/upgrade/Upgrade_Management_Nodes_and_CSM_Services.md
@@ -70,6 +70,12 @@ mentioned explicitly on this page, see [resource material](resource_material/REA
    After upgrading, if health checks indicate the Postgres pods are not in a healthy/running state, recovery procedures may be needed.
    See [Troubleshoot Postgres Database](../operations/kubernetes/Troubleshoot_Postgres_Database.md) for troubleshooting and recovery procedures.
 
+- Back-ups for Postgres databases
+
+   After upgrading, if any `*postgresql-db-backup` cronjob pods are in error, see [NCN Resource Checks](../troubleshooting/known_issues/ncn_resource_checks.md).
+   If the most recent `*postgresql-db-backup` cronjob pod is in error and the pod log indicates a failure
+   due to `pg_dumpall: error: pg_dump failed on database ...`, contact support to further investigate and resolve.
+
 - Troubleshooting Spire pods not starting on NCNs
 
    See [Troubleshoot Spire Failing to Start on NCNs](../operations/spire/Troubleshoot_Spire_Failing_to_Start_on_NCNs.md).


### PR DESCRIPTION
# Description

Adds a pointer to contact support if issues similar to CASMTRIAGE-4526 occur after an upgrade.
TBD : backport to main for csm 1.4

# Checklist Before Merging

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
