### PR TITLE
CASMINST-5818: Bump container image versions

### DIFF
--- a/workflows/iuf/operations/extract-release-distributions.yaml
+++ b/workflows/iuf/operations/extract-release-distributions.yaml
@@ -69,7 +69,7 @@ spec:
               - start-operation
             inline:
               script:
-                image: artifactory.algol60.net/csm-docker/stable/iuf:v0.0.4
+                image: artifactory.algol60.net/csm-docker/stable/iuf:v0.1.1
                 command: [sh]
                 source: |
                   #!/bin/sh

--- a/workflows/iuf/operations/ims-upload.yaml
+++ b/workflows/iuf/operations/ims-upload.yaml
@@ -226,7 +226,7 @@ spec:
 
     container:
       # replace image with standard ims-load-artifacts once PR is merged
-      image: artifactory.algol60.net/csm-docker/stable/cray-ims-load-artifacts:2.0.0
+      image: artifactory.algol60.net/csm-docker/stable/cray-ims-load-artifacts:2.0.1
       command: ['python3']
       args: ['-m', 'ims_load_artifacts.load_artifacts']
       env:


### PR DESCRIPTION
# Description

This change bumps the container image versions for the following
containers:

- cray-ims-load-artifacts
- iuf
- cf-gitea-import

Also needs to be backported to `release/1.4`.

# Checklist Before Merging

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
