### PR TITLE
CASMINST-5921 License check sporadically fails

### DIFF
--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -41,7 +41,7 @@ jobs:
 
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@v34
+      uses: tj-actions/changed-files@v35
 
     - name: License Check
       if: ${{ steps.changed-files.outputs.all_changed_files }}


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/docs-csm/pull/3226