### PR TITLE
CASMINST-5859 Remove erroneous `}`

### DIFF
--- a/install/deploy_final_non-compute_node.md
+++ b/install/deploy_final_non-compute_node.md
@@ -131,7 +131,7 @@ The steps in this section load hand-off data before a later procedure reboots th
     ```bash
     csi handoff bss-metadata \
         --data-file "${PITDATA}/configs/data.json" \
-        --kubernetes-ims-image-id "$K8S_IMS_IMAGE_ID}" \
+        --kubernetes-ims-image-id "$K8S_IMS_IMAGE_ID" \
         --storage-ims-image-id "$STORAGE_IMS_IMAGE_ID" && echo SUCCESS
     ```
 


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
Fixes incorrect `}`.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
