### PR TITLE
STP-3525: Update references to docs-sat

### DIFF
--- a/operations/sat/sat_in_csm.md
+++ b/operations/sat/sat_in_csm.md
@@ -46,12 +46,12 @@ SAT, all files and directories are created with the appropriate permissions.
 For full SAT documentation, refer to the [*HPE Cray EX System Admin Toolkit (SAT) Guide*](https://cray-hpe.github.io/docs-sat/).
 
 If SAT has not been installed before, some initial configuration is required (for example, authenticating to the API
-gateway with `sat auth`). To complete the initial configuration of SAT, refer to the following processes in the SAT documentation:
+gateway with `sat auth`). To complete the initial configuration of SAT, refer to the following post-installation procedures in the SAT documentation:
 
-- **SAT Authentication**
+- **Authenticate SAT Commands**
 - **Generate SAT S3 Credentials**
 - **Set System Revision Information**
 
 If the full SAT product stream is not being installed, it is recommended that you uninstall old versions of the
 SAT product stream to avoid confusion in the output of `sat showrev`. For more information,
-refer to the **Uninstall: Removing a Version of SAT** process in the SAT documentation.
+refer to **SAT Uninstall and Downgrade** in the SAT documentation.


### PR DESCRIPTION
# Description

Some sections in the SAT documentation were renamed and moved because of recent changes for IUF. References to these sections in docs-csm need to be updated.

Relates to:
- [STP-3525](https://jira-pro.its.hpecorp.net:8443/browse/STP-3525)

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.