### PR TITLE
CASMINST-5733 fix iuf stage: Loftsman Manifest Deploy

### DIFF
--- a/workflows/iuf/operations/loftsman-manifest-deploy.yaml
+++ b/workflows/iuf/operations/loftsman-manifest-deploy.yaml
@@ -33,74 +33,81 @@ spec:
         parameters:
           - name: auth_token
           - name: global_params
-      dag:
-        tasks:
-          - name: manifest-deploy
-            templateRef: 
-              name: iuf-base-template
-              template: shell-script
-            arguments:
-              parameters:
-                - name: dryRun
-                  value: false
-                - name: scriptContent
-                  value: |
-                    PRODUCT_NAME="{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.name')}}"
-                    JSON_CONTENT="{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.content')}}"
-                    LOFTSMAN_ENTRIES=$(echo "$JSON_CONTENT" | jq '.loftsman | length')
+      steps:
+      - - name: manifest-deploy
+          templateRef: 
+            name: iuf-base-template
+            template: shell-script
+          arguments:
+            parameters:
+              - name: dryRun
+                value: false
+              - name: scriptContent
+                value: |
+                  #!/usr/bin/bash
+                  PRODUCT_NAME=$(echo '{{inputs.parameters.global_params}}' | jq -r '.product_manifest.current_product.manifest.name')
+                  JSON_CONTENT=$(echo '{{inputs.parameters.global_params}}' | jq -r '.product_manifest.current_product.manifest')
+                  LOFTSMAN_ENTRIES=$(echo "$JSON_CONTENT" | jq '.content.loftsman | length')
+                  PARENT_PATH=$(echo '{{inputs.parameters.global_params}}' | jq -r '.stage_params."process-media".current_product.parent_directory')
 
-                    deploy_manifest() {
-                      manifest=$1
-                      product_name=$2
-                      exit_code=0
+                  if [[ -z "$LOFTSMAN_ENTRIES" ]]; then
+                      echo "ERROR Did not receive any loftsman context."
+                      exit 1
+                  fi
 
-                      if ! cray artifacts get config-data argo/loftsman/${product_name}/manifests/${manifest} ${manifest}; then
-                        echo "ERROR Could not get argo/loftsman/${product_name}/manifests/${manifest} from s3. It cannot be deployed because of this."
+                  deploy_manifest() {
+                    manifest=$1
+                    product_name=$2
+                    exit_code=0
+
+                    if ! cray artifacts get config-data argo/loftsman/${product_name}/manifests/"$(basename $manifest)" /tmp/"$(basename $manifest)"; then
+                      echo "ERROR Could not get argo/loftsman/${product_name}/manifests/"$(basename $manifest)" from s3. It cannot be deployed because of this."
+                      exit_code=1
+                    else
+                      echo "INFO Deploying ${manifest}"
+                      if ! loftsman ship --manifest-path /tmp/"$(basename $manifest)" --charts-repo https://packages.local/repository/charts; then
+                        echo "ERROR There was a problem deploying ${manifest}."
                         exit_code=1
-                      else
-                        echo "INFO Deploying ${manifest}"
-                        if ! loftsman ship --manifest-path ${manifest} --charts-repo https://packages.local/repository/charts; then
-                          echo "ERROR There was a problem deploying ${manifest}."
-                          exit_code=1
-                        fi
                       fi
-                      return $exit_code
-                    }
+                    fi
+                    return $exit_code
+                  }
 
-                    err=0
-                    for (( i=0; i< LOFTSMAN_ENTRIES; i++ )); do
-                      path_exists=true
-                      MANIFEST=$(echo "$JSON_CONTENT" | jq -r '.loftsman['$i'].path')
-                      DEPLOY=$(echo "$JSON_CONTENT" | jq -r '.loftsman['$i'].deploy')
+                  err=0
+                  for (( i=0; i< $LOFTSMAN_ENTRIES; i++ )); do
+                    path_exists=true
+                    MANIFEST=$(echo "$JSON_CONTENT" | jq -r '.content.loftsman['$i'].path')
+                    MANIFEST_PATH="${PARENT_PATH}/${MANIFEST}"
+                    DEPLOY=$(echo "$JSON_CONTENT" | jq -r '.content.loftsman['$i'].deploy')
+                    IS_DIR=false
+                    if [ -d $MANIFEST_PATH ]; then
+                      IS_DIR=true
+                    elif [ -f $MANIFEST_PATH ]; then
                       IS_DIR=false
-                      if [ -d $MANIFEST ]; then
-                        IS_DIR=true
-                      elif [ -f $MANIFEST ]; then
-                        IS_DIR=false
-                      else
-                        echo "ERROR Unable to find file or directory: $MANIFEST. (deploy=${DEPLOY})"
-                        err=1
-                        path_exists=false
-                      fi
-                      
-                      if ! $path_exists; then
-                        continue
-                      elif [[ $DEPLOY == "True" ]] || $DEPLOY 2> /dev/null; then
-                        if $IS_DIR; then
-                          echo "INFO Deploying loftsman manifests under $MANIFEST/"
-                          for manifest in "${MANIFEST}"/*.yml "${MANIFEST}"/*.yaml; do
-                            deploy_manifest ${manifest} $PRODUCT_NAME
-                            if [[ $? != 0 ]]; then err=1; fi
-                          done
-                        else
-                          deploy_manifest $MANIFEST $PRODUCT_NAME
-                          if [[ $? != 0 ]]; then err=1; fi
-                        fi
-                      else
-                        echo "INFO Not deploying argo/loftsman/${PRODUCT_NAME}/manifests/${MANIFEST} becasue loftsman.deploy=${DEPLOY}."
-                      fi
-                    done
-
-                    exit $err
-
+                    else
+                      echo "ERROR Unable to find file or directory: $MANIFEST_PATH. (deploy=${DEPLOY})"
+                      err=1
+                      path_exists=false
+                    fi
                     
+                    if ! $path_exists; then
+                      continue
+                    elif [[ "$DEPLOY" = "true" ]] || [[ "$DEPLOY" = "True" ]]; then
+                      if $IS_DIR; then
+                        echo "INFO Deploying loftsman manifests under $MANIFEST/"
+                        for manifest in "${MANIFEST_PATH}"/*.yml "${MANIFEST_PATH}"/*.yaml; do
+                          deploy_manifest ${manifest} $PRODUCT_NAME
+                          if [[ $? != 0 ]]; then err=1; fi
+                        done
+                      else
+                        deploy_manifest $MANIFEST_PATH $PRODUCT_NAME
+                        if [[ $? != 0 ]]; then err=1; fi
+                      fi
+                    else
+                      echo "INFO Not deploying argo/loftsman/${PRODUCT_NAME}/manifests/$(basename ${MANIFEST}) becasue loftsman.deploy=${DEPLOY}."
+                    fi
+                  done
+
+                  exit $err
+
+                  

--- a/workflows/iuf/operations/loftsman-manifest-deploy.yaml
+++ b/workflows/iuf/operations/loftsman-manifest-deploy.yaml
@@ -109,5 +109,3 @@ spec:
                   done
 
                   exit $err
-
-                  


### PR DESCRIPTION
# Description

Fix iuf stage: Loftsman Manifest Deploy.
Performed integration testing on frigg. 
<!--- Describe what this change is and what it is for. -->

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
