### PR TITLE
CASMHMS-5746 Update FAS procedures for component power off

### DIFF
--- a/operations/firmware/FAS_Recipes.md
+++ b/operations/firmware/FAS_Recipes.md
@@ -20,14 +20,14 @@ Refer to [FAS Filters](FAS_Filters.md) for more information on the content used 
 
 > **IMPORTANT:** Before updating a CMM:
 >
-> - The `hms-discovery` job must be stopped before updates are done and restarted after updates are complete.
->   - (`ncn-mw#`) Stop the `hms-discovery` job.
+> - Stop the `hms-discovery` job before updates are done, and then restart it after updates are complete.
+>   1. (`ncn-mw#`) Stop the `hms-discovery` job.
 >
 >     ```bash
 >     kubectl -n services patch cronjobs hms-discovery -p '{"spec":{"suspend":true}}'
 >     ```
 >
->   - (`ncn-mw#`) Start the `hms-discovery` job.
+>   1. (`ncn-mw#`) Start the `hms-discovery` job.
 >
 >     ```bash
 >     kubectl -n services patch cronjobs hms-discovery -p '{"spec":{"suspend":false}}'
@@ -36,11 +36,11 @@ Refer to [FAS Filters](FAS_Filters.md) for more information on the content used 
 > - Use CAPMC to make sure all chassis rectifier power is off.
 >   1. Check power status of the chassis.
 >
->     (`ncn-mw#`) If the chassis power is off, then everything else is off, and it is safe to proceed.
+>      (`ncn-mw#`) If the chassis power is off, then everything else is off, and it is safe to proceed.
 >
->     ```bash
->     cray capmc get_xname_status create --xnames x[1000-1008]c[0-7]
->     ```
+>      ```bash
+>      cray capmc get_xname_status create --xnames x[1000-1008]c[0-7]
+>      ```
 >
 >   1. If the chassis are still powered on, then use CAPMC to make sure everything is off.
 >

--- a/operations/firmware/FAS_Recipes.md
+++ b/operations/firmware/FAS_Recipes.md
@@ -21,13 +21,13 @@ Refer to [FAS Filters](FAS_Filters.md) for more information on the content used 
 > **IMPORTANT:** Before updating a CMM:
 >
 > - The `hms-discovery` job must be stopped before updates are done and restarted after updates are complete.
->   - `(ncn-mw#)` Stop the `hms-discovery` job.
+>   - (`ncn-mw#`) Stop the `hms-discovery` job.
 >
 >     ```bash
 >     kubectl -n services patch cronjobs hms-discovery -p '{"spec":{"suspend":true}}'
 >     ```
 >
->   - `(ncn-mw#)` Start the `hms-discovery` job.
+>   - (`ncn-mw#`) Start the `hms-discovery` job.
 >
 >     ```bash
 >     kubectl -n services patch cronjobs hms-discovery -p '{"spec":{"suspend":false}}'
@@ -36,7 +36,7 @@ Refer to [FAS Filters](FAS_Filters.md) for more information on the content used 
 > - Use CAPMC to make sure all chassis rectifier power is off.
 >   1. Check power status of the chassis.
 >
->     `(ncn-mw#)` If the chassis power is off, then everything else is off, and it is safe to proceed.
+>     (`ncn-mw#`) If the chassis power is off, then everything else is off, and it is safe to proceed.
 >
 >     ```bash
 >     cray capmc get_xname_status create --xnames x[1000-1008]c[0-7]
@@ -44,7 +44,7 @@ Refer to [FAS Filters](FAS_Filters.md) for more information on the content used 
 >
 >   1. If the chassis are still powered on, then use CAPMC to make sure everything is off.
 >
->      1. `(ncn-mw#)` Issue power off command.
+>      1. (`ncn-mw#`) Issue power off command.
 >
 >         This command may produce a large list of errors when talking to BMCs. This is expected if the hardware
 >         has been partially powered down.

--- a/operations/firmware/FAS_Recipes.md
+++ b/operations/firmware/FAS_Recipes.md
@@ -21,36 +21,36 @@ Refer to [FAS Filters](FAS_Filters.md) for more information on the content used 
 > **IMPORTANT:** Before updating a CMM:
 >
 > - The `hms-discovery` job must be stopped before updates are done and restarted after updates are complete.
->   - Stop the `hms-discovery` job.
+>   - (ncn-mw#) Stop the `hms-discovery` job.
 >
 >     ```bash
->     ncn-mw# kubectl -n services patch cronjobs hms-discovery -p '{"spec":{"suspend":true}}'
+>     kubectl -n services patch cronjobs hms-discovery -p '{"spec":{"suspend":true}}'
 >     ```
 >
->   - Start the `hms-discovery` job.
+>   - (ncn-mw#) Start the `hms-discovery` job.
 >
 >     ```bash
->     ncn-mw# kubectl -n services patch cronjobs hms-discovery -p '{"spec":{"suspend":false}}'
+>     kubectl -n services patch cronjobs hms-discovery -p '{"spec":{"suspend":false}}'
 >     ```
 >
 > - Use CAPMC to make sure all chassis rectifier power is off.
 >   1. Check power status of the chassis.
 >
->     If the chassis power is off, then everything else is off, and it is safe to proceed.
+>     (ncn-mw#) If the chassis power is off, then everything else is off, and it is safe to proceed.
 >
 >     ```bash
->     ncn-mw# cray capmc get_xname_status create --xnames x[1000-1008]c[0-7]
+>     cray capmc get_xname_status create --xnames x[1000-1008]c[0-7]
 >     ```
 >
 >   1. If the chassis are still powered on, then use CAPMC to make sure everything is off.
 >
->      1. Issue power off command.
+>      1. (ncn-mw#) Issue power off command.
 >
 >         This command may produce a large list of errors when talking to BMCs. This is expected if the hardware
 >         has been partially powered down.
 >
 >         ```bash
->         ncn-mw# cray capmc xname_off create --xnames x[1000-1008]c[0-7] --force true --continue true --recursive true
+>         cray capmc xname_off create --xnames x[1000-1008]c[0-7] --force true --continue true --recursive true
 >         ```
 >
 >      1. Verify that chassis power is off.

--- a/operations/firmware/FAS_Recipes.md
+++ b/operations/firmware/FAS_Recipes.md
@@ -20,10 +20,42 @@ Refer to [FAS Filters](FAS_Filters.md) for more information on the content used 
 
 > **IMPORTANT:** Before updating a CMM:
 >
-> - Make sure all slot and rectifier power is off.
-> - The `hms-discovery` job must also be stopped before updates and restarted after updates are complete.
->   - (`ncn-mw#`) Stop `hms-discovery` job: `kubectl -n services patch cronjobs hms-discovery -p '{"spec":{"suspend":true}}'`
->   - (`ncn-mw#`) Start `hms-discovery` job: `kubectl -n services patch cronjobs hms-discovery -p '{"spec":{"suspend":false}}'`
+> - The `hms-discovery` job must be stopped before updates are done and restarted after updates are complete.
+>   - Stop the `hms-discovery` job.
+>
+>     ```bash
+>     ncn-mw# kubectl -n services patch cronjobs hms-discovery -p '{"spec":{"suspend":true}}'
+>     ```
+>
+>   - Start the `hms-discovery` job.
+>
+>     ```bash
+>     ncn-mw# kubectl -n services patch cronjobs hms-discovery -p '{"spec":{"suspend":false}}'
+>     ```
+>
+> - Use CAPMC to make sure all chassis rectifier power is off.
+>   1. Check power status of the chassis.
+>
+>     If the chassis power is off, then everything else is off, and it is safe to proceed.
+>
+>     ```bash
+>     ncn-mw# cray capmc get_xname_status create --xnames x[1000-1008]c[0-7]
+>     ```
+>
+>   1. If the chassis are still powered on, then use CAPMC to make sure everything is off.
+>
+>      1. Issue power off command.
+>
+>         This command may produce a large list of errors when talking to BMCs. This is expected if the hardware
+>         has been partially powered down.
+>
+>         ```bash
+>         ncn-mw# cray capmc xname_off create --xnames x[1000-1008]c[0-7] --force true --continue true --recursive true
+>         ```
+>
+>      1. Verify that chassis power is off.
+>
+>         Repeat the earlier check of the chassis power.
 
 ```json
 {

--- a/operations/firmware/FAS_Recipes.md
+++ b/operations/firmware/FAS_Recipes.md
@@ -21,13 +21,13 @@ Refer to [FAS Filters](FAS_Filters.md) for more information on the content used 
 > **IMPORTANT:** Before updating a CMM:
 >
 > - The `hms-discovery` job must be stopped before updates are done and restarted after updates are complete.
->   - (ncn-mw#) Stop the `hms-discovery` job.
+>   - `(ncn-mw#)` Stop the `hms-discovery` job.
 >
 >     ```bash
 >     kubectl -n services patch cronjobs hms-discovery -p '{"spec":{"suspend":true}}'
 >     ```
 >
->   - (ncn-mw#) Start the `hms-discovery` job.
+>   - `(ncn-mw#)` Start the `hms-discovery` job.
 >
 >     ```bash
 >     kubectl -n services patch cronjobs hms-discovery -p '{"spec":{"suspend":false}}'
@@ -36,7 +36,7 @@ Refer to [FAS Filters](FAS_Filters.md) for more information on the content used 
 > - Use CAPMC to make sure all chassis rectifier power is off.
 >   1. Check power status of the chassis.
 >
->     (ncn-mw#) If the chassis power is off, then everything else is off, and it is safe to proceed.
+>     `(ncn-mw#)` If the chassis power is off, then everything else is off, and it is safe to proceed.
 >
 >     ```bash
 >     cray capmc get_xname_status create --xnames x[1000-1008]c[0-7]
@@ -44,7 +44,7 @@ Refer to [FAS Filters](FAS_Filters.md) for more information on the content used 
 >
 >   1. If the chassis are still powered on, then use CAPMC to make sure everything is off.
 >
->      1. (ncn-mw#) Issue power off command.
+>      1. `(ncn-mw#)` Issue power off command.
 >
 >         This command may produce a large list of errors when talking to BMCs. This is expected if the hardware
 >         has been partially powered down.


### PR DESCRIPTION
# Description

Improve the documentation for component power off when doing a FAS firmware update.

# Checklist Before Merging

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
