### PR TITLE
CASM-3768: Add workflowtemplate step that was mistakenly removed

### DIFF
--- a/workflows/iuf/operations/vcs-upload/vcs-upload-content.yaml
+++ b/workflows/iuf/operations/vcs-upload/vcs-upload-content.yaml
@@ -76,6 +76,18 @@ spec:
                   value: cray
                 - name: cf_import_gitea_url
                   value: "https://api-gw-service-nmn.local/vcs"
+        - - name: vcs-update-product-catalog
+            templateRef:
+              name: update-product-catalog-template
+              template: catalog-update
+            arguments:
+              parameters:
+              - name: product-name
+                value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.name')}}"
+              - name: product-version
+                value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.version')}}"
+              - name: yaml-content
+                value: "{{steps.gitea-upload-content.outputs.parameters.vcs-upload-content-results}}"
         - - name: cleanup
             template: cleanup-template
             arguments:


### PR DESCRIPTION
The vcs-update-product-catalog step was mistakenly removed by the following commit: 9075f64bb9806c0712d0a091bbbad14f2b284cac.

This commit adds the missing step back into the workflowtemplate.

Test Description: On frigg, I manually modified the workflowtemplate with this step and ensured the VCS information was added to the catalog.

# Description

See commit message

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
