### PR TITLE
CASMHMS-5780 SLS: removed private key option

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -81,7 +81,7 @@ The following features are now deprecated and will be removed from CSM in a futu
 
 * CAPMC v1 partial deprecation
 * HSM v1 interface
-* [BOS](glossary.md#boot-orchestration-service-bos) v1 is now deprecated, in favor of BOS v2. BOS v1 will be removed from CSM in the CSM-1.9 release.
+* [BOS](glossary.md#boot-orchestration-service-bos) v1 is now deprecated, in favor of BOS v2. BOS v1 will be removed from CSM in the CSM 1.9 release.
   * It is likely that even prior to BOS v1 being removed from CSM, the [Cray CLI](glossary.md#cray-cli-cray) will change its behavior when no
     version is explicitly specified in BOS commands. Currently it defaults to BOS v1, but it may change to default to BOS v2 even before BOS v1
     is removed from CSM.
@@ -90,7 +90,7 @@ See [Deprecated features](introduction/differences.md#deprecated-features).
 
 ## Removals
 
-* TBD
+* SLS support for downloading and uploading credentials in the `dumpstate` and `loadstate` REST APIs
 
 ## Known issues
 

--- a/introduction/differences.md
+++ b/introduction/differences.md
@@ -4,9 +4,9 @@ The most noteworthy changes since the previous release are described here.
 
 ## Topics
 
-   * [New Features](#new-features)
-   * [Deprecated Features](#deprecated-features)
-   * [Removed Features](#removed-features)
+* [New Features](#new-features)
+* [Deprecated Features](#deprecated-features)
+* [Removed Features](#removed-features)
 
 ## New Features
 
@@ -55,3 +55,4 @@ The following features have been completely removed:
 
 * `cray-conman` pod. This has been replaced by `cray-console-node`.
 * CFS v1 API and CLI. The v2 API and CLI have been the default since CSM 0.9 (Shasta 1.4).
+* SLS support for downloading and uploading credentials in the `dumpstate` and `loadstate` REST APIs.


### PR DESCRIPTION
# Description

Removed support for downloading and uploading credentials in SLS dumpstate and loadstate

[CASMHMS-5780](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5780)

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
