### PR TITLE
CASMINST-5967

### DIFF
--- a/workflows/iuf/operations/extract-release-distributions.yaml
+++ b/workflows/iuf/operations/extract-release-distributions.yaml
@@ -164,7 +164,7 @@ spec:
           media_dir={{inputs.parameters.media_dir}}
           cd $media_dir
           dir_name=`tar -tzf {{inputs.parameters.tarfile}} | head -1 | cut -f1 -d"/"`
-          [ ! -f $dir_name/iuf-product-manifest.yaml ] && tar -xvzf {{inputs.parameters.tarfile}} &> /dev/stderr
+          tar -xvzf {{inputs.parameters.tarfile}} &> /dev/stderr
           cat ${dir_name}/iuf-product-manifest.yaml > /tmp/manifest.yaml
           echo $media_dir/$dir_name > /tmp/original_location
         volumeMounts:


### PR DESCRIPTION
CASMINST-5967 BREAK/FIX: IUF process-media doesn't extract full tarball when previous run is aborted halfway through

Unfortunately, an optimization that was made to process-media is now causing a critical issue whereby an IUF run is aborted during process-media, and the next run assumes the extraction was successful, and hence doesn't re-extract fully.

We need to either remove this optimization or insert a file containing the md5 sum of tarball when extract is complete in order to skip.

<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
