### PR TITLE
CASMINST-5674: Add update-cfs-config stage and operations

### DIFF
--- a/workflows/iuf/operations/update-cfs-config/update-managed-cfs-config.yaml
+++ b/workflows/iuf/operations/update-cfs-config/update-managed-cfs-config.yaml
@@ -1,0 +1,67 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: update-managed-cfs-config
+spec:
+  entrypoint: main
+  templates:
+    ### Main Steps ###
+    - name: main
+      inputs:
+        parameters:
+          - name: auth_token
+          - name: global_params
+      steps:
+        - - name: sat-bootprep-run
+            templateRef:
+              name: sat-general-template
+              template: sat-wrapper
+            arguments:
+              parameters:
+                - name: auth_token
+                  value: "{{inputs.parameters.auth_token}}"
+                - name: media_dir
+                  value: "{{=jsonpath(inputs.parameters.global_params, '$.input_params.media_dir')}}"
+                - name: script_content
+                  value: |
+                    MEDIA_DIR="{{=jsonpath(inputs.parameters.global_params, '$.input_params.media_dir')}}"
+                    BOOTPREP_FILE_PATH="{{=jsonpath(inputs.parameters.global_params, '$.input_params.bootprep_config_managed')}}"
+                    if [[ -z "$BOOTPREP_FILE_PATH" ]]; then
+                      echo "No bootprep file provided. Skipping operation." 1>&2
+                      echo "{}"
+                      exit 0
+                    fi
+
+                    VARS_FILE_PATH=$(mktemp)
+                    cat > $VARS_FILE_PATH <<- 'EOF'
+                      {{=toJson(jsonpath(inputs.parameters.global_params, '$.site_params.products'))}}
+                    EOF
+                    sat bootprep run \
+                      --limit configurations \
+                      --overwrite-configs \
+                      --vars-file "$VARS_FILE_PATH" \
+                      --format json \
+                      $MEDIA_DIR/$BOOTPREP_FILE_PATH

--- a/workflows/iuf/operations/update-cfs-config/update-management-cfs-config.yaml
+++ b/workflows/iuf/operations/update-cfs-config/update-management-cfs-config.yaml
@@ -1,0 +1,67 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: update-management-cfs-config
+spec:
+  entrypoint: main
+  templates:
+    ### Main Steps ###
+    - name: main
+      inputs:
+        parameters:
+          - name: auth_token
+          - name: global_params
+      steps:
+        - - name: sat-bootprep-run
+            templateRef:
+              name: sat-general-template
+              template: sat-wrapper
+            arguments:
+              parameters:
+                - name: auth_token
+                  value: "{{inputs.parameters.auth_token}}"
+                - name: media_dir
+                  value: "{{=jsonpath(inputs.parameters.global_params, '$.input_params.media_dir')}}"
+                - name: script_content
+                  value: |
+                    MEDIA_DIR="{{=jsonpath(inputs.parameters.global_params, '$.input_params.media_dir')}}"
+                    BOOTPREP_FILE_PATH="{{=jsonpath(inputs.parameters.global_params, '$.input_params.bootprep_config_management')}}"
+                    if [[ -z "$BOOTPREP_FILE_PATH" ]]; then
+                      echo "No bootprep file provided. Skipping operation." 1>&2
+                      echo "{}"
+                      exit 0
+                    fi
+
+                    VARS_FILE_PATH=$(mktemp)
+                    cat > $VARS_FILE_PATH <<- 'EOF'
+                      {{=toJson(jsonpath(inputs.parameters.global_params, '$.site_params.products'))}}
+                    EOF
+                    sat bootprep run \
+                      --limit configurations \
+                      --overwrite-configs \
+                      --vars-file "$VARS_FILE_PATH" \
+                      --format json \
+                      $MEDIA_DIR/$BOOTPREP_FILE_PATH


### PR DESCRIPTION
This change adds the update-cfs-config-management and update-cfs-config-managed operations, and an overall update-cfs-config stage.

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
