### PR TITLE
CASM-3811: Provide default values for outputs

### DIFF
--- a/workflows/iuf/operations/ims-upload.yaml
+++ b/workflows/iuf/operations/ims-upload.yaml
@@ -222,6 +222,7 @@ spec:
       - name: ims_records
         valueFrom:
           path: /results/records.yaml
+          default: "{}"
 
     container:
       # replace image with standard ims-load-artifacts once PR is merged

--- a/workflows/iuf/operations/nexus-setup/nexus-docker-upload-template.yaml
+++ b/workflows/iuf/operations/nexus-setup/nexus-docker-upload-template.yaml
@@ -255,6 +255,7 @@ spec:
         - name: nexus_docker_load_results
           valueFrom:
             path: /results/records.yaml
+            default: "{}"
     nodeSelector:
       kubernetes.io/hostname: ncn-m001
     tolerations:

--- a/workflows/iuf/operations/nexus-setup/nexus-helm-upload-template.yaml
+++ b/workflows/iuf/operations/nexus-setup/nexus-helm-upload-template.yaml
@@ -254,6 +254,7 @@ spec:
         - name: nexus_helm_load_results
           valueFrom:
             path: /results/records.yaml
+            default: "{}"
     nodeSelector:
       kubernetes.io/hostname: ncn-m001
     tolerations:

--- a/workflows/iuf/operations/nexus-setup/nexus-setup-template.yaml
+++ b/workflows/iuf/operations/nexus-setup/nexus-setup-template.yaml
@@ -263,6 +263,7 @@ spec:
         - name: nexus_setup_results
           valueFrom:
             path: /results/records.yaml
+            default: "{}"
     container:
       image: "{{inputs.parameters.nexus_setup_image}}"
       command: [iuf-nexus-setup]

--- a/workflows/iuf/operations/vcs-upload/vcs-upload-content.yaml
+++ b/workflows/iuf/operations/vcs-upload/vcs-upload-content.yaml
@@ -225,6 +225,7 @@ spec:
           - name: vcs-upload-content-results
             valueFrom:
               path: /results/records.yaml
+              default: "{}"
       container:
         image: registry.local/artifactory.algol60.net/csm-docker/stable/cf-gitea-import:1.8.0-alpha.19_6747be7
         command:


### PR DESCRIPTION
For output parameters that are built from files expected to contain product catalog data, provide a default value. This protects against unexpected cases in which the results file was not written.

Test Description: I made the changes live on #frigg.

# Description

See commit message

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
