### PR TITLE
CASM-3592: Add product catalog update to IMS upload

### DIFF
--- a/workflows/iuf/operations/ims-upload.yaml
+++ b/workflows/iuf/operations/ims-upload.yaml
@@ -57,12 +57,18 @@ spec:
               parameters:
               - name: s3_credentials_secret_name
                 value: "{{steps.get-s3-secrets.outputs.parameters.secret_name}}"
-#    - - name: ims-update-product-catalog
-#        template: update-product-catalog-template
-#        arguments:
-#          parameters:
-#          - name: yaml-content
-#            value: "{{steps.ims-upload-content.outputs.parameters.ims_records}}"
+    - - name: ims-update-product-catalog
+        templateRef:
+          name: update-product-catalog-template
+          template: catalog-update
+        arguments:
+          parameters:
+          - name: product-name
+            value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.name')}}"
+          - name: product-version
+            value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.version')}}"
+          - name: yaml-content
+            value: "{{steps.ims-upload-content.outputs.parameters.ims_records}}"
 ### Templates ###
 ## get-s3-secrets-template ##
   - name: get-s3-secrets-template


### PR DESCRIPTION
This commit uses the update-product-catalog-template workflowtemplate to add updating the product catalog into the ims-upload operation of the deliver-product stage.

Test Description:
I used this version of ims-upload.yaml on frigg and ran the IUF CLI through the deliver-product stage.

# Description

See commit message

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
