### PR TITLE
CASMPET-5081 Add spire upgrade script

### DIFF
--- a/upgrade/scripts/upgrade/util/upgrade-spire.sh
+++ b/upgrade/scripts/upgrade/util/upgrade-spire.sh
@@ -59,9 +59,9 @@ RETRY_SECONDS=5
 until [ "$(kubectl get pods -n spire --no-headers | wc -l)" -ne 0 ]; do
   if [[ "$RETRY" -lt "$MAX_RETRIES" ]]; then
     RETRY="$((RETRY + 1))"
-    echo "spire-server is not ready. Will retry after $RETRY_SECONDS seconds. ($RETRY/$MAX_RETRIES)"
+    echo "Spire is still in the process of being uninstalled. Will retry after $RETRY_SECONDS seconds. ($RETRY/$MAX_RETRIES)"
   else
-    echo "spire-server did not start after $(echo "$RETRY_SECONDS" \* "$MAX_RETRIES" | bc) seconds."
+    echo "Spire did not completely uninstall after $(echo "$RETRY_SECONDS" \* "$MAX_RETRIES" | bc) seconds."
     exit 1
   fi
   sleep "$RETRY_SECONDS"

--- a/upgrade/scripts/upgrade/util/upgrade-spire.sh
+++ b/upgrade/scripts/upgrade/util/upgrade-spire.sh
@@ -36,10 +36,6 @@ function sshnh() {
   /usr/bin/ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "$@"
 }
 
-function scpnh() {
-  /usr/bin/scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "$@"
-}
-
 for node in $(kubectl get nodes -o name | cut -d"/" -f2) $(ceph node ls | jq -r '.[] | keys[]' | sort -u); do
   echo "$node: Stopping spire-agent"
   sshnh "$node" systemctl stop spire-agent

--- a/upgrade/scripts/upgrade/util/upgrade-spire.sh
+++ b/upgrade/scripts/upgrade/util/upgrade-spire.sh
@@ -33,22 +33,22 @@ agentsvidder="${datadir}/agent_svid.der"
 jointoken="${conf}/join_token"
 
 function sshnh() {
-	/usr/bin/ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "$@"
+  /usr/bin/ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "$@"
 }
 
 function scpnh() {
-	/usr/bin/scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "$@"
+  /usr/bin/scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "$@"
 }
 
 for node in $(kubectl get nodes -o name | cut -d"/" -f2) $(ceph node ls | jq -r '.[] | keys[]' | sort -u); do
-	echo "$node: Stopping spire-agent"
-	sshnh "$node" systemctl stop spire-agent
-	sshnh "$node" rm "${svidkey}" "${bundleder}" "${agentsvidder}" "${jointoken}"
+  echo "$node: Stopping spire-agent"
+  sshnh "$node" systemctl stop spire-agent
+  sshnh "$node" rm "${svidkey}" "${bundleder}" "${agentsvidder}" "${jointoken}"
 
-	sshnh "$node" zypper install -y spire-agent
+  sshnh "$node" zypper install -y spire-agent
 
-	echo "$node: Starting spire-agent"
-	sshnh "$node" systemctl start spire-agent
+  echo "$node: Starting spire-agent"
+  sshnh "$node" systemctl start spire-agent
 done
 
 echo "Uninstalling spire helm chart"
@@ -56,7 +56,20 @@ helm uninstall -n spire spire
 echo "Uninstalling spire PVCs"
 kubectl delete -n spire pvc spire-data-spire-server-0 spire-data-spire-server-1 spire-data-spire-server-2
 
-# WAIT HERE FOR SPIRE PODS TO BE REMOVED
+RETRY=0
+MAX_RETRIES=30
+RETRY_SECONDS=5
+
+until [ "$(kubectl get pods -n spire --no-headers | wc -l)" -ne 0 ]; do
+  if [[ "$RETRY" -lt "$MAX_RETRIES" ]]; then
+    RETRY="$((RETRY + 1))"
+    echo "spire-server is not ready. Will retry after $RETRY_SECONDS seconds. ($RETRY/$MAX_RETRIES)"
+  else
+    echo "spire-server did not start after $(echo "$RETRY_SECONDS" \* "$MAX_RETRIES" | bc) seconds."
+    exit 1
+  fi
+  sleep "$RETRY_SECONDS"
+done
 
 echo "Installing new spire helm chart"
 BUILDDIR="/tmp/build"
@@ -65,9 +78,9 @@ kubectl get secrets -n loftsman site-init -o jsonpath='{.data.customizations\.ya
 manifestgen -i "${CSM_ARTI_DIR}/manifests/sysmgmt.yaml" -c "${BUILDDIR}/customizations.yaml" -o "${BUILDDIR}/spireupgrade.yaml"
 charts="$(yq r $BUILDDIR/spireupgrade.yaml 'spec.charts[*].name')"
 for chart in $charts; do
-	if [[ $chart != "spire" ]]; then
-		yq d -i $BUILDDIR/spireupgrade.yaml "spec.charts.(name==$chart)"
-	fi
+  if [[ $chart != "spire" ]]; then
+    yq d -i $BUILDDIR/spireupgrade.yaml "spec.charts.(name==$chart)"
+  fi
 done
 
 yq w -i $BUILDDIR/spireupgrade.yaml "metadata.name" "spireupgrade"
@@ -75,7 +88,20 @@ yq d -i $BUILDDIR/spireupgrade.yaml "spec.sources"
 
 loftsman ship --charts-path "${CSM_ARTI_DIR}/helm/" --manifest-path $BUILDDIR/spireupgrade.yaml
 
-# WAIT HERE FOR SPIRE TO BE HEALTHY
+RETRY=0
+MAX_RETRIES=30
+RETRY_SECONDS=10
+
+until kubectl exec -itn spire spire-server-0 --container spire-server -- ./bin/spire-server healthcheck | grep -q 'Server is healthy'; do
+  if [[ "$RETRY" -lt "$MAX_RETRIES" ]]; then
+    RETRY="$((RETRY + 1))"
+    echo "spire-server is not ready. Will retry after $RETRY_SECONDS seconds. ($RETRY/$MAX_RETRIES)"
+  else
+    echo "spire-server did not start after $(echo "$RETRY_SECONDS" \* "$MAX_RETRIES" | bc) seconds."
+    exit 1
+  fi
+  sleep "$RETRY_SECONDS"
+done
 
 echo "Joining storage nodes to spire"
 /opt/cray/platform-utils/spire/fix-spire-on-storage.sh

--- a/upgrade/scripts/upgrade/util/upgrade-spire.sh
+++ b/upgrade/scripts/upgrade/util/upgrade-spire.sh
@@ -39,7 +39,7 @@ function sshnh() {
 for node in $(kubectl get nodes -o name | cut -d"/" -f2) $(ceph node ls | jq -r '.[] | keys[]' | sort -u); do
   echo "$node: Stopping spire-agent"
   sshnh "$node" systemctl stop spire-agent
-  sshnh "$node" rm "${svidkey}" "${bundleder}" "${agentsvidder}" "${jointoken}"
+  sshnh "$node" rm "${svidkey}" "${bundleder}" "${agentsvidder}" "${jointoken}" || true
 
   sshnh "$node" zypper install -y spire-agent
 


### PR DESCRIPTION
# Description

This adds the upgrade script for spire. This will require the spire-agent RPMs be uploaded to a csm rpm repo that's setup in zypper prior to being run.

# Checklist Before Merging

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
