### PR TITLE
CASMMON-257 adding metrics for management-nodes-rollout

### DIFF
--- a/workflows/iuf/operations/management-nodes-rollout/management-nodes-rollout.yaml
+++ b/workflows/iuf/operations/management-nodes-rollout/management-nodes-rollout.yaml
@@ -44,9 +44,9 @@ spec:
           help: "Count of step execution by result status"
           labels:
             - key: "opname"
-              value: "extract-release-distributions"
+              value: "management-nodes-rollout"
             - key: stage
-              value: "process-media"
+              value: "management-nodes-rollout"
             - key: type
               value: "global"
             - key: pname
@@ -374,9 +374,9 @@ spec:
             help: "Duration gauge by operation name in seconds"
             labels:
               - key: "opname"
-                value: "extract-release-distributions"
+                value: "management-nodes-rollout"
               - key: stage
-                value: "process-media"
+                value: "management-nodes-rollout"
               - key: type
                 value: "global"
               - key: pdname


### PR DESCRIPTION
Added metrics management-nodes-rollout get prom-metrics for update-cfs-config prepare-images stages
currently, iuf operation does not provide an inbuilt mechanism for r Prometheus metrics.
At the first step added epoch start and end time for extract-release-distributions operation. we are planing to use these metrics for creating grafana iuf timing dashboard.