### PR TITLE
CASMTRIAGE-4603 / CASMHMS-5855 - main

### DIFF
--- a/operations/security_and_authentication/Change_Credentials_on_ServerTech_PDUs.md
+++ b/operations/security_and_authentication/Change_Credentials_on_ServerTech_PDUs.md
@@ -210,37 +210,37 @@ all ServerTech PDUs in the system can be updated to the same global credentials.
 
 1. (`ncn-mw#`) After waiting 10 minutes, Check that the PDU has been correctly discovered by HSM:
 
-  ```bash
-  cray hsm inventory redfishEndpoints describe x3000m0 --format json
-  ```
+   ```bash
+   cray hsm inventory redfishEndpoints describe x3000m0 --format json
+   ```
 
-  Example output:
+   Example output:
 
-  ```json
-  {
-    "ID": "x3000m0",
-    "Type": "CabinetPDUController",
-    "Hostname": "x3000m0-rts:8083",
-    "Domain": "",
-    "FQDN": "x3000m0-rts:8083",
-    "Enabled": true,
-    "User": "root",
-    "Password": "",
-    "MACAddr": "000a9c6236a5",
-    "RediscoverOnUpdate": true,
-    "DiscoveryInfo": {
-      "LastDiscoveryAttempt": "2022-11-30T22:11:30.712119Z",
-      "LastDiscoveryStatus": "DiscoverOK",
-      "RedfishVersion": "2019.1"
-    }
-  }
-  ```
+   ```json
+   {
+     "ID": "x3000m0",
+     "Type": "CabinetPDUController",
+     "Hostname": "x3000m0-rts:8083",
+     "Domain": "",
+     "FQDN": "x3000m0-rts:8083",
+     "Enabled": true,
+     "User": "root",
+     "Password": "",
+     "MACAddr": "000a9c6236a5",
+     "RediscoverOnUpdate": true,
+     "DiscoveryInfo": {
+       "LastDiscoveryAttempt": "2022-11-30T22:11:30.712119Z",
+       "LastDiscoveryStatus": "DiscoverOK",
+       "RedfishVersion": "2019.1"
+     }
+   }
+   ```
 
-  (`ncn-mw#`)If the `FQDN` does not contain `rts:8083`, then a manual update to the HSM record is required:
+   (`ncn-mw#`)If the `FQDN` does not contain `rts:8083`, then a manual update to the HSM record is required:
 
-  ```bash
-  cray hsm inventory redfishEndpoints update x3000m0 --fqdn x3000m0-rts:8083 --id x3000m0 --hostname x3000m0-rts:8083
-  ```
+   ```bash
+   cray hsm inventory redfishEndpoints update x3000m0 --fqdn x3000m0-rts:8083 --id x3000m0 --hostname x3000m0-rts:8083
+   ```
 
-  Recheck `cray hsm inventory redfishEndpoints` to verify the FQDN was updated.
-  Repeat this step for each ServerTech PDU.
+   Recheck `cray hsm inventory redfishEndpoints` to verify the FQDN was updated.
+   Repeat this step for each ServerTech PDU.

--- a/operations/security_and_authentication/Change_Credentials_on_ServerTech_PDUs.md
+++ b/operations/security_and_authentication/Change_Credentials_on_ServerTech_PDUs.md
@@ -207,7 +207,7 @@ all ServerTech PDUs in the system can be updated to the same global credentials.
     1) "x3000m0/redfish/v1/Managers"
     2) "x3001m0/redfish/v1/Managers"
     ```
-    
+
 1. (`ncn-mw#`) After waiting 10 minutes, Check that the PDU has been correctly discovered by HSM:
 
   ```bash

--- a/operations/security_and_authentication/Change_Credentials_on_ServerTech_PDUs.md
+++ b/operations/security_and_authentication/Change_Credentials_on_ServerTech_PDUs.md
@@ -242,5 +242,5 @@ all ServerTech PDUs in the system can be updated to the same global credentials.
   cray hsm inventory redfishEndpoints update x3000m0 --fqdn x3000m0-rts:8083 --id x3000m0 --hostname x3000m0-rts:8083
   ```
 
-  Recheck `hsm inventory` to verify the FQDN was updated.
+  Recheck `cray hsm inventory redfishEndpoints` to verify the FQDN was updated.
   Repeat this step for each ServerTech PDU.

--- a/operations/security_and_authentication/Change_Credentials_on_ServerTech_PDUs.md
+++ b/operations/security_and_authentication/Change_Credentials_on_ServerTech_PDUs.md
@@ -207,3 +207,40 @@ all ServerTech PDUs in the system can be updated to the same global credentials.
     1) "x3000m0/redfish/v1/Managers"
     2) "x3001m0/redfish/v1/Managers"
     ```
+    
+1. (`ncn-mw#`) After waiting 10 minutes, Check that the PDU has been correctly discovered by HSM:
+
+  ```bash
+  cray hsm inventory redfishEndpoints describe x3000m0 --format json
+  ```
+
+  Example output:
+
+  ```json
+  {
+    "ID": "x3000m0",
+    "Type": "CabinetPDUController",
+    "Hostname": "x3000m0-rts:8083",
+    "Domain": "",
+    "FQDN": "x3000m0-rts:8083",
+    "Enabled": true,
+    "User": "root",
+    "Password": "",
+    "MACAddr": "000a9c6236a5",
+    "RediscoverOnUpdate": true,
+    "DiscoveryInfo": {
+      "LastDiscoveryAttempt": "2022-11-30T22:11:30.712119Z",
+      "LastDiscoveryStatus": "DiscoverOK",
+      "RedfishVersion": "2019.1"
+    }
+  }
+  ```
+
+  (`ncn-mw#`)If the `FQDN` does not contain `rts:8083`, then a manual update to the HSM record is required:
+
+  ```bash
+  cray hsm inventory redfishEndpoints update x3000m0 --fqdn x3000m0-rts:8083 --id x3000m0 --hostname x3000m0-rts:8083
+  ```
+
+  Recheck `hsm inventory` to verify the FQDN was updated.
+  Repeat this step for each ServerTech PDU.

--- a/operations/system_layout_service/Add_Liquid-Cooled_Cabinets_To_SLS.md
+++ b/operations/system_layout_service/Add_Liquid-Cooled_Cabinets_To_SLS.md
@@ -286,7 +286,7 @@ This procedure adds one or more liquid-cooled cabinets and associated CDU manage
     Perform the load state operation:
 
     ```bash
-    curl -s -k -H "Authorization: Bearer ${TOKEN}" -X POST -F sls_dump=@sls_input_file.json \
+    curl -s -k -H "Authorization: Bearer ${TOKEN}" -X POST -F sls_dump=@sls_dump.json \
         https://api-gw-service-nmn.local/apis/sls/v1/loadstate
     ```
 


### PR DESCRIPTION
# Description

CASMHMS-5855:
Updated PDU documentation to add command to manually update HSM record.

CASMTRIAGE-4603:
Fixed typo in command.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
