### PR TITLE
Explicitly add docs-csm-reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -78,6 +78,6 @@ Jenkinsfile.github                                       @Cray-HPE/csm-devops
 /operations/iuf/                                         @Cray-HPE/IUF
 
 # Include SSI on these CSM items.
-/install/                                                @Cray-HPE/metal @Cray-HPE/ssi-reviewers
-/operations/                                             @Cray-HPE/ssi-reviewers
-/upgrade/                                                @Cray-HPE/ssi-reviewers
+/install/                                                @Cray-HPE/docs-csm-reviewers @Cray-HPE/metal @Cray-HPE/ssi-reviewers
+/operations/                                             @Cray-HPE/docs-csm-reviewers @Cray-HPE/ssi-reviewers
+/upgrade/                                                @Cray-HPE/docs-csm-reviewers @Cray-HPE/ssi-reviewers


### PR DESCRIPTION
ssi-reviewers is constantly the only team being queried for reviews.
