### PR TITLE
CASM-3711: Add function to return NCN xnames from HSM SMD

### DIFF
--- a/scripts/operations/configuration/python_lib/api_requests.py
+++ b/scripts/operations/configuration/python_lib/api_requests.py
@@ -39,8 +39,8 @@ from .types import JSONDecodeError
 
 ADMIN_CLIENT_SECRET_NAME = "admin-client-auth"
 ADMIN_CLIENT_SECRET_NAMESPACE = "default"
-AUTH_TOKEN_URL = ("https://api-gw-service-nmn.local/"
-                  "keycloak/realms/shasta/protocol/openid-connect/token")
+API_GW_BASE_URL = "https://api-gw-service-nmn.local"
+AUTH_TOKEN_URL = f"{API_GW_BASE_URL}/keycloak/realms/shasta/protocol/openid-connect/token"
 
 # For type hints
 ApiResponse = requests.models.Response
@@ -111,7 +111,8 @@ def get_api_token(k8s_client: k8s.CoreV1API = None) -> str:
 
 
 def make_api_request_with_retries(request_method: Callable, url: str, add_api_token: bool = False,
-                                  k8s_client: k8s.CoreV1API = None, **request_kwargs) -> ApiResponse:
+                                  k8s_client: k8s.CoreV1API = None,
+                                  **request_kwargs) -> ApiResponse:
     """
     Makes request with specified method to specified URL with specified keyword arguments (if any).
     If a 5xx status code is returned, the request will be retried after a brief wait, a limited

--- a/scripts/operations/configuration/python_lib/hsm.py
+++ b/scripts/operations/configuration/python_lib/hsm.py
@@ -1,0 +1,66 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""Shared Python function library: HSM"""
+
+import traceback
+
+import logging
+
+from typing import List
+
+from . import api_requests
+from . import common
+from .types import JSONDecodeError
+
+SMD_BASE_URL = f"{api_requests.API_GW_BASE_URL}/apis/smd"
+SMD_HSM_COMPONENTS_URL = f"{SMD_BASE_URL}/hsm/v2/State/Components"
+
+
+def log_error_raise_exception(msg: str, parent_exception: Exception = None) -> None:
+    """
+    1) If a parent exception is passed in, make a debug log entry with its stack trace.
+    2) Log an error with the specified message.
+    3) Raise a ScriptException with the specified message (from the parent exception, if
+       specified)
+    """
+    if parent_exception is not None:
+        logging.debug(traceback.format_exc())
+    logging.error(msg)
+    if parent_exception is None:
+        raise common.ScriptException(msg)
+    raise common.ScriptException(msg) from parent_exception
+
+
+def get_management_ncn_xnames() -> List[str]:
+    """
+    Return a sorted list of the xnames of the management NCNs
+    """
+    params = {"type": "Node", "role": "Management"}
+    resp = api_requests.get_retry_validate(url=SMD_HSM_COMPONENTS_URL, expected_status_codes=200,
+                                           add_api_token=True, verify=False, params=params)
+    try:
+        component_list = resp.json()["Components"]
+        return sorted([comp["ID"] for comp in component_list])
+    except (JSONDecodeError, KeyError, TypeError) as exc:
+        log_error_raise_exception("Response from SMD has unexpected format", exc)

--- a/scripts/operations/configuration/python_lib/vault.py
+++ b/scripts/operations/configuration/python_lib/vault.py
@@ -270,7 +270,7 @@ class Vault():
         self.api_post(
             url=secret_url, expected_status_codes=API_STATUS_OK_EMPTY, json=secret_data)
 
-    def delete_csm_root_secret(self, **kwargs) -> None:
+    def delete_csm_root_secret(self) -> None:
         """
         Wrapper function that supplies the CSM root secret key to delete_secret()
         """


### PR DESCRIPTION
# Description

This adds a new Python module inside the scripts folder tree. Currently the module is not used, but it will enable future work. At present, the module consists primarily of a single function, which I tested in isolation on mug to verify that it worked as expected.

Some minor linting was also done to other files, to clean up a few minor linter complaints.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
