### PR TITLE
CASMINST-5670 - Request for more clarity on "external ssh test" in docs

### DIFF
--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -419,7 +419,9 @@ Overall status: PASSED (Passed: 40, Failed: 0)
 
 ### 4.3 External SSH access test execution
 
-The external SSH access tests may be run on any system external to the cluster.
+The external SSH access tests may be run on any system external to the cluster. The tests should not be run from another system
+running the Cray System Management software if that system was configured with the same internal network ranges as the system
+being tested as this will cause some tests to fail.
 
 1. (`external#`) Python version 3 must be installed (if it is not already).
 


### PR DESCRIPTION
# Description

If the External SSH tests are run from another CSM system that has overlapping (or default) network ranges for the Node Management and Hardware Management networks then some tests will fail.

An example would be running a check for `fanta` on `surtur`, both of which have been installed with default internal network values.

The test running on `surtur` will perform a DNS lookup for `sw-spine-001.hmn.fanta.dev.cray.com` and get the IP address `10.254.0.2` however that IP address also corresponds its own `sw-spine-001` switch so the SSH test will succeeds whereas if it was run from an external non-CSM host it would fail.

# Checklist Before Merging

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
