### PR TITLE
CASMINST-5667

### DIFF
--- a/background/ncn_kdump.md
+++ b/background/ncn_kdump.md
@@ -101,11 +101,24 @@ to be installed; the `crash` command can not thoroughly analyze a dump without t
 
         1. Install from Artifactory.
 
-            ```bash
-            zypper ar https://$ARTIFACTORY_USER:$ARTIFACTORY_TOKEN@artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Module-Basesystem/15-SP3/x86_64/update_debug/ temp-debug
-            . /srv/cray/scripts/metal/dracut-lib.sh
-            zypper --plus-content debug in -y kernel-default-debuginfo=${KVER%-default}
-            ```
+            > ***NOTE*** CSM does NOT support the use of proxy servers for anything other than downloading artifacts from external endpoints.
+            Using `http_proxy` or `https_proxy` in any way other than the following examples will cause many failures in subsequent steps.
+
+            * Without proxy:
+
+                ```bash
+                zypper ar https://$ARTIFACTORY_USER:$ARTIFACTORY_TOKEN@artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Module-Basesystem/15-SP3/x86_64/update_debug/ temp-debug
+                . /srv/cray/scripts/metal/dracut-lib.sh
+                zypper --plus-content debug in -y kernel-default-debuginfo=${KVER%-default}
+                ```
+
+            * With https proxy:
+
+                ```bash
+                https_proxy=https://example.proxy.net:443 zypper ar https://$ARTIFACTORY_USER:$ARTIFACTORY_TOKEN@artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Module-Basesystem/15-SP3/x86_64/update_debug/ temp-debug
+                . /srv/cray/scripts/metal/dracut-lib.sh
+                zypper --plus-content debug in -y kernel-default-debuginfo=${KVER%-default}
+                ```
 
 1. (`ncn#`) On the node with the dump, select a crash dump and navigate to its directory.
 

--- a/install/pre-installation.md
+++ b/install/pre-installation.md
@@ -45,26 +45,41 @@ Any steps run on an `external` server require that server to have the following 
    >
    > - `-C -` is used to allow partial downloads. These tarballs are large; in the event of a connection disruption, the same `curl` command can be used to continue the disrupted download.
    > - **If air-gapped or behind a strict firewall**, then the tarball must be obtained from the medium delivered by Cray-HPE. For these cases, copy or download the tarball to the working
-   >   directory and then proceed to the next step. The tarball will need to be fetched with `scp` during the [Download CSM tarball](#21-download-csm-tarball) step.
+   > directory and then proceed to the next step. The tarball will need to be fetched with `scp` during the [Download CSM tarball](#21-download-csm-tarball) step.
 
-   ```bash
-   # e.g. an alpha : CSM_RELEASE=1.3.0-alpha.99
-   # e.g. an RC    : CSM_RELEASE=1.3.0-rc.1
-   # e.g. a stable : CSM_RELEASE=1.3.0  
-   CSM_RELEASE=1.3.0-alpha.9
-   ```
+1. (`external#`) Set the CSM RELEASE version
 
-   ```bash
-   curl -C - -f -O "https://release.algol60.net/$(awk -F. '{print "csm-"$1"."$2}' <<< ${CSM_RELEASE})/csm/csm-${CSM_RELEASE}.tar.gz"
-   ```
+      ```bash
+      # e.g. an alpha : CSM_RELEASE=1.3.0-alpha.99
+      # e.g. an RC    : CSM_RELEASE=1.3.0-rc.1
+      # e.g. a stable : CSM_RELEASE=1.3.0  
+      CSM_RELEASE=1.3.0-alpha.9
+      ```
+
+1. (`external#`) Download the CSM tarball
+
+      > ***NOTE:*** CSM does NOT support the use of proxy servers for anything other than downloading artifacts from external endpoints.
+      Using `http_proxy` or `https_proxy` in any way other than the following examples will cause many failures in subsequent steps.
+
+      - Without proxy:
+
+         ```bash
+         curl -C - -f -O "https://release.algol60.net/$(awk -F. '{print "csm-"$1"."$2}' <<< ${CSM_RELEASE})/csm/csm-${CSM_RELEASE}.tar.gz"
+         ```
+
+      - With https proxy:
+
+         ```bash
+         https_proxy=https://example.proxy.net:443 curl -C - -f -O "https://release.algol60.net/$(awk -F. '{print "csm-"$1"."$2}' <<< ${CSM_RELEASE})/csm/csm-${CSM_RELEASE}.tar.gz"
+         ```
 
 1. (`external#`) Extract the LiveCD from the tarball.
 
-   ```bash
-   OUT_DIR="$(pwd)/csm-temp"
-   mkdir -pv "${OUT_DIR}"
-   tar -C "${OUT_DIR}" --wildcards --no-anchored --transform='s/.*\///' -xzvf "csm-${CSM_RELEASE}.tar.gz" 'cray-pre-install-toolkit-*.iso'
-   ```
+      ```bash
+      OUT_DIR="$(pwd)/csm-temp"
+      mkdir -pv "${OUT_DIR}"
+      tar -C "${OUT_DIR}" --wildcards --no-anchored --transform='s/.*\///' -xzvf "csm-${CSM_RELEASE}.tar.gz" 'cray-pre-install-toolkit-*.iso'
+      ```
 
 ### 1.2 Boot the LiveCD
 
@@ -361,11 +376,21 @@ These variables will need to be set for many procedures within the CSM installat
    - From Cray using `curl`:
 
       > - `-C -` is used to allow partial downloads. These tarballs are large; in the event of a connection disruption, the same `curl` command can be used to continue the disrupted download.
+      > - CSM does NOT support the use of proxy servers for anything other than downloading artifacts from external endpoints. Using `http_proxy` or `https_proxy` in any way other than the following examples will cause many failures in subsequent steps.
 
-      ```bash
-      curl -C - -f -o "/var/www/ephemeral/csm-${CSM_RELEASE}.tar.gz" \
-        "https://release.algol60.net/$(awk -F. '{print "csm-"$1"."$2}' <<< ${CSM_RELEASE})/csm/csm-${CSM_RELEASE}.tar.gz"
-      ```
+      - Without proxy:
+
+         ```bash
+         curl -C - -f -o "/var/www/ephemeral/csm-${CSM_RELEASE}.tar.gz" \
+         "https://release.algol60.net/$(awk -F. '{print "csm-"$1"."$2}' <<< ${CSM_RELEASE})/csm/csm-${CSM_RELEASE}.tar.gz"
+         ```
+
+      - With https proxy:
+
+         ```bash
+         https_proxy=https://example.proxy.net:443 curl -C - -f -o "/var/www/ephemeral/csm-${CSM_RELEASE}.tar.gz" \
+         "https://release.algol60.net/$(awk -F. '{print "csm-"$1"."$2}' <<< ${CSM_RELEASE})/csm/csm-${CSM_RELEASE}.tar.gz"
+         ```
 
    - `scp` from the external server used in [Prepare installation environment server](#11-prepare-installation-environment-server):
 

--- a/update_product_stream/README.md
+++ b/update_product_stream/README.md
@@ -22,11 +22,32 @@ be downloaded and extracted.
 
 1. Download the CSM software release tarball.
 
-   ```bash
-   ENDPOINT=URL_SERVER_Hosting_tarball
-   CSM_RELEASE=x.y.z
-   wget "${ENDPOINT}/csm-${CSM_RELEASE}.tar.gz"
-   ```
+   > ***NOTE:*** CSM does NOT support the use of proxy servers for anything other than downloading artifacts from external endpoints.
+Using `http_proxy` or `https_proxy` in any way other than the following examples will cause many failures in subsequent steps.
+
+   - Without proxy:
+
+     ```bash
+     ENDPOINT=URL_SERVER_Hosting_tarball
+     CSM_RELEASE=x.y.z
+     wget "${ENDPOINT}/csm-${CSM_RELEASE}.tar.gz"
+     ```
+
+   - With https proxy:
+
+     ```bash
+     ENDPOINT=URL_SERVER_Hosting_tarball
+     CSM_RELEASE=x.y.z
+     https_proxy=https://example.proxy.net:443 wget "${ENDPOINT}/csm-${CSM_RELEASE}.tar.gz"
+     ```
+
+   - With http proxy:
+
+     ```bash
+     ENDPOINT=URL_SERVER_Hosting_tarball
+     CSM_RELEASE=x.y.z
+     http_proxy=http://example.proxy.net:80 wget "${ENDPOINT}/csm-${CSM_RELEASE}.tar.gz"
+     ```
 
 1. Extract the release distribution.
 
@@ -119,6 +140,8 @@ This tarball can now be used in place of the original CSM software release tarba
 
 Acquire the latest documentation RPM. This may include updates, corrections, and enhancements that were not available until after the software release.
 
+> ***NOTE:*** CSM does NOT support the use of proxy servers for anything other than downloading artifacts from external endpoints. Using http proxies in any way other than the following examples will cause many failures in subsequent steps.
+
 1. Check the version of the currently installed CSM documentation.
 
    ```bash
@@ -127,11 +150,19 @@ Acquire the latest documentation RPM. This may include updates, corrections, and
 
 1. Download and upgrade the latest documentation RPM.
 
-   ```bash
-   rpm -Uvh --force https://release.algol60.net/csm-1.3/docs-csm/docs-csm-latest.rpm
-   ```
+   - Without proxy:
 
-   If this machine does not have direct internet access, then this RPM will need to be externally downloaded and copied to the system. This example copies it to `ncn-m001`.
+     ```bash
+     rpm -Uvh --force https://release.algol60.net/csm-1.3/docs-csm/docs-csm-latest.rpm
+     ```
+
+   - With https proxy:
+
+     ```bash
+     rpm -Uvh --force --httpproxy https://example.proxy.net --httpport 443 https://release.algol60.net/csm-1.3/docs-csm/docs-csm-latest.rpm
+     ```
+
+   If this machine does not have internet access with or without a proxy, then this RPM will need to be externally downloaded and copied to the system. This example copies it to `ncn-m001`.
 
    ```bash
    wget https://release.algol60.net/csm-1.3/docs-csm/docs-csm-latest.rpm -O docs-csm-latest.noarch.rpm

--- a/upgrade/Stage_0_Prerequisites.md
+++ b/upgrade/Stage_0_Prerequisites.md
@@ -48,13 +48,25 @@ after a break, always be sure that a typescript is running before proceeding.
 
    - If `ncn-m001` has internet access, then use the following commands to download and install the latest documentation.
 
-      > **Important:** The upgrade scripts expect the `docs-csm` RPM to be located at `/root/docs-csm-latest.noarch.rpm`; that is why these commands copy it there.
+      > **Important:** The upgrade scripts expect the `docs-csm` RPM to be located at `/root/docs-csm-latest.noarch.rpm`; that is why these commands copy it there.  
+      > ***NOTE:*** CSM does NOT support the use of proxy servers for anything other than downloading artifacts from external endpoints.
+      Using `http_proxy` or `https_proxy` in any way other than the following examples will cause many failures in subsequent steps.
 
-      ```bash
-      wget https://release.algol60.net/csm-1.3/docs-csm/docs-csm-latest.rpm \
+      - Without proxy:
+
+          ```bash
+          wget https://release.algol60.net/csm-1.3/docs-csm/docs-csm-latest.rpm \
           -O /root/docs-csm-latest.noarch.rpm &&
-      rpm -Uvh --force /root/docs-csm-latest.noarch.rpm
-      ```
+          rpm -Uvh --force /root/docs-csm-latest.noarch.rpm
+          ```
+
+      - With https proxy:
+
+          ```bash
+          https_proxy=https://example.proxy.net:443 wget https://release.algol60.net/csm-1.3/docs-csm/docs-csm-latest.rpm \
+          -O /root/docs-csm-latest.noarch.rpm &&
+          rpm -Uvh --force /root/docs-csm-latest.noarch.rpm
+          ```
 
    - Otherwise, use the following procedure to download and install the latest documentation.
 
@@ -159,6 +171,15 @@ after a break, always be sure that a typescript is running before proceeding.
    ENDPOINT=https://put.the/url/here/
    ```
 
+1. This step should ONLY be performed if an http proxy is required to access a public endpoint on the internet for the purpose of downloading artifacts.
+CSM does NOT support the use of proxy servers for anything other than downloading artifacts from external endpoints.
+The http proxy variables must be `unset` after the desired artifacts are downloaded. Failure to unset the http proxy variables after downloading artifacts will cause many failures in subsequent steps.
+
+   ```bash
+   export https_proxy=https://example.proxy.net:443
+   export http_proxy=http://example.proxy.net:80
+   ```
+
 1. (`ncn-m001#`) Run the script.
 
    **NOTE** For Cray/HPE internal installs, if `ncn-m001` can reach the internet, then the `--endpoint` argument may be omitted.
@@ -169,6 +190,13 @@ after a break, always be sure that a typescript is running before proceeding.
 
    ```bash
    /usr/share/doc/csm/upgrade/scripts/upgrade/prepare-assets.sh --csm-version ${CSM_RELEASE} --endpoint "${ENDPOINT}"
+   ```
+
+1. This step must be performed if an http proxy was set previously.
+
+   ```bash
+   unset https_proxy
+   unset http_proxy
    ```
 
 1. Skip the `Manual copy` subsection and proceed to [Stage 0.2 - Prerequisites](#stage-02---prerequisites)


### PR DESCRIPTION
# Description

Add http_proxy verbiage for the purpose of downloading artifacts from external endpoints using a proxy

https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5667

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
