### PR TITLE
CASMINST-5936, CASMINST-5885: Small fixes to update-cfs-config and prepare-images IUF stages

### DIFF
--- a/workflows/iuf/operations/prepare-images/prepare-managed-images-template.yaml
+++ b/workflows/iuf/operations/prepare-images/prepare-managed-images-template.yaml
@@ -73,7 +73,7 @@ spec:
                     MEDIA_DIR="{{=jsonpath(inputs.parameters.global_params, '$.input_params.media_dir')}}"
                     BOOTPREP_FILE_PATH="{{=jsonpath(inputs.parameters.global_params, '$.input_params.bootprep_config_managed')}}"
                     if [[ -z "$BOOTPREP_FILE_PATH" ]]; then
-                      echo "No bootprep file provided. Skipping operation." 1>&2
+                      echo "INFO No bootprep file provided. Skipping operation." 1>&2
                       echo "{}"
                       exit 0
                     fi

--- a/workflows/iuf/operations/prepare-images/prepare-managed-images-template.yaml
+++ b/workflows/iuf/operations/prepare-images/prepare-managed-images-template.yaml
@@ -85,6 +85,7 @@ spec:
                     sat bootprep run --limit images --limit session_templates \
                       --overwrite-images --overwrite-templates \
                       --vars-file "$VARS_FILE_PATH" --format json \
+                      --bos-version v2 \
                       $MEDIA_DIR/$BOOTPREP_FILE_PATH
         - - name: end-operation
             templateRef:

--- a/workflows/iuf/operations/prepare-images/prepare-management-images-template.yaml
+++ b/workflows/iuf/operations/prepare-images/prepare-management-images-template.yaml
@@ -85,6 +85,7 @@ spec:
                     sat bootprep run --limit images --limit session_templates \
                       --overwrite-images --overwrite-templates \
                       --vars-file "$VARS_FILE_PATH" --format json \
+                      --bos-version v2 \
                       $MEDIA_DIR/$BOOTPREP_FILE_PATH
         - - name: end-operation
             templateRef:

--- a/workflows/iuf/operations/prepare-images/prepare-management-images-template.yaml
+++ b/workflows/iuf/operations/prepare-images/prepare-management-images-template.yaml
@@ -73,7 +73,7 @@ spec:
                     MEDIA_DIR="{{=jsonpath(inputs.parameters.global_params, '$.input_params.media_dir')}}"
                     BOOTPREP_FILE_PATH="{{=jsonpath(inputs.parameters.global_params, '$.input_params.bootprep_config_management')}}"
                     if [[ -z "$BOOTPREP_FILE_PATH" ]]; then
-                      echo "No bootprep file provided. Skipping operation." 1>&2
+                      echo "INFO No bootprep file provided. Skipping operation." 1>&2
                       echo "{}"
                       exit 0
                     fi

--- a/workflows/iuf/operations/update-cfs-config/update-managed-cfs-config.yaml
+++ b/workflows/iuf/operations/update-cfs-config/update-managed-cfs-config.yaml
@@ -73,7 +73,7 @@ spec:
                     MEDIA_DIR="{{=jsonpath(inputs.parameters.global_params, '$.input_params.media_dir')}}"
                     BOOTPREP_FILE_PATH="{{=jsonpath(inputs.parameters.global_params, '$.input_params.bootprep_config_managed')}}"
                     if [[ -z "$BOOTPREP_FILE_PATH" ]]; then
-                      echo "No bootprep file provided. Skipping operation." 1>&2
+                      echo "INFO No bootprep file provided. Skipping operation." 1>&2
                       echo "{}"
                       exit 0
                     fi

--- a/workflows/iuf/operations/update-cfs-config/update-management-cfs-config.yaml
+++ b/workflows/iuf/operations/update-cfs-config/update-management-cfs-config.yaml
@@ -73,7 +73,7 @@ spec:
                     MEDIA_DIR="{{=jsonpath(inputs.parameters.global_params, '$.input_params.media_dir')}}"
                     BOOTPREP_FILE_PATH="{{=jsonpath(inputs.parameters.global_params, '$.input_params.bootprep_config_management')}}"
                     if [[ -z "$BOOTPREP_FILE_PATH" ]]; then
-                      echo "No bootprep file provided. Skipping operation." 1>&2
+                      echo "INFO No bootprep file provided. Skipping operation." 1>&2
                       echo "{}"
                       exit 0
                     fi


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

## CASMINST-5885

Use INFO prefix on messages for skipped bootprep stages

Use the "INFO " prefix in the messages printed by the operations in the
"update-cfs-config" and "prepare-images" stages when no bootprep file is
provided to the operations in those stages.

This will ensure these messages are displayed to the end user at INFO
level.

Test Description:
Tested in combination with CASMINST-5936 on frigg by running the
update-cfs-config and prepare-images stages without passing in bootprep
files for either management or managed nodes and confirmed that the
INFO-level messages were logged to stdout by the CLI.

## CASMINST-5936

Use BOS v2 in prepare-images stage

For consistency with the managed-nodes-rollout stage, use BOS v2 when
creating BOS session templates in the prepare-images stage. Although
only the prepare-managed-images operation within that stage is currently
expected to create BOS session templates, technically the
prepare-management-images operation could create BOS session templates
if they were defined in the management bootprep file, so pass the
`--bos-version v2` option there as well.

This change is not necessary in the `update-cfs-config` stage because
the two operations in that stage pass only `--limit configurations` to
`sat bootprep run`, which means BOS session templates will not be
created.

Test Description:
Tested in combination with CASMINST-5885 on frigg by uploading the
modified Argo workflow templates to K8s and running the `prepare-images`
stage with simple bootprep files for managed and management nodes.

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
