### PR TITLE
CRAYSAT-1617: Further expand on River BMC password configuration doc

### DIFF
--- a/operations/security_and_authentication/Change_Air-Cooled_Node_BMC_Credentials.md
+++ b/operations/security_and_authentication/Change_Air-Cooled_Node_BMC_Credentials.md
@@ -3,6 +3,9 @@
 This procedure describes how to use the System Admin Toolkit's (SAT) `sat bmccreds`
 command to set a global credential for all BMCs on air-cooled nodes.
 
+For more information including alternate methods of using `sat bmccreds`, see: [Set BMC Credentials Using SAT](../../operations/system_configuration_service/Set_BMC_Credentials.md),
+or the `sat-bmccreds(8)` man page by running `sat-man bmccreds`.
+
 ## Limitations
 
 All air-cooled and liquid-cooled BMCs share the same global credentials. The air-cooled Slingshot switch controllers (Router BMCs) must have the same credentials as the liquid-cooled Slingshot switch controllers.
@@ -15,7 +18,7 @@ SAT is installed and configured.
 
 ## Procedure
 
-1. Get the xnames for all air-cooled nodes.
+1. (`ncn-m#`) Get the xnames for all air-cooled nodes.
 
     The following operation will store the xnames in a variable named `RIVER_NODEBMC_XNAMES`.
 
@@ -24,8 +27,28 @@ SAT is installed and configured.
         --format json | jq -r '[.Components[] | .ID ]| join(",")')
     ```
 
-1. Set the same random password for every BMC on an air-cooled node.
+1. (`ncn-m#`) Set the same random password for every BMC on an air-cooled node.
+
+   The command will generate a single random string and apply it to every node BMC in the system.
 
     ```bash
     sat bmccreds --xnames $RIVER_NODEBMC_XNAMES --random-password --pw-domain system
     ```
+
+1. (Optional) View the generated password in Vault. The `sat bmccreds` command will not print the generated
+   random password, so it is necessary to view it in Vault.
+
+    1. (`ncn-m#`) Set the Vault alias, if it is not already set.
+
+        ```bash
+        VAULT_PASSWD=$(kubectl -n vault get secrets cray-vault-unseal-keys -o json | jq -r '.data["vault-root"]' |  base64 -d)
+        alias vault='kubectl -n vault exec -i cray-vault-0 -c vault -- env VAULT_TOKEN="$VAULT_PASSWD" VAULT_ADDR=http://127.0.0.1:8200 VAULT_FORMAT=json vault'
+        ```
+
+    1. (`ncn-m#`) View the password for a node BMC, for example by using the `RIVER_NODEBMC_XNAMES` environment
+       variable.
+
+        ```bash
+        echo $RIVER_NODEBMC_XNAMES
+        vault kv get secret/hms-creds/<XNAME>
+        ```


### PR DESCRIPTION
# Description

CRAYSAT-1617: Further expand on River BMC password configuration doc
* Provide more reference information on `sat bmccreds`, specifically linking to the more complete procedure found in the "system_configuration_service" directory as well as the `sat-bmccreds` man page.
* Reiterate what exactly this procedure does by adding a sentence more in the step that runs `sat bmccreds`.
* Add optional step to view the generated password in vault, and confirm that the `sat bmccreds` command itself is not supposed to echo the password.
* Ensure command prompts follow the documented convention.

# Checklist Before Merging

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams