### PR TITLE
CASMINST-5675: Create Argo workflow templates for prepare-images

### DIFF
--- a/workflows/iuf/operations/prepare-images/prepare-managed-images-template.yaml
+++ b/workflows/iuf/operations/prepare-images/prepare-managed-images-template.yaml
@@ -1,0 +1,65 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: prepare-managed-images
+spec:
+  entrypoint: main
+  templates:
+    ### Main Steps ###
+    - name: main
+      inputs:
+        parameters:
+          - name: auth_token
+          - name: global_params
+      steps:
+        - - name: sat-bootprep-run
+            templateRef:
+              name: sat-general-template
+              template: sat-wrapper
+            arguments:
+              parameters:
+                - name: auth_token
+                  value: "{{inputs.parameters.auth_token}}"
+                - name: media_dir
+                  value: "{{=jsonpath(inputs.parameters.global_params, '$.input_params.media_dir')}}"
+                - name: script_content
+                  value: |
+                    MEDIA_DIR="{{=jsonpath(inputs.parameters.global_params, '$.input_params.media_dir')}}"
+                    BOOTPREP_FILE_PATH="{{=jsonpath(inputs.parameters.global_params, '$.input_params.bootprep_config_managed')}}"
+                    if [[ -z "$BOOTPREP_FILE_PATH" ]]; then
+                      echo "No bootprep file provided. Skipping operation." 1>&2
+                      echo "{}"
+                      exit 0
+                    fi
+
+                    VARS_FILE_PATH=$(mktemp)
+                    cat > $VARS_FILE_PATH <<- 'EOF'
+                      {{=toJson(jsonpath(inputs.parameters.global_params, '$.site_params.products'))}}
+                    EOF
+                    sat bootprep run --limit images --limit session_templates \
+                      --overwrite-images --overwrite-templates \
+                      --vars-file "$VARS_FILE_PATH" --format json \
+                      $MEDIA_DIR/$BOOTPREP_FILE_PATH

--- a/workflows/iuf/operations/prepare-images/prepare-management-images-template.yaml
+++ b/workflows/iuf/operations/prepare-images/prepare-management-images-template.yaml
@@ -1,0 +1,65 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: prepare-management-images
+spec:
+  entrypoint: main
+  templates:
+    ### Main Steps ###
+    - name: main
+      inputs:
+        parameters:
+          - name: auth_token
+          - name: global_params
+      steps:
+        - - name: sat-bootprep-run
+            templateRef:
+              name: sat-general-template
+              template: sat-wrapper
+            arguments:
+              parameters:
+                - name: auth_token
+                  value: "{{inputs.parameters.auth_token}}"
+                - name: media_dir
+                  value: "{{=jsonpath(inputs.parameters.global_params, '$.input_params.media_dir')}}"
+                - name: script_content
+                  value: |
+                    MEDIA_DIR="{{=jsonpath(inputs.parameters.global_params, '$.input_params.media_dir')}}"
+                    BOOTPREP_FILE_PATH="{{=jsonpath(inputs.parameters.global_params, '$.input_params.bootprep_config_management')}}"
+                    if [[ -z "$BOOTPREP_FILE_PATH" ]]; then
+                      echo "No bootprep file provided. Skipping operation." 1>&2
+                      echo "{}"
+                      exit 0
+                    fi
+
+                    VARS_FILE_PATH=$(mktemp)
+                    cat > $VARS_FILE_PATH <<- 'EOF'
+                      {{=toJson(jsonpath(inputs.parameters.global_params, '$.site_params.products'))}}
+                    EOF
+                    sat bootprep run --limit images --limit session_templates \
+                      --overwrite-images --overwrite-templates \
+                      --vars-file "$VARS_FILE_PATH" --format json \
+                      $MEDIA_DIR/$BOOTPREP_FILE_PATH


### PR DESCRIPTION
# Description

Create two Argo workflow templates for the two operations in the
`prepare-images` IUF stage, `prepare-management-images` and
`prepare-managed-images`. The only difference between these two stages
is that they reerence a different bootprep input file from the input
parameters on the IUF Activity.

Note that currently these two operations will occur serially, which is
slower than if we did them concurrently. We could probably improve to
get them running concurrently, but it may not always be safe to run two
`sat bootprep` commands concurrently if they are trying to create items
with the same names.

Test Description:
Tested by running with a `sat bootprep` input file that defined a few
simple CFS configurations, an image built from the barebones recipe, a
customized version of that image, and a couple of session templates that
use that image and those configurations.

Should be tested again since a few minor changes were made.

Notably, should be tested again with a `sat bootprep` command that
fails, e.g. on an invalid bootprep file.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
