### PR TITLE
CASMCMS-8376: Correct CFS CLI command typo; minor linting

### DIFF
--- a/operations/configuration_management/Create_an_Image_Customization_CFS_Session.md
+++ b/operations/configuration_management/Create_an_Image_Customization_CFS_Session.md
@@ -37,7 +37,7 @@ cray ims images list --format json | jq -r 'any(.[]; .id == "5d64c8b2-4f0e-4b2e-
 
 Example output:
 
-```text
+```json
 true
 ```
 
@@ -54,7 +54,7 @@ cray cfs sessions create --name example \
     --target-definition image --format json \
     --target-group Application <IMS_IMAGE_ID> \
     --target-group Application_UAN <IMS_IMAGE_ID> \
-    --image-map <IMS_IMAGE_ID> <RESULTING_IMAGE_NAME>
+    --target-image-map <IMS_IMAGE_ID> <RESULTING_IMAGE_NAME>
 ```
 
 Example output:
@@ -88,20 +88,20 @@ Example output:
     "groups": [
       {
         "members": [
-          IMS_IMAGE_ID
+          "<IMS_IMAGE_ID>"
         ],
         "name": "Application"
       },
       {
         "members": [
-          IMS_IMAGE_ID
+          "<IMS_IMAGE_ID>
         ],
         "name": "Application_UAN"
       }
     ],
     "imageMap": {
-      "source_id": IMS_IMAGE_ID,
-      "result_name": RESULTING_IMAGE_NAME
+      "source_id": "<IMS_IMAGE_ID>",
+      "result_name": "<RESULTING_IMAGE_NAME>"
     }
   }
 }

--- a/operations/configuration_management/Create_an_Image_Customization_CFS_Session.md
+++ b/operations/configuration_management/Create_an_Image_Customization_CFS_Session.md
@@ -94,7 +94,7 @@ Example output:
       },
       {
         "members": [
-          "<IMS_IMAGE_ID>
+          "<IMS_IMAGE_ID>"
         ],
         "name": "Application_UAN"
       }

--- a/operations/image_management/Create_UAN_Boot_Images.md
+++ b/operations/image_management/Create_UAN_Boot_Images.md
@@ -217,18 +217,18 @@ and the HPE Cray Programming Environment\) that must be configured on the UANs.
     See the product manuals for further information on configuring other Cray products, as this procedure documents only the configuration of the UAN. More layers can be added
     to be configured in a single CFS session.
 
-    The following configuration example can be used for preboot image customization as well as post-boot node configuration.
+    The following configuration example can be used for preboot image customization as well as post-boot node configuration. This example contains only a single
+    layer. However, configuration layers for other products may be specified in the list after this layer, if desired.
 
     ```json
     {
       "layers": [
         {
-          "name": "uan-integration-PRODUCT\_VERSION",
+          "name": "uan-integration-PRODUCT_VERSION",
           "cloneUrl": "https://api-gw-service-nmn.local/vcs/cray/uan-config-management.git",
           "playbook": "site.yml",
           "commit": "ecece54b1eb65d484444c4a5ca0b244b329f4667"
-        }
-        # **{ ... add configuration layers for other products here, if desired ... }**
+        }        
       ]
     }
     ```
@@ -245,6 +245,9 @@ and the HPE Cray Programming Environment\) that must be configured on the UANs.
 
     Example output:
 
+    > This output uses the example single-layer configuration from earlier. If layers were added for additional products, then they will also
+    > appear in the output.
+
     ```json
     {
       "lastUpdated": "2021-07-28T03:26:00:37Z",
@@ -254,7 +257,7 @@ and the HPE Cray Programming Environment\) that must be configured on the UANs.
           "commit": "ecece54b1eb65d484444c4a5ca0b244b329f4667",
           "name": "uan-integration-PRODUCT_VERSION",
           "playbook": "site.yml"
-        }  # <-- Additional layers not shown, but would be inserted here
+        }
       ],
       "name": "uan-config-PRODUCT_VERSION"
     }
@@ -300,7 +303,7 @@ and the HPE Cray Programming Environment\) that must be configured on the UANs.
         ```bash
         UAN_IMAGE_ID=IMAGE_ID
         cray artifacts get boot-images ${UAN_IMAGE_ID}/rootfs ${UAN_IMAGE_ID}.squashfs
-        la ${UAN_IMAGE_ID}.squashfs
+        ls -A ${UAN_IMAGE_ID}.squashfs
         ```
 
         Example output:


### PR DESCRIPTION
# Description

The primary purpose of this PR is to correct a CFS CLI command that is not valid. The `--image-map` argument should be `--target-image-map`. I also did some additional minor linting.

Backport PRs:
1.4: https://github.com/Cray-HPE/docs-csm/pull/3025
1.3: https://github.com/Cray-HPE/docs-csm/pull/3026
1.2: https://github.com/Cray-HPE/docs-csm/pull/3027
1.0: https://github.com/Cray-HPE/docs-csm/pull/3028

The 1.3 and earlier PRs only contain the linting changes, as the CLI error does not exist in those branches.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
