### PR TITLE
CASMCMS-8376: Correct CFS CLI command typo; minor linting

### DIFF
--- a/operations/configuration_management/Create_an_Image_Customization_CFS_Session.md
+++ b/operations/configuration_management/Create_an_Image_Customization_CFS_Session.md
@@ -37,7 +37,7 @@ cray ims images list --format json | jq -r 'any(.[]; .id == "5d64c8b2-4f0e-4b2e-
 
 Example output:
 
-```text
+```json
 true
 ```
 

--- a/operations/image_management/Create_UAN_Boot_Images.md
+++ b/operations/image_management/Create_UAN_Boot_Images.md
@@ -217,18 +217,18 @@ and the HPE Cray Programming Environment\) that must be configured on the UANs.
     See the product manuals for further information on configuring other Cray products, as this procedure documents only the configuration of the UAN. More layers can be added
     to be configured in a single CFS session.
 
-    The following configuration example can be used for preboot image customization as well as post-boot node configuration.
+    The following configuration example can be used for preboot image customization as well as post-boot node configuration. This example contains only a single
+    layer. However, configuration layers for other products may be specified in the list after this layer, if desired.
 
     ```json
     {
       "layers": [
         {
-          "name": "uan-integration-PRODUCT\_VERSION",
+          "name": "uan-integration-PRODUCT_VERSION",
           "cloneUrl": "https://api-gw-service-nmn.local/vcs/cray/uan-config-management.git",
           "playbook": "site.yml",
           "commit": "ecece54b1eb65d484444c4a5ca0b244b329f4667"
-        }
-        # **{ ... add configuration layers for other products here, if desired ... }**
+        }        
       ]
     }
     ```
@@ -245,6 +245,9 @@ and the HPE Cray Programming Environment\) that must be configured on the UANs.
 
     Example output:
 
+    > This output uses the example single-layer configuration from earlier. If layers were added for additional products, then they will also
+    > appear in the output.
+
     ```json
     {
       "lastUpdated": "2021-07-28T03:26:00:37Z",
@@ -254,7 +257,7 @@ and the HPE Cray Programming Environment\) that must be configured on the UANs.
           "commit": "ecece54b1eb65d484444c4a5ca0b244b329f4667",
           "name": "uan-integration-PRODUCT_VERSION",
           "playbook": "site.yml"
-        }  # <-- Additional layers not shown, but would be inserted here
+        }
       ],
       "name": "uan-config-PRODUCT_VERSION"
     }
@@ -300,7 +303,7 @@ and the HPE Cray Programming Environment\) that must be configured on the UANs.
         ```bash
         UAN_IMAGE_ID=IMAGE_ID
         cray artifacts get boot-images ${UAN_IMAGE_ID}/rootfs ${UAN_IMAGE_ID}.squashfs
-        la ${UAN_IMAGE_ID}.squashfs
+        ls -A ${UAN_IMAGE_ID}.squashfs
         ```
 
         Example output:


### PR DESCRIPTION
Backport of just the linting parts of https://github.com/Cray-HPE/docs-csm/pull/3024 (the CLI mistake being corrected in that PR does not exist in 1.3 and earlier)