### PR TITLE
CASMTRIAGE-4697 Downgrade the kernel

### DIFF
--- a/background/ncn_kernel.md
+++ b/background/ncn_kernel.md
@@ -691,7 +691,7 @@ This value sets the `xname` for the node, detailing the geolocation of the node.
 | CSM 1.2.2                 | 5.3.18-150300.59.43.1      |                          |
 | CSM 1.3.0                 | 5.3.18-150300.59.**87.1**  | [`CVE-2022-33981`][23]   |
 | CSM 1.3.1                 | 5.3.18-150300.59.87.1      |                          |
-| CSM 1.4.0                 | 5.**14.21-150400.24.33.2** | SLES-15-SP4 Upgrade      |
+| CSM 1.4.0                 | 5.**14.21-150400.22.1**    | SLES-15-SP4 Upgrade      |
 
 [1]:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/networking_guide/sec-consistent_network_device_naming_using_biosdevname
 [2]:https://github.com/Cray-HPE/dracut-metal-mdsquash/blob/main/README.md#usage


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
The 150400.24 patch kernel is running into kernel panics during the CSM 1.4 install. The cause is unknown, we have opened a SUSE case (SUSE Case #00502283) with dumps in order to help debug the problem. Internal debugging has been fruitless.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
