### PR TITLE
CASMINST-5517:  Change csm tarball and docs-csm rpm download instructions to use release.algol60.net

### DIFF
--- a/install/pre-installation.md
+++ b/install/pre-installation.md
@@ -55,7 +55,7 @@ Any steps run on an `external` server require that server to have the following 
    ```
 
    ```bash
-   curl -C - -f -O "https://artifactory.algol60.net/artifactory/csm-releases/csm/$(awk -F. '{print $1"."$2}' <<< ${CSM_RELEASE})/csm-${CSM_RELEASE}.tar.gz"
+   curl -C - -f -O "https://release.algol60.net/$(awk -F. '{print "csm-"$1"."$2}' <<< ${CSM_RELEASE})/csm/csm-${CSM_RELEASE}.tar.gz"
    ```
 
 1. (`external#`) Extract the LiveCD from the tarball.
@@ -369,7 +369,7 @@ These variables will need to be set for many procedures within the CSM installat
 
       ```bash
       curl -C - -f -o "/var/www/ephemeral/csm-${CSM_RELEASE}.tar.gz" \
-        "https://artifactory.algol60.net/artifactory/csm-releases/csm/$(awk -F. '{print $1"."$2}' <<< ${CSM_RELEASE})/csm-${CSM_RELEASE}.tar.gz"
+        "https://release.algol60.net/$(awk -F. '{print "csm-"$1"."$2}' <<< ${CSM_RELEASE})/csm/csm-${CSM_RELEASE}.tar.gz"
       ```
 
    - `scp` from the external server used in [Prepare installation environment server](#11-prepare-installation-environment-server):

--- a/update_product_stream/README.md
+++ b/update_product_stream/README.md
@@ -128,13 +128,13 @@ Acquire the latest documentation RPM. This may include updates, corrections, and
 1. Download and upgrade the latest documentation RPM.
 
    ```bash
-   rpm -Uvh --force https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/docs-csm/1.4/noarch/docs-csm-latest.noarch.rpm
+   rpm -Uvh --force https://release.algol60.net/csm-1.4/docs-csm/docs-csm-latest.rpm
    ```
 
    If this machine does not have direct internet access, then this RPM will need to be externally downloaded and copied to the system. This example copies it to `ncn-m001`.
 
    ```bash
-   wget https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/docs-csm/1.4/noarch/docs-csm-latest.noarch.rpm -O docs-csm-latest.noarch.rpm
+   wget https://release.algol60.net/csm-1.4/docs-csm/docs-csm-latest.rpm -O docs-csm-latest.noarch.rpm
    scp docs-csm-latest.noarch.rpm ncn-m001:/root
    ssh ncn-m001
    rpm -Uvh --force /root/docs-csm-latest.noarch.rpm

--- a/upgrade/Stage_0_Prerequisites.md
+++ b/upgrade/Stage_0_Prerequisites.md
@@ -51,7 +51,7 @@ after a break, always be sure that a typescript is running before proceeding.
       > **Important:** The upgrade scripts expect the `docs-csm` RPM to be located at `/root/docs-csm-latest.noarch.rpm`; that is why these commands copy it there.
 
       ```bash
-      wget https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/docs-csm/1.4/noarch/docs-csm-latest.noarch.rpm \
+      wget https://release.algol60.net/csm-1.4/docs-csm/docs-csm-latest.rpm \
           -O /root/docs-csm-latest.noarch.rpm &&
       rpm -Uvh --force /root/docs-csm-latest.noarch.rpm
       ```

--- a/upgrade/scripts/upgrade/prepare-assets.sh
+++ b/upgrade/scripts/upgrade/prepare-assets.sh
@@ -89,8 +89,8 @@ if [[ -z ${TARBALL_FILE} ]]; then
     # Download tarball from internet
 
     if [[ -z ${ENDPOINT} ]]; then
-        # default endpoint to internal artifactory
-        ENDPOINT=https://artifactory.algol60.net/artifactory/csm-releases/csm/1.4/
+        # default endpoint to release.algol60.net
+        ENDPOINT=https://release.algol60.net/csm-1.4/csm/
         echo "Use internal endpoint: ${ENDPOINT}"
     fi
 


### PR DESCRIPTION
# Description

This changes any of the instructions or scripts for downloading/installing the CSM tarball or the docs-csm rpm to use release.algol60.net instead of artifactory.algol60.net since we cannot use artifactory.algol60.net for public access to the artifacts.

Any references to docker images (e.g. artifactory.algol60.net/csm-docker/stable/docker.io/library/openjdk:11-jre-slim) were left as it is because they should be coming from the local repository and not from the external artifactory.algol60.net.

background/ncn_kdump.md was also left as it is because it uses authentication to access the artifact in that case.

# Checklist Before Merging

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
