### PR TITLE
CASMPET-6332 replace less than and greater than signs with HTML entities

### DIFF
--- a/operations/utility_storage/Troubleshoot_ceph_image_with_none_tag.md
+++ b/operations/utility_storage/Troubleshoot_ceph_image_with_none_tag.md
@@ -1,8 +1,8 @@
-# Troubleshoot Ceph image with tag:'\<none\>'
+# Troubleshoot Ceph image with tag:'&lt;none&gt;'
 
-Use the following procedure to fix a ceph image with tag: \<none\>.
+Use the following procedure to fix a ceph image with tag: '&lt;none&gt;'.
 
-All of the following commands should be run from the storage node that contains ceph image with tag: \<none\>.
+All of the following commands should be run from the storage node that contains ceph image with tag: '&lt;none&gt;'.
 
 1. Run `podman images`.
 
@@ -33,7 +33,7 @@ All of the following commands should be run from the storage node that contains 
     ...
     ```
 
-1. Fix the tag by running the following script on the storage node with the tag: \<none\>.
+1. Fix the tag by running the following script on the storage node with the tag: '&lt;none&gt;'.
 
     1. Copy the script below and paste it into `/usr/share/doc/csm/scripts/fix_ceph_image_tag.sh`.
 

--- a/operations/utility_storage/Troubleshoot_ceph_image_with_none_tag.md
+++ b/operations/utility_storage/Troubleshoot_ceph_image_with_none_tag.md
@@ -1,8 +1,8 @@
 # Troubleshoot Ceph image with tag:'&lt;none&gt;'
 
-Use the following procedure to fix a ceph image with tag: '&lt;none&gt;'.
+Use the following procedure to fix a Ceph image with tag: '&lt;none&gt;'.
 
-All of the following commands should be run from the storage node that contains ceph image with tag: '&lt;none&gt;'.
+All of the following commands should be run from the storage node that contains Ceph image with tag: '&lt;none&gt;'.
 
 1. Run `podman images`.
 


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->
CASMPET-6332- replace less than and greater than signs with HTML entities
# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
