### PR TITLE
CASMPET-6034 add ability to use image-id in worker rebuild workflow

### DIFF
--- a/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh
+++ b/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh
@@ -37,6 +37,7 @@ upgrade=false
 rebuild=false
 zapOsds=false
 workflowType=""
+imageId=""
 
 function usage() {
     echo "CSM ncn worker and storage upgrade script"
@@ -49,14 +50,15 @@ function usage() {
     echo "--dry-run      Print out steps of workflow instead of running steps (default: ${dryRun})"
     echo "--upgrade      Perfrom a node upgrade. This only needs to be specified when upgrading storage nodes."
     echo "--rebuild      Perfrom a node rebuild. This only needs to be specified when rebuilding storage nodes"
+    echo "--image-id     The image-id that a worker or storage node should be booted into when a node is rebuilt. This is optional."
     echo "--zap-osds     Zap osds. Only do this if unable to wipe the node prior to rebuild. For example, when a storage node unintentionally goes down and needs to be rebuilt. (This can only be used with storage rebuilds)."
     echo
     echo "*COMMA_SEPARATED_NCN_HOSTNAMES"
     echo "  worker upgrade  - example 1) ncn-w001"
-    echo "  worker upgrade  - example 2) ncn-w001,ncn-w002,ncn-w003"
+    echo "  worker upgrade  - example 2) ncn-w001,ncn-w002,ncn-w003 --image-id <image-id>"
     echo "  storage upgrade - example 3) ncn-s001 --upgrade"
     echo "  storage upgrade - example 4) ncn-s001,ncn-s002,ncn-s003 --upgrade"
-    echo "  storage rebuild - example 5) ncn-s001 --rebuild"
+    echo "  storage rebuild - example 5) ncn-s001 --rebuild --image-id <image-id>"
     echo "  storage rebuild - example 6) ncn-s001,ncn-s002,ncn-s003 --rebuild"
     echo
 }
@@ -96,6 +98,11 @@ while [[ $# -gt 0 ]]; do
     --rebuild)
         rebuild=true
         shift # past argument
+        ;;
+    --image-id)
+        imageId="$2"
+        shift # past argument
+        shift # past value
         ;;
     --zap-osds)
         zapOsds=true
@@ -174,7 +181,8 @@ function createWorkflowPayload() {
 {
 "dryRun": ${dryRun},
 "hosts": ${jsonArray},
-"switchPassword": "${SW_ADMIN_PASSWORD}"
+"switchPassword": "${SW_ADMIN_PASSWORD}",
+"imageId": "${imageId}"
 }
 EOF
     fi
@@ -186,7 +194,8 @@ EOF
 "dryRun": ${dryRun},
 "hosts": ${jsonArray},
 "zapOsds": ${zapOsds},
-"workflowType": "${workflowType}"
+"workflowType": "${workflowType}",
+"imageId": "${imageId}"
 }
 EOF
     fi

--- a/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh
+++ b/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh
@@ -181,6 +181,15 @@ if [[ -n $desiredCfsConfig ]]; then
     fi
 fi
 
+# check that image-id exists if imageId is not empty
+if [[ -n $imageId ]]; then
+    cray ims images describe "$imageId" > /dev/null
+    if [[ $? -ne 0 ]]; then
+      # could not find the desired cfs configuration
+      exit 1
+    fi
+fi
+
 function uploadWorkflowTemplates() {
     "${basedir}"/../../../workflows/scripts/upload-rebuild-templates.sh
 }

--- a/workflows/ncn/worker/worker.common.parameters.yaml
+++ b/workflows/ncn/worker/worker.common.parameters.yaml
@@ -25,4 +25,5 @@
 parameters:
   - name: targetNcn
   - name: dryRun
+  - name: imageId
 {{end}}

--- a/workflows/ncn/worker/worker.common.parameters.yaml
+++ b/workflows/ncn/worker/worker.common.parameters.yaml
@@ -26,4 +26,5 @@ parameters:
   - name: targetNcn
   - name: dryRun
   - name: imageId
+  - name: desiredCfsConfig
 {{end}}

--- a/workflows/ncn/worker/worker.drain.yaml
+++ b/workflows/ncn/worker/worker.drain.yaml
@@ -82,7 +82,45 @@ tasks:
               /host_usr_bin/csi handoff bss-update-param --set cps.pm-node=1 --limit $TARGET_XNAME
             fi
  
-            IMAGE_ID={{ `{{inputs.parameters.imageId}}` }}  # not sure this is accurate
-            ## ADD COMMAND HERE TO SET IMAGE ID IN BSS IF IMAGE_ID recieved IS NOT BLANK OR EMPTY ##
-                  
+            # set image to boot into in BSS
+            IMAGE_ID={{ `{{inputs.parameters.imageId}}` }}
+            if [[ -n $IMAGE_ID ]]; then
+              echo "INFO  Changing boot image in bss to $IMAGE_ID"
+              METAL_SERVER=$(cray bss bootparameters list --hosts "${TARGET_XNAME}" --format json | jq '.[] |."params"' \
+              | awk -F 'metal.server=' '{print $2}' \
+              | awk -F ' ' '{print $1}')
+              NEW_METAL_SERVER="s3://${IMAGE_ID}/rootfs"
+              PARAMS=$(cray bss bootparameters list --hosts "${TARGET_XNAME}" --format json | jq '.[] |."params"' | \
+                  sed "/metal.server/ s|${METAL_SERVER}|${NEW_METAL_SERVER}|" | \
+                  sed "s/metal.no-wipe=1/metal.no-wipe=0/" | \
+                  tr -d \")
+              cray bss bootparameters update --hosts "${TARGET_XNAME}" \
+                --kernel "s3://${IMAGE_ID}/kernel" \
+                --initrd "s3://${IMAGE_ID}/initrd" \
+                --params "${PARAMS}"
+            else
+              echo "INFO  No Image ID was specified for the boot image. The image that will be booted is the current image in BSS."
+            fi
+  - name: update-cfs
+    templateRef:
+      name: kubectl-and-curl-template
+      template: shell-script
+    arguments:
+      parameters:
+        - name: dryRun
+          value: "{{ `{{inputs.parameters.dryRun}}` }}"
+        - name: scriptContent
+          value: |
+            TARGET_NCN={{ `{{inputs.parameters.targetNcn}}` }}
+            TARGET_XNAME=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management" | \
+                jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"$TARGET_NCN\")) | .Xname")
+            
+            DESIRED_CFS_CONFIG={{ `{{inputs.parameters.desiredCfsConfig}}` }}
+            if [[ -n $DESIRED_CFS_CONFIG ]]; then
+              echo "INFO  Changing CFS configuration to $DESIRED_CFS_CONFIG"
+              cray cfs components update ${TARGET_XNAME} --enabled false --desired-config "${DESIRED_CFS_CONFIG}"
+              cray cfs components describe "${TARGET_XNAME}"
+            else
+              echo "INFO  No desired CFS configuration was specified so the CFS configuration after reboot will be the current CFS configuration."
+            fi
 {{end}}

--- a/workflows/ncn/worker/worker.drain.yaml
+++ b/workflows/ncn/worker/worker.drain.yaml
@@ -76,8 +76,13 @@ tasks:
                 jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"$TARGET_NCN\")) | .Xname")
             /host_usr_bin/csi handoff bss-update-param --delete metal.no-wipe --limit $TARGET_XNAME
             /host_usr_bin/csi handoff bss-update-param --set metal.no-wipe=0 --limit $TARGET_XNAME
+
             CPS_PM_NODE=$( kubectl get node ${TARGET_NCN} -o json | jq -r '.metadata.labels."cps-pm-node"')
             if [ "$CPS_PM_NODE" = "True" ]; then
               /host_usr_bin/csi handoff bss-update-param --set cps.pm-node=1 --limit $TARGET_XNAME
             fi
+ 
+            IMAGE_ID={{ `{{inputs.parameters.imageId}}` }}  # not sure this is accurate
+            ## ADD COMMAND HERE TO SET IMAGE ID IN BSS IF IMAGE_ID recieved IS NOT BLANK OR EMPTY ##
+                  
 {{end}}

--- a/workflows/ncn/worker/worker.drain.yaml
+++ b/workflows/ncn/worker/worker.drain.yaml
@@ -63,7 +63,7 @@ tasks:
             done
   - name: update-bss
     templateRef:
-      name: kubectl-and-curl-template
+      name: iuf-base-template
       template: shell-script
     arguments:
       parameters:
@@ -74,8 +74,6 @@ tasks:
             TARGET_NCN={{ `{{inputs.parameters.targetNcn}}` }}
             TARGET_XNAME=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management" | \
                 jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"$TARGET_NCN\")) | .Xname")
-            /host_usr_bin/csi handoff bss-update-param --delete metal.no-wipe --limit $TARGET_XNAME
-            /host_usr_bin/csi handoff bss-update-param --set metal.no-wipe=0 --limit $TARGET_XNAME
 
             CPS_PM_NODE=$( kubectl get node ${TARGET_NCN} -o json | jq -r '.metadata.labels."cps-pm-node"')
             if [ "$CPS_PM_NODE" = "True" ]; then
@@ -84,26 +82,50 @@ tasks:
  
             # set image to boot into in BSS
             IMAGE_ID={{ `{{inputs.parameters.imageId}}` }}
+
             if [[ -n $IMAGE_ID ]]; then
+              # get needed paths
+              image_manifest_str=$(cray ims images describe $IMAGE_ID --format json | jq '.link.path')
+              image_manifest_str=${image_manifest_str#*s3://}
+              bucket="$( cut -d '/' -f 1 <<< "$image_manifest_str" )"
+              bucket_rm="${bucket}/"
+              path=${image_manifest_str#*${bucket_rm}}
+              path=${path%?}
+
+              temp_file="/tmp/$(echo $RANDOM | md5sum | head -c 21; echo).json"
+              cray artifacts get $bucket $path $temp_file
+
+              metal_image=$(jq '.artifacts | map({"path": .link.path, "type": .type}) | .[] | select( .type == "application/vnd.cray.image.rootfs.squashfs") | .path ' < $temp_file)
+              echo "Setting metal.server image to: $metal_image"
+              kernel_image=$(jq '.artifacts | map({"path": .link.path, "type": .type}) | .[] | select( .type == "application/vnd.cray.image.kernel") | .path ' < $temp_file)
+              kernel_image=$(echo "$kernel_image" | tr -d '"')
+              echo "Setting kernel image to: $kernel_image"
+              initrd_image=$(jq '.artifacts | map({"path": .link.path, "type": .type}) | .[] | select( .type == "application/vnd.cray.image.initrd") | .path ' < $temp_file)
+              initrd_image=$(echo "$initrd_image" | tr -d '"')
+              echo "Setting initrd image to: $initrd_image"
+
               echo "INFO  Changing boot image in bss to $IMAGE_ID"
               METAL_SERVER=$(cray bss bootparameters list --hosts "${TARGET_XNAME}" --format json | jq '.[] |."params"' \
               | awk -F 'metal.server=' '{print $2}' \
               | awk -F ' ' '{print $1}')
-              NEW_METAL_SERVER="s3://${IMAGE_ID}/rootfs"
+              NEW_METAL_SERVER=$metal_image
               PARAMS=$(cray bss bootparameters list --hosts "${TARGET_XNAME}" --format json | jq '.[] |."params"' | \
                   sed "/metal.server/ s|${METAL_SERVER}|${NEW_METAL_SERVER}|" | \
                   sed "s/metal.no-wipe=1/metal.no-wipe=0/" | \
                   tr -d \")
               cray bss bootparameters update --hosts "${TARGET_XNAME}" \
-                --kernel "s3://${IMAGE_ID}/kernel" \
-                --initrd "s3://${IMAGE_ID}/initrd" \
+                --kernel $kernel_image \
+                --initrd $initrd_image \
                 --params "${PARAMS}"
             else
               echo "INFO  No Image ID was specified for the boot image. The image that will be booted is the current image in BSS."
+              echo "INFO setting metal.no-wipe=0 in BSS"
+              /host_usr_bin/csi handoff bss-update-param --delete metal.no-wipe --limit $TARGET_XNAME
+              /host_usr_bin/csi handoff bss-update-param --set metal.no-wipe=0 --limit $TARGET_XNAME
             fi
   - name: update-cfs
     templateRef:
-      name: kubectl-and-curl-template
+      name: iuf-base-template
       template: shell-script
     arguments:
       parameters:
@@ -119,7 +141,6 @@ tasks:
             if [[ -n $DESIRED_CFS_CONFIG ]]; then
               echo "INFO  Changing CFS configuration to $DESIRED_CFS_CONFIG"
               cray cfs components update ${TARGET_XNAME} --enabled false --desired-config "${DESIRED_CFS_CONFIG}"
-              cray cfs components describe "${TARGET_XNAME}"
             else
               echo "INFO  No desired CFS configuration was specified so the CFS configuration after reboot will be the current CFS configuration."
             fi

--- a/workflows/ncn/worker/worker.rebuild.yaml
+++ b/workflows/ncn/worker/worker.rebuild.yaml
@@ -138,6 +138,8 @@ spec:
                 value: "{{$.DryRun}}"
               - name: imageId
                 value: "{{$.ImageId}}"
+              - name: desiredCfsConfig
+                value: "{{$.DesiredCfsConfig}}"
           # wipe and reboot: parallel
           #     once a worker node is drained from k8s
           #     we can safely wipe and reboot this node

--- a/workflows/ncn/worker/worker.rebuild.yaml
+++ b/workflows/ncn/worker/worker.rebuild.yaml
@@ -42,6 +42,15 @@ spec:
       hostPath:
         path: /usr/bin
         type: Directory
+    # the volumes below are needed for iuf-base-template
+    - name: ca-bundle
+      hostPath:
+        path: /var/lib/ca-certificates
+        type: Directory
+    # iuf needs to be specified but will not be used which is reasoning for using emptyDir'
+    - name: iuf
+      emptyDir:
+        sizeLimit: 1Mi
     - name: podinfo
       downwardAPI:
         items:
@@ -122,6 +131,10 @@ spec:
                   value: {{$value}}
                 - name: dryRun
                   value: "{{$.DryRun}}"
+                - name: imageId
+                  value: "{{$.ImageId}}"
+                - name: desiredCfsConfig
+                  value: "{{$.DesiredCfsConfig}}"
           # drain: sync
           #     Only one worker can be drained at a time
           - name: drain-{{$value}}
@@ -154,6 +167,10 @@ spec:
                 value: {{$value}}
               - name: dryRun
                 value: "{{$.DryRun}}"
+              - name: imageId
+                value: "{{$.ImageId}}"
+              - name: desiredCfsConfig
+                value: "{{$.DesiredCfsConfig}}"
           # after each: parallel
           #     once a worker node is rebooted
           #     we need to run post boot hooks
@@ -167,6 +184,10 @@ spec:
                   value: {{$value}}
                 - name: dryRun
                   value: "{{$.DryRun}}"
+                - name: imageId
+                  value: "{{$.ImageId}}"
+                - name: desiredCfsConfig
+                  value: "{{$.DesiredCfsConfig}}"
           # post rebuild: parallel
           #     Post rebuild validation can be run in parallel
           - name: post-rebuild-{{$value}}
@@ -179,6 +200,10 @@ spec:
                 value: {{$value}}
               - name: dryRun
                 value: "{{$.DryRun}}"
+              - name: imageId
+                value: "{{$.ImageId}}"
+              - name: desiredCfsConfig
+                value: "{{$.DesiredCfsConfig}}"
           {{- end }}
           - name: after-all
             template: after-all

--- a/workflows/ncn/worker/worker.rebuild.yaml
+++ b/workflows/ncn/worker/worker.rebuild.yaml
@@ -136,6 +136,8 @@ spec:
                 value: {{$value}}
               - name: dryRun
                 value: "{{$.DryRun}}"
+              - name: imageId
+                value: "{{$.ImageId}}"
           # wipe and reboot: parallel
           #     once a worker node is drained from k8s
           #     we can safely wipe and reboot this node


### PR DESCRIPTION
# Description

add ability to use image-id in worker rebuild workflow. This has not been tested and is just an example of how to add this functionality.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
