### PR TITLE
CASMTRIAGE-4794 - add etag into IMS Image Import docs.

### DIFF
--- a/operations/image_management/Import_External_Image_to_IMS.md
+++ b/operations/image_management/Import_External_Image_to_IMS.md
@@ -198,6 +198,14 @@ identified by a `type` value:
 * `application/vnd.cray.image.kernel`
 * `application/vnd.cray.image.parameters.boot`
 
+1. (`ncn-mw#`) Collect etag values for uploaded files.
+
+    ```bash
+    ROOTFS_ETAG=$( cray artifacts describe boot-images ${IMS_IMAGE_ID}/${IMS_ROOTFS_FILENAME} --format json | jq -r .artifact.ETag  | tr -d '"' )
+    KERNEL_ETAG=$( cray artifacts describe boot-images ${IMS_IMAGE_ID}/${IMS_KERNEL_FILENAME} --format json | jq -r .artifact.ETag  | tr -d '"' )
+    INITRD_ETAG=$( cray artifacts describe boot-images ${IMS_IMAGE_ID}/${IMS_INITRD_FILENAME} --format json | jq -r .artifact.ETag  | tr -d '"' )
+    ```
+
 1. (`ncn-mw#`) Generate an image manifest file.
 
     > If necessary, modify the following example to reflect the actual set of artifacts included in the image.
@@ -213,6 +221,7 @@ identified by a `type` value:
       "artifacts": [
         {
           "link": {
+              "etag": "${ROOTFS_ETAG}",
               "path": "s3://boot-images/${IMS_IMAGE_ID}/${IMS_ROOTFS_FILENAME}",
               "type": "s3"
           },
@@ -221,6 +230,7 @@ identified by a `type` value:
         },
         {
           "link": {
+              "etag": "${KERNEL_ETAG}",
               "path": "s3://boot-images/${IMS_IMAGE_ID}/${IMS_KERNEL_FILENAME}",
               "type": "s3"
           },
@@ -229,6 +239,7 @@ identified by a `type` value:
         },
         {
           "link": {
+              "etag": "${INITRD_ETAG}",
               "path": "s3://boot-images/${IMS_IMAGE_ID}/${IMS_INITRD_FILENAME}",
               "type": "s3"
           },
@@ -246,12 +257,19 @@ identified by a `type` value:
     cray artifacts create boot-images "${IMS_IMAGE_ID}/manifest.json" manifest.json
     ```
 
+1. (`ncn-mw#`) Collect the etag for the manifest file.
+
+    ```bash
+    MANIFEST_ETAG=$( cray artifacts describe boot-images ${IMS_IMAGE_ID}/manifest.json --format json | jq -r .artifact.ETag  | tr -d '"' )
+    ```
+
 1. (`ncn-mw#`) Update the IMS image record with the image manifest information.
 
     ```bash
     cray ims images update "${IMS_IMAGE_ID}" \
         --link-type s3 \
         --link-path "s3://boot-images/${IMS_IMAGE_ID}/manifest.json" \
+        --link-etag "${MANIFEST_ETAG}" \
         --format toml
     ```
 
@@ -265,5 +283,5 @@ identified by a `type` value:
     [link]
     type = "s3"
     path = "s3://boot-images/4e78488d-4d92-4675-9d83-97adfc17cb19/manifest.json"
-    etag = ""
+    etag = "627264cd4ab4d231a0b2bf42aabb4156"
     ```

--- a/scripts/operations/node_management/ncn-ims-image-upload.sh
+++ b/scripts/operations/node_management/ncn-ims-image-upload.sh
@@ -72,6 +72,10 @@ cray artifacts create boot-images "$IMS_IMAGE_ID/rootfs" "$IMS_ROOTFS_FILENAME" 
 cray artifacts create boot-images "$IMS_IMAGE_ID/kernel" "$IMS_KERNEL_FILENAME" > /dev/null
 cray artifacts create boot-images "$IMS_IMAGE_ID/initrd" "$IMS_INITRD_FILENAME" > /dev/null
 
+ROOTFS_ETAG=$( cray artifacts describe boot-images ${IMS_IMAGE_ID}/rootfs --format json | jq -r .artifact.ETag  | tr -d '"' )
+KERNEL_ETAG=$( cray artifacts describe boot-images ${IMS_IMAGE_ID}/kernel --format json | jq -r .artifact.ETag  | tr -d '"' )
+INITRD_ETAG=$( cray artifacts describe boot-images ${IMS_IMAGE_ID}/initrd --format json | jq -r .artifact.ETag  | tr -d '"' )
+
 cat <<EOF> ims_manifest.json
 {
   "created": "$(date '+%Y-%m-%d %H:%M:%S')",
@@ -79,6 +83,7 @@ cat <<EOF> ims_manifest.json
   "artifacts": [
     {
       "link": {
+        "etag": "${ROOTFS_ETAG}",
         "path": "s3://boot-images/$IMS_IMAGE_ID/rootfs",
         "type": "s3"
       },
@@ -87,6 +92,7 @@ cat <<EOF> ims_manifest.json
     },
     {
       "link": {
+        "etag": "${KERNEL_ETAG}",
         "path": "s3://boot-images/$IMS_IMAGE_ID/kernel",
         "type": "s3"
       },
@@ -95,6 +101,7 @@ cat <<EOF> ims_manifest.json
     },
     {
       "link": {
+        "etag": "${INITRD_ETAG}",
         "path": "s3://boot-images/$IMS_IMAGE_ID/initrd",
         "type": "s3"
       },
@@ -106,9 +113,11 @@ cat <<EOF> ims_manifest.json
 EOF
 
 cray artifacts create boot-images "$IMS_IMAGE_ID/manifest.json" ims_manifest.json > /dev/null
+MANIFEST_ETAG=$( cray artifacts describe boot-images ${IMS_IMAGE_ID}/manifest.json --format json | jq -r .artifact.ETag  | tr -d '"' )
 
 cray ims images update "$IMS_IMAGE_ID" \
         --link-type s3 \
+        --link-etag "${MANIFEST_ETAG}" \
         --link-path "s3://boot-images/$IMS_IMAGE_ID/manifest.json" > /dev/null
 
 echo "$IMS_IMAGE_ID"

--- a/scripts/operations/node_management/ncn-ims-image-upload.sh
+++ b/scripts/operations/node_management/ncn-ims-image-upload.sh
@@ -27,6 +27,8 @@
 test -n "$DEBUG" && set -x
 set -eou pipefail
 
+unset CRAY_FORMAT
+
 while [[ $# -gt 0 ]]; do
     case $1 in
         -k)


### PR DESCRIPTION
# Description

Add 'etag' information to the description of how to import a boot image into IMS. 

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
