### PR TITLE
CASMINST-5816: Bumping cf-gitea-import image

### DIFF
--- a/workflows/iuf/operations/vcs-upload/vcs-upload-content.yaml
+++ b/workflows/iuf/operations/vcs-upload/vcs-upload-content.yaml
@@ -226,7 +226,7 @@ spec:
             valueFrom:
               path: /results/records.yaml
       container:
-        image: registry.local/artifactory.algol60.net/csm-docker/stable/cf-gitea-import:1.8.0-alpha.19_6747be7
+        image: artifactory.algol60.net/csm-docker/stable/cf-gitea-import:1.8.0
         command:
           - "/bin/sh"
         args: ["-c", "/opt/csm/cf-gitea-import/argo_entrypoint.sh"]


### PR DESCRIPTION
# Description

Latest version of cf-gitea-import image to 1.8.0
[CASMINST-5816](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5816)
# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
