### PR TITLE
(CSM 1.2.2) CASMHMS-5866: Updates to the SLS and HSM postgres restore procedures.

### DIFF
--- a/operations/hardware_state_manager/Restore_HSM_Postgres_from_Backup.md
+++ b/operations/hardware_state_manager/Restore_HSM_Postgres_from_Backup.md
@@ -399,7 +399,7 @@ automatic backup created by the `cray-smd-postgresql-db-backup` Kubernetes cronj
     [Troubleshoot Issues with Redfish Endpoint Discovery](../node_management/Troubleshoot_Issues_with_Redfish_Endpoint_Discovery.md) procedure for guidance.
 
 17. **Perform this step only if the system has Intel management NCNs, otherwise for HPE or Gigabyte management NCNs skip this step.** Due to known firmware issues on Intel BMCs they do not report the MAC addresses of the management NICs via Redfish, and
-    when the BMC is discovered after restoring from a Postgres backup the management NIC MACs in HSM will have an empty component id. The following script will correct any Ethernet Interfaces for a Intel management NCN without a component ID.
+    when the BMC is discovered after restoring from a Postgres backup the management NIC MACs in HSM will have an empty component ID. The following script will correct any Ethernet Interfaces for a Intel management NCN without a component ID.
 
     ```bash
     ncn# \

--- a/operations/system_layout_service/Restore_SLS_Postgres_Database_from_Backup.md
+++ b/operations/system_layout_service/Restore_SLS_Postgres_Database_from_Backup.md
@@ -172,7 +172,7 @@ by the `cray-sls-postgresql-db-backup` Kubernetes cronjob.
     If there are issues with `verify_hsm_discovery.py`, then follow the "Interpreting HSM discovery results" section of the [Validate CSM Health document](../validate_csm_health.md#221-interpreting-hsm-discovery-results).
 
     ```bash
-    ncn# /opt/cray/csm/scripts/hms_verification/run_hms_ct_tests.sh -t sls
+    ncn# /opt/cray/tests/ncn-smoke/hms/hms-sls/sls_smoke_test_ncn-smoke.sh
     ncn# /opt/cray/platform-utils/ncnPostgresHealthChecks.sh
     ncn# /opt/cray/csm/scripts/hms_verification/verify_hsm_discovery.py
     ```


### PR DESCRIPTION
# Description

- SLS Postgres restore procedure
  - Use correct CT test command for SLS.

- HSM Postgres restore procedure
  - Wrong command prompt of ncn-w001# replaced with ncn#
  - Changed the set of commands used to populate the database to one that is compatible with files with colons in the file name
  - Added a WAR for properly repopulated ethernet interfaces for Intel Management NCNs.
  

Tested on Fanta with CSM 1.2.2
# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
