### PR TITLE
CASMINST-5576 - Internal SSH test fails if an Application node has no SubRole

### DIFF
--- a/scripts/operations/pyscripts/pyscripts/core/ssh/ssh_targets.py
+++ b/scripts/operations/pyscripts/pyscripts/core/ssh/ssh_targets.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -149,7 +149,7 @@ class SshTargets:
                 self.ncn_worker.append(host)
                 self.byHostname[host.hostname] = host
                 self.byXname[xname] = host
-            elif x["Type"] == "comptype_node" and x["ExtraProperties"]["Role"] == "Application" and x["ExtraProperties"]["SubRole"] == "UAN":
+            elif x["Type"] == "comptype_node" and x["ExtraProperties"]["Role"] == "Application" and ("SubRole" in x["ExtraProperties"] and x["ExtraProperties"]["SubRole"] == "UAN"):
                 host = SshHost(x["ExtraProperties"]["Aliases"][0], "root", x)
                 self.uan.append(host)
                 self.byHostname[host.hostname] = host


### PR DESCRIPTION
# Description

The `test_bican_internal` ssh test fails with a `KeyError` if an Application node exists in SLS that does not have a SubRole defined.

Testing

Baseline test with no SubRole defined
```
ncn-m001:~ # /usr/share/doc/csm/scripts/operations/pyscripts/start.py test_bican_internal
Going to test from node types ('ncn_master',) to node types ('ncn_master', 'spine_switch') on networks ('can', 'chn', 'cmn', 'nmn', 'nmnlb', 'hmn', 'hmnlb').
BICAN:CAN detected.
ncn-m002 password (leave blank and hit Enter if not using password):
ncn-m003 password (leave blank and hit Enter if not using password):
sw-spine-001 password (leave blank and hit Enter if not using password):
---snip---
Ran 14 tests in 239.383s. Overall status: PASSED (Passed: 14, Failed: 0)
```
UAN specific test with no SubRole defined (skipped as expected).
```
ncn-m001:~ # /usr/share/doc/csm/scripts/operations/pyscripts/start.py test_bican_internal --to-types uan
Going to test from node types ('ncn_master',) to node types ('uan',) on networks ('can', 'chn', 'cmn', 'nmn', 'nmnlb', 'hmn', 'hmnlb').
BICAN:CAN detected.
ncn-m002 password (leave blank and hit Enter if not using password):

Testing SSH access:
        From node type ncn_master, using ncn-m002
        Over network can (can.surtur.hpc.amslabs.hpecorp.net)
        To node type uan
        Expected to work: True
		^^^^ SKIPPED: Cannot find a suitable node for node type uan ^^^^
---snip---
Ran 0 tests in 0.001s. Overall status: PASSED (Passed: 0, Failed: 0)
```
UAN specific test with SubRole defined
```
ncn-m001:~ # /usr/share/doc/csm/scripts/operations/pyscripts/start.py test_bican_internal --to-types uan
Going to test from node types ('ncn_master',) to node types ('uan',) on networks ('can', 'chn', 'cmn', 'nmn', 'nmnlb', 'hmn', 'hmnlb').
BICAN:CAN detected.
ncn-m002 password (leave blank and hit Enter if not using password):
uan01 password (leave blank and hit Enter if not using password):

Testing SSH access:
        From node type ncn_master, using ncn-m002
        Over network can (can.surtur.hpc.amslabs.hpecorp.net)
        To node type uan, using uan01.can.surtur.hpc.amslabs.hpecorp.net
        Expected to work: True
		^^^^ PASSED ^^^^

Testing SSH access:
        From node type ncn_master, using ncn-m002
        Over network cmn (cmn.surtur.hpc.amslabs.hpecorp.net)
        To node type uan, using uan01.cmn.surtur.hpc.amslabs.hpecorp.net
        Expected to work: False
		^^^^ PASSED ^^^^

Testing SSH access:
        From node type ncn_master, using ncn-m002
        Over network chn (chn.surtur.hpc.amslabs.hpecorp.net)
        To node type uan, using uan01.chn.surtur.hpc.amslabs.hpecorp.net
        Expected to work: False
		^^^^ PASSED ^^^^

Testing SSH access:
        From node type ncn_master, using ncn-m002
        Over network nmn (nmn.surtur.hpc.amslabs.hpecorp.net)
        To node type uan, using uan01.nmn.surtur.hpc.amslabs.hpecorp.net
        Expected to work: True
		^^^^ PASSED ^^^^

Testing SSH access:
        From node type ncn_master, using ncn-m002
        Over network hmn (hmn.surtur.hpc.amslabs.hpecorp.net)
        To node type uan, using uan01.hmn.surtur.hpc.amslabs.hpecorp.net
        Expected to work: False
		^^^^ PASSED ^^^^

Testing SSH access:
        From node type ncn_master, using ncn-m002
        Over network nmnlb (nmnlb.surtur.hpc.amslabs.hpecorp.net)
        To node type uan, using uan01.nmnlb.surtur.hpc.amslabs.hpecorp.net
        Expected to work: False
		^^^^ PASSED ^^^^

Testing SSH access:
        From node type ncn_master, using ncn-m002
        Over network hmnlb (hmnlb.surtur.hpc.amslabs.hpecorp.net)
        To node type uan, using uan01.hmnlb.surtur.hpc.amslabs.hpecorp.net
        Expected to work: False
		^^^^ PASSED ^^^^


Ran 7 tests in 106.985s. Overall status: PASSED (Passed: 7, Failed: 0)
```
# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
