### PR TITLE
CASMINST-5800: remove extra forward slash

### DIFF
--- a/upgrade/scripts/upgrade/prepare-assets.sh
+++ b/upgrade/scripts/upgrade/prepare-assets.sh
@@ -118,7 +118,7 @@ if [[ -z ${TARBALL_FILE} ]]; then
         touch /etc/cray/upgrade/csm/myenv
         echo "====> ${state_name} ..."
         {
-        wget --progress=dot:giga ${ENDPOINT}/${CSM_REL_NAME}.tar.gz -P /etc/cray/upgrade/csm/
+        wget --progress=dot:giga ${ENDPOINT}${CSM_REL_NAME}.tar.gz -P /etc/cray/upgrade/csm/
         # set TARBALL_FILE to newly downloaded file
         TARBALL_FILE=/etc/cray/upgrade/csm/${CSM_REL_NAME}.tar.gz
         } >> ${LOG_FILE} 2>&1


### PR DESCRIPTION
# Description

Remove the extra forward slack in the file path, as it should be consistent with what the instruction says, i.e., `${ENDPOINT}${CSM_REL_NAME}.tar.gz`

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
