### PR TITLE
CASMINST-5689 Remove local-path field from operations in Stages.yaml

### DIFF
--- a/workflows/iuf/stages.yaml
+++ b/workflows/iuf/stages.yaml
@@ -28,101 +28,82 @@ stages:
     type: global
     operations:
       - name: extract-release-distributions
-        local-path: operations/extract-release-distributions.yaml # this is relative to stages.yaml, which is contained in workflows/iuf/ in docs-csm
         static-parameters: {} # any parameters that will be supplied statically to this operation.
 
   - name: pre-install-check
     type: global
     operations:
       - name: preflight-checks-for-services
-        local-path: operations/preflight-checks-for-services.yaml # this is relative to stages.yaml, which is contained in workflows/iuf/ in docs-csm
         static-parameters: {} # any parameters that will be supplied statically to this operation.
 
   - name: deliver-product
     type: product
     operations:
       - name: loftsman-manifest-upload
-        local-path: operations/loftsman-manifest-upload.yaml # this is relative to stages.yaml, which is contained in workflows/iuf/ in docs-csm
         static-parameters: {} # any parameters that will be supplied statically to this operation.
       - name: s3-upload
-        local-path: operations/s3-upload.yaml # this is relative to stages.yaml, which is contained in workflows/iuf/ in docs-csm
         static-parameters: {} # any parameters that will be supplied statically to this operation.
       - name: nexus-setup
-        local-path: operations/nexus-setup/nexus-setup-template.yaml # this is relative to stages.yaml, which is contained in workflows/iuf/ in docs-csm
         static-parameters: # any parameters that will be supplied statically to this operation.
           nexus-setup-image: artifactory.algol60.net/csm-docker/unstable/cray-nexus-setup:0.8.0-20221021164623-e8d3d3d
       - name: nexus-rpm-upload
-        local-path: operations/nexus-setup/nexus-rpm-upload.yaml # this is relative to stages.yaml, which is contained in workflows/iuf/ in docs-csm
         static-parameters: {} # any parameters that will be supplied statically to this operation.
       - name: nexus-docker-upload
-        local-path: operations/nexus-setup/nexus-docker-upload.yaml # this is relative to stages.yaml, which is contained in workflows/iuf/ in docs-csm
         static-parameters: {} # any parameters that will be supplied statically to this operation.
       - name: nexus-helm-upload
-        local-path: operations/nexus-setup/nexus-helm-upload.yaml # this is relative to stages.yaml, which is contained in workflows/iuf/ in docs-csm
         static-parameters: {} # any parameters that will be supplied statically to this operation.
       - name: vcs-upload
-        local-path: operations/vcs-upload/vcs-upload-content.yaml # this is relative to stages.yaml, which is contained in workflows/iuf/ in docs-csm
         static-parameters: {} # any parameters that will be supplied statically to this operation.
       - name: ims-upload
-        local-path: operations/ims-upload.yaml # this is relative to stages.yaml, which is contained in workflows/iuf/ in docs-csm
         static-parameters: {} # any parameters that will be supplied statically to this operation.
 
   - name: update-vcs-config
     type: product
     operations:
       - name: update-working-branch
-        local-path: operations/update-working-branch.yaml # this is relative to stages.yaml, which is contained in workflows/iuf/ in docs-csm
         static-parameters: {} # any parameters that will be supplied statically to this operation.
 
   - name: update-cfs-config
     type: global
     operations:
       - name: update-cfs-config
-        local-path: operations/update-cfs-config.yaml # this is relative to stages.yaml, which is contained in workflows/iuf/ in docs-csm
         static-parameters: {} # any parameters that will be supplied statically to this operation.
 
   - name: deploy-product
     type: product
     operations:
       - name: loftsman-manifest-deploy
-        local-path: operations/loftsman-manifest-deploy.yaml # this is relative to stages.yaml, which is contained in workflows/iuf/ in docs-csm
         static-parameters: {} # any parameters that will be supplied statically to this operation.
       - name: set-product-active
-        local-path: operations/set-product-active.yaml # this is relative to stages.yaml, which is contained in workflows/iuf/ in docs-csm
         static-parameters: {} # any parameters that will be supplied statically to this operation.
 
   - name: prepare-images
     type: global
     operations:
       - name: prepare-images
-        local-path: operations/prepare-images.yaml # this is relative to stages.yaml, which is contained in workflows/iuf/ in docs-csm
         static-parameters: {} # any parameters that will be supplied statically to this operation.
 
   - name: management-nodes-rollout
     type: global
     operations:
       - name: management-nodes-rollout
-        local-path: operations/management-nodes-rollout.yaml # this is relative to stages.yaml, which is contained in workflows/iuf/ in docs-csm
         static-parameters: {} # any parameters that will be supplied statically to this operation.
 
   - name: post-install-service-check
     type: product
     operations:
       - name: post-install-service-check
-        local-path: operations/post-install-service-check.yaml # this is relative to stages.yaml, which is contained in workflows/iuf/ in docs-csm
         static-parameters: {} # any parameters that will be supplied statically to this operation.
 
   - name: managed-nodes-rollout
     type: global
     operations:
       - name: managed-nodes-rollout
-        local-path: operations/managed-nodes-rollout.yaml # this is relative to stages.yaml, which is contained in workflows/iuf/ in docs-csm
         static-parameters: {} # any parameters that will be supplied statically to this operation.
 
   - name: post-install-check
     type: product
     operations:
       - name: post-install-check
-        local-path: operations/post-install-check.yaml # this is relative to stages.yaml, which is contained in workflows/iuf/ in docs-csm
         static-parameters: {} # any parameters that will be supplied statically to this operation.
 


### PR DESCRIPTION
# Description

This is simply removing an attribute that we no longer use from IUF's stages.yaml. There are no doc changes.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
