### PR TITLE
CASM-3700: Add WorkflowTemplate to add product to catalog

### DIFF
--- a/workflows/iuf/operations/add-product-to-product-catalog.yaml
+++ b/workflows/iuf/operations/add-product-to-product-catalog.yaml
@@ -1,0 +1,49 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: add-product-to-product-catalog
+spec:
+  entrypoint: main
+  templates:
+### Main Steps ###
+  - name: main
+    inputs:
+      parameters:
+      - name: global_params
+    steps:
+    - - name: update-product-catalog
+        templateRef:
+          name: update-product-catalog-template
+          template: catalog-update
+        arguments:
+          parameters:
+          - name: product-name
+            value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.name')}}"
+          - name: product-version
+            value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.version')}}"
+          - name: yaml-content
+            value: "{}"

--- a/workflows/iuf/stages.yaml
+++ b/workflows/iuf/stages.yaml
@@ -39,6 +39,8 @@ stages:
   - name: deliver-product
     type: product
     operations:
+      - name: add-product-to-product-catalog
+        static-parameters: {} # any parameters that will be supplied statically to this operation.
       - name: loftsman-manifest-upload
         static-parameters: {} # any parameters that will be supplied statically to this operation.
       - name: s3-upload


### PR DESCRIPTION
This commit adds an operation in the deliver-product stage to insert the a product/version into the product catalog. This guarantees that even products that do not insert any VCS/IMS content will still be recorded in the product catalog.

Test Description: Ran this workflow on frigg.

# Description

See commit message

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
