### PR TITLE
CASMINST-3943: Update CSM health check troubleshooting information, specifically for issues related to unconfigured CLI

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -540,6 +540,8 @@ subroles
 subslots
 substep
 substeps
+subtest
+subtests
 SuSE
 sysfs
 syslog

--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -12,6 +12,9 @@ The following are examples of when to run health checks:
 
 The areas should be tested in the order they are listed on this page. Errors in an earlier check may cause errors in later checks because of dependencies.
 
+Each section of this health check document provides links to relevant troubleshooting procedures. If additional help is needed, see
+[CSM Troubleshooting Information](../troubleshooting/README.md).
+
 ## Topics
 
 - [0. Cray command line interface](#0-cray-command-line-interface)
@@ -132,7 +135,8 @@ Information to assist with troubleshooting some of the components mentioned in t
 
 ## 2. Hardware Management Services health checks
 
-The checks in this section require that the [Cray CLI is configured](#0-cray-command-line-interface) on nodes where the checks are executed.
+> The checks in this section do not require that the [Cray CLI is configured](#0-cray-command-line-interface),
+> but in the case of failures, some of the tests will provide troubleshooting suggestions that involve using the CLI.
 
 Execute the HMS tests to confirm that the Hardware Management Services are running and operational.
 
@@ -361,6 +365,9 @@ Known issues that may prevent hardware from getting discovered by Hardware State
 
 ## 3 Software Management Services (SMS) health checks
 
+This test requires that the Cray CLI is configured on nodes where the test is executed.
+See [Cray command line interface](#0-cray-command-line-interface).
+
 (`ncn-mw#`) To validate all SMS services, run the following:
 
 ```bash
@@ -372,6 +379,8 @@ Successful output ends with a line similar to the following:
 ```text
 SUCCESS: All 6 service tests passed: bos, cfs, conman, ims, tftp, vcs
 ```
+
+For more details, including known issues and other command line options, see [Software Management Services health checks](../troubleshooting/known_issues/sms_health_check.md).
 
 ## 4. Gateway health and SSH access checks
 

--- a/troubleshooting/interpreting_hms_health_check_results.md
+++ b/troubleshooting/interpreting_hms_health_check_results.md
@@ -1,8 +1,7 @@
 # Interpreting HMS Health Check Results
 
-## Table of contents
-
 - [Introduction](#introduction)
+- [Prerequisites](#prerequisites)
 - [Overview](#overview)
 - [Execution](#execution)
 - [Failure analysis](#failure-analysis)
@@ -22,6 +21,11 @@
 ## Introduction
 
 This document describes how to interpret the results of the HMS Health Check scripts and techniques for troubleshooting when failures occur.
+
+## Prerequisites
+
+The HMS health checks will not fail if the Cray CLI is not configured. However, some of the troubleshooting suggestions for investigating test failures
+involve using the CLI. For information on configuring the Cray CLI, see [Cray command line interface](../operations/validate_csm_health.md#0-cray-command-line-interface).
 
 ## Overview
 

--- a/troubleshooting/known_issues/issues_with_ncn_health_checks.md
+++ b/troubleshooting/known_issues/issues_with_ncn_health_checks.md
@@ -2,6 +2,9 @@
 
 - The first pass of running these tests may fail due to `cloud-init` not being completed on the storage nodes. In the case of failure, wait for five minutes and rerun the tests.
 
+- Some of the tests will fail if the Cray CLI is not configured on the management NCNs.
+  See [Cray command line interface](../../operations/validate_csm_health.md#0-cray-command-line-interface).
+
 - For any failures related to SSL certificates, see the [SSL Certificate Validation Issues](ssl_certificate_validation_issues.md) troubleshooting guide.
 
 - `Kubernetes Query BSS Cloud-init for ca-certs`

--- a/troubleshooting/known_issues/sms_health_check.md
+++ b/troubleshooting/known_issues/sms_health_check.md
@@ -4,9 +4,13 @@
 1. [Interpreting `cmsdev` Results](#32-interpreting-cmsdev-results)
 1. [Known issues with SMS tests](#33-known-issues-with-sms-tests)
 
+   - [Cray CLI](#cray-cli)
+   - [Etcd-restores](#etcd-restores)
+
 ## 3.1 SMS test execution
 
-The test in this section requires that the [Cray CLI is configured](../../operations/configure_cray_cli.md#configure-the-cray-command-line-interface-cray-cli) on nodes where the test is executed.
+This test requires that the Cray CLI is configured on nodes where the test is executed.
+See [Cray command line interface](../../operations/validate_csm_health.md#0-cray-command-line-interface).
 
 The following test can be run on any Kubernetes node (any master or worker node, but **not** on the PIT node).
 
@@ -34,6 +38,13 @@ The following test can be run on any Kubernetes node (any master or worker node,
 Additional test execution details can be found in `/opt/cray/tests/cmsdev.log`.
 
 ## 3.3 Known issues with SMS tests
+
+### Cray CLI
+
+Some of the subtests may fail if the Cray CLI is not configured on the management NCN where `cmsdev` is executed.
+See [Cray command line interface](../../operations/validate_csm_health.md#0-cray-command-line-interface).
+
+### Etcd restores
 
 If an Etcd restore has been performed on one of the SMS services (such as BOS), then the first Etcd pod that
 comes up after the restore will not have a PVC (Persistent Volume Claim) attached to it (until the pod is restarted).


### PR DESCRIPTION
# Description

The Cray CLI being configured is mentioned at the top of the CSM health checks page, but it is not mentioned in most of the troubleshooting sections for the tests which require it to be configured. This PR corrects that. It also clarifies the actual CLI requirements for HMS tests.

# Checklist

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
