### PR TITLE
CASM-3699: Additions to scripts/operations/configuration/python_lib

### DIFF
--- a/scripts/operations/configuration/python_lib/k8s.py
+++ b/scripts/operations/configuration/python_lib/k8s.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -32,9 +32,14 @@ import kubernetes.client.api
 import kubernetes.config
 
 from . import common
+from .types import JSONObject
 
-K8S_CONFIGURATION = None
-K8S_API_CLIENT = None
+# To help for type hinting in other modules
+CoreV1API = kubernetes.client.api.core_v1_api.CoreV1Api
+V1ClientConfiguration = kubernetes.client.configuration.Configuration
+V1ConfigMap = kubernetes.client.models.v1_config_map.V1ConfigMap
+V1Secret = kubernetes.client.models.v1_secret.V1Secret
+V1Service = kubernetes.client.models.v1_service.V1Service
 
 
 def log_error_raise_exception(msg: str, parent_exception: Exception = None) -> None:
@@ -52,70 +57,107 @@ def log_error_raise_exception(msg: str, parent_exception: Exception = None) -> N
     raise common.ScriptException(msg) from parent_exception
 
 
-def get_configuration() -> kubernetes.client.configuration.Configuration:
+def get_configuration() -> V1ClientConfiguration:
     """
     Creates a default Kubernetes configuration and returns it.
     """
-    global K8S_CONFIGURATION
-    if K8S_CONFIGURATION is None:
-        logging.debug("Loading Kubernetes configuration")
-        try:
-            kubernetes.config.load_kube_config()
-        except Exception as exc:
-            log_error_raise_exception(
-                "Error loading Kubernetes configuration", exc)
-        logging.debug("Getting default copy of Kubernetes configuration")
-        try:
-            K8S_CONFIGURATION = kubernetes.client.Configuration().get_default_copy()
-        except Exception as exc:
-            log_error_raise_exception(
-                "Error getting default copy of Kubernetes configuration", exc)
-    return K8S_CONFIGURATION
+    logging.debug("Loading Kubernetes configuration")
+    try:
+        kubernetes.config.load_kube_config()
+    except Exception as exc:
+        log_error_raise_exception(
+            "Error loading Kubernetes configuration", exc)
+    logging.debug("Getting default copy of Kubernetes configuration")
+    try:
+        return kubernetes.client.Configuration().get_default_copy()
+    except Exception as exc:
+        log_error_raise_exception(
+            "Error getting default copy of Kubernetes configuration", exc)
 
 
-def get_api_client() -> kubernetes.client.api.core_v1_api.CoreV1Api:
+def get_api_client() -> CoreV1API:
     """
     Creates a Kubernetes API client and returns it.
     """
-    global K8S_API_CLIENT
-    if K8S_API_CLIENT is None:
-        logging.info("Initializing Kubernetes client")
-        k8s_config = get_configuration()
-        logging.debug("Setting client default Kubernetes configuration")
+    logging.info("Initializing Kubernetes client")
+    k8s_config = get_configuration()
+    logging.debug("Setting client default Kubernetes configuration")
+    try:
+        kubernetes.client.Configuration.set_default(k8s_config)
+    except Exception as exc:
+        log_error_raise_exception(
+            "Error setting default Kubernetes configuration", exc)
+    try:
+        return kubernetes.client.api.core_v1_api.CoreV1Api()
+    except Exception as exc:
+        log_error_raise_exception("Error obtaining Kubernetes API client", exc)
+
+
+def get_data_field(k8s_object, label: str) -> JSONObject:
+    """
+    Returns the data field from the specified object. Raises an exception (using the
+    provided label) if there is a problem.
+    """
+    try:
+        return k8s_object.data
+    except AttributeError as exc:
+        log_error_raise_exception(
+            f"Error accessing data field in {label}", exc)
+
+
+class Client:
+    """
+    Kubernetes API client object. Takes care of the setup steps and provides simplified API calls.
+    """
+    def __init__(self):
+        self.client = get_api_client()
+
+    def get_config_map(self, name: str, namespace: str) -> V1ConfigMap:
+        """
+        Wrapper for read_namespaced_config_map function
+        """
+        configmap_label = f"{namespace}/{name} Kubernetes configmap"
+        logging.debug(f"Getting {configmap_label}")
         try:
-            kubernetes.client.Configuration.set_default(k8s_config)
+            return self.client.read_namespaced_config_map(name=name, namespace=namespace)
         except Exception as exc:
             log_error_raise_exception(
-                "Error setting default Kubernetes configuration", exc)
+                f"Error retrieving {configmap_label}", exc)
+
+    def get_config_map_data(self, name: str, namespace: str) -> JSONObject:
+        """
+        Calls get_config_map function, then extracts the data field from the response.
+        """
+        configmap_label = f"{namespace}/{name} Kubernetes configmap"
+        configmap = self.get_config_map(name=name, namespace=namespace)
+        return get_data_field(configmap, label=configmap_label)
+
+    def get_secret(self, name: str, namespace: str) -> V1Secret:
+        """
+        Wrapper for read_namespaced_secret function
+        """
+        secret_label = f"{namespace}/{name} Kubernetes secret"
+        logging.debug(f"Getting {secret_label}")
         try:
-            K8S_API_CLIENT = kubernetes.client.api.core_v1_api.CoreV1Api()
+            return self.client.read_namespaced_secret(name=name, namespace=namespace)
         except Exception as exc:
-            log_error_raise_exception(
-                "Error obtaining Kubernetes API client", exc)
-    return K8S_API_CLIENT
+            log_error_raise_exception(f"Error retrieving {secret_label}", exc)
 
+    def get_secret_data(self, name: str, namespace: str) -> JSONObject:
+        """
+        Calls get_secret function, then extracts the data field from the response.
+        """
+        secret_label = f"{namespace}/{name} Kubernetes secret"
+        secret = self.get_secret(name=name, namespace=namespace)
+        return get_data_field(secret, label=secret_label)
 
-def get_secret(name: str, namespace: str) -> kubernetes.client.models.v1_secret.V1Secret:
-    """
-    Wrapper for read_namespaced_secret function
-    """
-    api_client = get_api_client()
-    secret_label = f"{namespace}/{name} Kubernetes secret"
-    logging.debug(f"Getting {secret_label}")
-    try:
-        return api_client.read_namespaced_secret(name=name, namespace=namespace)
-    except Exception as exc:
-        log_error_raise_exception(f"Error retrieving {secret_label}", exc)
-
-
-def get_service(name: str, namespace: str) -> kubernetes.client.models.v1_service.V1Service:
-    """
-    Wrapper for read_namespaced_service function
-    """
-    api_client = get_api_client()
-    service_label = f"{namespace}/{name} Kubernetes service"
-    logging.debug(f"Getting {service_label}")
-    try:
-        return api_client.read_namespaced_service(name=name, namespace=namespace)
-    except Exception as exc:
-        log_error_raise_exception(f"Error retrieving {service_label}", exc)
+    def get_service(self, name: str, namespace: str) -> V1Service:
+        """
+        Wrapper for read_namespaced_service function
+        """
+        service_label = f"{namespace}/{name} Kubernetes service"
+        logging.debug(f"Getting {service_label}")
+        try:
+            return self.client.read_namespaced_service(name=name, namespace=namespace)
+        except Exception as exc:
+            log_error_raise_exception(f"Error retrieving {service_label}", exc)

--- a/scripts/operations/configuration/python_lib/product_catalog.py
+++ b/scripts/operations/configuration/python_lib/product_catalog.py
@@ -1,0 +1,210 @@
+#
+# MIT License
+#
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""Shared Python function library: Cray product catalog"""
+
+import traceback
+from typing import Dict, ItemsView
+
+import logging
+import packaging.version
+import yaml
+
+from . import common
+from . import k8s
+
+from .types import JSONObject
+
+K8S_NAMESPACE = "services"
+K8S_CONFIG_MAP_NAME = "cray-product-catalog"
+
+# Used for type hinting
+ProductVersionMap = Dict[str, JSONObject]
+ProductCatalogMap = Dict[str, ProductVersionMap]
+
+
+def log_error_raise_exception(msg: str, parent_exception: Exception = None) -> None:
+    """
+    1) If a parent exception is passed in, make a debug log entry with its stack trace.
+    2) Log an error with the specified message.
+    3) Raise a ScriptException with the specified message (from the parent exception, if
+       specified)
+    """
+    if parent_exception is not None:
+        logging.debug(traceback.format_exc())
+    logging.error(msg)
+    if parent_exception is None:
+        raise common.ScriptException(msg)
+    raise common.ScriptException(msg) from parent_exception
+
+
+def parse_product_yaml(label: str, yaml_string: str) -> JSONObject:
+    """
+    Converts the YAML string for a product catalog product entry into its
+    dictionary form. Raises an exception if there are problems.
+    """
+    try:
+        decoded_yaml = yaml.safe_load(yaml_string)
+    except (AttributeError, yaml.scanner.ScannerError) as exc:
+        log_error_raise_exception(
+            f"Error decoding YAML data from {label}", exc)
+    # Ensure that we are actually returning a dictionary
+    try:
+        return {key: value for key, value in decoded_yaml.items()}
+    except (AttributeError, TypeError) as exc:
+        # Attribute error if 'items' attribute does not exist
+        # Type error if 'items' is not callable
+        log_error_raise_exception(
+            f"YAML data from {label} has an unexpected format", exc)
+
+
+def get_latest_version(product_version_map: ProductVersionMap,
+                       strict_versioning: bool = False,
+                       ignore_invalid_versions: bool = True) -> str:
+    """
+    Given a product version map from the product catalog, sort the version strings
+    and return the latest one.
+
+    If strict_versioning is false, then the generic packaging.version.parse() function will be
+    used to parse the version strings. Otherwise the packaging.versions.Version() constructor will
+    be used. The latter is more strict about what it considers to be a valid version.
+
+    If ignore_invalid_versions is true, any version string keys that are not valid will be excluded
+    from the sorting. Otherwise, invalid version strings will raise an exception.
+
+    Returns None if there are no valid version strings.
+    """
+    all_version_strings = list(product_version_map.keys())
+    logging.debug("get_latest_version: strict_versioning = %s, ignore_invalid_versions=%s, "
+                  "all_version_strings=%s", strict_versioning, ignore_invalid_versions,
+                  all_version_strings)
+    version_object_to_string = dict()
+    for version_string in all_version_strings:
+        try:
+            if strict_versioning:
+                version_object = packaging.version.Version(version_string)
+            else:
+                version_object = packaging.version.parse(version_string)
+            version_object_to_string[version_object] = version_string
+        except packaging.version.InvalidVersion as exc:
+            if ignore_invalid_versions:
+                logging.debug("get_latest_version: Ignoring invalid version string '%s'",
+                              version_string)
+                continue
+            log_error_raise_exception(
+                f"Invalid product version string in Cray product catalog: '{version_string}'", exc)
+    if not version_object_to_string:
+        logging.debug("get_latest_version: No valid version strings found")
+        return None
+    sorted_version_objects = sorted(version_object_to_string.keys())
+    latest_version_object = sorted_version_objects[-1]
+    # return corresponding string
+    latest_version_string = version_object_to_string[latest_version_object]
+    logging.debug(
+        "get_latest_version: latest_version_string = '%s'", latest_version_string)
+    return latest_version_string
+
+
+class ProductCatalog:
+    """
+    A snapshot of the current Cray product catalog configmap in Kubernetes.
+    """
+    def __init__(self, k8s_client: k8s.CoreV1API = None):
+        """
+        Retrieves the Cray Product Catalog configmap and returns its data field.
+        """
+        if k8s_client is None:
+            k8s_client = k8s.Client()
+        self.data = k8s_client.get_config_map_data(name=K8S_CONFIG_MAP_NAME,
+                                                   namespace=K8S_NAMESPACE)
+
+    def get_items(self) -> ItemsView:
+        """
+        Returns an item listing of the data field.
+        Raises an exception if there are any problems.
+        """
+        try:
+            return self.data.items()
+        except (AttributeError, TypeError) as exc:
+            # Attribute error if 'items' attribute does not exist
+            # Type error if 'items' is not callable
+            log_error_raise_exception(f"{K8S_NAMESPACE}/{K8S_CONFIG_MAP_NAME} Kubernetes configmap"
+                                      " has an unexpected format", exc)
+
+    def get_installed_products(self) -> ProductCatalogMap:
+        """
+        Returns the product mapping from the Cray Product Catalog configmap.
+        Parses the YAML of each product listing. Raises an exception if there
+        are any problems.
+        """
+        label = f"{K8S_NAMESPACE}/{K8S_CONFIG_MAP_NAME} Kubernetes configmap"
+        # This could be done in a single return / dictionary construction, but the following is
+        # more readable for those unfamiliar with the code, I think.
+        installed_products_map = dict()
+        for product_name, product_yaml in self.get_items():
+            installed_products_map[product_name] = parse_product_yaml(
+                label=f"'{product_name}' entry in {label}", yaml_string=product_yaml)
+        return installed_products_map
+
+    def get_installed_product_versions(self, requested_product_name: str) -> ProductVersionMap:
+        """
+        Returns just the specified product entry from the Cray Product Catalog configmap,
+        after parsing its YAML. Raises an exception if there are any problems.
+        Note that this will not examine other product entries in the configmap (if there
+        are any).
+        """
+        label = f"{K8S_NAMESPACE}/{K8S_CONFIG_MAP_NAME} Kubernetes configmap"
+        for product_name, product_yaml in self.get_items():
+            if product_name == requested_product_name:
+                return parse_product_yaml(label=f"'{requested_product_name}' entry in {label}",
+                                          yaml_string=product_yaml)
+        # Return an empty mapping if no versions are installed
+        return dict()
+
+    def get_installed_csm_versions(self) -> ProductVersionMap:
+        """
+        CSM-specific wrapper for get_installed_product_versions
+        """
+        return self.get_installed_product_versions("csm")
+
+    def get_latest_cfs_information(self, product_name: str) -> Dict[str, str]:
+        """
+        Returns the configuration data mapping from the latest installed version of the specified
+        product
+        """
+        label = (f"'{product_name}' entry in {K8S_NAMESPACE}/{K8S_CONFIG_MAP_NAME} "
+                 "Kubernetes configmap")
+        installed_version_map = self.get_installed_product_versions(
+            product_name)
+        latest_version_string = get_latest_version(installed_version_map)
+        try:
+            return installed_version_map[latest_version_string]["configuration"]
+        except KeyError as exc:
+            log_error_raise_exception(
+                f"No 'configuration' field found in {label}", exc)
+
+    def get_latest_csm_cfs_information(self) -> Dict[str, str]:
+        """
+        CSM-specific wrapper for get_latest_cfs_information
+        """
+        return self.get_latest_cfs_information("csm")

--- a/scripts/operations/configuration/python_lib/types.py
+++ b/scripts/operations/configuration/python_lib/types.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -23,7 +23,16 @@
 #
 """Shared Python function library: Type hints"""
 
-from typing import Any, Dict
+from typing import Any, Dict, Union
+
+from packaging.version import LegacyVersion, Version
+import simplejson.errors
 
 # A simplified type hint to use for JSON objects
 JSONObject = Dict[str, Any]
+
+# A generic version type that covers both Version and LegacyVersion
+GenericVersion = Union[LegacyVersion, Version]
+
+# So we can catch exceptions decoding JSON
+JSONDecodeError = simplejson.errors.JSONDecodeError

--- a/scripts/operations/configuration/python_lib/vault.py
+++ b/scripts/operations/configuration/python_lib/vault.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -27,25 +27,18 @@ import traceback
 
 import base64
 import logging
-import requests
-
-# So we can catch exceptions decoding JSON
-import simplejson.errors
 
 from . import api_requests
 from . import common
 from . import k8s
 
-from .types import JSONObject
+from .types import JSONDecodeError, JSONObject
 
 K8S_NAMESPACE = "vault"
 K8S_SECRET_NAME = "cray-vault-unseal-keys"
 K8S_SERVICE_NAME = "cray-vault"
 
 CSM_ROOT_SECRET_KEY = "csm/users/root"
-
-TOKEN_STRING = None
-API_URL = None
 
 API_STATUS_OK_WITH_DATA = 200
 API_STATUS_OK_EMPTY = 204
@@ -67,34 +60,36 @@ def log_error_raise_exception(msg: str, parent_exception: Exception = None) -> N
     raise common.ScriptException(msg) from parent_exception
 
 
-def get_token_string() -> str:
+def get_token_string(k8s_client: k8s.CoreV1API) -> str:
     """
     Retrieve the Vault Kubernetes secret, extract the token string from it,
     decode it from base-64, and return it as a string.
     """
-    global TOKEN_STRING
-    if TOKEN_STRING is None:
-        # Obtain Vault token string from Kubernetes secret
-        secret_label = f"{K8S_NAMESPACE}/{K8S_SECRET_NAME} Kubernetes secret"
-        logging.info(f"Getting Vault token from {secret_label}")
-        vault_secret = k8s.get_secret(
-            name=K8S_SECRET_NAME, namespace=K8S_NAMESPACE)
-        try:
-            encoded_vault_token = vault_secret.data["vault-root"]
-        except (AttributeError, KeyError, TypeError) as exc:
-            log_error_raise_exception(
-                f"{secret_label} has an unexpected format", exc)
-        # return decoded bytes as a string
-        try:
-            TOKEN_STRING = base64.standard_b64decode(
-                encoded_vault_token).decode()
-        except Exception as exc:
-            log_error_raise_exception(
-                f"Error decoding token in {secret_label}", exc)
-    return TOKEN_STRING
+    # Retrieve the Vault Kubernetes secret
+    secret_label = f"{K8S_NAMESPACE}/{K8S_SECRET_NAME} Kubernetes secret"
+    logging.debug("Getting Vault token from %s", secret_label)
+    vault_secret_data = k8s_client.get_secret_data(
+        name=K8S_SECRET_NAME, namespace=K8S_NAMESPACE)
+
+    # Extract the token string from it,
+    try:
+        encoded_vault_token = vault_secret_data["vault-root"]
+    except (KeyError, TypeError) as exc:
+        log_error_raise_exception(
+            f"{secret_label} has an unexpected format", exc)
+
+    # Decode it from base-64
+    try:
+        token_bytes = base64.standard_b64decode(encoded_vault_token)
+    except Exception as exc:
+        log_error_raise_exception(
+            f"Error decoding token in {secret_label}", exc)
+
+    # Return it as a string.
+    return token_bytes.decode()
 
 
-def get_api_url() -> str:
+def get_api_url(k8s_client: k8s.CoreV1API) -> str:
     """
     1. Looks up the vault/cray-vault service in Kubernetes
     2. Retrieves the cluster IP address of the service
@@ -102,50 +97,37 @@ def get_api_url() -> str:
     4. Finds the API port.
     5. Assembles the base URL for the Vault API
     """
-    global API_URL
-    if API_URL is None:
-        logging.debug("Finding Vault API URL")
-        service_label = f"{K8S_NAMESPACE}/{K8S_SERVICE_NAME} Kubernetes service"
-        vault_service = k8s.get_service(
-            name=K8S_SERVICE_NAME, namespace=K8S_NAMESPACE)
+    logging.debug("Finding Vault API URL")
+    service_label = f"{K8S_NAMESPACE}/{K8S_SERVICE_NAME} Kubernetes service"
+    vault_service = k8s_client.get_service(name=K8S_SERVICE_NAME, namespace=K8S_NAMESPACE)
 
-        try:
-            vault_ip = vault_service.spec.cluster_ip
-            for vault_port in vault_service.spec.ports:
-                if vault_port.name == 'http-api-port':
-                    API_URL = f"http://{vault_ip}:{vault_port.port}"
-                    break
-        except (AttributeError, KeyError, TypeError) as exc:
-            log_error_raise_exception(
-                f"{service_label} has an unexpected format", exc)
+    try:
+        vault_ip = vault_service.spec.cluster_ip
+        for vault_port in vault_service.spec.ports:
+            if vault_port.name == 'http-api-port':
+                api_url = f"http://{vault_ip}:{vault_port.port}"
+                logging.debug(f"API URL = {api_url}")
+                return api_url
+    except (AttributeError, KeyError, TypeError) as exc:
+        log_error_raise_exception(
+            f"{service_label} has an unexpected format", exc)
 
-        if API_URL is None:
-            log_error_raise_exception(
-                f"No 'http-api-port' port found for {service_label}")
-        logging.debug(f"API_URL = {API_URL}")
-    return API_URL
+    log_error_raise_exception(
+        f"No 'http-api-port' port found for {service_label}")
 
 
-def get_secret_api_url(secret_key: str) -> str:
-    """
-    Given the key for a Vault secret, returns the API URL for that secret.
-    Essentially this is just appending the secret key to the base API URL.
-    """
-    api_url_base = get_api_url()
-    return f"{api_url_base}/v1/secret/{secret_key}"
-
-
-def get_secret_data_from_response(api_response: requests.models.Response) -> JSONObject:
+def get_secret_data_from_response(api_response: api_requests.ApiResponse) -> JSONObject:
     """
     This is used to parse an API response to a Vault read request and extract the
     secret data (a JSON object). That data is returned. An exception is raised if
     anything goes wrong with this. The status code of the response is not validated.
     """
     if not api_response.text:
-        log_error_raise_exception("Vault response to read secret request has empty body")
+        log_error_raise_exception(
+            "Vault response to read secret request has empty body")
     try:
         resp_body = api_response.json()
-    except simplejson.errors.JSONDecodeError as exc:
+    except JSONDecodeError as exc:
         log_error_raise_exception(
             "Error decoding JSON in Vault response to read secret request", exc)
     try:
@@ -155,134 +137,153 @@ def get_secret_data_from_response(api_response: requests.models.Response) -> JSO
             "Vault response to read secret request is not in expected format", exc)
 
 
-def get_api_request_headers(additional_headers: JSONObject = None) -> JSONObject:
+class Vault():
     """
-    Return the headers to use for Vault API requests. If additional_headers are
-    provided, the function returns a dictionary of the default headers updated using
-    the additional headers.
-    """
-    default_headers = {"X-Vault-Request": "true", "X-Vault-Token": get_token_string()}
-    if additional_headers is None:
-        return default_headers
-    default_headers.update(additional_headers)
-    return default_headers
-
-
-def vault_api_delete(**kwargs) -> requests.models.Response:
-    """
-    Just a function wrapper to simplify making DELETE requests to Vault
-    using api_requests.retry_request_validate_status()
-    It specifies the request_method argument. If the caller
-    specifies headers, the default headers (from delete_api_request_headers())
-    will be updated with those values.
+    Used as an interface into Vault.
+    This object assumes that the Vault secret token is not
+    being changed over the lifetime of this object. If that becomes a problem, changes
+    will need to be made to handle it. The same is true of the service IP addresses and ports.
     """
 
-    # Get additional headers, if any, and remove them from the keyword arguments
-    additional_headers = kwargs.pop("headers", None)
-    # Generate request headers, combining additional ones, if any
-    request_headers = get_api_request_headers(additional_headers)
-    return api_requests.retry_request_validate_status(request_method=requests.delete,
-                                                      headers=request_headers, **kwargs)
+    def __init__(self, k8s_client: k8s.CoreV1API = None):
+        """
+        Obtains and stores the Vault token from the Kubernetes secret.
+        Obtains and stores the service IP address and port from Kubernetes, and saves
+        the API base URL constructed from them.
+        """
+        if k8s_client is None:
+            k8s_client = k8s.Client()
+        self.token_string = get_token_string(k8s_client)
+        self.api_url = get_api_url(k8s_client)
 
+    def get_secret_api_url(self, secret_key: str) -> str:
+        """
+        Given the key for a Vault secret, returns the API URL for that secret.
+        Essentially this is just appending the secret key to the base API URL.
+        """
+        return f"{self.api_url}/v1/secret/{secret_key}"
 
-def vault_api_get(**kwargs) -> requests.models.Response:
-    """
-    Just a function wrapper to simplify making GET requests to Vault
-    using api_requests.retry_request_validate_status()
-    It specifies the request_method argument. If the caller
-    specifies headers, the default headers (from get_api_request_headers())
-    will be updated with those values.
-    """
+    def get_api_request_headers(self, additional_headers: JSONObject = None) -> JSONObject:
+        """
+        Return the headers to use for Vault API requests. If additional_headers are
+        provided, the function returns a dictionary of the default headers updated using
+        the additional headers.
+        """
+        headers = {"X-Vault-Request": "true",
+                   "X-Vault-Token": self.token_string}
+        if additional_headers is not None:
+            headers.update(additional_headers)
+        return headers
 
-    # Get additional headers, if any, and remove them from the keyword arguments
-    additional_headers = kwargs.pop("headers", None)
-    # Generate request headers, combining additional ones, if any
-    request_headers = get_api_request_headers(additional_headers)
-    return api_requests.retry_request_validate_status(request_method=requests.get,
-                                                      headers=request_headers, **kwargs)
+    def api_delete(self, **kwargs) -> api_requests.ApiResponse:
+        """
+        Just a function wrapper to simplify making DELETE requests to Vault
+        using api_requests.retry_request_validate_status()
+        It specifies the request_method argument. If the caller
+        specifies headers, the default headers (from delete_api_request_headers())
+        will be updated with those values.
+        """
 
+        # Get additional headers, if any, and remove them from the keyword arguments
+        additional_headers = kwargs.pop("headers", None)
+        # Generate request headers, combining additional ones, if any
+        request_headers = self.get_api_request_headers(additional_headers)
+        return api_requests.delete_retry_validate(headers=request_headers, **kwargs)
 
-def vault_api_post(**kwargs) -> requests.models.Response:
-    """
-    Just a function wrapper to simplify making POST requests to Vault
-    using api_requests.retry_request_validate_status()
-    It specifies the request_method argument. If the caller
-    specifies headers, the default headers (from post_api_request_headers())
-    will be updated with those values.
-    """
+    def api_get(self, **kwargs) -> api_requests.ApiResponse:
+        """
+        Just a function wrapper to simplify making GET requests to Vault
+        using api_requests.retry_request_validate_status()
+        It specifies the request_method argument. If the caller
+        specifies headers, the default headers (from get_api_request_headers())
+        will be updated with those values.
+        """
 
-    # Get additional headers, if any, and remove them from the keyword arguments
-    additional_headers = kwargs.pop("headers", None)
-    # Generate request headers, combining additional ones, if any
-    request_headers = get_api_request_headers(additional_headers)
-    return api_requests.retry_request_validate_status(request_method=requests.post,
-                                                      headers=request_headers, **kwargs)
+        # Get additional headers, if any, and remove them from the keyword arguments
+        additional_headers = kwargs.pop("headers", None)
+        # Generate request headers, combining additional ones, if any
+        request_headers = self.get_api_request_headers(additional_headers)
+        return api_requests.get_retry_validate(headers=request_headers, **kwargs)
 
+    def api_post(self, **kwargs) -> api_requests.ApiResponse:
+        """
+        Just a function wrapper to simplify making POST requests to Vault
+        using api_requests.retry_request_validate_status()
+        It specifies the request_method argument. If the caller
+        specifies headers, the default headers (from post_api_request_headers())
+        will be updated with those values.
+        """
 
-def delete_secret(secret_key: str) -> None:
-    """
-    Deletes the specified secret key from Vault. This is also required in the case where the last
-    field of data in a secret is being removed, because Vault does not allow for empty secrets.
-    Raises an exception if anything goes wrong.
-    """
-    secret_url = get_secret_api_url(secret_key)
-    logging.debug(f"{secret_key} secret URL = {secret_url}")
-    logging.debug(f"Deleting {secret_key} secret from Vault")
-    vault_api_delete(url=secret_url, expected_status_codes=API_STATUS_OK_EMPTY)
+        # Get additional headers, if any, and remove them from the keyword arguments
+        additional_headers = kwargs.pop("headers", None)
+        # Generate request headers, combining additional ones, if any
+        request_headers = self.get_api_request_headers(additional_headers)
+        return api_requests.post_retry_validate(headers=request_headers, **kwargs)
 
+    def delete_secret(self, secret_key: str) -> None:
+        """
+        Deletes the specified secret key from Vault. This is also required in the case where the
+        last field of data in a secret is being removed, because Vault does not allow for empty
+        secrets.
+        Raises an exception if anything goes wrong.
+        """
+        secret_url = self.get_secret_api_url(secret_key)
+        logging.debug(f"{secret_key} secret URL = {secret_url}")
+        logging.debug(f"Deleting {secret_key} secret from Vault")
+        self.api_delete(
+            url=secret_url, expected_status_codes=API_STATUS_OK_EMPTY)
 
-def get_secret(secret_key: str, must_exist: bool = False) -> JSONObject:
-    """
-    Retrieves the Vault secret with the specified key and returns its contents.
-    The must_exist argument governs whether a 404 response status code results
-    in an exception or not. If must_exist is False and the response is 404, then
-    None is returned.
-    An exception is raised if any problems occur
-    """
-    secret_url = get_secret_api_url(secret_key)
-    logging.debug(f"{secret_key} secret URL = {secret_url}")
-    if must_exist:
-        expected_status_codes = {API_STATUS_OK_WITH_DATA}
-    else:
-        expected_status_codes = {API_STATUS_OK_WITH_DATA, API_STATUS_NOT_FOUND}
+    def get_secret(self, secret_key: str, must_exist: bool = False) -> JSONObject:
+        """
+        Retrieves the Vault secret with the specified key and returns its contents.
+        The must_exist argument governs whether a 404 response status code results
+        in an exception or not. If must_exist is False and the response is 404, then
+        None is returned.
+        An exception is raised if any problems occur
+        """
+        secret_url = self.get_secret_api_url(secret_key)
+        logging.debug(f"{secret_key} secret URL = {secret_url}")
+        if must_exist:
+            expected_status_codes = {API_STATUS_OK_WITH_DATA}
+        else:
+            expected_status_codes = {
+                API_STATUS_OK_WITH_DATA, API_STATUS_NOT_FOUND}
 
-    logging.debug(f"Reading {secret_key} secret from Vault")
-    resp = vault_api_get(url=secret_url, expected_status_codes=expected_status_codes)
-    if resp.status_code == API_STATUS_NOT_FOUND:
-        # Since an exception was not raised, this must mean we are in the case where this is okay.
-        # So return None.
-        return None
-    # Return the secret data from the response
-    return get_secret_data_from_response(resp)
+        logging.debug(f"Reading {secret_key} secret from Vault")
+        resp = self.api_get(
+            url=secret_url, expected_status_codes=expected_status_codes)
+        if resp.status_code == API_STATUS_NOT_FOUND:
+            # Since an exception was not raised, this must mean we are in the case where
+            #  this is okay. So return None.
+            return None
+        # Return the secret data from the response
+        return get_secret_data_from_response(resp)
 
+    def write_secret(self, secret_key: str, secret_data: JSONObject) -> None:
+        """
+        Writes the specified secret data to Vault using the specified secret key.
+        Raises an exception if anything goes wrong.
+        """
+        secret_url = self.get_secret_api_url(secret_key)
+        logging.debug(f"{secret_key} secret URL = {secret_url}")
+        logging.debug(f"Writing {secret_key} secret to Vault")
+        self.api_post(
+            url=secret_url, expected_status_codes=API_STATUS_OK_EMPTY, json=secret_data)
 
-def write_secret(secret_key: str, secret_data: JSONObject) -> None:
-    """
-    Writes the specified secret data to Vault using the specified secret key.
-    Raises an exception if anything goes wrong.
-    """
-    secret_url = get_secret_api_url(secret_key)
-    logging.debug(f"{secret_key} secret URL = {secret_url}")
-    logging.debug(f"Writing {secret_key} secret to Vault")
-    vault_api_post(url=secret_url, expected_status_codes=API_STATUS_OK_EMPTY, json=secret_data)
+    def delete_csm_root_secret(self, **kwargs) -> None:
+        """
+        Wrapper function that supplies the CSM root secret key to delete_secret()
+        """
+        self.delete_secret(secret_key=CSM_ROOT_SECRET_KEY)
 
+    def get_csm_root_secret(self, **kwargs) -> JSONObject:
+        """
+        Wrapper function that supplies the CSM root secret key to get_secret()
+        """
+        return self.get_secret(secret_key=CSM_ROOT_SECRET_KEY, **kwargs)
 
-def delete_csm_root_secret(**kwargs) -> None:
-    """
-    Wrapper function that supplies the CSM root secret key to delete_secret()
-    """
-    delete_secret(secret_key=CSM_ROOT_SECRET_KEY, **kwargs)
-
-
-def get_csm_root_secret(**kwargs) -> JSONObject:
-    """
-    Wrapper function that supplies the CSM root secret key to get_secret()
-    """
-    return get_secret(secret_key=CSM_ROOT_SECRET_KEY, **kwargs)
-
-
-def write_csm_root_secret(**kwargs) -> None:
-    """
-    Wrapper function that supplies the CSM root secret key to write_secret()
-    """
-    write_secret(secret_key=CSM_ROOT_SECRET_KEY, **kwargs)
+    def write_csm_root_secret(self, **kwargs) -> None:
+        """
+        Wrapper function that supplies the CSM root secret key to write_secret()
+        """
+        self.write_secret(secret_key=CSM_ROOT_SECRET_KEY, **kwargs)

--- a/scripts/operations/configuration/python_lib/vcs.py
+++ b/scripts/operations/configuration/python_lib/vcs.py
@@ -1,0 +1,87 @@
+#
+# MIT License
+#
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""Shared Python function library: VCS"""
+
+import traceback
+
+import base64
+import logging
+
+from typing import Tuple
+
+from . import common
+from . import k8s
+
+
+K8S_NAMESPACE = "services"
+K8S_SECRET_NAME = "vcs-user-credentials"
+
+
+def log_error_raise_exception(msg: str, parent_exception: Exception = None) -> None:
+    """
+    1) If a parent exception is passed in, make a debug log entry with its stack trace.
+    2) Log an error with the specified message.
+    3) Raise a ScriptException with the specified message (from the parent exception, if
+       specified)
+    """
+    if parent_exception is not None:
+        logging.debug(traceback.format_exc())
+    logging.error(msg)
+    if parent_exception is None:
+        raise common.ScriptException(msg)
+    raise common.ScriptException(msg) from parent_exception
+
+
+def get_vcs_credentials(k8s_client: k8s.CoreV1API = None) -> Tuple[str, str]:
+    """
+    Retrieve and decode the vcs_username and vcs_password from the VCS Kubernetes secret
+    """
+    if k8s_client is None:
+        k8s_client = k8s.Client()
+    secret_label = f"{K8S_NAMESPACE}/{K8S_SECRET_NAME} Kubernetes secret"
+    vcs_secret = k8s_client.get_secret(
+        name=K8S_SECRET_NAME, namespace=K8S_NAMESPACE)
+    try:
+        vcs_secret_data = vcs_secret.data
+    except AttributeError as exc:
+        log_error_raise_exception(
+            f"{secret_label} has an unexpected format", exc)
+    try:
+        encoded_username = vcs_secret_data["vcs_username"]
+        logging.debug("Encoded VCS username obtained")
+        encoded_password = vcs_secret_data["vcs_password"]
+        logging.debug("Encoded VCS password obtained")
+    except (KeyError, TypeError) as exc:
+        log_error_raise_exception(
+            f"{secret_label} has an unexpected format", exc)
+    # decode bytes to strings
+    try:
+        decoded_username = base64.standard_b64decode(encoded_username).decode()
+        logging.debug("VCS username decoded")
+        decoded_password = base64.standard_b64decode(encoded_password).decode()
+        logging.debug("VCS password decoded")
+    except Exception as exc:
+        log_error_raise_exception(
+            f"Error decoding credentials in {secret_label}", exc)
+    return decoded_username, decoded_password


### PR DESCRIPTION
# Description

Changes to enable upcoming work in [CASM-3714](https://jira-pro.its.hpecorp.net:8443/browse/CASM-3714)

- Refactor some of the modules in `scripts/operations/configuration/python_lib`
- Add modules to obtain VCS credentials and to query the Cray product catalog configmap in Kubernetes

I tested this on frigg.
I regression tested by testing the `write_root_secrets_to_vault.py` script.
I tested the new features at the interactive console and verified that they worked as expected.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
