### PR TITLE
Exclude worker being rebuilt from precache step (CASMPET-6207)

### DIFF
--- a/upgrade/1.2/scripts/rebuild/ncn-rebuild-worker-nodes.sh
+++ b/upgrade/1.2/scripts/rebuild/ncn-rebuild-worker-nodes.sh
@@ -41,7 +41,7 @@ state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
 if [[ $state_recorded == "0" ]]; then
     echo "====> ${state_name} ..."
 
-    workers="$(kubectl get node --selector='!node-role.kubernetes.io/master' -o name | sed -e 's,^node/,,' | paste -sd,)"
+    workers="$(kubectl get nodes --selector='!node-role.kubernetes.io/master' --no-headers=true -o custom-columns=NAME:.metadata.name | grep -v ${target_ncn} | paste -sd,)"
     export PDSH_SSH_ARGS_APPEND="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
     kubectl get configmap -n nexus cray-precache-images -o json | jq -r '.data.images_to_cache' | while read image; do echo >&2 "+ caching $image"; pdsh -w "$workers" "crictl pull $image" 2>/dev/null; done
 


### PR DESCRIPTION
# Description

Skip caching images on (likely unhealthy) worker being rebuilt (https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6207)

# Checklist Before Merging

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
