### PR TITLE
CASMTRIAGE-4824 make install_csi hook more robust

### DIFF
--- a/workflows/ncn/hooks/before-all/install-csi.yaml
+++ b/workflows/ncn/hooks/before-all/install-csi.yaml
@@ -32,5 +32,23 @@ spec:
     source /srv/cray/scripts/metal/metal-lib.sh
     csi_url=$(paginate "https://packages.local/service/rest/v1/components?repository=csm-sle-15sp4" \
       | jq -r  '.items[] | .assets[] | .downloadUrl' | grep "cray-site-init" | sort -V | tail -1)
-    pdsh -S -w $(grep -oP 'ncn-\m\d+' /etc/hosts | sort -u | tr -t '\n' ',') "zypper install -y $csi_url"
+    if [[ -z $csi_url ]]; then
+      csi_url=$(paginate "https://packages.local/service/rest/v1/components?repository=csm-sle-15sp3" \
+        | jq -r  '.items[] | .assets[] | .downloadUrl' | grep "cray-site-init" | sort -V | tail -1)
+      if [[ -n $csi_url ]]; then
+        echo "WARNING  when upgrading or rebuilding to csm-1.4, the packages.local repository should be csm-sle-15sp4. However, no csi url was found \
+        in csm-sle-15sp4 and it was found in csm-sle-15sp3."
+      else
+        echo "ERROR no url for installing csi was found at https://packages.local/service/rest/v1/components?repository=csm-sle-15sp4 or https://packages.local/service/rest/v1/components?repository=csm-sle-15sp3."
+        echo "Check that nexus is functional."
+        exit 1
+      fi
+    fi
+    installed=$(pdsh -w $(grep -oP 'ncn-\m\d+' /etc/hosts | sort -u | tr -t '\n' ',') "zypper install -y $csi_url" | grep "cray-site-init.*done\|No update candidate for 'cray-site-init" | wc -l)
+    if [[ $installed -lt $(grep -oP 'ncn-\m\d+' /etc/hosts | sort -u | wc -l) ]]; then
+      echo "ERROR installing csi on master nodes. Make sure valid SSH keys exist from ncn-m001 to other master nodes. Manually run - zypper install -y $csi_url on master nodes."
+      exit 1
+    else
+      echo "csi successfully installed on master nodes"
+    fi
   templateRefName: ssh-template

--- a/workflows/ncn/hooks/before-all/install-csi.yaml
+++ b/workflows/ncn/hooks/before-all/install-csi.yaml
@@ -40,7 +40,7 @@ spec:
         in csm-sle-15sp4 and it was found in csm-sle-15sp3."
       else
         echo "ERROR no url for installing csi was found at https://packages.local/service/rest/v1/components?repository=csm-sle-15sp4 or https://packages.local/service/rest/v1/components?repository=csm-sle-15sp3."
-        echo "Check that nexus is functional."
+        echo "Check that Nexus is functional."
         exit 1
       fi
     fi

--- a/workflows/ncn/hooks/before-all/install-csi.yaml
+++ b/workflows/ncn/hooks/before-all/install-csi.yaml
@@ -30,19 +30,12 @@ metadata:
 spec:
   scriptContent: |
     source /srv/cray/scripts/metal/metal-lib.sh
-    csi_url=$(paginate "https://packages.local/service/rest/v1/components?repository=csm-sle-15sp4" \
+    csi_url=$(paginate "https://packages.local/service/rest/v1/components?repository=csm-sle-15sp3" \
       | jq -r  '.items[] | .assets[] | .downloadUrl' | grep "cray-site-init" | sort -V | tail -1)
     if [[ -z $csi_url ]]; then
-      csi_url=$(paginate "https://packages.local/service/rest/v1/components?repository=csm-sle-15sp3" \
-        | jq -r  '.items[] | .assets[] | .downloadUrl' | grep "cray-site-init" | sort -V | tail -1)
-      if [[ -n $csi_url ]]; then
-        echo "WARNING  when upgrading or rebuilding to csm-1.4, the packages.local repository should be csm-sle-15sp4. However, no csi url was found \
-        in csm-sle-15sp4 and it was found in csm-sle-15sp3."
-      else
-        echo "ERROR no url for installing csi was found at https://packages.local/service/rest/v1/components?repository=csm-sle-15sp4 or https://packages.local/service/rest/v1/components?repository=csm-sle-15sp3."
+        echo "ERROR no url for installing csi was found at https://packages.local/service/rest/v1/components?repository=csm-sle-15sp3."
         echo "Check that Nexus is functional."
         exit 1
-      fi
     fi
     installed=$(pdsh -w $(grep -oP 'ncn-\m\d+' /etc/hosts | sort -u | tr -t '\n' ',') "zypper install -y $csi_url" | grep "cray-site-init.*done\|No update candidate for 'cray-site-init" | wc -l)
     if [[ $installed -lt $(grep -oP 'ncn-\m\d+' /etc/hosts | sort -u | wc -l) ]]; then


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

Make install_csi hook more robust. It will check both sp3 and sp4 for link to install csi and will only fail if unable to install csi, independent of installing other repositories. Provides an error message if nexus appears to be down.

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
