### PR TITLE
CASMINST-5696: Adding noarch to the docs-csm-latest rpm name

### DIFF
--- a/update_product_stream/README.md
+++ b/update_product_stream/README.md
@@ -128,13 +128,13 @@ Acquire the latest documentation RPM. This may include updates, corrections, and
 1. Download and upgrade the latest documentation RPM.
 
    ```bash
-   rpm -Uvh --force https://release.algol60.net/csm-1.3/docs-csm/docs-csm-latest.rpm
+   rpm -Uvh --force https://release.algol60.net/csm-1.3/docs-csm/docs-csm-latest.noarch.rpm
    ```
 
    If this machine does not have direct internet access, then this RPM will need to be externally downloaded and copied to the system. This example copies it to `ncn-m001`.
 
    ```bash
-   wget https://release.algol60.net/csm-1.3/docs-csm/docs-csm-latest.rpm -O docs-csm-latest.noarch.rpm
+   wget https://release.algol60.net/csm-1.3/docs-csm/docs-csm-latest.noarch.rpm -O docs-csm-latest.noarch.rpm
    scp docs-csm-latest.noarch.rpm ncn-m001:/root
    ssh ncn-m001
    rpm -Uvh --force /root/docs-csm-latest.noarch.rpm

--- a/upgrade/Stage_0_Prerequisites.md
+++ b/upgrade/Stage_0_Prerequisites.md
@@ -51,7 +51,7 @@ after a break, always be sure that a typescript is running before proceeding.
       > **Important:** The upgrade scripts expect the `docs-csm` RPM to be located at `/root/docs-csm-latest.noarch.rpm`; that is why these commands copy it there.
 
       ```bash
-      wget https://release.algol60.net/csm-1.3/docs-csm/docs-csm-latest.rpm \
+      wget https://release.algol60.net/csm-1.3/docs-csm/docs-csm-latest.noarch.rpm \
           -O /root/docs-csm-latest.noarch.rpm &&
       rpm -Uvh --force /root/docs-csm-latest.noarch.rpm
       ```


### PR DESCRIPTION
# Description

The link for the latest docs-csm rpm was changed last night to add in the "noarch" architecture.  Updating the docs accordingly.

# Checklist Before Merging

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
