### PR TITLE
CASMINST-5746

### DIFF
--- a/workflows/iuf/stages.yaml
+++ b/workflows/iuf/stages.yaml
@@ -41,28 +41,48 @@ stages:
     operations:
       - name: add-product-to-product-catalog
         static-parameters: {} # any parameters that will be supplied statically to this operation.
+        required-manifest-attributes: []
       - name: loftsman-manifest-upload
         static-parameters: {} # any parameters that will be supplied statically to this operation.
+        required-manifest-attributes:
+          - content.loftsman
       - name: s3-upload
         static-parameters: {} # any parameters that will be supplied statically to this operation.
+        required-manifest-attributes:
+          - content.s3
       - name: nexus-setup
         static-parameters: {} # any parameters that will be supplied statically to this operation.
+        required-manifest-attributes:
+          - content.nexus_blob_stores
+          - content.nexus_repositories
       - name: nexus-rpm-upload
         static-parameters: {} # any parameters that will be supplied statically to this operation.
+        required-manifest-attributes:
+          - content.rpms
       - name: nexus-docker-upload
         static-parameters: {} # any parameters that will be supplied statically to this operation.
+        required-manifest-attributes:
+          - content.docker
       - name: nexus-helm-upload
         static-parameters: {} # any parameters that will be supplied statically to this operation.
+        required-manifest-attributes:
+          - content.helm
       - name: vcs-upload
         static-parameters: {} # any parameters that will be supplied statically to this operation.
+        required-manifest-attributes:
+          - content.vcs
       - name: ims-upload
         static-parameters: {} # any parameters that will be supplied statically to this operation.
+        required-manifest-attributes:
+          - content.ims
 
   - name: update-vcs-config
     type: product
     operations:
       - name: vcs-update-working-branch
         static-parameters: {} # any parameters that will be supplied statically to this operation.
+        required-manifest-attributes:
+          - content.vcs
 
   - name: update-cfs-config
     type: global
@@ -77,6 +97,8 @@ stages:
     operations:
       - name: loftsman-manifest-deploy
         static-parameters: {} # any parameters that will be supplied statically to this operation.
+        required-manifest-attributes:
+          - content.loftsman
 
   - name: prepare-images
     type: global


### PR DESCRIPTION
[CASMINST-5746](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5746)
Summary: IUF operator should conditionally include operations based IUF product manifest contents

# User story
As a product developer, I want the IUF to skip operations that do not apply to my product based on the contents of my IUF product manifest, so that unnecessary operations are not executed and misleading information is not presented to the user through logs or product catalog.

# UAC
The stages.yaml needs to be updated to add a JSON path expression that indicates the property it consumes from the IUF Product Manifest.

If the property specified for a given operation in stages.yaml is not present in the IUF product manifest for a given product, then the IUF operator should omit the operation for that product entirely from the Argo workflow it constructs.
Background information


<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
