### PR TITLE
CASMHMS-5780 SLS: removed private key option

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -159,6 +159,7 @@ CSM 1.2 contains approximately 2000 changes spanning bug fixes, new feature deve
   * The `cray-dns-unbound-manager` CronJob will be deprecated in a future release once all DNS records are migrated to PowerDNS.
   * The introduction of PowerDNS and Bifurcated CAN will introduce some node and service naming changes.
   * See the [PowerDNS Migration Guide](operations/network/dns/PowerDNS_migration.md) for more information.
+* SLS support for downloading and uploading credentials in the SLS `dumpstate` and `loadstate` REST APIs is deprecated.
 
 See [Deprecated features](introduction/differences.md#deprecated_features).
 

--- a/introduction/differences.md
+++ b/introduction/differences.md
@@ -51,6 +51,7 @@ The following features are no longer supported and are planned to be removed in 
 * The Compute Rolling Upgrade Service (CRUS) is deprecated in CSM 1.2.0 and will be removed in a future CSM release. Enhanced BOS functionality will replace CRUS. This includes the ability
   to stage changes to nodes that can be acted upon later when the node reboots. It also includes the ability to reboot nodes without specifying any boot artifacts. This latter
   ability relies on the artifacts already having been staged.
+* SLS support for downloading and uploading credentials in the `dumpstate` and `loadstate` REST APIs.
 
 <a name="removed_features"></a>
 

--- a/operations/system_layout_service/Dump_SLS_Information.md
+++ b/operations/system_layout_service/Dump_SLS_Information.md
@@ -1,19 +1,17 @@
 # Dump SLS Information
 
-Perform a dump of the System Layout Service \(SLS\) database and an encrypted dump of the credentials stored in Vault.
-
-This procedure will create three files in the current directory \(private\_key.pem, public\_key.pem, sls\_dump.json\). These files should be kept in a safe and secure place as the private key can decrypt the encrypted passwords stored in the SLS dump file.
+Perform a dump of the System Layout Service \(SLS\) database.
 
 This procedure preserves the information stored in SLS when backing up or reinstalling the system.
+It will create the file, `sls_dump.json`, in the current directory.
 
-### Prerequisites
+## Prerequisites
 
 This procedure requires administrative privileges.
 
-### Procedure
+## Procedure
 
-
-1.  Use the get\_token function to retrieve a token to validate requests to the API gateway.
+1. Use the get\_token function to retrieve a token to validate requests to the API gateway.
 
     ```bash
     ncn-m001# function get_token () {
@@ -24,27 +22,12 @@ This procedure requires administrative privileges.
     }
     ```
 
-2.  Generate a private and public key pair.
+2. Perform the SLS dump.
 
-    Execute the following commands to generate a private and public key to use for the dump.
-
-    ```bash
-    ncn-m001# openssl genpkey -out private_key.pem -algorithm RSA -pkeyopt rsa_keygen_bits:2048
-    ncn-w001# openssl rsa -in private_key.pem -outform PEM -pubout -out public_key.pem
-    ```
-
-    The above commands will create two files the private key private\_key.pem file and the public key public\_key.pem file.
-
-    Make sure to use a new private and public key pair for each dump operation, and do not reuse an existing private and public key pair. The private key should be treated securely because it will be required to decrypt the SLS dump file when the dump is loaded back into SLS. Once the private key is used to load state back into SLS, it should be considered insecure.
-
-3.  Perform the SLS dump.
-
-    The SLS dump will be stored in the sls\_dump.json file. The sls\_dump.json and private\_key.pem files are required to perform the SLS load state operation.
+    The SLS dump will be stored in the `sls_dump.json` file.
 
     ```bash
-    ncn-m001# curl -X POST \
+    ncn-m001# curl -X GET \
     https://api-gw-service-nmn.local/apis/sls/v1/dumpstate \
-    -H "Authorization: Bearer $(get_token)" \
-    -F public_key=@public_key.pem > sls_dump.json
+    -H "Authorization: Bearer $(get_token)" > sls_dump.json
     ```
-

--- a/operations/system_layout_service/Load_SLS_Database_with_Dump_File.md
+++ b/operations/system_layout_service/Load_SLS_Database_with_Dump_File.md
@@ -1,17 +1,16 @@
 # Load SLS Database with Dump File
 
-Load the contents of the SLS dump file to restore SLS to the state of the system at the time of the dump. This will upload and overwrite the current SLS database with the contents of the SLS dump file, and update Vault with the encrypted credentials.
+Load the contents of the SLS dump file to restore SLS to the state of the system at the time of the dump. This will upload and overwrite the current SLS database with the contents of the SLS dump file.
 
 Use this procedure to restore SLS data after a system re-install.
 
-### Prerequisites
+## Prerequisites
 
 The System Layout Service \(SLS\) database has been dumped. See [Dump SLS Information](Dump_SLS_Information.md) for more information.
 
-### Procedure
+## Procedure
 
-
-1.  Use the get\_token function to retrieve a token to validate requests to the API gateway.
+1. Use the get\_token function to retrieve a token to validate requests to the API gateway.
 
     ```bash
     ncn-m001# function get_token () {
@@ -22,17 +21,13 @@ The System Layout Service \(SLS\) database has been dumped. See [Dump SLS Inform
     }
     ```
 
-2.  Load the dump file into SLS.
+2. Load the dump file into SLS.
 
-    This will upload and overwrite the current SLS database with the contents of the posted file, as well as update the Vault with the encrypted credentials. The private key that was used to generate the SLS dump file is required.
+    This will upload and overwrite the current SLS database with the contents of the posted file.
 
     ```bash
     ncn-m001# curl -X POST \
     https://api-gw-service-nmn.local/apis/sls/v1/loadstate \
     -H "Authorization: Bearer $(get_token)" \
-    -F sls_dump=@sls_dump.json \
-    -F private_key=@private_key.pem
+    -F sls_dump=@sls_dump.json
     ```
-
-    After performing the load state operation, the private key should be considered insecure and should no longer be used.
-


### PR DESCRIPTION
# Description

Removed support for downloading and uploading credentials in SLS dumpstate and loadstate

[CASMHMS-5780](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5780)

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
