### PR TITLE
CASMINST-5979: Correct procedures for customizing NCN image timezone post-install

### DIFF
--- a/operations/README.md
+++ b/operations/README.md
@@ -73,6 +73,7 @@ Build and customize image recipes with the Image Management Service (IMS).
 - [Build a New UAN Image Using the Default Recipe](image_management/Build_a_New_UAN_Image_Using_the_Default_Recipe.md)
 - [Build an Image Using IMS REST Service](image_management/Build_an_Image_Using_IMS_REST_Service.md)
 - [Import External Image to IMS](image_management/Import_External_Image_to_IMS.md)
+- [Import NCN Image to IMS](image_management/Import_NCN_Image_to_IMS.md)
 - [Customize an Image Root Using IMS](image_management/Customize_an_Image_Root_Using_IMS.md)
   - [Create UAN Boot Images](image_management/Create_UAN_Boot_Images.md)
   - [Convert TGZ Archives to SquashFS Images](image_management/Convert_TGZ_Archives_to_SquashFS_Images.md)

--- a/operations/configuration_management/Management_Node_Image_Customization.md
+++ b/operations/configuration_management/Management_Node_Image_Customization.md
@@ -27,8 +27,8 @@ Specifically, determine the ID of the NCN boot image in the [Image Management Se
 How to do this varies depending on whether or not this procedure is being done as part of a CSM upgrade.
 
 * [Get IMS ID during CSM upgrade](#get-ims-id-during-csm-upgrade)
-* [Get IMS ID of booted NCN, outside of a CSM upgrade](#get-ims-id-of-booted-ncn-outside-of-a-csm-upgrade)
 * [Get IMS ID of any management NCN, outside of a CSM upgrade](#get-ims-id-of-any-management-ncn-outside-of-a-csm-upgrade)
+* [Get IMS ID of booted NCN, outside of a CSM upgrade](#get-ims-id-of-booted-ncn-outside-of-a-csm-upgrade)
 
 #### Get IMS ID during CSM upgrade
 
@@ -41,10 +41,60 @@ provided instructions for how to set the `NCN_IMS_IMAGE_ID` variable.
 NCN_IMS_IMAGE_ID=<UUID-value>
 ```
 
+#### Get IMS ID of any management NCN, outside of a CSM upgrade
+
+If not doing a CSM upgrade, then identify the image by examining that NCN's boot parameters in the
+[Boot Script Service (BSS)](../../glossary.md#boot-script-service-bss).
+
+> This procedure can be used whether or not the NCN in question is booted. It obtains the boot image which will be used the next time
+> that the NCN boots. This may not necessarily match what the NCN is currently booted with.
+
+1. (`ncn-mw#`) Set `NCN_XNAME` to the [component name (xname)](../../glossary.md#xname) of the NCN whose boot image is to be used.
+
+   * If customizing a Kubernetes NCN image, since this procedure is being carried out on a Kubernetes NCN, the simplest option is to use
+     the xname of the current node:
+
+     ```bash
+     NCN_XNAME=$(cat /etc/cray/xname)
+     echo "${NCN_XNAME}"
+     ```
+
+   * If customizing a Ceph NCN image, the same method can be used over SSH to a storage NCN:
+
+     For example:
+
+     ```bash
+     NCN_XNAME=$(ssh ncn-s001 cat /etc/cray/xname)
+     echo "${NCN_XNAME}"
+     ```
+
+1. (`ncn-mw#`) Extract the S3 path prefix for the image that will be used on the next boot of the chosen NCN.
+
+   This prefix corresponds to the IMS image ID of the boot image.
+
+   ```bash
+   NCN_IMS_IMAGE_ID=$(cray bss bootparameters list --name "${NCN_XNAME}" --format json | \
+                        jq -r '.[0].params' | \
+                        sed 's#\(^.*[[:space:]]\|^\)metal[.]server=[^[:space:]]*/boot-images/\([^[:space:]]\+\)/rootfs.*#\2#')
+   echo "${NCN_IMS_IMAGE_ID}"
+   ```
+
+   The output should be a UUID string. For example, `8f41cc54-82f8-436c-905f-869f216ce487`.
+
+   > The command used in this substep is extracting the location of the NCN image from the `metal.server` boot parameter for the
+   > NCN in BSS. For more information on that parameter, see [`metal.server` boot parameter](../../background/ncn_kernel.md#metalserver).
+
 #### Get IMS ID of booted NCN, outside of a CSM upgrade
 
 If not doing a CSM upgrade, and if the image to be modified is the image currently booted on an NCN, then identify the image
 by examining the boot parameters used to boot the NCN in question.
+
+> Notes:
+>
+> * Even after a CSM install is completed, all of the management NCNs except for `ncn-m001` will have been booted from the
+>   PIT node. For such nodes, this method will not work, because their boot parameters will be pointing to the PIT node rather than to S3.
+> * This method will not work for nodes which are booted from disk, only for nodes which booted over the network. Network boots are the default
+>   behavior, but disk boots may be necessary in special cases.
 
 1. (`ncn-mw#`) Set the `BOOTED_NCN` variable to the hostname of the NCN that is booted using the image that is to be modified.
 
@@ -71,44 +121,13 @@ by examining the boot parameters used to boot the NCN in question.
    > the `/proc/cmdline` file on the booted NCN. For more information on that parameter, see
    > [`metal.server` boot parameter](../../background/ncn_kernel.md#metalserver).
 
-#### Get IMS ID of any management NCN, outside of a CSM upgrade
-
-If not doing a CSM upgrade, and if the image to be modified is the boot image of an NCN that is not currently booted, then
-identify the image by examining that NCN's boot parameters in the
-[Boot Script Service (BSS)](../../glossary.md#boot-script-service-bss).
-
-> This procedure can also be used for an NCN which is booted, but the procedure obtains the boot image which will be used the next time
-> that the NCN boots. This may not necessarily match what the NCN is currently booted with.
-
-1. (`ncn-mw#`) Set `NCN_XNAME` to the [component name (xname)](../../glossary.md#xname) of the NCN whose boot image is to be used.
-
-   ```bash
-   NCN_XNAME=<xname>
-   ```
-
-1. (`ncn-mw#`) Extract the S3 path prefix for the image that will be used on the next boot of the chosen NCN.
-
-   This prefix corresponds to the IMS image ID of the boot image.
-
-   ```bash
-   NCN_IMS_IMAGE_ID=$(cray bss bootparameters list --name "${NCN_XNAME}" --format json | \
-                        jq -r '.[0].params' | \
-                        sed 's#\(^.*[[:space:]]\|^\)metal[.]server=[^[:space:]]*/boot-images/\([^[:space:]]\+\)/rootfs.*#\2#')
-   echo "${NCN_IMS_IMAGE_ID}"
-   ```
-
-   The output should be a UUID string. For example, `8f41cc54-82f8-436c-905f-869f216ce487`.
-
-   > The command used in this substep is extracting the location of the NCN image from the `metal.server` boot parameter for the
-   > NCN in BSS. For more information on that parameter, see [`metal.server` boot parameter](../../background/ncn_kernel.md#metalserver).
-
 ### 2. Create a CFS configuration, if needed
 
 If `sat bootprep` was used to create a configuration in the [Configuration Framework Service (CFS)](../../glossary.md#configuration-framework-service-cfs)
 for management node image customization, then one does not need to be created now.
 For example. this will be the case if this procedure is being followed as part of
 [Worker Image Customization](Worker_Image_Customization.md). If `sat bootprep` was used to create the CFS configuration,
-then skip this step and proceed to [Run the CFS image customization session](#4-run-the-cfs-image-customization-session).
+then skip this step and proceed to [Run the CFS image customization session](#3-run-the-cfs-image-customization-session).
 
 1. (`ncn-mw#`) Clone the `csm-config-management` repository.
 

--- a/operations/image_management/Import_External_Image_to_IMS.md
+++ b/operations/image_management/Import_External_Image_to_IMS.md
@@ -2,7 +2,11 @@
 
 The Image Management Service \(IMS\) is typically used to build images from IMS recipes and customize Images that are already known to IMS.
 However, it is sometimes the case that an image is built using a mechanism other than by IMS and needs to be added to IMS. In these cases,
-the following procedure can be used to add this external image to IMS and upload the image's artifact(s) to the Simple Storage Service (S3).
+the following procedure can be used to add this external image to IMS and upload the image's artifacts to the Simple Storage Service (S3).
+
+An automated tool is available to help the specific case of starting with image artifacts for a
+[Non-Compute Node (NCN)](../../glossary.md#non-compute-node-ncn) that are not yet in S3 or IMS. For more information, see
+[Import an NCN Image to IMS](Import_NCN_Image_to_IMS.md).
 
 * [Prerequisites](#prerequisites)
 * [Limitations](#limitations)
@@ -29,8 +33,6 @@ the following procedure can be used to add this external image to IMS and upload
   * An image root file is required.
   * Optionally, additional image artifacts may be specified including a kernel, `initrd`, and kernel parameters file.
 
-* A token providing S3 credentials has been generated.
-
 ## Limitations
 
 * The commands in this procedure must be run as the `root` user.
@@ -49,8 +51,8 @@ for example, for NCN boot images. If the actual set of image artifacts differs f
 
     IMS requires that an image's root filesystem is in SquashFS format. Select one of the following options based on the current state of the image root being used:
 
+    * If the image being added meets the above requirements, then skip the rest of this section and proceed to the next step.
     * If the image being added is in `tgz` format, then refer to [Convert TGZ Archives to SquashFS Images](Convert_TGZ_Archives_to_SquashFS_Images.md).
-    * If the image being added meets the above requirements, then proceed to [Create image record in IMS](#2-create-image-record-in-ims).
     * If the image root is in a format other than `tgz` or SquashFS, then convert the image root to `tgz`/SquashFS before continuing.
 
 ### 2. Set helper variables

--- a/operations/image_management/Import_NCN_Image_to_IMS.md
+++ b/operations/image_management/Import_NCN_Image_to_IMS.md
@@ -1,0 +1,103 @@
+# Import an NCN Image to IMS
+
+This page documents an automated tool which takes a set of [Non-Compute Node (NCN)](../../glossary.md#non-compute-node-ncn)
+kernel, `initrd`, and SquashFS artifact files, uploads them into the Simple Storage Service (S3), and registers them as an image in the
+[Image Management Service (IMS)](../../glossary.md#image-management-service-ims).
+
+For the more general (and more manual) procedure for how to register images in IMS, see
+[Import an External Image to IMS](Import_External_Image_to_IMS.md). In addition to providing a more detailed
+explanation of the various subtasks being carried out, that procedure also covers such variations as:
+
+* Converting to SquashFS from other formats
+* Importing images that are not for NCNs
+* Including boot parameters as part of the image manifest file
+
+* [Prerequisites](#prerequisites)
+* [Limitations](#limitations)
+* [Procedure](#procedure)
+    1. [Set helper variables](#1-set-helper-variables)
+    1. [Upload artifacts and create IMS image record](#2-upload-artifacts-and-create-ims-image-record)
+
+## Prerequisites
+
+* CSM is fully installed, configured, and healthy.
+  * The Image Management Service \(IMS\) is healthy.
+  * The Simple Storage Service \(S3\) is healthy.
+  * The NCN Certificate Authority \(CA\) public key has been properly installed into the CA cache for this system.
+  * These may be validated by performing the following health checks:
+    * [Platform health checks](../validate_csm_health.md#1-platform-health-checks)
+    * [Software Management Service health checks](../validate_csm_health.md#3-software-management-services-sms-health-checks)
+* The Cray CLI is configured.
+  * See [Configure the Cray CLI](../configure_cray_cli.md).
+* The CSM documentation RPM must be installed on the node where the procedure is being run. See
+  [Check for Latest Documentation](../../update_product_stream/README.md#check-for-latest-documentation).
+* Image artifact files are available on the system where the procedure is being run.
+  * A SquashFS image root file, a kernel file, and an `initrd` file are required.
+
+## Limitations
+
+* The commands in this procedure must be run as the `root` user.
+
+## Procedure
+
+This procedure may be run on any master or worker NCN.
+
+### 1. Set helper variables
+
+Set variables for all of the image artifact files: `IMS_ROOTFS_FILENAME`, `IMS_INITRD_FILENAME`, and `IMS_KERNEL_FILENAME`.
+
+1. (`ncn-mw#`) Set the `IMS_ROOTFS_FILENAME` variable to the path and file name of the SquashFS image root file.
+
+    For example:
+
+    ```bash
+    IMS_ROOTFS_FILENAME=my_ncn_artifacts/sles_15_image.squashfs
+    ```
+
+1. (`ncn-mw#`) Set the `IMS_INITRD_FILENAME` variable to the path and file name of the `initrd` file.
+
+    For example:
+
+    ```bash
+    IMS_INITRD_FILENAME=my_ncn_artifacts/initrd
+    ```
+
+1. (`ncn-mw#`) Set the `IMS_KERNEL_FILENAME` variable to the file name of the kernel file.
+
+    For example:
+
+    ```bash
+    IMS_KERNEL_FILENAME=my_ncn_artifacts/kernel
+    ```
+
+1. (`ncn-mw#`) Set the `IMS_IMAGE_NAME` variable to a name for the new image in IMS.
+
+    > This is just a label for the image in IMS -- it does not need to correspond to an actual artifact or file.
+
+    For example:
+
+    ```bash
+    IMS_IMAGE_NAME=rootfs-k8s-customized-version-2
+    ```
+
+### 2. Upload artifacts and create IMS image record
+
+1. (`ncn-mw#`) Set the path to the IMS image upload script.
+
+   ```bash
+   NCN_IMS_IMAGE_UPLOAD_SCRIPT=$(rpm -ql docs-csm | grep ncn-ims-image-upload[.]sh)
+   echo "${NCN_IMS_IMAGE_UPLOAD_SCRIPT}"
+   ```
+
+1. (`ncn-mw#`) Register the new NCN image in IMS.
+
+    ```bash
+    NEW_NCN_IMS_ID=$( "$NCN_IMS_IMAGE_UPLOAD_SCRIPT}" --no-cpc \
+                          -i "${IMS_INITRD_FILENAME}" \
+                          -k "${IMS_KERNEL_FILENAME}" \
+                          -s "${IMS_ROOTFS_FILENAME}" \
+                          -n "${IMS_IMAGE_NAME}" )
+    echo "${NEW_NCN_IMS_ID}"
+    ```
+
+    The IMS ID (in UUID format) of the new NCN image should be shown.

--- a/scripts/operations/node_management/ncn-ims-image-upload.sh
+++ b/scripts/operations/node_management/ncn-ims-image-upload.sh
@@ -22,82 +22,82 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-# shellcheck disable=SC2086
 
-test -n "$DEBUG" && set -x
+test -n "${DEBUG}" && set -x
 set -eo pipefail
 
 unset CRAY_FORMAT
+UPDATE_CPC=true
+
+function err_exit() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+function nonblank_arg_required() {
+    # $1 $2 ... current command line arguments
+    [[ $# -ge 2 ]] || err_exit "'$1' parameter requires an argument"
+    [[ -n $2 ]] || err_exit "Argument to '$1' parameter may not be empty"
+}
+
+function file_exists_nonempty() {
+    # $1 $2 ... current command line arguments
+    nonblank_arg_required "$@"
+    [[ -e $2 ]] || err_exit "File argument to '$1' does not exist: '$2'"
+    [[ -f $2 ]] || err_exit "File argument to '$1' exists but is not a regular file: '$2'"
+    [[ -s $2 ]] || err_exit "File argument to '$1' exists but is zero size: '$2'"
+}
+
+function update_cpc() {
+    [[ ${UPDATE_CPC} == true ]]
+}
 
 while [[ $# -gt 0 ]]; do
-    case $1 in
-        -k)
-            IMS_KERNEL_FILENAME=$2
-            shift
-            shift
-            ;;
-        -i)
-            IMS_INITRD_FILENAME=$2
-            shift
-            shift
-            ;;
-        -s)
-            IMS_ROOTFS_FILENAME=$2
-            shift
-            shift
-            ;;
+    case "$1" in
+        -i)         file_exists_nonempty  "$@" ; IMS_INITRD_FILENAME=$2 ; shift ;;
+        -k)         file_exists_nonempty  "$@" ; IMS_KERNEL_FILENAME=$2 ; shift ;;
+        -n)         nonblank_arg_required "$@" ; IMS_IMAGE_NAME=$2      ; shift ;;
+        -s)         file_exists_nonempty  "$@" ; IMS_ROOTFS_FILENAME=$2 ; shift ;;
+        --no-cpc)   UPDATE_CPC=false ;;
+        *)          err_exit "Unknown argument: '$1'" ;;
     esac
+    shift
 done
 
-if [ -z "$IMS_KERNEL_FILENAME" ]; then
-    echo "Error: required option (-k) is missing" >&2
-    exit 1
+[[ -n ${IMS_KERNEL_FILENAME} ]] || err_exit "Required option (-k) is missing"
+[[ -n ${IMS_INITRD_FILENAME} ]] || err_exit "Required option (-i) is missing"
+[[ -n ${IMS_ROOTFS_FILENAME} ]] || err_exit "Required option (-s) is missing"
+
+# Some parameters are only required if we're updating the product catalog
+if update_cpc; then
+
+    [[ -n ${CSM_RELEASE} ]] || err_exit "\$CSM_RELEASE is not specified"
+    [[ -n ${PITDATA} || -f /etc/pit-release ]] || err_exit "\$PITDATA is not specified"
+    [[ -n ${CSM_ARTI_DIR} || -n ${CSM_PATH} ]] || err_exit "One of \$CSM_ARTI_DIR or \$CSM_PATH must be set to the path of unpacked CSM tarball"
+
+    CSM_TARBALL=${CSM_ARTI_DIR:-$CSM_PATH}
+    CPC_VERSION=$(find "${CSM_TARBALL}"/docker/artifactory.algol60.net/csm-docker/stable/ -maxdepth 1 | awk -F':' /cray-product-catalog-update/'{print $NF}' | sort -V | tail -1)
 fi
 
-if [ -z "$IMS_INITRD_FILENAME" ]; then
-    echo "Error: required option (-i) is missing" >&2
-    exit 1
-fi
+IMS_ROOTFS_MD5SUM=$(md5sum "${IMS_ROOTFS_FILENAME}" | awk '{ print $1 }')
+IMS_INITRD_MD5SUM=$(md5sum "${IMS_INITRD_FILENAME}" | awk '{ print $1 }')
+IMS_KERNEL_MD5SUM=$(md5sum "${IMS_KERNEL_FILENAME}" | awk '{ print $1 }')
 
-if [ -z "$IMS_ROOTFS_FILENAME" ]; then
-    echo "Error: required option (-s) is missing" >&2
-    exit 1
-fi
+# Use default value for IMS image name if one was not passed in
+[[ -n ${IMS_IMAGE_NAME} ]] || IMS_IMAGE_NAME=$(basename "${IMS_ROOTFS_FILENAME}")
 
-if [[ -z ${CSM_RELEASE} ]]; then
-    echo "\$CSM_RELEASE is not specified" >&2
-    exit 1
-fi
-
-if [[ -z ${PITDATA} ]] && [[ -f /etc/pit-release ]]; then
-    echo "\$PITDATA is not specified"
-    exit 1
-fi
-
-if [[ -z ${CSM_ARTI_DIR} ]] && [[ -z ${CSM_PATH} ]]; then
-    echo "One of \$CSM_ARTI_DIR or \$CSM_PATH must be set to the path of unpacked CSM tarball" >&2
-    exit 1
-fi
-
-CSM_TARBALL=${CSM_ARTI_DIR:-$CSM_PATH}
-
-CPC_VERSION=$(find "$CSM_TARBALL"/docker/artifactory.algol60.net/csm-docker/stable/ -maxdepth 1 | awk -F':' /cray-product-catalog-update/'{print $NF}' | sort -V | tail -1)
-
-IMS_ROOTFS_MD5SUM=$(md5sum "$IMS_ROOTFS_FILENAME" | awk '{ print $1 }')
-IMS_INITRD_MD5SUM=$(md5sum "$IMS_INITRD_FILENAME" | awk '{ print $1 }')
-IMS_KERNEL_MD5SUM=$(md5sum "$IMS_KERNEL_FILENAME" | awk '{ print $1 }')
-
-IMS_IMAGE_NAME=$(basename "${IMS_ROOTFS_FILENAME}")
 IMS_IMAGE_ID=$(cray ims images create --name "${IMS_IMAGE_NAME}" --format json | jq -r .id)
-cray artifacts create boot-images "$IMS_IMAGE_ID/rootfs" "$IMS_ROOTFS_FILENAME" > /dev/null
-cray artifacts create boot-images "$IMS_IMAGE_ID/kernel" "$IMS_KERNEL_FILENAME" > /dev/null
-cray artifacts create boot-images "$IMS_IMAGE_ID/initrd" "$IMS_INITRD_FILENAME" > /dev/null
+cray artifacts create boot-images "${IMS_IMAGE_ID}/rootfs" "${IMS_ROOTFS_FILENAME}" > /dev/null
+cray artifacts create boot-images "${IMS_IMAGE_ID}/kernel" "${IMS_KERNEL_FILENAME}" > /dev/null
+cray artifacts create boot-images "${IMS_IMAGE_ID}/initrd" "${IMS_INITRD_FILENAME}" > /dev/null
 
-ROOTFS_ETAG=$( cray artifacts describe boot-images ${IMS_IMAGE_ID}/rootfs --format json | jq -r .artifact.ETag  | tr -d '"' )
-KERNEL_ETAG=$( cray artifacts describe boot-images ${IMS_IMAGE_ID}/kernel --format json | jq -r .artifact.ETag  | tr -d '"' )
-INITRD_ETAG=$( cray artifacts describe boot-images ${IMS_IMAGE_ID}/initrd --format json | jq -r .artifact.ETag  | tr -d '"' )
+ROOTFS_ETAG=$( cray artifacts describe boot-images "${IMS_IMAGE_ID}/rootfs" --format json | jq -r .artifact.ETag  | tr -d '"' )
+KERNEL_ETAG=$( cray artifacts describe boot-images "${IMS_IMAGE_ID}/kernel" --format json | jq -r .artifact.ETag  | tr -d '"' )
+INITRD_ETAG=$( cray artifacts describe boot-images "${IMS_IMAGE_ID}/initrd" --format json | jq -r .artifact.ETag  | tr -d '"' )
 
-cat <<EOF> ims_manifest.json
+IMS_MANIFEST_JSON=$(mktemp -p . ims_manifest_XXX.json)
+
+cat <<EOF> "${IMS_MANIFEST_JSON}"
 {
   "created": "$(date '+%Y-%m-%d %H:%M:%S')",
   "version": "1.0",
@@ -105,67 +105,72 @@ cat <<EOF> ims_manifest.json
     {
       "link": {
         "etag": "${ROOTFS_ETAG}",
-        "path": "s3://boot-images/$IMS_IMAGE_ID/rootfs",
+        "path": "s3://boot-images/${IMS_IMAGE_ID}/rootfs",
         "type": "s3"
       },
-      "md5": "$IMS_ROOTFS_MD5SUM",
+      "md5": "${IMS_ROOTFS_MD5SUM}",
       "type": "application/vnd.cray.image.rootfs.squashfs"
     },
     {
       "link": {
         "etag": "${KERNEL_ETAG}",
-        "path": "s3://boot-images/$IMS_IMAGE_ID/kernel",
+        "path": "s3://boot-images/${IMS_IMAGE_ID}/kernel",
         "type": "s3"
       },
-      "md5": "$IMS_KERNEL_MD5SUM",
+      "md5": "${IMS_KERNEL_MD5SUM}",
       "type": "application/vnd.cray.image.kernel"
     },
     {
       "link": {
         "etag": "${INITRD_ETAG}",
-        "path": "s3://boot-images/$IMS_IMAGE_ID/initrd",
+        "path": "s3://boot-images/${IMS_IMAGE_ID}/initrd",
         "type": "s3"
       },
-      "md5": "$IMS_INITRD_MD5SUM",
+      "md5": "${IMS_INITRD_MD5SUM}",
       "type": "application/vnd.cray.image.initrd"
     }
   ]
 }
 EOF
 
-cray artifacts create boot-images "$IMS_IMAGE_ID/manifest.json" ims_manifest.json > /dev/null
-MANIFEST_ETAG=$( cray artifacts describe boot-images ${IMS_IMAGE_ID}/manifest.json --format json | jq -r .artifact.ETag  | tr -d '"' )
+cray artifacts create boot-images "${IMS_IMAGE_ID}/manifest.json" "${IMS_MANIFEST_JSON}" > /dev/null
+MANIFEST_ETAG=$( cray artifacts describe boot-images "${IMS_IMAGE_ID}/manifest.json" --format json | jq -r .artifact.ETag  | tr -d '"' )
 
-cray ims images update "$IMS_IMAGE_ID" \
+cray ims images update "${IMS_IMAGE_ID}" \
         --link-type s3 \
         --link-etag "${MANIFEST_ETAG}" \
-        --link-path "s3://boot-images/$IMS_IMAGE_ID/manifest.json" > /dev/null
+        --link-path "s3://boot-images/${IMS_IMAGE_ID}/manifest.json" > /dev/null
 
-# shellcheck disable=SC2089
-PODMAN_RUN="podman run --rm --name ncn-cpc \
-    --user root \
-    -e PRODUCT=csm \
-    -e PRODUCT_VERSION=$CSM_RELEASE \
-    -e YAML_CONTENT_STRING=\"{images: {\"$IMS_IMAGE_NAME\": {id: \"$IMS_IMAGE_ID\"}}}\" \
-    -e KUBECONFIG=/.kube/admin.conf \
-    -e VALIDATE_SCHEMA=\"true\" \
-    -v /etc/kubernetes:/.kube:ro \
-    registry.local/artifactory.algol60.net/csm-docker/stable/cray-product-catalog-update:$CPC_VERSION"
+if update_cpc; then
 
-# shellcheck disable=SC2090
-if test -f /etc/pit-release; then
-    FM=$(jq -r '."Global"."meta-data"."first-master-hostname"' < "${PITDATA}"/configs/data.json)
-    ssh $FM $PODMAN_RUN >& /dev/null
-else
-    podman run --rm --name ncn-cpc \
+    # shellcheck disable=SC2089
+    PODMAN_RUN="podman run --rm --name ncn-cpc \
         --user root \
         -e PRODUCT=csm \
-        -e PRODUCT_VERSION=$CSM_RELEASE \
-        -e YAML_CONTENT_STRING="{images: {\"$IMS_IMAGE_NAME\": {id: \"$IMS_IMAGE_ID\"}}}" \
+        -e PRODUCT_VERSION=${CSM_RELEASE} \
+        -e YAML_CONTENT_STRING=\"{images: {\"${IMS_IMAGE_NAME}\": {id: \"${IMS_IMAGE_ID}\"}}}\" \
         -e KUBECONFIG=/.kube/admin.conf \
-        -e VALIDATE_SCHEMA="true" \
+        -e VALIDATE_SCHEMA=\"true\" \
         -v /etc/kubernetes:/.kube:ro \
-        registry.local/artifactory.algol60.net/csm-docker/stable/cray-product-catalog-update:$CPC_VERSION >& /dev/null
+        registry.local/artifactory.algol60.net/csm-docker/stable/cray-product-catalog-update:${CPC_VERSION}"
+
+    if [[ -f /etc/pit-release ]]; then
+        FM=$(jq -r '."Global"."meta-data"."first-master-hostname"' < "${PITDATA}"/configs/data.json)
+
+        # shellcheck disable=SC2090
+        ssh "${FM}" ${PODMAN_RUN} >& /dev/null
+    else
+        podman run --rm --name ncn-cpc \
+            --user root \
+            -e PRODUCT=csm \
+            -e PRODUCT_VERSION="${CSM_RELEASE}" \
+            -e YAML_CONTENT_STRING="{images: {\"$IMS_IMAGE_NAME\": {id: \"$IMS_IMAGE_ID\"}}}" \
+            -e KUBECONFIG=/.kube/admin.conf \
+            -e VALIDATE_SCHEMA="true" \
+            -v /etc/kubernetes:/.kube:ro \
+            registry.local/artifactory.algol60.net/csm-docker/stable/cray-product-catalog-update:"${CPC_VERSION}" >& /dev/null
+    fi
+
 fi
 
-echo "$IMS_IMAGE_ID"
+echo "${IMS_IMAGE_ID}"


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

The procedure to update NCN timezones has a few errors in it. In addition, after the CSM install is done, it really should only be used just for timezones, and passwords/SSH keys should be handled using CFS. This PR overhauls that procedure (and makes some small script tweaks) to accomplish the above. While writing and testing these changes, I found other odds and ends in related procedures that I also cleaned up with this PR.

I tested this on fanta except for actually updating the entries in BSS (but I did test the commands to do that -- I just had them echo rather than run the final command to do the update).

- [1.4 backport PR](https://github.com/Cray-HPE/docs-csm/pull/3310)
- [1.3 backport PR](https://github.com/Cray-HPE/docs-csm/pull/3311)

The PRs should be reviewed by at least one of the following folks before merging: @heemstra , @haasken-hpe , @deantroe , @don-bahls-hpe 

Notes/caveats:

- I eventually want to replace the manual code being used to update the BSS entries in this procedure. I wrote up a script to do it (just a more careful version of the basic shell commands being done), but I think that may be better off in a separate PR (just because this one is already getting on the large side). I know that the **csi** tool has that ability, but unless we're going to start making that available on the NCNs by default, I'd like to move away from relying on it for operational procedures (see [CASMINST-4784](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4784)).
- In a recent discussion with @haasken-hpe and @leliasen-hpe , we identified further changes which are going to be needed to procedures in this PR, as well as related procedures. However, more thought and planning is required before we make those. 

Given the above two points, some feedback for this PR may get shunted into a future ticket, since we know more work is required. The most important thing that this PR needs to be accomplishing is to fix the broken timezone procedure.

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
