### PR TITLE
CASMMON-260 Update prometheus-kafka-adapter error doc for CSM 1.4+

### DIFF
--- a/operations/system_management_health/Prometheus_Kafka_Error.md
+++ b/operations/system_management_health/Prometheus_Kafka_Error.md
@@ -1,6 +1,6 @@
 # `prometheus-kafka-adapter` errors during installation
 
-On a fresh install of CSM 1.3.1, the Prometheus log has following example errors:
+On a fresh install of CSM, the Prometheus log has following example errors:
 
 ```text
 ts=2022-12-05T13:35:53.495Z caller=dedupe.go:112 component=remote level=warn remote_name=2eb187 


### PR DESCRIPTION
Description
Update documentation for the Prometheus log being flooded with Prometheus-Kafka-adapter errors during installation for CSM 1.4+.

[CASMMON-260](https://jira-pro.its.hpecorp.net:8443/browse/CASMMON-260)