### PR TITLE
CASM-3712/CASM-3713: Create Python functions to get/update BSS bootparameters & CFS configs/sessions

### DIFF
--- a/scripts/operations/configuration/python_lib/bss.py
+++ b/scripts/operations/configuration/python_lib/bss.py
@@ -1,0 +1,190 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""Shared Python function library: BSS"""
+
+import traceback
+
+import logging
+
+from typing import Dict, List
+
+from . import api_requests
+from . import common
+from .types import JSONDecodeError
+
+BSS_BASE_URL = f"{api_requests.API_GW_BASE_URL}/apis/bss"
+BSS_BOOTPARAMS_URL = f"{BSS_BASE_URL}/boot/v1/bootparameters"
+
+
+def log_error_raise_exception(msg: str, parent_exception: Exception = None) -> None:
+    """
+    1) If a parent exception is passed in, make a debug log entry with its stack trace.
+    2) Log an error with the specified message.
+    3) Raise a ScriptException with the specified message (from the parent exception, if
+       specified)
+    """
+    if parent_exception is not None:
+        logging.debug(traceback.format_exc())
+    logging.error(msg)
+    if parent_exception is None:
+        raise common.ScriptException(msg)
+    raise common.ScriptException(msg) from parent_exception
+
+
+def get_bootparameters(xname_list: List[str] = None,
+                       expected_to_exist: bool = True) -> List[dict]:
+    """
+    Queries BSS for all bootparameters for the specified xnames (or all bootparameters, if
+    no xnames are specified). Returns the list of these bootparameters.
+    common.ScriptException is raised on error.
+
+    By default, if any xnames are specified, and bootparameters are not found for one or more of
+    them, then an exception is raised. This behavior can be overridden with the expected_to_exist
+    argument. If no xnames are specified, then the expected_to_exist argument has no effect.
+    """
+    request_kwargs = {"url": BSS_BOOTPARAMS_URL, "add_api_token": True,
+                      "expected_status_codes": {200}}
+
+    if xname_list:
+        request_kwargs["json"] = {"hosts": xname_list}
+        if not expected_to_exist:
+            request_kwargs["expected_status_codes"].add(404)
+
+    resp = api_requests.get_retry_validate(**request_kwargs)
+    if resp.status_code == 404:
+        # This will only happen if expected_to_exist is set to False and no host entries
+        # were found for the query. In this case, return an empty list.
+        return []
+
+    try:
+        bootparams_list = list(resp.json())
+    except (JSONDecodeError, TypeError) as exc:
+        log_error_raise_exception("Response from BSS has unexpected format", exc)
+
+    if not xname_list or not expected_to_exist:
+        # If no xnames were specified, or if we are not validating that the xnames all were found,
+        # then whatever list we got back is what we return
+        return bootparams_list
+
+    # Reaching here means that we did specify xname(s) and we do expect them to exist. We
+    # got a 200 status code from the request, but this does NOT ensure that every xname
+    # was found. It means that at least one was found. In this case, we must manually check
+    # that all xnames were found.
+
+    logging.debug("Validating that all specified xnames are present in BSS response")
+    missing_xnames = set(xname_list)
+    for bootparam in bootparams_list:
+        try:
+            missing_xnames.difference_update(bootparam["hosts"])
+        except (KeyError, TypeError) as exc:
+            # KeyError - if bootparam does not have a hosts field. This should always be the case,
+            #   since we sent a request with an explicit host list.
+            # TypeError - To cover the case where bootparam is not a mapping-type object, or where
+            #   bootparam["hosts"] is not a list, both of which should be the case.
+            log_error_raise_exception("Response from BSS has unexpected format", exc)
+
+    if missing_xnames:
+        missing_xnames_str = ", ".join(sorted(list(missing_xnames)))
+        log_error_raise_exception("One or more queried xnames were not found in BSS"
+                                  f" bootparameters: {missing_xnames_str}")
+
+    logging.debug("No xnames missing from BSS response")
+    return bootparams_list
+
+
+def get_bootparameters_map(xname_list: List[str]) -> Dict[str, dict]:
+    """
+    Queries BSS for all bootparameters for the specified xnames. Returns a dictionary mapping
+    every xname to its corresponding bootparameters. An exception is raised if bootparameters
+    are not found for any of the xnames. common.ScriptException is raised on error.
+    """
+    bootparams_list = get_bootparameters(xname_list=xname_list, expected_to_exist=True)
+    bootparams_map = {}
+    for xname in xname_list:
+        for bootparam in bootparams_list:
+            # Not protecting the following with try...except because that is handled inside
+            # get_bootparameters()
+            if xname in bootparam["hosts"]:
+                bootparams_map[xname] = bootparam
+                break
+
+    if len(bootparams_map) != len(xname_list):
+        log_error_raise_exception(f"Number of xnames {len(xname_list)} does not match corresponding"
+                                  f" number of BSS bootparameters {len(bootparams_map)}")
+    return bootparams_map
+
+
+def update_bootparameters_artifacts(xname_list: List[str], kernel: str, initrd: str,
+                                    rootfs: str) -> None:
+    """
+    For the specified host xnames, updates the BSS bootparameters to use the specified kernel,
+    initrd, and rootfs artifacts. The artifacts are expected to be full S3 paths (i.e.
+    "s3://boot-images/k8s/0.3.49/rootfs").
+    The rootfs artifact is updated in the "params" string field.
+    The kernel and initrd artifacts are updated in their corresponding string fields.
+    Nothing is returned on success.
+    common.ScriptException is raised on error.
+    """
+    bootparameters_map = get_bootparameters_map(xname_list)
+    # In order to avoid leaving BSS in an inconsistent state, first we make sure that all of the
+    # specified xnames have "params" fields and that we can find a metal.server link in them. While
+    # we're at it, go ahead and generate the updated params field.
+    updated_params_field = {}
+    for xname in xname_list:
+        logging.debug(f"Generating updated params string for {xname}")
+        try:
+            current_params = bootparameters_map[xname]["params"]
+        except KeyError as exc:
+            # The KeyError should be from "params", since the get_bootparameters_map function should
+            # have raised an exception if the xname itself was not found.
+            log_error_raise_exception(f"No 'params' field found in BSS bootparameters for {xname}",
+                                      exc)
+
+        new_params_list = []
+        found = False
+        for current_param in current_params.split():
+            if current_param.find("metal.server=") == 0:
+                new_params_list.append(f"metal.server={rootfs}")
+                found = True
+                continue
+            new_params_list.append(current_param)
+        if not found:
+            log_error_raise_exception("No metal.server string found in 'params' field of BSS"
+                                      f" bootparameters for {xname}")
+        updated_params = " ".join(new_params_list)
+        logging.debug(f"Updated BSS bootparameters 'params' field for {xname}: {updated_params}")
+        updated_params_field[xname] = updated_params
+
+    # Now do the updates for each xname
+    request_kwargs = {"url": BSS_BOOTPARAMS_URL, "add_api_token": True,
+                      "expected_status_codes": 200}
+
+    for xname, updated_params in updated_params_field.items():
+        logging.info(f"Updating BSS bootparameters for {xname} with kernel '{kernel}', initrd "
+                     f"{initrd}, and rootfs {rootfs}")
+        request_json = {"hosts": [xname], "params": updated_params, "kernel": kernel,
+                        "initrd": initrd}
+        api_requests.patch_retry_validate(json=request_json, **request_kwargs)
+
+    logging.info("BSS bootparameters updated for all specified xnames")

--- a/scripts/operations/configuration/python_lib/bss.py
+++ b/scripts/operations/configuration/python_lib/bss.py
@@ -27,7 +27,7 @@ import traceback
 
 import logging
 
-from typing import Dict, List
+from typing import Dict, List, Union
 
 from . import api_requests
 from . import common
@@ -37,7 +37,7 @@ BSS_BASE_URL = f"{api_requests.API_GW_BASE_URL}/apis/bss"
 BSS_BOOTPARAMS_URL = f"{BSS_BASE_URL}/boot/v1/bootparameters"
 
 
-def log_error_raise_exception(msg: str, parent_exception: Exception = None) -> None:
+def log_error_raise_exception(msg: str, parent_exception: Union[Exception, None] = None) -> None:
     """
     1) If a parent exception is passed in, make a debug log entry with its stack trace.
     2) Log an error with the specified message.
@@ -52,7 +52,7 @@ def log_error_raise_exception(msg: str, parent_exception: Exception = None) -> N
     raise common.ScriptException(msg) from parent_exception
 
 
-def get_bootparameters(xname_list: List[str] = None,
+def get_bootparameters(xname_list: Union[List[str], None] = None,
                        expected_to_exist: bool = True) -> List[dict]:
     """
     Queries BSS for all bootparameters for the specified xnames (or all bootparameters, if

--- a/scripts/operations/configuration/python_lib/cfs.py
+++ b/scripts/operations/configuration/python_lib/cfs.py
@@ -1,0 +1,150 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""Shared Python function library: CFS"""
+
+import traceback
+
+import logging
+
+from typing import Dict, List
+
+from . import api_requests
+from . import common
+from .types import JSONDecodeError
+
+CFS_BASE_URL = f"{api_requests.API_GW_BASE_URL}/apis/cfs"
+CFS_V2_BASE_URL = f"{CFS_BASE_URL}/v2"
+CFS_V2_CONFIGS_URL = f"{CFS_V2_BASE_URL}/configurations"
+CFS_V2_SESSIONS_URL = f"{CFS_V2_BASE_URL}/sessions"
+
+
+def log_error_raise_exception(msg: str, parent_exception: Exception = None) -> None:
+    """
+    1) If a parent exception is passed in, make a debug log entry with its stack trace.
+    2) Log an error with the specified message.
+    3) Raise a ScriptException with the specified message (from the parent exception, if
+       specified)
+    """
+    if parent_exception is not None:
+        logging.debug(traceback.format_exc())
+    logging.error(msg)
+    if parent_exception is None:
+        raise common.ScriptException(msg)
+    raise common.ScriptException(msg) from parent_exception
+
+
+def get_session(session_name: str, expected_to_exist: bool = True) -> dict:
+    """
+    Queries CFS for the specified session and returns it. Throws an exception if it
+    is not found, unless expected_to_exist is set to False, in which case None is
+    returned.
+    """
+    request_kwargs = {"url": f"{CFS_V2_SESSIONS_URL}/{session_name}",
+                      "add_api_token": True,
+                      "expected_status_codes": {200}}
+
+    if not expected_to_exist:
+        request_kwargs["expected_status_codes"].add(404)
+
+    resp = api_requests.get_retry_validate(**request_kwargs)
+    if resp.status_code == 404:
+        # This will only happen if expected_to_exist is set to False and the session
+        # was not found. In this case, return None.
+        return None
+
+    try:
+        return resp.json()
+    except JSONDecodeError as exc:
+        log_error_raise_exception("Response from CFS has unexpected format", exc)
+
+
+def create_dynamic_session(session_name: str, config_name: str,
+                           xname_limit: List[str] = None) -> dict:
+    """
+    Creates a CFS session of dynamic type with the specified name, running the specified
+    CFS configuration. By default this will be run on all applicable nodes, based on
+    the Ansible inventory and the node types defined in the Ansible play. This can be
+    limited by specifying a list of xnames.
+
+    The CFS session entry is returned if successful. Otherwise an exception is raised.
+    """
+    request_kwargs = {"url": CFS_V2_SESSIONS_URL,
+                      "json": {"name": session_name, "configurationName": config_name},
+                      "add_api_token": True,
+                      "expected_status_codes": {200}}
+    if xname_limit:
+        request_kwargs["json"]["ansibleLimit"] = ",".join(xname_limit)
+
+    resp = api_requests.post_retry_validate(**request_kwargs)
+
+    try:
+        return resp.json()
+    except JSONDecodeError as exc:
+        log_error_raise_exception("Response from CFS has unexpected format", exc)
+
+
+def get_configuration(config_name: str, expected_to_exist: bool = True) -> dict:
+    """
+    Queries CFS for the specified configuration and returns it. Throws an exception if it
+    is not found, unless expected_to_exist is set to False, in which case None is
+    returned.
+    """
+    request_kwargs = {"url": f"{CFS_V2_CONFIGS_URL}/{config_name}",
+                      "add_api_token": True,
+                      "expected_status_codes": {200}}
+
+    if not expected_to_exist:
+        request_kwargs["expected_status_codes"].add(404)
+
+    resp = api_requests.get_retry_validate(**request_kwargs)
+    if resp.status_code == 404:
+        # This will only happen if expected_to_exist is set to False and it
+        # was not found. In this case, return None.
+        return None
+
+    try:
+        return resp.json()
+    except JSONDecodeError as exc:
+        log_error_raise_exception("Response from CFS has unexpected format", exc)
+
+
+def create_configuration(config_name: str, layers: List[Dict[str, str]]) -> dict:
+    """
+    Creates a CFS configuration with the specified name and layers.
+    The layers should be dictionaries with the following fields set:
+        cloneUrl, commit, name, playbook
+
+    The CFS configuration is returned if successful. Otherwise an exception is raised.
+    """
+    request_kwargs = {"url": f"{CFS_V2_CONFIGS_URL}/{config_name}",
+                      "json": {"layers": layers},
+                      "add_api_token": True,
+                      "expected_status_codes": {200}}
+
+    resp = api_requests.put_retry_validate(**request_kwargs)
+
+    try:
+        return resp.json()
+    except JSONDecodeError as exc:
+        log_error_raise_exception("Response from CFS has unexpected format", exc)

--- a/scripts/operations/configuration/python_lib/cfs.py
+++ b/scripts/operations/configuration/python_lib/cfs.py
@@ -27,7 +27,7 @@ import traceback
 
 import logging
 
-from typing import Dict, List
+from typing import Dict, List, Union
 
 from . import api_requests
 from . import common
@@ -39,7 +39,7 @@ CFS_V2_CONFIGS_URL = f"{CFS_V2_BASE_URL}/configurations"
 CFS_V2_SESSIONS_URL = f"{CFS_V2_BASE_URL}/sessions"
 
 
-def log_error_raise_exception(msg: str, parent_exception: Exception = None) -> None:
+def log_error_raise_exception(msg: str, parent_exception: Union[Exception, None] = None) -> None:
     """
     1) If a parent exception is passed in, make a debug log entry with its stack trace.
     2) Log an error with the specified message.
@@ -54,7 +54,7 @@ def log_error_raise_exception(msg: str, parent_exception: Exception = None) -> N
     raise common.ScriptException(msg) from parent_exception
 
 
-def get_session(session_name: str, expected_to_exist: bool = True) -> dict:
+def get_session(session_name: str, expected_to_exist: bool = True) -> Union[dict, None]:
     """
     Queries CFS for the specified session and returns it. Throws an exception if it
     is not found, unless expected_to_exist is set to False, in which case None is
@@ -80,7 +80,7 @@ def get_session(session_name: str, expected_to_exist: bool = True) -> dict:
 
 
 def create_dynamic_session(session_name: str, config_name: str,
-                           xname_limit: List[str] = None) -> dict:
+                           xname_limit: Union[List[str], None] = None) -> dict:
     """
     Creates a CFS session of dynamic type with the specified name, running the specified
     CFS configuration. By default this will be run on all applicable nodes, based on
@@ -104,7 +104,7 @@ def create_dynamic_session(session_name: str, config_name: str,
         log_error_raise_exception("Response from CFS has unexpected format", exc)
 
 
-def get_configuration(config_name: str, expected_to_exist: bool = True) -> dict:
+def get_configuration(config_name: str, expected_to_exist: bool = True) -> Union[dict, None]:
     """
     Queries CFS for the specified configuration and returns it. Throws an exception if it
     is not found, unless expected_to_exist is set to False, in which case None is

--- a/scripts/operations/configuration/python_lib/hsm.py
+++ b/scripts/operations/configuration/python_lib/hsm.py
@@ -58,7 +58,7 @@ def get_management_ncn_xnames() -> List[str]:
     """
     params = {"type": "Node", "role": "Management"}
     resp = api_requests.get_retry_validate(url=SMD_HSM_COMPONENTS_URL, expected_status_codes=200,
-                                           add_api_token=True, verify=False, params=params)
+                                           add_api_token=True, params=params)
     try:
         component_list = resp.json()["Components"]
         return sorted([comp["ID"] for comp in component_list])


### PR DESCRIPTION
# Description

This PR creates a few Python functions used to query and update BSS bootparameters, and to query and create CFS configurations and sessions. These functions are not currently used by any scripts, but will be used in upcoming PRs.

I tested the BSS functions on mug and validated that they worked as expected. 
I tested the CFS functions on fanta and validated that they worked as expected.
Of course, they will be tested further when they are integrated into other scripts in the future.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
