### PR TITLE
CASM-3755: Remove set-product-active from stages.yaml

### DIFF
--- a/workflows/iuf/stages.yaml
+++ b/workflows/iuf/stages.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -75,8 +75,6 @@ stages:
     type: product
     operations:
       - name: loftsman-manifest-deploy
-        static-parameters: {} # any parameters that will be supplied statically to this operation.
-      - name: set-product-active
         static-parameters: {} # any parameters that will be supplied statically to this operation.
 
   - name: prepare-images


### PR DESCRIPTION
# Description

This commit removes the 'set-product-active' operation from the IUF deploy-product stage.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
