### PR TITLE
CASMINST-5759: Use CMN LB for NLS Keycloak setup

### DIFF
--- a/upgrade/scripts/upgrade/util/upgrade-cray-nls.sh
+++ b/upgrade/scripts/upgrade/util/upgrade-cray-nls.sh
@@ -43,11 +43,20 @@ function deployNLS() {
 }
 
 function patchKeycloak() {
+
+    # Get the SYSTEM_DOMAIN from cloud-init 
+    SYSTEM_NAME=$(craysys metadata get system-name)
+    SITE_DOMAIN=$(craysys metadata get site-domain)
+    SYSTEM_DOMAIN=${SYSTEM_NAME}.${SITE_DOMAIN}
+
+    # Use the CMN LB/Ingress
+    KC_URL="auth.cmn.${SYSTEM_DOMAIN}"
     ARGO_URL=$(kubectl get VirtualService/cray-argo -n argo -o json | jq -r '.spec.hosts[0]')
     KC_CLIENT_ID=$(kubectl get secrets keycloak-master-admin-auth -o jsonpath='{.data.client-id}' -n services | base64 -d)
     KC_USERNAME=$(kubectl get secrets keycloak-master-admin-auth -o jsonpath='{.data.user}' -n services | base64 -d)
     KC_PASSWORD=$(kubectl get secrets keycloak-master-admin-auth -o jsonpath='{.data.password}' -n services | base64 -d)
 
+    export KC_URL="${KC_URL}"
     export ARGO_URL="${ARGO_URL}"
     export KC_CLIENT_ID="${KC_CLIENT_ID}"
     export KC_USERNAME="${KC_USERNAME}"


### PR DESCRIPTION
# Description

Update `upgrade-cray-nls.sh` and `nls-keycloak-configure.py` to use the CMN LB (e.g., `auth.cmn`) vs. NMN LB. This due to policy changes in OPA for Keycloak that block access the master realm OIDC endpoints and the keycloak admin API endpoints for the NMN LB. 

Tested on Wasp by executing the `upgrade-cray-nls.sh` twice, directly via shell. The first time after removing the WebOrigin and redirectUrls from the oauth2-proxy-customer-management client, and then verifying the script populated. The second execution verified idempotent behavior (did not set the additional URLs on the client if they existed).  