### PR TITLE
CASMINST-5817: add error checking for template input

### DIFF
--- a/workflows/iuf/operations/loftsman-manifest-upload/loftsman-manifest-upload-template.yaml
+++ b/workflows/iuf/operations/loftsman-manifest-upload/loftsman-manifest-upload-template.yaml
@@ -72,6 +72,21 @@ spec:
                 PARENT_DIR=$(echo '{{inputs.parameters.global_params}}' | jq -r '.stage_params."process-media".current_product.parent_directory')
                 PRODUCT=$(echo '{{inputs.parameters.global_params}}' | jq -r '.product_manifest.current_product.manifest.name')
 
+                if [[ "${CONTENT,,}" == "null" ]] || [[ "$CONTENT" == "" ]]; then
+                    echo "ERROR current_product.manifest is null or empty"
+                    exit 1
+                fi
+
+                if [[ "${PARENT_DIR,,}" == "null" ]] || [[ "$PARENT_DIR" == "" ]]; then
+                    echo "ERROR current_product.parent_directory is null or empty"
+                    exit 1
+                fi
+
+                if [[ "${PRODUCT,,}" == "null" ]] || [[ "$PRODUCT" == "" ]]; then
+                    echo "ERROR current_product.manifest.name is null or empty"
+                    exit 1
+                fi
+
                 /usr/local/bin/loftsman-manifest-upload "$CONTENT" "$PARENT_DIR" "$PRODUCT"
     - - name: end-operation
         templateRef:

--- a/workflows/iuf/operations/s3-upload/s3-upload-template.yaml
+++ b/workflows/iuf/operations/s3-upload/s3-upload-template.yaml
@@ -71,6 +71,16 @@ spec:
                 CONTENT=$(echo '{{inputs.parameters.global_params}}' | jq -r '.product_manifest.current_product.manifest')
                 PARENT_DIR=$(echo '{{inputs.parameters.global_params}}' | jq -r '.stage_params."process-media".current_product.parent_directory')
 
+                if [[ "${CONTENT,,}" == "null" ]] || [[ "$CONTENT" == "" ]]; then
+                    echo "ERROR current_product.manifest is null or empty"
+                    exit 1
+                fi
+
+                if [[ "${PARENT_DIR,,}" == "null" ]] || [[ "$PARENT_DIR" == "" ]]; then
+                    echo "ERROR current_product.parent_directory is null or empty"
+                    exit 1
+                fi
+
                 /usr/local/bin/s3-upload "$CONTENT" "$PARENT_DIR"
     - - name: end-operation
         templateRef:


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
