### PR TITLE
CASMMON-247 adding deliver-product metrics

### DIFF
--- a/workflows/iuf/operations/ims-upload.yaml
+++ b/workflows/iuf/operations/ims-upload.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -31,11 +31,34 @@ spec:
   templates:
 ### Main Steps ###
   - name: main
+    metrics:
+        prometheus:
+        - name: operation_counter
+          help: "Count of step execution by result status"
+          labels:
+            - key: "opname"
+              value: "ims-upload"
+            - key: stage
+              value: "deliver-product"
+            - key: type
+              value: "product"
+            - key: pname
+              value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.name')}}"
+            - key: pversion
+              value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.version')}}"
+            - key: status
+              value: "{{status}}"
+          counter:
+            value: "1"
     inputs:
       parameters:
       - name: auth_token
       - name: global_params
     steps:
+    - - name: start-operation
+        templateRef:
+          name: workflow-template-record-time-template
+          template: record-time-template
     - - name: get-s3-secrets
         template: get-s3-secrets-template
     - - name: ims-upload-content
@@ -67,6 +90,60 @@ spec:
             value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.version')}}"
           - name: yaml-content
             value: "{{steps.ims-upload-content.outputs.parameters.ims_records}}"
+    - - name: end-operation
+        templateRef:
+          name: workflow-template-record-time-template
+          template: record-time-template
+    - - name:  prom-metrics
+        template: prom-metrics
+        arguments:
+          parameters:
+          - name: opstart
+            value: "{{steps.start-operation.outputs.result}}"
+          - name: opend
+            value: "{{steps.end-operation.outputs.result}}"
+          - name: pdname
+            value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.name')}}"
+          - name: pdversion
+            value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.version')}}"
+  - name: prom-metrics
+    inputs:
+      parameters:
+      - name: opstart
+      - name: opend
+      - name: pdname
+      - name: pdversion
+    metrics:
+      prometheus:
+        - name: operation_time
+          help: "Duration gauge by operation name in seconds"
+          labels:
+            - key: opname
+              value: "ims-upload"
+            - key: stage
+              value: "deliver-product"
+            - key: type
+              value: "product"
+            - key: pdname
+              value: "{{inputs.parameters.pdname}}"
+            - key: pdversion
+              value: "{{inputs.parameters.pdversion}}"
+            - key: opstart
+              value: "{{inputs.parameters.opstart}}"
+            - key: opend
+              value: "{{inputs.parameters.opend}}"
+          gauge:
+            value: "{{outputs.parameters.diff-time-value}}"
+    outputs:
+      parameters:
+        - name: diff-time-value
+          globalName: diff-time-value
+          valueFrom:
+            path: /tmp/diff_time.txt
+    container:
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/alpine/git:2.32.0
+      command: [sh, -c]
+      args: ["DIFF_TIME=$(expr {{inputs.parameters.opend}} - {{inputs.parameters.opstart}}); echo $DIFF_TIME; echo $DIFF_TIME > /tmp/diff_time.txt"]
 ### Templates ###
 ## get-s3-secrets-template ##
   - name: get-s3-secrets-template
@@ -91,7 +168,7 @@ spec:
           factor: "2"
           maxDuration: "1m"
     script:
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:latest-v1.21.1-amd64
+      image: registry.local/artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:latest-v1.21.1-amd64
       command: [bash]
       source: |
         function sync_item() {
@@ -148,7 +225,8 @@ spec:
         default: ""
 
     container:
-      image: artifactory.algol60.net/csm-docker/stable/cray-ims-load-artifacts:2.0.1
+      # replace image with standard ims-load-artifacts once PR is merged
+      image: artifactory.algol60.net/csm-docker/stable/cray-ims-load-artifacts:2.0.0
       command: ['python3']
       args: ['-m', 'ims_load_artifacts.load_artifacts']
       env:
@@ -219,7 +297,7 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
     script:
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:latest-v1.21.1-amd64
+      image: registry.local/artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:latest-v1.21.1-amd64
       command: [bash]
       source: |
         kubectl -n argo delete secret/{{inputs.parameters.s3_credentials_secret_name}}

--- a/workflows/iuf/operations/loftsman-manifest-deploy.yaml
+++ b/workflows/iuf/operations/loftsman-manifest-deploy.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -29,11 +29,34 @@ spec:
   entrypoint: main
   templates:
     - name: main
+      metrics:
+        prometheus:
+        - name: operation_counter
+          help: "Count of step execution by result status"
+          labels:
+            - key: "opname"
+              value: "loftsman-manifest-deploy"
+            - key: stage
+              value: "deploy-product"
+            - key: type
+              value: "product"
+            - key: pname
+              value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.name')}}"
+            - key: pversion
+              value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.version')}}"
+            - key: status
+              value: "{{status}}"
+          counter:
+            value: "1"
       inputs:
         parameters:
           - name: auth_token
           - name: global_params
       steps:
+      - - name: start-operation
+          templateRef:
+            name: workflow-template-record-time-template
+            template: record-time-template
       - - name: manifest-deploy
           templateRef: 
             name: iuf-base-template
@@ -109,3 +132,57 @@ spec:
                   done
 
                   exit $err
+      - - name: end-operation
+          templateRef:
+            name: workflow-template-record-time-template
+            template: record-time-template
+      - - name:  prom-metrics
+          template: prom-metrics
+          arguments:
+            parameters:
+            - name: opstart
+              value: "{{steps.start-operation.outputs.result}}"
+            - name: opend
+              value: "{{steps.end-operation.outputs.result}}"
+            - name: pdname
+              value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.name')}}"
+            - name: pdversion
+              value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.version')}}"
+    - name: prom-metrics
+      inputs:
+        parameters:
+        - name: opstart
+        - name: opend
+        - name: pdname
+        - name: pdversion
+      metrics:
+        prometheus:
+          - name: operation_time
+            help: "Duration gauge by operation name in seconds"
+            labels:
+              - key: opname
+                value: "loftsman-manifest-deploy"
+              - key: stage
+                value: "deploy-product"
+              - key: type
+                value: "product"
+              - key: pdname
+                value: "{{inputs.parameters.pdname}}"
+              - key: pdversion
+                value: "{{inputs.parameters.pdversion}}"
+              - key: opstart
+                value: "{{inputs.parameters.opstart}}"
+              - key: opend
+                value: "{{inputs.parameters.opend}}"
+            gauge:
+              value: "{{outputs.parameters.diff-time-value}}"
+      outputs:
+        parameters:
+          - name: diff-time-value
+            globalName: diff-time-value
+            valueFrom:
+              path: /tmp/diff_time.txt
+      container:
+        image: artifactory.algol60.net/csm-docker/stable/docker.io/alpine/git:2.32.0
+        command: [sh, -c]
+        args: ["DIFF_TIME=$(expr {{inputs.parameters.opend}} - {{inputs.parameters.opstart}}); echo $DIFF_TIME; echo $DIFF_TIME > /tmp/diff_time.txt"]

--- a/workflows/iuf/operations/loftsman-manifest-upload/loftsman-manifest-upload-template.yaml
+++ b/workflows/iuf/operations/loftsman-manifest-upload/loftsman-manifest-upload-template.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -31,10 +31,33 @@ spec:
   templates:
 ### Main Steps ###
   - name: main
+    metrics:
+        prometheus:
+        - name: operation_counter
+          help: "Count of step execution by result status"
+          labels:
+            - key: "opname"
+              value: "loftsman-manifest-upload"
+            - key: stage
+              value: "deliver-product"
+            - key: type
+              value: "product"
+            - key: pname
+              value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.name')}}"
+            - key: pversion
+              value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.version')}}"
+            - key: status
+              value: "{{status}}"
+          counter:
+            value: "1"
     inputs:
       parameters:
         - name: global_params
     steps:
+    - - name: start-operation
+        templateRef:
+          name: workflow-template-record-time-template
+          template: record-time-template
     - - name: loftsman-manifest-upload
         templateRef:
           name: iuf-base-template
@@ -50,3 +73,57 @@ spec:
                 PRODUCT=$(echo '{{inputs.parameters.global_params}}' | jq -r '.product_manifest.current_product.manifest.name')
 
                 /usr/local/bin/loftsman-manifest-upload "$CONTENT" "$PARENT_DIR" "$PRODUCT"
+    - - name: end-operation
+        templateRef:
+          name: workflow-template-record-time-template
+          template: record-time-template
+    - - name:  prom-metrics
+        template: prom-metrics
+        arguments:
+          parameters:
+          - name: opstart
+            value: "{{steps.start-operation.outputs.result}}"
+          - name: opend
+            value: "{{steps.end-operation.outputs.result}}"
+          - name: pdname
+            value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.name')}}"
+          - name: pdversion
+            value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.version')}}" 
+  - name: prom-metrics
+    inputs:
+      parameters:
+      - name: opstart
+      - name: opend
+      - name: pdname
+      - name: pdversion
+    metrics:
+      prometheus:
+        - name: operation_time
+          help: "Duration gauge by operation name in seconds"
+          labels:
+            - key: opname
+              value: "loftsman-manifest-upload"
+            - key: stage
+              value: "deliver-product"
+            - key: type
+              value: "product"
+            - key: pdname
+              value: "{{inputs.parameters.pdname}}"
+            - key: pdversion
+              value: "{{inputs.parameters.pdversion}}"
+            - key: opstart
+              value: "{{inputs.parameters.opstart}}"
+            - key: opend
+              value: "{{inputs.parameters.opend}}"
+          gauge:
+            value: "{{outputs.parameters.diff-time-value}}"
+    outputs:
+      parameters:
+        - name: diff-time-value
+          globalName: diff-time-value
+          valueFrom:
+            path: /tmp/diff_time.txt
+    container:
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/alpine/git:2.32.0
+      command: [sh, -c]
+      args: ["DIFF_TIME=$(expr {{inputs.parameters.opend}} - {{inputs.parameters.opstart}}); echo $DIFF_TIME; echo $DIFF_TIME > /tmp/diff_time.txt"]

--- a/workflows/iuf/operations/nexus-setup/nexus-docker-upload-template.yaml
+++ b/workflows/iuf/operations/nexus-setup/nexus-docker-upload-template.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -31,11 +31,34 @@ spec:
   templates:
 ### Main Steps ###
   - name: main
+    metrics:
+        prometheus:
+        - name: operation_counter
+          help: "Count of step execution by result status"
+          labels:
+            - key: "opname"
+              value: "nexus-docker-upload"
+            - key: stage
+              value: "deliver-product"
+            - key: type
+              value: "product"
+            - key: pname
+              value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.name')}}"
+            - key: pversion
+              value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.version')}}"
+            - key: status
+              value: "{{status}}"
+          counter:
+            value: "1"
     inputs:
       parameters:
       - name: auth_token
       - name: global_params
     steps:
+    - - name: start-operation
+        templateRef:
+          name: workflow-template-record-time-template
+          template: record-time-template
     - - name: nexus-get-prerequisites
         template: nexus-get-prerequisites-template
         arguments:
@@ -61,6 +84,60 @@ spec:
             value: "{{steps.nexus-get-prerequisites.outputs.parameters.current_product_manifest}}"
           - name: product_directory
             value: "{{steps.nexus-get-prerequisites.outputs.parameters.product_directory}}"
+    - - name: end-operation
+        templateRef:
+          name: workflow-template-record-time-template
+          template: record-time-template
+    - - name:  prom-metrics
+        template: prom-metrics
+        arguments:
+          parameters:
+          - name: opstart
+            value: "{{steps.start-operation.outputs.result}}"
+          - name: opend
+            value: "{{steps.end-operation.outputs.result}}"
+          - name: pdname
+            value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.name')}}"
+          - name: pdversion
+            value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.version')}}"
+  - name: prom-metrics
+    inputs:
+      parameters:
+      - name: opstart
+      - name: opend
+      - name: pdname
+      - name: pdversion
+    metrics:
+      prometheus:
+        - name: operation_time
+          help: "Duration gauge by operation name in seconds"
+          labels:
+            - key: opname
+              value: "nexus-docker-upload"
+            - key: stage
+              value: "deliver-product"
+            - key: type
+              value: "product"
+            - key: pdname
+              value: "{{inputs.parameters.pdname}}"
+            - key: pdversion
+              value: "{{inputs.parameters.pdversion}}"
+            - key: opstart
+              value: "{{inputs.parameters.opstart}}"
+            - key: opend
+              value: "{{inputs.parameters.opend}}"
+          gauge:
+            value: "{{outputs.parameters.diff-time-value}}"
+    outputs:
+      parameters:
+        - name: diff-time-value
+          globalName: diff-time-value
+          valueFrom:
+            path: /tmp/diff_time.txt
+    container:
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/alpine/git:2.32.0
+      command: [sh, -c]
+      args: ["DIFF_TIME=$(expr {{inputs.parameters.opend}} - {{inputs.parameters.opstart}}); echo $DIFF_TIME; echo $DIFF_TIME > /tmp/diff_time.txt"]
 ### Templates ###
 ## nexus-get-prerequisites-template ##
   - name: nexus-get-prerequisites-template

--- a/workflows/iuf/operations/nexus-setup/nexus-helm-upload-template.yaml
+++ b/workflows/iuf/operations/nexus-setup/nexus-helm-upload-template.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -31,11 +31,34 @@ spec:
   templates:
 ### Main Steps ###
   - name: main
+    metrics:
+        prometheus:
+        - name: operation_counter
+          help: "Count of step execution by result status"
+          labels:
+            - key: "opname"
+              value: "nexus-helm-upload"
+            - key: stage
+              value: "deliver-product"
+            - key: type
+              value: "product"
+            - key: pname
+              value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.name')}}"
+            - key: pversion
+              value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.version')}}"
+            - key: status
+              value: "{{status}}"
+          counter:
+            value: "1"
     inputs:
       parameters:
       - name: auth_token
       - name: global_params
     steps:
+    - - name: start-operation
+        templateRef:
+          name: workflow-template-record-time-template
+          template: record-time-template
     - - name: nexus-get-prerequisites
         template: nexus-get-prerequisites-template
         arguments:
@@ -61,6 +84,60 @@ spec:
             value: "{{steps.nexus-get-prerequisites.outputs.parameters.current_product_manifest}}"
           - name: product_directory
             value: "{{steps.nexus-get-prerequisites.outputs.parameters.product_directory}}"
+    - - name: end-operation
+        templateRef:
+          name: workflow-template-record-time-template
+          template: record-time-template
+    - - name:  prom-metrics
+        template: prom-metrics
+        arguments:
+          parameters:
+          - name: opstart
+            value: "{{steps.start-operation.outputs.result}}"
+          - name: opend
+            value: "{{steps.end-operation.outputs.result}}"
+          - name: pdname
+            value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.name')}}"
+          - name: pdversion
+            value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.version')}}"
+  - name: prom-metrics
+    inputs:
+      parameters:
+      - name: opstart
+      - name: opend
+      - name: pdname
+      - name: pdversion
+    metrics:
+      prometheus:
+        - name: operation_time
+          help: "Duration gauge by operation name in seconds"
+          labels:
+            - key: opname
+              value: "nexus-helm-upload"
+            - key: stage
+              value: "deliver-product"
+            - key: type
+              value: "product"
+            - key: pdname
+              value: "{{inputs.parameters.pdname}}"
+            - key: pdversion
+              value: "{{inputs.parameters.pdversion}}"
+            - key: opstart
+              value: "{{inputs.parameters.opstart}}"
+            - key: opend
+              value: "{{inputs.parameters.opend}}"
+          gauge:
+            value: "{{outputs.parameters.diff-time-value}}"
+    outputs:
+      parameters:
+        - name: diff-time-value
+          globalName: diff-time-value
+          valueFrom:
+            path: /tmp/diff_time.txt
+    container:
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/alpine/git:2.32.0
+      command: [sh, -c]
+      args: ["DIFF_TIME=$(expr {{inputs.parameters.opend}} - {{inputs.parameters.opstart}}); echo $DIFF_TIME; echo $DIFF_TIME > /tmp/diff_time.txt"]
 ### Templates ###
 ## nexus-get-prerequisites-template ##
   - name: nexus-get-prerequisites-template

--- a/workflows/iuf/operations/nexus-setup/nexus-rpm-upload-template.yaml
+++ b/workflows/iuf/operations/nexus-setup/nexus-rpm-upload-template.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -31,11 +31,34 @@ spec:
   templates:
 ### Main Steps ###
   - name: main
+    metrics:
+        prometheus:
+        - name: operation_counter
+          help: "Count of step execution by result status"
+          labels:
+            - key: "opname"
+              value: "nexus-rpm-upload"
+            - key: stage
+              value: "deliver-product"
+            - key: type
+              value: "product"
+            - key: pname
+              value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.name')}}"
+            - key: pversion
+              value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.version')}}"
+            - key: status
+              value: "{{status}}"
+          counter:
+            value: "1"
     inputs:
       parameters:
         - name: auth_token
         - name: global_params
     steps:
+    - - name: start-operation
+        templateRef:
+          name: workflow-template-record-time-template
+          template: record-time-template
     - - name: nexus-get-prerequisites
         template: nexus-get-prerequisites-template
         arguments:
@@ -61,6 +84,61 @@ spec:
             value: "{{steps.nexus-get-prerequisites.outputs.parameters.current_product_manifest}}"
           - name: product_directory
             value: "{{steps.nexus-get-prerequisites.outputs.parameters.product_directory}}"
+    - - name: end-operation
+        templateRef:
+          name: workflow-template-record-time-template
+          template: record-time-template
+    - - name:  prom-metrics
+        template: prom-metrics
+        arguments:
+          parameters:
+          - name: opstart
+            value: "{{steps.start-operation.outputs.result}}"
+          - name: opend
+            value: "{{steps.end-operation.outputs.result}}"
+          - name: pdname
+            value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.name')}}"
+          - name: pdversion
+            value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.version')}}"
+  - name: prom-metrics
+    inputs:
+      parameters:
+      - name: opstart
+      - name: opend
+      - name: pdname
+      - name: pdversion
+    metrics:
+      prometheus:
+        - name: operation_time
+          help: "Duration gauge by operation name in seconds"
+          labels:
+            - key: opname
+              value: "nexus-rpm-upload"
+            - key: stage
+              value: "deliver-product"
+            - key: type
+              value: "product"
+            - key: pdname
+              value: "{{inputs.parameters.pdname}}"
+            - key: pdversion
+              value: "{{inputs.parameters.pdversion}}"
+            - key: opstart
+              value: "{{inputs.parameters.opstart}}"
+            - key: opend
+              value: "{{inputs.parameters.opend}}"
+          gauge:
+            value: "{{outputs.parameters.diff-time-value}}"
+    outputs:
+      parameters:
+        - name: diff-time-value
+          globalName: diff-time-value
+          valueFrom:
+            path: /tmp/diff_time.txt
+    container:
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/alpine/git:2.32.0
+      command: [sh, -c]
+      args: ["DIFF_TIME=$(expr {{inputs.parameters.opend}} - {{inputs.parameters.opstart}}); echo $DIFF_TIME; echo $DIFF_TIME > /tmp/diff_time.txt"]
+
 ### Templates ###
 ## nexus-get-prerequisites-template ##
   - name: nexus-get-prerequisites-template

--- a/workflows/iuf/operations/nexus-setup/nexus-setup-template.yaml
+++ b/workflows/iuf/operations/nexus-setup/nexus-setup-template.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -31,11 +31,34 @@ spec:
   templates:
 ### Main Steps ###
   - name: main
+    metrics:
+        prometheus:
+        - name: operation_counter
+          help: "Count of step execution by result status"
+          labels:
+            - key: "opname"
+              value: "nexus-setup"
+            - key: stage
+              value: "deliver-product"
+            - key: type
+              value: "product"
+            - key: pname
+              value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.name')}}"
+            - key: pversion
+              value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.version')}}"
+            - key: status
+              value: "{{status}}"
+          counter:
+            value: "1"
     inputs:
       parameters:
         - name: auth_token
         - name: global_params
     steps:
+    - - name: start-operation
+        templateRef:
+          name: workflow-template-record-time-template
+          template: record-time-template
     - - name: nexus-get-prerequisites
         template: nexus-get-prerequisites-template
         arguments:
@@ -61,6 +84,62 @@ spec:
             value: "{{steps.nexus-get-prerequisites.outputs.parameters.current_product_manifest}}"
           - name: product_directory
             value: "{{steps.nexus-get-prerequisites.outputs.parameters.product_directory}}"
+    
+    - - name: end-operation
+        templateRef:
+          name: workflow-template-record-time-template
+          template: record-time-template
+    - - name:  prom-metrics
+        template: prom-metrics
+        arguments:
+          parameters:
+          - name: opstart
+            value: "{{steps.start-operation.outputs.result}}"
+          - name: opend
+            value: "{{steps.end-operation.outputs.result}}"
+          - name: pdname
+            value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.name')}}"
+          - name: pdversion
+            value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.version')}}"
+  - name: prom-metrics
+    inputs:
+      parameters:
+      - name: opstart
+      - name: opend
+      - name: pdname
+      - name: pdversion
+    metrics:
+      prometheus:
+        - name: operation_time
+          help: "Duration gauge by operation name in seconds"
+          labels:
+            - key: opname
+              value: "nexus-setup"
+            - key: stage
+              value: "deliver-product"
+            - key: type
+              value: "product"
+            - key: pdname
+              value: "{{inputs.parameters.pdname}}"
+            - key: pdversion
+              value: "{{inputs.parameters.pdversion}}"
+            - key: opstart
+              value: "{{inputs.parameters.opstart}}"
+            - key: opend
+              value: "{{inputs.parameters.opend}}"
+          gauge:
+            value: "{{outputs.parameters.diff-time-value}}"
+    outputs:
+      parameters:
+        - name: diff-time-value
+          globalName: diff-time-value
+          valueFrom:
+            path: /tmp/diff_time.txt
+    container:
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/alpine/git:2.32.0
+      command: [sh, -c]
+      args: ["DIFF_TIME=$(expr {{inputs.parameters.opend}} - {{inputs.parameters.opstart}}); echo $DIFF_TIME; echo $DIFF_TIME > /tmp/diff_time.txt"]
+
 ### Templates ###
 ## nexus-get-prerequisites-template ##
   - name: nexus-get-prerequisites-template

--- a/workflows/iuf/operations/preflight-checks-for-services.yaml
+++ b/workflows/iuf/operations/preflight-checks-for-services.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -34,13 +34,38 @@ spec:
   entrypoint: main
   templates:
     - name: main
+      metrics:
+        prometheus:
+        - name: operation_counter
+          help: "Count of step execution by result status"
+          labels:
+            - key: "opname"
+              value: "preflight-checks-for-services"
+            - key: stage
+              value: "pre-install-check"
+            - key: type
+              value: "global"
+            - key: pname
+              value: "global"
+            - key: pversion
+              value: "global"
+            - key: status
+              value: "{{status}}"
+          counter:
+            value: "1"
       inputs:
         parameters:
           - name: auth_token
           - name: global_params
       dag:
         tasks:
+          - name: start-operation
+            templateRef:
+              name: workflow-template-record-time-template
+              template: record-time-template
           - name: preflight-checks
+            dependencies:
+              - start-operation
             templateRef: 
               name: iuf-base-template
               template: shell-script
@@ -108,6 +133,59 @@ spec:
                     fi
 
                     exit $error_flag
+          - name: end-operation
+            dependencies:
+              - preflight-checks
+            templateRef:
+              name: workflow-template-record-time-template
+              template: record-time-template      
+          - name: prom-metrics
+            dependencies:
+              - start-operation
+              - end-operation
+            template: prom-metrics
+            arguments:
+              parameters:
+              - name: opstart
+                value: "{{tasks.start-operation.outputs.result}}"
+              - name: opend
+                value: "{{tasks.end-operation.outputs.result}}"
       volumeMounts:
         - name: ca-bundle
           mountPath: /var/lib/ca-certificates
+    - name: prom-metrics
+      inputs:
+        parameters:
+        - name: opstart
+        - name: opend
+      metrics:
+        prometheus:
+          - name: operation_time
+            help: "Duration gauge by operation name in seconds"
+            labels:
+              - key: "opname"
+                value: "preflight-checks-for-services"
+              - key: stage
+                value: "pre-install-check"
+              - key: type
+                value: "global"
+              - key: pdname
+                value: "global"
+              - key: pdversion
+                value: "global"
+              - key: "opstart"
+                value: "{{inputs.parameters.opstart}}"
+              - key: "opend"
+                value: "{{inputs.parameters.opend}}"
+            gauge:
+              value: "{{outputs.parameters.diff-time-value}}"
+      outputs:
+        parameters:
+          - name: diff-time-value
+            globalName: diff-time-value
+            valueFrom:
+              path: /tmp/diff_time.txt
+      container:
+        image: artifactory.algol60.net/csm-docker/stable/docker.io/alpine/git:2.32.0
+        command: [sh, -c]
+        args: ["DIFF_TIME=$(expr {{inputs.parameters.opend}} - {{inputs.parameters.opstart}}); echo $DIFF_TIME; echo $DIFF_TIME > /tmp/diff_time.txt"]

--- a/workflows/iuf/operations/s3-upload/s3-upload-template.yaml
+++ b/workflows/iuf/operations/s3-upload/s3-upload-template.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -31,10 +31,33 @@ spec:
   templates:
 ### Main Steps ###
   - name: main
+    metrics:
+        prometheus:
+        - name: operation_counter
+          help: "Count of step execution by result status"
+          labels:
+            - key: "opname"
+              value: "s3-upload"
+            - key: stage
+              value: "deliver-product"
+            - key: type
+              value: "product"
+            - key: pname
+              value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.name')}}"
+            - key: pversion
+              value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.version')}}"
+            - key: status
+              value: "{{status}}"
+          counter:
+            value: "1"
     inputs:
       parameters:
         - name: global_params
     steps:
+    - - name: start-operation
+        templateRef:
+          name: workflow-template-record-time-template
+          template: record-time-template
     - - name: s3-upload
         templateRef:
           name: iuf-base-template
@@ -49,3 +72,57 @@ spec:
                 PARENT_DIR=$(echo '{{inputs.parameters.global_params}}' | jq -r '.stage_params."process-media".current_product.parent_directory')
 
                 /usr/local/bin/s3-upload "$CONTENT" "$PARENT_DIR"
+    - - name: end-operation
+        templateRef:
+          name: workflow-template-record-time-template
+          template: record-time-template
+    - - name:  prom-metrics
+        template: prom-metrics
+        arguments:
+          parameters:
+          - name: opstart
+            value: "{{steps.start-operation.outputs.result}}"
+          - name: opend
+            value: "{{steps.end-operation.outputs.result}}"
+          - name: pdname
+            value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.name')}}"
+          - name: pdversion
+            value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.version')}}"
+  - name: prom-metrics
+    inputs:
+      parameters:
+      - name: opstart
+      - name: opend
+      - name: pdname
+      - name: pdversion
+    metrics:
+      prometheus:
+        - name: operation_time
+          help: "Duration gauge by operation name in seconds"
+          labels:
+            - key: opname
+              value: "s3-upload"
+            - key: stage
+              value: "deliver-product"
+            - key: type
+              value: "product"
+            - key: pdname
+              value: "{{inputs.parameters.pdname}}"
+            - key: pdversion
+              value: "{{inputs.parameters.pdversion}}"
+            - key: opstart
+              value: "{{inputs.parameters.opstart}}"
+            - key: opend
+              value: "{{inputs.parameters.opend}}"
+          gauge:
+            value: "{{outputs.parameters.diff-time-value}}"
+    outputs:
+      parameters:
+        - name: diff-time-value
+          globalName: diff-time-value
+          valueFrom:
+            path: /tmp/diff_time.txt
+    container:
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/alpine/git:2.32.0
+      command: [sh, -c]
+      args: ["DIFF_TIME=$(expr {{inputs.parameters.opend}} - {{inputs.parameters.opstart}}); echo $DIFF_TIME; echo $DIFF_TIME > /tmp/diff_time.txt"]

--- a/workflows/iuf/operations/vcs-upload/vcs-upload-content.yaml
+++ b/workflows/iuf/operations/vcs-upload/vcs-upload-content.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -30,11 +30,34 @@ spec:
   templates:
     ### Main Steps ###
     - name: main
+      metrics:
+        prometheus:
+        - name: operation_counter
+          help: "Count of step execution by result status"
+          labels:
+            - key: "opname"
+              value: "vcs-upload"
+            - key: stage
+              value: "deliver-product"
+            - key: type
+              value: "product"
+            - key: pname
+              value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.name')}}"
+            - key: pversion
+              value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.version')}}"
+            - key: status
+              value: "{{status}}"
+          counter:
+            value: "1"
       inputs:
         parameters:
           - name: auth_token
           - name: global_params
       steps:
+        - - name: start-operation
+            templateRef:
+              name: workflow-template-record-time-template
+              template: record-time-template
         - - name: get-vcs-secrets
             template: get-vcs-secrets-template
         - - name: gitea-upload-content
@@ -53,24 +76,66 @@ spec:
                   value: cray
                 - name: cf_import_gitea_url
                   value: "https://api-gw-service-nmn.local/vcs"
-        - - name: vcs-update-product-catalog
-            templateRef:
-              name: update-product-catalog-template
-              template: catalog-update
-            arguments:
-              parameters:
-              - name: product-name
-                value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.name')}}"
-              - name: product-version
-                value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.version')}}"
-              - name: yaml-content
-                value: "{{steps.gitea-upload-content.outputs.parameters.vcs-upload-content-results}}"
         - - name: cleanup
             template: cleanup-template
             arguments:
               parameters:
                 - name: vcs_user_credentials_secret_name
                   value: "{{steps.get-vcs-secrets.outputs.parameters.secret_name}}"
+        - - name: end-operation
+            templateRef:
+              name: workflow-template-record-time-template
+              template: record-time-template
+        - - name:  prom-metrics
+            template: prom-metrics
+            arguments:
+              parameters:
+              - name: opstart
+                value: "{{steps.start-operation.outputs.result}}"
+              - name: opend
+                value: "{{steps.end-operation.outputs.result}}"
+              - name: pdname
+                value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.name')}}"
+              - name: pdversion
+                value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.version')}}"
+    - name: prom-metrics
+      inputs:
+        parameters:
+        - name: opstart
+        - name: opend
+        - name: pdname
+        - name: pdversion
+      metrics:
+        prometheus:
+          - name: operation_time
+            help: "Duration gauge by operation name in seconds"
+            labels:
+              - key: opname
+                value: "vcs-upload"
+              - key: stage
+                value: "deliver-product"
+              - key: type
+                value: "product"
+              - key: pdname
+                value: "{{inputs.parameters.pdname}}"
+              - key: pdversion
+                value: "{{inputs.parameters.pdversion}}"
+              - key: opstart
+                value: "{{inputs.parameters.opstart}}"
+              - key: opend
+                value: "{{inputs.parameters.opend}}"
+            gauge:
+              value: "{{outputs.parameters.diff-time-value}}"
+      outputs:
+        parameters:
+          - name: diff-time-value
+            globalName: diff-time-value
+            valueFrom:
+              path: /tmp/diff_time.txt
+      container:
+        image: artifactory.algol60.net/csm-docker/stable/docker.io/alpine/git:2.32.0
+        command: [sh, -c]
+        args: ["DIFF_TIME=$(expr {{inputs.parameters.opend}} - {{inputs.parameters.opstart}}); echo $DIFF_TIME; echo $DIFF_TIME > /tmp/diff_time.txt"]
     ### Templates ###
     ## get-vcs-secrets-template ##
     - name: get-vcs-secrets-template


### PR DESCRIPTION
CASMMON-247 currently, iuf operation does not provide an inbuilt mechanism for r Prometheus metrics.
At the first step added epoch start and end time for extract-release-distributions operation. we are planing to use these metrics for creating grafana iuf timing dashboard.

Please note we are unable to create WorkflowTemplate for the Prometheus metrics. So we have used it directly in extract-release-distributions.yaml.

Testing: tested on frigg.

 curl 10.43.0.244:9090/metrics |grep preflight-checks-for-services
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0argo_workflows_operation_counter{opname="preflight-checks-for-services",pname="global",pversion="global",stage="pre-install-check",status="Succeeded",type="global"} 2
argo_workflows_operation_time{opend="1673326026",opname="preflight-checks-for-services",opstart="1673325994",pdname="global",pdversion="global",stage="pre-install-check",type="global"} 32
argo_workflows_operation_time{opend="1673329989",opname="preflight-checks-for-services",opstart="1673329958",pdname="global",pdversion="global",stage="pre-install-check",type="global"} 31
100 72819    0 72819    0     0  13.8M      0 --:--:-- --:--:-- --:--:-- 13.8M



 curl 10.43.0.244:9090/metrics |grep loftsman-manifest-upload
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0argo_workflows_operation_counter{opname="loftsman-manifest-upload",pname="cos",pversion="2.5.66-20221201160455-9ecebe2",stage="deliver-product",status="Succeeded",type="product"} 1
argo_workflows_operation_time{opend="1673332716",opname="loftsman-manifest-upload",opstart="1673332679",pdname="cos",pdversion="2.5.66-20221201160455-9ecebe2",stage="deliver-product",type="product"} 37
100 73787    0 73787    0     0  11.7M      0 --:--:-- --:--:-- --:--:-- 14.0M



 s3_upload
 ncn-m001:/usr/share/doc/csm/workflows/iuf/operations # curl 10.43.0.244:9090/metrics |grep s3-upload
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0argo_workflows_operation_counter{opname="s3-upload",pname="cos",pversion="2.5.66-20221201160455-9ecebe2",stage="deliver-product",status="Succeeded",type="product"} 1
argo_workflows_operation_time{opend="1673333946",opname="s3-upload",opstart="1673333925",pdname="cos",pdversion="2.5.66-20221201160455-9ecebe2",stage="deliver-product",type="product"} 21
100 74549    0 74549    0     0  10.1M      0 --:--:-- --:--:-- --:--:-- 11.8M

curl 10.43.0.244:9090/metrics |grep nexus-rpm-upload
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0argo_workflows_operation_counter{opname="nexus-rpm-upload",pname="cos",pversion="2.5.66-20221201160455-9ecebe2",stage="deliver-product",status="Succeeded",type="product"} 1
argo_workflows_operation_time{opend="1673341918",opname="nexus-rpm-upload",opstart="1673341841",pdname="cos",pdversion="2.5.66-20221201160455-9ecebe2",stage="deliver-product",type="product"} 77
100 76647    0 76647    0     0  12.1M      0 --:--:-- --:--:-- --:--:-- 12.1M

 curl 10.43.0.244:9090/metrics |grep s3-upload
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0argo_workflows_operation_counter{opname="s3-upload",pname="cos",pversion="2.5.66-20221201160455-9ecebe2",stage="deliver-product",status="Succeeded",type="product"} 1
argo_workflows_operation_time{opend="1673333946",opname="s3-upload",opstart="1673333925",pdname="cos",pdversion="2.5.66-20221201160455-9ecebe2",stage="deliver-product",type="product"} 21
100 74549    0 74549    0     0  10.1M      0 --:--:-- --:--:-- --:--:-- 11.8M


 curl 10.43.0.244:9090/metrics |grep nexus-docker-upload
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0argo_workflows_operation_counter{opname="nexus-docker-upload",pname="cos",pversion="2.5.66-20221201160455-9ecebe2",stage="deliver-product",status="Succeeded",type="product"} 1
argo_workflows_operation_time{opend="1673343111",opname="nexus-docker-upload",opstart="1673343067",pdname="cos",pdversion="2.5.66-20221201160455-9ecebe2",stage="deliver-product",type="product"} 44


ncn-m001:/usr/share/doc/csm/workflows/iuf/operations # curl 10.43.0.244:9090/metrics |grep nexus-helm-upload
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0argo_workflows_operation_counter{opname="nexus-helm-upload",pname="cos",pversion="2.5.66-20221201160455-9ecebe2",stage="deliver-product",status="Succeeded",type="product"} 1
argo_workflows_operation_time{opend="1673343813",opname="nexus-helm-upload",opstart="1673343772",pdname="cos",pdversion="2.5.66-20221201160455-9ecebe2",stage="deliver-product",type="product"} 41
100 79623    0 79623    0     0  9719k      0 --:--:-- --:--:-- --:--:-- 9719k


 curl 10.43.0.244:9090/metrics |grep vcs-upload
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0argo_workflows_operation_counter{opname="vcs-upload",pname="cos",pversion="2.5.66-20221201160455-9ecebe2",stage="deliver-product",status="Succeeded",type="product"} 1
argo_workflows_operation_time{opend="1673344869",opname="vcs-upload",opstart="1673344827",pdname="cos",pdversion="2.5.66-20221201160455-9ecebe2",stage="deliver-product",type="product"} 42


 curl 10.43.0.244:9090/metrics |grep ims-upload
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0argo_workflows_operation_counter{opname="ims-upload",pname="cos",pversion="2.5.66-20221201160455-9ecebe2",stage="deliver-product",status="Succeeded",type="product"} 1
argo_workflows_operation_time{opend="1673344944",opname="ims-upload",opstart="1673344890",pdname="cos",pdversion="2.5.66-20221201160455-9ecebe2",stage="deliver-product",type="product"} 54
100 81729    0 81729    0     0  15.5M      0 --:--:-- --:--:-- --:--:-- 19.4M
