### PR TITLE
CASMTRIAGE-4693 upgrades need to load kernel modules

### DIFF
--- a/workflows/ncn/hooks/after-each/kernel-module-workaround.yaml
+++ b/workflows/ncn/hooks/after-each/kernel-module-workaround.yaml
@@ -1,0 +1,91 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+apiVersion: cray-nls.hpe.com/v1
+kind: Hook
+metadata:
+  name: ensure-kernel-modules-are-loaded-for-ceph
+  labels:
+    after-each: "true"
+spec:
+  scriptContent: |
+    ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null {{inputs.parameters.targetNcn}} \
+      '
+      cat << EOF > /etc/modprobe.d/99-ceph-rbd.conf
+      #
+      # (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+      #
+      # Permission is hereby granted, free of charge, to any person obtaining a
+      # copy of this software and associated documentation files (the "Software"),
+      # to deal in the Software without restriction, including without limitation
+      # the rights to use, copy, modify, merge, publish, distribute, sublicense,
+      # and/or sell copies of the Software, and to permit persons to whom the
+      # Software is furnished to do so, subject to the following conditions:
+      #
+      # The above copyright notice and this permission notice shall be included
+      # in all copies or substantial portions of the Software.
+      #
+      # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+      # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+      # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+      # THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+      # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+      # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+      # OTHER DEALINGS IN THE SOFTWARE.
+      #
+      options fscache defer_create=1 defer_lookup=1 debug=0
+      options nbd max_part=31
+      EOF
+      cat << EOF > /etc/modules-load.d/99-ceph-rbd.conf
+      #
+      # (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+      #
+      # Permission is hereby granted, free of charge, to any person obtaining a
+      # copy of this software and associated documentation files (the "Software"),
+      # to deal in the Software without restriction, including without limitation
+      # the rights to use, copy, modify, merge, publish, distribute, sublicense,
+      # and/or sell copies of the Software, and to permit persons to whom the
+      # Software is furnished to do so, subject to the following conditions:
+      #
+      # The above copyright notice and this permission notice shall be included
+      # in all copies or substantial portions of the Software.
+      #
+      # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+      # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+      # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+      # THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+      # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+      # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+      # OTHER DEALINGS IN THE SOFTWARE.
+      #
+      ceph
+      fscache
+      libceph
+      libcrc32c
+      nbd
+      rbd
+      EOF
+
+      systemctl restart systemd-modules-load.service
+      '
+  templateRefName: ssh-template


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
These kernel modules must be loaded for ceph-rbd pods to run properly on the new SP4 kernel.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
