### PR TITLE
CASM-3717 implement hooks

### DIFF
--- a/workflows/iuf/hooks/master-host-hook-script.yaml
+++ b/workflows/iuf/hooks/master-host-hook-script.yaml
@@ -1,0 +1,68 @@
+#
+# MIT License
+#
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: master-host-hook-script
+spec:
+  entrypoint: main
+  templates:
+    - inputs:
+        parameters:
+          - name: auth_token
+          - name: global_params
+          - name: script_path
+      name: main
+      steps:
+        - - arguments:
+              parameters:
+                - name: dryRun
+                  value: 'false'
+                - name: scriptContent
+                  value: >
+                    set -e
+
+                    global_params_file=$(echo $RANDOM | md5sum | head -c 20; echo)
+
+                    echo "INFO  Saving global_params into file /tmp/${global_params_file}.json"
+
+                    cat << EOF > /tmp/${global_params_file}.json
+
+                    {{inputs.parameters.global_params}}
+
+                    EOF
+
+                    echo "INFO  Calling {{inputs.parameters.script_path}}"
+
+                    chmod +x {{inputs.parameters.script_path}}
+
+                    auth_token="{{inputs.parameters.auth_token}}"
+
+                    cd "{{=jsonpath(inputs.parameters.global_params, '$.stage_params.process-media.current_product.parent_directory')}}"
+                    
+                    global_params="/tmp/${global_params_file}.json" sh -c {{inputs.parameters.script_path}}
+            name: call-hook-script
+            templateRef:
+              name: ssh-template
+              template: shell-script

--- a/workflows/iuf/samples/global_params_example.json
+++ b/workflows/iuf/samples/global_params_example.json
@@ -84,7 +84,7 @@
           "parent_directory": "/etc/iuf/alice_230116/cos-2.5.34-20221012230953"
         },
         "sdu": {
-          "parent_directory": "/etc/iuf/alice_230116/sdu-1.2.3",
+          "parent_directory": "/etc/iuf/alice_230116/sdu-1.2.3"
         }
       },
       "current_product": {

--- a/workflows/iuf/stages.yaml
+++ b/workflows/iuf/stages.yaml
@@ -109,3 +109,8 @@ stages:
     operations:
       - name: post-install-check
         static-parameters: {} # any parameters that will be supplied statically to this operation.
+
+
+# The following are the template references to hook scripts.
+hooks:
+  master_host: master-host-hook-script

--- a/workflows/scripts/upload-rebuild-templates.sh
+++ b/workflows/scripts/upload-rebuild-templates.sh
@@ -38,6 +38,7 @@ function upload_iuf_install_template {
     kubectl -n argo delete configmap iuf-install-workflow-stages-files || true
     kubectl -n argo create configmap iuf-install-workflow-stages-files --from-file="${basedir}/../iuf/stages.yaml"
     kubectl -n argo apply -f "${basedir}/../iuf/operations" --recursive
+    kubectl -n argo apply -f "${basedir}/../iuf/hooks" --recursive
 }
 
 function upload_worker_rebuild_template {


### PR DESCRIPTION
# Description

Implement the IUF hooks template.

1. Added a hooks section in stages.yaml, where each template is mapped to the execution context. This would allow us to add new execution contexts without waiting on the cray-nls server code.
2. The master_host template uses the existing ssh-template to ssh into m001 and run the specified hook script.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
