### PR TITLE
CASMINST-5761: Update Keycloak Docs to use CMN LB

### DIFF
--- a/operations/security_and_authentication/Access_the_Keycloak_User_Management_UI.md
+++ b/operations/security_and_authentication/Access_the_Keycloak_User_Management_UI.md
@@ -15,7 +15,7 @@ See [Create Internal User Accounts in the Keycloak Shasta Realm](Create_Internal
 
 ## Procedure
 
-1. Point a browser at `https://auth.cmn.SYSTEM_DOMAIN_NAME/keycloak/`, replacing `SYSTEM_DOMAIN_NAME` with the actual NCN's DNS name.
+1. Point a browser at `https://auth.cmn.SYSTEM_DOMAIN_NAME/keycloak/`, replacing `SYSTEM_DOMAIN_NAME` with the actual NCN's DNS name. Use of the `auth.cmn.` sub-domain is required for administrative access to Keycloak.
 
     The following is an example URL for a system: `https://auth.cmn.system1.us.cray.com/keycloak/`
 

--- a/operations/security_and_authentication/Change_Keycloak_Token_Lifetime.md
+++ b/operations/security_and_authentication/Change_Keycloak_Token_Lifetime.md
@@ -9,7 +9,7 @@ Note: The default value for these settings is 365 days.
 
 Log in to Keycloak with the default admin credentials.
 
-Point a browser at `https://auth.SYSTEM_DOMAIN_NAME/keycloak/admin`, replacing `SYSTEM_DOMAIN_NAME` with the actual NCN's DNS name.
+Point a browser at `https://auth.cmn.SYSTEM_DOMAIN_NAME/keycloak/admin`, replacing `SYSTEM_DOMAIN_NAME` with the actual NCN's DNS name. Use of the `auth.cmn.` sub-domain is required for administrative access to Keycloak.
 
 The following is an example URL for a system: `https://auth.cmn.system1.us.cray.com/keycloak/admin`
 

--- a/operations/security_and_authentication/Change_the_Keycloak_Admin_Password.md
+++ b/operations/security_and_authentication/Change_the_Keycloak_Admin_Password.md
@@ -8,7 +8,7 @@ This procedure uses SYSTEM\_DOMAIN\_NAME as an example for the DNS name of the n
 
 1. Log in to Keycloak with the default admin credentials.
 
-    Point a browser at `https://auth.cmn.SYSTEM_DOMAIN_NAME/keycloak/admin`, replacing SYSTEM\_DOMAIN\_NAME with the actual NCN's DNS name.
+    Point a browser at `https://auth.cmn.SYSTEM_DOMAIN_NAME/keycloak/admin`, replacing SYSTEM\_DOMAIN\_NAME with the actual NCN's DNS name. Use of the `auth.cmn.` sub-domain is required for administrative access to Keycloak.
 
     The following is an example URL for a system: `auth.cmn.system1.us.cray.com/keycloak/admin`
 

--- a/operations/security_and_authentication/Change_the_LDAP_Server_IP_Address_for_Existing_LDAP_Server_Content.md
+++ b/operations/security_and_authentication/Change_the_LDAP_Server_IP_Address_for_Existing_LDAP_Server_Content.md
@@ -45,18 +45,21 @@ Follow the steps in only one of the sections below:
     ```bash
     MASTER_USERNAME=$(kubectl get secret -n services keycloak-master-admin-auth -ojsonpath='{.data.user}' | base64 -d)
     MASTER_PASSWORD=$(kubectl get secret -n services keycloak-master-admin-auth -ojsonpath='{.data.password}' | base64 -d)
+    SITE_DOMAIN="$(craysys metadata get site-domain)"
+    SYSTEM_NAME="$(craysys metadata get system-name)"
+    AUTH_FQDN="auth.cmn.${SYSTEM_NAME}.${SITE_DOMAIN}"
 
     function get_master_token {
       curl -ks -d client_id=admin-cli -d username="${MASTER_USERNAME}" -d password="${MASTER_PASSWORD}" \
-          -d grant_type=password https://api-gw-service-nmn.local/keycloak/realms/master/protocol/openid-connect/token | \
-        python -c "import sys.json; print json.load(sys.stdin)['access_token']"
+          -d grant_type=password "https://${AUTH_FQDN}/keycloak/realms/master/protocol/openid-connect/token" | \
+        jq -r .access_token
     }
     ```
 
 1. (`ncn-mw#`) Get the component ID for the LDAP user federation.
 
     ```bash
-    COMPONENT_ID=$(curl -s -H "Authorization: Bearer $(get_master_token)" https://api-gw-service-nmn.local/keycloak/admin/realms/shasta/components \
+    COMPONENT_ID=$(curl -s -H "Authorization: Bearer $(get_master_token)" https://${AUTH_FQDN}/keycloak/admin/realms/shasta/components \
         | jq -r '.[] | select(.providerId=="ldap").id')
 
     echo "${COMPONENT_ID}"
@@ -71,7 +74,7 @@ Follow the steps in only one of the sections below:
 1. (`ncn-mw#`) Get the current representation of the LDAP user federation.
 
     ```bash
-    curl -s -H "Authorization: Bearer $(get_master_token)" "https://api-gw-service-nmn.local/keycloak/admin/realms/shasta/components/${COMPONENT_ID}" \
+    curl -s -H "Authorization: Bearer $(get_master_token)" "https://${AUTH_FQDN}/keycloak/admin/realms/shasta/components/${COMPONENT_ID}" \
         | jq . > keycloak_ldap.json
     ```
 
@@ -117,5 +120,5 @@ Follow the steps in only one of the sections below:
 
     ```bash
     curl -i -XPUT -H "Authorization: Bearer $(get_master_token)" -H "Content-Type: application/json" -d @keycloak_ldap.json \
-        "https://api-gw-service-nmn.local/keycloak/admin/realms/shasta/components/${COMPONENT_ID}"
+        "https://${AUTH_FQDN}/keycloak/admin/realms/shasta/components/${COMPONENT_ID}"
     ```

--- a/operations/security_and_authentication/Create_a_Service_Account_in_Keycloak.md
+++ b/operations/security_and_authentication/Create_a_Service_Account_in_Keycloak.md
@@ -71,12 +71,14 @@ Follow the steps in only one of the following sections, depending on if it is pr
    ```bash
    MASTER_USERNAME=$(kubectl get secret -n services keycloak-master-admin-auth -ojsonpath='{.data.user}' | base64 -d)
    MASTER_PASSWORD=$(kubectl get secret -n services keycloak-master-admin-auth -ojsonpath='{.data.password}' | base64 -d)
+   SITE_DOMAIN="$(craysys metadata get site-domain)"
+   SYSTEM_NAME="$(craysys metadata get system-name)"
+   AUTH_FQDN="auth.cmn.${SYSTEM_NAME}.${SITE_DOMAIN}"
 
    function get_master_token {
-     curl -ks -d client_id=admin-cli -d username=$MASTER_USERNAME \
-             -d password=$MASTER_PASSWORD -d grant_type=password \
-             https://api-gw-service-nmn.local/keycloak/realms/master/protocol/openid-connect/token \
-     | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])"
+     curl -ks -d client_id=admin-cli -d username="${MASTER_USERNAME}" -d password="${MASTER_PASSWORD}" \
+         -d grant_type=password "https://${AUTH_FQDN}/keycloak/realms/master/protocol/openid-connect/token" | \
+     jq -r .access_token
    }
    ```
 
@@ -106,13 +108,13 @@ Follow the steps in only one of the following sections, depending on if it is pr
      ]
    }
    ' \
-   https://api-gw-service-nmn.local/keycloak/admin/realms/shasta/clients
+   "https://${AUTH_FQDN}/keycloak/admin/realms/shasta/clients"
    ```
 
    Output similar to the following is expected:
 
    ```text
    HTTP/2 201
-   location: https://api-gw-service-nmn.local/keycloak/admin/realms/shasta/clients/bd8084d2-08bf-45cb-ab94-ee81e39921be
+   location: https://auth.cmn.system1.us.cray.com/keycloak/admin/realms/shasta/clients/bd8084d2-08bf-45cb-ab94-ee81e39921be
    content-length: 0
    ```

--- a/operations/security_and_authentication/Remove_the_LDAP_User_Federation_from_Keycloak.md
+++ b/operations/security_and_authentication/Remove_the_LDAP_User_Federation_from_Keycloak.md
@@ -32,11 +32,14 @@ Follow the steps in only one of the sections below:
     ```bash
     MASTER_USERNAME=$(kubectl get secret -n services keycloak-master-admin-auth -ojsonpath='{.data.user}' | base64 -d)
     MASTER_PASSWORD=$(kubectl get secret -n services keycloak-master-admin-auth -ojsonpath='{.data.password}' | base64 -d)
+    SITE_DOMAIN="$(craysys metadata get site-domain)"
+    SYSTEM_NAME="$(craysys metadata get system-name)"
+    AUTH_FQDN="auth.cmn.${SYSTEM_NAME}.${SITE_DOMAIN}"
 
     function get_master_token {
       curl -ks -d client_id=admin-cli -d username="${MASTER_USERNAME}" -d password="${MASTER_PASSWORD}" \
-          -d grant_type=password https://api-gw-service-nmn.local/keycloak/realms/master/protocol/openid-connect/token | \
-        python -c "import sys.json; print json.load(sys.stdin)['access_token']"
+          -d grant_type=password "https://${AUTH_FQDN}/keycloak/realms/master/protocol/openid-connect/token" | \
+        jq -r .access_token
     }
     ```
 
@@ -44,7 +47,7 @@ Follow the steps in only one of the sections below:
 
     ```bash
     COMPONENT_ID=$(curl -s -H "Authorization: Bearer $(get_master_token)" \
-            https://api-gw-service-nmn.local/keycloak/admin/realms/shasta/components \
+            "https://${AUTH_FQDN}/keycloak/admin/realms/shasta/components" \
         | jq -r '.[] | select(.providerId=="ldap").id')
 
     echo "${COMPONENT_ID}"
@@ -59,7 +62,7 @@ Follow the steps in only one of the sections below:
 1. (`ncn-mw#`) Delete the LDAP user federation by performing a `DELETE` operation on the LDAP resource.
 
     ```bash
-    curl -i -XDELETE -H "Authorization: Bearer $(get_master_token)" "https://api-gw-service-nmn.local/keycloak/admin/realms/shasta/components/${COMPONENT_ID}"
+    curl -i -XDELETE -H "Authorization: Bearer $(get_master_token)" "https://${AUTH_FQDN}/keycloak/admin/realms/shasta/components/${COMPONENT_ID}"
     ```
 
     If the operation is successful, then the expected HTTP status code is 204. In this case, the command output should begin with the following line:

--- a/operations/security_and_authentication/Retrieve_an_Authentication_Token.md
+++ b/operations/security_and_authentication/Retrieve_an_Authentication_Token.md
@@ -1,6 +1,6 @@
 # Retrieve an Authentication Token
 
-Retrieve a token for authenticating to one of the API gateways, for the `shasta` realm. 
+Retrieve a token for authenticating to one of the API gateways, for the `shasta` realm.
 
 The following are important properties of authentication tokens:
 

--- a/operations/security_and_authentication/Retrieve_an_Authentication_Token.md
+++ b/operations/security_and_authentication/Retrieve_an_Authentication_Token.md
@@ -1,6 +1,6 @@
 # Retrieve an Authentication Token
 
-Retrieve a token for authenticating to one of the API gateways.
+Retrieve a token for authenticating to one of the API gateways, for the `shasta` realm. 
 
 The following are important properties of authentication tokens:
 
@@ -12,7 +12,7 @@ The API gateways use OAuth2 for authentication. A token is required to authentic
 
 There are multiple API gateways that are used to access services from the different networks.
 
-- `services-gateway` accessible at `api.nmnlb.SYSETM_DOMAIN_NAME` or `api-gw-service-nmn.local`
+- `services-gateway` accessible at `api.nmnlb.SYSTEM_DOMAIN_NAME` or `api-gw-service-nmn.local`
 - `customer-admin-gateway` accessible at `api.cmn.SYSTEM_DOMAIN_NAME`
 - `customer-user-gateway` accessible at `api.can.SYSTEM_DOMAIN_NAME` or `api.chn.SYSTEM_DOMAIN_NAME`
 


### PR DESCRIPTION
# Description

Update Keycloak operational documentation to use CMN vs NMN LB. This as the latter requests will now fail due to OPA policy restrictions put in place via [CASMSEC-371](https://jira-pro.its.hpecorp.net:8443/browse/CASMSEC-371) in CSM 1.3.1 (also in 1.2.2 and 1.4.0, shortly main as well). See https://github.com/Cray-HPE/cray-opa/pull/77. 

The documentation is backward compatible with all 1.3 releases, as they all included the CMN LB and Keycloak access (virtual service) on the ingress path. 

Additional Detail:

* Did not update secret attributes for master admin auth re: internalTokenUrl.
* Use `jq` consistently where possible (vs. mixture of `jq`, and `python`)
* Added double-quotes to URLs for consistency

Also needed in 1.2 re: 1.2.2 patch [CASMINST-5832](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5832), 1.4 [CASMINST-5833](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5833), and main [CASMINST-5834](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5834). 

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
