### PR TITLE
CASMINST-5935 / CASMINST-5904

### DIFF
--- a/operations/iuf/IUF.md
+++ b/operations/iuf/IUF.md
@@ -642,11 +642,16 @@ The following actions may be useful if errors are encountered when executing `iu
 - Examine IUF log files as described in the [Output and log files](#output-and-log-files) section for information not provided on `iuf` standard output.
 - Use the [Argo UI](../argo/Using_the_Argo_UI.md) to find the Argo pod that corresponds to the failed IUF operation. This can be done by finding the Argo workflow identifier displayed on [`iuf` standard output](#iuf-output) for the failed
   IUF operation and performing an Argo UI query with that value. Argo workflow identifiers can also be found by running [`iuf activity`](#activities). The Argo UI will provide additional log information that may help debug the issue.
+- There are two methods for limiting the list of Argo workflows displayed by the Argo UI.
+  1. Display a single workflow of an activity by specifying the Argo workflow identifier, e.g. `admin-230126-ebjx3-process-media-cq89t`, after the Argo UI "magnifying glass" icon.
+  1. Display all workflows for an IUF activity by specifying the activity identifier, e.g. `activity=admin-230126`, in the Argo UI `LABELS` filter.
 - If an error is associated with a script invoked by a product's [stage hook](#stages-and-hooks), the script can be found in the expanded product distribution file located in the media directory (`iuf -m MEDIA_DIR`). Examine the
   `hooks` entry in the product's `iuf-product-manifest.yaml` file in the media directory for the path to the script.
 - If the source of the error can not be determined by the previous methods, details on the underlying commands executed by an IUF stage can be found in the IUF `workflows` directory. The [Stages and hooks](#stages-and-hooks) section
   of this document includes links to descriptions of each stage. Each of those descriptions includes an **Execution Details** section describing how to find the appropriate code in the IUF `workflows` directory to understand the
   workflow and debug the issue.
+- If an Argo step fails, Argo will attempt to re-execute the step. If the retry succeeds, the failed step will still be displayed, colored red, in the Argo UI alongside the successful retry step, colored green. Although the failed
+  step is still displayed, it did not affect the success of the overall workflow and can be ignored.
 
 ## Recovering from failures
 

--- a/operations/iuf/examples/iuf_restart.md
+++ b/operations/iuf/examples/iuf_restart.md
@@ -1,3 +1,19 @@
 # `iuf restart` Examples
 
-[ IMPLEMENTATION PENDING ]
+(`ncn-m001#`) Begin executing stages `process-media` through `deliver-product` for activity `admin-230126`.
+
+```bash
+iuf -a admin-230126 run -b process-media -e deliver-product
+```
+
+(`ncn-m001#`) Forcefully abort activity `admin-230126` while it is still executing, causing the current stage to fail immediately.
+
+```bash
+iuf -a admin-230126 abort
+```
+
+(`ncn-m001#`) Restart activity `admin-230126` to re-execute all steps in all stages of the IUF session specified earlier via `iuf run`.
+
+```bash
+iuf -a admin-230126 restart
+```

--- a/operations/iuf/examples/iuf_resume.md
+++ b/operations/iuf/examples/iuf_resume.md
@@ -1,3 +1,20 @@
 # `iuf resume` Examples
 
-[ IMPLEMENTATION PENDING ]
+(`ncn-m001#`) Begin executing stages `process-media` through `deliver-product` for activity `admin-230126`.
+
+```bash
+iuf -a admin-230126 run -b process-media -e deliver-product
+```
+
+(`ncn-m001#`) Forcefully abort activity `admin-230126` while it is still executing, causing the current stage to fail immediately.
+
+```bash
+iuf -a admin-230126 abort -f
+```
+
+(`ncn-m001#`) Resume activity `admin-230126` to re-execute any failed or aborted steps in the most recent stage of the IUF session specified earlier via `iuf run` and then execute any remaining steps that were not run prior
+the execution of `iuf abort`.
+
+```bash
+iuf -a admin-230126 resume
+```

--- a/operations/iuf/stages/update_vcs_config.md
+++ b/operations/iuf/stages/update_vcs_config.md
@@ -45,7 +45,7 @@ The following describes how `update-vcs-config` determines how to create or merg
 - If the specified customer branch does not exist and a previous customer branch cannot be identified, the specified customer branch will be branched from the pristine branch.
 
 `update-vcs-config` will display information describing the operations performed. In the case of an error, such as a merge conflict, error information will be displayed and `iuf` will exit so the administrator can resolve the issue.
-Once it is resolved, the session can be continued with `iuf resume` or can be abandoned with `iuf abort`.
+Once it is resolved, the session can be continued with `iuf resume`, restarted with `iuf restart`, or abandoned with `iuf abort`.
 
 **`NOTE`** Any product-specific stage hooks specified for `update-vcs-config` will also be executed and may also create or modify VCS content. Refer to individual product documentation for information on any stage hook operations performed by the product.
 


### PR DESCRIPTION
Address IUF doc issues CASMINST-5935 and CASMINST-5904. 

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
