### PR TITLE
CASMINST-5843, CASMINST-5902, CASMINST-5876: Fix bugs in ims-upload, vcs-upload, and update-vcs-config IUF stages

### DIFF
--- a/workflows/iuf/operations/ims-upload.yaml
+++ b/workflows/iuf/operations/ims-upload.yaml
@@ -225,7 +225,7 @@ spec:
           default: "{}"
 
     container:
-      image: artifactory.algol60.net/csm-docker/unstable/cray-ims-load-artifacts:2.1.0-bug-CASMINST-5843.12_b65b903
+      image: artifactory.algol60.net/csm-docker/stable/cray-ims-load-artifacts:2.1.0
       command:
         - "/bin/sh"
       args: ["-c", "/ims_load_artifacts/argo_entrypoint.sh"]

--- a/workflows/iuf/operations/ims-upload.yaml
+++ b/workflows/iuf/operations/ims-upload.yaml
@@ -225,10 +225,10 @@ spec:
           default: "{}"
 
     container:
-      # replace image with standard ims-load-artifacts once PR is merged
-      image: artifactory.algol60.net/csm-docker/stable/cray-ims-load-artifacts:2.0.1
-      command: ['python3']
-      args: ['-m', 'ims_load_artifacts.load_artifacts']
+      image: artifactory.algol60.net/csm-docker/unstable/cray-ims-load-artifacts:2.1.0-bug-CASMINST-5843.12_b65b903
+      command:
+        - "/bin/sh"
+      args: ["-c", "/ims_load_artifacts/argo_entrypoint.sh"]
       env:
       - name: LOG_LEVEL
         value: INFO
@@ -265,17 +265,16 @@ spec:
       - name: IUF_RELEASE_PATH
         value: "{{inputs.parameters.iuf_release_mount_path}}"
       volumeMounts:
-      - name: certs # mount cluster certs to ca-certificates.crt for curl/http libraries
-        mountPath: /etc/ssl/certs/ca-certificates.crt
-        subPath: platform-ca-certs.crt
+      - name: certs
+        mountPath: /usr/local/share/ca-certificates
       - name: results
         mountPath: /results
       - name: release-distribution
         mountPath: "{{inputs.parameters.iuf_release_mount_path}}"
     volumes:
     - name: certs
-      hostPath:
-        path: /etc/pki/trust/anchors
+      configMap:
+        name: cray-configmap-ca-public-key
     - name: release-distribution
       hostPath:
         path: "{{inputs.parameters.iuf_release_mount_path}}"

--- a/workflows/iuf/operations/vcs-update/vcs-update-working-branch.yaml
+++ b/workflows/iuf/operations/vcs-update/vcs-update-working-branch.yaml
@@ -71,6 +71,11 @@ spec:
                   value: "{{steps.get-vcs-secrets.outputs.parameters.secret_name}}"
                 - name: cf_update_gitea_org
                   value: cray #default
+                - name: cf_update_gitea_repo
+                  value: >
+                    {{="repo_name" in jsonpath(inputs.parameters.global_params, "$.product_manifest.current_product.manifest.content.vcs") ?
+                    jsonpath(inputs.parameters.global_params, "$.product_manifest.current_product.manifest.content.vcs.repo_name") :
+                    ""}}
                 - name: cf_update_product_name
                   value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.name')}}"
                 - name: cf_update_product_version
@@ -215,6 +220,7 @@ spec:
           - name: cf_update_product_name
           - name: cf_update_product_version
           - name: cf_update_gitea_org
+          - name: cf_update_gitea_repo
           - name: global_params
           - name: pristine_branch
             value: "{{inputs.parameters.cf_update_gitea_org}}/{{inputs.parameters.cf_update_product_name}}/{{inputs.parameters.cf_update_product_version}}"
@@ -245,6 +251,8 @@ spec:
             value: "{{inputs.parameters.cf_update_product_version}}"
           - name: CF_UPDATE_GITEA_ORG
             value: "{{inputs.parameters.cf_update_gitea_org}}"
+          - name: CF_UPDATE_GITEA_REPO
+            value: "{{inputs.parameters.cf_update_gitea_repo}}"
           - name: PRISTINE_BRANCH
             value: "{{inputs.parameters.pristine_branch}}"
           - name: CUSTOMER_BRANCH

--- a/workflows/iuf/operations/vcs-update/vcs-update-working-branch.yaml
+++ b/workflows/iuf/operations/vcs-update/vcs-update-working-branch.yaml
@@ -192,6 +192,7 @@ spec:
           rc=$?
           echo $destination_name >> /tmp/secret_name
           exit $rc
+
     ## gitea-update-content ##
     - name: gitea-update-content
       nodeSelector:
@@ -216,11 +217,13 @@ spec:
           - name: customer_branch
             value: "{{=jsonpath(inputs.parameters.global_params, '$.site_params.current_product.working_branch')}}"
       container:
-        image: artifactory.algol60.net/csm-docker/stable/cf-gitea-update:1.0.2
+        image: artifactory.algol60.net/csm-docker/unstable/cf-gitea-update:1.0.3-beta.1_206fefd
         command:
           - "/bin/sh"
         args: ["-c", "/opt/csm/cf-gitea-update/entrypoint.sh"]
         env:
+          - name: REQUESTS_CA_BUNDLE
+            value: /etc/ssl/certs/ca-certificates.crt
           - name: CF_UPDATE_GITEA_USER
             valueFrom:
               secretKeyRef:
@@ -244,13 +247,12 @@ spec:
           - name: CUSTOMER_BRANCH
             value: "{{inputs.parameters.customer_branch}}"
         volumeMounts:
-          - name: certs # mount cluster certs to ca-certificates.crt for curl/http libraries
-            mountPath: /etc/ssl/certs/ca-certificates.crt
-            subPath: platform-ca-certs.crt
+          - name: certs
+            mountPath: /usr/local/share/ca-certificates
       volumes:
         - name: certs
-          hostPath:
-            path: /etc/pki/trust/anchors
+          configMap:
+            name: cray-configmap-ca-public-key
     ## cleanup-template ##
     ## Remove the secret created earlier.
     - name: cleanup-template

--- a/workflows/iuf/operations/vcs-update/vcs-update-working-branch.yaml
+++ b/workflows/iuf/operations/vcs-update/vcs-update-working-branch.yaml
@@ -226,7 +226,7 @@ spec:
             value: "{{inputs.parameters.cf_update_gitea_org}}/{{inputs.parameters.cf_update_product_name}}/{{inputs.parameters.cf_update_product_version}}"
           - name: customer_branch
       container:
-        image: artifactory.algol60.net/csm-docker/unstable/cf-gitea-update:1.0.3-beta.1_206fefd
+        image: artifactory.algol60.net/csm-docker/stable/cf-gitea-update:1.0.3
         command:
           - "/bin/sh"
         args: ["-c", "/opt/csm/cf-gitea-update/entrypoint.sh"]

--- a/workflows/iuf/operations/vcs-update/vcs-update-working-branch.yaml
+++ b/workflows/iuf/operations/vcs-update/vcs-update-working-branch.yaml
@@ -75,6 +75,10 @@ spec:
                   value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.name')}}"
                 - name: cf_update_product_version
                   value: "{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.version')}}"
+                - name: customer_branch
+                  value: >
+                    {{='working_branch' in jsonpath(inputs.parameters.global_params, '$.site_params.current_product') ?
+                    jsonpath(inputs.parameters.global_params, '$.site_params.current_product.working_branch') : ''}}
         - - name: cleanup
             template: cleanup-template
             arguments:
@@ -215,7 +219,6 @@ spec:
           - name: pristine_branch
             value: "{{inputs.parameters.cf_update_gitea_org}}/{{inputs.parameters.cf_update_product_name}}/{{inputs.parameters.cf_update_product_version}}"
           - name: customer_branch
-            value: "{{=jsonpath(inputs.parameters.global_params, '$.site_params.current_product.working_branch')}}"
       container:
         image: artifactory.algol60.net/csm-docker/unstable/cf-gitea-update:1.0.3-beta.1_206fefd
         command:

--- a/workflows/iuf/operations/vcs-upload/vcs-upload-content.yaml
+++ b/workflows/iuf/operations/vcs-upload/vcs-upload-content.yaml
@@ -233,7 +233,7 @@ spec:
               path: /results/records.yaml
               default: "{}"
       container:
-        image: artifactory.algol60.net/csm-docker/unstable/cf-gitea-import:1.9.0-bug-CASMINST-5843.16_f017da7
+        image: artifactory.algol60.net/csm-docker/stable/cf-gitea-import:1.9.0
         command:
           - "/bin/sh"
         args: ["-c", "/opt/csm/cf-gitea-import/argo_entrypoint.sh"]

--- a/workflows/iuf/operations/vcs-upload/vcs-upload-content.yaml
+++ b/workflows/iuf/operations/vcs-upload/vcs-upload-content.yaml
@@ -74,6 +74,11 @@ spec:
                   value: "{{=jsonpath(inputs.parameters.global_params, '$.stage_params.process-media.current_product.parent_directory')}}/{{=jsonpath(inputs.parameters.global_params, '$.product_manifest.current_product.manifest.content.vcs.path')}}"
                 - name: cf_import_gitea_org
                   value: cray
+                - name: cf_import_gitea_repo
+                  value: >
+                    {{="repo_name" in jsonpath(inputs.parameters.global_params, "$.product_manifest.current_product.manifest.content.vcs") ?
+                    jsonpath(inputs.parameters.global_params, "$.product_manifest.current_product.manifest.content.vcs.repo_name") :
+                    ""}}
                 - name: cf_import_gitea_url
                   value: "https://api-gw-service-nmn.local/vcs"
         - - name: vcs-update-product-catalog
@@ -219,6 +224,7 @@ spec:
           - name: cf_import_product_name
           - name: cf_import_product_version
           - name: cf_import_gitea_org
+          - name: cf_import_gitea_repo
           - name: cf_import_content_hostpath
       outputs:
         parameters:
@@ -252,6 +258,8 @@ spec:
             value: "{{inputs.parameters.cf_import_product_version}}"
           - name: CF_IMPORT_GITEA_ORG
             value: "{{inputs.parameters.cf_import_gitea_org}}"
+          - name: CF_IMPORT_GITEA_REPO
+            value: "{{inputs.parameters.cf_import_gitea_repo}}"
           - name: CF_IMPORT_CONTENT
             value: /content
         volumeMounts:

--- a/workflows/iuf/operations/vcs-upload/vcs-upload-content.yaml
+++ b/workflows/iuf/operations/vcs-upload/vcs-upload-content.yaml
@@ -227,7 +227,7 @@ spec:
               path: /results/records.yaml
               default: "{}"
       container:
-        image: artifactory.algol60.net/csm-docker/stable/cf-gitea-import:1.8.1
+        image: artifactory.algol60.net/csm-docker/unstable/cf-gitea-import:1.9.0-bug-CASMINST-5843.16_f017da7
         command:
           - "/bin/sh"
         args: ["-c", "/opt/csm/cf-gitea-import/argo_entrypoint.sh"]
@@ -259,9 +259,8 @@ spec:
             mountPath: /content
           - name: results
             mountPath: /results
-          - name: certs # mount cluster certs to ca-certificates.crt for curl/http libraries
-            mountPath: /etc/ssl/certs/ca-certificates.crt
-            subPath: platform-ca-certs.crt
+          - name: certs
+            mountPath: /usr/local/share/ca-certificates
       volumes:
         - name: content
           hostPath:
@@ -270,8 +269,8 @@ spec:
         - name: results
           emptyDir: {}
         - name: certs
-          hostPath:
-            path: /etc/pki/trust/anchors
+          configMap:
+            name: cray-configmap-ca-public-key
     ## cleanup-template ##
     ## Remove the secret created earlier.
     - name: cleanup-template


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

## CASMINST-5843

Adds changes to the following templates:

- ims-upload
- vcs-upload
- vcs-update-working-branch

Required to mount certs via a configMap instead of hostPath due to storage issues from IUF

## CASMINST-5902

Update the Argo workflow template that implements the `update-vcs-config` stage of the IUF to properly handle a product that doesn't have a `working_branch` in the site parameters. This requires a corresponding update to the cf-gitea-update image to handle an empty string value for the CUSTOMER_BRANCH environment variable.


## CASMINST-5876

Update the Argo workflow templates that implement the `vcs-upload` and `update-vcs-config` stages of the IUF, so that they can create repos named according to the new `content.vcs.repo_name` property which was added in the IUF Product Manifest schema.

This requires changes to the cf-gitea-import and cf-gitea-update container images.

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
