### PR TITLE
CASM-3635: write_root_secrets_to_vault.py: Add options to clear or retain root password and/or SSH keys in Vault

### DIFF
--- a/scripts/operations/configuration/python_lib/api_requests.py
+++ b/scripts/operations/configuration/python_lib/api_requests.py
@@ -26,7 +26,9 @@
 import logging
 import time
 import traceback
-from typing import Callable
+from typing import Callable, Container, Union
+
+import requests
 
 from . import common
 
@@ -48,21 +50,17 @@ def log_error_raise_exception(msg: str, parent_exception: Exception = None) -> N
 
 def make_api_request_with_retries(request_method: Callable,
                                   url: str,
-                                  expected_status_code: int,
-                                  **request_kwargs):
+                                  **request_kwargs) -> requests.models.Response:
     """
     Makes request with specified method to specified URL with specified keyword arguments (if any).
-    If the expected status code is returned, then the response body is returned (or None, if empty).
     If a 5xx status code is returned, the request will be retried after a brief wait, a limited
-    number of times.
-    If the expected status code is never returned (or an unexpected and non-5xx status code is
-    ever returned), then raise an exception
+    number of times. If this persists, an exception is raised. Otherwise, the response is returned.
     """
     try:
         method_name = request_method.__name__.upper()
-    except Exception as e:
+    except Exception as exc:
         log_error_raise_exception(
-            "Unexpected error determining API request method name", e)
+            "Unexpected error determining API request method name", exc)
 
     count = 0
     max_attempts = 6
@@ -71,31 +69,38 @@ def make_api_request_with_retries(request_method: Callable,
         logging.info(f"Making {method_name} request to {url}")
         try:
             resp = request_method(url, **request_kwargs)
-        except Exception as e:
+        except Exception as exc:
             log_error_raise_exception(
-                f"Error making {method_name} request to {url}", e)
+                f"Error making {method_name} request to {url}", exc)
         logging.debug(f"Response status code = {resp.status_code}")
-        if resp.status_code == expected_status_code:
-            if resp.text:
-                try:
-                    return resp.json()
-                except Exception as e:
-                    logging.debug(f"Response reason = {resp.reason}")
-                    logging.debug(f"Response text = {resp.text}")
-                    log_error_raise_exception(
-                        f"Error parsing {url} {method_name} response as JSON", e)
-            else:
-                return None
+        if not 500 <= resp.status_code <= 599:
+            return resp
         logging.debug(f"Response reason = {resp.reason}")
         logging.debug(f"Response text = {resp.text}")
-        if not 500 <= resp.status_code <= 599:
-            log_error_raise_exception(
-                "Unexpected status code received in response to API request."
-                f"Received {resp.status_code}, expecting {expected_status_code}")
-        elif count >= max_attempts:
+        if count >= max_attempts:
             log_error_raise_exception(
                 f"API request unsuccessful even after {max_attempts} attempts")
         logging.info("Sleeping 3 seconds before retrying..")
         time.sleep(3)
     log_error_raise_exception(
         "PROGRAMMING LOGIC ERROR: make_api_request_with_retries function should get here")
+
+
+def retry_request_validate_status(expected_status_codes: Union[int, Container[int]],
+                                  **kwargs_to_make_api_request_with_retries
+                                 ) -> requests.models.Response:
+    """
+    Wrapper function for make_api_request_with_retries that validates the status code of the
+    response.
+    expected_status_codes specifies the expected status code(s) for the API request.
+    It can be a single int, or a collection of ints. If the response status code does not match,
+    an exception is raised. Otherwise, the response is returned.
+    """
+    if isinstance(expected_status_codes, int):
+        expected_status_codes = {expected_status_codes}
+    response = make_api_request_with_retries(
+        **kwargs_to_make_api_request_with_retries)
+    if response.status_code not in expected_status_codes:
+        log_error_raise_exception(f"Response status code ({response.status_code}) does not match"
+                                  f" any expected status codes ({expected_status_codes})")
+    return response

--- a/scripts/operations/configuration/python_lib/args.py
+++ b/scripts/operations/configuration/python_lib/args.py
@@ -31,7 +31,7 @@ import os
 from typing import Callable, List
 
 
-text_file_type = argparse.FileType('rt', encoding="utf-8")
+TEXT_FILE_TYPE = argparse.FileType('rt', encoding="utf-8")
 
 
 def get_text_file_contents(file_name: str,
@@ -47,7 +47,7 @@ def get_text_file_contents(file_name: str,
     """
     # Use the built-in argparse FileType to open the file for reading.
     # This will automatically raise appropriate errors if there are any issues.
-    file_contents = text_file_type(file_name).read()
+    file_contents = TEXT_FILE_TYPE(file_name).read()
 
     if value_validator is not None:
         try:
@@ -126,7 +126,7 @@ class PasswordPromptAction(argparse.Action):
     and then validate that it meets the minimum and maximum length requirements (if any).
     """
 
-    def __init__(self, option_strings: List, dest: str, nargs = 0,
+    def __init__(self, option_strings: List, dest: str, nargs=0,
                  min_length: int = None, max_length: int = None, **kwargs):
         """
         Initialize the custom action, storing the length requirements for later use

--- a/scripts/operations/configuration/python_lib/k8s.py
+++ b/scripts/operations/configuration/python_lib/k8s.py
@@ -61,15 +61,15 @@ def get_configuration() -> kubernetes.client.configuration.Configuration:
         logging.debug("Loading Kubernetes configuration")
         try:
             kubernetes.config.load_kube_config()
-        except Exception as e:
+        except Exception as exc:
             log_error_raise_exception(
-                "Error loading Kubernetes configuration", e)
+                "Error loading Kubernetes configuration", exc)
         logging.debug("Getting default copy of Kubernetes configuration")
         try:
             K8S_CONFIGURATION = kubernetes.client.Configuration().get_default_copy()
-        except Exception as e:
+        except Exception as exc:
             log_error_raise_exception(
-                "Error getting default copy of Kubernetes configuration", e)
+                "Error getting default copy of Kubernetes configuration", exc)
     return K8S_CONFIGURATION
 
 
@@ -84,14 +84,14 @@ def get_api_client() -> kubernetes.client.api.core_v1_api.CoreV1Api:
         logging.debug("Setting client default Kubernetes configuration")
         try:
             kubernetes.client.Configuration.set_default(k8s_config)
-        except Exception as e:
+        except Exception as exc:
             log_error_raise_exception(
-                "Error setting default Kubernetes configuration", e)
+                "Error setting default Kubernetes configuration", exc)
         try:
             K8S_API_CLIENT = kubernetes.client.api.core_v1_api.CoreV1Api()
-        except Exception as e:
+        except Exception as exc:
             log_error_raise_exception(
-                "Error obtaining Kubernetes API client", e)
+                "Error obtaining Kubernetes API client", exc)
     return K8S_API_CLIENT
 
 
@@ -104,8 +104,8 @@ def get_secret(name: str, namespace: str) -> kubernetes.client.models.v1_secret.
     logging.debug(f"Getting {secret_label}")
     try:
         return api_client.read_namespaced_secret(name=name, namespace=namespace)
-    except Exception as e:
-        log_error_raise_exception(f"Error retrieving {secret_label}", e)
+    except Exception as exc:
+        log_error_raise_exception(f"Error retrieving {secret_label}", exc)
 
 
 def get_service(name: str, namespace: str) -> kubernetes.client.models.v1_service.V1Service:
@@ -117,5 +117,5 @@ def get_service(name: str, namespace: str) -> kubernetes.client.models.v1_servic
     logging.debug(f"Getting {service_label}")
     try:
         return api_client.read_namespaced_service(name=name, namespace=namespace)
-    except Exception as e:
-        log_error_raise_exception(f"Error retrieving {service_label}", e)
+    except Exception as exc:
+        log_error_raise_exception(f"Error retrieving {service_label}", exc)

--- a/scripts/operations/configuration/python_lib/types.py
+++ b/scripts/operations/configuration/python_lib/types.py
@@ -1,0 +1,29 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""Shared Python function library: Type hints"""
+
+from typing import Any, Dict
+
+# A simplified type hint to use for JSON objects
+JSONObject = Dict[str, Any]


### PR DESCRIPTION
# Description

**NOTE**: This PR depends on changes in [this yet-to-be-merged PR](https://github.com/Cray-HPE/docs-csm/pull/2828). That is why the PR is against that branch instead of main. I will move this PR to be against main branch once that one merges.

The primary change in this PR is the addition of arguments to the write_root_secrets_to_vault.py script. Previously the script always set values for the password and both SSH keys. These new arguments add the following options:
- Delete field from root secret in Vault
- Retain current value (if any) from root secret in Vault

Each of those options can be specified independently for either SSH key or the root password hash, in addition to the previous options.

This now allows users to use the tool to make changes to just one of the fields, or to remove the field from Vault (which is a supported option for admins who do not want to enable passwordless SSH or do not want the root password kept in Vault).

The default behavior of the tool remains unchanged.

I also did some refactoring of the tool and its libraries as part of this.

I tested the changes on fanta, both the new options and the previous ones.

The new tool options are not yet being documented. They are being added as part of larger work for [CASM-3367](https://jira-pro.its.hpecorp.net:8443/browse/CASM-3367).

# Checklist Before Merging

- [*] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [*] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [*] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
