### PR TITLE
CASMHMS-5785 Fix HSM CLI calls in docs-csm CSM-1.4

### DIFF
--- a/operations/hardware_state_manager/Component_Memberships.md
+++ b/operations/hardware_state_manager/Component_Memberships.md
@@ -27,13 +27,13 @@ By default, the memberships collection contains all components, regardless of if
 Retrieve all node memberships:
 
 ```bash
-cray hsm memberships list --type node
+cray hsm memberships list --type Node
 ```
 
 Retrieve only nodes not in a partition:
 
 ```bash
-cray hsm memberships list --type node --partition NULL
+cray hsm memberships list --type Node --partition NULL
 ```
 
 ### Retrieve Membership Data for a Given Component

--- a/operations/hardware_state_manager/Component_Memberships.md
+++ b/operations/hardware_state_manager/Component_Memberships.md
@@ -1,8 +1,11 @@
 # Component Memberships
 
-Memberships are a read-only resource that is generated automatically by changes to groups and partitions. Each component in `/hsm/v2/State/Components` is represented. Filter options are available to prune the list, or a specific component name (xname) can be given. All groups and the partition \(if any\) of each component are listed.
+Memberships are a read-only resource that is generated automatically by changes to groups and partitions. Each component
+in `/hsm/v2/State/Components` is represented. Filter options are available to prune the list, or a specific component name
+(xname) can be given. All groups and the partition \(if any\) of each component are listed.
 
-At this point in time, only information about node components is needed. The `--type` node filter option is used in the commands below to retrieve information about node memberships only.
+At this point in time, only information about node components is needed. The `--type` node filter option is used in the
+commands below to retrieve information about node memberships only.
 
 The following is an example membership:
 
@@ -20,9 +23,10 @@ The following is an example membership:
 
 **Troubleshooting:** If the Cray CLI has not been initialized, the CLI commands will not work.
 
-### Retrieve Group and Partition Memberships
+## Retrieve Group and Partition Memberships
 
-By default, the memberships collection contains all components, regardless of if they are in a group. However, a filtered subset is desired more frequently. Querying the memberships collection supports the same query options as `/hsm/v2/State/Components`.
+By default, the memberships collection contains all components, regardless of if they are in a group. However, a filtered subset
+is desired more frequently. Querying the memberships collection supports the same query options as `/hsm/v2/State/Components`.
 
 Retrieve all node memberships:
 
@@ -36,11 +40,10 @@ Retrieve only nodes not in a partition:
 cray hsm memberships list --type Node --partition NULL
 ```
 
-### Retrieve Membership Data for a Given Component
+## Retrieve Membership Data for a Given Component
 
 Any components in `/hsm/v2/State/Components` can have its group and memberships looked up with its individual component component name (xname).
 
 ```bash
 cray hsm memberships describe MEMBER_ID
 ```
-

--- a/operations/hardware_state_manager/Restore_HSM_Postgres_from_Backup.md
+++ b/operations/hardware_state_manager/Restore_HSM_Postgres_from_Backup.md
@@ -422,7 +422,7 @@ automatic backup created by the `cray-smd-postgresql-db-backup` Kubernetes cronj
     Get the number of node objects stored in HSM:
 
     ```bash
-    cray hsm state components list --type node --format json | jq .Components[].ID | wc -l
+    cray hsm state components list --type Node --format json | jq .Components[].ID | wc -l
     ```
 
 1. (`ncn#`) Resync the component state and inventory.

--- a/operations/hardware_state_manager/Restore_HSM_Postgres_without_a_Backup.md
+++ b/operations/hardware_state_manager/Restore_HSM_Postgres_without_a_Backup.md
@@ -40,7 +40,7 @@ This procedure is intended to repopulate HSM in the event when no Postgres backu
 2. Verify that the service is functional.
 
     ```bash
-    cray hsm service ready
+    cray hsm service ready list
     ```
 
     Example output:
@@ -53,7 +53,7 @@ This procedure is intended to repopulate HSM in the event when no Postgres backu
 3. Get the number of node objects stored in HSM.
 
     ```bash
-    cray hsm state components list --type node --format json | jq .[].ID | wc -l
+    cray hsm state components list --type Node --format json | jq .Components[].ID | wc -l
     ```
 
 4. Restart MEDS and REDS.
@@ -70,7 +70,7 @@ This procedure is intended to repopulate HSM in the event when no Postgres backu
     Wait for the RedfishEndpoints table to get repopulated and discovery to complete.
 
     ```bash
-    cray hsm inventory RedfishEndpoints list --format json | jq .[].ID | wc -l
+    cray hsm inventory redfishEndpoints list --format json | jq .RedfishEndpoints[].ID | wc -l
     100
     cray hsm inventory redfishEndpoints list --format json | grep -c "DiscoveryStarted"
     0

--- a/operations/hardware_state_manager/Restore_HSM_Postgres_without_a_Backup.md
+++ b/operations/hardware_state_manager/Restore_HSM_Postgres_without_a_Backup.md
@@ -2,13 +2,13 @@
 
 This procedure is intended to repopulate HSM in the event when no Postgres backup exists.
 
-### Prerequisite
+## Prerequisite
 
 - Healthy System Layout Service (SLS). Recovered first if also affected.
 
 - Healthy HSM service.
 
-  Verify all 3 HSM postgres replicas are up and running:
+  Verify all 3 HSM Postgres replicas are up and running:
 
   ```bash
   kubectl -n services get pods -l cluster-name=cray-smd-postgres
@@ -16,14 +16,14 @@ This procedure is intended to repopulate HSM in the event when no Postgres backu
 
   Example output:
 
-  ```
+  ```text
   NAME                  READY   STATUS    RESTARTS   AGE
   cray-smd-postgres-0   3/3     Running   0          18d
   cray-smd-postgres-1   3/3     Running   0          18d
   cray-smd-postgres-2   3/3     Running   0          18d
   ```
 
-### Procedure
+## Procedure
 
 1. Re-run the HSM loader job.
 
@@ -45,7 +45,7 @@ This procedure is intended to repopulate HSM in the event when no Postgres backu
 
     Example output:
 
-    ```
+    ```text
     code = 0
     message = "HSM is healthy"
     ```
@@ -58,7 +58,7 @@ This procedure is intended to repopulate HSM in the event when no Postgres backu
 
 4. Restart MEDS and REDS.
 
-    To repopulate HSM with components, restart MEDS and REDS so that they will add known RedfishEndpoints back in to HSM. This will also kick off HSM rediscovery to repopulate components and hardware inventory.
+    To repopulate HSM with components, restart MEDS and REDS so that they will add known `RedfishEndpoints` back in to HSM. This will also kick off HSM rediscovery to repopulate components and hardware inventory.
 
     ```bash
     kubectl scale deployment cray-meds -n services --replicas=0
@@ -82,12 +82,12 @@ This procedure is intended to repopulate HSM in the event when no Postgres backu
     cray hsm inventory redfishEndpoints list --format json | grep LastDiscoveryStatus | grep -v -c "DiscoverOK"
     ```
 
-    If any of the RedfishEndpoint entries have a `LastDiscoveryStatus` other than `DiscoverOK` after discovery has completed, refer to the [Troubleshoot Issues with Redfish Endpoint Discovery](../node_management/Troubleshoot_Issues_with_Redfish_Endpoint_Discovery.md) procedure for guidance.
+    If any of the RedfishEndpoint entries have a `LastDiscoveryStatus` other than `DiscoverOK` after discovery has completed, refer
+    to the [Troubleshoot Issues with Redfish Endpoint Discovery](../node_management/Troubleshoot_Issues_with_Redfish_Endpoint_Discovery.md) procedure for guidance.
 
 6. Re-apply any component group or partition customizations.
 
     Any component groups or partitions created before HSM's Postgres information was lost will need to be manually re-entered.
 
-    * [Manage Component Groups](Manage_Component_Groups.md)
-    * [Manage Component Partitions](Manage_Component_Partitions.md)
-
+    - [Manage Component Groups](Manage_Component_Groups.md)
+    - [Manage Component Partitions](Manage_Component_Partitions.md)

--- a/operations/security_and_authentication/Updating_the_Liquid-Cooled_EX_Cabinet_Default_Credentials_after_a_CEC_Password_Change.md
+++ b/operations/security_and_authentication/Updating_the_Liquid-Cooled_EX_Cabinet_Default_Credentials_after_a_CEC_Password_Change.md
@@ -224,11 +224,20 @@ Before redeploying MEDS, update the `customizations.yaml` file in the `site-init
 
     ```bash
     \
-    REDFISH_ENDPOINTS=$(cray hsm inventory redfishEndpoints list --type '!RouterBMC' --format json | jq .RedfishEndpoints[].ID -r | sort -V )
+    cray hsm inventory redfishEndpoints list --format json > /tmp/redfishEndpoints.json
     cray hsm state components list --format json  > /tmp/components.json
 
+    REDFISH_ENDPOINTS=$(jq .RedfishEndpoints[].ID -r /tmp/redfishEndpoints.json | sort -V)
     for RF in $REDFISH_ENDPOINTS; do
         echo "$RF: Checking..."
+        TYPE=$(jq -r --arg XNAME "$RF" '.RedfishEndpoints[] | select(.ID == $XNAME).Type' /tmp/redfishEndpoints.json)
+        if [[ -z "$TYPE" ]]; then
+            echo "$RF missing Type, skipping..."
+            continue
+        elif [[ "$TYPE" == "RouterBMC" ]]; then
+            echo "$RF is a RouterBMC, skipping..."
+            continue
+        fi
         CLASS=$(jq -r --arg XNAME "$RF" '.Components[] | select(.ID == $XNAME).Class' /tmp/components.json)
         if [[ "$CLASS" != "Mountain" ]]; then
             echo "$RF is not Mountain, skipping..."
@@ -267,11 +276,17 @@ Before redeploying MEDS, update the `customizations.yaml` file in the `site-init
 
     ```bash
     \
-    cray hsm inventory redfishEndpoints list --laststatus '!DiscoverOK' --type '!RouterBMC' --format json > /tmp/redfishEndpoints.json
+    cray hsm inventory redfishEndpoints list --laststatus '!DiscoverOK' --format json > /tmp/redfishEndpoints.json
     cray hsm state components list --format json  > /tmp/components.json
 
     REDFISH_ENDPOINTS=$(jq .RedfishEndpoints[].ID -r /tmp/redfishEndpoints.json | sort -V)
     for RF in $REDFISH_ENDPOINTS; do
+        TYPE=$(jq -r --arg XNAME "$RF" '.RedfishEndpoints[] | select(.ID == $XNAME).Type' /tmp/redfishEndpoints.json)
+        if [[ -z "$TYPE" ]]; then
+            continue
+        elif [[ "$TYPE" == "RouterBMC" ]]; then
+            continue
+        fi
         CLASS=$(jq -r --arg XNAME "$RF" '.Components[] | select(.ID == $XNAME).Class' /tmp/components.json)
         if [[ "$CLASS" != "Mountain" ]]; then
             continue
@@ -421,11 +436,17 @@ Before redeploying MEDS, update the `customizations.yaml` file in the `site-init
 
     ```bash
     \
-    cray hsm inventory redfishEndpoints list --laststatus '!DiscoverOK' --type '!RouterBMC' --format json > /tmp/redfishEndpoints.json
+    cray hsm inventory redfishEndpoints list --laststatus '!DiscoverOK' --format json > /tmp/redfishEndpoints.json
     cray hsm state components list --format json  > /tmp/components.json
 
     REDFISH_ENDPOINTS=$(jq .RedfishEndpoints[].ID -r /tmp/redfishEndpoints.json | sort -V)
     for RF in $REDFISH_ENDPOINTS; do
+        TYPE=$(jq -r --arg XNAME "$RF" '.RedfishEndpoints[] | select(.ID == $XNAME).Type' /tmp/redfishEndpoints.json)
+        if [[ -z "$TYPE" ]]; then
+            continue
+        elif [[ "$TYPE" == "RouterBMC" ]]; then
+            continue
+        fi
         CLASS=$(jq -r --arg XNAME "$RF" '.Components[] | select(.ID == $XNAME).Class' /tmp/components.json)
         if [[ "$CLASS" != "Mountain" ]]; then
             continue

--- a/upgrade/scripts/cfs/wait_for_configuration.sh
+++ b/upgrade/scripts/cfs/wait_for_configuration.sh
@@ -81,7 +81,7 @@ elif [[ -n $ROLE ]] || [[ -n $SUBROLE ]]; then
   if [[ -n $SUBROLE ]]; then
     SUBROLE_PARAMETER="--subrole $SUBROLE"
   fi
-  XNAMES=$(cray hsm state components list --type node $ROLE_PARAMETER $SUBROLE_PARAMETER --format json \
+  XNAMES=$(cray hsm state components list --type Node $ROLE_PARAMETER $SUBROLE_PARAMETER --format json \
     | jq -r '.Components | map(.ID) | join(",")')
   XNAME_PARAMETER="--ids ${XNAMES}"
 fi


### PR DESCRIPTION
### Summary and Scope

This change fixes several Cray CLI calls for HSM that are broken in our documentation. In CSM-1.3 a change was made to switch the "type" field in HSM /State/Components from a string to an enum which now requires the argument to be capitalized to match the expected case.

### Issues and Related PRs

* Resolves CASMHMS-5785 in CSM-1.4.

### Testing

This change was tested by running the updated CLI calls for HSM on Wasp running CSM-1.4 and verifying that they no longer failed and now return the expected data.

### Risks and Mitigations

Low risk.