### PR TITLE
CASMINST-3950: Provide more precise and appropriate links for configuring the Cray CLI before validating CSM health

### DIFF
--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -46,13 +46,15 @@ The areas should be tested in the order they are listed on this page. Errors in 
 
 ## 0. Cray command line interface
 
-The first time these checks are performed during a CSM install, the Cray Command Line Interface (CLI) has not yet been configured.
-Some of the health check tests cannot be run without the Cray CLI being configured. Tests with this dependency are noted in their
-descriptions below. These tests may be skipped but **this is not recommended**.
+Some of the health check tests will fail if the Cray Command Line Interface (CLI) is not configured on the management NCNs.
+Tests with this dependency are noted in their descriptions below. These tests may be skipped but **this is not recommended**.
 
-The Cray CLI must be configured on all NCNs and the PIT node. The following procedures explain how to do this:
+If running these checks during an initial CSM install, then to find details on configuring the Cray CLI, see
+[Configure the Cray command line interface](../install/configure_administrative_access.md#1-configure-the-cray-command-line-interface)
+from the install documentation.
 
-1. [Configure the Cray command line interface](../install/configure_administrative_access.md#1-configure-the-cray-command-line-interface)
+If running these checks after the initial CSM install, then to find details on configuring the Cray CLI, see
+[Configure the Cray CLI](configure_cray_cli.md) from the operational documentation.
 
 ## 1. Platform health checks
 


### PR DESCRIPTION
# Description

Some of the CSM health validation tests require the Cray CLI to be configured. The procedure for doing this varies slightly based on whether it is being done during an install versus being done later. This PR modifies the instructions and links accordingly.

# Checklist

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
