### PR TITLE
(CSM 1.3) CASMHMS-5907: The proper cabinet class wasn't being set in SLS when adding a EX2500 cabinet

### DIFF
--- a/operations/system_layout_service/Add_Liquid-Cooled_Cabinets_To_SLS.md
+++ b/operations/system_layout_service/Add_Liquid-Cooled_Cabinets_To_SLS.md
@@ -272,22 +272,10 @@ This procedure adds one or more liquid-cooled cabinets and associated CDU manage
     diff sls_dump.original.json sls_dump.json
     ```
 
-1. (`ncn-m#`) Perform an SLS load state operation to replace the contents of SLS with the data from the `sls_dump.json` file.
-
-    Get an API Token:
+1. (`ncn-m#`) Perform a SLS load state operation to replace the contents of SLS with the data from the `sls_dump.json` file.
 
     ```bash
-    TOKEN=$(curl -s -S -d grant_type=client_credentials \
-                -d client_id=admin-client \
-                -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
-                https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
-    ```
-
-    Perform the load state operation:
-
-    ```bash
-    curl -s -k -H "Authorization: Bearer ${TOKEN}" -X POST -F sls_dump=@sls_dump.json \
-        https://api-gw-service-nmn.local/apis/sls/v1/loadstate
+    cray sls loadstate create sls_dump.json
     ```
 
 1. MEDS will automatically start looking for potential hardware in the newly added liquid-cooled cabinets.

--- a/scripts/operations/system_layout_service/add_liquid_cooled_cabinet.py
+++ b/scripts/operations/system_layout_service/add_liquid_cooled_cabinet.py
@@ -2,7 +2,7 @@
 
 # MIT License
 #
-# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2022-2023] Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -215,7 +215,7 @@ for chassis in chassis_list:
                     "Xname": nodeXname,
                     "Type": "comptype_node",
                     "TypeString": "Node",
-                    "Class": args.cabinet_type,
+                    "Class": cabinet_class,
                     "ExtraProperties": {
                         "NID": currentNID,
                         "Role": "Compute",


### PR DESCRIPTION
# Description
CASMHMS-5907: The proper cabinet class wasn't being set in SLS when adding a EX2500 cabinet to SLS. Replace SLS load state curl command with the appropriate craycli equivalent. 
<!--- Describe what this change is and what it is for. -->

Tested on Bradi when adding a EX2500 cabinet.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
