### PR TITLE
CASMINST-5715 fix global params schema and example

### DIFF
--- a/workflows/iuf/samples/global_params_example.json
+++ b/workflows/iuf/samples/global_params_example.json
@@ -46,14 +46,10 @@
     "products": ["cos", "sdu"],
     "media_dir": "/etc/iuf/alice_230116",
     "bootprep_config_managed": [
-      {
-        "contents": "boot prep file contents as a string"
-      }
+      "media_dir/relative/path/to/bootprep/config/managed/file"
     ],
     "bootprep_config_management": [
-      {
-        "contents": "boot prep file contents as a string"
-      }
+      "media_dir/relative/path/to/bootprep/config/management/file"
     ],
     "limit_nodes": ["x12413515", "x15464574"]
   },

--- a/workflows/iuf/samples/global_params_schema.yaml
+++ b/workflows/iuf/samples/global_params_schema.yaml
@@ -91,22 +91,16 @@ properties:
         type: string
       bootprep_config_managed:
         description: >
-          Each item is inline contents of the bootprep files.
+          Each item is the path to the bootprep config file for managed nodes, relative to the media_dir
         type: array
         items:
-          type: object
-          properties:
-            contents:
-              type: string
+          type: string
       bootprep_config_management:
         description: >
-          Each item is inline contents of the bootprep files.
-        items:
-          type: object
-          properties:
-            contents:
-              type: string
+          Each item is the path to the bootprep config file for management nodes, relative to the media_dir
         type: array
+        items:
+          type: string
       limit_nodes:
         description: >
           Each item is the xname of a node.


### PR DESCRIPTION
# Description

Small change mainly meant for IUF developers to update the schema of global params for bootprep config files.

# Checklist Before Merging

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
