### PR TITLE
CASMINST 5618 initial IUF content (#3056)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -74,6 +74,9 @@ Jenkinsfile.github                                       @Cray-HPE/csm-devops
 # SAT Items
 /operations/sat                                          @Cray-HPE/system-admin-toolkit-admin
 
+# IUF Items
+/operations/iuf/                                         @Cray-HPE/IUF
+
 # Include SSI on these CSM items.
 /install/                                                @Cray-HPE/metal @Cray-HPE/ssi-reviewers
 /operations/                                             @Cray-HPE/ssi-reviewers

--- a/.spelling
+++ b/.spelling
@@ -278,6 +278,7 @@ iLO5
 iLOM
 IMS
 IMS-hosted
+in_progress
 inband
 InfiniBand
 IP
@@ -291,6 +292,7 @@ iPXE
 iSCSI
 Istio
 Istio's
+IUF
 Jetstack
 Jinja
 Jinja2
@@ -336,6 +338,8 @@ Luks
 LVM
 LVMs
 macOS
+managed-nodes-rollout
+management-nodes-rollout
 maneuver
 maneuvers
 Mbs
@@ -490,6 +494,7 @@ Runbook
 S-8000
 S-8024
 S-8031
+S-8052
 sC
 SCSD
 sC-ToR
@@ -574,6 +579,8 @@ Unsuspend
 untainting
 Untar
 untarred
+update-cfs-config
+update-vcs-config
 upgrader
 Upgrader
 upgrader's
@@ -618,6 +625,7 @@ virtualization
 virtualized
 VLANs
 VSF-enabled
+waiting_admin
 webhook
 webserver
 webUI
@@ -679,6 +687,10 @@ Lorem
 - introduction/site_survey.md
 # To allow Site Init
 Init
+
+- operations/iuf/IUF.md
+sessionid
+SESSIONID
 
 - operations/network/external_dns/Update_the_cmn-external-dns_Value_Post-Installation.md
 LoadBalancer

--- a/install/pre-installation.md
+++ b/install/pre-installation.md
@@ -441,6 +441,17 @@ in `/etc/environment` from the [Download CSM tarball](#21-download-csm-tarball) 
            update -y cray-site-init
        ```
 
+   1. Install `iuf-cli`.
+
+       > ***NOTE*** This provides `iuf`, a command line interface to the [Install and Upgrade Framework](../operations/iuf/IUF.md).
+
+       ```bash
+       zypper \
+           --plus-repo "${CSM_PATH}/rpm/cray/csm/sle-$(awk -F= '/VERSION=/{gsub(/["-]/, "") ; print tolower($NF)}' /etc/os-release)/" \
+           --no-gpg-checks \
+           install -y iuf-cli
+       ```
+
    1. Install `csm-testing` RPM.
 
        > ***NOTE*** This package provides the necessary tests and their dependencies for validating the pre-installation, installation, and more.

--- a/operations/README.md
+++ b/operations/README.md
@@ -37,6 +37,8 @@ The following administrative topics can be found in this guide:
 - [Spire](#spire)
 - [Update firmware with FAS](#update-firmware-with-fas)
 - [User Access Service (UAS)](#user-access-service-uas)
+- [System Admin Toolkit (SAT)](#system-admin-toolkit-sat)
+- [Install and Upgrade Framework (IUF)](#install-and-upgrade-framework-iuf)
 
 ## CSM product management
 
@@ -727,3 +729,11 @@ components. In CSM 1.3 and newer, the `sat` command is available on the Kubernet
 product stream.
 
 - [System Admin Toolkit in CSM](sat/sat_in_csm.md)
+
+## Install and Upgrade Framework (IUF)
+
+The Install and Upgrade Framework (IUF) provides a CLI and API which automates operations required to install, upgrade
+and deploy non-CSM product content onto an HPE Cray EX system. Each product distribution includes an `iuf-product-manifest.yaml`
+file which IUF uses to determine what operations are needed to install, upgrade, and deploy the product.
+
+- [Install and Upgrade Framework (IUF)](iuf/IUF.md)

--- a/operations/iuf/IUF.md
+++ b/operations/iuf/IUF.md
@@ -1,0 +1,545 @@
+# Install and Upgrade Framework
+
+## Overview
+
+The Install and Upgrade Framework (IUF) provides a CLI and API which automates operations required to install, upgrade
+ and deploy non-CSM product content onto an HPE Cray EX system. These products are documented in the
+_HPE Cray EX System Software Stack Installation and Upgrade Guide for CSM (S-8052)_.
+Each product distribution includes an `iuf-product-manifest.yaml` file which IUF uses to determine what operations are needed to
+install, upgrade, and deploy the product. IUF operates on all of the product distribution files found in a single
+media directory.
+
+IUF groups the install, upgrade, and deploy operations into stages. The administrator can execute some or all of the stages
+with one or multiple products in a single activity. `iuf` arguments for all stages can be specified prior to execution
+in order to automate the operations and minimize user interaction.
+
+In addition, IUF provides metric and annotation capabilities which can be used to view status and record historical
+information associated with an install or upgrade.
+
+IUF utilizes [Argo workflows](../argo/Using_Argo_Workflows.md) to execute and parallelize IUF operations and to provide
+visibility into the status of the operations through the [Argo UI](../argo/Using_the_Argo_UI.md). The `iuf` CLI invokes
+Argo workflows based on the subcommand specified. The Argo workflows are not controlled by `iuf` once they has been created, but
+`iuf` does display status to the administrator as the Argo workflows execute.
+
+The following IUF topics are discussed in the sections below.
+
+- [Limitations](#limitations)
+- [Initial Install and Upgrade Workflows](#initial-install-and-upgrade-workflows)
+- [Activities](#activities)
+- [Argo Workflows](#argo-workflows)
+- [Stages and Hooks](#stages-and-hooks)
+- [`iuf` CLI](#iuf-cli)
+- [Output and Log Files](#output-and-log-files)
+- [Site and Recipe Variables](#site-and-recipe-variables)
+- [Product Workflows](#product-workflows)
+- [Troubleshooting](#troubleshooting)
+
+## Limitations
+
+- `iuf` must be executed from `ncn-m001`.
+- While IUF enables non-interactive deployment of product software, it does not automatically configure the software beyond merging new VCS release branch content to customer working branches. For example, if a product requires
+  manual configuration, the administrator must stop IUF execution after the `update-vcs-config` stage, perform the manual configurations steps, and then resume with the next IUF stage (`update-cfs-config`).
+- IUF leverages `sat bootprep` for CFS configuration and image creation. It is intended to be used with the configuration files provided in the HPC CSM Software Recipe and requires the administrator to verify and customize
+  those configurations to their specific needs.
+- IUF will fail and provide feedback to the administrator in the event of an error, but it cannot automatically resolve issues.
+- IUF does not handle many aspects of installs and upgrades of CSM itself and cannot be used until a base level of CSM functionality is present.
+
+## Initial Install and Upgrade Workflows
+
+The time at which IUF stages are executed in an initial install or upgrade workflow depends on whether CSM itself is also being installed or upgraded in addition to non-CSM products. This table describes the different use cases
+and tasks performed.
+
+| Operation       | Content          | Tasks |
+| --------------- | ---------------- | ----- |
+| initial install | CSM and products | Install CSM, **ignoring** any IUF stages embedded in the CSM installation documentation. Then execute all IUF stages to install product content with CSM fully functional. |
+| initial install | products only    | Execute IUF stages to install non-CSM product content |
+| upgrade         | CSM and products | Upgrade CSM, **including** any IUF stages embedded in the CSM installation documentation |
+| upgrade         | products only    | Execute IUF stages to upgrade non-CSM product content |
+
+<< TODO: INSERT INITIAL INSTALL AND UPGRADE DIAGRAMS HERE >>
+
+## Activities
+
+An activity is a user-specified unique string identifier used to group and track IUF actions, typically those needed to complete an install or upgrade using a set of product distribution files. An example of an activity
+identifier is `admin-230127`. `iuf` subcommands accept an activity as input, and the corresponding IUF output and log files are organized by that activity. The activity can be specified via an `iuf` argument or an environment
+variable; for more details, see `iuf -h`.  The activity will be created automatically upon the first invocation of `iuf` with that given activity string.
+
+IUF provides operational metrics associated with an activity (e.g. the time duration of each stage executed). Users can also create annotations for an activity, e.g. to note that an operation has been paused, to note that time was
+spent debugging an issue, etc. `iuf` subcommands can be invoked to display a summary of actions, annotations, and metrics associated with an activity.
+
+The following example shows history and status information associated with the `admin-230127` activity:
+
+(`ncn-m001#`) List operations for an IUF activity.
+
+```bash
+iuf -a admin-230127 activity
++-------------------------------------------------------------------------------------------------------------------------------+
+| Activity: admin-230127                                                                                                        |
++---------------------+-------------+--------------------------------------------+-----------+----------+-----------------------+
+| Start               | Category    | Argo Workflow                              | Status    | Duration | Comment               |
++---------------------+-------------+--------------------------------------------+-----------+----------+-----------------------+
+| 2023-01-27t20:37:42 | in_progress | admin-230127-zb268-process-media-v5dsw     | Succeeded | 0:01:54  | Run process-media     |
+| 2023-01-27t20:39:36 | in_progress | admin-230127-f1w34-pre-install-check-ztsrg | Failed    | 0:01:16  | Run pre-install-check |
+| 2023-01-27t20:40:52 | debug       | None                                       | n/a       | 0:31:11  | None                  |
+| 2023-01-27t21:12:03 | in_progress | admin-230127-7jtws-process-media-29hzl     | Succeeded | 0:02:00  | Run process-media     |
+| 2023-01-27t21:14:03 | in_progress | admin-230127-o7sp4-pre-install-check-phm2w | Failed    | 0:26:09  | Run pre-install-check |
+| 2023-01-27t21:40:12 | debug       | None                                       | n/a       | 0:57:40  | None                  |
+| 2023-01-27t22:37:52 | in_progress | admin-230127-zgd6o-process-media-zvnqk     | Succeeded | 0:02:06  | Run process-media     |
+| 2023-01-27t22:39:58 | in_progress | admin-230127-svs41-pre-install-check-89gjf | Failed    | 0:01:31  | Run pre-install-check |
+| 2023-01-27t22:41:29 | debug       | None                                       | n/a       | 0:52:26  | None                  |
+| 2023-01-27t23:33:55 | in_progress | admin-230127-0f2xe-update-vcs-config-trpjw | Failed    | 0:00:53  | Run update-vcs-config |
+| 2023-01-27t23:34:48 | debug       | None                                       | n/a       | 0:00:00  | None                  |
++---------------------+-------------+--------------------------------------------+-----------+----------+-----------------------+
+
+Summary:
+  Start time: 2023-01-27t20:37:40
+    End time: 2023-01-27t23:34:48
+
+   in_progress: 0:35:49
+         debug: 2:21:17
+```
+
+## Argo Workflows
+
+[Argo workflows](../argo/Using_Argo_Workflows.md) orchestrate jobs on Kubernetes. IUF utilizes Argo workflows to execute and manage product install, upgrade, and deploy operations. For example, if an administrator invokes IUF to
+execute the `process-media` and `pre-install-check` stages for a product, two Argo workflows will be created: one associated with the `process-media` stage and one associated with the `pre-install-check` stage. Not all operations
+in an activity are associated with an Argo workflow, however. For example, annotation events and time spent waiting for the administrator to invoke the next operation do not result in the execution of IUF install and upgrade
+operations, and thus are not associated with an Argo workflow.
+
+Each Argo workflow created by IUF has a unique string identifier associated with it. An example of an IUF Argo workflow identifier is `admin-230127-zb268-process-media-v5dsw`. Argo workflow identifiers are recorded in IUF log
+files and are displayed by `iuf activity` as shown in the [Activities](#activities) section.
+
+Most Argo workflows created by IUF create multiple independent Argo steps to execute the workflow. `iuf` displays both Argo workflow and Argo step information on standard output as an IUF session executes. Argo
+workflow identifiers are prefixed with `ARGO WORKFLOW:` text and Argo steps for that workflow are displayed in an indented format underneath it. The [Output and Log Files](#output-and-log-files) section provides
+an example of `iuf` output.
+
+## Stages and Hooks
+
+Install and upgrade operations performed by IUF are organized into stages. The administrator can execute one or more stages in a single invocation of `iuf run`. A single stage can execute with the content of one or more products.
+IUF operates on all products found in a single media directory specified by the administrator. When possible, IUF will parallelize execution for products within a stage, e.g. the `process-media` stage will extract content for all
+products found in the media directory at the same time.
+
+A stage will not complete until it has completed execution for all products specified in the activity. If an error is encountered while executing a stage for a given product, IUF will allow other products to complete the execution
+of the stage and will then stop execution. It will create an entry within the activity with the corresponding Argo workflow, set its `Status` to `Failed`, and report the stage result as `Error`.
+
+IUF provides a hook capability for all stages. This allows a product to execute additional scripts before and/or after a given stage executes. Hooks allow products to perform special actions that IUF does not perform itself at an
+appropriate time in an initial install or upgrade workflow. These hook scripts are executed automatically by IUF; no input from the administrator is required. All product scripts registered via a pre-stage hooks must complete before
+the stage executes, and no product post-stage hook will execute until the stage itself has completed.
+
+The administrator may execute one, multiple, or all stages in a single `iuf run` invocation depending on the task to be accomplished. If multiple stages are specified, they must be executed in the order listed below. The `iuf run`
+subcommand provides arguments to specify which stages are to be run and if any stages should be skipped. The following table lists all of the stages in the order they are executed when performing an initial install or upgrade of
+one or more products. This information is also provided by the `iuf list-stages` subcommand.
+
+**`NOTE`** Click the links in the `Stage` column for additional details about the stages.
+
+| Stage                                                              | Description                                                                              |
+| ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
+| [process-media](stages/process_media.md)                           | Inventory and extract products in the media directory for use in subsequent stages       |
+| [pre-install-check](stages/pre_install_check.md)                   | Perform pre-install readiness checks                                                     |
+| [deliver-product](stages/deliver_product.md)                       | Upload product content onto the system                                                   |
+| [update-vcs-config](stages/update_vcs_config.md)                   | Merge working branches and perform automated VCS configuration                           |
+| [update-cfs-config](stages/update_cfs_config.md)                   | Update CFS configuration (executes `sat bootprep`)                                       |
+| [prepare-images](stages/prepare_images.md)                         | Build and configure management node and/or managed node images (executes `sat bootprep`) |
+| [management-nodes-rollout](stages/management_nodes_rollout.md)     | Rolling reboot or live update of management nodes                                        |
+| [deploy-product](stages/deploy_product.md)                         | Deploy services to system                                                                |
+| [post-install-service-check](stages/post_install_service_check.md) | Perform post-install checks of processed services                                        |
+| [managed-nodes-rollout](stages/managed_nodes_rollout.md)           | Rolling reboot or live update of managed nodes nodes                                     |
+| [post-install-check](stages/post_install_check.md)                 | Perform post-install checks                                                              |
+
+## `iuf` CLI
+
+The `iuf` command line interface is used to invoke all IUF operations. The `iuf` command provides the following subcommands.
+
+| Subcommand  | Description                                         |
+| ----------- | --------------------------------------------------- |
+| run         | Initiates execution of IUF operations               |
+| abort       | Abort a paused IUF session                          |
+| resume      | Resume a paused IUF session from where it stopped   |
+| restart     | Re-run a paused IUF session from the beginning      |
+| activity    | Display IUF activity details, annotate IUF activity |
+| list-stages | Display stages and status for a given IUF activity  |
+
+### Global Arguments
+
+Global arguments may be specified when invoking `iuf`. They must be specified before any `iuf` subcommand and its subcommand-specific arguments are specified.
+
+The following example shows the global arguments available:
+
+```bash
+usage: iuf [-h] [-i INPUT_FILE] [-w] [-a ACTIVITY] [-c CONCURRENCY] [-b BASE_DIR] [-s STATE_DIR] [-m MEDIA_DIR]
+           [--log-dir LOG_DIR] [-l {CRITICAL,ERROR,WARNING,INFO,DEBUG,TRACE}] [-v]
+           {run,activity,list-stages|ls,resume,restart,abort} ...
+
+The CSM Install and Upgrade Framework (IUF) CLI.
+
+options:
+  -h, --help            show this help message and exit
+  -i INPUT_FILE, --input-file INPUT_FILE
+                        YAML input file used to provide arguments to `iuf`. Command line arguments will override
+                        entries in the input file. Can also be set via the IUF_INPUT_FILE environment variable.
+  -w, --write-input-file
+                        Create a new input file populated with default values overridden by any other command line
+                        options also specified. The file is named via the `-i` argument. The command exits once the
+                        file has been created.
+  -a ACTIVITY, --activity ACTIVITY
+                        Activity name. Must be a unique identifier. Activity names must only contain letters (A-Za-z),
+                        numbers (0-9), periods (.), and dashes (-). Can also be set via the IUF_ACTIVITY environment
+                        variable.
+  -c CONCURRENCY, --concurrency CONCURRENCY
+                        Run Argo processes concurrently. Defaults to a fully concurrent model. To use at most N
+                        threads, specify `concurrency N`.
+  -b BASE_DIR, --base-dir BASE_DIR
+                        Base directory for state and log file directories. Defaults to ${RBD_BASE_DIR}/iuf/[activity],
+                        where ${RBD_BASE_DIR} is /etc/cray/upgrade/csm.
+  -s STATE_DIR, --state-dir STATE_DIR
+                        A directory used to store the current state of stages, used by `iuf` but primarily not of
+                        interest to users. Defaults to [base-dir]/state.
+  -m MEDIA_DIR, --media-dir MEDIA_DIR
+                        Location of installation media to be used. Defaults to ${RBD_BASE_DIR}/[activity], where
+                        ${RBD_BASE_DIR} is /etc/cray/upgrade/csm. `iuf` cannot access installation media outside of
+                        ${RBD_BASE_DIR}, however input files provided by other `iuf` arguments can exist outside of
+                        ${RBD_BASE_DIR}.
+  --log-dir LOG_DIR     Location used to store log files. Defaults to [base-dir]/log.
+  -l {CRITICAL,ERROR,WARNING,INFO,DEBUG,TRACE}, --level {CRITICAL,ERROR,WARNING,INFO,DEBUG,TRACE}
+                        Set the log message level that determines what is displayed on `iuf` standard output. Messages
+                        of this level or higher are displayed.
+  -v, --verbose         generate more verbose messages
+
+subcommands:
+  {run,activity,list-stages|ls,resume,restart,abort}
+```
+
+### Input File
+
+As described in the [Output and Log Files](#output-and-log-files) section, the `-i INPUT_FILE` argument can be used to read `iuf` arguments and values from a YAML input file. Both global and subcommand-specific arguments can be
+specified in the input file. If an input file is used in addition to `iuf` arguments, the `iuf` arguments take precedence. The name of an entries in the input file corresponds to the long form name of the `iuf` argument with
+hyphens replaced by underscores.
+
+The following in an example of a partial `iuf` input file:
+
+```yaml
+global:
+    activity: admin-230127
+    concurrency: null
+    base_dir: null
+    state_dir: /etc/cray/upgrade/csm/iuf/admin-230127/state
+    media_dir: /opt/cray/iuf/reference_media
+    media_host: ncn-m001
+    log_dir: /etc/cray/upgrade/csm/iuf/admin-230127/log
+    dryrun: false
+    level: INFO
+    verbose: false
+abort:
+    comment: null
+activity:
+    time: null
+    create: false
+[...]
+```
+
+### Subcommands
+
+#### `run`
+
+The `run` subcommand is used to execute one or more IUF stages. The `-b`, `-e`, `-r` and `-s` arguments can be specified to limit the stages executed. If none of those arguments are specified, `iuf run` will execute all stages
+in order. If an activity identifier is not provided via `-a`, a new activity will be created automatically.
+
+The following example shows the arguments that may be specified when invoking `iuf run`:
+
+```bash
+usage: iuf run [-h] [-b BEGIN_STAGE] [-e END_STAGE] [-r RUN_STAGES [RUN_STAGES ...]] [-s SKIP_STAGES [SKIP_STAGES ...]]
+               [-F FORCE] [-bc BOOTPREP_CONFIG_MANAGED] [-bm BOOTPREP_CONFIG_MANAGEMENT] [-bpcd BOOTPREP_CONFIG_DIR]
+               [-rv RECIPE_VARS] [-sv SITE_VARS] [-mrs {reboot,stage}] [-cmrp CONCURRENT_MANAGEMENT_ROLLOUT_PERCENTAGE]
+               [--limit-managed-rollout LIMIT_MANAGED_ROLLOUT [LIMIT_MANAGED_ROLLOUT ...]]
+               [--limit-management-rollout LIMIT_MANAGEMENT_ROLLOUT [LIMIT_MANAGEMENT_ROLLOUT ...]]
+               [-mrp MASK_RECIPE_PRODS [MASK_RECIPE_PRODS ...]]
+
+Run IUF stages to execute install, upgrade and/or deploy operations for a given activity.
+
+options:
+  -h, --help            show this help message and exit
+  -b BEGIN_STAGE, --begin-stage BEGIN_STAGE
+                        The first stage to execute.
+  -e END_STAGE, --end-stage END_STAGE
+                        The last stage to execute.
+  -r RUN_STAGES [RUN_STAGES ...], --run-stages RUN_STAGES [RUN_STAGES ...]
+                        Run the specified stages only. This argument is not compatible with `-b`, `-e`, or `-s`.
+  -s SKIP_STAGES [SKIP_STAGES ...], --skip-stages SKIP_STAGES [SKIP_STAGES ...]
+                        Skip the execution of the specified stages.
+  -F FORCE, --force FORCE
+                        Force re-execution of stage operations.
+  -bc BOOTPREP_CONFIG_MANAGED, --bootprep-config-managed BOOTPREP_CONFIG_MANAGED
+                        List of `sat bootprep` config files for managed (compute and
+                        application) nodes. Note the path is relative to the media directory (`iuf --media-dir`).
+  -bm BOOTPREP_CONFIG_MANAGEMENT, --bootprep-config-management BOOTPREP_CONFIG_MANAGEMENT
+                        List of `sat bootprep` config files for management NCNs.
+                        Note the path is relative to the media directory (`iuf --media-dir`).
+  -bpcd BOOTPREP_CONFIG_DIR, --bootprep-config-dir BOOTPREP_CONFIG_DIR
+                        Directory containing HPE `product_vars.yaml` and `sat bootprep` configuration files. The expected content is:
+                                $(BOOTPREP_CONFIG_DIR)/product_vars.yaml
+                                $(BOOTPREP_CONFIG_DIR)/bootprep/compute-and-uan-bootprep.yaml
+                                $(BOOTPREP_CONFIG_DIR)/bootprep/management-bootprep.yaml
+  -rv RECIPE_VARS, --recipe-vars RECIPE_VARS
+                        Path to a recipe variables YAML file. HPE provides the `product_vars.yaml` recipe variables file with each release.
+  -sv SITE_VARS, --site-vars SITE_VARS
+                        Path to a site variables YAML file. This file allows the user to override values defined in
+                        the recipe variables YAML file. Defaults to ${RBD_BASE_DIR}/${IUF_ACTIVITY}/site_vars.yaml.
+  -mrs {reboot,stage}, --managed-rollout-strategy {reboot,stage}
+                        Method to update the managed nodes. Accepted values are 'reboot' (reboot nodes _now_) or
+                        'stage' (set up nodes to reboot into new image after next WLM job). Defaults to 'stage'.
+  -cmrp CONCURRENT_MANAGEMENT_ROLLOUT_PERCENTAGE, --concurrent-management-rollout-percentage CONCURRENT_MANAGEMENT_ROLLOUT_PERCENTAGE
+                        Limit the number of management nodes that roll out
+                        concurrently based on the percentage specified. Must be an integer
+                        between 1-100. Defaults to 20 (percent).
+  --limit-managed-rollout LIMIT_MANAGED_ROLLOUT [LIMIT_MANAGED_ROLLOUT ...]
+                        Override list used to target specific nodes only when rolling out managed nodes.
+  --limit-management-rollout LIMIT_MANAGEMENT_ROLLOUT [LIMIT_MANAGEMENT_ROLLOUT ...]
+                        Override list used to target specific role_subrole(s) only when rolling out management nodes.
+  -mrp MASK_RECIPE_PRODS [MASK_RECIPE_PRODS ...], --mask-recipe-prods MASK_RECIPE_PRODS [MASK_RECIPE_PRODS ...]
+                        If `--recipe-vars` is specified, mask the versions found within the recipe variables YAML
+                        file for the specified products, such that the largest version of the package already installed on
+                        the system (found in the product catalog) is used instead of the version supplied in the HPC CSM
+                        Software Recipe. Note that the versions found via `--site-vars` (or the versions being installed)
+                        will override it as well.
+```
+
+These [examples](examples/iuf_run.md) highlight common use cases of `iuf run`.
+
+#### `abort`
+
+The `abort` subcommand is specified by the administrator to end a paused IUF session instead of attempting to resume or restart it.
+
+The following arguments may be specified when invoking `iuf abort`:
+
+```bash
+[ IMPLEMENTATION PENDING ]
+```
+
+These [examples](examples/iuf_abort.md) highlight common use cases of `iuf abort`.
+
+#### `resume`
+
+The `resume` subcommand is specified by the administrator to resume a paused IUF session.
+
+The following arguments may be specified when invoking `iuf resume`:
+
+```bash
+[ IMPLEMENTATION PENDING ]
+```
+
+These [examples](examples/iuf_resume.md) highlight common use cases of `iuf resume`.
+
+#### `restart`
+
+The `restart` subcommand is specified by the administrator to restart a paused IUF session from the beginning of the session. This allows the administrator to make changes to the environment and re-execute the IUF session.
+
+The following arguments may be specified when invoking `iuf restart`:
+
+```bash
+[ IMPLEMENTATION PENDING ]
+```
+
+These [examples](examples/iuf_restart.md) highlight common use cases of `iuf restart`.
+
+#### `activity`
+
+The `activity` subcommand allows the administrator to create a new activity, display details for an activity, and create, update, and annotate activity states. These operations allow the administrator to easily determine the status
+of IUF activity operations and associate time-based metrics and user-specified comments with them.
+
+The activity details displayed are:
+
+| Column         | Description                                                      |
+| -------------- | ---------------------------------------------------------------- |
+| Start          | The time that this operation began execution                     |
+| Category       | The state of the activity when the operation was created         |
+| Argo Workflow  | The Argo workflow associated with the operation                  |
+| Status         | The status of the operation                                      |
+| Duration       | How long the operation has been in this state (if not completed) |
+| Comment        | User-specified comments associated with the operation            |
+
+Values for `Category` are:
+
+| Category Value | Description                                                                          |
+| -------------- | ------------------------------------------------------------------------------------ |
+| in_progress    | An Argo workflow was initiated at the time recorded in `Start`                       |
+| waiting_admin  | No activity operations were in progress beginning at time recorded in `Start`        |
+| paused         | The administrator paused activity operations at the time recorded in `Start`         |
+| debug          | The administrator started debugging an issue at the time recorded in `Start`         |
+| blocked        | The administrator reported being blocked by an issue at the time recorded in `Start` |
+
+Values for `Status` are:
+
+| Status Value | Description                                                                    |
+| ------------ | ------------------------------------------------------------------------------ |
+| Succeeded    | The `Argo Workflow` completed successfully                                     |
+| Failed       | The `Argo Workflow` failed                                                     |
+| Running      | The `Argo Workflow` is currently executing                                     |
+| n/a          | The activity entry is not associated with an `Argo Workflow` and has no status |
+
+**`NOTE`** Each row displayed by `iuf activity` is a historical entry associated with the recorded `Start` and the `Duration` time values. For example, the `Category` value `in_progress` signifies that an Argo Workflow was put
+in progress at the time the entry was created, but it may not still be running when `iuf activity` is executed. The `Status` value provides context on whether an Argo Workflow is still executing.
+
+The following arguments may be specified when invoking `iuf activity`:
+
+```bash
+usage: iuf activity [-h] [--time TIME] [--create] [--comment COMMENT] [--status {Succeeded,Failed,Running,n/a}] [--sessionid SESSIONID]
+                    [{in_progress,waiting_admin,paused,debug,blocked}]
+
+Create, display, or annotate activity information.
+
+positional arguments:
+  {in_progress,waiting_admin,paused,debug,blocked}
+                        activity state value
+
+options:
+  -h, --help            show this help message and exit
+  --time TIME           A time value used when creating or modifying an activity entry. Must be specified and match an existing time value to modify that
+                        entry. Defaults to now.
+  --create              Create a new activity entry.
+  --comment COMMENT     A comment to be associated with an activity entry.
+  --status {Succeeded,Failed,Running,n/a}
+                        A status value to be associated with an activity entry.
+  --sessionid SESSIONID
+                        An Argo workflow session identifier to be associated with an activity entry.
+```
+
+These [examples](examples/iuf_activity.md) highlight common use cases of `iuf activity`.
+
+#### `list-stages`
+
+The `list-stages` subcommand displays the stages for a given activity, the status of each stage, and the time spent in each stage.
+
+The following arguments may be specified when invoking `iuf list-stages`:
+
+```bash
+usage: iuf list-stages [-h]
+
+List IUF stage information and status for a given activity specified via `-a`.
+
+options:
+  -h, --help  show this help message and exit
+```
+
+These [examples](examples/iuf_list_stages.md) highlight common use cases of `iuf list-stages`.
+
+## Output and Log Files
+
+### `iuf` Output
+
+`iuf` subcommands display status information to standard output as IUF stages execute. Stages are made up of one or more Argo workflows, each performing a series of tasks via Argo steps. `iuf` output primarily consists of:
+
+- stage begin messages
+- stage end summaries
+- Argo workflow identifiers created when executing a stage
+- Argo pod and step begin and end messages
+- completion status of each phase (Succeeded, Failed)
+- time duration metrics
+
+In addition, any IUF log messages generated by IUF or products with a severity of `INFO` or higher are printed to standard output.
+
+The Argo workflow identifiers displayed, like `admin-230127-zb268-process-media-v5dsw` in the example below, can be queried in the [Argo UI](../argo/Using_the_Argo_UI.md) to provide access to more detailed log
+information and monitoring capabilities. The lines prefixed with `BEGIN:` and `FINISHED:` primarily map to Argo steps and pods that are linked to the corresponding Argo workflow in the Argo UI.
+
+(`ncn-m001#`) Example of `iuf` output.
+
+```bash
+iuf -a admin-230127 -m admin-230127/media run --site-vars /opt/cray/iuf/site_vars.yaml --bootprep-config-dir /etc/cray/upgrade/csm/iuf/hpc-csm-software-recipe-23.1.18/vcs -e update-vcs-config
+INFO   ARGO WORKFLOW: admin-230127-zb268-process-media-v5dsw
+INFO              BEGIN: extract-release-distributions
+INFO              BEGIN: start-operation
+INFO           FINISHED: start-operation [Succeeded]
+INFO              BEGIN: list-tar-files
+INFO           FINISHED: list-tar-files [Succeeded]
+INFO              BEGIN: extract-tar-files
+INFO              BEGIN: extract-tar-files(0:cpe-slurm-23.02-sles15-1.2.9-20230123212534_30822fc.tar.gz)
+INFO           FINISHED: extract-tar-files [Succeeded]
+INFO           FINISHED: extract-tar-files(0:cpe-slurm-23.02-sles15-1.2.9-20230123212534_30822fc.tar.gz) [Succeeded]
+INFO              BEGIN: end-operation
+INFO           FINISHED: end-operation [Succeeded]
+INFO              BEGIN: prom-metrics
+INFO           FINISHED: extract-release-distributions [Succeeded]
+INFO           FINISHED: prom-metrics [Succeeded]
+INFO          RESULT: Succeeded
+INFO        DURATION: 0:01:51
+INFO Dumping rendered site variables to /etc/cray/upgrade/csm/iuf/admin-230127/state/session_vars.yaml
+INFO IUF SESSION: admin-230127-f1w34
+INFO       IUF STAGE: pre-install-check
+INFO   ARGO WORKFLOW: admin-230127-f1w34-pre-install-check-ztsrg
+INFO              BEGIN: preflight-checks-for-services
+INFO              BEGIN: start-operation
+INFO           FINISHED: start-operation [Succeeded]
+INFO              BEGIN: preflight-checks
+INFO              BEGIN: preflight-checks(0)
+[...]
+```
+
+### Log Files
+
+IUF stores detailed information in log files which are stored on a Ceph Block Device typically mounted at `/etc/cray/upgrade/`. The default log file directory location can be overridden with the `iuf -b` and `iuf --log-dir`
+options (see `iuf -h` for details).
+
+Log files are organized by activity identifiers, for example `admin-230127`. The top-level `state` directory contains information internal to the implementation of IUF and is most often uninteresting to the administrator.
+The content in the top-level `log` directory contains information about the operations executed while installing, upgrading and deploying product software and will likely be useful if a problem occurs. The following
+describes the contents of the files in the `log` directory for an activity:
+
+| Path                               | Description                                                                |
+| ---------------------------------- | -------------------------------------------------------------------------- |
+| `log/install.log`                  | Link to most recent log file in `log/<directory>/`                         |
+| `log/<directory>/`                 | Time-stamped directory created when a new `iuf` command is executed        |
+| `log/<directory>/install.log`      | Log file with content created by `iuf`                                     |
+| `log/<directory>/argo_logs/<file>` | Log files with content created by Argo as Argo pods execute IUF operations |
+
+(`ncn-m001#`) Display log files for a given activity.
+
+```bash
+cd /etc/cray/upgrade/csm/iuf/admin-230127
+
+find . -type f,l | sort -r
+./log/install.log
+./log/20230127203740/install.log
+./log/20230127203740/argo_logs/admin-230127-zb268-process-media-v5dsw-2642752133.txt
+./log/20230127203740/argo_logs/admin-230127-zb268-process-media-v5dsw-2337635292.txt
+./log/20230127203740/argo_logs/admin-230127-zb268-process-media-v5dsw-2192584523.txt
+./log/20230127203740/argo_logs/admin-230127-f1w34-pre-install-check-ztsrg-3983759619.txt
+./log/20230127203740/argo_logs/admin-230127-f1w34-pre-install-check-ztsrg-3010622324.txt
+./log/20230127203740/argo_logs/admin-230127-f1w34-pre-install-check-ztsrg-1366701318.txt
+[...]
+```
+
+## Site and Recipe Variables
+
+IUF site and recipe variables allow the administrator to customize product, product version, and branch values used by IUF
+when executing IUF stages. They ensure automated VCS branch merging, CFS configuration creation, and IMS image creation
+operations are performed with values adhering to site preferences.
+
+Site variables are typically defined in a `site_vars.yaml` file created by the site administrator. The HPC CSM Software Recipe
+provides a default recipe variables file named `product_vars.yaml`. The recipe variable file allows HPE to provide default
+variables and values while the recipe variable file allows the administrator to extend or override the variables and values.
+If both files are used and specific variables are defined in both files, the values specified in the site variable file takes
+precedence.
+
+The `iuf run` subcommand has arguments that allow the administrator to reference the site and/or recipe variable files. The
+variables specified in the files are used by IUF when executing the `update-vcs-config`, `update-cfs-config`, and `prepare-images`
+stages. For example, the `working_branch` variable defines the naming convention used by IUF to find or create a product's VCS branch
+containing site-customized configuration content, which happens as part of the `update-vcs-config` stage.
+
+An example use case for site and recipe variables is provided in the [`update-vcs-config`](stages/update_vcs_config.md) stage documentation.
+
+## Product Workflows
+
+The following are examples of workflows for installing and upgrading product content using `iuf`.
+
+- [Upgrade All Products Provided in a HPC CSM Software Recipe](workflows/upgrade_all_products.md)
+
+## Troubleshooting
+
+The following actions may be useful if errors are encountered when executing `iuf`.
+
+- Examine IUF log files as described in the [Output and Log Files](#output-and-log-files) section for information not provided on `iuf` standard output.
+- Use the [Argo UI](../argo/Using_the_Argo_UI.md) to find the Argo pod that corresponds to the failed IUF operation. This can be done by finding the Argo workflow identifier displayed on [`iuf` standard output](#iuf-output) for the failed
+  IUF operation and performing an Argo UI query with that value. Argo workflow identifiers can also be found by running [`iuf activity`](#activities). The Argo UI will provide additional log information that may help debug the issue.
+- If an error is associated with a script invoked by a product's [stage hook](#stages-and-hooks), the script can be found in the expanded product distribution file located in the media directory (`iuf -m MEDIA_DIR`). Examine the
+  `hooks` entry in the product's `iuf-product-manifest.yaml` file in the media directory for the path to the script.
+- If the source of the error can not be determined by the previous methods, details on the underlying commands executed by an IUF stage can be found in the IUF `workflows` directory. The [Stages and Hooks](#stages-and-hooks) section
+  of this document includes links to descriptions of each stage. Each of those descriptions includes an **Execution Details** section describing how to find the appropriate code in the IUF `workflows` directory to understand the
+  workflow and debug the issue.

--- a/operations/iuf/examples/iuf_abort.md
+++ b/operations/iuf/examples/iuf_abort.md
@@ -1,0 +1,3 @@
+# `iuf abort` Examples
+
+[ IMPLEMENTATION PENDING ]

--- a/operations/iuf/examples/iuf_activity.md
+++ b/operations/iuf/examples/iuf_activity.md
@@ -1,0 +1,96 @@
+# `iuf activity` Examples
+
+(`ncn-m001#`) Display an activity.
+
+```bash
+iuf -a admin-230126 activity
++-----------------------------------------------------------------------------------------------------------------------------------+
+| Activity: admin-230126                                                                                                            |
++---------------------+---------------+--------------------------------------------+-----------+----------+-------------------------+
+| Start               | Category      | Argo Workflow                              | Status    | Duration | Comment                 |
++---------------------+---------------+--------------------------------------------+-----------+----------+-------------------------+
+| 2023-01-27t00:04:05 | in_progress   | admin-230126-ebjx3-process-media-cq89t     | Succeeded | 0:01:22  | Run process-media       |
+| 2023-01-27t00:05:27 | in_progress   | admin-230126-cu8ei-pre-install-check-qllzx | Succeeded | 0:00:58  | Run pre-install-check   |
+| 2023-01-27t00:06:25 | in_progress   | admin-230126-cu8ei-deliver-product-qd5hr   | Succeeded | 0:10:20  | Run deliver-product     |
+| 2023-01-27t00:16:45 | waiting_admin | None                                       | n/a       | 0:41:15  | None                    |
+| 2023-01-27t00:58:00 | paused        | None                                       | n/a       | 1:02:00  | went home to sleep      |
+| 2023-01-27t02:00:00 | paused        | None                                       | n/a       | 15:05:58 | still sleeping          |
+| 2023-01-27t17:05:58 | blocked       | None                                       | n/a       | 1:57:54  | waiting for new package |
+| 2023-01-27t19:03:52 | in_progress   | admin-230126-7iz3n-process-media-f622g     | Succeeded | 0:01:23  | Run process-media       |
+| 2023-01-27t19:05:15 | waiting_admin | None                                       | n/a       | 0:00:00  | None                    |
++---------------------+---------------+--------------------------------------------+-----------+----------+-------------------------+
+
+Summary:
+  Start time: 2023-01-27t00:04:03
+    End time: 2023-01-27t19:05:15
+
+   in_progress: 0:14:03
+ waiting_admin: 0:41:15
+        paused: 16:07:58
+         debug: 0:00:00
+       blocked: 1:57:54
+```
+
+(`ncn-m001#`) Create a new activity entry.
+
+```bash
+iuf -a admin-230126 activity --create --comment "testing debug feature" debug
++-----------------------------------------------------------------------------------------------------------------------------------+
+| Activity: admin-230126                                                                                                            |
++---------------------+---------------+--------------------------------------------+-----------+----------+-------------------------+
+| Start               | Category      | Argo Workflow                              | Status    | Duration | Comment                 |
++---------------------+---------------+--------------------------------------------+-----------+----------+-------------------------+
+| 2023-01-27t00:04:05 | in_progress   | admin-230126-ebjx3-process-media-cq89t     | Succeeded | 0:01:22  | Run process-media       |
+| 2023-01-27t00:05:27 | in_progress   | admin-230126-cu8ei-pre-install-check-qllzx | Succeeded | 0:00:58  | Run pre-install-check   |
+| 2023-01-27t00:06:25 | in_progress   | admin-230126-cu8ei-deliver-product-qd5hr   | Succeeded | 0:10:20  | Run deliver-product     |
+| 2023-01-27t00:16:45 | waiting_admin | None                                       | n/a       | 0:41:15  | None                    |
+| 2023-01-27t00:58:00 | paused        | None                                       | n/a       | 1:02:00  | went home to sleep      |
+| 2023-01-27t02:00:00 | paused        | None                                       | n/a       | 15:05:58 | still sleeping          |
+| 2023-01-27t17:05:58 | blocked       | None                                       | n/a       | 1:57:54  | waiting for new package |
+| 2023-01-27t19:03:52 | in_progress   | admin-230126-7iz3n-process-media-f622g     | Succeeded | 0:01:23  | Run process-media       |
+| 2023-01-27t19:05:15 | waiting_admin | None                                       | n/a       | 0:01:00  | None                    |
+| 2023-01-27t19:06:15 | debug         | None                                       | n/a       | 0:00:00  | testing debug feature   |
++---------------------+---------------+--------------------------------------------+-----------+----------+-------------------------+
+
+Summary:
+  Start time: 2023-01-27t00:04:03
+    End time: 2023-01-27t19:06:15
+
+   in_progress: 0:14:03
+ waiting_admin: 0:42:15
+        paused: 16:07:58
+         debug: 0:00:00
+       blocked: 1:57:54
+```
+
+(`ncn-m001#`) Edit the comment associated with an existing activity entry.
+
+```bash
+iuf -a admin-230126 activity --time 2023-01-27t19:06:15 --comment "comment updated" debug
++-----------------------------------------------------------------------------------------------------------------------------------+
+| Activity: admin-230126                                                                                                            |
++---------------------+---------------+--------------------------------------------+-----------+----------+-------------------------+
+| Start               | Category      | Argo Workflow                              | Status    | Duration | Comment                 |
++---------------------+---------------+--------------------------------------------+-----------+----------+-------------------------+
+| 2023-01-27t00:04:05 | in_progress   | admin-230126-ebjx3-process-media-cq89t     | Succeeded | 0:01:22  | Run process-media       |
+| 2023-01-27t00:05:27 | in_progress   | admin-230126-cu8ei-pre-install-check-qllzx | Succeeded | 0:00:58  | Run pre-install-check   |
+| 2023-01-27t00:06:25 | in_progress   | admin-230126-cu8ei-deliver-product-qd5hr   | Succeeded | 0:10:20  | Run deliver-product     |
+| 2023-01-27t00:16:45 | waiting_admin | None                                       | n/a       | 0:41:15  | None                    |
+| 2023-01-27t00:58:00 | paused        | None                                       | n/a       | 1:02:00  | went home to sleep      |
+| 2023-01-27t02:00:00 | paused        | None                                       | n/a       | 15:05:58 | still sleeping          |
+| 2023-01-27t17:05:58 | blocked       | None                                       | n/a       | 1:57:54  | waiting for new package |
+| 2023-01-27t19:03:52 | in_progress   | admin-230126-7iz3n-process-media-f622g     | Succeeded | 0:01:23  | Run process-media       |
+| 2023-01-27t19:05:15 | waiting_admin | None                                       | n/a       | 0:01:00  | None                    |
+| 2023-01-27t19:06:15 | debug         | None                                       | n/a       | 0:00:00  | comment updated         |
++---------------------+---------------+--------------------------------------------+-----------+----------+-------------------------+
+
+Summary:
+  Start time: 2023-01-27t00:04:03
+    End time: 2023-01-27t19:06:15
+
+   in_progress: 0:14:03
+ waiting_admin: 0:42:15
+        paused: 16:07:58
+         debug: 0:00:00
+       blocked: 1:57:54
+```

--- a/operations/iuf/examples/iuf_list_stages.md
+++ b/operations/iuf/examples/iuf_list_stages.md
@@ -1,0 +1,28 @@
+# `iuf list-stages` Examples
+
+(`ncn-m001#`) List the stages for activity `admin-230126` along with their status and duration values.
+
+```bash
+iuf -a admin-230126 list-stages
++----------------------------+---------------------------------------------------------------------------------------+-----------+----------+
+| Stage                      | Description                                                                           | Status    | Duration |
++----------------------------+---------------------------------------------------------------------------------------+-----------+----------+
+| process-media              | Inventory and extract products in the media directory for use in subsequent stages    | Succeeded | 0:01:21  |
+| pre-install-check          | Perform pre-install readiness checks                                                  | Succeeded | 0:01:13  |
+| deliver-product            | Upload product content onto the system                                                | Succeeded | 0:09:56  |
+| update-vcs-config          | Merge working branches and perform automated VCS configuration                        | Succeeded | 0:01:12  |
+| update-cfs-config          | Update CFS configuration utilizing sat bootprep                                       | N/A       | N/A      |
+| prepare-images             | Build and configure management node and/or managed node images utilizing sat bootprep | N/A       | N/A      |
+| management-nodes-rollout   | Rolling rebuild of management nodes                                                   | N/A       | N/A      |
+| deploy-product             | Deploy services to system                                                             | N/A       | N/A      |
+| post-install-service-check | Perform post-install checks of deployed product services                              | N/A       | N/A      |
+| managed-nodes-rollout      | Rolling reboot of managed nodes                                                       | N/A       | N/A      |
+| post-install-check         | Perform post-install checks                                                           | N/A       | N/A      |
++----------------------------+---------------------------------------------------------------------------------------+-----------+----------+
+Stage Summary
+activity: admin-230126
+command line: iuf -a admin-230126 -m admin-230126/media run --site-vars /mnt/developer/admin/admin_site_vars.yaml --bootprep-config-dir /etc/cray/upgrade/csm/iuf/hpc-csm-software-recipe-23.1.18/vcs -r deliver-product
+log dir: /etc/cray/upgrade/csm/iuf/admin-230126/log
+media dir: /opt/cray/iuf/admin-230126/media
+ran stages: process-media pre-install-check deliver-product update-vcs-config
+```

--- a/operations/iuf/examples/iuf_restart.md
+++ b/operations/iuf/examples/iuf_restart.md
@@ -1,0 +1,3 @@
+# `iuf restart` Examples
+
+[ IMPLEMENTATION PENDING ]

--- a/operations/iuf/examples/iuf_resume.md
+++ b/operations/iuf/examples/iuf_resume.md
@@ -1,0 +1,3 @@
+# `iuf resume` Examples
+
+[ IMPLEMENTATION PENDING ]

--- a/operations/iuf/examples/iuf_run.md
+++ b/operations/iuf/examples/iuf_run.md
@@ -1,0 +1,7 @@
+# `iuf run` Examples
+
+(`ncn-m001#`) << TODO >>
+
+```bash
+<< TODO >>
+```

--- a/operations/iuf/stages/deliver_product.md
+++ b/operations/iuf/stages/deliver_product.md
@@ -1,0 +1,42 @@
+# `deliver-product`
+
+The `deliver-product` stage delivers the content provided in the product distribution file to the system. Artifacts will be uploaded to the following locations based on entries specified in the product `iuf-product-manifest.yaml` file.
+
+| Location                      | `iuf-product-manifest.yaml` Entry |
+| ----------------------------- | --------------------------------- |
+| S3 Content                    | `s3`                              |
+| S3 Loftsman Manifests         | `loftsman`                        |
+| Nexus Docker Registries       | `docker`                          |
+| Nexus Helm Chart Repositories | `helm`                            |
+| Nexus RPM Blob Stores         | `nexus_blob_stores`               |
+| Nexus RPM Repositories        | `nexus_repositories`              |
+| Nexus RPMs                    | `rpms`                            |
+| VCS Content                   | `vcs`                             |
+| IMS Images and Recipes        | `ims`                             |
+
+The versioned product catalog entry for the product is updated as the new content is uploaded.
+
+## Impact
+
+The `deliver-product` stage does not change the running state of the system as the new content has been uploaded, but not deployed.
+
+## Input
+
+The following arguments are most often used with the `deliver-product` stage. See `iuf -h` and `iuf run -h` for additional arguments.
+
+| Input           | `iuf` Argument | Description |
+| --------------- | -------------- | ----------- |
+| activity        | `-a ACTIVITY`  | activity created for the install or upgrade operations|
+
+## Execution Details
+
+The code executed by this stage exists within IUF. See the `deliver-product` entry in `/usr/share/doc/csm/workflows/iuf/stages.yaml` and the corresponding file(s) in `/usr/share/doc/csm/workflows/iuf/operations/`
+for details on the commands executed.
+
+## Example
+
+(`ncn-m001#`) Execute the `deliver-product` stage.
+
+```bash
+iuf -a joe-install-20230107 run -r deliver-product
+```

--- a/operations/iuf/stages/deploy_product.md
+++ b/operations/iuf/stages/deploy_product.md
@@ -1,0 +1,27 @@
+# deploy-product
+
+The `deploy-product` stage uses Loftsman to deploy product microservices to the system. The microservices are specified in the `loftsman` entry in each product's `iuf-product-manifest.yaml` file within the product distribution file.
+
+## Impact
+
+The `deploy-product` stage changes the running state of the system.
+
+## Input
+
+The following arguments are most often used with the `deploy-product` stage. See `iuf -h` and `iuf run -h` for additional arguments.
+
+| Input           | `iuf` Argument | Description |
+| --------------- | -------------- | ----------- |
+| activity        | `-a ACTIVITY`  | activity created for the install or upgrade operations |
+
+## Execution Details
+
+The code executed by this stage exists within IUF. See the `deploy-product` entry in `/usr/share/doc/csm/workflows/iuf/stages.yaml` and the corresponding file(s) in `/usr/share/doc/csm/workflows/iuf/operations/` for details on the commands executed.
+
+## Example
+
+(`ncn-m001#`) Execute the `deploy-product` stage.
+
+```bash
+iuf -a joe-install-20230107 run -r deploy-product
+```

--- a/operations/iuf/stages/managed_nodes_rollout.md
+++ b/operations/iuf/stages/managed_nodes_rollout.md
@@ -1,0 +1,28 @@
+# managed-nodes-rollout
+
+The `managed-nodes-rollout` stage performs a controlled reboot of the managed compute and application nodes in order to reboot them to a new image and configuration.
+
+## Impact
+
+The `managed-nodes-rollout` stage changes the running state of the system.
+
+## Input
+
+The following arguments are most often used with the `managed-nodes-rollout` stage. See `iuf -h` and `iuf run -h` for additional arguments.
+
+| Input           | `iuf` Argument | Description |
+| --------------- | -------------- | ----------- |
+| activity        | `-a ACTIVITY`  | activity created for the install or upgrade operations |
+
+## Execution Details
+
+The code executed by this stage exists within IUF. See the `managed-nodes-rollout` entry in `/usr/share/doc/csm/workflows/iuf/stages.yaml` and the corresponding file(s) in `/usr/share/doc/csm/workflows/iuf/operations/`
+for details on the commands executed.
+
+## Example
+
+(`ncn-m001#`) Execute the `managed-nodes-rollout` stage.
+
+```bash
+iuf -a joe-install-20230107 run -r managed-nodes-rollout
+```

--- a/operations/iuf/stages/management_nodes_rollout.md
+++ b/operations/iuf/stages/management_nodes_rollout.md
@@ -1,0 +1,29 @@
+# management-nodes-rollout
+
+The `management-nodes-rollout` stage performs a controlled rebuild of the management worker nodes in order to reboot them to a new image and configuration. IUF will account for the necessary minimum number of critical software
+instances running on worker nodes to ensure the `management-nodes-rollout` stage operates without impacting software availability.
+
+## Impact
+
+The `management-nodes-rollout` stage changes the running state of the system.
+
+## Input
+
+The following arguments are most often used with the `management-nodes-rollout` stage. See `iuf -h` and `iuf run -h` for additional arguments.
+
+| Input           | `iuf` Argument | Description |
+| --------------- | -------------- | ----------- |
+| activity        | `-a ACTIVITY`  | activity created for the install or upgrade operations |
+
+## Execution Details
+
+The code executed by this stage exists within IUF. See the `management-nodes-rollout` entry in `/usr/share/doc/csm/workflows/iuf/stages.yaml` and the corresponding file(s) in `/usr/share/doc/csm/workflows/iuf/operations/`
+for details on the commands executed.
+
+## Example
+
+(`ncn-m001#`) Execute the `management-nodes-rollout` stage.
+
+```bash
+iuf -a joe-install-20230107 run -r management-nodes-rollout
+```

--- a/operations/iuf/stages/post_install_check.md
+++ b/operations/iuf/stages/post_install_check.md
@@ -1,0 +1,29 @@
+# post-install-check
+
+The `post-install-check` stage validates that the managed compute and application nodes deployed by the preceding `managed-node-rollout` stage are executing correctly. It primarily executes pre- and post-stage hook scripts
+provided by products in their `iuf-product-manifest.yaml` file.
+
+## Impact
+
+The `post-install-check` stage does not change the running state of the system.
+
+## Input
+
+The following arguments are most often used with the `post-install-check` stage. See `iuf -h` and `iuf run -h` for additional arguments.
+
+| Input           | `iuf` Argument | Description |
+| --------------- | -------------- | ----------- |
+| activity        | `-a ACTIVITY`  | activity created for the install or upgrade operations |
+
+## Execution Details
+
+The code executed by this stage exists within IUF. See the `post-install-check` entry in `/usr/share/doc/csm/workflows/iuf/stages.yaml` and the corresponding file(s) in `/usr/share/doc/csm/workflows/iuf/operations/`
+for details on the commands executed.
+
+## Example
+
+(`ncn-m001#`) Execute the `post-install-check` stage.
+
+```bash
+iuf -a joe-install-20230107 run -r post-install-check
+```

--- a/operations/iuf/stages/post_install_service_check.md
+++ b/operations/iuf/stages/post_install_service_check.md
@@ -1,0 +1,29 @@
+# post-install-service-check
+
+The `post-install-service-check` stage validates that the microservices deployed by the preceding `deploy-product` stage are executing correctly. It primarily executes pre- and post-stage hook scripts provided by products
+in their `iuf-product-manifest.yaml` file.
+
+## Impact
+
+The `post-install-service-check` stage does not change the running state of the system.
+
+## Input
+
+The following arguments are most often used with the `post-install-service-check` stage. See `iuf -h` and `iuf run -h` for additional arguments.
+
+| Input           | `iuf` Argument | Description |
+| --------------- | -------------- | ----------- |
+| activity        | `-a ACTIVITY`  | activity created for the install or upgrade operations |
+
+## Execution Details
+
+The code executed by this stage exists within IUF. See the `post-install-service-check` entry in `/usr/share/doc/csm/workflows/iuf/stages.yaml` and the corresponding file(s) in `/usr/share/doc/csm/workflows/iuf/operations/`
+for details on the commands executed.
+
+## Example
+
+(`ncn-m001#`) Execute the `post-install-service-check` stage.
+
+```bash
+iuf -a joe-install-20230107 run -r post-install-service-check
+```

--- a/operations/iuf/stages/pre_install_check.md
+++ b/operations/iuf/stages/pre_install_check.md
@@ -1,0 +1,29 @@
+# `pre-install-check`
+
+The `pre-install-check` stage ensures that CSM is operating properly so that products can be installed. For example, it verifies that S3 storage is functional, that CFS, VCS, and IMS microservices are functional, etc. Products may
+provide hook scripts to perform additional product-specific system checks.
+
+## Impact
+
+The `pre-install-check` stage does not change the running state of the system.
+
+## Input
+
+The following arguments are most often used with the `pre-install-check` stage. See `iuf -h` and `iuf run -h` for additional arguments.
+
+| Input           | `iuf` Argument | Description |
+| --------------- | -------------- | ----------- |
+| activity        | `-a ACTIVITY`  | activity created for the install or upgrade operations |
+
+## Execution Details
+
+The code executed by this stage exists within IUF. See the `pre-install-check` entry in `/usr/share/doc/csm/workflows/iuf/stages.yaml` and the corresponding file(s) in `/usr/share/doc/csm/workflows/iuf/operations/`
+for details on the commands executed.
+
+## Example
+
+(`ncn-m001#`) Execute the `pre-install-check` stage.
+
+```bash
+iuf -a joe-install-20230107 run -r pre-install-check
+```

--- a/operations/iuf/stages/prepare_images.md
+++ b/operations/iuf/stages/prepare_images.md
@@ -1,0 +1,31 @@
+# prepare-images
+
+The `prepare-images` stage configures NCN management node images and builds and configures compute node, application node, and GPU images. It also creates new BOS session templates corresponding to the new node and image content.
+The `prepare-images` stage does not reboot nodes to the new images however.
+
+<< TODO: add details on determines what products/configurations/etc. are used to create images >>
+
+## Impact
+
+The `prepare-images` stage does not change the running state of the system as it does not deploy the newly created images.
+
+## Input
+
+The following arguments are most often used with the `prepare-images` stage. See `iuf -h` and `iuf run -h` for additional arguments.
+
+| Input           | `iuf` Argument | Description |
+| --------------- | -------------- | ----------- |
+| activity        | `-a ACTIVITY`  | activity created for the install or upgrade operations |
+
+## Execution Details
+
+The code executed by this stage utilizes `sat bootprep` to build and customize images. See the `prepare-images` entry in `/usr/share/doc/csm/workflows/iuf/stages.yaml` and the corresponding file(s) in `/usr/share/doc/csm/workflows/iuf/operations/`
+for details on the commands executed.
+
+## Example
+
+(`ncn-m001#`) Execute the `prepare-images` stage.
+
+```bash
+iuf -a joe-install-20230107 run -r prepare-images
+```

--- a/operations/iuf/stages/process_media.md
+++ b/operations/iuf/stages/process_media.md
@@ -1,0 +1,30 @@
+# `process-media`
+
+The `process-media` stage extracts all product distribution files found in the media directory specified by the user via `-m`. The product content is extracted into that same directory. All future stages associated with the activity
+will execute for all applicable products found in the media directory.
+
+## Impact
+
+The `process-media` stage does not change the running state of the system.
+
+## Input
+
+The following arguments are most often used with the `process-media`. See `iuf -h` and `iuf run -h` for additional arguments.
+
+| Input           | `iuf` Argument | Description |
+| --------------- | -------------- | ----------- |
+| activity        | `-a ACTIVITY`  | activity created for the install or upgrade operations |
+| media directory | `-m MEDIA_DIR` | directory containing the product distribution files to be installed |
+
+## Execution Details
+
+The code executed by this stage exists within IUF. See the `process-media` entry in `/usr/share/doc/csm/workflows/iuf/stages.yaml` and the corresponding file(s) in `/usr/share/doc/csm/workflows/iuf/operations/`
+for details on the commands executed.
+
+## Example
+
+(`ncn-m001#`) Execute the `process-media` stage with product distribution content found in `/opt/cray/iuf/joe/`.
+
+```bash
+iuf -a joe-install-20230107 -m /opt/cray/iuf/joe/ run -r process-media
+```

--- a/operations/iuf/stages/update_cfs_config.md
+++ b/operations/iuf/stages/update_cfs_config.md
@@ -1,0 +1,33 @@
+# update-cfs-config
+
+The `update-cfs-config` stage creates updated CFS configurations used for image customization and personalization of NCN, compute, and application nodes. This stage only creates the CFS configurations; the `prepare-images`,
+`management-nodes-rollout`, and `management-nodes-rollout` stages executed after `update-cfs-config` use the CFS configuration.
+
+**`NOTE`** Before `update-cfs-config` is executed, any desired site configuration customizations in VCS should be performed. Refer to individual product documentation for configuration customization details.
+
+<< TODO: add details on what determines what products/versions/branches/etc. are used to create configurations >>
+
+## Impact
+
+The `update-cfs-config` stage does not change the running state of the system as it does not deploy the newly created CFS configurations.
+
+## Input
+
+The following arguments are most often used with the `update-cfs-config` stage. See `iuf -h` and `iuf run -h` for additional arguments.
+
+| Input           | `iuf` Argument | Description |
+| --------------- | -------------- | ----------- |
+| activity        | `-a ACTIVITY`  | activity created for the install or upgrade operations |
+
+## Execution Details
+
+The code executed by this stage utilizes `sat bootprep` to create CFS configurations. See the `update-cfs-config` entry in `/usr/share/doc/csm/workflows/iuf/stages.yaml` and the corresponding file(s) in
+`/usr/share/doc/csm/workflows/iuf/operations/` for details on the commands executed.
+
+## Example
+
+(`ncn-m001#`) Execute the `update-cfs-config` stage.
+
+```bash
+iuf -a joe-install-20230107 run -r update-cfs-config
+```

--- a/operations/iuf/stages/update_vcs_config.md
+++ b/operations/iuf/stages/update_vcs_config.md
@@ -1,0 +1,144 @@
+# update-vcs-config
+
+The `update-vcs-config` stage performs a variety of update operations for each product being installed that provides a configuration management repository in VCS. It ensures new product configuration content has been uploaded to VCS in
+a pristine branch and attempts to merge the new product configuration content into a corresponding customer branch.
+
+**`NOTE`** After `update-vcs-config` has completed and before proceeding to additional stages, any desired site configuration customizations should be performed. Refer to individual product documentation for configuration customization details.
+
+`update-vcs-config` details are explained in the following sections:
+
+- [Impact](#impact)
+- [Prerequisites](#prerequisites)
+- [Terminology](#terminology)
+- [Branch Creation and Modification](#branch-creation-and-modification)
+- [Customer Branch Name](#customer-branch-name)
+- [Input](#input)
+- [Execution Details](#execution-details)
+- [Example](#example)
+
+## Impact
+
+The `update-vcs-config` stage does not change the running state of the system.
+
+## Prerequisites
+
+Before executing the `update-vcs-config` stage, ensure any desired site variables have been defined. [Site variables and/or recipe variables](../IUF.md#site-and-recipe-variables) are passed to `iuf` as parameters to customize
+product, product version, and branch values used by IUF when executing stages such as `update-vcs-config`.
+
+## Terminology
+
+- **Pristine branch**: the branch provided by HPE for a given product, e.g. `cray/cos/2.4.79`
+- **Customer branch**: the customer's working branch for a given product, e.g. `integration-2.4.79`
+- **Previous customer branch**: the latest existing customer branch for a given product which predates the specified customer branch, e.g. `integration-2.3.50`
+
+## Branch Creation and Modification
+
+The following describes how `update-vcs-config` determines how to create or merge VCS content to the customer branch:
+
+- If no customer branch has been specified, `update-vcs-config` with display a warning, perform no operations, and exits without error. While it is valid not to specify a customer branch in certain cases, the administrator should
+  verify that this is the desired behavior and that the VCS configuration and the corresponding CFS configurations to be used in the `update-cfs-config` stage match and are valid.
+- If the specified customer branch exists, the content from the pristine branch will be merged into the customer branch.
+- If the specified customer branch does not exist, `update-vcs-config` will attempt to identify branches that matches the pattern of the customer branch, select the matching branch with the most recent version, and consider it the
+  previous customer branch. The specified customer branch will be branched from the previous customer branch, and the content from the pristine branch will be merged into the specified customer branch.
+- If the specified customer branch does not exist and a previous customer branch cannot be identified, the specified customer branch will be branched from the pristine branch.
+
+`update-vcs-config` will display information describing the operations performed. In the case of an error, such as a merge conflict, error information will be displayed and `iuf` will exit so the administrator can resolve the issue.
+Once it is resolved, the session can be continued with `iuf resume` or can be abandoned with `iuf abort`.
+
+**`NOTE`** Any product-specific stage hooks specified for `update-vcs-config` will also be executed and may also create or modify VCS content. Refer to individual product documentation for information on any stage hook operations performed by the product.
+
+## Customer Branch Name
+
+The customer branch name is determined through one or a combination of the following sources:
+
+### Recipe Variables
+
+Recipe variables are provided via the `product_vars.yaml` file in the HPC CSM Software Recipe and provide a list of products and versions intended to be used together. `product_vars.yaml` also contains default settings and
+`working_branch` variable entries for products. These values are intended as defaults and can be overridden with site variables.
+
+Overall defaults are defined in default section of `product_vars.yaml`, for example:
+
+```yaml
+# set site specific default working_branch with an entry in a default section in site_vars.yaml
+default:
+  working_branch: "integration-{{version_x_y_z}}"
+```
+
+Each product that utilizes a working branch will contain a `working_branch` entry in `product_vars.yaml`, for example:
+
+```yaml
+cos:
+  version: 2.4.86
+  working_branch: "{{ working_branch }}"
+```
+
+In this example, the COS reference to `{{ working_branch}}` will be substituted with the value specified in the default section for `working_branch`. Thus, the COS value for `working_branch` will be `integration-{{version_x_y_z}}`,
+which will in turn be substituted with the actual product value, resulting in the final value `integration-2.4.86`.
+
+### Site Variables
+
+Site variables, typically specified in a `site_vars.yaml` file, allow the administrator to override values provided by recipe variables, including both default values and product-specific entries.
+
+Variable substitutions can be used in `site_vars.yaml` to specify the desired branching values, minimizing the need to make updates to the file. For example, to change the working branch for all products that use a default
+working branch, the administrator can simply provide a default section in `site_vars.yaml` with a new value for `working_branch`. In the following example, adding this section in `site_vars.yaml` will result in all products
+using the default branch to only use the `x.y` portion of the version instead of the `x.y.z` values specified in the `product_vars.yaml` file.
+
+```yaml
+default:
+  working_branch: "integration-{{version_x_y}}"
+```
+
+In a similar fashion, product-specific entries can be made in `site_vars.yaml` to override individual products, for example:
+
+```yaml
+cos:
+  working_branch: "test-{{ version_x_y_z }}"
+```
+
+Remember that content in `site_vars.yaml` overrides entries in `product_vars.yaml`, e.g. if a product entry in `site_vars.yaml` contained a `version` entry, that value would mask the `version` entry present in `product_vars.yaml`.
+
+### Session Variables
+
+Session variables are the set of product/version combinations being installed by the current activity. These values are internal to `iuf`.
+
+### Mechanics
+
+`iuf` builds a set of effective site variables utilized by back-end IUF operations by performing a set of merges and substitutions:
+
+1. The base set of data is created from the most recent product entries in the product catalog.
+1. Recipe variables, if specified, will be merged, overriding any matching entries. **Caveat**: Any product specified with the `iuf run` `--mask-recipe-prods` argument will be omitted from this merge, i.e. the version found in step 1 will be used instead.
+1. Site variables, if specified, will be merged, overriding any matching entries.
+1. Session variables will be merged, overriding any matching entries.
+
+Once `iuf` has performed the merges, it performs substitutions based on the following supported variables:
+
+```yaml
+{{name}} - product name from the product manifest
+{{version_x_y}} - x.y portion of the product version
+{{version_x_y_z}} - x.y.z portion of the product version
+{{working_branch}} - default working branch
+```
+
+## Input
+
+The following arguments are most often used with the `update-vcs-config` stage. See `iuf -h` and `iuf run -h` for additional arguments.
+
+| Input            | `iuf` Argument | Description   |
+| ---------------- | -------------- |-------------- |
+| activity         | `-a ACTIVITY`  | activity created for the install or upgrade operations |
+| site variables   | `--site-vars`  | path to YAML file containing site defaults and any overrides |
+| recipe variables | `--bootprep-config-dir` | Path to `vcs` directory within the expanded HPC CSM Software Recipe product distribution file. If no `sat bootprep` related arguments are supplied, a copy of the contents from VCS will be used if present. |
+
+## Execution Details
+
+The code executed by this stage exists within IUF. See the `update-vcs-config` entry in `/usr/share/doc/csm/workflows/iuf/stages.yaml` and the corresponding file(s) in `/usr/share/doc/csm/workflows/iuf/operations/`
+for details on the commands executed.
+
+## Example
+
+(`ncn-m001#`) Run all stages up to and including `update-vcs-config` using the specified `site_vars.yaml` file and the `product_vars.yaml` file found in the `hpc-csm-software-recipe-23.03.0/vcs` directory of the
+22.03.0 HPC CSM Software Recipe distribution file.
+
+```bash
+iuf -a activity-20230123 -m /etc/cray/upgrade/csm/activity-20230123 run --site-vars /etc/cray/upgrade/csm/iuf/site_vars.yaml --bootprep-config-dir /etc/cray/upgrade/csm/activity-20230123/hpc-csm-software-recipe-23.03.0/vcs -e update-vcs-config
+```

--- a/operations/iuf/workflows/upgrade_all_products.md
+++ b/operations/iuf/workflows/upgrade_all_products.md
@@ -1,0 +1,120 @@
+# Upgrade All Products Provided in a HPC CSM Software Recipe
+
+The following example describes a hypothetical upgrade procedure of all non-CSM product content provided with a HPC CSM Software Recipe release. CSM itself is not upgraded. All stages of `iuf` are executed to perform a complete
+upgrade. All of the new software provided in the release is deployed and all management NCNs and managed compute and application (UAN) nodes are rebooted to new images and CFS configurations.
+
+1. Create a timestamped directory on `ncn-m001` and copy all distribution files from the HPC CSM Software Recipe to it.
+
+    (`ncn-m001#`) Populate activity directory with product content.
+
+    ```bash
+    DATE=`date +%Y%m%d%H%M%S`
+    ACTIVITY_DIR=/etc/cray/upgrade/csm/iuf/${DATE}
+    mkdir ${ACTIVITY_DIR}
+    cd ${ACTIVITY_DIR}
+    scp <HPC CSM Software Recipe content path> .
+    ```
+
+1. Create a `site_vars.yaml` file in the `/etc/cray/upgrade/csm/iuf` directory and define variables to reflect site preferences.
+
+    (`ncn-m001#`) Prepare site variables file.
+
+    ```bash
+    SITE_VARS_FILE=/etc/cray/upgrade/csm/iuf/site_vars.yaml
+    vi ${SITE_VARS_FILE}
+    ```
+
+1. Invoke `iuf run` to create an activity named `activity-all-products-upgrade` and use `-e` to execute the [`process-media`](../stages/process_media.md), [`pre-install-check`](../stages/pre_install_check.md),
+   [`deliver-product`](../stages/deliver_product.md), and [`update-vcs-config`](../stages/update_vcs_config.md) stages. Perform the upgrade using product content found in the `${ACTIVITY_DIR}` directory. Use site variables
+   from the `${SITE_VARS_FILE}` file and recipe variables from the `product_vars.yaml` file found in the `${ACTIVITY_DIR}/hpc-csm-software-recipe-23.03.0/vcs` `sat bootprep` configuration directory.
+
+    (`ncn-m001#`) Execute the stages beginning with `process-media` and ending with `update-vcs-config`.
+
+    ```bash
+    iuf -a activity-all-products-upgrade -m ${ACTIVITY_DIR} run --site-vars ${SITE_VARS_FILE} --bootprep-config-dir ${ACTIVITY_DIR}/hpc-csm-software-recipe-23.03.0/vcs -e update-vcs-config
+    ```
+
+    Once this step has completed:
+
+    - product content has been extracted from the product distribution files in `${ACTIVITY_DIR}`
+    - pre-install checks have been performed for CSM and all products found in `${ACTIVITY_DIR}`
+    - product content for all products found in `${ACTIVITY_DIR}` has been uploaded to the system
+    - product content uploaded to the system has been recorded in the product catalog
+    - product configuration content has been merged to VCS branches as described in the [update-vcs-config stage documentation](../stages/update_vcs_config.md)
+    - per-stage product hooks have executed for the `process-media`, `pre-install-check`, `deliver-product`, and `update-vcs-config` stages
+
+1. Before executing the `update-cfs-config` stage, make any site customizations to product content stored in VCS to ensure CFS configurations and any resulting images are created with the correct content and configuration values.
+
+1. Invoke `iuf run` with `-r` to execute the [`update-cfs-config`](../stages/update_cfs_config.md) and [`prepare-images`](../stages/prepare_images.md) stages. The `-m`, `--site-vars`, and `--bootprep-config-dir` arguments are the
+   same as the initial invocation of `iuf run` as all steps in this example use the same IUF activity, media, and variables.
+
+    (`ncn-m001#`) Execute the `update-cfs-config` and `prepare-images` stages.
+
+    ```bash
+    iuf -a activity-all-products-upgrade -m ${ACTIVITY_DIR} run --site-vars ${SITE_VARS_FILE} --bootprep-config-dir ${ACTIVITY_DIR}/hpc-csm-software-recipe-23.03.0/vcs -r update-cfs-config prepare-images
+    ```
+
+    Once this step has completed:
+
+    - new CFS configurations have been created for management NCNs and managed compute and application (UAN) nodes
+    - new images have been created for management NCNs and managed compute and application (UAN) nodes
+    - new BOS session templates have been created to boot managed compute and application (UAN) nodes with the new images and CFS configurations
+    - per-stage product hooks have executed for the `update-cfs-config` and `prepare-images` stages
+
+1. Inspect the newly-created management NCN and managed node images and CFS configurations to ensure they are correct before rebooting to the new content.
+
+1. Invoke `iuf run` with `-r` to execute the [`management-nodes-rollout`](../stages/management_nodes_rollout.md) stage. The `-m`, `--site-vars`, and `--bootprep-config-dir` arguments are the same as the initial invocation of `iuf run`
+   as all steps in this example use the same IUF activity, media, and variables.
+
+    (`ncn-m001#`) Execute the `management-nodes-rollout` stage.
+
+    ```bash
+    iuf -a activity-all-products-upgrade -m ${ACTIVITY_DIR} run --site-vars ${SITE_VARS_FILE} --bootprep-config-dir ${ACTIVITY_DIR}/hpc-csm-software-recipe-23.03.0/vcs -r management-nodes-rollout
+    ```
+
+    Once this step has completed:
+
+    - all management NCN nodes have been rebooted to the images and CFS configurations created in previous steps in this example
+    - per-stage product hooks have executed for the `management-nodes-rollout` stage
+
+1. Invoke `iuf run` with `-r` to execute the [`deploy-product`](../stages/deploy_product.md) and [`post-install-service-check`](../stages/post_install_service_check.md) stages. The `-m`, `--site-vars`, and `--bootprep-config-dir`
+   arguments are the same as the initial invocation of `iuf run` as all steps in this example use the same IUF activity, media, and variables.
+
+    (`ncn-m001#`) Execute the `deploy-product` and `post-install-service-check` stages.
+
+    ```bash
+    iuf -a activity-all-products-upgrade -m ${ACTIVITY_DIR} run --site-vars ${SITE_VARS_FILE} --bootprep-config-dir ${ACTIVITY_DIR}/hpc-csm-software-recipe-23.03.0/vcs -r deploy-product post-install-service-check
+    ```
+
+    Once this step has completed:
+
+    - new versions of product microservices have been deployed
+    - service checks have been run to verify product microservices are executing as expected
+    - per-stage product hooks have executed for the `deploy-product` and `post-install-service-check` stages
+
+1. Invoke `iuf run` with `-r` to execute the [`managed-nodes-rollout`](../stages/managed_nodes_rollout.md) stage. The `-m`, `--site-vars`, and `--bootprep-config-dir` arguments are the same as the initial invocation of `iuf run` as all
+   steps in this example use the same IUF activity, media, and variables.
+
+    (`ncn-m001#`) Execute the `managed-nodes-rollout` stage.
+
+    ```bash
+    iuf -a activity-all-products-upgrade -m ${ACTIVITY_DIR} run --site-vars ${SITE_VARS_FILE} --bootprep-config-dir ${ACTIVITY_DIR}/hpc-csm-software-recipe-23.03.0/vcs -r managed-nodes-rollout
+    ```
+
+    Once this step has completed:
+
+    - all managed compute and application (UAN) nodes have been rebooted to the images and CFS configurations created in previous steps in this example
+    - per-stage product hooks have executed for the `managed-nodes-rollout` stage
+
+1. Invoke `iuf run` with `-r` to execute the [`post-install-check`](../stages/post_install_check.md) stage. The `-m`, `--site-vars`, and `--bootprep-config-dir` arguments are the same as the initial invocation of `iuf run` as all steps in
+   this example use the same IUF activity, media, and variables.
+
+    (`ncn-m001#`) Execute the `post-install-check` stage.
+
+    ```bash
+    iuf -a activity-all-products-upgrade -m ${ACTIVITY_DIR} run --site-vars ${SITE_VARS_FILE} --bootprep-config-dir ${ACTIVITY_DIR}/hpc-csm-software-recipe-23.03.0/vcs -r post-install-check
+    ```
+
+    Once this step has completed:
+
+    - per-stage product hooks have executed to verify product software is executing as expected


### PR DESCRIPTION
* CASMINST-5618 initial IUF content

Add initial IUF content within the operations section. Additional changes and additions are required in this section and none of the other sections of the documentation have been updated to refer to it yet.

* CASMINST-5618 initial IUF content

Add detailed documentation for the update-vcs-config IUF stage.

* CASMINST-5618 initial IUF content

Add an IUF workflow example of upgrading all products in a recipe release without upgrading CSM itself.

* CASMINST-5618 initial IUF content

This commit futher fleshes out IUF details, including:
  - fixing the format of session IDs in examples
  - including updated help text for multiple commands
  - adding details about the IUF CLI output
  - adding initial troubleshooting information
  - changing the username in example output to be consistent
  - removing detailed output from the stage examples to focus on the CLI invocations
  - adding descriptions to the stage input tables
  - adding an impact subsection to the stage files

* CASMINST-5618 initial IUF content

Add additional troubleshooting entries.

* CASMINST-5618 initial IUF content

Address PR check failures.

* CASMINST-5618: Add iuf-cli install instructions

Add iuf-cli install instructions to the pre-installation section.

* CASMINST-5618 initial IUF content

Address review comments and PR build check failures. Add CODEOWNERS entry for IUF. Add IUF terms to .spelling.

* CASMINST-5618 initial IUF content

Address PR build check failures. Add more IUF terms to .spelling. Change terminology from "sessions" to "Argo workflows" and add more details on Argo. Update outdated `iuf` output examples. Better explain activity entry values. Improve explanation of log files. Mark abort, retry, and resume subcommands as pending implementation.

* CASMINST-5618 initial IUF content

Add IUF entry to README.md file.

(cherry picked from commit 40a49f8493cb5df61e5443064f02e4e4abb9ea91)

# Description

Add the initial description of the Install and Upgrade Framework (IUF) which manages install/upgrade/deploy procedures for the Alice recipe.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
