### PR TITLE
More explicit instructions for PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,23 @@
+---
+name: 🐛 Report a bug
+about: Create a report to help us improve 
+---
+
+##### SUMMARY
+
+##### ISSUE TYPE
+- Bug Report
+
+##### STEPS TO REPRODUCE
+
+1.
+2.
+3.
+4.
+
+##### EXPECTED RESULTS
+
+
+##### ACTUAL RESULTS
+
+

--- a/.github/ISSUE_TEMPLATE/docs.md
+++ b/.github/ISSUE_TEMPLATE/docs.md
@@ -1,0 +1,12 @@
+---
+name: 📝 Documentation Report
+about: Ask us about documentation
+---
+
+##### SUMMARY
+
+
+##### ISSUE TYPE
+- Documentation Report
+
+##### ADDITIONAL INFORMATION

--- a/.github/ISSUE_TEMPLATE/rfe.md
+++ b/.github/ISSUE_TEMPLATE/rfe.md
@@ -1,0 +1,11 @@
+---
+name: ✨ Request for enhancement (RFE)
+about: Suggest an idea for this project
+---
+
+##### SUMMARY
+
+##### ISSUE TYPE
+- RFE
+
+##### ADDITIONAL INFORMATION

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,50 @@
+<!---
+    NOTE: This HTML style comment does not show in the PR.
+
+
+    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
+    MAY BE MERGED.
+
+    If more time is needed for review, please do one of the following:
+
+    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
+    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button
+
+    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
+    be merged by a repository maintainer or CASM release manager at will.
+
+--->
 # Description
+<!--- 
+    NOTE: This HTML style comment does not show in the PR.
 
-<!--- Describe what this change is and what it is for. -->
+    Describe what this change is and what it is for.
 
-# Checklist Before Merging
+    Include any related PRs URLs:
 
-<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
-<!--- unchecked checkbox: [ ] -->
-<!--- checked checkbox: [x] -->
-<!--- invalid checkbox: [] -->
+Relates to:
+- pr-link-1
+- pr-link-N
+-->
+
+# Checklist
+<!---
+    NOTE: This HTML style comment does not show in the PR. 
+
+    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between
+
+    unchecked checkbox: [ ]
+    checked checkbox: [x]
+    invalid checkbox: []
+    invalid checkbox: [x ]
+    invalid checkbox: [ x]
+    invalid checkbox: [ x ]
+-->
 
 - [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
 - [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
 - [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
 
+<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
 [1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
 [2]: https://github.com/Cray-HPE/teams


### PR DESCRIPTION
# Description

<!--- Describe what this change is and what it is for. -->
Implementing some more explicit instructions in the PR template after receiving copious feedback on:
- checkboxes
- premature merge
- dependent/required/related content

This also includes an issue template to assist with external users making Github Issues.

# Checklist Before Merging

<!--- An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
