### PR TITLE
CASM-3718: Update ims-load-artifacts image path

### DIFF
--- a/workflows/iuf/operations/ims-upload.yaml
+++ b/workflows/iuf/operations/ims-upload.yaml
@@ -91,7 +91,7 @@ spec:
           factor: "2"
           maxDuration: "1m"
     script:
-      image: registry.local/artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:latest-v1.21.1-amd64
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:latest-v1.21.1-amd64
       command: [bash]
       source: |
         function sync_item() {
@@ -148,8 +148,7 @@ spec:
         default: ""
 
     container:
-      # replace image with standard ims-load-artifacts once PR is merged
-      image: registry.local/artifactory.algol60.net/artifactory/csm-docker/stable/cray-ims-load-artifacts:2.0.0
+      image: artifactory.algol60.net/csm-docker/stable/cray-ims-load-artifacts:2.0.1
       command: ['python3']
       args: ['-m', 'ims_load_artifacts.load_artifacts']
       env:
@@ -220,7 +219,7 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
     script:
-      image: registry.local/artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:latest-v1.21.1-amd64
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:latest-v1.21.1-amd64
       command: [bash]
       source: |
         kubectl -n argo delete secret/{{inputs.parameters.s3_credentials_secret_name}}


### PR DESCRIPTION
# Description

This change removes the registry.local prefix from the image paths in the ims-upload workflow template.

Test Description:
Upload ims-load-artifacts images to Nexus on internal system, update workflow templates, and run IUF against a COS product distribution.


# Checklist Before Merging

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
