### PR TITLE
CASMTRIAGE-4867: correctly handle the targetNcns input

### DIFF
--- a/workflows/ncn/hooks/before-all/move-critical-singleton-pods.yaml
+++ b/workflows/ncn/hooks/before-all/move-critical-singleton-pods.yaml
@@ -29,13 +29,13 @@ metadata:
     before-all: "true"
 spec:
   scriptContent: |
-    targetNcns={{inputs.parameters.targetNcns}}
+    targetNcns="{{inputs.parameters.targetNcns}}"
     echo "targetNcns: $targetNcns"
-    # example input of targetNcns: ["ncn-w001","ncn-w002","ncn-w003"]
-    # remove '[', ']' and '"' to: ncn-w001,ncn-w002,ncn-w003
-    targetNcns=$(echo $targetNcns | tr -d '"[]')
+    # example input of targetNcns: [ncn-w001 ncn-w002 ncn-w003]
+    # remove '[' and ']'
+    targetNcns=${targetNcns:1:-1}
     # convert to array
-    targetNcnsArray=(${targetNcns//,/ })
+    targetNcnsArray=($targetNcns)
     # set last rebuilding worker to nodeMoveTo
     nodeMoveTo=${targetNcnsArray[-1]}
     echo "last worker node to be rebuilt: $nodeMoveTo"


### PR DESCRIPTION
# Description

The original code assumed a different format of targetNcns input. This PR handles the targetNcns input param correctly.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
