### PR TITLE
CASMINST-5921 License check sporadically fails

### DIFF
--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -41,7 +41,7 @@ jobs:
 
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@v34
+      uses: tj-actions/changed-files@v35
 
     - name: License Check
       if: ${{ steps.changed-files.outputs.all_changed_files }}


### PR DESCRIPTION
# Description
License check sporadically fails to determine the list of changed files. This seems to be happening due to a bug in `tj-actions/changed-files@v34`, which does not filter out temporary merge commits, created by Github to assess mergeability of PR. The `tj-actions/changed-files@v34` has this problem addressed.

# Checklist
- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
