### PR TITLE
CASMINST-5812: Split prepare-images and update-cfs-config IUF stages

### DIFF
--- a/workflows/iuf/stages.yaml
+++ b/workflows/iuf/stages.yaml
@@ -67,7 +67,9 @@ stages:
   - name: update-cfs-config
     type: global
     operations:
-      - name: update-cfs-config
+      - name: update-management-cfs-config
+        static-parameters: {} # any parameters that will be supplied statically to this operation.
+      - name: update-managed-cfs-config
         static-parameters: {} # any parameters that will be supplied statically to this operation.
 
   - name: deploy-product
@@ -79,7 +81,9 @@ stages:
   - name: prepare-images
     type: global
     operations:
-      - name: prepare-images
+      - name: prepare-management-images
+        static-parameters: {} # any parameters that will be supplied statically to this operation.
+      - name: prepare-managed-images
         static-parameters: {} # any parameters that will be supplied statically to this operation.
 
   - name: management-nodes-rollout


### PR DESCRIPTION

# Description

Split the `prepare-images` and `update-cfs-config` IUF stages into two operations, one for management nodes and one for managed nodes. The IUF CLI accepts separate options for specifying the bootprep file for the management nodes vs. the managed nodes. The `sat bootprep` command expects to receive only on input file per invocation. As such, we would already have to call it twice. Splitting the two invocations into separate operations will make it easier for the subsequent stages, `management_nodes_rollout` and `managed_nodes_rollout`, to obtain the output describing the CFS configurations, IMS images, and BOS session templates that were created for the type of nodes being rolled out.

Note that currently, the IUF runs operations serially within a stage. There is a Jira (CASMINST-5702) to improve this so that operations in a stage can be run in parallel. This will significantly speed up the `prepare-images` stage by creating management node and managed node images in parallel.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
