### PR TITLE
CASMINST-5900: direct cray-product-catalog-update output to /dev/null

### DIFF
--- a/scripts/operations/node_management/ncn-ims-image-upload.sh
+++ b/scripts/operations/node_management/ncn-ims-image-upload.sh
@@ -144,6 +144,6 @@ podman run --rm --name ncn-cpc \
     -e KUBECONFIG=/.kube/admin.conf \
     -e VALIDATE_SCHEMA="true" \
     -v /etc/kubernetes:/.kube:ro \
-    artifactory.algol60.net/csm-docker/stable/cray-product-catalog-update:$CPC_VERSION
+    artifactory.algol60.net/csm-docker/stable/cray-product-catalog-update:$CPC_VERSION > /dev/null
 
 echo "$IMS_IMAGE_ID"

--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -600,13 +600,15 @@ if [[ ${state_recorded} == "0" && $(hostname) == "ncn-m001" ]]; then
     set -o pipefail
     IMS_UPLOAD_SCRIPT=$(rpm -ql docs-csm | grep ncn-ims-image-upload.sh)
 
+    UUID_REGEX='^\{?[A-F0-9a-f]{8}-[A-F0-9a-f]{4}-[A-F0-9a-f]{4}-[A-F0-9a-f]{4}-[A-F0-9a-f]{12}\}?$'
+
     export IMS_ROOTFS_FILENAME="${artdir}/kubernetes/secure-kubernetes-${KUBERNETES_VERSION}-${arch}.squashfs"
     export IMS_INITRD_FILENAME="${artdir}/kubernetes/initrd.img-${KUBERNETES_VERSION}-${arch}.xz"
     # do not quote this glob.  bash will add single ticks (') around it, preventing expansion later
     resolve_kernel_glob=$(echo ${artdir}/kubernetes/*-${arch}.kernel)
     export IMS_KERNEL_FILENAME=$resolve_kernel_glob
     K8S_IMS_IMAGE_ID=$($IMS_UPLOAD_SCRIPT)
-    [[ -n ${K8S_IMS_IMAGE_ID} ]]
+    [[ -n ${K8S_IMS_IMAGE_ID} ]] && [[ ${K8S_IMS_IMAGE_ID} =~ $UUID_REGEX ]]
 
     export IMS_ROOTFS_FILENAME="${artdir}/storage-ceph/secure-storage-ceph-${CEPH_VERSION}-${arch}.squashfs"
     export IMS_INITRD_FILENAME="${artdir}/storage-ceph/initrd.img-${CEPH_VERSION}-${arch}.xz"
@@ -614,7 +616,7 @@ if [[ ${state_recorded} == "0" && $(hostname) == "ncn-m001" ]]; then
     resolve_kernel_glob=$(echo ${artdir}/storage-ceph/*-${arch}.kernel)
     export IMS_KERNEL_FILENAME=$resolve_kernel_glob
     STORAGE_IMS_IMAGE_ID=$($IMS_UPLOAD_SCRIPT)
-    [[ -n ${STORAGE_IMS_IMAGE_ID} ]]
+    [[ -n ${STORAGE_IMS_IMAGE_ID} ]] && [[ ${STORAGE_IMS_IMAGE_ID} =~ $UUID_REGEX ]]
     set +o pipefail
 
     # clean up any previous set values just in case.


### PR DESCRIPTION
When the code to update the cray product catalog with NCN image info was added, the output for the `podman` call was not redirected to /dev/null. As a result, that output was processed by `prerequisites.sh`, which lead to other problems downstream.

This commit does two things:
1. Redirects stdout from the podman call to /dev/null
2. Adds a regex check on the output from the script to ensure the only thing we're getting is a valid UUID.

<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
