### PR TITLE
CASMHMS-5780 SLS: removed private key option

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -193,7 +193,7 @@ see [Deprecated Features](introduction/deprecated_features/README.md).
 
 ## Removals
 
-* TBD
+* SLS support for downloading and uploading credentials in the `dumpstate` and `loadstate` REST APIs
 
 ## Known issues
 

--- a/introduction/deprecated_features/README.md
+++ b/introduction/deprecated_features/README.md
@@ -15,6 +15,9 @@ features are listed first).
   * It is likely that even prior to BOS v1 being removed from CSM, the [Cray CLI](../../glossary.md#cray-cli-cray) will change its behavior when no
     version is explicitly specified in BOS commands. Currently it defaults to BOS v1, but it may change to default to BOS v2 even before BOS v1
     is removed from CSM.
+* [System Layout Service (SLS)](../../glossary.md#system-layout-service-sls) removed public and private key options from the `loadstate` and `dumpstate` REST API
+  * The SLS `loadstate` and `dumpstate` no longer support the option to load or dump credential information. This includes the removal of the `public_key` and
+    `private_key` options that were used for encryption and decryption.
 
 ## Deprecated in CSM 1.2
 

--- a/operations/system_layout_service/Dump_SLS_Information.md
+++ b/operations/system_layout_service/Dump_SLS_Information.md
@@ -1,49 +1,21 @@
 # Dump SLS Information
 
-Perform a dump of the System Layout Service \(SLS\) database and an encrypted dump of the credentials stored in Vault.
+Perform a dump of the System Layout Service \(SLS\) database.
 
-This procedure will create three files in the current directory \(private\_key.pem, public\_key.pem, sls\_dump.json\). These files should be kept in a safe and secure place as the private key can decrypt the encrypted passwords stored in the SLS dump file.
+This procedure will create the file `sls_dump.json` in the current directory.
 
 This procedure preserves the information stored in SLS when backing up or reinstalling the system.
 
-### Prerequisites
+## Prerequisites
 
-This procedure requires administrative privileges.
+- The Cray Command Line Interface is configured. See [Configure the Cray CLI](../configure_cray_cli.md).
+- This procedure requires administrative privileges.
 
-### Procedure
+## Procedure
 
-1.  Use the get\_token function to retrieve a token to validate requests to the API gateway.
+(`ncn-mw#`) Perform the SLS dump.
+The SLS dump will be stored in the `sls_dump.json` file. The `sls_dump.json` file is required to perform the SLS load state operation.
 
-    ```bash
-    function get_token () {
-        curl -s -S -d grant_type=client_credentials \
-            -d client_id=admin-client \
-            -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
-            https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token'
-    }
-    ```
-
-2.  Generate a private and public key pair.
-
-    Execute the following commands to generate a private and public key to use for the dump.
-
-    ```bash
-    openssl genpkey -out private_key.pem -algorithm RSA -pkeyopt rsa_keygen_bits:2048
-    openssl rsa -in private_key.pem -outform PEM -pubout -out public_key.pem
-    ```
-
-    The above commands will create two files the private key private\_key.pem file and the public key public\_key.pem file.
-
-    Make sure to use a new private and public key pair for each dump operation, and do not reuse an existing private and public key pair. The private key should be treated securely because it will be required to decrypt the SLS dump file when the dump is loaded back into SLS. Once the private key is used to load state back into SLS, it should be considered insecure.
-
-3.  Perform the SLS dump.
-
-    The SLS dump will be stored in the sls\_dump.json file. The sls\_dump.json and private\_key.pem files are required to perform the SLS load state operation.
-
-    ```bash
-    curl -X POST \
-    https://api-gw-service-nmn.local/apis/sls/v1/dumpstate \
-    -H "Authorization: Bearer $(get_token)" \
-    -F public_key=@public_key.pem > sls_dump.json
-    ```
-
+```bash
+cray sls dumpstate list --format json > sls_dump.json
+```

--- a/operations/system_layout_service/Load_SLS_Database_with_Dump_File.md
+++ b/operations/system_layout_service/Load_SLS_Database_with_Dump_File.md
@@ -1,37 +1,20 @@
 # Load SLS Database with Dump File
 
-Load the contents of the SLS dump file to restore SLS to the state of the system at the time of the dump. This will upload and overwrite the current SLS database with the contents of the SLS dump file, and update Vault with the encrypted credentials.
+Load the contents of the SLS dump file to restore SLS to the state of the system at the time of the dump. This will upload and overwrite the current SLS database with the contents of the SLS dump file.
 
 Use this procedure to restore SLS data after a system re-install.
 
-### Prerequisites
+## Prerequisites
 
-The System Layout Service \(SLS\) database has been dumped. See [Dump SLS Information](Dump_SLS_Information.md) for more information.
+- The System Layout Service \(SLS\) database has been dumped. See [Dump SLS Information](Dump_SLS_Information.md) for more information.
+- The Cray Command Line Interface is configured. See [Configure the Cray CLI](../configure_cray_cli.md).
+- This procedure requires administrative privileges.
 
-### Procedure
+## Procedure
 
-1.  Use the get\_token function to retrieve a token to validate requests to the API gateway.
+(`ncn-mw#`) Load the dump file into SLS.
+This will upload and overwrite the current SLS database with the contents of the posted file.
 
-    ```bash
-    function get_token () {
-        curl -s -S -d grant_type=client_credentials \
-            -d client_id=admin-client \
-            -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
-            https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token'
-    }
-    ```
-
-2.  Load the dump file into SLS.
-
-    This will upload and overwrite the current SLS database with the contents of the posted file, as well as update the Vault with the encrypted credentials. The private key that was used to generate the SLS dump file is required.
-
-    ```bash
-    curl -X POST \
-    https://api-gw-service-nmn.local/apis/sls/v1/loadstate \
-    -H "Authorization: Bearer $(get_token)" \
-    -F sls_dump=@sls_dump.json \
-    -F private_key=@private_key.pem
-    ```
-
-    After performing the load state operation, the private key should be considered insecure and should no longer be used.
-
+```bash
+cray sls loadstate create sls_dump.json
+```


### PR DESCRIPTION
# Description

Removed support for downloading and uploading credentials in SLS dumpstate and loadstate

[CASMHMS-5780](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5780)

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
