### PR TITLE
CASMHMS-5890 Add workaround for set_ssh_keys.py script

### DIFF
--- a/operations/system_configuration_service/Configure_BMC_and_Controller_Parameters_with_scsd.md
+++ b/operations/system_configuration_service/Configure_BMC_and_Controller_Parameters_with_scsd.md
@@ -59,16 +59,19 @@ Usage: set_ssh_keys.py [options]
 Apply the workaround to the `set_ssh_keys.py` script.
 
 1. Delete the following lines:
+
 ```text
-		if not "Class" in comp:
-			if comp['Type'] == "CabinetPDUController":
+      if not "Class" in comp:
+         if comp['Type'] == "CabinetPDUController":
 ```
-2. Replace the deleted lines with the following:
+
+1. Replace the deleted lines with the following:
+
 ```text
-		if "Class" in comp:
-			tclass = comp['Class']
-		else:
-			if comp['Type'] == "CabinetPDUController" or comp['Type'] == "CabinetPDUPowerConnector":
+      if "Class" in comp:
+         tclass = comp['Class']
+      else:
+         if comp['Type'] == "CabinetPDUController" or comp['Type'] == "CabinetPDUPowerConnector":
 ```
 
 If no command line arguments are needed, SSH keys are set on all discovered mountain controllers using the root account's public RSA key. Using an alternate key requires the `--sshkey=key` argument:

--- a/operations/system_configuration_service/Configure_BMC_and_Controller_Parameters_with_scsd.md
+++ b/operations/system_configuration_service/Configure_BMC_and_Controller_Parameters_with_scsd.md
@@ -56,6 +56,21 @@ Usage: set_ssh_keys.py [options]
    --sshkey=key     SSH key to set on BMCs. If none is specified, will use
 ```
 
+Apply the workaround to the `set_ssh_keys.py` script.
+
+1. Delete the following lines:
+```text
+		if not "Class" in comp:
+			if comp['Type'] == "CabinetPDUController":
+```
+2. Replace the deleted lines with the following:
+```text
+		if "Class" in comp:
+			tclass = comp['Class']
+		else:
+			if comp['Type'] == "CabinetPDUController" or comp['Type'] == "CabinetPDUPowerConnector":
+```
+
 If no command line arguments are needed, SSH keys are set on all discovered mountain controllers using the root account's public RSA key. Using an alternate key requires the `--sshkey=key` argument:
 
 ```bash


### PR DESCRIPTION
# Description

Added a workaround for the set_ssh_keys.py script.

# Checklist Before Merging
- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
