### PR TITLE
MTL-1708 Build & Publish SP4 RPMs

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -26,7 +26,6 @@
 @Library('csm-shared-library') _
 
 def sleImage = 'artifactory.algol60.net/csm-docker/stable/csm-docker-sle'
-def sleVersion = '15.3'
 def major
 def minor
 def patch
@@ -35,7 +34,6 @@ if ( isStable ) {
     (major, minor, patch) = env.TAG_NAME.tokenize('.')
     major = major.replaceAll("^v","")
 }
-
 pipeline {
     agent {
         label "metal-gcp-builder"
@@ -55,58 +53,97 @@ pipeline {
         ADDITIONAL_VERSIONS = "${env.VERSION == env.TAG_POINTS_AT_HEAD ? 'latest' : ''}"
         SLACK_CHANNEL_ALERTS = "csm-release-alerts"
     }
-    
+
     stages {
-      stage('Prepare: RPMs') {
-            agent {
-                docker {
-                    image "${sleImage}:${sleVersion}"
-                    reuseNode true
+
+        stage('Build & Publish') {
+
+            matrix {
+
+                agent {
+                    node {
+                        label "metal-gcp-builder"
+                        customWorkspace "${env.WORKSPACE}/${sleVersion}"
+                    }
                 }
-            }
-            steps {
-                script {
-                    withCredentials([gitUsernamePassword(credentialsId: 'jenkins-algol60-cray-hpe-github-integration')]) {
-                        runLibraryScript("addRpmMetaData.sh", "${env.NAME}.spec")
-                        sh "git update-index --assume-unchanged ${env.NAME}.spec"
-                        sh "echo ${env.BRANCH_NAME}"
-                        sh "env"
-                        sh "make prepare"
+
+                axes {
+                    axis {
+                        name 'sleVersion'
+                        values 15.3, 15.4
+                    }
+                }
+
+                stages {
+
+                    stage('Prepare: RPMs') {
+                        agent {
+                            docker {
+                                label 'docker'
+                                reuseNode true
+                                image "${sleImage}:${sleVersion}"
+                            }
+                        }
+                        steps {
+                            withCredentials([gitUsernamePassword(credentialsId: 'jenkins-algol60-cray-hpe-github-integration')]) {
+                                runLibraryScript("addRpmMetaData.sh", "${env.NAME}.spec")
+                                sh "git update-index --assume-unchanged ${env.NAME}.spec"
+                                sh "echo ${env.BRANCH_NAME}"
+                                sh "env"
+                                sh "make prepare"
+                            }
+                        }
+                    }
+
+                    stage('Build: RPMs') {
+                        agent {
+                            docker {
+                                label 'docker'
+                                reuseNode true
+                                image "${sleImage}:${sleVersion}"
+                            }
+                        }
+                        steps {
+                            withCredentials([gitUsernamePassword(credentialsId: 'jenkins-algol60-cray-hpe-github-integration')]) {
+                                sh "make rpm"
+                            }
+                        }
+                    }
+
+                    stage('Publish: RPMs') {
+                        steps {
+                            script {
+                                if( isStable ){
+                                    RELEASE_FOLDER = "/${major}.${minor}"
+                                } else {
+                                    RELEASE_FOLDER = ""
+                                }
+                                ADDITIONAL_VERSIONS = ("${env.ADDITIONAL_VERSIONS}" == "null") ? [] : ["${env.ADDITIONAL_VERSIONS}"]
+                                sles_version_parts = "${sleVersion}".tokenize('.')
+                                sles_major = "${sles_version_parts[0]}"
+                                sles_minor = "${sles_version_parts[1]}"
+                                publishCsmRpms(
+                                        additionalVersions: ADDITIONAL_VERSIONS,
+                                        arch: "noarch",
+                                        component: env.NAME + RELEASE_FOLDER,
+                                        isStable: isStable,
+                                        os: "sle-${sles_major}sp${sles_minor}",
+                                        pattern: "dist/rpmbuild/RPMS/noarch/*.rpm",
+                                )
+                                publishCsmRpms(
+                                        additionalVersions: ADDITIONAL_VERSIONS,
+                                        arch: "src",
+                                        component: env.NAME + RELEASE_FOLDER,
+                                        isStable: isStable,
+                                        os: "sle-${sles_major}sp${sles_minor}",
+                                        pattern: "dist/rpmbuild/SRPMS/*.rpm",
+                                )
+                            }
+                        }
                     }
                 }
             }
-      }
-      stage('Build: RPMs') {
-          agent {
-              docker {
-                  image "${sleImage}:${sleVersion}"
-                  reuseNode true
-              }
-          }
-          steps {
-              script {
-                  withCredentials([gitUsernamePassword(credentialsId: 'jenkins-algol60-cray-hpe-github-integration')]) {
-                      sh "make rpm"
-                  }
-                }
-            }
-      }
-      stage('Publish: RPMs') {
-          steps {
-            script {
-                if( isStable ){
-                    RELEASE_FOLDER = "/${major}.${minor}"
-                } else {
-                    RELEASE_FOLDER = ""
-                }
-                ADDITIONAL_VERSIONS = ("${env.ADDITIONAL_VERSIONS}" == "null") ? [] : ["${env.ADDITIONAL_VERSIONS}"]
-                publishCsmRpms(component: env.NAME + RELEASE_FOLDER, pattern: "dist/rpmbuild/RPMS/noarch/${env.NAME}-${env.VERSION}*noarch.rpm", os: 'sle-15sp2', arch: "noarch", isStable: isStable, additionalVersions: ADDITIONAL_VERSIONS)
-                publishCsmRpms(component: env.NAME + RELEASE_FOLDER, pattern: "dist/rpmbuild/RPMS/noarch/${env.NAME}-${env.VERSION}*noarch.rpm", os: 'sle-15sp3', arch: "noarch", isStable: isStable, additionalVersions: ADDITIONAL_VERSIONS)
-                publishCsmRpms(component: env.NAME + RELEASE_FOLDER, pattern: "dist/rpmbuild/SRPMS/${env.NAME}-${env.VERSION}*src.rpm", os: 'sle-15sp2', arch: "src", isStable: isStable, additionalVersions: ADDITIONAL_VERSIONS)
-                publishCsmRpms(component: env.NAME + RELEASE_FOLDER, pattern: "dist/rpmbuild/SRPMS/${env.NAME}-${env.VERSION}*src.rpm", os: 'sle-15sp3', arch: "src", isStable: isStable, additionalVersions: ADDITIONAL_VERSIONS)
-            }
         }
-      }
     }
     post {
         failure {


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
Continue to build and publish SP3 RPMs while publishing SP4 RPMs. Include the correct, respective metadata in each RPM.

***NOTE*** This ceases publishing RPMs to sle-15sp2. I'll make a CSM PR to ensure we pull this RPM from sp4 repos per MTL-1708.

The SLES 15SP3 build creates an RPM with SP3 metadata and publishes it to `sle-15sp3`:

```bash
Name        : docs-csm
Version     : 1.4.32~2~ga3857d74
Release     : 1
Architecture: noarch
Install Date: (not installed)
Group       : Unspecified
Size        : 47271850
License     : MIT License
Signature   : (none)
Source RPM  : docs-csm-1.4.32~2~ga3857d74-1.src.rpm
Build Date  : Fri 02 Dec 2022 09:31:01 PM UTC
Build Host  : 56213bd6d7a9
Relocations : (not relocatable)
Vendor      : Hewlett Packard Enterprise Company
URL         : https://github.com/Cray-HPE/docs-csm.git
Summary     : Documentation for Cray System Management (CSM) Installation and Upgrade
Description :
Git Repository: docs-csm
Git Branch: MTL-1708-build
Git Commit Revision: a3857d74
Git Commit Timestamp: Fri Dec 2 15:28:21 2022 -0600

This package contains documentation about how to install or upgrade
the Cray System Management (CSM) software and related supporting
operational procedures to manage HPE Cray EX systems. This documentation
is in Markdown format starting at /usr/share/doc/csm/README.md.
Distribution: SUSE Linux Enterprise Server 15 SP3
```

The SLES 15SP4 build creates an RPM with SP4 metadata, and publishes it to `sle-15sp4`:

```bash
Name        : docs-csm
Version     : 1.4.32~2~ga3857d74
Release     : 1
Architecture: noarch
Install Date: (not installed)
Group       : Unspecified
Size        : 47271850
License     : MIT License
Signature   : (none)
Source RPM  : docs-csm-1.4.32~2~ga3857d74-1.src.rpm
Build Date  : Fri 02 Dec 2022 09:31:09 PM UTC
Build Host  : e94a621f8f05
Relocations : (not relocatable)
Packager    : https://www.suse.com/
Vendor      : Hewlett Packard Enterprise Company
URL         : https://github.com/Cray-HPE/docs-csm.git
Summary     : Documentation for Cray System Management (CSM) Installation and Upgrade
Description :
Git Repository: docs-csm
Git Branch: MTL-1708-build
Git Commit Revision: a3857d74
Git Commit Timestamp: Fri Dec 2 15:28:21 2022 -0600

This package contains documentation about how to install or upgrade
the Cray System Management (CSM) software and related supporting
operational procedures to manage HPE Cray EX systems. This documentation
is in Markdown format starting at /usr/share/doc/csm/README.md.
Distribution: SUSE Linux Enterprise Server 15 SP4
```

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
