### PR TITLE
CASMPET-5243 add storage node rebuild workflow

### DIFF
--- a/operations/node_management/Rebuild_NCNs/Rebuild_NCNs.md
+++ b/operations/node_management/Rebuild_NCNs/Rebuild_NCNs.md
@@ -69,7 +69,19 @@ make sure that the following conditions are met:
 
 ### Storage node
 
-See [Prepare storage nodes](Prepare_Storage_Nodes.md).
+#### Option 1
+
+Rebuild the storage node manually. See [Prepare storage nodes](Prepare_Storage_Nodes.md).
+
+#### Option 2 (Tech preview)
+
+Rebuild the storage node automatically. This rebuilds a storage node via argo workflows. See [Using the Argo UI](../operations/argo/Using_the_Argo_UI.md) and [Using Argo Workflows](../operations/argo/Using_Argo_Workflows.md) before starting the rebuild.
+
+(`ncn-m001#`) Rebuild storage node ncn-s00x:
+
+```bash
+/usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh ncn-s00x --rebuild
+```
 
 ## Validation
 

--- a/workflows/ncn/storage/common.bss-no-wipe.yaml
+++ b/workflows/ncn/storage/common.bss-no-wipe.yaml
@@ -21,9 +21,9 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-{{define "common.set-bss-no-wipe"}}
+{{define "common.set-bss-no-wipe-1"}}
 tasks:
-  - name: set-bss-no-wipe
+  - name: set-bss-no-wipe-1
     templateRef:
       name: kubectl-and-curl-template
       template: shell-script
@@ -33,16 +33,28 @@ tasks:
           value: "{{ `{{inputs.parameters.dryRun}}` }}"
         - name: scriptContent
           value: |
-            WIPE_OSDS="{{ `{{inputs.parameters.wipeOsds}}` }}"
-            no_wipe_flag=1
-            if $WIPE_OSDS; then
-              no_wipe_flag=0
-            fi
-            echo "WIPE_OSDS: $WIPE_OSDS"
-            echo "metal.no-wipe is being set to ${no_wipe_flag}."
             TARGET_NCN={{ `{{inputs.parameters.targetNcn}}` }}
-            echo "Setting metal.no-wipe=${no_wipe_flag}"
+            echo "Setting metal.no-wipe=1"
             TARGET_XNAME=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management" | \
                 jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"$TARGET_NCN\")) | .Xname")
-            /host_usr_bin/csi handoff bss-update-param --set metal.no-wipe=${no_wipe_flag} --limit $TARGET_XNAME
+            /host_usr_bin/csi handoff bss-update-param --set metal.no-wipe=1 --limit $TARGET_XNAME
+{{end}}
+
+{{define "common.set-bss-no-wipe-0"}}
+tasks:
+  - name: set-bss-no-wipe-0
+    templateRef:
+      name: kubectl-and-curl-template
+      template: shell-script
+    arguments:
+      parameters:
+        - name: dryRun
+          value: "{{ `{{inputs.parameters.dryRun}}` }}"
+        - name: scriptContent
+          value: |
+            TARGET_NCN={{ `{{inputs.parameters.targetNcn}}` }}
+            echo "Setting metal.no-wipe=0"
+            TARGET_XNAME=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management" | \
+                jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"$TARGET_NCN\")) | .Xname")
+            /host_usr_bin/csi handoff bss-update-param --set metal.no-wipe=0 --limit $TARGET_XNAME
 {{end}}

--- a/workflows/ncn/storage/common.bss-no-wipe.yaml
+++ b/workflows/ncn/storage/common.bss-no-wipe.yaml
@@ -1,0 +1,48 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+{{define "common.set-bss-no-wipe"}}
+tasks:
+  - name: set-bss-no-wipe
+    templateRef:
+      name: kubectl-and-curl-template
+      template: shell-script
+    arguments:
+      parameters:
+        - name: dryRun
+          value: "{{ `{{inputs.parameters.dryRun}}` }}"
+        - name: scriptContent
+          value: |
+            WIPE_OSDS="{{ `{{inputs.parameters.wipeOsds}}` }}"
+            no_wipe_flag=1
+            if $WIPE_OSDS; then
+              no_wipe_flag=0
+            fi
+            echo "WIPE_OSDS: $WIPE_OSDS"
+            echo "metal.no-wipe is being set to ${no_wipe_flag}."
+            TARGET_NCN={{ `{{inputs.parameters.targetNcn}}` }}
+            echo "Setting metal.no-wipe=${no_wipe_flag}"
+            TARGET_XNAME=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management" | \
+                jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"$TARGET_NCN\")) | .Xname")
+            /host_usr_bin/csi handoff bss-update-param --set metal.no-wipe=${no_wipe_flag} --limit $TARGET_XNAME
+{{end}}

--- a/workflows/ncn/storage/common.envar.yaml
+++ b/workflows/ncn/storage/common.envar.yaml
@@ -1,0 +1,44 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+{{define "common.envar"}}
+
+TOKEN=$(curl -k -s -S -d grant_type=client_credentials \
+   -d client_id=admin-client \
+   -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
+   https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
+
+TARGET_NCN={{ `{{inputs.parameters.targetNcn}}` }}
+TARGET_XNAME=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management" | \
+     jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"$TARGET_NCN\")) | .Xname")
+TARGET_MGMT_XNAME=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management" | \
+  jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"$TARGET_NCN\")) | .Parent")
+
+TARGET_NCN_mgmt_host="${TARGET_NCN}-mgmt"
+
+
+export IPMI_USERNAME=$(curl -XGET -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds"| jq -r ".Targets[] | select(.Xname | contains(\"$TARGET_MGMT_XNAME\")) | .Username")
+export IPMI_PASSWORD=$(curl -XGET -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds"| jq -r ".Targets[] | select(.Xname | contains(\"$TARGET_MGMT_XNAME\")) | .Password")
+
+{{end}}

--- a/workflows/ncn/storage/common.reboot-node.yaml
+++ b/workflows/ncn/storage/common.reboot-node.yaml
@@ -1,0 +1,171 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+{{define "common.reboot-node"}}
+tasks:
+  - name: "validate-bss-ntp"
+    templateRef:
+      name: ssh-template
+      template: shell-script
+    arguments:
+      parameters:
+        - name: dryRun
+          value: "{{ `{{inputs.parameters.dryRun}}` }}"
+        - name: scriptContent
+          value: |
+            {{- include "common.envar" . | indent 12 }}
+            if ! cray bss bootparameters list --hosts $TARGET_XNAME --format json | jq '.[] |."cloud-init"."user-data".ntp' | grep -q '/etc/chrony.d/cray.conf'; then
+              echo "${TARGET_NCN} is missing NTP data in BSS. Please see the procedure which can be found in the 'Known Issues and Bugs' section titled 'Fix BSS Metadata' on the 'Configure NTP on NCNs' page of the CSM documentation."
+              exit 1
+            fi
+  - name: "get-bootscript-last-access-timestamp"
+    dependencies:
+      - validate-bss-ntp
+    templateRef:
+      name: kubectl-and-curl-template
+      template: shell-script
+    arguments:
+      parameters:
+        - name: dryRun
+          value: "{{ `{{inputs.parameters.dryRun}}` }}"
+        - name: scriptContent
+          value: |
+            TARGET_NCN={{ `{{inputs.parameters.targetNcn}}` }}
+            TARGET_XNAME=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management" | \
+                jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"$TARGET_NCN\")) | .Xname")
+            /host_usr_bin/csi handoff bss-update-param --set metal.no-wipe=0 --limit $TARGET_XNAME
+            bootscript_last_epoch=$(curl -s -k -H "Content-Type: application/json" \
+            -H "Authorization: Bearer ${TOKEN}" \
+            "https://api-gw-service-nmn.local/apis/bss/boot/v1/endpoint-history?name=$TARGET_XNAME" \
+            | jq '.[]| select(.endpoint=="bootscript")|.last_epoch' 2> /dev/null)
+            
+            if [[ $bootscript_last_epoch -gt 0 ]]; then
+              echo $bootscript_last_epoch
+            else
+              # sometimes we don't have endpoint history
+              # because a node might never pxe booted in the past
+              # we set it to zero as default value
+              bootscript_last_epoch=0
+              echo $bootscript_last_epoch
+            fi
+  - name: "pxe-boot-node"
+    dependencies:
+      - get-bootscript-last-access-timestamp
+    templateRef:
+      name: ssh-template
+      template: shell-script
+    arguments:
+      parameters:
+        - name: dryRun
+          value: "{{ `{{inputs.parameters.dryRun}}` }}"
+        - name: scriptContent
+          value: |
+            {{- include "common.envar" . | indent 12 }}
+            
+            # Set ncn to pxe boot
+            ipmitool -I lanplus -U ${IPMI_USERNAME} -E -H $TARGET_NCN_mgmt_host chassis bootdev pxe options=efiboot
+            echo "Set node to pxe boot."
+            powerStatus=$(ipmitool -I lanplus -U ${IPMI_USERNAME} -E -H $TARGET_NCN_mgmt_host chassis power status)
+            if [[ "$powerStatus" == *"is on"* ]]; then
+              # power cycle node
+              ipmitool -I lanplus -U ${IPMI_USERNAME} -E -H $TARGET_NCN_mgmt_host chassis power off
+              sleep 20
+            fi
+            ipmitool -I lanplus -U ${IPMI_USERNAME} -E -H $TARGET_NCN_mgmt_host chassis power on
+  - name: "wait-for-boot"
+    dependencies:
+      - pxe-boot-node
+    templateRef:
+      name: ssh-template
+      template: shell-script
+    arguments:
+      parameters:
+        - name: dryRun
+          value: "{{ `{{inputs.parameters.dryRun}}` }}"
+        - name: scriptContent
+          value: |
+            {{- include "common.envar" . | indent 12 }}
+            bootscript_last_epoch="{{ `{{tasks.get-bootscript-last-access-timestamp.outputs.result}}` }}"
+            
+            # wait for boot
+            counter=0
+            echo "waiting for boot: $TARGET_NCN ..."
+            while true
+            do
+                set +e
+                while true
+                do
+                    tmp_bootscript_last_epoch=$(curl -s -k -H "Content-Type: application/json" \
+                        -H "Authorization: Bearer ${TOKEN}" \
+                        "https://api-gw-service-nmn.local/apis/bss/boot/v1/endpoint-history?name=$TARGET_XNAME" \
+                        | jq '.[]| select(.endpoint=="bootscript")|.last_epoch' 2> /dev/null)
+                    if [[ $? -eq 0 ]]; then
+                        break
+                    fi
+                done
+                set -e
+                if [[ $tmp_bootscript_last_epoch -ne $bootscript_last_epoch ]]; then
+                    echo "bootscript fetched"
+                    break
+                fi
+                echo "waiting for boot: $TARGET_NCN ..."
+                counter=$((counter+1))
+                if [ $counter -gt 300 ]; then
+                    counter=0
+                    ipmitool -I lanplus -U ${IPMI_USERNAME} -E -H $TARGET_NCN_mgmt_host chassis power cycle
+                    echo "Boot timeout, power cycle again"
+                fi
+                sleep 2
+            done
+  - name: "wait-for-cloud-init"
+    dependencies:
+      - wait-for-boot
+    templateRef:
+      name: ssh-template
+      template: shell-script
+    arguments:
+      parameters:
+        - name: dryRun
+          value: "{{ `{{inputs.parameters.dryRun}}` }}"
+        - name: scriptContent
+          value: |
+            {{- include "common.envar" . | indent 12 }}
+            # wait random seconds (1-10s) until ssh is working
+            echo "wait for ssh ..."
+            while ! ssh "${TARGET_NCN}" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null 'ls /var/log/cloud-init-output.log'
+            do
+              echo "wait for ssh ..."
+              sleep $(( ( RANDOM % 10 )  + 1 ))
+            done
+            # wait for cloud-init
+            # ssh commands are expected to fail for a while, so we temporarily disable set -e
+            set +e
+            echo "waiting for cloud-init: $TARGET_NCN ..."
+            while true ; do
+                ssh "${TARGET_NCN}" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null 'cat /var/log/cloud-init-output.log | grep "The system is finally up"' &> /dev/null && break
+                echo "waiting for cloud-init: $TARGET_NCN ..."
+                sleep 20
+            done
+            # Restore set -e
+            set -e
+{{end}}

--- a/workflows/ncn/storage/storage.common.parameters.yaml
+++ b/workflows/ncn/storage/storage.common.parameters.yaml
@@ -25,5 +25,4 @@
 parameters:
   - name: targetNcn
   - name: dryRun
-  - name: zapOsds
 {{end}}

--- a/workflows/ncn/storage/storage.common.parameters.yaml
+++ b/workflows/ncn/storage/storage.common.parameters.yaml
@@ -21,7 +21,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-{{define "worker.common.parameters"}}
+{{define "storage.common.parameters"}}
 parameters:
   - name: targetNcn
   - name: dryRun

--- a/workflows/ncn/storage/storage.common.parameters.yaml
+++ b/workflows/ncn/storage/storage.common.parameters.yaml
@@ -1,0 +1,29 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+{{define "worker.common.parameters"}}
+parameters:
+  - name: targetNcn
+  - name: dryRun
+  - name: zapOsds
+{{end}}

--- a/workflows/ncn/storage/storage.rebuild.new.yaml
+++ b/workflows/ncn/storage/storage.rebuild.new.yaml
@@ -105,11 +105,7 @@ spec:
                     source /srv/cray/scripts/metal/metal-lib.sh
                     csi_url=$(paginate "https://packages.local/service/rest/v1/components?repository=csm-sle-15sp3" \
                       | jq -r  '.items[] | .assets[] | .downloadUrl' | grep "cray-site-init" | sort -V | tail -1)
-                    pdsh -S -w $(grep -oP 'ncn-\m\d+' /etc/hosts | sort -u | tr -t '\n' ',') "zypper install -y $csi_url"
-                    if [[ $? -eq 106 ]]; then
-                      # csi is already installed
-                      exit 0
-                    fi
+                    pdsh -S -w $(grep -oP 'ncn-\m\d+' /etc/hosts | sort -u | tr -t '\n' ',') "zypper install -y $csi_url" || [[ $? -eq 106 ]] # code 106 means "nothing to do, csi is installed"
           {{- range $index,$value := .TargetNcns}}
           - name: verify-bss-runcmd
             templateRef:
@@ -213,7 +209,7 @@ spec:
                     echo "Successfully checked bootloader on $TARGET_NCN and removed /metal/recovery."
           # storage nodes rebuild with bss.no-wipe=0
           - name: set-bss-no-wipe-0-{{$value}}
-            template: set-bss-no-wipe
+            template: set-bss-no-wipe-0
             dependencies:
               - enter-ceph-orch-maintenance-mode
             arguments:
@@ -222,8 +218,6 @@ spec:
                 value: {{$value}}
               - name: dryRun
                 value: "{{$.DryRun}}"
-              - name: wipeOsds
-                value: "true" # TODO wipe-osds
           # reboot node and wait for cloud-init before proceeding
           - name: reboot-{{$value}}
             dependencies: 
@@ -239,7 +233,7 @@ spec:
                 value: "{{$.DryRun}}"
           # set bss.no-wipe to 1 so that node will not be accidentally wiped
           - name: set-bss-no-wipe-1-{{$value}}
-            template: set-bss-no-wipe
+            template: set-bss-no-wipe-1
             dependencies:
               - reboot-{{$value}}
             arguments:
@@ -248,8 +242,6 @@ spec:
                 value: {{$value}}
               - name: dryRun
                 value: "{{$.DryRun}}"
-              - name: wipeOsds
-                value: "false"
           - name: copy-ceph-pub-to-{{$value}}
             dependencies:
               - reboot-{{$value}}
@@ -371,7 +363,7 @@ spec:
                 - name: scriptContent
                   value: |
                     TARGET_NCN={{$value}}
-                    zapOsds={{$.ZapOsds}}
+                    zapOsds=false#{{$.ZapOsds}}
                     echo "zapOsds parameter recieved is: $zapOsds"
                     echo "not going to zap osds despite parameter"
                     #if $zapOsds; then
@@ -458,6 +450,8 @@ spec:
                       systemctl enable keepalived.service
                       systemctl restart keepalived.service'
           - name: post-rebuild-ceph-health-check
+            dependencies:
+              - add-nodes-haproxy-keepalived
             templateRef:
               name: ssh-template
               template: shell-script
@@ -469,11 +463,16 @@ spec:
                   value: |
                     /opt/cray/tests/install/ncn/scripts/ceph-service-status.sh -v true || /opt/cray/tests/install/ncn/scripts/ceph-service-status.sh -A true -v true
           {{- end }}
-    - name: set-bss-no-wipe
+    - name: set-bss-no-wipe-0
       inputs:
         {{- include "storage.common.parameters" . | indent 8 }}
       dag:
-        {{- include "common.set-bss-no-wipe" . | indent 8 }}
+        {{- include "common.set-bss-no-wipe-0" . | indent 8 }}
+    - name: set-bss-no-wipe-1
+      inputs:
+        {{- include "storage.common.parameters" . | indent 8 }}
+      dag:
+        {{- include "common.set-bss-no-wipe-1" . | indent 8 }}
     - name: reboot-node
       inputs:
         {{- include "storage.common.parameters" . | indent 8 }}

--- a/workflows/ncn/storage/storage.rebuild.new.yaml
+++ b/workflows/ncn/storage/storage.rebuild.new.yaml
@@ -1,0 +1,481 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: ncn-lifecycle-rebuild-
+  labels:
+    target-ncns: "{{$length := len .TargetNcns }}{{range $index,$value := .TargetNcns }}{{$myvar := add $index 1}}{{if lt $myvar $length}}{{$value}}.{{else}}{{$value}}{{end}}{{ end }}"
+    type: rebuild
+    node-type: storage
+spec:
+  podMetadata:
+    annotations:
+      sidecar.istio.io/inject: "false"    
+  volumes:
+    - name: ssh
+      hostPath:
+        path: /root/.ssh
+        type: Directory
+    - name: host-usr-bin
+      hostPath:
+        path: /usr/bin
+        type: Directory
+    - name: podinfo
+      downwardAPI:
+        items:
+          - path: "labels"
+            fieldRef:
+              fieldPath: metadata.labels
+          - path: "annotations"
+            fieldRef:
+              fieldPath: metadata.annotations
+  # schedule workflow jobs asap
+  priorityCLassName: system-node-critical
+  # Pod GC strategy must be one of the following:
+  # * OnPodCompletion - delete pods immediately when pod is completed (including errors/failures)
+  # * OnPodSuccess - delete pods immediately when pod is successful
+  # * OnWorkflowCompletion - delete pods when workflow is completed
+  # * OnWorkflowSuccess - delete pods when workflow is successful
+  podGC:
+    strategy: OnPodCompletion
+  # allow workflow jobs running on master node
+  #   we may have a situation that all worker nodes
+  #   are marked as "being rebuilt" (cray.nls=ncn-w001)
+  tolerations:
+    - key: "node-role.kubernetes.io/master"
+      operator: "Exists"
+      effect: "NoSchedule"
+  affinity:
+    nodeAffinity:
+      # avoid putting workflow jobs onto workers that will be rebuilt
+      # this label is set onto each workers at beginning of workflow
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: cray.nls
+            operator: NotIn
+            values:
+            {{- range $index,$value := .TargetNcns }}
+            - {{$value -}}
+            {{- end }}
+      # try to use master nodes as much as possible
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 50
+          preference:
+            matchExpressions:
+            - key: node-role.kubernetes.io/master
+              operator: Exists
+  entrypoint: main
+  templates:
+    - name: main
+      dag:
+        tasks:
+          - name: install-csi
+            templateRef:
+              name: ssh-template
+              template: shell-script
+            arguments:
+              parameters:
+                - name: dryRun
+                  value: "{{$.DryRun}}"
+                - name: scriptContent
+                  value: |
+                    source /srv/cray/scripts/metal/metal-lib.sh
+                    csi_url=$(paginate "https://packages.local/service/rest/v1/components?repository=csm-sle-15sp3" \
+                      | jq -r  '.items[] | .assets[] | .downloadUrl' | grep "cray-site-init" | sort -V | tail -1)
+                    pdsh -S -w $(grep -oP 'ncn-\m\d+' /etc/hosts | sort -u | tr -t '\n' ',') "zypper install -y $csi_url"
+                    if [[ $? -eq 106 ]]; then
+                      # csi is already installed
+                      exit 0
+                    fi
+          {{- range $index,$value := .TargetNcns}}
+          - name: verify-bss-runcmd
+            templateRef:
+              name: ssh-template
+              template: shell-script
+            arguments:
+              parameters:
+                - name: dryRun
+                  value: "{{$.DryRun}}"
+                - name: scriptContent
+                  value: |
+                    TARGET_NCN={{$value}}
+                    TARGET_XNAME=$(ssh $TARGET_NCN cat /etc/cray/xname)
+                    cloud_init_script=$(cray bss bootparameters list --name ${TARGET_XNAME} --format=json|jq -r '.[]|.["cloud-init"]|.["user-data"].runcmd' | grep "storage-ceph-cloudinit.sh") || cloud_init_script=""
+                    if [[ -n $cloud_init_script ]]; then
+                      # fix BSS run command
+                      python3 /usr/share/doc/csm/scripts/patch-ceph-runcmd.py
+                      # verify the run command has been fixed
+                      cloud_init_script=$(cray bss bootparameters list --name ${TARGET_XNAME} --format=json|jq -r '.[]|.["cloud-init"]|.["user-data"].runcmd' | grep "storage-ceph-cloudinit.sh")
+                      if [[ -n $cloud_init_script ]]; then
+                        echo "ERROR: There was an issue removing 'storage-ceph-cloudinit.sh' from the BSS run command. Run 'python3 /usr/share/doc/csm/scripts/patch-ceph-runcmd.py' to fix this manually."
+                        exit 1
+                      fi
+                    else
+                      echo "BSS run command is correct."
+                    fi
+          - name: stop-haproxy-keepalived-on-{{$value}}
+            templateRef:
+              name: ssh-template
+              template: shell-script
+            arguments:
+              parameters:
+                - name: dryRun
+                  value: "{{$.DryRun}}"
+                - name: scriptContent
+                  value: |
+                    ssh {{$value}} "systemctl stop haproxy; systemctl stop keepalived"
+          - name: enter-ceph-orch-maintenance-mode
+            dependencies:
+              - stop-haproxy-keepalived-on-{{$value}}
+              - install-csi
+              - verify-bss-runcmd
+            templateRef:
+              name: ssh-template
+              template: shell-script
+            arguments:
+              parameters:
+                - name: dryRun
+                  value: "{{$.DryRun}}"
+                - name: scriptContent
+                  value: |
+                    TARGET_NCN={{$value}}
+                    if [[ -n $(ceph health detail | grep "$TARGET_NCN is in maintenance") ]]; then
+                      echo "$TARGET_NCN is already in maintenance mode"
+                    else
+                      ceph orch host maintenance enter $TARGET_NCN --force
+                      if [[ $? -ne 0 ]]; then
+                        echo "ERROR setting maintenance mode on $TARGET_NCN"
+                        exit 1
+                      fi
+                    fi
+          - name: destroy-and-purge-osds-on-{{$value}}
+            dependencies:
+              - enter-ceph-orch-maintenance-mode
+            templateRef:
+              name: ssh-template
+              template: shell-script
+            arguments:
+              parameters:
+                - name: dryRun
+                  value: "{{$.DryRun}}"
+                - name: scriptContent
+                  value: |
+                    TARGET_NCN={{$value}}
+                    if true; then
+                      echo "WipeOSDs is 'true' so osds on $TARGET_NCN are being removed."
+                      for node in ncn-s001 ncn-s002 ncn-s003; do
+                        if [[ $node != $TARGET_NCN ]]; then
+                          ssh $node 'for osd in $(ceph osd ls-tree '"$TARGET_NCN"'); do ceph osd destroy osd.$osd --force; ceph osd purge osd.$osd --force; done'
+                          break
+                        fi
+                      done
+                    else
+                      echo "WipeOSDs is false so this step is skipped."
+                      exit 0
+                    fi
+          - name: "validate-boot-loader"
+            dependencies:
+              - enter-ceph-orch-maintenance-mode
+            templateRef:
+              name: ssh-template
+              template: shell-script
+            arguments:
+              parameters:
+                - name: dryRun
+                  value: "{{$.DryRun}}"
+                - name: scriptContent
+                  value: |
+                    TARGET_NCN={{$value}}
+                    ssh $TARGET_NCN '/opt/cray/tests/install/ncn/scripts/check_bootloader.sh; rm -rf /metal/recovery/*'
+                    echo "Successfully checked bootloader on $TARGET_NCN and removed /metal/recovery."
+          # storage nodes rebuild with bss.no-wipe=0
+          - name: set-bss-no-wipe-0-{{$value}}
+            template: set-bss-no-wipe
+            dependencies:
+              - enter-ceph-orch-maintenance-mode
+            arguments:
+              parameters:
+              - name: targetNcn
+                value: {{$value}}
+              - name: dryRun
+                value: "{{$.DryRun}}"
+              - name: wipeOsds
+                value: "true" # TODO wipe-osds
+          # reboot node and wait for cloud-init before proceeding
+          - name: reboot-{{$value}}
+            dependencies: 
+              - set-bss-no-wipe-0-{{$value}}
+              - destroy-and-purge-osds-on-{{$value}}
+              - validate-boot-loader
+            template: reboot-node
+            arguments:
+              parameters:
+              - name: targetNcn
+                value: {{$value}}
+              - name: dryRun
+                value: "{{$.DryRun}}"
+          # set bss.no-wipe to 1 so that node will not be accidentally wiped
+          - name: set-bss-no-wipe-1-{{$value}}
+            template: set-bss-no-wipe
+            dependencies:
+              - reboot-{{$value}}
+            arguments:
+              parameters:
+              - name: targetNcn
+                value: {{$value}}
+              - name: dryRun
+                value: "{{$.DryRun}}"
+              - name: wipeOsds
+                value: "false"
+          - name: copy-ceph-pub-to-{{$value}}
+            dependencies:
+              - reboot-{{$value}}
+            templateRef:
+              name: ssh-template
+              template: shell-script
+            arguments:
+              parameters:
+                - name: dryRun
+                  value: "{{$.DryRun}}"
+                - name: scriptContent
+                  value: |
+                    TARGET_NCN={{$value}}
+                    # update ssh key to node
+                    TARGET_ip=$(host ${TARGET_NCN} | awk '{ print $NF }')
+                    ssh-keygen -R ${TARGET_NCN} -f ~/.ssh/known_hosts > /dev/null 2>&1
+                    ssh-keygen -R ${TARGET_ip} -f ~/.ssh/known_hosts > /dev/null 2>&1
+                    ssh-keyscan -H ${TARGET_NCN},${TARGET_ip} >> ~/.ssh/known_hosts
+                    # copy ceph.pub to node
+                    ceph cephadm get-pub-key > ~/ceph.pub
+                    ssh-copy-id -f -i ~/ceph.pub root@${TARGET_NCN}
+          - name: "exit-ceph-orch-maintenance-mode"
+            dependencies:
+              - copy-ceph-pub-to-{{$value}}
+              - set-bss-no-wipe-1-{{$value}}
+            templateRef:
+              name: ssh-template
+              template: shell-script
+            arguments:
+              parameters:
+                - name: dryRun
+                  value: "{{$.DryRun}}"
+                - name: scriptContent
+                  value: |
+                    TARGET_NCN={{$value}}
+                    ceph orch host maintenance exit $TARGET_NCN
+                    if [[ $? -ne 0 ]]; then
+                      echo "ERROR exiting maintenance mode on $TARGET_NCN"
+                      exit 1
+                    fi
+          - name: update-ssh-keys-on-{{$value}}
+            dependencies:
+              - reboot-{{$value}}
+            templateRef:
+              name: ssh-template
+              template: shell-script
+            arguments:
+              parameters:
+                - name: dryRun
+                  value: "{{$.DryRun}}"
+                - name: scriptContent
+                  value: |
+                    TARGET_NCN={{$value}}
+                    TARGET_NCN_ip=$(host ${TARGET_NCN} | awk '{ print $NF }')
+                    # update ssh keys for rebuilt node on host and on ncn-s001/2/3
+                    ssh $TARGET_NCN "truncate --size=0 ~/.ssh/known_hosts 2>&1"
+                    for node in ncn-s001 ncn-s002 ncn-s003; do
+                      if ! host ${node}; then
+                        echo "Unable to get IP address of $node"
+                        exit 1
+                      else
+                        ncn_ip=$(host ${node} | awk '{ print $NF }')
+                      fi
+                      # add new authorized_hosts entry for the node
+                      ssh $TARGET_NCN "ssh-keyscan -H ""${node},${ncn_ip}"" >> ~/.ssh/known_hosts"
+                      
+                      if [[ "$TARGET_NCN" != "$node" ]]; then
+                        ssh $node "if [[ ! -f ~/.ssh/known_hosts ]]; then > ~/.ssh/known_hosts; fi; ssh-keygen -R $TARGET_NCN -f ~/.ssh/known_hosts > /dev/null 2>&1; ssh-keygen -R $TARGET_NCN_ip -f ~/.ssh/known_hosts > /dev/null 2>&1; ssh-keyscan -H ${TARGET_NCN},${TARGET_NCN_ip} >> ~/.ssh/known_hosts"
+                      fi
+                    done
+          - name: copy-files-to-{{$value}}
+            dependencies:
+              - update-ssh-keys-on-{{$value}}
+            templateRef:
+              name: ssh-template
+              template: shell-script
+            arguments:
+              parameters:
+                - name: dryRun
+                  value: "{{$.DryRun}}"
+                - name: scriptContent
+                  value: |
+                    TARGET_NCN={{$value}}
+                    for node in ncn-s001 ncn-s002 ncn-s003; do
+                      if [[ "$TARGET_NCN" == "$node" ]]; then
+                        continue
+                      else
+                        if [[ "$TARGET_NCN" =~ ^("ncn-s001"|"ncn-s002"|"ncn-s003")$ ]]
+                        then
+                          scp $node:/etc/ceph/* ${TARGET_NCN}:/etc/ceph
+                        else
+                          scp $node:/etc/ceph/\{rgw.pem,ceph.conf,ceph_conf_min,ceph.client.ro.keyring\}  ${TARGET_NCN}:/etc/ceph/
+                        fi
+                        break
+                      fi
+                    done
+                    # copy ceph.client.ro.keyring
+                    if ! $(ceph auth get client.ro >/dev/null 2>/dev/null); then
+                      ceph-authtool -C /etc/ceph/ceph.client.ro.keyring -n client.ro --cap mon 'allow r' --cap mds 'allow r' --cap osd 'allow r' --cap mgr 'allow r' --gen-key
+                    fi
+                    if [ -f "/etc/ceph/ceph.client.ro.keyring" ]; then
+                      ceph auth import -i /etc/ceph/ceph.client.ro.keyring
+                    else
+                      ceph auth get client.ro -o /etc/ceph/ceph.client.ro.keyring
+                      ceph auth import -i /etc/ceph/ceph.client.ro.keyring
+                    fi
+                    for node in $(ceph orch host ls --format=json|jq -r '.[].hostname'); do scp /etc/ceph/ceph.client.ro.keyring $node:/etc/ceph/ceph.client.ro.keyring; done
+          - name: "zap-osds" #only if needed
+            dependencies:
+              - copy-files-to-{{$value}}
+              - exit-ceph-orch-maintenance-mode
+            templateRef:
+              name: ssh-template
+              template: shell-script
+            arguments:
+              parameters:
+                - name: dryRun
+                  value: "{{$.DryRun}}"
+                - name: scriptContent
+                  value: |
+                    TARGET_NCN={{$value}}
+                    zapOsds={{$.ZapOsds}}
+                    echo "zapOsds parameter recieved is: $zapOsds"
+                    echo "not going to zap osds despite parameter"
+                    #if $zapOsds; then
+                    if false; then
+                      echo "Zapping-OSDs..."
+                      for drive in $(ceph orch device ls $TARGET_NCN --format json-pretty |jq -r '.[].devices[].path'); do
+                        ceph orch device zap $TARGET_NCN $drive --force
+                      done
+                    else
+                      echo "OSDs are not being zapped."
+                      echo "OSDs only need to be zapped if unable to wipe the node prior to rebuild. For example, when a storage node unintentionally goes down and needs to be rebuilt."
+                      echo "If this is incorrect and the OSDs should be zapped, after the node rebuild completes, follow the instructions at docs-csm/operations/utility_storage/Add_Ceph_Node.md 'Zapping OSDs'."
+                    fi
+          - name: "deploy-rados-gateway"
+            dependencies:
+              - zap-osds
+            templateRef:
+              name: ssh-template
+              template: shell-script
+            arguments:
+              parameters:
+                - name: dryRun
+                  value: "{{$.DryRun}}"
+                - name: scriptContent
+                  value: |
+                    if true; then # this will change once num_rgw_instances is configurable
+                      # deploy rados gateway on all storage nodes
+                      storage_nodes=$(ceph orch host ls --format json | jq -r '.[].hostname' | tr '\n' ' ')
+                    else #once configurable, change num='2'
+                      # deploy rados gateway on specified 'n' storage nodes, (deploys on ncn-s00[1-n] nodes)
+                      storage_nodes=$(ceph orch host ls --format json |jq -r '.[].hostname' | tr '\n' ' ' | awk -v num='2' -F" " '{ for (x=1; x<=num; x++) printf("%s ", $x) }')
+                    fi
+                    # remove space at end of string
+                    storage_nodes="${storage_nodes%?}"
+                    ceph orch apply rgw site1 zone1 --placement="${storage_nodes}" --port=8080
+                    sleep 20
+                    
+                    # ensure rgw is running on desired nodes
+                    success=false
+                    count=0
+                    while [[ $count -lt 30 ]] && ! $success; do
+                      success=true
+                      for node in $storage_nodes; do
+                        if ! ceph orch ps $node --daemon_type rgw | grep "running"; then
+                          echo "Not all rgw daemons are running yet..."
+                          sleep 30
+                          let count=${count}+1
+                          success=false
+                          break
+                        fi
+                      done
+                    done
+                    if ! $success; then
+                      echo "Error: RGW is not running on all nodes: ${storage_nodes}. Run 'ceph -s' to see if an issue is shown. It may take more time for all daemons to start running."
+                      exit 1
+                    else
+                      echo "RGW is 'running' on $storage_nodes"
+                    fi
+          - name: "add-nodes-haproxy-keepalived"
+            dependencies:
+              - deploy-rados-gateway
+            templateRef:
+              name: ssh-template
+              template: shell-script
+            arguments:
+              parameters:
+                - name: dryRun
+                  value: "{{$.DryRun}}"
+                - name: scriptContent
+                  value: |
+                    if true; then # this will change once num_rgw_instances is configurable
+                      # deploy haproxy and keepalived on all storage nodes
+                      num_storage_nodes=$(ceph orch host ls | tail -1 | awk '{print $1}')
+                    else
+                      # deploy haproxy and keepalived on specified 'n' storage nodes, (deploys on ncn-s00[1-n] nodes)
+                      num_storage_nodes=3
+                    fi
+                    pdsh -w ncn-s00[1-${num_storage_nodes}] -f 2 \
+                      'source /srv/cray/scripts/metal/update_apparmor.sh
+                      reconfigure-apparmor; /srv/cray/scripts/metal/generate_haproxy_cfg.sh > /etc/haproxy/haproxy.cfg
+                      systemctl enable haproxy.service
+                      systemctl restart haproxy.service
+                      /srv/cray/scripts/metal/generate_keepalived_conf.sh > /etc/keepalived/keepalived.conf
+                      systemctl enable keepalived.service
+                      systemctl restart keepalived.service'
+          - name: post-rebuild-ceph-health-check
+            templateRef:
+              name: ssh-template
+              template: shell-script
+            arguments:
+              parameters:
+                - name: dryRun
+                  value: "{{$.DryRun}}"
+                - name: scriptContent
+                  value: |
+                    /opt/cray/tests/install/ncn/scripts/ceph-service-status.sh -v true || /opt/cray/tests/install/ncn/scripts/ceph-service-status.sh -A true -v true
+          {{- end }}
+    - name: set-bss-no-wipe
+      inputs:
+        {{- include "storage.common.parameters" . | indent 8 }}
+      dag:
+        {{- include "common.set-bss-no-wipe" . | indent 8 }}
+    - name: reboot-node
+      inputs:
+        {{- include "storage.common.parameters" . | indent 8 }}
+      dag:
+        {{- include "common.reboot-node" . | indent 8 }}

--- a/workflows/ncn/storage/storage.rebuild.yaml
+++ b/workflows/ncn/storage/storage.rebuild.yaml
@@ -205,7 +205,7 @@ spec:
                 - name: scriptContent
                   value: |
                     TARGET_NCN={{$value}}
-                    ssh $TARGET_NCN '/opt/cray/tests/install/ncn/scripts/check_bootloader.sh; rm -rf /metal/recovery/*'
+                    ssh $TARGET_NCN 'if [[ ! -f /opt/cray/tests/install/ncn/scripts/check_bootloader.sh ]]; then echo "Error: this file is not present /opt/cray/tests/install/ncn/scripts/check_bootloader.sh. Please make sure the latest docs has been downloaded"; exit 1; fi; /opt/cray/tests/install/ncn/scripts/check_bootloader.sh; rm -rf /metal/recovery/*'
                     echo "Successfully checked bootloader on $TARGET_NCN and removed /metal/recovery."
           # storage nodes rebuild with bss.no-wipe=0
           - name: set-bss-no-wipe-0-{{$value}}
@@ -277,10 +277,15 @@ spec:
                 - name: scriptContent
                   value: |
                     TARGET_NCN={{$value}}
-                    ceph orch host maintenance exit $TARGET_NCN
-                    if [[ $? -ne 0 ]]; then
-                      echo "ERROR exiting maintenance mode on $TARGET_NCN"
-                      exit 1
+                    if [[ -n $(ceph health detail | grep "$TARGET_NCN is in maintenance") ]]; then
+                      echo "$TARGET_NCN is in maintenance mode. Exiting maintence mode now."
+                      ceph orch host maintenance exit $TARGET_NCN
+                      if [[ $? -ne 0 ]]; then
+                        echo "ERROR exiting maintenance mode on $TARGET_NCN"
+                        exit 1
+                      fi
+                    else
+                      echo "$TARGET_NCN is not in maintenance mode. Nothing to do."
                     fi
           - name: update-ssh-keys-on-{{$value}}
             dependencies:
@@ -331,7 +336,7 @@ spec:
                       else
                         if [[ "$TARGET_NCN" =~ ^("ncn-s001"|"ncn-s002"|"ncn-s003")$ ]]
                         then
-                          scp $node:/etc/ceph/* ${TARGET_NCN}:/etc/ceph
+                          scp $node:/etc/ceph/\{rgw.pem,ceph.conf,ceph_conf_min,ceph.client.ro.keyring,ceph.client.admin.keyring\} ${TARGET_NCN}:/etc/ceph
                         else
                           scp $node:/etc/ceph/\{rgw.pem,ceph.conf,ceph_conf_min,ceph.client.ro.keyring\}  ${TARGET_NCN}:/etc/ceph/
                         fi
@@ -363,11 +368,8 @@ spec:
                 - name: scriptContent
                   value: |
                     TARGET_NCN={{$value}}
-                    zapOsds=false#{{$.ZapOsds}}
-                    echo "zapOsds parameter recieved is: $zapOsds"
-                    echo "not going to zap osds despite parameter"
-                    #if $zapOsds; then
-                    if false; then
+                    zapOsds={{$.ZapOsds}}
+                    if $zapOsds; then
                       echo "Zapping-OSDs..."
                       for drive in $(ceph orch device ls $TARGET_NCN --format json-pretty |jq -r '.[].devices[].path'); do
                         ceph orch device zap $TARGET_NCN $drive --force
@@ -389,13 +391,8 @@ spec:
                   value: "{{$.DryRun}}"
                 - name: scriptContent
                   value: |
-                    if true; then # this will change once num_rgw_instances is configurable
-                      # deploy rados gateway on all storage nodes
-                      storage_nodes=$(ceph orch host ls --format json | jq -r '.[].hostname' | tr '\n' ' ')
-                    else #once configurable, change num='2'
-                      # deploy rados gateway on specified 'n' storage nodes, (deploys on ncn-s00[1-n] nodes)
-                      storage_nodes=$(ceph orch host ls --format json |jq -r '.[].hostname' | tr '\n' ' ' | awk -v num='2' -F" " '{ for (x=1; x<=num; x++) printf("%s ", $x) }')
-                    fi
+                    # deploy rados gateway on all storage nodes
+                    storage_nodes=$(ceph orch host ls --format json | jq -r '.[].hostname' | tr '\n' ' ')
                     # remove space at end of string
                     storage_nodes="${storage_nodes%?}"
                     ceph orch apply rgw site1 zone1 --placement="${storage_nodes}" --port=8080
@@ -434,14 +431,8 @@ spec:
                   value: "{{$.DryRun}}"
                 - name: scriptContent
                   value: |
-                    if true; then # this will change once num_rgw_instances is configurable
-                      # deploy haproxy and keepalived on all storage nodes
-                      num_storage_nodes=$(ceph orch host ls | tail -1 | awk '{print $1}')
-                    else
-                      # deploy haproxy and keepalived on specified 'n' storage nodes, (deploys on ncn-s00[1-n] nodes)
-                      num_storage_nodes=3
-                    fi
-                    pdsh -w ncn-s00[1-${num_storage_nodes}] -f 2 \
+                    num_storage_nodes=$(ceph orch host ls | tail -1 | awk '{print $1}')
+                    pdsh -R ssh -w ncn-s00[1-${num_storage_nodes}] -S -f 2 \
                       'source /srv/cray/scripts/metal/update_apparmor.sh
                       reconfigure-apparmor; /srv/cray/scripts/metal/generate_haproxy_cfg.sh > /etc/haproxy/haproxy.cfg
                       systemctl enable haproxy.service

--- a/workflows/ncn/storage/storage.rebuild.yaml
+++ b/workflows/ncn/storage/storage.rebuild.yaml
@@ -205,7 +205,12 @@ spec:
                 - name: scriptContent
                   value: |
                     TARGET_NCN={{$value}}
-                    ssh $TARGET_NCN 'if [[ ! -f /opt/cray/tests/install/ncn/scripts/check_bootloader.sh ]]; then echo "Error: this file is not present /opt/cray/tests/install/ncn/scripts/check_bootloader.sh. Please make sure the latest docs has been downloaded"; exit 1; fi; /opt/cray/tests/install/ncn/scripts/check_bootloader.sh; rm -rf /metal/recovery/*'
+                    if [[ ! -f /opt/cray/tests/install/ncn/scripts/check_bootloader.sh ]]; then 
+                      echo "Error: this file is not present /opt/cray/tests/install/ncn/scripts/check_bootloader.sh on ncn-m001."
+                      exit 1
+                    fi
+                    scp /opt/cray/tests/install/ncn/scripts/check_bootloader.sh $TARGET_NCN:/opt/cray/tests/install/ncn/scripts/check_bootloader.sh
+                    ssh $TARGET_NCN '/opt/cray/tests/install/ncn/scripts/check_bootloader.sh; rm -rf /metal/recovery/*'
                     echo "Successfully checked bootloader on $TARGET_NCN and removed /metal/recovery."
           # storage nodes rebuild with bss.no-wipe=0
           - name: set-bss-no-wipe-0-{{$value}}
@@ -368,7 +373,7 @@ spec:
                 - name: scriptContent
                   value: |
                     TARGET_NCN={{$value}}
-                    zapOsds={{$.ZapOsds}}
+                    zapOsds="{{$.ZapOsds}}"
                     if $zapOsds; then
                       echo "Zapping-OSDs..."
                       for drive in $(ceph orch device ls $TARGET_NCN --format json-pretty |jq -r '.[].devices[].path'); do


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
Add storage node rebuild workflow. This will be used for IUF stage: management-node-rollout.
This procedure has been tested on Surtur and Frigg.

Example [rebuild on surtur](https://argo.cmn.surtur.hpc.amslabs.hpecorp.net/workflows/argo/ncn-lifecycle-rebuild-74rjp?tab=workflow)

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
