### PR TITLE
CASMINST-5801: Eschew / characters in NCN IMS image name

### DIFF
--- a/scripts/operations/node_management/ncn-ims-image-upload.sh
+++ b/scripts/operations/node_management/ncn-ims-image-upload.sh
@@ -66,7 +66,8 @@ IMS_ROOTFS_MD5SUM=$(md5sum "$IMS_ROOTFS_FILENAME" | awk '{ print $1 }')
 IMS_INITRD_MD5SUM=$(md5sum "$IMS_INITRD_FILENAME" | awk '{ print $1 }')
 IMS_KERNEL_MD5SUM=$(md5sum "$IMS_KERNEL_FILENAME" | awk '{ print $1 }')
 
-IMS_IMAGE_ID=$(cray ims images create --name "$IMS_ROOTFS_FILENAME" --format json | jq -r .id)
+IMS_IMAGE_NAME=$(basename "${IMS_ROOTFS_FILENAME}")
+IMS_IMAGE_ID=$(cray ims images create --name "${IMS_IMAGE_NAME}" --format json | jq -r .id)
 cray artifacts create boot-images "$IMS_IMAGE_ID/rootfs" "$IMS_ROOTFS_FILENAME" > /dev/null
 cray artifacts create boot-images "$IMS_IMAGE_ID/kernel" "$IMS_KERNEL_FILENAME" > /dev/null
 cray artifacts create boot-images "$IMS_IMAGE_ID/initrd" "$IMS_INITRD_FILENAME" > /dev/null
@@ -78,24 +79,24 @@ cat <<EOF> ims_manifest.json
   "artifacts": [
     {
       "link": {
-	  "path": "s3://boot-images/$IMS_IMAGE_ID/rootfs",
-          "type": "s3"
+        "path": "s3://boot-images/$IMS_IMAGE_ID/rootfs",
+        "type": "s3"
       },
       "md5": "$IMS_ROOTFS_MD5SUM",
       "type": "application/vnd.cray.image.rootfs.squashfs"
     },
     {
       "link": {
-	  "path": "s3://boot-images/$IMS_IMAGE_ID/kernel",
-          "type": "s3"
+        "path": "s3://boot-images/$IMS_IMAGE_ID/kernel",
+        "type": "s3"
       },
       "md5": "$IMS_KERNEL_MD5SUM",
       "type": "application/vnd.cray.image.kernel"
     },
     {
       "link": {
-	  "path": "s3://boot-images/$IMS_IMAGE_ID/initrd",
-          "type": "s3"
+        "path": "s3://boot-images/$IMS_IMAGE_ID/initrd",
+        "type": "s3"
       },
       "md5": "$IMS_INITRD_MD5SUM",
       "type": "application/vnd.cray.image.initrd"


### PR DESCRIPTION
# Description

IMS image customization breaks when run on IMS images with names that contain / characters. This PR modifies the CSM upgrade script responsible for create the NCN images in IMS, having it use the basename of the squashfs file, rather than its entire path.

The other small edits in the file were correcting inconsistent use of tabs and regular spaces, but have no functional impact.

I tested the commands manually on wasp to verify that they work as expected.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
