### PR TITLE
CASMINST-5440 Use license checker from private csm-docker [release/1.2]

### DIFF
--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -29,15 +29,20 @@ on:
 jobs:
   license-check:
     runs-on: ubuntu-latest
+
+    container:
+      image: artifactory.algol60.net/csm-docker/stable/license-checker:latest
+      credentials:
+          username: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_USERNAME }}
+          password: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_TOKEN }}
+
     steps:
     - uses: actions/checkout@v3
 
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@v18.7
+      uses: tj-actions/changed-files@v34
 
     - name: License Check
       if: ${{ steps.changed-files.outputs.all_changed_files }}
-      uses: docker://artifactory.algol60.net/csm-docker/stable/license-checker:latest
-      with:
-        args: ${{ steps.changed-files.outputs.all_changed_files }}
+      run: /usr/local/bin/python3 /license_check/license_check.py ${{ steps.changed-files.outputs.all_changed_files }}


### PR DESCRIPTION
# Description

The `artifactory.algol60.net/csm-docker` docker registry will become private since January 2023. This change is to provide authentication context for license checking github workflow, which is using container hosted in this registry.

# Testing

Tested by temporarily adding `push:` event to the list of events which trigger workflow:
https://github.com/Cray-HPE/docs-csm/actions/runs/3633719040/jobs/6131051266