### PR TITLE
CASM-3727: Update product catalog with loftsman information

### DIFF
--- a/workflows/iuf/operations/loftsman-manifest-upload/loftsman-manifest-upload-template.yaml
+++ b/workflows/iuf/operations/loftsman-manifest-upload/loftsman-manifest-upload-template.yaml
@@ -88,6 +88,20 @@ spec:
                 fi
 
                 /usr/local/bin/loftsman-manifest-upload "$CONTENT" "$PARENT_DIR" "$PRODUCT"
+
+    - - name: loftsman-update-product-catalog
+        templateRef:
+          name: update-product-catalog-template
+          template: catalog-update
+        arguments:
+          parameters:
+            - name: product-name
+              value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.name')}}"
+            - name: product-version
+              value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.version')}}"
+            - name: yaml-content
+              value: "{{steps.loftsman-manifest-upload.outputs.parameters.output}}"
+
     - - name: end-operation
         templateRef:
           name: workflow-template-record-time-template


### PR DESCRIPTION
# Description

Update the product catalog with Loftsman manifest data.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
