### PR TITLE
CASMMON-247 : operations record timestamps for prometheus metrics

### DIFF
--- a/workflows/iuf/operations/extract-release-distributions.yaml
+++ b/workflows/iuf/operations/extract-release-distributions.yaml
@@ -41,7 +41,13 @@ spec:
           - name: global_params
       dag:
         tasks:
+          - name: start-operation
+            templateRef:
+              name: workflow-template-record-time-template
+              template: record-time-template
           - name: list-tar-files
+            dependencies:
+              - start-operation
             inline:
               script:
                 image: artifactory.algol60.net/csm-docker/stable/iuf:v0.0.4
@@ -70,6 +76,55 @@ spec:
                   value: "{{=jsonpath(inputs.parameters.global_params, '$.input_params.media_dir')}}"
             withParam: "{{tasks.list-tar-files.outputs.result}}"
             template: extract-tar-files
+          - name: end-operation
+            dependencies:
+              - extract-tar-files
+            templateRef:
+              name: workflow-template-record-time-template
+              template: record-time-template
+          - name: prom-metrics
+            dependencies:
+              - start-operation
+              - end-operation
+            template: prom-metrics
+            arguments:
+              parameters:
+              - name: opstart
+                value: "{{tasks.start-operation.outputs.result}}"
+              - name: opend
+                value: "{{tasks.end-operation.outputs.result}}"
+
+
+    - name: prom-metrics
+      inputs:
+        parameters:
+        - name: opstart
+        - name: opend
+      metrics:
+        prometheus:
+          - name: operation_time
+            help: "Duration gauge by operation name in seconds"
+            labels:
+              - key: "opname"
+                value: "extract-release-distributions"
+              - key: stage
+                value: "global"
+              - key: "opstart"
+                value: "{{inputs.parameters.opstart}}"
+              - key: "opend"
+                value: "{{inputs.parameters.opend}}"
+            gauge:
+              value: "{{outputs.parameters.diff-time-value}}"
+      outputs:
+        parameters:
+          - name: diff-time-value
+            globalName: diff-time-value
+            valueFrom:
+              path: /tmp/diff_time.txt
+      container:
+        image: registry.local/alpine:3.7
+        command: [sh, -c]
+        args: ["DIFF_TIME=$(expr {{inputs.parameters.opend}} - {{inputs.parameters.opstart}}); echo $DIFF_TIME; echo $DIFF_TIME > /tmp/diff_time.txt"]
     - name: extract-tar-files
       inputs:
         parameters:

--- a/workflows/iuf/operations/operation-record-time.yaml
+++ b/workflows/iuf/operations/operation-record-time.yaml
@@ -1,3 +1,26 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:

--- a/workflows/iuf/operations/operation-record-time.yaml
+++ b/workflows/iuf/operations/operation-record-time.yaml
@@ -1,0 +1,12 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: workflow-template-record-time-template
+spec:
+  entrypoint: record-time-template
+  templates:
+  - name: record-time-template
+    container:
+      image: registry.local/alpine:3.7
+      command: [date]
+      args: ["+%s"]


### PR DESCRIPTION
# Description

currently, iuf operation does not provide an inbuilt mechanism for r Prometheus metrics.
At the first step added epoch start and end time for extract-release-distributions operation. we are planing to use these metrics for creating grafana iuf timing dashboard.

Please note we are unable to create WorkflowTemplate for the Prometheus metrics. So we have used it directly in extract-release-distributions.yaml.

Testing: tested on frigg.

# TYPE argo_workflows_operation_time gauge
argo_workflows_operation_time{opend="1671087764",opname="extract-release-distributions",opstart="1671087694",stage="global"} 70


