### PR TITLE
CASMMON-257 adding metrics for update-cfs-config prepare-images stages 

### DIFF
--- a/workflows/iuf/operations/prepare-images/prepare-managed-images-template.yaml
+++ b/workflows/iuf/operations/prepare-images/prepare-managed-images-template.yaml
@@ -30,11 +30,34 @@ spec:
   templates:
     ### Main Steps ###
     - name: main
+      metrics:
+        prometheus:
+        - name: operation_counter
+          help: "Count of step execution by result status"
+          labels:
+            - key: "opname"
+              value: "prepare-managed-images"
+            - key: stage
+              value: "prepare-images"
+            - key: type
+              value: "global"
+            - key: pname
+              value: "global"
+            - key: pversion
+              value: "global"
+            - key: status
+              value: "{{status}}"
+          counter:
+            value: "1"
       inputs:
         parameters:
           - name: auth_token
           - name: global_params
       steps:
+        - - name: start-operation
+            templateRef:
+              name: workflow-template-record-time-template
+              template: record-time-template
         - - name: sat-bootprep-run
             templateRef:
               name: sat-general-template
@@ -63,3 +86,59 @@ spec:
                       --overwrite-images --overwrite-templates \
                       --vars-file "$VARS_FILE_PATH" --format json \
                       $MEDIA_DIR/$BOOTPREP_FILE_PATH
+        - - name: end-operation
+            templateRef:
+              name: workflow-template-record-time-template
+              template: record-time-template
+
+        - - name:  prom-metrics
+            template: prom-metrics
+            arguments:
+              parameters:
+              - name: opstart
+                value: "{{steps.start-operation.outputs.result}}"
+              - name: opend
+                value: "{{steps.end-operation.outputs.result}}"
+              - name: pdname
+                value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.name')}}"
+              - name: pdversion
+                value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.version')}}"
+
+    - name: prom-metrics
+      inputs:
+        parameters:
+        - name: opstart
+        - name: opend
+        - name: pdname
+        - name: pdversion
+      metrics:
+        prometheus:
+          - name: operation_time
+            help: "Duration gauge by operation name in seconds"
+            labels:
+              - key: opname
+                value: "prepare-managed-images"
+              - key: stage
+                value: "prepare-images"
+              - key: type
+                value: "global"
+              - key: pdname
+                value: "global"
+              - key: pdversion
+                value: "global"
+              - key: opstart
+                value: "{{inputs.parameters.opstart}}"
+              - key: opend
+                value: "{{inputs.parameters.opend}}"
+            gauge:
+              value: "{{outputs.parameters.diff-time-value}}"
+      outputs:
+        parameters:
+          - name: diff-time-value
+            globalName: diff-time-value
+            valueFrom:
+              path: /tmp/diff_time.txt
+      container:
+        image: artifactory.algol60.net/csm-docker/stable/docker.io/alpine/git:2.32.0
+        command: [sh, -c]
+        args: ["DIFF_TIME=$(expr {{inputs.parameters.opend}} - {{inputs.parameters.opstart}}); echo $DIFF_TIME; echo $DIFF_TIME > /tmp/diff_time.txt"] 

--- a/workflows/iuf/operations/prepare-images/prepare-management-images-template.yaml
+++ b/workflows/iuf/operations/prepare-images/prepare-management-images-template.yaml
@@ -30,11 +30,34 @@ spec:
   templates:
     ### Main Steps ###
     - name: main
+      metrics:
+       prometheus:
+       - name: operation_counter
+         help: "Count of step execution by result status"
+         labels:
+           - key: "opname"
+             value: "prepare-management-images"
+           - key: stage
+             value: "prepare-images"
+           - key: type
+             value: "global"
+           - key: pname
+             value: "global"
+           - key: pversion
+             value: "global"
+           - key: status
+             value: "{{status}}"
+         counter:
+           value: "1"
       inputs:
         parameters:
           - name: auth_token
           - name: global_params
       steps:
+        - - name: start-operation
+            templateRef:
+              name: workflow-template-record-time-template
+              template: record-time-template
         - - name: sat-bootprep-run
             templateRef:
               name: sat-general-template
@@ -63,3 +86,59 @@ spec:
                       --overwrite-images --overwrite-templates \
                       --vars-file "$VARS_FILE_PATH" --format json \
                       $MEDIA_DIR/$BOOTPREP_FILE_PATH
+        - - name: end-operation
+            templateRef:
+              name: workflow-template-record-time-template
+              template: record-time-template
+
+        - - name:  prom-metrics
+            template: prom-metrics
+            arguments:
+              parameters:
+              - name: opstart
+                value: "{{steps.start-operation.outputs.result}}"
+              - name: opend
+                value: "{{steps.end-operation.outputs.result}}"
+              - name: pdname
+                value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.name')}}"
+              - name: pdversion
+                value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.version')}}"
+
+    - name: prom-metrics
+      inputs:
+        parameters:
+        - name: opstart
+        - name: opend
+        - name: pdname
+        - name: pdversion
+      metrics:
+        prometheus:
+          - name: operation_time
+            help: "Duration gauge by operation name in seconds"
+            labels:
+              - key: opname
+                value: "prepare-managed-images"
+              - key: stage
+                value: "prepare-images"
+              - key: type
+                value: "global"
+              - key: pdname
+                value: "global"
+              - key: pdversion
+                value: "global"
+              - key: opstart
+                value: "{{inputs.parameters.opstart}}"
+              - key: opend
+                value: "{{inputs.parameters.opend}}"
+            gauge:
+              value: "{{outputs.parameters.diff-time-value}}"
+      outputs:
+        parameters:
+          - name: diff-time-value
+            globalName: diff-time-value
+            valueFrom:
+              path: /tmp/diff_time.txt
+      container:
+        image: artifactory.algol60.net/csm-docker/stable/docker.io/alpine/git:2.32.0
+        command: [sh, -c]
+        args: ["DIFF_TIME=$(expr {{inputs.parameters.opend}} - {{inputs.parameters.opstart}}); echo $DIFF_TIME; echo $DIFF_TIME > /tmp/diff_time.txt"]              

--- a/workflows/iuf/operations/update-cfs-config/update-managed-cfs-config.yaml
+++ b/workflows/iuf/operations/update-cfs-config/update-managed-cfs-config.yaml
@@ -30,11 +30,34 @@ spec:
   templates:
     ### Main Steps ###
     - name: main
+      metrics:
+        prometheus:
+        - name: operation_counter
+          help: "Count of step execution by result status"
+          labels:
+            - key: "opname"
+              value: "update-managed-cfs-config"
+            - key: stage
+              value: "update-cfs-config"
+            - key: type
+              value: "global"
+            - key: pname
+              value: "global"
+            - key: pversion
+              value: "global"
+            - key: status
+              value: "{{status}}"
+          counter:
+            value: "1"
       inputs:
         parameters:
           - name: auth_token
           - name: global_params
       steps:
+        - - name: start-operation
+            templateRef:
+              name: workflow-template-record-time-template
+              template: record-time-template
         - - name: sat-bootprep-run
             templateRef:
               name: sat-general-template
@@ -65,3 +88,59 @@ spec:
                       --vars-file "$VARS_FILE_PATH" \
                       --format json \
                       $MEDIA_DIR/$BOOTPREP_FILE_PATH
+        - - name: end-operation
+            templateRef:
+              name: workflow-template-record-time-template
+              template: record-time-template
+
+        - - name:  prom-metrics
+            template: prom-metrics
+            arguments:
+              parameters:
+              - name: opstart
+                value: "{{steps.start-operation.outputs.result}}"
+              - name: opend
+                value: "{{steps.end-operation.outputs.result}}"
+              - name: pdname
+                value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.name')}}"
+              - name: pdversion
+                value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.version')}}"
+        
+    - name: prom-metrics
+      inputs:
+        parameters:
+        - name: opstart
+        - name: opend
+        - name: pdname
+        - name: pdversion
+      metrics:
+        prometheus:
+          - name: operation_time
+            help: "Duration gauge by operation name in seconds"
+            labels:
+              - key: opname
+                value: "update-managed-cfs-config"
+              - key: stage
+                value: "update-cfs-config"
+              - key: type
+                value: "global"
+              - key: pdname
+                value: "global"
+              - key: pdversion
+                value: "global"
+              - key: opstart
+                value: "{{inputs.parameters.opstart}}"
+              - key: opend
+                value: "{{inputs.parameters.opend}}"
+            gauge:
+              value: "{{outputs.parameters.diff-time-value}}"
+      outputs:
+        parameters:
+          - name: diff-time-value
+            globalName: diff-time-value
+            valueFrom:
+              path: /tmp/diff_time.txt
+      container:
+        image: artifactory.algol60.net/csm-docker/stable/docker.io/alpine/git:2.32.0
+        command: [sh, -c]
+        args: ["DIFF_TIME=$(expr {{inputs.parameters.opend}} - {{inputs.parameters.opstart}}); echo $DIFF_TIME; echo $DIFF_TIME > /tmp/diff_time.txt"]  

--- a/workflows/iuf/operations/update-cfs-config/update-management-cfs-config.yaml
+++ b/workflows/iuf/operations/update-cfs-config/update-management-cfs-config.yaml
@@ -30,11 +30,34 @@ spec:
   templates:
     ### Main Steps ###
     - name: main
+      metrics:
+        prometheus:
+        - name: operation_counter
+          help: "Count of step execution by result status"
+          labels:
+            - key: "opname"
+              value: "update-management-cfs-config"
+            - key: stage
+              value: "update-cfs-config"
+            - key: type
+              value: "global"
+            - key: pname
+              value: "global"
+            - key: pversion
+              value: "global"
+            - key: status
+              value: "{{status}}"
+          counter:
+            value: "1"
       inputs:
         parameters:
           - name: auth_token
           - name: global_params
       steps:
+        - - name: start-operation
+            templateRef:
+              name: workflow-template-record-time-template
+              template: record-time-template
         - - name: sat-bootprep-run
             templateRef:
               name: sat-general-template
@@ -65,3 +88,59 @@ spec:
                       --vars-file "$VARS_FILE_PATH" \
                       --format json \
                       $MEDIA_DIR/$BOOTPREP_FILE_PATH
+        - - name: end-operation
+            templateRef:
+              name: workflow-template-record-time-template
+              template: record-time-template
+
+        - - name:  prom-metrics
+            template: prom-metrics
+            arguments:
+              parameters:
+              - name: opstart
+                value: "{{steps.start-operation.outputs.result}}"
+              - name: opend
+                value: "{{steps.end-operation.outputs.result}}"
+              - name: pdname
+                value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.name')}}"
+              - name: pdversion
+                value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.version')}}"
+
+    - name: prom-metrics
+      inputs:
+        parameters:
+        - name: opstart
+        - name: opend
+        - name: pdname
+        - name: pdversion
+      metrics:
+        prometheus:
+          - name: operation_time
+            help: "Duration gauge by operation name in seconds"
+            labels:
+              - key: opname
+                value: "update-management-cfs-config"
+              - key: stage
+                value: "update-cfs-config"
+              - key: type
+                value: "global"
+              - key: pdname
+                value: "global"
+              - key: pdversion
+                value: "global"
+              - key: opstart
+                value: "{{inputs.parameters.opstart}}"
+              - key: opend
+                value: "{{inputs.parameters.opend}}"
+            gauge:
+              value: "{{outputs.parameters.diff-time-value}}"
+      outputs:
+        parameters:
+          - name: diff-time-value
+            globalName: diff-time-value
+            valueFrom:
+              path: /tmp/diff_time.txt
+      container:
+        image: artifactory.algol60.net/csm-docker/stable/docker.io/alpine/git:2.32.0
+        command: [sh, -c]
+        args: ["DIFF_TIME=$(expr {{inputs.parameters.opend}} - {{inputs.parameters.opstart}}); echo $DIFF_TIME; echo $DIFF_TIME > /tmp/diff_time.txt"]


### PR DESCRIPTION
Added stub operations to get prom-metrics for update-cfs-config prepare-images stages 
currently, iuf operation does not provide an inbuilt mechanism for r Prometheus metrics.
At the first step added epoch start and end time for extract-release-distributions operation. we are planing to use these metrics for creating grafana iuf timing dashboard.

Please note we are unable to create WorkflowTemplate for the Prometheus metrics. So we have used it directly in extract-release-distributions.yaml.

Testing: tested on frigg.

iuf -a ram-1  -m /opt/cray/iuf/rambabu  run --site-vars /opt/cray/iuf/site_vars.yaml --bootprep-config-dir /etc/cray/upgrade/csm/iuf/hpc-csm-software-recipe-23.1.18/vcs -b  prepare-images -e prepare-images
INFO All logs will be stored in /etc/cray/upgrade/csm/iuf/ram-1/log/20230130130542
INFO Dumping rendered site variables to /etc/cray/upgrade/csm/iuf/ram-1/state/session_vars.yaml
INFO IUF SESSION: ram-1-952ds
INFO       IUF STAGE: prepare-images
INFO   ARGO WORKFLOW: ram-1-952ds-prepare-images-7ns2r
INFO              BEGIN: prepare-management-images
INFO              BEGIN: [0]
INFO              BEGIN: start-operation
INFO           FINISHED: [0] [Succeeded]
INFO           FINISHED: start-operation [Succeeded]
INFO              BEGIN: [1]
INFO              BEGIN: sat-bootprep-run
INFO             Configuration file "/root/.config/sat/sat.toml" generated.
INFO           FINISHED: [1] [Succeeded]
INFO           FINISHED: sat-bootprep-run [Succeeded]
INFO              BEGIN: [2]
INFO              BEGIN: end-operation
INFO           FINISHED: [2] [Succeeded]
INFO           FINISHED: end-operation [Succeeded]
INFO              BEGIN: [3]
INFO              BEGIN: prom-metrics
INFO           FINISHED: prepare-management-images [Succeeded]
INFO           FINISHED: [3] [Succeeded]
INFO           FINISHED: prom-metrics [Succeeded]
INFO              BEGIN: prepare-managed-images
INFO              BEGIN: [0]
INFO              BEGIN: start-operation
INFO           FINISHED: [0] [Succeeded]
INFO           FINISHED: start-operation [Succeeded]
INFO              BEGIN: [1]
INFO              BEGIN: sat-bootprep-run
INFO             Configuration file "/root/.config/sat/sat.toml" generated.
INFO           FINISHED: [1] [Succeeded]
INFO           FINISHED: sat-bootprep-run [Succeeded]
INFO              BEGIN: [2]
INFO              BEGIN: end-operation
INFO           FINISHED: [2] [Succeeded]
INFO           FINISHED: end-operation [Succeeded]
INFO              BEGIN: [3]
INFO              BEGIN: prom-metrics
INFO           FINISHED: prepare-managed-images [Succeeded]
INFO           FINISHED: [3] [Succeeded]
INFO           FINISHED: prom-metrics [Succeeded]
INFO          RESULT: Succeeded
INFO        DURATION: 0:01:33
INFO Dumping rendered site variables to /etc/cray/upgrade/csm/iuf/ram-1/state/session_vars.yaml
INFO Install completed in 0:01:36
----------------
Stage Summary
activity: ram-1
command line: iuf -a ram-1 -m /opt/cray/iuf/rambabu run --site-vars /opt/cray/iuf/site_vars.yaml --bootprep-config-dir /etc/cray/upgrade/csm/iuf/hpc-csm-software-recipe-23.1.18/vcs -b prepare-images -e prepare-images
log dir: /etc/cray/upgrade/csm/iuf/ram-1/log
media dir: /opt/cray/iuf/rambabu
ran stages: deliver-product update-cfs-config prepare-images


 curl 10.43.0.244:9090/metrics |grep prepare-images
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0argo_workflows_operation_counter{opname="prepare-managed-images",pname="global",pversion="global",stage="prepare-images",status="Succeeded",type="global"} 1
argo_workflows_operation_counter{opname="prepare-management-images",pname="global",pversion="global",stage="prepare-images",status="Succeeded",type="global"} 1
argo_workflows_operation_time{opend="1675083969",opname="prepare-managed-images",opstart="1675083947",pdname="global",pdversion="global",stage="prepare-images",type="global"} 22
argo_workflows_operation_time{opend="1675084011",opname="prepare-managed-images",opstart="1675083988",pdname="global",pdversion="global",stage="prepare-images",type="global"} 23
100  485k    0  485k    0     0  22.5M      0 --:--:-- --:--:-- --:--:-- 22.5M




iuf -a ram-1  -m /opt/cray/iuf/rambabu  run --site-vars /opt/cray/iuf/site_vars.yaml --bootprep-config-dir /etc/cray/upgrade/csm/iuf/hpc-csm-software-recipe-23.1.18/vcs -b  update-cfs-config -e update-cfs-config
INFO All logs will be stored in /etc/cray/upgrade/csm/iuf/ram-1/log/20230130130913
INFO Dumping rendered site variables to /etc/cray/upgrade/csm/iuf/ram-1/state/session_vars.yaml
INFO IUF SESSION: ram-1-z5mh9
INFO       IUF STAGE: update-cfs-config
INFO   ARGO WORKFLOW: ram-1-z5mh9-update-cfs-config-6lj69
INFO              BEGIN: update-management-cfs-config
INFO              BEGIN: [0]
INFO              BEGIN: start-operation
INFO           FINISHED: [0] [Succeeded]
INFO           FINISHED: start-operation [Succeeded]
INFO              BEGIN: [1]
INFO              BEGIN: sat-bootprep-run
INFO             Configuration file "/root/.config/sat/sat.toml" generated.
INFO           FINISHED: [1] [Succeeded]
INFO           FINISHED: sat-bootprep-run [Succeeded]
INFO              BEGIN: [2]
INFO              BEGIN: end-operation
INFO           FINISHED: [2] [Succeeded]
INFO           FINISHED: end-operation [Succeeded]
INFO              BEGIN: [3]
INFO              BEGIN: prom-metrics
INFO           FINISHED: update-management-cfs-config [Succeeded]
INFO           FINISHED: [3] [Succeeded]
INFO           FINISHED: prom-metrics [Succeeded]
INFO              BEGIN: update-managed-cfs-config
INFO              BEGIN: [0]
INFO              BEGIN: start-operation
INFO           FINISHED: [0] [Succeeded]
INFO           FINISHED: start-operation [Succeeded]
INFO              BEGIN: [1]
INFO              BEGIN: sat-bootprep-run
INFO             Configuration file "/root/.config/sat/sat.toml" generated.
INFO           FINISHED: [1] [Succeeded]
INFO           FINISHED: sat-bootprep-run [Succeeded]
INFO              BEGIN: [2]
INFO              BEGIN: end-operation
INFO           FINISHED: [2] [Succeeded]
INFO           FINISHED: end-operation [Succeeded]
INFO              BEGIN: [3]
INFO              BEGIN: prom-metrics
INFO           FINISHED: update-managed-cfs-config [Succeeded]
INFO           FINISHED: [3] [Succeeded]
INFO           FINISHED: prom-metrics [Succeeded]
INFO          RESULT: Succeeded
INFO        DURATION: 0:01:33
INFO Dumping rendered site variables to /etc/cray/upgrade/csm/iuf/ram-1/state/session_vars.yaml
INFO Install completed in 0:01:36
----------------
Stage Summary
activity: ram-1
command line: iuf -a ram-1 -m /opt/cray/iuf/rambabu run --site-vars /opt/cray/iuf/site_vars.yaml --bootprep-config-dir /etc/cray/upgrade/csm/iuf/hpc-csm-software-recipe-23.1.18/vcs -b update-cfs-config -e update-cfs-config
log dir: /etc/cray/upgrade/csm/iuf/ram-1/log
media dir: /opt/cray/iuf/rambabu
ran stages: deliver-product update-cfs-config prepare-images
----------------
curl 10.43.0.244:9090/metrics |grep update-cfs-config
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0argo_workflows_operation_counter{opname="update-managed-cfs-config",pname="global",pversion="global",stage="update-cfs-config",status="Succeeded",type="global"} 1
argo_workflows_operation_counter{opname="update-management-cfs-config",pname="global",pversion="global",stage="update-cfs-config",status="Succeeded",type="global"} 1
argo_workflows_operation_time{opend="1675084179",opname="update-management-cfs-config",opstart="1675084157",pdname="global",pdversion="global",stage="update-cfs-config",type="global"} 22
argo_workflows_operation_time{opend="1675084221",opname="update-managed-cfs-config",opstart="1675084199",pdname="global",pdversion="global",stage="update-cfs-config",type="global"} 22
100  486k    0  486k    0     0  21.5M      0 --:--:-- --:--:-- --:--:-- 21.5M



