### PR TITLE
adding arti docker images

### DIFF
--- a/workflows/iuf/operations/extract-release-distributions.yaml
+++ b/workflows/iuf/operations/extract-release-distributions.yaml
@@ -122,7 +122,7 @@ spec:
             valueFrom:
               path: /tmp/diff_time.txt
       container:
-        image: registry.local/alpine:3.7
+        image: artifactory.algol60.net/csm-docker/stable/docker.io/alpine/git:2.32.0
         command: [sh, -c]
         args: ["DIFF_TIME=$(expr {{inputs.parameters.opend}} - {{inputs.parameters.opstart}}); echo $DIFF_TIME; echo $DIFF_TIME > /tmp/diff_time.txt"]
     - name: extract-tar-files

--- a/workflows/iuf/operations/operation-record-time.yaml
+++ b/workflows/iuf/operations/operation-record-time.yaml
@@ -30,6 +30,6 @@ spec:
   templates:
   - name: record-time-template
     container:
-      image: registry.local/alpine:3.7
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/alpine/git:2.32.0
       command: [date]
       args: ["+%s"]


### PR DESCRIPTION
# Description
CASMMON-247 : added csm arti docker iamges operations record timestamps for prometheus metrics

Test logs on frigg

ncn-m001:/usr/share/doc/csm/workflows/iuf/operations # curl 10.43.0.244:9090/metrics |grep operation_time
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0# HELP argo_workflows_operation_time Duration gauge by operation name in seconds
# TYPE argo_workflows_operation_time gauge
argo_workflows_operation_time{opend="1671087764",opname="extract-release-distributions",opstart="1671087694",stage="global"} 70

