### PR TITLE
`dracut-lib.sh` is in `common/` not `metal/`

### DIFF
--- a/background/ncn_kdump.md
+++ b/background/ncn_kdump.md
@@ -81,7 +81,7 @@ to be installed; the `crash` command can not thoroughly analyze a dump without t
 
         ```bash
         zypper ar https://packages.local/repository/csm-${CSM_RELEASE}-embedded csm-embedded
-        . /srv/cray/scripts/metal/dracut-lib.sh
+        . /srv/cray/scripts/common/dracut-lib.sh
         zypper --plus-content debug in -y kernel-default-debuginfo=${KVER%-default}
         ```
 
@@ -108,7 +108,7 @@ to be installed; the `crash` command can not thoroughly analyze a dump without t
 
                 ```bash
                 zypper ar https://$ARTIFACTORY_USER:$ARTIFACTORY_TOKEN@artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Module-Basesystem/15-SP3/x86_64/update_debug/ temp-debug
-                . /srv/cray/scripts/metal/dracut-lib.sh
+                . /srv/cray/scripts/common/dracut-lib.sh
                 zypper --plus-content debug in -y kernel-default-debuginfo=${KVER%-default}
                 ```
 
@@ -116,7 +116,7 @@ to be installed; the `crash` command can not thoroughly analyze a dump without t
 
                 ```bash
                 https_proxy=https://example.proxy.net:443 zypper ar https://$ARTIFACTORY_USER:$ARTIFACTORY_TOKEN@artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Module-Basesystem/15-SP3/x86_64/update_debug/ temp-debug
-                . /srv/cray/scripts/metal/dracut-lib.sh
+                . /srv/cray/scripts/common/dracut-lib.sh
                 zypper --plus-content debug in -y kernel-default-debuginfo=${KVER%-default}
                 ```
 
@@ -146,7 +146,7 @@ to be installed; the `crash` command can not thoroughly analyze a dump without t
     > that of the currently running kernel.
 
     ```bash
-    . /srv/cray/scripts/metal/dracut-lib.sh
+    . /srv/cray/scripts/common/dracut-lib.sh
     crash ./vmlinux-${KVER}.gz ./vmcore
     ```
 
@@ -248,6 +248,6 @@ restarting the `kdump.service` daemon.
 1. (`ncn#`) Verify that a new `kdump` image exists for the current kernel.
 
     ```bash
-    . /srv/cray/scripts/metal/dracut-lib.sh
+    . /srv/cray/scripts/common/dracut-lib.sh
     ls -l /boot/initrd-${KVER}-kdump
     ```

--- a/background/ncn_kdump.md
+++ b/background/ncn_kdump.md
@@ -81,7 +81,7 @@ to be installed; the `crash` command can not thoroughly analyze a dump without t
 
         ```bash
         zypper ar https://packages.local/repository/csm-${CSM_RELEASE}-embedded csm-embedded
-        . /srv/cray/scripts/common/dracut-lib.sh
+        KVER=$(rpm -q --queryformat='%{VERSION}-%{RELEASE}' kernel-default)
         zypper --plus-content debug in -y kernel-default-debuginfo=${KVER%-default}
         ```
 
@@ -108,7 +108,7 @@ to be installed; the `crash` command can not thoroughly analyze a dump without t
 
                 ```bash
                 zypper ar https://$ARTIFACTORY_USER:$ARTIFACTORY_TOKEN@artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Module-Basesystem/15-SP3/x86_64/update_debug/ temp-debug
-                . /srv/cray/scripts/common/dracut-lib.sh
+                KVER=$(rpm -q --queryformat='%{VERSION}-%{RELEASE}' kernel-default)
                 zypper --plus-content debug in -y kernel-default-debuginfo=${KVER%-default}
                 ```
 
@@ -116,7 +116,7 @@ to be installed; the `crash` command can not thoroughly analyze a dump without t
 
                 ```bash
                 https_proxy=https://example.proxy.net:443 zypper ar https://$ARTIFACTORY_USER:$ARTIFACTORY_TOKEN@artifactory.algol60.net/artifactory/sles-mirror/Updates/SLE-Module-Basesystem/15-SP3/x86_64/update_debug/ temp-debug
-                . /srv/cray/scripts/common/dracut-lib.sh
+                KVER=$(rpm -q --queryformat='%{VERSION}-%{RELEASE}' kernel-default)
                 zypper --plus-content debug in -y kernel-default-debuginfo=${KVER%-default}
                 ```
 


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
Fixes `-bash: /srv/cray/scripts/metal/dracut-lib.sh: No such file or directory`.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
