### PR TITLE
CASMINST-5691: Adds managed nodes rollout IUF operation

### DIFF
--- a/workflows/iuf/operations/managed-nodes/managed-nodes-rollout.yaml
+++ b/workflows/iuf/operations/managed-nodes/managed-nodes-rollout.yaml
@@ -1,0 +1,248 @@
+#
+# MIT License
+#
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: managed-nodes-rollout
+spec:
+  entrypoint: main
+  templates:
+    ### Main Steps ###
+    - name: main
+      metrics:
+        prometheus:
+        - name: operation_counter
+          help: "Count of step execution by result status"
+          labels:
+            - key: "opname"
+              value: "managed-nodes-rollout"
+            - key: stage
+              value: "managed-nodes-rollout"
+            - key: type
+              value: "global"
+            - key: pname
+              value: "global"
+            - key: pversion
+              value: "global"
+            - key: status
+              value: "{{status}}"
+          counter:
+            value: "1"
+      inputs:
+        parameters:
+          - name: auth_token
+          - name: global_params
+      steps:
+        - - name: start-operation
+            templateRef:
+              name: workflow-template-record-time-template
+              template: record-time-template
+        - - name: build-sat-general-subcommand
+            template: build-sat-general-subcommand
+            arguments:
+              parameters:
+                - name: prepare_images_output
+                  value: "{{=jsonpath(inputs.parameters.global_params, '$.stage_params.prepare-images.global.prepare-managed-images.sat-bootprep-run.script_stdout')}}"
+                - name: managed_rollout_strategy
+                  value: "{{=jsonpath(inputs.parameters.global_params, '$.input_params.managed_rollout_strategy')}}"
+                - name: limit_managed_nodes
+                  value: "{{=jsonpath(inputs.parameters.global_params, '$.input_params.limit_managed_nodes')}}"
+        - - name: sat-bootsys-reboot
+            templateRef:
+              name: sat-general-template
+              template: sat-wrapper
+            arguments:
+              parameters:
+                - name: media_dir
+                  value: "{{=jsonpath(inputs.parameters.global_params, '$.input_params.media_dir')}}"
+                - name: auth_token
+                  value: "{{inputs.parameters.auth_token}}"
+                - name: script_content
+                  value: |
+                    {{steps.build-sat-general-subcommand.outputs.parameters.sat_command}}
+        - - name: end-operation
+            templateRef:
+              name: workflow-template-record-time-template
+              template: record-time-template
+        - - name:  prom-metrics
+            template: prom-metrics
+            arguments:
+              parameters:
+              - name: opstart
+                value: "{{steps.start-operation.outputs.result}}"
+              - name: opend
+                value: "{{steps.end-operation.outputs.result}}"
+              - name: pdname
+                value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.name')}}"
+              - name: pdversion
+                value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.version')}}"
+
+    - name: prom-metrics
+      inputs:
+        parameters:
+        - name: opstart
+        - name: opend
+        - name: pdname
+        - name: pdversion
+      metrics:
+        prometheus:
+          - name: operation_time
+            help: "Duration gauge by operation name in seconds"
+            labels:
+              - key: opname
+                value: "managed-nodes-rollout"
+              - key: stage
+                value: "managed-nodes-rollout"
+              - key: type
+                value: "global"
+              - key: pdname
+                value: "global"
+              - key: pdversion
+                value: "global"
+              - key: opstart
+                value: "{{inputs.parameters.opstart}}"
+              - key: opend
+                value: "{{inputs.parameters.opend}}"
+            gauge:
+              value: "{{outputs.parameters.diff-time-value}}"
+      outputs:
+        parameters:
+          - name: diff-time-value
+            globalName: diff-time-value
+            valueFrom:
+              path: /tmp/diff_time.txt
+      container:
+        image: artifactory.algol60.net/csm-docker/stable/docker.io/alpine/git:2.32.0
+        command: [sh, -c]
+        args: ["DIFF_TIME=$(expr {{inputs.parameters.opend}} - {{inputs.parameters.opstart}}); echo $DIFF_TIME; echo $DIFF_TIME > /tmp/diff_time.txt"]      
+
+    - name: build-sat-general-subcommand
+      nodeSelector:
+        kubernetes.io/hostname: ncn-m001
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+      metadata:
+        annotations:
+          sidecar.istio.io/inject: "false"
+      inputs:
+        parameters:
+          - name: prepare_images_output
+          - name: managed_rollout_strategy
+          - name: limit_managed_nodes
+      outputs:
+        parameters:
+          - name: sat_command
+            valueFrom:
+              path: /tmp/sat_command.txt
+      script:
+        image: artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell:latest-v1.21.1-amd64
+        command: [bash]
+        source: |
+          #!/bin/bash
+          JSONPATH='jsonpath'
+          prepare_images_output='{{inputs.parameters.prepare_images_output}}'
+          managed_rollout_strategy="{{inputs.parameters.managed_rollout_strategy}}"
+          limit_managed_nodes="{{inputs.parameters.limit_managed_nodes}}"
+
+          function main_sat_command {
+              print_inputs_variables
+              if [ -z "$managed_rollout_strategy" ] || [[ "$managed_rollout_strategy" == *"$JSONPATH"* ]] ; then
+                  echo "ERROR: No managed_rollout_strategy provided."
+                  exit 1
+              elif [ -z "$prepare_images_output" ] || [[ "$prepare_images_output" == *"$JSONPATH"* ]] ; then
+                  echo "ERROR: No prepare_images_output provided."
+                  exit 1
+              fi
+
+              if [[ "$limit_managed_nodes" == *"$JSONPATH"* ]] ; then
+                  limit_managed_nodes=""
+              fi
+              parse_session_templates
+              clean_limit_managed_nodes
+              sat_bootsys_subcommand
+          }
+
+          function parse_session_templates {
+              tmpfile=$(mktemp /tmp/script.XXXXXX)
+              echo "${prepare_images_output}" | jq ".session_templates" >> "$tmpfile"
+              count=$(jq '. | length' "$tmpfile")
+              if [[ "$count" == "0" ]]; then
+                  echo "ERROR: No session templates provided to parse, prepare_images_output is empty."
+                  exit 1
+              fi
+
+              session_templates_string=""
+              delim=""
+              for ((i=0; i < $count; i++)); do
+                  template_name=$(jq -r '.['$i'].name' "$tmpfile")
+                  session_templates_string="$session_templates_string$delim$template_name"
+                  delim=","
+              done
+
+              rm "${tmpfile}"
+              if [ "$session_templates_string" == "" ]; then
+                  echo "ERROR: Failed to parse session_templates from prepare_images_output"
+                  exit 1
+              fi
+              echo "$session_templates_string"
+          }
+
+          function clean_limit_managed_nodes {
+            limit_managed_nodes=${limit_managed_nodes//[/}
+            limit_managed_nodes=${limit_managed_nodes//]/}
+            limit_managed_nodes=${limit_managed_nodes// /,}
+            echo "limit_managed_nodes = $limit_managed_nodes"
+          }
+
+          function sat_bootsys_subcommand {
+              bos_timeout=3000
+              sat_command=""
+              if [ "$managed_rollout_strategy" == "reboot" ]; then
+                  sat_command="sat bootsys --bos-version v2 reboot --disruptive --stage bos-operations --bos-templates $session_templates_string --bos-shutdown-timeout $bos_timeout --bos-boot-timeout $bos_timeout"
+              elif [ "$managed_rollout_strategy" == "stage" ]; then
+                  sat_command="sat bootsys --bos-version v2 reboot --stage bos-operations --staged-session --bos-templates $session_templates_string --bos-shutdown-timeout $bos_timeout --bos-boot-timeout $bos_timeout"
+              fi
+
+              if [ ! -z "$limit_managed_nodes" ]; then
+                  sat_command="$sat_command --bos-limit $limit_managed_nodes"
+              fi
+
+              if [ -z "$sat_command" ] ; then
+                  echo "ERROR: Failed to create a valid sat bootsys command."
+                  exit 1
+              fi
+
+              output_file=/tmp/sat_command.txt
+              touch "$output_file"
+              echo "$sat_command" >> "$output_file"
+          }
+
+          function print_inputs_variables {
+              echo "prepare_images_output = $prepare_images_output"
+              echo "managed_rollout_strategy = $managed_rollout_strategy"
+              echo "limit_managed_nodes = $limit_managed_nodes" 
+          }
+
+          main_sat_command

--- a/workflows/iuf/operations/vcs-upload/vcs-upload-content.yaml
+++ b/workflows/iuf/operations/vcs-upload/vcs-upload-content.yaml
@@ -227,11 +227,13 @@ spec:
               path: /results/records.yaml
               default: "{}"
       container:
-        image: artifactory.algol60.net/csm-docker/stable/cf-gitea-import:1.8.0
+        image: artifactory.algol60.net/csm-docker/stable/cf-gitea-import:1.8.1
         command:
           - "/bin/sh"
         args: ["-c", "/opt/csm/cf-gitea-import/argo_entrypoint.sh"]
         env:
+          - name: IUF_LOGGING
+            value: "true"
           - name: CF_IMPORT_GITEA_USER
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
Abstracts SAT and BOS V2 staged rebooting of managed compute and application nodes. This workflow wraps SAT and does preprocessing of IUF stage data to forward the requests to BOS V2.

# Description

<!--- Describe what this change is and what it is for. -->
JIRA https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5691

Needed for IUF code feature freeze.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
