### PR TITLE
CASMCMS-8335: Update CFS documentation to reflect container/layer changes

### DIFF
--- a/operations/configuration_management/Ansible_Execution_Environments.md
+++ b/operations/configuration_management/Ansible_Execution_Environments.md
@@ -1,8 +1,8 @@
 # Ansible Execution Environments
 
-Configuration Framework Service \(CFS\) sessions are comprised of a single Kubernetes pod with several containers. Inventory and Git clone setup containers run first, and a teardown container runs last \(if the session is running an image customization\).
+Configuration Framework Service \(CFS\) sessions are comprised of a single Kubernetes pod with several containers. The `inventory` and `git-clone` containers run first, and a `teardown` container runs last \(if the session is running an image customization\).
 
-The containers that run the Ansible code cloned from the Git repositories in the configuration layers are Ansible Execution Environments \(AEE\). The AEE is provided as a SLES-based docker image, which includes Ansible version 2.9.11 installed using Python 3.6. In addition to the base Ansible installation, CFS also includes several Ansible modules and plug-ins that are required for CFS and Ansible to work properly on the system.
+The container that runs the Ansible code cloned from the Git repositories in the configuration layers is the  Ansible Execution Environments \(AEE\). The AEE is provided as a SLES-based docker image, which includes Ansible version 2.9.11 installed using Python 3.6. In addition to the base Ansible installation, CFS also includes several Ansible modules and plug-ins that are required for CFS and Ansible to work properly on the system.
 
 The following modules and plug-ins are available:
 

--- a/operations/configuration_management/Ansible_Execution_Environments.md
+++ b/operations/configuration_management/Ansible_Execution_Environments.md
@@ -2,7 +2,7 @@
 
 Configuration Framework Service \(CFS\) sessions are comprised of a single Kubernetes pod with several containers. The `inventory` and `git-clone` containers run first, and a `teardown` container runs last \(if the session is running an image customization\).
 
-The container that runs the Ansible code cloned from the Git repositories in the configuration layers is the  Ansible Execution Environments \(AEE\).
+The container that runs the Ansible code cloned from the Git repositories in the configuration layers is the Ansible Execution Environments \(AEE\).
 The AEE is provided as a SLES-based docker image, which includes Ansible version 2.9.11 installed using Python 3.6.
 In addition to the base Ansible installation, CFS also includes several Ansible modules and plug-ins that are required for CFS and Ansible to work properly on the system.
 

--- a/operations/configuration_management/Ansible_Execution_Environments.md
+++ b/operations/configuration_management/Ansible_Execution_Environments.md
@@ -2,7 +2,9 @@
 
 Configuration Framework Service \(CFS\) sessions are comprised of a single Kubernetes pod with several containers. The `inventory` and `git-clone` containers run first, and a `teardown` container runs last \(if the session is running an image customization\).
 
-The container that runs the Ansible code cloned from the Git repositories in the configuration layers is the  Ansible Execution Environments \(AEE\). The AEE is provided as a SLES-based docker image, which includes Ansible version 2.9.11 installed using Python 3.6. In addition to the base Ansible installation, CFS also includes several Ansible modules and plug-ins that are required for CFS and Ansible to work properly on the system.
+The container that runs the Ansible code cloned from the Git repositories in the configuration layers is the  Ansible Execution Environments \(AEE\).
+The AEE is provided as a SLES-based docker image, which includes Ansible version 2.9.11 installed using Python 3.6.
+In addition to the base Ansible installation, CFS also includes several Ansible modules and plug-ins that are required for CFS and Ansible to work properly on the system.
 
 The following modules and plug-ins are available:
 
@@ -20,7 +22,7 @@ The following modules and plug-ins are available:
 
 * **`shasta_s3_cred.py` Module**
 
-  This module is provided to obtain access to S3 credentials stored in Kubernetes secrets in the cluster, specifically secrets with names such as <service\>-s3-credentials.
+  This module is provided to obtain access to S3 credentials stored in Kubernetes secrets in the cluster, specifically secrets with names such as `<service\>-s3-credentials`.
 
   An example of using this module is as follows:
 
@@ -33,5 +35,4 @@ The following modules and plug-ins are available:
     no_log: true
   ```
 
-  The access key is available at "\{\{ creds.access\_key \}\}" and the secret key is at "\{\{ creds.secret\_key \}\}".
-
+  The access key is available at `\{\{ creds.access\_key \}\}` and the secret key is at `\{\{ creds.secret\_key \}\}`.

--- a/operations/configuration_management/Configuration_Sessions.md
+++ b/operations/configuration_management/Configuration_Sessions.md
@@ -2,9 +2,13 @@
 
 Once configurations have been created with the required layers and values set in the configuration repositories \(or the additional inventory repository\), create a Configuration Framework Session \(CFS\) session to apply the configuration to the targets.
 
-Sessions are created via the Cray CLI or through the CFS REST API. A session stages Ansible inventory \(whether dynamic, static, or image customization\), launches Ansible Execution Environments \(AEE\) in order for each configuration layer in the service mesh, tears down the environments as required, and reports the session status to the CFS API.
+Sessions are created via the Cray CLI or through the CFS REST API.
+A session stages Ansible inventory \(whether dynamic, static, or image customization\), launches Ansible Execution Environments \(AEE\) in order for each configuration layer in the service mesh,
+tears down the environments as required, and reports the session status to the CFS API.
 
-When a session target is an Image Management Service \(IMS\) image ID for the purposes of pre-boot image customization, the CFS session workflow varies slightly. The inventory staging instead calls IMS to expose the requested image root\(s\) via SSH. After the AEE\(s\) finish applying the configuration layers, CFS then instructs IMS to tear down the image root environment and package up the resultant image and records the new image ID in the session metadata.
+When a session target is an Image Management Service \(IMS\) image ID for the purposes of pre-boot image customization, the CFS session workflow varies slightly.
+The inventory staging instead calls IMS to expose the requested image root\(s\) via SSH. After the AEE\(s\) finish applying the configuration layers,
+CFS then instructs IMS to tear down the image root environment and package up the resultant image and records the new image ID in the session metadata.
 
 ## Session Naming Conventions
 
@@ -22,7 +26,7 @@ will be set to `true`, `false`, or `unknown` in the event that CFS was unable to
 job associated with the session.
 * `--min-age`/`--max-age`: Returns only the sessions that fall within the given age. For example,
 `--max-age` could be used to list only the recent sessions, or `--min-age` could be used to find old sessions
-for cleanup. Age is given in the format "1d" for days, or "6h" for hours.
+for cleanup. Age is given in the format `1d` for days, or `6h` for hours.
 * `--tags`: Sessions can be created with searchable tags. By default, this includes the
 `bos_session` tag when CFS is triggered by BOS. This can be searched using the following command:
 
@@ -36,7 +40,8 @@ CFS progresses through a session by running a series of commands in containers l
 
 * **`git-clone`**
 
-  This init container is responsible for cloning the configuration repositories and checking out the branch/commit specified in each configuration layer. This init container also clones the repository specified in the parameter `additionalInventoryUrl`, if specified.
+  This `init` container is responsible for cloning the configuration repositories and checking out the branch/commit specified in each configuration layer.
+  This `init` container also clones the repository specified in the parameter `additionalInventoryUrl`, if specified.
 
 * **`inventory`**
 
@@ -49,4 +54,3 @@ CFS progresses through a session by running a series of commands in containers l
 * **`teardown`**
 
   This container waits for the `ansible` to complete and subsequently calls IMS to package up customized image roots. The container only exists when the session `--target-definition` is `image`.
-

--- a/operations/configuration_management/Configuration_Sessions.md
+++ b/operations/configuration_management/Configuration_Sessions.md
@@ -34,27 +34,19 @@ for cleanup. Age is given in the format "1d" for days, or "6h" for hours.
 
 CFS progresses through a session by running a series of commands in containers located in a Kubernetes job pod. Four container types are present in the job pod which pertain to CFS session setup, execution, and teardown:
 
-* **`git-clone-*`**
+* **`git-clone`**
 
-  These init containers are responsible for cloning the configuration repository and checking out the branch/commit specified in each configuration layer.
-
-  These containers are run in the same order as the layers are specified, and their names are indexed appropriately: `git-clone-0`, `git-clone-1`, and so on.
-
-* **`git-clone-hosts`**
-
-  This init container clones the repository specified in the parameter `additionalInventoryUrl`, if specified.
+  This init container is responsible for cloning the configuration repositories and checking out the branch/commit specified in each configuration layer. This init container also clones the repository specified in the parameter `additionalInventoryUrl`, if specified.
 
 * **`inventory`**
 
   This container is responsible for generating the dynamic inventory or for communicating to IMS to stage boot image roots that need to be made available via SSH when the session `--target-definition` is `image`.
 
-* **`ansible-*`**
+* **`ansible`**
 
-  These containers run the AEE after CFS injects the inventory and Git repository content from previous containers. One container is executed for each configuration layer specified.
-
-  These containers are run in the same order as the layers are specified, and their names are indexed appropriately: `ansible-0`, `ansible-1`, and so on.
+  This container runs the AEE after CFS injects the inventory and Git repository content from previous containers. This container runs the Ansible configuration for each layer specified.
 
 * **`teardown`**
 
-  This container waits for the last `ansible-*` to complete and subsequently calls IMS to package up customized image roots. The container only exists when the session `--target-definition` is `image`.
+  This container waits for the `ansible` to complete and subsequently calls IMS to package up customized image roots. The container only exists when the session `--target-definition` is `image`.
 

--- a/operations/configuration_management/Troubleshoot_Ansible_Play_Failures_in_CFS_Sessions.md
+++ b/operations/configuration_management/Troubleshoot_Ansible_Play_Failures_in_CFS_Sessions.md
@@ -42,19 +42,19 @@ Use this procedure to obtain important triage information for Ansible plays bein
     Example output:
 
     ```text
-    Error from server (BadRequest): a container name must be specified for pod cfs-e8e48c2a-448f-4e6b-86fa-dae534b1702e-pnxmn, choose one of: [inventory ansible-0 istio-proxy] or one of the init containers: [git-clone-0 istio-init]
+    Error from server (BadRequest): a container name must be specified for pod cfs-e8e48c2a-448f-4e6b-86fa-dae534b1702e-pnxmn, choose one of: [inventory ansible istio-proxy] or one of the init containers: [git-clone istio-init]
     ```
 
     Issues rarely occur in the `istio-init` and `istio-proxy` containers. These containers can be ignored for now.
 
-1. (`ncn-mw#`) Check the `git-clone-0`, `inventory`, and `ansible-0` containers, in that order.
+1. (`ncn-mw#`) Check the `git-clone`, `inventory`, and `ansible` containers, in that order.
 
     > If there are additional Ansible pods, examine those as well, in ascending order.
 
-    1. Check the `git-clone-0` container.
+    1. Check the `git-clone` container.
 
         ```bash
-        kubectl logs -n services "${CFS_POD_NAME}" git-clone-0
+        kubectl logs -n services "${CFS_POD_NAME}" git-clone
         ```
 
     1. Check the `inventory` container.
@@ -88,14 +88,14 @@ Use this procedure to obtain important triage information for Ansible plays bein
         2019-12-05 15:00:12,227 - INFO    - cray.cfs.inventory - Writing out the inventory to /inventory/hosts
         ```
 
-    1. Check the `ansible-0` container.
+    1. Check the `ansible` container.
 
         Look towards the end of the Ansible log in the `PLAY RECAP` section to see if any targets failed.
         If a target failed, then look above in the log at the immediately preceding play.
         In the example below, the `ncmp_hsn_cns` role has an issue when being run against the compute nodes.
 
         ```bash
-        kubectl logs -n services "${CFS_POD_NAME}" ansible-0
+        kubectl logs -n services "${CFS_POD_NAME}" ansible
         ```
 
         Example output:

--- a/operations/configuration_management/View_Configuration_Session_Logs.md
+++ b/operations/configuration_management/View_Configuration_Session_Logs.md
@@ -39,14 +39,10 @@ To view the logs of the various containers:
 kubectl logs -n services ${CFS_POD_NAME} -c ${CONTAINER_NAME}
 ```
 
-The `${CONTAINER_NAME}` value is one of the containers mentioned in [Configuration Sessions](Configuration_Sessions.md). Depending on the number of configuration layers in the
-session, some sessions will have more containers available. Use the `-f` option in the previous command to follow the logs if the session is still running.
-
-To view the Ansible logs, determine which configuration layer's logs to view from the order of the configuration set in the session. For example, if it is the first layer,
-then the `${CONTAINER_NAME}` will be `ansible-0`.
+The `${CONTAINER_NAME}` value is one of the containers mentioned in [Configuration Sessions](Configuration_Sessions.md). To view the Ansible logs, the `${CONTAINER_NAME}` will be `ansible`.
 
 ```bash
-kubectl logs -n services ${CFS_POD_NAME} -c ansible-0
+kubectl logs -n services ${CFS_POD_NAME} -c ansible
 ```
 
-The `git-clone-#` and `ansible-#` containers may not start at 0 and may not be numbered sequentially if the session was created with the `--configuration-limit` option.
+Use the `-f` option with the previous command to follow the logs if the session is still running.

--- a/operations/power_management/Power_On_and_Boot_Compute_Nodes_and_User_Access_Nodes.md
+++ b/operations/power_management/Power_On_and_Boot_Compute_Nodes_and_User_Access_Nodes.md
@@ -60,18 +60,10 @@ This procedure boots all compute nodes and user access nodes \(UANs\) in the con
 
         CFS sessions which are in `Not Ready` status are still in progress. CFS sessions with status `Error` had a failure in one of the layers.
 
-    1. Inspect all layers of Ansible configuration to find a failed layer.
+    1. Inspect the Ansible logs to find a failed layer.
 
         ```bash
-        kubectl logs -f -n services cfs-51a7665d-l63d-41ab-e93e-796d5cb7b823-czkhk ansible-0
-        kubectl logs -f -n services cfs-51a7665d-l63d-41ab-e93e-796d5cb7b823-czkhk ansible-1
-        kubectl logs -f -n services cfs-51a7665d-l63d-41ab-e93e-796d5cb7b823-czkhk ansible-2
-        kubectl logs -f -n services cfs-51a7665d-l63d-41ab-e93e-796d5cb7b823-czkhk ansible-3
-        kubectl logs -f -n services cfs-51a7665d-l63d-41ab-e93e-796d5cb7b823-czkhk ansible-4
-        kubectl logs -f -n services cfs-51a7665d-l63d-41ab-e93e-796d5cb7b823-czkhk ansible-5
-        kubectl logs -f -n services cfs-51a7665d-l63d-41ab-e93e-796d5cb7b823-czkhk ansible-6
-        kubectl logs -f -n services cfs-51a7665d-l63d-41ab-e93e-796d5cb7b823-czkhk ansible-7
-        kubectl logs -f -n services cfs-51a7665d-l63d-41ab-e93e-796d5cb7b823-czkhk ansible-8
+        kubectl logs -f -n services cfs-51a7665d-l63d-41ab-e93e-796d5cb7b823-czkhk ansible
         ```
 
 1. (`ncn-m001#`) Check that the slingshot switches are all online.


### PR DESCRIPTION
# Description

Updates the CFS docs to reflect a 1.3.1 change to collapse all configuration layers into a single container.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.