### PR TITLE
CASMINST-5848-release-1.4 allow IUF-stage: loftsman_manifest_deploy to accept `*.yaml` files when looking for loftsman manifests

### DIFF
--- a/workflows/iuf/operations/loftsman-manifest-deploy.yaml
+++ b/workflows/iuf/operations/loftsman-manifest-deploy.yaml
@@ -122,8 +122,8 @@ spec:
                       continue
                     elif [[ "$DEPLOY" = "true" ]] || [[ "$DEPLOY" = "True" ]]; then
                       if $IS_DIR; then
-                        echo "INFO Deploying loftsman manifests under $MANIFEST/"
-                        manifest_files=$(ls "${MANIFEST_PATH}"/*.yml "${MANIFEST_PATH}"/*.yaml 2>/dev/null)
+                        echo "INFO Deploying loftsman manifests under $MANIFEST_PATH/"
+                        manifest_files=$(ls "${MANIFEST_PATH}"/*.yml "${MANIFEST_PATH}"/*.yaml 2>/dev/null) || true
                         for manifest in $manifest_files; do
                           deploy_manifest ${manifest} $PRODUCT_NAME
                           if [[ $? != 0 ]]; then err=1; fi
@@ -133,7 +133,7 @@ spec:
                         if [[ $? != 0 ]]; then err=1; fi
                       fi
                     else
-                      echo "INFO Not deploying argo/loftsman/${PRODUCT_NAME}/${PRODUCT_VERSION}/manifests/$(basename ${MANIFEST}) because loftsman.deploy=${DEPLOY}."
+                      echo "NOTICE Not deploying argo/loftsman/${PRODUCT_NAME}/${PRODUCT_VERSION}/manifests/$(basename ${MANIFEST}) because loftsman.deploy=${DEPLOY}."
                     fi
                   done
 

--- a/workflows/iuf/operations/loftsman-manifest-deploy.yaml
+++ b/workflows/iuf/operations/loftsman-manifest-deploy.yaml
@@ -123,7 +123,7 @@ spec:
                     elif [[ "$DEPLOY" = "true" ]] || [[ "$DEPLOY" = "True" ]]; then
                       if $IS_DIR; then
                         echo "INFO Deploying loftsman manifests under $MANIFEST/"
-                        manifest_files=$(ls "$manifest_path"/*.yml "$manifest_path"/*.yaml 2>/dev/null)
+                        manifest_files=$(ls "${MANIFEST_PATH}"/*.yml "${MANIFEST_PATH}"/*.yaml 2>/dev/null)
                         for manifest in $manifest_files; do
                           deploy_manifest ${manifest} $PRODUCT_NAME
                           if [[ $? != 0 ]]; then err=1; fi

--- a/workflows/iuf/operations/loftsman-manifest-deploy.yaml
+++ b/workflows/iuf/operations/loftsman-manifest-deploy.yaml
@@ -123,7 +123,8 @@ spec:
                     elif [[ "$DEPLOY" = "true" ]] || [[ "$DEPLOY" = "True" ]]; then
                       if $IS_DIR; then
                         echo "INFO Deploying loftsman manifests under $MANIFEST/"
-                        for manifest in "${MANIFEST_PATH}"/*.yml "${MANIFEST_PATH}"/*.yaml; do
+                        manifest_files=$(ls "$manifest_path"/*.yml "$manifest_path"/*.yaml 2>/dev/null)
+                        for manifest in $manifest_files; do
                           deploy_manifest ${manifest} $PRODUCT_NAME
                           if [[ $? != 0 ]]; then err=1; fi
                         done


### PR DESCRIPTION
# Description

allow IUF-stage: loftsman_manifest_deploy to accept `*.yaml` files when looking for loftsman manifests
# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
