### PR TITLE
Renew apiserver-etcd-client after updating other certs during upgrade  (CASMPET-6194)

### DIFF
--- a/upgrade/scripts/k8s/upgrade_control_plane.sh
+++ b/upgrade/scripts/k8s/upgrade_control_plane.sh
@@ -75,4 +75,19 @@ do
   echo ""
   echo "Successfully upgraded kube-system pods for $master."
   echo ""
+  echo "Upgrading apiserver-etcd-client certificate for $master:"
+  echo ""
+  pdsh -b -S -w $master "kubeadm certs renew apiserver-etcd-client --config /etc/kubernetes/kubeadmcfg.yaml"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo ""
+    echo "ERROR: The 'kubeadm certs renew apiserver-etcd-client' failed. The output from this script should be inspected"
+    echo "       and addressed before moving on with the upgrade. If unable to determine the issue"
+    echo "       and run this script without errors, discontinue the upgrade and contact HPE Service"
+    echo "       for support."
+    exit 1
+  fi
+  echo ""
+  echo "Successfully upgraded  apiserver-etcd-client certificate for $master."
+  echo ""
 done


### PR DESCRIPTION
# Description

Fix for https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6194, Tested in craystack:

```
.
.
Successfully upgraded kube-system pods for ncn-m003.

Upgrading apiserver-etcd-client certificate for ncn-m003:

ncn-m003: Warning: Permanently added 'ncn-m003,10.103.17.152' (ECDSA) to the list of known hosts.
ncn-m003: certificate the apiserver uses to access etcd renewed

Successfully upgraded  apiserver-etcd-client certificate for ncn-m003.
```

```
CERTIFICATE                EXPIRES                  RESIDUAL TIME   CERTIFICATE AUTHORITY   EXTERNALLY MANAGED
admin.conf                 Dec 19, 2023 22:00 UTC   364d            ca                      no
apiserver                  Dec 19, 2023 21:59 UTC   364d            ca                      no
apiserver-etcd-client      Dec 19, 2023 22:00 UTC   364d            etcd-ca                 no
apiserver-kubelet-client   Dec 19, 2023 21:59 UTC   364d            ca                      no
controller-manager.conf    Dec 19, 2023 22:00 UTC   364d            ca                      no
etcd-healthcheck-client    Dec 13, 2023 23:42 UTC   359d            etcd-ca                 no
etcd-peer                  Dec 13, 2023 23:42 UTC   359d            etcd-ca                 no
etcd-server                Dec 13, 2023 23:42 UTC   359d            etcd-ca                 no
front-proxy-client         Dec 19, 2023 21:59 UTC   364d            front-proxy-ca          no
scheduler.conf             Dec 19, 2023 22:00 UTC   364d            ca                      no
```

# Checklist Before Merging

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
