### PR TITLE
CSAMINST-5982 abort worker rebuild workflow if managment-nodes-rollout is stopped

### DIFF
--- a/workflows/iuf/operations/management-nodes-rollout/management-nodes-rollout.yaml
+++ b/workflows/iuf/operations/management-nodes-rollout/management-nodes-rollout.yaml
@@ -383,6 +383,9 @@ spec:
       dag:
         tasks:
           - name: rebuild-set
+            hooks:
+              exit:
+                template: exit-worker-rebuild-set
             templateRef:
               name: ssh-template
               template: shell-script
@@ -471,6 +474,47 @@ spec:
           current_count="{{inputs.parameters.count}}"
           counter=$(($current_count + 1 ))
           echo $counter
+    - name: exit-worker-rebuild-set
+      dag:
+        tasks:
+          - name: clean-up-worker-rebuild
+            templateRef:
+              name: ssh-template
+              template: shell-script
+            arguments:
+              parameters:
+              - name: dryRun
+                value: "{{$.DryRun}}"
+              - name: scriptContent
+                value: |
+                  lifecycle_pods_exist=false
+                  int=0
+                  while [[ $int -lt 3 ]]; do
+                    if [[ -n $(kubectl get pods -n argo | grep "ncn-lifecycle-rebuild" | grep -v "Completed") ]]; then
+                      lifecycle_pods_exist=true
+                      break
+                    fi
+                    int=$(($int + 1))
+                    sleep 2
+                  done
+                  if $lifecycle_pods_exist; then
+                    echo "NOTCIE a worker rebuild workflow is still runnning, this will delete any running worker-rebuild pods and stop the worker rebuild workflow"
+                    removed_all_pods=false
+                    while ! $removed_all_pods; do
+                      lifecycle_pods=$(kubectl get pods -n argo | grep "ncn-lifecycle-rebuild" | grep -v "Completed" | awk '{print $1}') || lifecycle_pods=""
+                      for pod in $lifecycle_pods; do
+                        echo "INFO delete pod:$pod in argo namespace"
+                        kubectl delete pod -n argo $pod
+                      done
+                      sleep 10
+                      if [[ -z $(kubectl get pods -n argo | grep "ncn-lifecycle-rebuild" | grep -v "Completed" | awk '{print $1}') ]]; then
+                        echo "NOTICE all worker rebuild workflow pods have been deleted and the worker rebuild has been stopped."
+                        removed_all_pods=true
+                      fi
+                    done
+                  else
+                    echo "INFO  no worker rebuild workflow is running. This step is doing nothing. This is expected if the worker rebuild workflow completed or has stopped."
+                  fi
     - name: prom-metrics
       inputs:
         parameters:


### PR DESCRIPTION

<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

If the management-nodes-rollout IUF stage is stopped while rebuilding workers, this will delete any pods running for the worker rebuild workflow. The goal of this is to abort the worker rebuild workflow if the managment-nodes-rollout workflow is aborted.

The new logic has been tested on its own but this has not been tested with an IUF CLI abort.

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
