### PR TITLE
MTL-1949: register NCN boot artifacts with IMS immediately

### DIFF
--- a/background/ncn_kernel.md
+++ b/background/ncn_kernel.md
@@ -231,10 +231,10 @@ This parameter's value tells the initramFS where to download the kernel, `initrd
 | NCN Type | Default Value(s) | Context |
 | :------: | :------------ | :------ |
 | All | `http://pit/<hostname>` | `/proc/cmdline` |
-| All | `http://rgw-vip.nmn/boot-images/k8s/<version>/rootfs<auth-token>` | `/proc/cmdline` |
-| All | `http://rgw-vip.nmn/boot-images/ceph/<version>/rootfs?<auth-token>` | `/proc/cmdline` |
-| All | `s3://boot-images/ceph/<version>/rootfs` | `cray-bss` |
-| All | `s3://boot-images/ceph/<version>/rootfs` | `cray-bss` |
+| All | `http://rgw-vip.nmn/$K8S_IMS_IMAGE_ID/rootfs?<auth-token>` | `/proc/cmdline` |
+| All | `http://rgw-vip.nmn/$CEPH_IMS_IMAGE_ID/rootfs?<auth-token>` | `/proc/cmdline` |
+| All | `s3://boot-images/$K8S_IMS_IMAGE_ID/rootfs` | `cray-bss` |
+| All | `s3://boot-images/$CEPH_IMS_IMAGE_ID/rootfs` | `cray-bss` |
 
 For more information, see [`dracut-metal-mdsquash`'s usage on `metal.server`][2].
 

--- a/install/deploy_final_non-compute_node.md
+++ b/install/deploy_final_non-compute_node.md
@@ -87,25 +87,33 @@ The steps in this section load hand-off data before a later procedure reboots th
 
 1. (`pit#`) Upload NCN boot artifacts into S3.
 
-    ```bash
-    set -o pipefail
-    kubernetes_rootfs="$(readlink -f /var/www/ncn-m002/rootfs)" &&
-    kubernetes_initrd="$(readlink -f /var/www/ncn-m002/initrd.img.xz)"  &&
-    kubernetes_kernel="$(readlink -f /var/www/ncn-m002/kernel)"  &&
-    kubernetes_version="$(basename ${kubernetes_rootfs} .squashfs | awk -F '-' '{print $NF}')" &&
-    ceph_rootfs="$(readlink -f /var/www/ncn-s001/rootfs)" &&
-    ceph_initrd="$(readlink -f /var/www/ncn-s001/initrd.img.xz)" &&
-    ceph_kernel="$(readlink -f /var/www/ncn-s001/kernel)" &&
-    ceph_version="$(basename ${ceph_rootfs} .squashfs | awk -F '-' '{print $NF}')" &&
-    cray artifacts create boot-images "k8s/${kubernetes_version}/rootfs" "${kubernetes_rootfs}" &&
-    cray artifacts create boot-images "k8s/${kubernetes_version}/initrd" "${kubernetes_initrd}" &&
-    cray artifacts create boot-images "k8s/${kubernetes_version}/kernel" "${kubernetes_kernel}" &&
-    cray artifacts create boot-images "ceph/${ceph_version}/rootfs" "${ceph_rootfs}" &&
-    cray artifacts create boot-images "ceph/${ceph_version}/initrd" "${ceph_initrd}" &&
-    cray artifacts create boot-images "ceph/${ceph_version}/kernel" "${ceph_kernel}" && echo SUCCESS
-    ```
+    1. Upload Kubernetes NCN artifacts.
 
-    Ensure that the output from the above command chain ends with `SUCCESS`.
+        ```bash
+        set -o pipefail
+        IMS_UPLOAD_SCRIPT=$(rpm -ql docs-csm | grep ncn-ims-image-upload.sh) &&
+            export IMS_ROOTFS_FILENAME="$(readlink -f /var/www/ncn-m002/rootfs)" &&
+            export IMS_INITRD_FILENAME="$(readlink -f /var/www/ncn-m002/initrd.img.xz)"  &&
+            export IMS_KERNEL_FILENAME="$(readlink -f /var/www/ncn-m002/kernel)"  &&
+            K8S_IMS_IMAGE_ID=$($IMS_UPLOAD_SCRIPT) &&
+            [[ -n ${K8S_IMS_IMAGE_ID} ]] &&
+            echo -e "Kubernetes NCN image IMS ID: ${K8S_IMS_IMAGE_ID}\nSUCCESS"
+        ```
+
+        Ensure that the output from the above command chain ends with `SUCCESS`.
+
+    1. Upload Storage NCN artifacts.
+
+        ```bash
+        export IMS_ROOTFS_FILENAME="$(readlink -f /var/www/ncn-s001/rootfs)" &&
+            export IMS_INITRD_FILENAME="$(readlink -f /var/www/ncn-s001/initrd.img.xz)" &&
+            export IMS_KERNEL_FILENAME="$(readlink -f /var/www/ncn-s001/kernel)" &&
+            STORAGE_IMS_IMAGE_ID=$($IMS_UPLOAD_SCRIPT) &&
+            [[ -n ${STORAGE_IMS_IMAGE_ID} ]] &&
+            echo -e "Storage NCN image IMS ID: ${STORAGE_IMS_IMAGE_ID}\nSUCCESS"
+        ```
+
+        Ensure that the output from the above command chain ends with `SUCCESS`.
 
 1. (`pit#`) Get a token to use for authenticated communication with the gateway.
 
@@ -122,13 +130,13 @@ The steps in this section load hand-off data before a later procedure reboots th
     > **`NOTE`** This step will prompt for the root password of the NCNs.
 
     ```bash
-    kubernetes_rootfs="$(readlink -f /var/www/ncn-m002/rootfs)" &&
-    ceph_rootfs="$(readlink -f /var/www/ncn-s001/rootfs)" &&
     csi handoff bss-metadata \
         --data-file "${PITDATA}/configs/data.json" \
-        --kubernetes-file "${kubernetes_rootfs}" \
-        --storage-ceph-file "${ceph_rootfs}" && echo SUCCESS
+        --kubernetes-ims-image-id "$K8S_IMS_IMAGE_ID}" \
+        --storage-ims-image-id "$STORAGE_IMS_IMAGE_ID" && echo SUCCESS
     ```
+
+    Ensure that the output from the above command chain ends with `SUCCESS`.
 
 1. (`pit#`) Patch the metadata for the Ceph nodes to have the correct run commands.
 

--- a/operations/configuration_management/Worker_Image_Customization.md
+++ b/operations/configuration_management/Worker_Image_Customization.md
@@ -77,11 +77,11 @@ All of the following are prerequisites on the node where this procedure is being
 
     - The linked procedure gives examples of customizing a Kubernetes NCN image, which is what needs to be done in this case.
     - In the steps to identify the NCN image and obtain its artifacts, do the following based on the current scenario:
-      - (`ncn-m001#`) If doing this as part of a CSM upgrade, then use the following command to set the `ARTIFACT_VERSION` variable.
+      - (`ncn-m001#`) If doing this as part of a CSM upgrade, then use the following command to set the `NCN_IMS_IMAGE_ID` variable.
 
           ```bash
-          ARTIFACT_VERSION=$(grep "^export KUBERNETES_VERSION=" /etc/cray/upgrade/csm/myenv | tail -1 | cut -d= -f2)
-          echo "${ARTIFACT_VERSION}"
+          NCN_IMS_IMAGE_ID=$(grep "^export NCN_IMS_IMAGE_ID=" /etc/cray/upgrade/csm/myenv | tail -1 | cut -d= -f2)
+          echo "${NCN_IMS_IMAGE_ID}"
           ```
 
       - Otherwise, follow the instructions in the linked procedure to identify the currently booted image for one of the worker NCNs.

--- a/scripts/operations/node_management/ncn-ims-image-upload.sh
+++ b/scripts/operations/node_management/ncn-ims-image-upload.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# shellcheck disable=SC2086
+
+test -n "$DEBUG" && set -x
+set -eou pipefail
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -k)
+            IMS_KERNEL_FILENAME=$2
+            shift
+            shift
+            ;;
+        -i)
+            IMS_INITRD_FILENAME=$2
+            shift
+            shift
+            ;;
+        -s)
+            IMS_ROOTFS_FILENAME=$2
+            shift
+            shift
+            ;;
+    esac
+done
+
+if [ -z "$IMS_KERNEL_FILENAME" ]; then
+    echo "Error: required option (-k) is missing" >&2
+    exit 1
+fi
+
+if [ -z "$IMS_INITRD_FILENAME" ]; then
+    echo "Error: required option (-i) is missing" >&2
+    exit 1
+fi
+
+if [ -z "$IMS_ROOTFS_FILENAME" ]; then
+    echo "Error: required option (-s) is missing" >&2
+    exit 1
+fi
+
+IMS_ROOTFS_MD5SUM=$(md5sum "$IMS_ROOTFS_FILENAME" | awk '{ print $1 }')
+IMS_INITRD_MD5SUM=$(md5sum "$IMS_INITRD_FILENAME" | awk '{ print $1 }')
+IMS_KERNEL_MD5SUM=$(md5sum "$IMS_KERNEL_FILENAME" | awk '{ print $1 }')
+
+IMS_IMAGE_ID=$(cray ims images create --name "$IMS_ROOTFS_FILENAME" --format json | jq -r .id)
+cray artifacts create boot-images "$IMS_IMAGE_ID/rootfs" "$IMS_ROOTFS_FILENAME" > /dev/null
+cray artifacts create boot-images "$IMS_IMAGE_ID/kernel" "$IMS_KERNEL_FILENAME" > /dev/null
+cray artifacts create boot-images "$IMS_IMAGE_ID/initrd" "$IMS_INITRD_FILENAME" > /dev/null
+
+cat <<EOF> ims_manifest.json
+{
+  "created": "$(date '+%Y-%m-%d %H:%M:%S')",
+  "version": "1.0",
+  "artifacts": [
+    {
+      "link": {
+	  "path": "s3://boot-images/$IMS_IMAGE_ID/rootfs",
+          "type": "s3"
+      },
+      "md5": "$IMS_ROOTFS_MD5SUM",
+      "type": "application/vnd.cray.image.rootfs.squashfs"
+    },
+    {
+      "link": {
+	  "path": "s3://boot-images/$IMS_IMAGE_ID/kernel",
+          "type": "s3"
+      },
+      "md5": "$IMS_KERNEL_MD5SUM",
+      "type": "application/vnd.cray.image.kernel"
+    },
+    {
+      "link": {
+	  "path": "s3://boot-images/$IMS_IMAGE_ID/initrd",
+          "type": "s3"
+      },
+      "md5": "$IMS_INITRD_MD5SUM",
+      "type": "application/vnd.cray.image.initrd"
+    }
+  ]
+}
+EOF
+
+cray artifacts create boot-images "$IMS_IMAGE_ID/manifest.json" ims_manifest.json > /dev/null
+
+cray ims images update "$IMS_IMAGE_ID" \
+        --link-type s3 \
+        --link-path "s3://boot-images/$IMS_IMAGE_ID/manifest.json" > /dev/null
+
+echo "$IMS_IMAGE_ID"

--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -533,13 +533,6 @@ if [[ ${state_recorded} == "0" && $(hostname) == "ncn-m001" ]]; then
     NCN_IMAGE_MOD_SCRIPT=$(rpm -ql docs-csm | grep ncn-image-modification.sh)
     set +o pipefail
 
-    # clean up any previous set values just in case.
-    sed -i 's/^export CEPH_VERSION.*//' /etc/cray/upgrade/csm/myenv
-    sed -i 's/^export KUBERNETES_VERSION.*//' /etc/cray/upgrade/csm/myenv
-    KUBERNETES_VERSION=$(find "${artdir}/kubernetes" -name 'kubernetes*.squashfs' -exec basename {} .squashfs \; | awk -F '-' '{print $NF}')
-    CEPH_VERSION=$(find "${artdir}/storage-ceph" -name 'storage-ceph*.squashfs' -exec basename {} .squashfs \; | awk -F '-' '{print $NF}')
-    echo "export CEPH_VERSION=${CEPH_VERSION}" >> /etc/cray/upgrade/csm/myenv
-    echo "export KUBERNETES_VERSION=${KUBERNETES_VERSION}" >> /etc/cray/upgrade/csm/myenv
     k8s_done=0
     ceph_done=0
     if [[ -f ${artdir}/kubernetes/secure-kubernetes-${KUBERNETES_VERSION}.squashfs ]]; then
@@ -548,7 +541,7 @@ if [[ ${state_recorded} == "0" && $(hostname) == "ncn-m001" ]]; then
     if [[ -f ${artdir}/storage-ceph/secure-storage-ceph-${CEPH_VERSION}.squashfs ]]; then
         ceph_done=1
     fi
-    
+
     if [[ ${k8s_done} = 1 && ${ceph_done} = 1 ]]; then
         echo "Already ran ${NCN_IMAGE_MOD_SCRIPT}, skipping re-run."
     else
@@ -561,14 +554,71 @@ if [[ ${state_recorded} == "0" && $(hostname) == "ncn-m001" ]]; then
     fi
 
     set -o pipefail
-    cray artifacts create boot-images "k8s/${KUBERNETES_VERSION}/rootfs" "${artdir}/kubernetes/secure-kubernetes-${KUBERNETES_VERSION}.squashfs"
-    cray artifacts create boot-images "k8s/${KUBERNETES_VERSION}/initrd" "${artdir}/kubernetes/initrd.img-${KUBERNETES_VERSION}.xz"
-    cray artifacts create boot-images "k8s/${KUBERNETES_VERSION}/kernel" "${artdir}"/kubernetes/*.kernel
-    cray artifacts create boot-images "ceph/${CEPH_VERSION}/rootfs" "${artdir}/storage-ceph/secure-storage-ceph-${CEPH_VERSION}.squashfs" 
-    cray artifacts create boot-images "ceph/${CEPH_VERSION}/initrd" "${artdir}/storage-ceph/initrd.img-${CEPH_VERSION}.xz" 
-    cray artifacts create boot-images "ceph/${CEPH_VERSION}/kernel" "${artdir}"/storage-ceph/*.kernel
+    IMS_UPLOAD_SCRIPT=$(rpm -ql docs-csm | grep ncn-ims-image-upload.sh)
+
+    export IMS_ROOTFS_FILENAME="${artdir}/kubernetes/secure-kubernetes-${KUBERNETES_VERSION}.squashfs"
+    export IMS_INITRD_FILENAME="${artdir}/kubernetes/initrd.img-${KUBERNETES_VERSION}.xz"
+    export IMS_KERNEL_FILENAME="${artdir}/kubernetes/*.kernel"
+    K8S_IMS_IMAGE_ID=$($IMS_UPLOAD_SCRIPT)
+    [[ -n ${K8S_IMS_IMAGE_ID} ]]
+
+    export IMS_ROOTFS_FILENAME="${artdir}/storage-ceph/secure-storage-ceph-${CEPH_VERSION}.squashfs"
+    export IMS_INITRD_FILENAME="${artdir}/storage-ceph/initrd.img-${CEPH_VERSION}.xz"
+    export IMS_KERNEL_FILENAME="${artdir}/storage-ceph/*.kernel"
+    STORAGE_IMS_IMAGE_ID=$($IMS_UPLOAD_SCRIPT)
+    [[ -n ${STORAGE_IMS_IMAGE_ID} ]]
     set +o pipefail
 
+    # clean up any previous set values just in case.
+    sed -i 's/^export STORAGE_IMS_IMAGE_ID.*//' /etc/cray/upgrade/csm/myenv
+    sed -i 's/^export KUBERNETES_IMS_IMAGE_ID.*//' /etc/cray/upgrade/csm/myenv
+    echo "export STORAGE_IMS_IMAGE_ID=${STORAGE_IMS_IMAGE_ID}" >> /etc/cray/upgrade/csm/myenv
+    echo "export K8S_IMS_IMAGE_ID=${K8S_IMS_IMAGE_ID}" >> /etc/cray/upgrade/csm/myenv
+
+    echo "Retrieving a list of all management node component names (xnames)"
+    set -o pipefail
+
+    WORKER_XNAMES=$(cray hsm state components list --role Management --subrole Worker --type Node --format json | jq -r '.Components | map(.ID) | join(",")')
+    [[ -n "${WORKER_XNAMES}" ]]
+    MASTER_XNAMES=$(cray hsm state components list --role Management --subrole Master --type Node --format json | jq -r '.Components | map(.ID) | join(",")')
+    [[ -n "${MASTER_XNAMES}" ]]
+    K8S_XNAMES="$WORKER_XNAMES $MASTER_XNAMES"
+    K8S_XNAME_LIST=${K8S_XNAMES//,/ }
+    STORAGE_XNAMES=$(cray hsm state components list --role Management --subrole Storage --type Node --format json | jq -r '.Components | map(.ID) | join(",")')
+    [[ -n "${STORAGE_XNAMES}" ]]
+    STORAGE_XNAME_LIST=${STORAGE_XNAMES//,/ }
+    set +o pipefail
+
+    for xname in ${K8S_XNAME_LIST}; do
+        METAL_SERVER=$(cray bss bootparameters list --hosts "${xname}" --format json | jq '.[] |."params"' \
+            | awk -F 'metal.server=' '{print $2}' \
+            | awk -F ' ' '{print $1}')
+        NEW_METAL_SERVER="s3://boot-images/${K8S_IMS_IMAGE_ID}/rootfs"
+        PARAMS=$(cray bss bootparameters list --hosts "${xname}" --format json | jq '.[] |."params"' | \
+            sed "/metal.server/ s|${METAL_SERVER}|${NEW_METAL_SERVER}|" | \
+            sed "s/metal.no-wipe=1/metal.no-wipe=0/" | \
+            tr -d \")
+
+        cray bss bootparameters update --hosts "${xname}" \
+            --kernel "s3://boot-images/${K8S_IMS_IMAGE_ID}/kernel" \
+            --initrd "s3://boot-images/${K8S_IMS_IMAGE_ID}/initrd" \
+            --params "${PARAMS}"
+    done
+    for xname in ${STORAGE_XNAME_LIST}; do
+        METAL_SERVER=$(cray bss bootparameters list --hosts "${xname}" --format json | jq '.[] |."params"' \
+            | awk -F 'metal.server=' '{print $2}' \
+            | awk -F ' ' '{print $1}')
+        NEW_METAL_SERVER="s3://boot-images/${STORAGE_IMS_IMAGE_ID}/rootfs"
+        PARAMS=$(cray bss bootparameters list --hosts "${xname}" --format json | jq '.[] |."params"' | \
+            sed "/metal.server/ s|${METAL_SERVER}|${NEW_METAL_SERVER}|" | \
+            sed "s/metal.no-wipe=1/metal.no-wipe=0/" | \
+            tr -d \")
+
+        cray bss bootparameters update --hosts "${xname}" \
+            --kernel "s3://boot-images/${STORAGE_IMS_IMAGE_ID}/kernel" \
+            --initrd "s3://boot-images/${STORAGE_IMS_IMAGE_ID}/initrd" \
+            --params "${PARAMS}"
+    done
     } >> "${LOG_FILE}" 2>&1
     record_state "${state_name}" "$(hostname)" | tee -a "${LOG_FILE}"
 else
@@ -606,11 +656,6 @@ if [[ ${state_recorded} == "0" && $(hostname) == "ncn-m001" ]]; then
         --request PUT \
         --data @cloud-init-global_update.json \
         https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters
-
-    csi upgrade metadata --1-2-to-1-3 \
-        --k8s-version "${KUBERNETES_VERSION}" \
-        --storage-version "${CEPH_VERSION}"
-
     } >> "${LOG_FILE}" 2>&1
     record_state "${state_name}" "$(hostname)" | tee -a "${LOG_FILE}"
     echo


### PR DESCRIPTION
# Description

Prior to these changes, we were using craycli to update NCN artifacts, but they were unknown to IMS. This commit, paired with a change to CSI (https://github.com/Cray-HPE/cray-site-init/pull/273), associates the NCN boot artifacts with IMS immediately.  This will allow e.g. `sat` to work with the images.


<!--- Describe what this change is and what it is for. -->

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
