### PR TITLE
CASMINST-5866: Bumping version cf-gitea-import 1.8.1

### DIFF
--- a/workflows/iuf/operations/vcs-upload/vcs-upload-content.yaml
+++ b/workflows/iuf/operations/vcs-upload/vcs-upload-content.yaml
@@ -227,11 +227,13 @@ spec:
               path: /results/records.yaml
               default: "{}"
       container:
-        image: artifactory.algol60.net/csm-docker/stable/cf-gitea-import:1.8.0
+        image: artifactory.algol60.net/csm-docker/stable/cf-gitea-import:1.9.0
         command:
           - "/bin/sh"
         args: ["-c", "/opt/csm/cf-gitea-import/argo_entrypoint.sh"]
         env:
+          - name: IUF_LOGGING
+            value: "true"
           - name: CF_IMPORT_GITEA_USER
             valueFrom:
               secretKeyRef:

--- a/workflows/iuf/operations/vcs-upload/vcs-upload-content.yaml
+++ b/workflows/iuf/operations/vcs-upload/vcs-upload-content.yaml
@@ -227,7 +227,7 @@ spec:
               path: /results/records.yaml
               default: "{}"
       container:
-        image: artifactory.algol60.net/csm-docker/stable/cf-gitea-import:1.9.0
+        image: artifactory.algol60.net/csm-docker/stable/cf-gitea-import:1.8.1
         command:
           - "/bin/sh"
         args: ["-c", "/opt/csm/cf-gitea-import/argo_entrypoint.sh"]


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->

Bumping cf-gitea-import image to latest, contains IUF required fixes regarding logging.
[CASMINST-5866](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5866)

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
