### PR TITLE
CASMINST-5957: Replace CSM 1.6 references with CSM 1.5

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -193,7 +193,13 @@ see [Deprecated Features](introduction/deprecated_features/README.md).
 
 ## Removals
 
-* SLS support for downloading and uploading credentials in the `dumpstate` and `loadstate` REST APIs
+* [SLS](glossary.md#system-layout-service-sls) support for downloading and uploading credentials in the `dumpstate` and `loadstate` REST APIs
+
+The following previously deprecated feature now has an announced CSM version when it will be removed:
+
+* [CRUS](glossary.md#compute-rolling-upgrade-service-crus) was deprecated in CSM 1.2, and will be removed in CSM 1.5.
+
+For a list of all features with an announced removal target, see [Removals](introduction/deprecated_features/README.md#removals).
 
 ## Known issues
 

--- a/glossary.md
+++ b/glossary.md
@@ -137,7 +137,7 @@ management status of nodes, handling each of the steps required to upgrade compu
 
 See [Compute Rolling Upgrades](operations/index.md#compute-rolling-upgrades).
 
-> **`NOTE`** CRUS was deprecated in CSM 1.2.0 and it will be removed in CSM 1.6.0.
+> **`NOTE`** CRUS was deprecated in CSM 1.2.0 and it will be removed in CSM 1.5.0.
 > See the following links for more information:
 >
 > * [Rolling Upgrades with BOS V2](operations/boot_orchestration/Rolling_Upgrades.md)

--- a/introduction/deprecated_features/README.md
+++ b/introduction/deprecated_features/README.md
@@ -6,7 +6,36 @@ When a feature is first deprecated, it may not yet be announced in which CSM ver
 been made, that information will be available on this page. For any deprecated features listed on this page that do not yet have an announced CSM
 version for their planned removal, customers are still strongly encouraged to make plans to migrate away from the deprecated feature.
 
-This page groups the deprecated features by the CSM release in which they were deprecated, in reverse chronological order (the most recently deprecated
+* [Removals](#removals)
+  * [Removals in CSM 1.3](#removals-in-csm-13)
+  * [Removals in CSM 1.5](#removals-in-csm-15)
+  * [Removals in CSM 1.9](#removals-in-csm-19)
+* [Deprecations](#deprecations)
+  * [Deprecated in CSM 1.3](#deprecated-in-csm-13)
+  * [Deprecated in CSM 1.2](#deprecated-in-csm-12)
+  * [Deprecated in CSM 1.0](#deprecated-in-csm-10)
+  * [Deprecated in CSM 0.9.3](#deprecated-in-csm-093)
+
+## Removals
+
+Any features that are being removed in the current or upcoming CSM releases are listed in this section, grouped by the CSM release when they are being removed,
+in chronological order.
+
+### Removals in CSM 1.3
+
+* [SLS](../../glossary.md#system-layout-service-sls) support for downloading and uploading credentials in the `dumpstate` and `loadstate` REST APIs
+
+### Removals in CSM 1.5
+
+* [Compute Rolling Upgrade Service (CRUS)](../../glossary.md#compute-rolling-upgrade-service-crus)
+
+### Removals in CSM 1.9
+
+* [Boot Orchestration Service (BOS)](../../glossary.md#boot-orchestration-service-bos) v1
+
+## Deprecations
+
+This section groups the deprecated features by the CSM release in which they were deprecated, in reverse chronological order (the most recently deprecated
 features are listed first).
 
 ## Deprecated in CSM 1.3
@@ -22,9 +51,9 @@ features are listed first).
 ## Deprecated in CSM 1.2
 
 * [Hardware Management Notification Fanout Daemon (HMNFD)](../../glossary.md#hardware-management-notification-fanout-daemon-hmnfd) v1 REST API
-  * The v1 HMNFD APIs are targeted for removal in the CSM 1.6 release.
+  * The v1 HMNFD APIs are targeted for removal in the CSM 1.5 release.
 * [Compute Rolling Upgrade Service (CRUS)](../../glossary.md#compute-rolling-upgrade-service-crus)
-  * CRUS is targeted for removal in the CSM 1.6 release.
+  * CRUS will be removed in the CSM 1.5 release.
   * Enhanced BOS functionality will replace CRUS. See [Rolling Upgrades using BOS](../../operations/boot_orchestration/Rolling_Upgrades.md).
 * The `--template-body` option for the [BOS](../../glossary.md#boot-orchestration-service-bos) Cray CLI.
 

--- a/operations/README.md
+++ b/operations/README.md
@@ -183,7 +183,7 @@ Use the Ceph Object Gateway Simple Storage Service \(S3\) API to manage artifact
 Upgrade sets of compute nodes with the Compute Rolling Upgrade Service \(CRUS\) without requiring an entire set of nodes to be out of service at once. CRUS enables
 administrators to limit the impact on production caused from upgrading compute nodes by working through one step of the upgrade process at a time.
 
-> **NOTE** CRUS was deprecated in CSM 1.2.0 and it will be removed in CSM 1.6.0. See [Deprecated Features](../introduction/deprecated_features/README.md).
+> **NOTE** CRUS was deprecated in CSM 1.2.0 and it will be removed in CSM 1.5.0. See [Deprecated Features](../introduction/deprecated_features/README.md).
 
 - [Rolling Upgrades using BOS](boot_orchestration/Rolling_Upgrades.md)
 - [Compute Rolling Upgrade Service (CRUS)](compute_rolling_upgrades/Compute_Rolling_Upgrades.md)

--- a/operations/boot_orchestration/Rolling_Upgrades.md
+++ b/operations/boot_orchestration/Rolling_Upgrades.md
@@ -3,8 +3,8 @@
 > **`NOTE`** This section is for BOS V2 only.
 
 <!-- -->
-> **`NOTE`** This feature is the replacement for the Compute Rolling Upgrade Service (CRUS). CRUS was deprecated in CSM 1.2.0 and it will be removed in CSM 1.6.0.
-> See [Deprecated features](../../introduction/deprecated_features/README.md).
+> **`NOTE`** This feature is the replacement for the Compute Rolling Upgrade Service (CRUS). CRUS was deprecated in CSM 1.2.0 and it will be removed in CSM 1.5.0.
+> See [Deprecated Features](../../introduction/deprecated_features/README.md).
 
 BOS V2 allows users to stage boot artifacts, configuration, and an operation such as a reboot.
 The workload manager can later trigger the operation through BOS to apply that staged information, allowing rolling updates when nodes have no job running on them.

--- a/operations/compute_rolling_upgrades/CRUS_Workflow.md
+++ b/operations/compute_rolling_upgrades/CRUS_Workflow.md
@@ -1,6 +1,6 @@
 # CRUS Workflow
 
-> **`NOTE`** CRUS was deprecated in CSM 1.2.0 and it will be removed in CSM 1.6.0.
+> **`NOTE`** CRUS was deprecated in CSM 1.2.0 and it will be removed in CSM 1.5.0.
 > See the following links for more information:
 >
 > - [Rolling Upgrades with BOS V2](../boot_orchestration/Rolling_Upgrades.md)

--- a/operations/compute_rolling_upgrades/Compute_Rolling_Upgrades.md
+++ b/operations/compute_rolling_upgrades/Compute_Rolling_Upgrades.md
@@ -1,6 +1,6 @@
 # Compute Rolling Upgrades
 
-> **`NOTE`** CRUS was deprecated in CSM 1.2.0 and it will be removed in CSM 1.6.0.
+> **`NOTE`** CRUS was deprecated in CSM 1.2.0 and it will be removed in CSM 1.5.0.
 > See the following links for more information:
 >
 > - [Rolling Upgrades with BOS V2](../boot_orchestration/Rolling_Upgrades.md)

--- a/operations/compute_rolling_upgrades/Troubleshoot_Nodes_Failing_to_Upgrade_in_a_CRUS_Session.md
+++ b/operations/compute_rolling_upgrades/Troubleshoot_Nodes_Failing_to_Upgrade_in_a_CRUS_Session.md
@@ -1,6 +1,6 @@
 # Troubleshoot Nodes Failing to Upgrade in a CRUS Session
 
-> **`NOTE`** CRUS was deprecated in CSM 1.2.0 and it will be removed in CSM 1.6.0.
+> **`NOTE`** CRUS was deprecated in CSM 1.2.0 and it will be removed in CSM 1.5.0.
 > See the following links for more information:
 >
 > - [Rolling Upgrades with BOS V2](../boot_orchestration/Rolling_Upgrades.md)

--- a/operations/compute_rolling_upgrades/Troubleshoot_a_Failed_CRUS_Session_Due_to_Bad_Parameters.md
+++ b/operations/compute_rolling_upgrades/Troubleshoot_a_Failed_CRUS_Session_Due_to_Bad_Parameters.md
@@ -1,6 +1,6 @@
 # Troubleshoot a Failed CRUS Session Because of Bad Parameters
 
-> **`NOTE`** CRUS was deprecated in CSM 1.2.0 and it will be removed in CSM 1.6.0.
+> **`NOTE`** CRUS was deprecated in CSM 1.2.0 and it will be removed in CSM 1.5.0.
 > See the following links for more information:
 >
 > - [Rolling Upgrades with BOS V2](../boot_orchestration/Rolling_Upgrades.md)

--- a/operations/compute_rolling_upgrades/Troubleshoot_a_Failed_CRUS_Session_Due_to_Unmet_Conditions.md
+++ b/operations/compute_rolling_upgrades/Troubleshoot_a_Failed_CRUS_Session_Due_to_Unmet_Conditions.md
@@ -1,6 +1,6 @@
 # Troubleshoot a Failed CRUS Session Because of Unmet Conditions
 
-> **`NOTE`** CRUS was deprecated in CSM 1.2.0 and it will be removed in CSM 1.6.0.
+> **`NOTE`** CRUS was deprecated in CSM 1.2.0 and it will be removed in CSM 1.5.0.
 > See the following links for more information:
 >
 > - [Rolling Upgrades with BOS V2](../boot_orchestration/Rolling_Upgrades.md)

--- a/operations/compute_rolling_upgrades/Upgrade_Compute_Nodes_with_CRUS.md
+++ b/operations/compute_rolling_upgrades/Upgrade_Compute_Nodes_with_CRUS.md
@@ -1,6 +1,6 @@
 # Upgrade Compute Nodes with CRUS
 
-> **`NOTE`** CRUS was deprecated in CSM 1.2.0 and it will be removed in CSM 1.6.0.
+> **`NOTE`** CRUS was deprecated in CSM 1.2.0 and it will be removed in CSM 1.5.0.
 > See the following links for more information:
 >
 > - [Rolling Upgrades with BOS V2](../boot_orchestration/Rolling_Upgrades.md)

--- a/operations/kubernetes/Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md
+++ b/operations/kubernetes/Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md
@@ -86,7 +86,7 @@ Repopulate clusters for CPS.
 
 ### CRUS
 
-> **NOTE** CRUS was deprecated in CSM 1.2.0 and it will be removed in CSM 1.6.0.
+> **NOTE** CRUS was deprecated in CSM 1.2.0 and it will be removed in CSM 1.5.0.
 > See the following links for more information:
 >
 > - [Rolling Upgrades with BOS V2](../boot_orchestration/Rolling_Upgrades.md)

--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -61,7 +61,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 
 ## Compute rolling upgrades
 
-CRUS was deprecated in CSM 1.2.0 and it will be removed in CSM 1.6.0. See [Deprecated Features](../introduction/deprecated_features/README.md).
+CRUS was deprecated in CSM 1.2.0 and it will be removed in CSM 1.5.0. See [Deprecated Features](../introduction/deprecated_features/README.md).
 
 * [Nodes Failing to Upgrade in a CRUS Session](../operations/compute_rolling_upgrades/Troubleshoot_Nodes_Failing_to_Upgrade_in_a_CRUS_Session.md)
 * [Failed CRUS Session Because of Unmet Conditions](../operations/compute_rolling_upgrades/Troubleshoot_a_Failed_CRUS_Session_Due_to_Unmet_Conditions.md)


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/docs-csm/pull/3274