### PR TITLE
MTL-2048 Account for `ARCH` in NCN artifacts

### DIFF
--- a/background/ncn_images.md
+++ b/background/ncn_images.md
@@ -25,15 +25,15 @@ To boot an NCN, you need three artifacts for each node-type (`kubernetes-master/
 
 1. The Kubernetes SquashFS ([stable][4] or [unstable][5])
 
-   * `initrd.img-[RELEASE].xz`
-   * `$version-[RELEASE].kernel`
-   * `kubernetes-[RELEASE].squashfs`
+   * `initrd.img-[RELEASE]-[ARCH].xz`
+   * `$version-[RELEASE]-[ARCH].kernel`
+   * `kubernetes-[RELEASE]-[ARCH].squashfs`
 
 1. The CEPH SquashFS ([stable][6] or [unstable][7])
 
    * `initrd.img-[RELEASE].xz`
    * `$version-[RELEASE].kernel`
-   * `storage-ceph-[RELEASE].squashfs`
+   * `storage-ceph-[RELEASE]-[ARCH].squashfs`
 
 ### LiveCD Server
 
@@ -79,13 +79,13 @@ To boot an NCN, you need three artifacts for each node-type (`kubernetes-master/
    Resolving images to boot ...
    Images resolved
    Kubernetes Boot Selection:
-   kernel: /var/www/ephemeral/data/k8s/fe775c6-1659395320990/5.3.18-150300.59.76-default-fe775c6-1659395320990.kernel
-   initrd: /var/www/ephemeral/data/k8s/fe775c6-1659395320990/initrd.img-fe775c6-1659395320990.xz
-   squash: /var/www/ephemeral/data/k8s/fe775c6-1659395320990/secure-kubernetes-fe775c6-1659395320990.squashfs
+   kernel: /var/www/ephemeral/data/k8s/fe775c6-1659395320990/5.3.18-150300.59.76-default-fe775c6-1659395320990-x86_64.kernel
+   initrd: /var/www/ephemeral/data/k8s/fe775c6-1659395320990/initrd.img-fe775c6-1659395320990-x86_64.xz
+   squash: /var/www/ephemeral/data/k8s/fe775c6-1659395320990/secure-kubernetes-fe775c6-1659395320990-x86_64.squashfs
    Storage Boot Selection:
-   kernel: /var/www/ephemeral/data/ceph/fe775c6-1659395320990/5.3.18-150300.59.76-default-fe775c6-1659395320990.kernel
-   initrd: /var/www/ephemeral/data/ceph/fe775c6-1659395320990/initrd.img-fe775c6-1659395320990.xz
-   squash: /var/www/ephemeral/data/ceph/fe775c6-1659395320990/secure-storage-ceph-fe775c6-1659395320990.squashfs
+   kernel: /var/www/ephemeral/data/ceph/fe775c6-1659395320990/5.3.18-150300.59.76-default-fe775c6-1659395320990-x86_64.kernel
+   initrd: /var/www/ephemeral/data/ceph/fe775c6-1659395320990/initrd.img-fe775c6-1659395320990-x86_64.xz
+   squash: /var/www/ephemeral/data/ceph/fe775c6-1659395320990/secure-storage-ceph-fe775c6-1659395320990-x86_64.squashfs
    Attempting to set all known BMCs (from /etc/conman.conf) to DHCP mode
    current BMC count: 0
    Waiting on 9 to request DHCP ...
@@ -109,49 +109,49 @@ To boot an NCN, you need three artifacts for each node-type (`kubernetes-master/
    ```bash
    ncn-m001:
    total 4
-   lrwxrwxrwx 1 root root 53 Dec 26 06:11 rootfs -> ../ephemeral/data/k8s/0.0.8/kubernetes-0.0.8.squashfs
-   lrwxrwxrwx 1 root root 47 Dec 26 06:11 initrd.img.xz -> ../ephemeral/data/k8s/0.0.8/initrd.img-0.0.8.xz
-   lrwxrwxrwx 1 root root 61 Dec 26 06:11 kernel -> ../ephemeral/data/k8s/0.0.8/5.3.18-24.37-default-0.0.8.kernel
+   lrwxrwxrwx 1 root root 53 Dec 26 06:11 rootfs -> ../ephemeral/data/k8s/0.0.8/kubernetes-0.0.8-x86_64.squashfs
+   lrwxrwxrwx 1 root root 47 Dec 26 06:11 initrd.img.xz -> ../ephemeral/data/k8s/0.0.8/initrd.img-0.0.8-x86_64.xz
+   lrwxrwxrwx 1 root root 61 Dec 26 06:11 kernel -> ../ephemeral/data/k8s/0.0.8/5.3.18-24.37-default-0.0.8-x86_64.kernel
 
    ncn-m002:
    total 4
-   lrwxrwxrwx 1 root root 53 Dec 26 06:11 rootfs -> ../ephemeral/data/k8s/0.0.8/kubernetes-0.0.8.squashfs
-   lrwxrwxrwx 1 root root 47 Dec 26 06:11 initrd.img.xz -> ../ephemeral/data/k8s/0.0.8/initrd.img-0.0.8.xz
-   lrwxrwxrwx 1 root root 61 Dec 26 06:11 kernel -> ../ephemeral/data/k8s/0.0.8/5.3.18-24.37-default-0.0.8.kernel
+   lrwxrwxrwx 1 root root 53 Dec 26 06:11 rootfs -> ../ephemeral/data/k8s/0.0.8/kubernetes-0.0.8-x86_64.squashfs
+   lrwxrwxrwx 1 root root 47 Dec 26 06:11 initrd.img.xz -> ../ephemeral/data/k8s/0.0.8/initrd.img-0.0.8-x86_64.xz
+   lrwxrwxrwx 1 root root 61 Dec 26 06:11 kernel -> ../ephemeral/data/k8s/0.0.8/5.3.18-24.37-default-0.0.8-x86_64.kernel
 
    ncn-m003:
    total 4
-   lrwxrwxrwx 1 root root 53 Dec 26 06:11 rootfs -> ../ephemeral/data/k8s/0.0.8/kubernetes-0.0.8.squashfs
-   lrwxrwxrwx 1 root root 47 Dec 26 06:11 initrd.img.xz -> ../ephemeral/data/k8s/0.0.8/initrd.img-0.0.8.xz
-   lrwxrwxrwx 1 root root 61 Dec 26 06:11 kernel -> ../ephemeral/data/k8s/0.0.8/5.3.18-24.37-default-0.0.8.kernel
+   lrwxrwxrwx 1 root root 53 Dec 26 06:11 rootfs -> ../ephemeral/data/k8s/0.0.8/kubernetes-0.0.8-x86_64.squashfs
+   lrwxrwxrwx 1 root root 47 Dec 26 06:11 initrd.img.xz -> ../ephemeral/data/k8s/0.0.8/initrd.img-0.0.8-x86_64.xz
+   lrwxrwxrwx 1 root root 61 Dec 26 06:11 kernel -> ../ephemeral/data/k8s/0.0.8/5.3.18-24.37-default-0.0.8-x86_64.kernel
 
    ncn-s001:
    total 4
-   lrwxrwxrwx 1 root root 56 Dec 26 06:11 rootfs -> ../ephemeral/data/ceph/0.0.7/storage-ceph-0.0.7.squashfs
+   lrwxrwxrwx 1 root root 56 Dec 26 06:11 rootfs -> ../ephemeral/data/ceph/0.0.7/storage-ceph-0.0.7-x86_64.squashfs
    lrwxrwxrwx 1 root root 48 Dec 26 06:11 initrd.img.xz -> ../ephemeral/data/ceph/0.0.7/initrd.img-0.0.7.xz
    lrwxrwxrwx 1 root root 62 Dec 26 06:11 kernel -> ../ephemeral/data/ceph/0.0.7/5.3.18-24.37-default-0.0.7.kernel
 
    ncn-s002:
    total 4
-   lrwxrwxrwx 1 root root 56 Dec 26 06:11 rootfs -> ../ephemeral/data/ceph/0.0.7/storage-ceph-0.0.7.squashfs
+   lrwxrwxrwx 1 root root 56 Dec 26 06:11 rootfs -> ../ephemeral/data/ceph/0.0.7/storage-ceph-0.0.7-x86_64.squashfs
    lrwxrwxrwx 1 root root 48 Dec 26 06:11 initrd.img.xz -> ../ephemeral/data/ceph/0.0.7/initrd.img-0.0.7.xz
    lrwxrwxrwx 1 root root 62 Dec 26 06:11 kernel -> ../ephemeral/data/ceph/0.0.7/5.3.18-24.37-default-0.0.7.kernel
 
    ncn-s003:
    total 4
-   lrwxrwxrwx 1 root root 56 Dec 26 06:11 rootfs -> ../ephemeral/data/ceph/0.0.7/storage-ceph-0.0.7.squashfs
+   lrwxrwxrwx 1 root root 56 Dec 26 06:11 rootfs -> ../ephemeral/data/ceph/0.0.7/storage-ceph-0.0.7-x86_64.squashfs
    lrwxrwxrwx 1 root root 48 Dec 26 06:11 initrd.img.xz -> ../ephemeral/data/ceph/0.0.7/initrd.img-0.0.7.xz
    lrwxrwxrwx 1 root root 62 Dec 26 06:11 kernel -> ../ephemeral/data/ceph/0.0.7/5.3.18-24.37-default-0.0.7.kernel
 
    ncn-w002:
    total 4
-   lrwxrwxrwx 1 root root 53 Dec 26 06:11 rootfs -> ../ephemeral/data/k8s/0.0.8/kubernetes-0.0.8.squashfs
-   lrwxrwxrwx 1 root root 47 Dec 26 06:11 initrd.img.xz -> ../ephemeral/data/k8s/0.0.8/initrd.img-0.0.8.xz
-   lrwxrwxrwx 1 root root 61 Dec 26 06:11 kernel -> ../ephemeral/data/k8s/0.0.8/5.3.18-24.37-default-0.0.8.kernel
+   lrwxrwxrwx 1 root root 53 Dec 26 06:11 rootfs -> ../ephemeral/data/k8s/0.0.8/kubernetes-0.0.8-x86_64.squashfs
+   lrwxrwxrwx 1 root root 47 Dec 26 06:11 initrd.img.xz -> ../ephemeral/data/k8s/0.0.8/initrd.img-0.0.8-x86_64.xz
+   lrwxrwxrwx 1 root root 61 Dec 26 06:11 kernel -> ../ephemeral/data/k8s/0.0.8/5.3.18-24.37-default-0.0.8-x86_64.kernel
 
    ncn-w003:
    total 4
-   lrwxrwxrwx 1 root root 53 Dec 26 06:11 rootfs -> ../ephemeral/data/k8s/0.0.8/kubernetes-0.0.8.squashfs
-   lrwxrwxrwx 1 root root 47 Dec 26 06:11 initrd.img.xz -> ../ephemeral/data/k8s/0.0.8/initrd.img-0.0.8.xz
-   lrwxrwxrwx 1 root root 61 Dec 26 06:11 kernel -> ../ephemeral/data/k8s/0.0.8/5.3.18-24.37-default-0.0.8.kernel
+   lrwxrwxrwx 1 root root 53 Dec 26 06:11 rootfs -> ../ephemeral/data/k8s/0.0.8/kubernetes-0.0.8-x86_64.squashfs
+   lrwxrwxrwx 1 root root 47 Dec 26 06:11 initrd.img.xz -> ../ephemeral/data/k8s/0.0.8/initrd.img-0.0.8-x86_64.xz
+   lrwxrwxrwx 1 root root 61 Dec 26 06:11 kernel -> ../ephemeral/data/k8s/0.0.8/5.3.18-24.37-default-0.0.8-x86_64.kernel
    ```

--- a/install/pre-installation.md
+++ b/install/pre-installation.md
@@ -502,8 +502,8 @@ in `/etc/environment` from the [Download CSM tarball](#21-download-csm-tarball) 
        echo "${NCN_MOD_SCRIPT}"
        "${NCN_MOD_SCRIPT}" -p \
           -d /root/.ssh \
-          -k "/var/www/ephemeral/data/k8s/${KUBERNETES_VERSION}/kubernetes-${KUBERNETES_VERSION}.squashfs" \
-          -s "/var/www/ephemeral/data/ceph/${CEPH_VERSION}/storage-ceph-${CEPH_VERSION}.squashfs"
+          -k "/var/www/ephemeral/data/k8s/${KUBERNETES_VERSION}/kubernetes-${KUBERNETES_VERSION}-$(uname -i).squashfs" \
+          -s "/var/www/ephemeral/data/ceph/${CEPH_VERSION}/storage-ceph-${CEPH_VERSION}-$(uname -i).squashfs"
        ```
 
 1. (`pit#`) Log the currently installed PIT packages.

--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
@@ -30,9 +30,9 @@ All of the commands in this procedure are intended to be run on a single master 
       - [Enter password and generate hash](#enter-password-and-generate-hash)
     - [Timezone](#timezone)
     - [Examples](#examples)
-      - [Example 1: New keys, copy password, keep UTC](#example-1-new-keys-copy-password-keep-utc)
-      - [Example 2: Provide keys, prompt for password, change timezone](#example-2-provide-keys-prompt-for-password-change-timezone)
-      - [Example 3: New keys, no password change, keep UTC, no prompting](#example-3-new-keys-no-password-change-keep-utc-no-prompting)
+      - [Example 1: New keys, copy password, keep UTC](#example-1--new-keys-copy-password-keep-utc)
+      - [Example 2: Provide keys, prompt for password, change timezone](#example-2--provide-keys-prompt-for-password-change-timezone)
+      - [Example 3: New keys, no password change, keep UTC, no prompting](#example-3--new-keys-no-password-change-keep-utc-no-prompting)
 
 1. [Upload artifacts into S3](#4-upload-artifacts-into-s3)
 1. [Update BSS](#5-update-bss)
@@ -172,7 +172,7 @@ To have the script generate the SSH keys automatically, it must be provided with
 - To view the complete list of supported `ssh-keygen` options, view the script usage statement by running it with the `-h` argument.
 - If the `-N` option is not used to specify the passphrase, then the script will prompt for the passphrase when it generates the keys.
   - Even specifying an empty passphrase will prevent being prompted to enter the passphrase during script execution.
-    See [Example 3](#example-3-new-keys-no-password-change-keep-utc-no-prompting).
+    See [Example 3](#example-3--new-keys-no-password-change-keep-utc-no-prompting).
 
 ##### Administrator-provided keys
 

--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md
@@ -19,9 +19,9 @@ see [Set NCN Image Root Password, SSH Keys, and Timezone](Change_NCN_Image_Root_
   - [Enter password and generate hash](#enter-password-and-generate-hash)
 - [Timezone](#timezone)
 - [Examples](#examples)
-  - [Example 1: New keys, copy PIT password, keep UTC](#example-1-new-keys-copy-pit-password-keep-utc)
-  - [Example 2: Provide keys, prompt for password, change timezone](#example-2-provide-keys-prompt-for-password-change-timezone)
-  - [Example 3: New keys, copy PIT password, keep UTC, no prompting](#example-3-new-keys-copy-pit-password-keep-utc-no-prompting)
+  - [Example 1: New keys, copy PIT password, keep UTC](#example-1--new-keys-copy-pit-password-keep-utc)
+  - [Example 2: Provide keys, prompt for password, change timezone](#example-2--provide-keys-prompt-for-password-change-timezone)
+  - [Example 3: New keys, copy PIT password, keep UTC, no prompting](#example-3--new-keys-copy-pit-password-keep-utc-no-prompting)
 - [Cleanup](#cleanup)
 
 ## Overview
@@ -59,7 +59,7 @@ To have the script generate the SSH keys automatically, it must be provided with
 - To view the complete list of supported `ssh-keygen` options, view the script usage statement by running it with the `-h` argument.
 - If the `-N` option is not used to specify the passphrase, then the script will prompt for the passphrase when it generates the keys.
   - Even specifying an empty passphrase will prevent being prompted to enter the passphrase during script execution.
-    See [Example 3](#example-3-new-keys-copy-pit-password-keep-utc-no-prompting).
+    See [Example 3](#example-3--new-keys-copy-pit-password-keep-utc-no-prompting).
 
 ### Administrator-provided keys
 
@@ -131,8 +131,8 @@ CEPH_VERSION="$(find ${CSM_PATH}/images/storage-ceph -name '*.squashfs' -exec ba
    
 $NCN_MOD_SCRIPT -p \
                 -t rsa \
-                -k "${PITDATA}/data/k8s/${KUBERNETES_VERSION}/kubernetes-${KUBERNETES_VERSION}.squashfs" \
-                -s "${PITDATA}/data/ceph/${CEPH_VERSION}/storage-ceph-${CEPH_VERSION}.squashfs"
+                -k "${PITDATA}/data/k8s/${KUBERNETES_VERSION}/kubernetes-${KUBERNETES_VERSION}-$(uname -i).squashfs" \
+                -s "${PITDATA}/data/ceph/${CEPH_VERSION}/storage-ceph-${CEPH_VERSION}-$(uname -i).squashfs"
 ```
 
 ### Example 2: Provide keys, prompt for password, change timezone
@@ -144,8 +144,8 @@ administrator for the `root` user password during execution. It changes the time
 $NCN_MOD_SCRIPT -p \
                 -d /my/pre-existing/keys \
                 -z America/Chicago \
-                -k "${PITDATA}/data/k8s/${KUBERNETES_VERSION}/kubernetes-${KUBERNETES_VERSION}.squashfs" \
-                -s "${PITDATA}/data/ceph/${CEPH_VERSION}/storage-ceph-${CEPH_VERSION}.squashfs"
+                -k "${PITDATA}/data/k8s/${KUBERNETES_VERSION}/kubernetes-${KUBERNETES_VERSION}-$(uname -i).squashfs" \
+                -s "${PITDATA}/data/ceph/${CEPH_VERSION}/storage-ceph-${CEPH_VERSION}-$(uname -i).squashfs"
 ```
 
 ### Example 3: New keys, copy PIT password, keep UTC, no prompting
@@ -159,8 +159,8 @@ export SQUASHFS_ROOT_PW_HASH=$(awk -F':' /^root:/'{print $2}' < /etc/shadow)
 $NCN_MOD_SCRIPT -p \
                 -t rsa \
                 -N "" \
-                -k "${PITDATA}/data/k8s/${KUBERNETES_VERSION}/kubernetes-${KUBERNETES_VERSION}.squashfs" \
-                -s "${PITDATA}/data/ceph/${CEPH_VERSION}/storage-ceph-${CEPH_VERSION}.squashfs"
+                -k "${PITDATA}/data/k8s/${KUBERNETES_VERSION}/kubernetes-${KUBERNETES_VERSION}-$(uname -i).squashfs" \
+                -s "${PITDATA}/data/ceph/${CEPH_VERSION}/storage-ceph-${CEPH_VERSION}-$(uname -i).squashfs"
 ```
 
 ## Cleanup

--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -534,7 +534,8 @@ if [[ ${state_recorded} == "0" && $(hostname) == "ncn-m001" ]]; then
 
     k8s_done=0
     ceph_done=0
-    if [[ -f ${artdir}/kubernetes/secure-kubernetes-${KUBERNETES_VERSION}.squashfs ]]; then
+    arch="$(uname -i)"
+    if [[ -f ${artdir}/kubernetes/secure-kubernetes-${KUBERNETES_VERSION}-${arch}.squashfs ]]; then
         k8s_done=1
     fi
     if [[ -f ${artdir}/storage-ceph/secure-storage-ceph-${CEPH_VERSION}.squashfs ]]; then
@@ -544,26 +545,26 @@ if [[ ${state_recorded} == "0" && $(hostname) == "ncn-m001" ]]; then
     if [[ ${k8s_done} = 1 && ${ceph_done} = 1 ]]; then
         echo "Already ran ${NCN_IMAGE_MOD_SCRIPT}, skipping re-run."
     else
-        rm -f "${artdir}/storage-ceph/secure-storage-ceph-${CEPH_VERSION}.squashfs" "${artdir}/kubernetes/secure-kubernetes-${KUBERNETES_VERSION}.squashfs"
+        rm -f "${artdir}/storage-ceph/secure-storage-ceph-${CEPH_VERSION}-${arch}.squashfs" "${artdir}/kubernetes/secure-kubernetes-${KUBERNETES_VERSION}-${arch}.squashfs"
         DEBUG=1 "${NCN_IMAGE_MOD_SCRIPT}" \
             -d /root/.ssh \
-            -k "${artdir}/kubernetes/kubernetes-${KUBERNETES_VERSION}.squashfs" \
-            -s "${artdir}/storage-ceph/storage-ceph-${CEPH_VERSION}.squashfs" \
+            -k "${artdir}/kubernetes/kubernetes-${KUBERNETES_VERSION}-${arch}.squashfs" \
+            -s "${artdir}/storage-ceph/storage-ceph-${CEPH_VERSION}-${arch}.squashfs" \
             -p
     fi
 
     set -o pipefail
     IMS_UPLOAD_SCRIPT=$(rpm -ql docs-csm | grep ncn-ims-image-upload.sh)
 
-    export IMS_ROOTFS_FILENAME="${artdir}/kubernetes/secure-kubernetes-${KUBERNETES_VERSION}.squashfs"
-    export IMS_INITRD_FILENAME="${artdir}/kubernetes/initrd.img-${KUBERNETES_VERSION}.xz"
-    export IMS_KERNEL_FILENAME="${artdir}/kubernetes/*.kernel"
+    export IMS_ROOTFS_FILENAME="${artdir}/kubernetes/secure-kubernetes-${KUBERNETES_VERSION}-${arch}.squashfs"
+    export IMS_INITRD_FILENAME="${artdir}/kubernetes/initrd.img-${KUBERNETES_VERSION}-${arch}.xz"
+    export IMS_KERNEL_FILENAME="${artdir}/kubernetes/*-${arch}.kernel"
     K8S_IMS_IMAGE_ID=$($IMS_UPLOAD_SCRIPT)
     [[ -n ${K8S_IMS_IMAGE_ID} ]]
 
-    export IMS_ROOTFS_FILENAME="${artdir}/storage-ceph/secure-storage-ceph-${CEPH_VERSION}.squashfs"
-    export IMS_INITRD_FILENAME="${artdir}/storage-ceph/initrd.img-${CEPH_VERSION}.xz"
-    export IMS_KERNEL_FILENAME="${artdir}/storage-ceph/*.kernel"
+    export IMS_ROOTFS_FILENAME="${artdir}/storage-ceph/secure-storage-ceph-${CEPH_VERSION}-${arch}.squashfs"
+    export IMS_INITRD_FILENAME="${artdir}/storage-ceph/initrd.img-${CEPH_VERSION}-${arch}.xz"
+    export IMS_KERNEL_FILENAME="${artdir}/storage-ceph/*-${arch}.kernel"
     STORAGE_IMS_IMAGE_ID=$($IMS_UPLOAD_SCRIPT)
     [[ -n ${STORAGE_IMS_IMAGE_ID} ]]
     set +o pipefail


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
In lieu of the upcoming aarch64 architecture, all artifacts built by the node-images repository will now denote their architecture. NCNs may never have aarch64 support, but their artifacts are built from the node-images repository.

This change modifies the usage of The NCN artifacts, referring to them with their new names that include their architecture. Without this change, none of the procedures that use the NCN artifacts will be usable.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
