### PR TITLE
CASMINST-5762 add product version to path when pulling manifest for loftsman_manifest_deploy stage

### DIFF
--- a/workflows/iuf/operations/loftsman-manifest-deploy.yaml
+++ b/workflows/iuf/operations/loftsman-manifest-deploy.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/workflows/iuf/operations/loftsman-manifest-deploy.yaml
+++ b/workflows/iuf/operations/loftsman-manifest-deploy.yaml
@@ -72,6 +72,11 @@ spec:
                   JSON_CONTENT=$(echo '{{inputs.parameters.global_params}}' | jq -r '.product_manifest.current_product.manifest')
                   LOFTSMAN_ENTRIES=$(echo "$JSON_CONTENT" | jq '.content.loftsman | length')
                   PARENT_PATH=$(echo '{{inputs.parameters.global_params}}' | jq -r '.stage_params."process-media".current_product.parent_directory')
+                  PRODUCT_VERSION=$(echo "$JSON_CONTENT" | jq -r '.version')
+                  if [[ "${PRODUCT_VERSION,,}" == "null" ]] || [[ -z "$PRODUCT_VERSION" ]]; then
+                      echo "ERROR product version not found in manifest"
+                      exit 1
+                  fi
 
                   if [[ -z "$LOFTSMAN_ENTRIES" ]]; then
                       echo "ERROR Did not receive any loftsman context."
@@ -83,8 +88,8 @@ spec:
                     product_name=$2
                     exit_code=0
 
-                    if ! cray artifacts get config-data argo/loftsman/${product_name}/manifests/"$(basename $manifest)" /tmp/"$(basename $manifest)"; then
-                      echo "ERROR Could not get argo/loftsman/${product_name}/manifests/"$(basename $manifest)" from s3. It cannot be deployed because of this."
+                    if ! cray artifacts get config-data argo/loftsman/${product_name}/${PRODUCT_VERSION}/manifests/"$(basename $manifest)" /tmp/"$(basename $manifest)"; then
+                      echo "ERROR Could not get argo/loftsman/${product_name}/${PRODUCT_VERSION}/manifests/"$(basename $manifest)" from s3. It cannot be deployed because of this."
                       exit_code=1
                     else
                       echo "INFO Deploying ${manifest}"
@@ -127,7 +132,7 @@ spec:
                         if [[ $? != 0 ]]; then err=1; fi
                       fi
                     else
-                      echo "INFO Not deploying argo/loftsman/${PRODUCT_NAME}/manifests/$(basename ${MANIFEST}) becasue loftsman.deploy=${DEPLOY}."
+                      echo "INFO Not deploying argo/loftsman/${PRODUCT_NAME}/${PRODUCT_VERSION}/manifests/$(basename ${MANIFEST}) becasue loftsman.deploy=${DEPLOY}."
                     fi
                   done
 

--- a/workflows/iuf/operations/loftsman-manifest-deploy.yaml
+++ b/workflows/iuf/operations/loftsman-manifest-deploy.yaml
@@ -132,7 +132,7 @@ spec:
                         if [[ $? != 0 ]]; then err=1; fi
                       fi
                     else
-                      echo "INFO Not deploying argo/loftsman/${PRODUCT_NAME}/${PRODUCT_VERSION}/manifests/$(basename ${MANIFEST}) becasue loftsman.deploy=${DEPLOY}."
+                      echo "INFO Not deploying argo/loftsman/${PRODUCT_NAME}/${PRODUCT_VERSION}/manifests/$(basename ${MANIFEST}) because loftsman.deploy=${DEPLOY}."
                     fi
                   done
 


### PR DESCRIPTION

# Description

add product version to path when pulling manifest for loftsman_manifest_deploy stage. This is necessary due to changes being made to the loftsman_manifest_upload stage.

This has not been tested because it cannot be tested on its own. But will be tested through IUF integration testing.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
