### PR TITLE
CASM-3591: Add product catalog update to VCS upload

### DIFF
--- a/workflows/iuf/operations/vcs-upload/vcs-upload-content.yaml
+++ b/workflows/iuf/operations/vcs-upload/vcs-upload-content.yaml
@@ -53,6 +53,18 @@ spec:
                   value: cray
                 - name: cf_import_gitea_url
                   value: "https://api-gw-service-nmn.local/vcs"
+        - - name: vcs-update-product-catalog
+            templateRef:
+              name: update-product-catalog-template
+              template: catalog-update
+            arguments:
+              parameters:
+              - name: product-name
+                value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.name')}}"
+              - name: product-version
+                value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.version')}}"
+              - name: yaml-content
+                value: "{{steps.gitea-upload-content.outputs.parameters.vcs-upload-content-results}}"
         - - name: cleanup
             template: cleanup-template
             arguments:


### PR DESCRIPTION
This commit uses the update-product-catalog-template workflowtemplate to add updating the product catalog into the vcs-upload-content operation of the deliver-product stage.

Test Description: I used this version of the vcs-upload-content workflowtemplate on frigg and ran the IUF CLI through the deliver-product stage.

# Description

See commit message

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
