### PR TITLE
CASMTRIAGE-4793 Add note about in family ceph upgrade for 1.4 upgrades

### DIFF
--- a/upgrade/Stage_1.md
+++ b/upgrade/Stage_1.md
@@ -38,7 +38,7 @@ For more information, see [Using the Argo UI](../operations/argo/Using_the_Argo_
 **IMPORTANT:**
 
 - ***If upgrading from CSM 1.3 to CSM 1.4, the Ceph version is not being upgraded, and this step must be executed!***
-- If the upgrade is staying with a CSM release, e.g. `CSM-1.4.0-rc1` to `CSM-1.4.0-rc2`, then you will need to run the following to point the Ceph cluster to use the Ceph container image stored in Nexus.
+- If the upgrade is staying within a CSM release family, e.g. `CSM-1.4.0-rc1` to `CSM-1.4.0-rc2`, then you will need to run the following to point the Ceph cluster to use the Ceph container image stored in Nexus.
 - The issue stems from slightly different `sha` values for the Ceph containers for in-family CSM storage node images which will prevent the Ceph containers from starting.
 - This will utilize the upgrade procedure to accomplish this as it has built in checks and health monitoring to better manage this rolling restart of the Ceph containers with the image stored in Nexus.  Please see [`cubs_tool` usage for further information](../operations/utility_storage/Cubs_tool_Usage.md)
 

--- a/upgrade/Stage_1.md
+++ b/upgrade/Stage_1.md
@@ -37,9 +37,10 @@ For more information, see [Using the Argo UI](../operations/argo/Using_the_Argo_
 
 **IMPORTANT:**
 
-> If the upgrade is staying with a CSM release, e.g. `CSM-1.4.0-rc1` to `CSM-1.4.0-rc2`, then you will need to run the following to point the Ceph cluster to use the Ceph container image stored in Nexus.
-> The issue stems from slightly different `sha` values for the Ceph containers for in-family CSM storage node images which will prevent the Ceph containers from starting.
-> This will utilize the upgrade procedure to accomplish this as it has built in checks and health monitoring to better manage this rolling restart of the Ceph containers with the image stored in Nexus.  Please see [`cubs_tool` usage for further information](../operations/utility_storage/Cubs_tool_Usage.md)
+- ***If upgrading from CSM 1.3 to CSM 1.4, the Ceph version is not being upgraded, and this step must be executed!***
+- If the upgrade is staying with a CSM release, e.g. `CSM-1.4.0-rc1` to `CSM-1.4.0-rc2`, then you will need to run the following to point the Ceph cluster to use the Ceph container image stored in Nexus.
+- The issue stems from slightly different `sha` values for the Ceph containers for in-family CSM storage node images which will prevent the Ceph containers from starting.
+- This will utilize the upgrade procedure to accomplish this as it has built in checks and health monitoring to better manage this rolling restart of the Ceph containers with the image stored in Nexus.  Please see [`cubs_tool` usage for further information](../operations/utility_storage/Cubs_tool_Usage.md)
 
 (`ncn-s001#`) In family upgrade to a new container with the same Ceph version:
 


### PR DESCRIPTION
# Description

Fix for https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4793 -- make it clear we need to do the in family upgrade when upgrading from 1.3 to 1.4.

# Checklist Before Merging

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.