### PR TITLE
CASMINST-5860: fix pod move logic

### DIFF
--- a/workflows/ncn/hooks/before-all/move-critical-singleton-pods.yaml
+++ b/workflows/ncn/hooks/before-all/move-critical-singleton-pods.yaml
@@ -29,17 +29,20 @@ metadata:
     before-all: "true"
 spec:
   scriptContent: |
-    targetNcns="{{.TargetNcns}}"
-    # remove '[' and ']'
-    targetNcns=${targetNcns:1:-1}
+    targetNcns={{inputs.parameters.targetNcns}}
+    echo "targetNcns: $targetNcns"
+    # example input of targetNcns: ["ncn-w001","ncn-w002","ncn-w003"]
+    # remove '[', ']' and '"' to: ncn-w001,ncn-w002,ncn-w003
+    targetNcns=$(echo $targetNcns | tr -d '"[]')
     # convert to array
-    targetNcnsArray=($targetNcns)
+    targetNcnsArray=(${targetNcns//,/ })
     # set last rebuilding worker to nodeMoveTo
     nodeMoveTo=${targetNcnsArray[-1]}
+    echo "last worker node to be rebuilt: $nodeMoveTo"
     # try to find a node that is not in targetNcns
     nodes=$(kubectl get nodes | grep "ncn-w" | awk '{print $1}')
     for node in $nodes;do
-      if echo $targetNcns | grep $node; then
+      if [[ $targetNcns == *$node* ]]; then
         echo "skip $node"
       else
         nodeMoveTo=${node}

--- a/workflows/ncn/worker/worker.rebuild.yaml
+++ b/workflows/ncn/worker/worker.rebuild.yaml
@@ -98,6 +98,8 @@ spec:
               parameters:
                 - name: dryRun
                   value: "{{$.DryRun}}"
+                - name: targetNcns
+                  value: "{{$.TargetNcns}}"
           {{- range $index,$value := .TargetNcns }}
           - name: add-labels-{{$value}}
             template: add-labels
@@ -191,6 +193,7 @@ spec:
       inputs:
         parameters:
           - name: dryRun
+          - name: targetNcns
       dag:
         tasks:
 {{ getHooks "before-all" . | indent 8 }}


### PR DESCRIPTION
# Description

Worker node rebuild workflow had a regression in CSM 1.4 on where to move critical singleton pods. This PR fixes the regression.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
