### PR TITLE
CASMPET-6171 main : Reorg Cert md, add section for apiserver-etcd-cli…

### DIFF
--- a/upgrade/Upgrade_Management_Nodes_and_CSM_Services.md
+++ b/upgrade/Upgrade_Management_Nodes_and_CSM_Services.md
@@ -60,6 +60,11 @@ mentioned explicitly on this page, see [resource material](resource_material/REA
    it may be necessary to restore that cluster from backup. See
    [Restore Bare-Metal etcd Clusters from an S3 Snapshot](../operations/kubernetes/Restore_Bare-Metal_etcd_Clusters_from_an_S3_Snapshot.md) for that procedure.
 
+- Bare-metal Etcd certificate
+
+   After upgrading, `apiserver-etcd-client` certificate may need to been renewed. See [Kubernetes and Bare Metal EtcD Certificate Renewal](../operations/kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md#renew-etcd-certificate)
+   for procedures to check and renew this certificate.
+
 - Back-ups for `etcd-operator` Clusters
 
    After upgrading, if health checks indicate that Etcd pods are not in a healthy/running state, recovery procedures may be needed. See


### PR DESCRIPTION
# Description
Reorg Cert_Renewal.md to add a TOC and other cleanup
Add section for apiserver-etcd-client only renewal
Add to upgrade troubleshooting

CAST-31670 noted that the apiserver-etcd-client was not getting renewed. Checking other systems, it was found that the `kubeadm cert renew all` which is documented in the Cert_Renewal...md does renew this cert, but the `kubeadm upgrade apply` which is done as part of the CSM upgrades does not renew this cert.  
Added to the Cert_Renewal...md a section - how to renew just this one cert and pointer to this from the upgrade troubleshooting to check/renew.
The long term fix will come with CASMPET-6194 in CSM 1.6 to update the image to add the add’l cert renewal during upgrade.

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
