### PR TITLE
CASMINST-5704: Fix whitespace issue in gateway test

### DIFF
--- a/scripts/operations/gateway-test/gateway-test-defn.yaml
+++ b/scripts/operations/gateway-test/gateway-test-defn.yaml
@@ -33,10 +33,8 @@ test-networks:
   gateway: services-gateway
 - name: can
   gateway: customer-user-gateway
-- name: chn
-  gateway: customer-user-gateway
 
-reachable-networks: [ "can", "chn" ]
+reachable-networks: [ "can" ]
 
 ingress_api_services:
 - name: cray-argo

--- a/scripts/operations/gateway-test/gateway-test.py
+++ b/scripts/operations/gateway-test/gateway-test.py
@@ -233,7 +233,7 @@ if __name__ == '__main__':
 #      CASMINST-5583: removing CHN test from 1.3 until test case can be redesigned.
 #      if "chn" in slsnetworks:
 #        USER_NET = "chn"
-    	reachnets.append(USER_NET)
+        reachnets.append(USER_NET)
 
     if NODE_TYPE == "ncn":
       reachnets.append("nmnlb")


### PR DESCRIPTION
# Description

Fixes whitespace issue that is causing gateway test failures on systems that don't have CHN.
This was introduced in https://github.com/Cray-HPE/docs-csm/pull/2871.

Tested on fanta (where the issue was found) with CAN and on wasp with CHN.

While testing on wasp, I found another case where the test fails if CHN is actually functional.

```
Getting token for chn
auth.chn.wasp.dev.cray.com is reachable
Token successfully retrieved at https://auth.chn.wasp.dev.cray.com/keycloak/realms/shasta/protocol/openid-connect/token

FAIL: Token retrieved for chn network which should be unreachable
```

The original fix was meant to disable CHN in the gateway tests because we cannot guarantee that it will be functional (i.e. if slingshot is not installed yet).   However, missed a place in gateway-test-defn.yaml where it also needs to be removed.

# Checklist Before Merging

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

