### PR TITLE
CASMINST-5957: Replace CSM 1.6 references with CSM 1.5

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # Cray System Management (CSM) - Release Notes
 
-[CSM](glossary.md#cray-system-management-csm) 1.6 contains many changes spanning bug fixes, new feature development, and documentation improvements. This page lists some of the highlights.
+[CSM](glossary.md#cray-system-management-csm) 1.5 contains many changes spanning bug fixes, new feature development, and documentation improvements. This page lists some of the highlights.
 
 ## New
 
@@ -39,4 +39,4 @@ For a list of all features with an announced removal target, see [Removals](intr
 
 ## Known issues
 
-### Security vulnerability exceptions in CSM 1.6
+### Security vulnerability exceptions in CSM 1.5

--- a/glossary.md
+++ b/glossary.md
@@ -132,7 +132,7 @@ and CDU status to the CMMs for evaluation and/or action.
 
 ## Compute Rolling Upgrade Service (CRUS)
 
-> **`NOTE`** CRUS was deprecated in CSM 1.2.0 and removed in CSM 1.6.0. See [Deprecated Features](introduction/deprecated_features/README.md).
+> **`NOTE`** CRUS was deprecated in CSM 1.2.0 and removed in CSM 1.5.0. See [Deprecated Features](introduction/deprecated_features/README.md).
 
 See [Rolling Upgrades using BOS](operations/boot_orchestration/Rolling_Upgrades.md).
 

--- a/install/pre-installation.md
+++ b/install/pre-installation.md
@@ -51,9 +51,9 @@ Any steps run on an `external` server require that server to have the following 
 
       > Example release versions:
       >
-      > - An alpha build: `CSM_RELEASE=1.6.0-alpha.99`
-      > - A release candidate: `CSM_RELEASE=1.6.0-rc.1`
-      > - A stable release: `CSM_RELEASE=1.6.0`
+      > - An alpha build: `CSM_RELEASE=1.5.0-alpha.99`
+      > - A release candidate: `CSM_RELEASE=1.5.0-rc.1`
+      > - A stable release: `CSM_RELEASE=1.5.0`
 
       ```bash
       CSM_RELEASE=<value>
@@ -268,9 +268,9 @@ These variables will need to be set for many procedures within the CSM installat
 
       > Example release versions:
       >
-      > - An alpha build: `CSM_RELEASE=1.6.0-alpha.99`
-      > - A release candidate: `CSM_RELEASE=1.6.0-rc.1`
-      > - A stable release: `CSM_RELEASE=1.6.0`
+      > - An alpha build: `CSM_RELEASE=1.5.0-alpha.99`
+      > - A release candidate: `CSM_RELEASE=1.5.0-rc.1`
+      > - A stable release: `CSM_RELEASE=1.5.0`
 
       ```bash
       export CSM_RELEASE=<value>

--- a/introduction/deprecated_features/README.md
+++ b/introduction/deprecated_features/README.md
@@ -7,7 +7,7 @@ been made, that information will be available on this page. For any deprecated f
 version for their planned removal, customers are still strongly encouraged to make plans to migrate away from the deprecated feature.
 
 * [Removals](#removals)
-  * [Removals in CSM 1.6](#removals-in-csm-16)
+  * [Removals in CSM 1.5](#removals-in-csm-15)
   * [Removals in CSM 1.9](#removals-in-csm-19)
 * [Deprecations](#deprecations)
   * [Deprecated in CSM 1.3](#deprecated-in-csm-13)
@@ -24,7 +24,7 @@ in chronological order.
 
 * [SLS](../../glossary.md#system-layout-service-sls) support for downloading and uploading credentials in the `dumpstate` and `loadstate` REST APIs
 
-### Removals in CSM 1.6
+### Removals in CSM 1.5
 
 * [Compute Rolling Upgrade Service (CRUS)](../../glossary.md#compute-rolling-upgrade-service-crus)
 
@@ -48,9 +48,9 @@ features are listed first).
 ### Deprecated in CSM 1.2
 
 * [Hardware Management Notification Fanout Daemon (HMNFD)](../../glossary.md#hardware-management-notification-fanout-daemon-hmnfd) v1 REST API
-  * The v1 HMNFD APIs are targeted for removal in the CSM 1.6 release.
+  * The v1 HMNFD APIs are targeted for removal in the CSM 1.5 release.
 * [Compute Rolling Upgrade Service (CRUS)](../../glossary.md#compute-rolling-upgrade-service-crus)
-  * CRUS will be removed in CSM 1.6.
+  * CRUS will be removed in CSM 1.5.
   * Enhanced [BOS](../../glossary.md#boot-orchestration-service-bos) functionality will replace CRUS. This includes the ability to stage changes to nodes that can be acted upon later when the node reboots.
     It also includes the ability to reboot nodes without specifying any boot artifacts, provided that the artifacts had been previously staged.
 * The `--template-body` option for the [BOS](../../glossary.md#boot-orchestration-service-bos) Cray CLI.

--- a/operations/README.md
+++ b/operations/README.md
@@ -182,7 +182,7 @@ Use the Ceph Object Gateway Simple Storage Service \(S3\) API to manage artifact
 
 ## Compute rolling upgrades
 
-**NOTE** CRUS was deprecated in CSM 1.2.0 and removed in CSM 1.6.0. See the following links for more information:
+**NOTE** CRUS was deprecated in CSM 1.2.0 and removed in CSM 1.5.0. See the following links for more information:
 
 - [Rolling Upgrades using BOS](boot_orchestration/Rolling_Upgrades.md)
 - [Deprecated Features](../introduction/deprecated_features/README.md)

--- a/operations/boot_orchestration/Rolling_Upgrades.md
+++ b/operations/boot_orchestration/Rolling_Upgrades.md
@@ -3,7 +3,7 @@
 > **`NOTE`** This section is for BOS V2 only.
 
 <!-- -->
-> **`NOTE`** This feature is the replacement for the Compute Rolling Upgrade Service (CRUS). CRUS was deprecated in CSM 1.2.0 and removed in CSM 1.6.0.
+> **`NOTE`** This feature is the replacement for the Compute Rolling Upgrade Service (CRUS). CRUS was deprecated in CSM 1.2.0 and removed in CSM 1.5.0.
 > See [Deprecated Features](../../introduction/deprecated_features/README.md).
 
 BOS V2 allows users to stage boot artifacts, configuration, and an operation such as a reboot.


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/docs-csm/pull/3274