### PR TITLE
CASMINST-5979: Correct some NCN customization procedures

### DIFF
--- a/operations/README.md
+++ b/operations/README.md
@@ -71,6 +71,7 @@ Build and customize image recipes with the Image Management Service (IMS).
 - [Build a New UAN Image Using the Default Recipe](image_management/Build_a_New_UAN_Image_Using_the_Default_Recipe.md)
 - [Build an Image Using IMS REST Service](image_management/Build_an_Image_Using_IMS_REST_Service.md)
 - [Import External Image to IMS](image_management/Import_External_Image_to_IMS.md)
+- [Import NCN Image to IMS](image_management/Import_NCN_Image_to_IMS.md)
 - [Customize an Image Root Using IMS](image_management/Customize_an_Image_Root_Using_IMS.md)
   - [Create UAN Boot Images](image_management/Create_UAN_Boot_Images.md)
   - [Convert TGZ Archives to SquashFS Images](image_management/Convert_TGZ_Archives_to_SquashFS_Images.md)

--- a/operations/configuration_management/Management_Node_Image_Customization.md
+++ b/operations/configuration_management/Management_Node_Image_Customization.md
@@ -82,8 +82,12 @@ The Cray command line interface must be configured on the node where the command
     * If not doing a CSM upgrade, and if the image to be modified is the image currently booted on an NCN, then identify the image
       by examining the boot parameters used to boot the NCN in question.
 
-      > Note that even after a CSM install is completed, all of the management NCNs except for `ncn-m001` will have been booted from the
-      > PIT node. For such nodes, this method will not work, because their boot parameters will be pointing to the PIT node rather than to S3.
+      > Notes:
+      >
+      > * Even after a CSM install is completed, all of the management NCNs except for `ncn-m001` will have been booted from the
+      >   PIT node. For such nodes, this method will not work, because their boot parameters will be pointing to the PIT node rather than to S3.
+      > * This method will not work for nodes which are booted from disk, only for nodes which booted over the network. Network boots are the default
+      >   behavior, but disk boots may be necessary in special cases.
 
       1. Set the `BOOTED_NCN` variable to the hostname of the NCN that is booted using the image that is to be modified.
 

--- a/operations/image_management/Import_External_Image_to_IMS.md
+++ b/operations/image_management/Import_External_Image_to_IMS.md
@@ -2,7 +2,11 @@
 
 The Image Management Service \(IMS\) is typically used to build images from IMS recipes and customize Images that are already known to IMS.
 However, it is sometimes the case that an image is built using a mechanism other than by IMS and needs to be added to IMS. In these cases,
-the following procedure can be used to add this external image to IMS and upload the image's artifact(s) to the Simple Storage Service (S3).
+the following procedure can be used to add this external image to IMS and upload the image's artifacts to the Simple Storage Service (S3).
+
+An automated tool is available to help the specific case of starting with image artifacts for a
+[Non-Compute Node (NCN)](../../glossary.md#non-compute-node-ncn) that are not yet in S3 or IMS. For more information, see
+[Import an NCN Image to IMS](Import_NCN_Image_to_IMS.md).
 
 * [Prerequisites](#prerequisites)
 * [Limitations](#limitations)
@@ -29,8 +33,6 @@ the following procedure can be used to add this external image to IMS and upload
   * An image root file is required.
   * Optionally, additional image artifacts may be specified including a kernel, `initrd`, and kernel parameters file.
 
-* A token providing S3 credentials has been generated.
-
 ## Limitations
 
 * The commands in this procedure must be run as the `root` user.
@@ -49,8 +51,8 @@ for example, for NCN boot images. If the actual set of image artifacts differs f
 
     IMS requires that an image's root filesystem is in SquashFS format. Select one of the following options based on the current state of the image root being used:
 
+    * If the image being added meets the above requirements, then skip the rest of this section and proceed to the next step.
     * If the image being added is in `tgz` format, then refer to [Convert TGZ Archives to SquashFS Images](Convert_TGZ_Archives_to_SquashFS_Images.md).
-    * If the image being added meets the above requirements, then proceed to [Create image record in IMS](#2-create-image-record-in-ims).
     * If the image root is in a format other than `tgz` or SquashFS, then convert the image root to `tgz`/SquashFS before continuing.
 
 ### 2. Set helper variables

--- a/operations/image_management/Import_NCN_Image_to_IMS.md
+++ b/operations/image_management/Import_NCN_Image_to_IMS.md
@@ -1,0 +1,103 @@
+# Import an NCN Image to IMS
+
+This page documents an automated tool which takes a set of [Non-Compute Node (NCN)](../../glossary.md#non-compute-node-ncn)
+kernel, `initrd`, and SquashFS artifact files, uploads them into the Simple Storage Service (S3), and registers them as an image in the
+[Image Management Service (IMS)](../../glossary.md#image-management-service-ims).
+
+For the more general (and more manual) procedure for how to register images in IMS, see
+[Import an External Image to IMS](Import_External_Image_to_IMS.md). In addition to providing a more detailed
+explanation of the various subtasks being carried out, that procedure also covers such variations as:
+
+* Converting to SquashFS from other formats
+* Importing images that are not for NCNs
+* Including boot parameters as part of the image manifest file
+
+* [Prerequisites](#prerequisites)
+* [Limitations](#limitations)
+* [Procedure](#procedure)
+    1. [Set helper variables](#1-set-helper-variables)
+    1. [Upload artifacts and create IMS image record](#2-upload-artifacts-and-create-ims-image-record)
+
+## Prerequisites
+
+* CSM is fully installed, configured, and healthy.
+  * The Image Management Service \(IMS\) is healthy.
+  * The Simple Storage Service \(S3\) is healthy.
+  * The NCN Certificate Authority \(CA\) public key has been properly installed into the CA cache for this system.
+  * These may be validated by performing the following health checks:
+    * [Platform health checks](../validate_csm_health.md#1-platform-health-checks)
+    * [Software Management Service health checks](../validate_csm_health.md#3-software-management-services-sms-health-checks)
+* The Cray CLI is configured.
+  * See [Configure the Cray CLI](../configure_cray_cli.md).
+* The CSM documentation RPM must be installed on the node where the procedure is being run. See
+  [Check for Latest Documentation](../../update_product_stream/README.md#check-for-latest-documentation).
+* Image artifact files are available on the system where the procedure is being run.
+  * A SquashFS image root file, a kernel file, and an `initrd` file are required.
+
+## Limitations
+
+* The commands in this procedure must be run as the `root` user.
+
+## Procedure
+
+This procedure may be run on any master or worker NCN.
+
+### 1. Set helper variables
+
+Set variables for all of the image artifact files: `IMS_ROOTFS_FILENAME`, `IMS_INITRD_FILENAME`, and `IMS_KERNEL_FILENAME`.
+
+1. (`ncn-mw#`) Set the `IMS_ROOTFS_FILENAME` variable to the path and file name of the SquashFS image root file.
+
+    For example:
+
+    ```bash
+    IMS_ROOTFS_FILENAME=my_ncn_artifacts/sles_15_image.squashfs
+    ```
+
+1. (`ncn-mw#`) Set the `IMS_INITRD_FILENAME` variable to the path and file name of the `initrd` file.
+
+    For example:
+
+    ```bash
+    IMS_INITRD_FILENAME=my_ncn_artifacts/initrd
+    ```
+
+1. (`ncn-mw#`) Set the `IMS_KERNEL_FILENAME` variable to the file name of the kernel file.
+
+    For example:
+
+    ```bash
+    IMS_KERNEL_FILENAME=my_ncn_artifacts/kernel
+    ```
+
+1. (`ncn-mw#`) Set the `IMS_IMAGE_NAME` variable to a name for the new image in IMS.
+
+    > This is just a label for the image in IMS -- it does not need to correspond to an actual artifact or file.
+
+    For example:
+
+    ```bash
+    IMS_IMAGE_NAME=rootfs-k8s-customized-version-2
+    ```
+
+### 2. Upload artifacts and create IMS image record
+
+1. (`ncn-mw#`) Set the path to the IMS image upload script.
+
+   ```bash
+   NCN_IMS_IMAGE_UPLOAD_SCRIPT=$(rpm -ql docs-csm | grep ncn-ims-image-upload[.]sh)
+   echo "$NCN_IMS_IMAGE_UPLOAD_SCRIPT}"
+   ```
+
+1. (`ncn-mw#`) Register the new NCN image in IMS.
+
+    ```bash
+    NEW_NCN_IMS_ID=$( "$NCN_IMS_IMAGE_UPLOAD_SCRIPT}" --no-cpc \
+                          -i "${IMS_INITRD_FILENAME}" \
+                          -k "${IMS_KERNEL_FILENAME}" \
+                          -s "${IMS_ROOTFS_FILENAME}" \
+                          -n "${IMS_IMAGE_NAME}" )
+    echo "${NEW_NCN_IMS_ID}"
+    ```
+
+    The IMS ID (in UUID format) of the new NCN image should be shown.

--- a/operations/image_management/Import_NCN_Image_to_IMS.md
+++ b/operations/image_management/Import_NCN_Image_to_IMS.md
@@ -86,7 +86,7 @@ Set variables for all of the image artifact files: `IMS_ROOTFS_FILENAME`, `IMS_I
 
    ```bash
    NCN_IMS_IMAGE_UPLOAD_SCRIPT=$(rpm -ql docs-csm | grep ncn-ims-image-upload[.]sh)
-   echo "$NCN_IMS_IMAGE_UPLOAD_SCRIPT}"
+   echo "${NCN_IMS_IMAGE_UPLOAD_SCRIPT}"
    ```
 
 1. (`ncn-mw#`) Register the new NCN image in IMS.

--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
@@ -230,12 +230,12 @@ This step updates the entries in BSS for the NCNs to use the new images.
       for xname in "${K8S_XNAMES[@]}"; do
          echo "${xname}"
          cray bss bootparameters list --name "${xname}" --format json > "bss_${xname}.json" &&
-            sed -i.$(date +%Y%m%d_%H%M%S%N).orig "s@/${K8S_IMS_ID}\([\"/[:space:]]\)@/${NEW_K8S_IMS_ID}\1@g" "bss_${xname}.json" &&
-            kernel=$(cat "bss_${xname}.json" | jq '.[]  .kernel') &&
-            initrd=$(cat "bss_${xname}.json" | jq '.[]  .initrd') &&
-            params=$(cat "bss_${xname}.json" | jq '.[]  .params') &&
-            cray bss bootparameters update --initrd "${initrd}" --kernel "${kernel}" --params "${params}" --hosts "${xname}" --format json ||
-            echo "ERROR updating BSS for ${xname}"
+         sed -i.$(date +%Y%m%d_%H%M%S%N).orig "s@/${K8S_IMS_ID}\([\"/[:space:]]\)@/${NEW_K8S_IMS_ID}\1@g" "bss_${xname}.json" &&
+         kernel=$(cat "bss_${xname}.json" | jq -r '.[]  .kernel') &&
+         initrd=$(cat "bss_${xname}.json" | jq -r '.[]  .initrd') &&
+         params=$(cat "bss_${xname}.json" | jq -r '.[]  .params') &&
+         cray bss bootparameters update --initrd "${initrd}" --kernel "${kernel}" --params "${params}" --hosts "${xname}" --format json ||
+         echo "ERROR updating BSS for ${xname}"
       done
       ```
 
@@ -257,12 +257,12 @@ This step updates the entries in BSS for the NCNs to use the new images.
       for xname in "${CEPH_XNAMES[@]}"; do
          echo "${xname}"
          cray bss bootparameters list --name "${xname}" --format json > "bss_${xname}.json" &&
-            sed -i.$(date +%Y%m%d_%H%M%S%N).orig "s@/${CEPH_IMS_ID}\([\"/[:space:]]\)@/${NEW_CEPH_IMS_ID}\1@g" "bss_${xname}.json" &&
-            kernel=$(cat "bss_${xname}.json" | jq '.[]  .kernel') &&
-            initrd=$(cat "bss_${xname}.json" | jq '.[]  .initrd') &&
-            params=$(cat "bss_${xname}.json" | jq '.[]  .params') &&
-            cray bss bootparameters update --initrd "${initrd}" --kernel "${kernel}" --params "${params}" --hosts "${xname}" --format json ||
-            echo "ERROR updating BSS for ${xname}"
+         sed -i.$(date +%Y%m%d_%H%M%S%N).orig "s@/${CEPH_IMS_ID}\([\"/[:space:]]\)@/${NEW_CEPH_IMS_ID}\1@g" "bss_${xname}.json" &&
+         kernel=$(cat "bss_${xname}.json" | jq -r '.[]  .kernel') &&
+         initrd=$(cat "bss_${xname}.json" | jq -r '.[]  .initrd') &&
+         params=$(cat "bss_${xname}.json" | jq -r '.[]  .params') &&
+         cray bss bootparameters update --initrd "${initrd}" --kernel "${kernel}" --params "${params}" --hosts "${xname}" --format json ||
+         echo "ERROR updating BSS for ${xname}"
       done
       ```
 

--- a/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
+++ b/operations/security_and_authentication/Change_NCN_Image_Root_Password_and_SSH_Keys.md
@@ -1,40 +1,53 @@
 # Set NCN Image Root Password, SSH Keys, and Timezone
 
-Modify the NCN images by setting the `root` user password and adding SSH keys for the `root` user account.
-If desired, also change the timezone for the NCNs.
+This page outlines procedures to modify the following things for [Non-Compute Nodes (NCNs)](../../glossary.md#non-compute-node-ncn):
 
-This procedure shows this process being done any time after the first time installation of the CSM
-software has been completed and the PIT node is booted as a regular master node. To change the NCN images
-from the PIT node during CSM installation, see
-[Set NCN Image Root Password, SSH Keys, and Timezone on PIT Node](Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md).
+- `root` user password
+- `root` user SSH keys
+- Timezone
 
 All of the commands in this procedure are intended to be run on a single master or worker node.
+
+- [Prerequisites](#prerequisites)
+- [Changing `root` password and SSH keys](#changing-root-password-and-ssh-keys)
+- [Changing timezone](#changing-timezone)
 
 ## Prerequisites
 
 - This procedure can only be done after the PIT node is rebuilt to become a normal master node.
+  - To change the NCN images from the PIT node during CSM installation, see [Set NCN Image Root Password, SSH Keys, and Timezone on PIT Node](Change_NCN_Image_Root_Password_and_SSH_Keys_on_PIT_Node.md).
 - The Cray CLI must be configured on the node where the procedure is being done. See [Configure the Cray Command Line Interface](../configure_cray_cli.md).
 - The CSM documentation RPM must be installed on the node where the procedure is being run. See [Check for Latest Documentation](../../update_product_stream/README.md#check-for-latest-documentation).
 
-## Procedure
+## Changing `root` password and SSH keys
+
+In order to modify the `root` user password and/or SSH keys, first the desired values must be set in Vault. Then the
+[Configuration Framework Service (CFS)](../../glossary.md#configuration-framework-service-cfs)
+is used to take these values from Vault and make the changes to the running NCNs and/or the NCN images.
+
+1. Set the desired password and SSH keys in Vault.
+
+   See [Configure the root password and SSH keys in Vault](../CSM_product_management/Configure_Non-Compute_Nodes_with_CFS.md#2-configure-the-root-password-and-ssh-keys-in-vault).
+
+1. Make the changes on the running NCNs (if desired) using node personalization.
+
+   See [NCN Node Personalization](../configuration_management/NCN_Node_Personalization.md).
+
+1. Make the changes to the NCN images (if desired).
+
+   See [Management Node Image Customization](../configuration_management/Management_Node_Image_Customization.md).
+
+## Changing timezone
+
+The timezone only needs to be modified if a non-default (that is, non-UTC) timezone is desired. This procedure involves modifying the NCN image
+artifacts, registering the modified images in the [Image Management Service (IMS)](../../glossary.md#image-management-service-ims), updating the
+NCN entries in the [Boot Script Service (BSS)](../../glossary.md#boot-script-service-bss) to use the modified images,
+and finally rebuilding the NCNs to make the changes take effect.
 
 1. [Preparation](#1-preparation)
 1. [Get NCN artifacts](#2-get-ncn-artifacts)
 1. [Customize the images](#3-customize-the-images)
-
-    - [SSH keys](#ssh-keys)
-      - [Script-generated keys](#script-generated-keys)
-      - [Administrator-provided keys](#administrator-provided-keys)
-    - [Password](#password)
-      - [Use node password](#use-node-password)
-      - [Enter password and generate hash](#enter-password-and-generate-hash)
-    - [Timezone](#timezone)
-    - [Examples](#examples)
-      - [Example 1: New keys, copy password, keep UTC](#example-1-new-keys-copy-password-keep-utc)
-      - [Example 2: Provide keys, prompt for password, change timezone](#example-2-provide-keys-prompt-for-password-change-timezone)
-      - [Example 3: New keys, no password change, keep UTC, no prompting](#example-3-new-keys-no-password-change-keep-utc-no-prompting)
-
-1. [Upload artifacts into S3](#4-upload-artifacts-into-s3)
+1. [Import new images into IMS](#4-import-new-images-into-ims)
 1. [Update BSS](#5-update-bss)
 1. [Cleanup](#6-cleanup)
 1. [Rebuild NCNs](#7-rebuild-ncns)
@@ -49,106 +62,79 @@ mkdir -pv /run/initramfs/overlayfs/workingarea && cd /run/initramfs/overlayfs/wo
 
 ### 2. Get NCN artifacts
 
-1. (`ncn-mw#`) List available Kubernetes NCN images.
+The IMS image IDs of the current NCN images will be identified by examining the boot parameters of a Kubernetes NCN and a storage NCN in the
+[Boot Script Service (BSS)](../../glossary.md#boot-script-service-bss). This procedure can be used whether or not the NCNs in question are booted.
+It obtains the boot image which will be used the next time that the NCN boots. This may not necessarily match what the NCN is currently booted with.
 
-    The Kubernetes image is used by the master and worker nodes.
+1. (`ncn-mw#`) Get the ID of the Kubernetes NCN image in IMS.
 
-    ```bash
-    cray artifacts list ncn-images --format json | jq '.artifacts[] .Key' | grep k8s | grep squashfs
-    ```
+   1. Set `K8S_NCN_XNAME` to the [component name (xname)](../../glossary.md#xname) of a Kubernetes NCN.
 
-    Example output:
+      Since this procedure is being carried out on a Kubernetes NCN, the simplest thing to do is use the xname of the current node.
 
-    ```text
-    "k8s-filesystem.squashfs"
-    "k8s/0.1.107/filesystem.squashfs"
-    "k8s/0.1.109/filesystem.squashfs"
-    "k8s/0.1.48/filesystem.squashfs"
-    ```
+      ```bash
+      K8S_NCN_XNAME=$(cat /etc/cray/xname)
+      echo "${K8S_NCN_XNAME}"
+      ```
 
-1. (`ncn-mw#`) Set Kubernetes image version variables.
+   1. Extract the S3 path prefix for the image that will be used on the next boot of the chosen NCN.
 
-    - Set `K8SVERSION` to the version of the image to be modified.
-    - Set `K8SNEW` to the version label to use for the modified image.
+      This prefix corresponds to the IMS image ID of the boot image.
 
-    This example uses `k8s/0.1.109` for the current version and adds a suffix for the new version.
+      ```bash
+      K8S_IMS_ID=$(cray bss bootparameters list --name "${K8S_NCN_XNAME}" --format json | \
+                       jq -r '.[0].params' | \
+                       sed 's#\(^.*[[:space:]]\|^\)metal[.]server=[^[:space:]]*/boot-images/\([^[:space:]]\+\)/rootfs.*#\2#')
+      echo "${K8S_IMS_ID}"
+      ```
 
-    ```bash
-    K8SVERSION=0.1.109
-    K8SNEW=${K8SVERSION}-2
-    ```
+      The output should be a UUID string. For example, `8f41cc54-82f8-436c-905f-869f216ce487`.
 
-1. (`ncn-mw#`) Make a temporary directory for the Kubernetes artifacts using the current version string.
+      > The command used in this substep is extracting the location of the NCN image from the `metal.server` boot parameter for the
+      > NCN in BSS. For more information on that parameter, see [`metal.server` boot parameter](../../background/ncn_kernel.md#metalserver).
 
-    ```bash
-    mkdir -pv k8s/${K8SVERSION}
-    ```
+1. (`ncn-mw#`) Get the ID of the storage NCN image in IMS.
 
-1. (`ncn-mw#`) Download the Kubernetes NCN artifacts.
+   1. Set `CEPH_NCN_XNAME` to the xname of a storage NCN.
 
-    ```bash
-    for art in filesystem.squashfs initrd kernel ; do
-        cray artifacts get ncn-images k8s/${K8SVERSION}/${art} k8s/${K8SVERSION}/${art}
-    done
-    ```
+      For example:
 
-1. (`ncn-mw#`) List available Ceph images.
+      ```bash
+      CEPH_NCN_XNAME=$(ssh ncn-s001 cat /etc/cray/xname)
+      echo "${CEPH_NCN_XNAME}"
+      ```
 
-    The Ceph image is used by the utility storage nodes.
+   1. Get the IMS ID of the Ceph NCN image.
 
-    ```bash
-    cray artifacts list ncn-images --format json | jq '.artifacts[] .Key' | grep ceph | grep squashfs
-    ```
+      ```bash
+      CEPH_IMS_ID=$(cray bss bootparameters list --name "${CEPH_NCN_XNAME}" --format json | \
+                       jq -r '.[0].params' | \
+                       sed 's#\(^.*[[:space:]]\|^\)metal[.]server=[^[:space:]]*/boot-images/\([^[:space:]]\+\)/rootfs.*#\2#')
+      echo "${CEPH_IMS_ID}"
+      ```
 
-    Example output:
+      The output should be a UUID string. For example, `8f41cc54-82f8-436c-905f-869f216ce487`.
 
-    ```text
-    "ceph-filesystem.squashfs"
-    "ceph/0.1.107/filesystem.squashfs"
-    "ceph/0.1.113/filesystem.squashfs"
-    "ceph/0.1.48/filesystem.squashfs"
-    ```
+1. (`ncn-mw#`) Make temporary directories for the artifacts using the ID strings.
 
-1. (`ncn-mw#`) Set Ceph image version variables.
+   ```bash
+   K8S_DIR="$(pwd)/k8s/${K8S_IMS_ID}"
+   CEPH_DIR="$(pwd)/ceph/${CEPH_IMS_ID}"
+   mkdir -pv "${K8S_DIR}" "${CEPH_DIR}"
+   ```
 
-    - Set `CEPHVERSION` to the version of the image to be modified.
-    - Set `CEPHNEW` to the version label to use for the modified image.
+1. (`ncn-mw#`) Download the NCN artifacts.
 
-    This example uses `ceph/0.1.113` for the current version and adds a suffix for the new version.
-
-    ```bash
-    CEPHVERSION=0.1.113
-    CEPHNEW=${CEPHVERSION}-2
-    ```
-
-1. (`ncn-mw#`) Make a temporary directory for the Ceph artifacts using the current version string.
-
-    ```bash
-    mkdir -pv ceph/${CEPHVERSION}
-    ```
-
-1. (`ncn-mw#`) Download the storage NCN artifacts.
-
-    ```bash
-    for art in filesystem.squashfs initrd kernel ; do
-        cray artifacts get ncn-images ceph/${CEPHVERSION}/${art} ceph/${CEPHVERSION}/${art}
-    done
-    ```
+   ```bash
+   for art in rootfs initrd kernel ; do
+       cray artifacts get boot-images "${K8S_IMS_ID}/${art}" "${K8S_DIR}/${art}"
+       cray artifacts get boot-images "${CEPH_IMS_ID}/${art}" "${CEPH_DIR}/${art}"
+   done
+   ```
 
 ### 3. Customize the images
 
-Add SSH keys and the `root` password to the NCN SquashFS images. Optionally set their timezone, if a timezone other than UTC
-(the default) is desired. This is all done by running the `ncn-image-modification.sh` script.
-
-(`ncn-mw#`) Set the path to the script:
-
-```bash
-NCN_MOD_SCRIPT=$(rpm -ql docs-csm | grep ncn-image-modification[.]sh)
-```
-
-This document provides common ways of using the script to accomplish this. However, specific environments may require
-deviations from these examples. In those cases, it may be helpful to view the complete script usage statement by running
-it with only the `-h` argument.
+This is done by running the `ncn-image-modification.sh` script.
 
 The Kubernetes NCN image location is specified with the `-k` argument to the script, and the storage NCN image location is
 specified with the `-s` argument to the script. Both images should be customized with a single call to the script to ensure that
@@ -157,150 +143,67 @@ they receive matching customizations, unless specifically desiring otherwise.
 The new customized images are created in their original image's directory. They have the same name as the original image, except
 with the `secure-` prefix added. The original image is moved into a subdirectory named `old`, for backup purposes.
 
-There are several choices to be made during this process:
+1. (`ncn-mw#`) Set the path to the script.
 
-- SSH key files can be provided to the script, or the script can generate them itself.
-- The hashed `root` password can be provided to the script, or the script can prompt for password entry when it is running.
-- To use a non-default timezone, that must be passed into the script.
+   ```bash
+   NCN_MOD_SCRIPT=$(rpm -ql docs-csm | grep ncn-image-modification[.]sh)
+   echo "${NCN_MOD_SCRIPT}"
+   ```
 
-#### SSH keys
+1. (`ncn-mw#`) Designate the desired timezone for the NCN images.
 
-##### Script-generated keys
+   Set the `NCN_TZ` variable to the desired timezone (for example, `America/Chicago`).
+   Valid timezone options can be listed by running `timedatectl list-timezones`.
 
-To have the script generate the SSH keys automatically, it must be provided with the `ssh-keygen` options to use.
+   ```bash
+   NCN_TZ=<desired timezone>
+   echo "${NCN_TZ}"
+   ```
 
-- To view the complete list of supported `ssh-keygen` options, view the script usage statement by running it with the `-h` argument.
-- If the `-N` option is not used to specify the passphrase, then the script will prompt for the passphrase when it generates the keys.
-  - Even specifying an empty passphrase will prevent being prompted to enter the passphrase during script execution.
-    See [Example 3](#example-3-new-keys-no-password-change-keep-utc-no-prompting).
+1. (`ncn-mw#`) Run the script to change the timezone in the images.
 
-##### Administrator-provided keys
+   The default timezone in the NCN images is UTC. This is changed by passing the `-Z` argument to the script.
 
-To provide SSH keys to the script, specify the directory containing them with the `-d` argument.
+   ```bash
+   "${NCN_MOD_SCRIPT}" -Z "${NCN_TZ}" \
+                       -k ${K8S_DIR}/rootfs \
+                       -s ${CEPH_DIR}/rootfs
+   ```
 
-- The script assumes that public keys in that directory have the `.pub` file extension.
-- The entire contents of this directory will be copied into the `/root/.ssh` directory in the images.
-- After copying the directory contents, the script updates the `/root/.ssh/authorized_keys` file in the images
-  with the new public keys.
-  - This is usually the desired behavior, but it can be overridden by specifying the `-a` argument. In that
-    case, the script will **not** update the `authorized_keys` file after copying the directory contents.
+### 4. Import new images into IMS
 
-#### Password
+1. (`ncn-mw#`) Set the path to the IMS image upload script.
 
-In order for the script to set `root` passwords in the images, the `-p` argument must be included when calling it.
+   ```bash
+   NCN_IMS_IMAGE_UPLOAD_SCRIPT=$(rpm -ql docs-csm | grep ncn-ims-image-upload[.]sh)
+   echo "$NCN_IMS_IMAGE_UPLOAD_SCRIPT}"
+   ```
 
-If the `SQUASHFS_ROOT_PW_HASH` environment variable is exported, the script will use that as the new `root` password hash for the images.
-Otherwise, the script will prompt for the password to be entered during its execution.
-
-##### Use node password
-
-(`ncn-mw#`) If wanting to use the same `root` user password that is being used on the node where this procedure is being run, then
-the following command can be used to set the `SQUASHFS_ROOT_PW_HASH` variable.
-
-```bash
-export SQUASHFS_ROOT_PW_HASH=$(awk -F':' /^root:/'{print $2}' < /etc/shadow)
-```
-
-##### Enter password and generate hash
-
-(`ncn-mw#`) The following script can be used to manually enter a new password, and then generate its hash.
-
-> This script uses `read -s` to prevent the password from being echoed to the screen or saved
-> in the shell history. It unsets the plaintext password variables at the end, so that only
-> the hash is preserved.
-
-```bash
-read -r -s -p "Enter root password for NCN images: " PW1 ; echo ; if [[ -z ${PW1} ]]; then
-    echo "ERROR: Password cannot be blank"
-else
-    read -r -s -p "Enter again: " PW2
-    echo
-    if [[ ${PW1} != ${PW2} ]]; then
-        echo "ERROR: Passwords do not match"
-    else
-        export SQUASHFS_ROOT_PW_HASH=$(echo -n "${PW1}" | openssl passwd -6 -salt $(< /dev/urandom tr -dc ./A-Za-z0-9 | head -c4) --stdin)
-        [[ -n ${SQUASHFS_ROOT_PW_HASH} ]] && echo "Password hash set and exported" || echo "ERROR: Problem generating hash"
-    fi
-fi ; unset PW1 PW2
-```
-
-#### Timezone
-
-The default timezone in the NCN images is UTC. This can optionally be changed by passing the `-z` argument to the
-script. Valid timezone options can be listed by running `timedatectl list-timezones`.
-
-#### Examples
-
-##### Example 1: New keys, copy password, keep UTC
-
-(`ncn-mw#`) This example has the script generate new SSH keys (prompting the administrator for the SSH key passphrase) and
-copies the `root` user password from the current node. It does not change the timezone from the UTC default.
-
-```bash
-export SQUASHFS_ROOT_PW_HASH=$(awk -F':' /^root:/'{print $2}' < /etc/shadow)
-$NCN_MOD_SCRIPT -p \
-                -t rsa \
-                -k k8s/${K8SVERSION}/filesystem.squashfs \
-                -s ceph/${CEPHVERSION}/filesystem.squashfs
-```
-
-##### Example 2: Provide keys, prompt for password, change timezone
-
-(`ncn-mw#`) This example uses existing SSH keys located in the `/my/pre-existing/keys` directory. The script prompts the
-administrator for the `root` user password during execution. It changes the timezone to `America/Chicago`.
-
-```bash
-$NCN_MOD_SCRIPT -p \
-                -d /my/pre-existing/keys \
-                -z America/Chicago \
-                -k k8s/${K8SVERSION}/filesystem.squashfs \
-                -s ceph/${CEPHVERSION}/filesystem.squashfs
-```
-
-##### Example 3: New keys, no password change, keep UTC, no prompting
-
-(`ncn-mw#`) This example has the script generate new SSH keys. It does not change the `root` password, nor does it
-change the timezone from the UTC default. A blank passphrase is provided, so that the script requires
-no input from the administrator while it is running.
-
-```bash
-$NCN_MOD_SCRIPT -t rsa \
-                -N "" \
-                -k k8s/${K8SVERSION}/filesystem.squashfs \
-                -s ceph/${CEPHVERSION}/filesystem.squashfs
-```
-
-### 4. Upload artifacts into S3
-
-1. (`ncn-mw#`) Upload the new Kubernetes image into S3.
+1. (`ncn-mw#`) Register the new Kubernetes image in IMS.
 
     ```bash
-    cray artifacts create boot-images k8s/${K8SNEW}/filesystem.squashfs k8s/${K8SVERSION}/secure-filesystem.squashfs
+    NEW_K8S_IMS_ID=$( "${NCN_IMS_IMAGE_UPLOAD_SCRIPT}" --no-cpc \
+                          -i "${K8S_DIR}/initrd" \
+                          -k "${K8S_DIR}/kernel" \
+                          -s "${K8S_DIR}/secure-rootfs" \
+                          -n "rootfs-k8s-${K8S_IMS_ID}-tz" )
+    echo "${NEW_K8S_IMS_ID}"
     ```
 
-1. (`ncn-mw#`) Upload the Kubernetes kernel and `initrd` into S3 under the new version string.
+    The IMS ID (in UUID format) of the new Kubernetes image should be shown.
+
+1. (`ncn-mw#`) Register the new Ceph image in IMS.
 
     ```bash
-    for art in initrd kernel ; do
-        cray artifacts create boot-images k8s/${K8SNEW}/${art} k8s/${K8SVERSION}/${art}
-    done
+    NEW_CEPH_IMS_ID=$( "$NCN_IMS_IMAGE_UPLOAD_SCRIPT}" --no-cpc \
+                          -i "${CEPH_DIR}/initrd" \
+                          -k "${CEPH_DIR}/kernel" \
+                          -s "${CEPH_DIR}/secure-rootfs" \
+                          -n "rootfs-ceph-${CEPH_IMS_ID}-tz" )
+    echo "${NEW_CEPH_IMS_ID}"
     ```
 
-1. (`ncn-mw#`) Upload the new Ceph image into S3.
-
-    ```bash
-    cray artifacts create boot-images ceph/${CEPHNEW}/filesystem.squashfs ceph/${CEPHVERSION}/secure-filesystem.squashfs
-    ```
-
-1. (`ncn-mw#`) Upload the Ceph kernel and `initrd` into S3 under the new version string.
-
-    ```bash
-    for art in initrd kernel ; do
-        cray artifacts create boot-images ceph/${CEPHNEW}/${art} ceph/${CEPHVERSION}/${art}
-    done
-    ```
-
-The Kubernetes and storage images now have the image changes.
+    The IMS ID (in UUID format) of the new Kubernetes image should be shown.
 
 ### 5. Update BSS
 
@@ -310,39 +213,58 @@ This step updates the entries in BSS for the NCNs to use the new images.
 
 1. (`ncn-mw#`) Update BSS for master and worker nodes.
 
-    > This uses the `K8SVERSION` and `K8SNEW` variables defined earlier.
+   1. Make a list of xnames of Kubernetes NCNs.
 
-    ```bash
-    for node in $(grep -oP "(ncn-[mw]\w+)" /etc/hosts | sort -u); do
-        echo $node
-        xname=$(ssh $node cat /etc/cray/xname)
-        echo $xname
-        cray bss bootparameters list --name $xname --format json > bss_$xname.json
-        sed -i.$(date +%Y%m%d_%H%M%S%N).orig "s@/k8s/${K8SVERSION}\([\"/[:space:]]\)@/k8s/${K8SNEW}\1@g" bss_$xname.json
-        kernel=$(cat bss_$xname.json | jq '.[]  .kernel')
-        initrd=$(cat bss_$xname.json | jq '.[]  .initrd')
-        params=$(cat bss_$xname.json | jq '.[]  .params')
-        cray bss bootparameters update --initrd $initrd --kernel $kernel --params "$params" --hosts $xname --format json
-    done
-    ```
+      ```bash
+      K8S_XNAMES=( $(cray hsm state components list --role Management --type Node --format json |
+                         jq -r '.Components | .[] | select( .SubRole == "Master" or .SubRole == "Worker" ) | .ID' |
+                         tr '\n' ' ') )
+      echo "${#K8S_XNAMES[@]} Kubernetes NCNs found: ${K8S_XNAMES[@]}"
+      ```
+
+   1. Update BSS entries for each Kubernetes NCN xname.
+
+      > This uses the `K8S_IMS_ID` and `NEW_K8S_IMS_ID` variables defined earlier.
+
+      ```bash
+      for xname in "${K8S_XNAMES[@]}"; do
+         echo "${xname}"
+         cray bss bootparameters list --name "${xname}" --format json > "bss_${xname}.json" &&
+            sed -i.$(date +%Y%m%d_%H%M%S%N).orig "s@/${K8S_IMS_ID}\([\"/[:space:]]\)@/${NEW_K8S_IMS_ID}\1@g" "bss_${xname}.json" &&
+            kernel=$(cat "bss_${xname}.json" | jq '.[]  .kernel') &&
+            initrd=$(cat "bss_${xname}.json" | jq '.[]  .initrd') &&
+            params=$(cat "bss_${xname}.json" | jq '.[]  .params') &&
+            cray bss bootparameters update --initrd "${initrd}" --kernel "${kernel}" --params "${params}" --hosts "${xname}" --format json ||
+            echo "ERROR updating BSS for ${xname}"
+      done
+      ```
 
 1. (`ncn-mw#`) Update BSS for utility storage nodes.
 
-    > This uses the `CEPHVERSION` and `CEPHNEW` variables defined earlier.
+   1. Make a list of xnames of storage NCNs.
 
-    ```bash
-    for node in $(grep -oP "(ncn-s\w+)" /etc/hosts | sort -u); do
-        echo $node
-        xname=$(ssh $node cat /etc/cray/xname)
-        echo $xname
-        cray bss bootparameters list --name $xname --format json > bss_$xname.json
-        sed -i.$(date +%Y%m%d_%H%M%S%N).orig "s@/ceph/${CEPHVERSION}\([\"/[:space:]]\)@/ceph/${CEPHNEW}\1@g" bss_$xname.json
-        kernel=$(cat bss_$xname.json | jq '.[]  .kernel')
-        initrd=$(cat bss_$xname.json | jq '.[]  .initrd')
-        params=$(cat bss_$xname.json | jq '.[]  .params')
-        cray bss bootparameters update --initrd $initrd --kernel $kernel --params "$params" --hosts $xname --format json
-    done
-    ```
+      ```bash
+      CEPH_XNAMES=( $(cray hsm state components list --role Management --subrole Storage --type Node --format json | 
+                          jq -r '.Components | map(.ID) | join(" ")') )
+      echo "${#CEPH_XNAMES[@]} storage NCNs found: ${CEPH_XNAMES[@]}"
+      ```
+
+   1. Update BSS entries for each Kubernetes NCN xname.
+
+      > This uses the `CEPH_IMS_ID` and `NEW_CEPH_IMS_ID` variables defined earlier.
+
+      ```bash
+      for xname in "${CEPH_XNAMES[@]}"; do
+         echo "${xname}"
+         cray bss bootparameters list --name "${xname}" --format json > "bss_${xname}.json" &&
+            sed -i.$(date +%Y%m%d_%H%M%S%N).orig "s@/${CEPH_IMS_ID}\([\"/[:space:]]\)@/${NEW_CEPH_IMS_ID}\1@g" "bss_${xname}.json" &&
+            kernel=$(cat "bss_${xname}.json" | jq '.[]  .kernel') &&
+            initrd=$(cat "bss_${xname}.json" | jq '.[]  .initrd') &&
+            params=$(cat "bss_${xname}.json" | jq '.[]  .params') &&
+            cray bss bootparameters update --initrd "${initrd}" --kernel "${kernel}" --params "${params}" --hosts "${xname}" --format json ||
+            echo "ERROR updating BSS for ${xname}"
+      done
+      ```
 
 ### 6. Cleanup
 

--- a/scripts/operations/node_management/ncn-image-modification.sh
+++ b/scripts/operations/node_management/ncn-image-modification.sh
@@ -41,10 +41,9 @@ SUPPLIED_HASH="${SQUASHFS_ROOT_PW_HASH:-""}"
 TIMEZONE=""
 TZ_ONLY="no"
 
-function tz_only
+function tz_only()
 {
     [[ ${TZ_ONLY} == yes ]]
-    return $?
 }
 
 function cleanup() {
@@ -174,7 +173,7 @@ function process_args() {
                 ;;
             -b)
                 # Check for mutually exclusive combinations
-                [[ -z ${SSH_KEY_DIR} ]] || usage_exit "-d cannot be specified with -b"
+                [[ -z ${SSH_KEY_DIR} ]] || usage_exit "-b cannot be specified with -d"
                 [[ ${TZ_ONLY} != yes ]] || usage_exit "-b cannot be specified with -Z"
 
                 SSH_KEYGEN_ARGS+=("-b $2")
@@ -183,7 +182,7 @@ function process_args() {
                 ;;
             -C)
                 # Check for mutually exclusive combinations
-                [[ -z ${SSH_KEY_DIR} ]] || usage_exit "-d cannot be specified with -C"
+                [[ -z ${SSH_KEY_DIR} ]] || usage_exit "-C cannot be specified with -d"
                 [[ ${TZ_ONLY} != yes ]] || usage_exit "-C cannot be specified with -Z"
 
                 # ensure the comment is quoted in case it contains spaces
@@ -193,7 +192,7 @@ function process_args() {
                 ;;
             -d)
                 # Check for mutually exclusive combinations
-                [[ ${#SSH_KEYGEN_ARGS[*]} -eq 0 ]] || usage_exit "-d cannot be specified along with ssk-keygen arguments"
+                [[ ${#SSH_KEYGEN_ARGS[*]} -eq 0 ]] || usage_exit "-d cannot be specified along with ssh-keygen arguments"
                 [[ ${TZ_ONLY} != yes ]] || usage_exit "-d cannot be specified with -Z"
 
                 SSH_KEY_DIR=$2
@@ -211,7 +210,7 @@ function process_args() {
                 ;;
             -N)
                 # Check for mutually exclusive combinations
-                [[ -z ${SSH_KEY_DIR} ]] || usage_exit "-d cannot be specified with -N"
+                [[ -z ${SSH_KEY_DIR} ]] || usage_exit "-N cannot be specified with -d"
                 [[ ${TZ_ONLY} != yes ]] || usage_exit "-N cannot be specified with -Z"
 
                 # escape quotes in case passphrase is empty
@@ -233,7 +232,7 @@ function process_args() {
                 ;;
             -t)
                 # Check for mutually exclusive combinations
-                [[ -z ${SSH_KEY_DIR} ]] || usage_exit "-d cannot be specified with -t"
+                [[ -z ${SSH_KEY_DIR} ]] || usage_exit "-t cannot be specified with -d"
                 [[ ${TZ_ONLY} != yes ]] || usage_exit "-t cannot be specified with -Z"
 
                 KEYTYPE=$2
@@ -252,9 +251,9 @@ function process_args() {
                 ;;
             -Z)
                 # Check for mutually exclusive arguments
-                [[ -z ${SSH_KEY_DIR} ]] || usage_exit "-d cannot be specified with -Z"
-                [[ ${#SSH_KEYGEN_ARGS[*]} -eq 0 ]] || usage_exit "-Z cannot be specified along with ssk-keygen arguments"
-                [[ ${CHANGE_PASSWORD} == no ]] || usage_exit "-p cannot be specified with -Z"
+                [[ -z ${SSH_KEY_DIR} ]] || usage_exit "-Z cannot be specified with -d"
+                [[ ${#SSH_KEYGEN_ARGS[*]} -eq 0 ]] || usage_exit "-Z cannot be specified along with ssh-keygen arguments"
+                [[ ${CHANGE_PASSWORD} == no ]] || usage_exit "-Z cannot be specified with -p"
 
                 TIMEZONE="$2"
                 TZ_ONLY="yes"

--- a/scripts/operations/node_management/ncn-image-modification.sh
+++ b/scripts/operations/node_management/ncn-image-modification.sh
@@ -41,8 +41,7 @@ SUPPLIED_HASH="${SQUASHFS_ROOT_PW_HASH:-""}"
 TIMEZONE=""
 TZ_ONLY="no"
 
-function tz_only()
-{
+function tz_only() {
     [[ ${TZ_ONLY} == yes ]]
 }
 
@@ -127,15 +126,13 @@ function usage() {
 
 }
 
-function usage_exit()
-{
+function usage_exit() {
     echo "ERROR: $*" >&2
     usage
     exit 1
 }
 
-function err_exit()
-{
+function err_exit() {
     echo "ERROR: $*" >&2
     exit 1
 }

--- a/scripts/operations/node_management/ncn-image-modification.sh
+++ b/scripts/operations/node_management/ncn-image-modification.sh
@@ -26,7 +26,6 @@
 set -eo pipefail
 test -n "$DEBUG" && set -x
 
-
 # Globals
 CHANGE_PASSWORD="no"
 CLEANUP_INVOKED="no"
@@ -40,7 +39,13 @@ SSH_KEY_DIR=""
 START_DIR=$PWD
 SUPPLIED_HASH="${SQUASHFS_ROOT_PW_HASH:-""}"
 TIMEZONE=""
+TZ_ONLY="no"
 
+function tz_only
+{
+    [[ ${TZ_ONLY} == yes ]]
+    return $?
+}
 
 function cleanup() {
     local squashfs_root
@@ -68,20 +73,18 @@ function cleanup() {
     cd "$START_DIR"
 }
 
-
 function err_report() {
     echo "Error on line $1"
     cleanup
 }
 
-
 # it's a trap!
 trap 'err_report $LINENO' ERR TERM HUP INT
 trap 'cleanup' EXIT
 
-
 function usage() {
     echo -e "Usage: $(basename "$0") [-p] [-d dir] [ -z timezone] [-k kubernetes-squashfs-file] [-s storage-squashfs-file] [ssh-keygen arguments]\n"
+    echo -e "Usage: $(basename "$0") [ -Z timezone] [-k kubernetes-squashfs-file] [-s storage-squashfs-file]\n"
     echo    "       This script semi-automates the process of changing the timezone, root"
     echo    "       password, and adding new ssh keys for the root user to the NCN squashfs"
     echo -e "       image(s).\n"
@@ -106,6 +109,7 @@ function usage() {
     echo -e "                      being prompted.\n"
     echo    "       -z timezone    By default the timezone on NCNs is UTC. Use this option to"
     echo -e "                      override.\n"
+    echo -e "       -Z timezone    Same as -z, except SSH keys and passwords are not modified in the image."
     echo -e "SUPPORTED SSH-KEYGEN ARGUMENTS\n"
     echo    "       The following ssh-keygen(1) arguments are supported by this script:"
     echo    "       [-b bits] [-t dsa | ecdsa | ecdsa-sk | ed25519 | ed25519-sk | rsa]"
@@ -124,24 +128,23 @@ function usage() {
 
 }
 
-
-function preflight_sanity() {
-    if [ "$(whoami)" != "root" ]; then
-        echo "ERROR: the script must be run by the root user"
-        exit 1
-    fi
-
-    if ! command -v ssh-keygen >& /dev/null; then
-        echo "ERROR: ssh-keygen was not found on the system"
-        exit 1
-    fi
-
-    if ! command -v mksquashfs >& /dev/null; then
-        echo "ERROR: mksquashfs was not found on the system"
-        exit 1
-    fi
+function usage_exit
+{
+    echo "ERROR: $*" >&2
+    usage
+    exit 1
 }
 
+function err_exit
+{
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+function preflight_sanity() {
+    [ "$(whoami)" == "root" ] || err_exit "the script must be run by the root user"
+    command -v mksquashfs >& /dev/null || err_exit "mksquashfs was not found on the system"
+}
 
 function verify_ssh_keys() {
     local key_dir=$1
@@ -155,53 +158,47 @@ function verify_ssh_keys() {
     for key in $private_keys; do
         touch "$TMPDIR"/empty-file
         # we're only looking for malformed keys here vs ensuring private & public keys match, etc.
-        if ! ssh-keygen -Y sign -f "$key" -n file "$TMPDIR"/empty-file; then
-            echo "ERROR: unable to verify private key: $key"
-            exit 1
-        fi
+        ssh-keygen -Y sign -f "$key" -n file "$TMPDIR"/empty-file || err_exit "unable to verify private key: $key"
     done
 }
-
 
 function process_args() {
     while [[ $# -gt 0 ]]; do
         case $1 in
             -a)
+                # Technically this is mutually exclusive with -Z, but practically -Z kind of implies -a anyway,
+                # so the behavior should match what the person wants anyway. Therefore, not checking for that
+                # combination.
                 MODIFY_AUTHORIZED_KEYS="no"
                 shift # past argument
                 ;;
             -b)
-                if [ -n "$SSH_KEY_DIR" ]; then
-                    echo "-d cannot be specified with -b"
-                    usage
-                    exit 1
-                fi
+                # Check for mutually exclusive combinations
+                [[ -z ${SSH_KEY_DIR} ]] || usage_exit "-d cannot be specified with -b"
+                [[ ${TZ_ONLY} != yes ]] || usage_exit "-b cannot be specified with -Z"
+
                 SSH_KEYGEN_ARGS+=("-b $2")
                 shift # past argument
                 shift # past value
                 ;;
             -C)
-                if [ -n "$SSH_KEY_DIR" ]; then
-                    echo "-d cannot be specified with -C"
-                    usage
-                    exit 1
-                fi
+                # Check for mutually exclusive combinations
+                [[ -z ${SSH_KEY_DIR} ]] || usage_exit "-d cannot be specified with -C"
+                [[ ${TZ_ONLY} != yes ]] || usage_exit "-C cannot be specified with -Z"
+
                 # ensure the comment is quoted in case it contains spaces
                 SSH_KEYGEN_ARGS+=("-C \"$2\"")
                 shift # past argument
                 shift # past value
                 ;;
             -d)
-                if [ ${#SSH_KEYGEN_ARGS[*]} -ne 0 ]; then
-                    echo "-d cannot be specified along with ssk-keygen arguments"
-                    usage
-                    exit 1
-                fi
+                # Check for mutually exclusive combinations
+                [[ ${#SSH_KEYGEN_ARGS[*]} -eq 0 ]] || usage_exit "-d cannot be specified along with ssk-keygen arguments"
+                [[ ${TZ_ONLY} != yes ]] || usage_exit "-d cannot be specified with -Z"
+
                 SSH_KEY_DIR=$2
-                if ! test -d "$SSH_KEY_DIR"; then
-                    echo "ERROR: directory $SSH_KEY_DIR not found"
-                    exit 1
-                fi
+                [[ -d ${SSH_KEY_DIR} ]] || usage_exit "directory not found or not a directory: ${SSH_KEY_DIR}"
+
                 # no longer using TMPDIR for keys
                 KEY_SOURCE=$SSH_KEY_DIR
                 verify_ssh_keys "$KEY_SOURCE"
@@ -213,11 +210,10 @@ function process_args() {
                 exit 0
                 ;;
             -N)
-                if [ -n "$SSH_KEY_DIR" ]; then
-                    echo "-d cannot be specified with -N"
-                    usage
-                    exit 1
-                fi
+                # Check for mutually exclusive combinations
+                [[ -z ${SSH_KEY_DIR} ]] || usage_exit "-d cannot be specified with -N"
+                [[ ${TZ_ONLY} != yes ]] || usage_exit "-N cannot be specified with -Z"
+
                 # escape quotes in case passphrase is empty
                 SSH_KEYGEN_ARGS+=("-N \"$2\"")
                 shift # past argument
@@ -229,22 +225,39 @@ function process_args() {
                 shift # past value
                 ;;
             -p)
+                # Check for mutually exclusive combinations
+                [[ ${TZ_ONLY} != yes ]] || usage_exit "-p cannot be specified with -Z"
+
                 CHANGE_PASSWORD="yes"
                 shift # past argument
                 ;;
             -t)
-                if [ -n "$SSH_KEY_DIR" ]; then
-                    echo "-d cannot be specified with -t"
-                    usage
-                    exit 1
-                fi
+                # Check for mutually exclusive combinations
+                [[ -z ${SSH_KEY_DIR} ]] || usage_exit "-d cannot be specified with -t"
+                [[ ${TZ_ONLY} != yes ]] || usage_exit "-t cannot be specified with -Z"
+
                 KEYTYPE=$2
                 SSH_KEYGEN_ARGS+=("-t $2")
                 shift # past argument
                 shift # past value
                 ;;
             -z)
+                # Technically this is mutually exclusive with -Z, but practically -Z kind of implies -z anyway,
+                # so the behavior should match what the person wants anyway. Therefore, not checking for that
+                # combination.
+
                 TIMEZONE="$2"
+                shift # past argument
+                shift # past value
+                ;;
+            -Z)
+                # Check for mutually exclusive arguments
+                [[ -z ${SSH_KEY_DIR} ]] || usage_exit "-d cannot be specified with -Z"
+                [[ ${#SSH_KEYGEN_ARGS[*]} -eq 0 ]] || usage_exit "-Z cannot be specified along with ssk-keygen arguments"
+                [[ ${CHANGE_PASSWORD} == no ]] || usage_exit "-p cannot be specified with -Z"
+
+                TIMEZONE="$2"
+                TZ_ONLY="yes"
                 shift # past argument
                 shift # past value
                 ;;
@@ -262,18 +275,24 @@ function process_args() {
         fi
     fi
 
-    if [ -z "$SSH_KEY_DIR" ] && [ ${#SSH_KEYGEN_ARGS[*]} -eq 0 ]; then
-        echo "ERROR: refusing to create new images without ssh keys. Please use the -d option"
-        echo "       or supply ssh-keygen arguments on the command line."
-        usage
-        exit 1
-    fi
+    # Some things only need to be done if not in TZ-only mode
+    if ! tz_only ; then
 
-    if [ -n "$KEYTYPE" ]; then
-        SSH_KEYGEN_ARGS+=("-f $KEY_SOURCE/id_$KEYTYPE")
+        command -v ssh-keygen >& /dev/null || err_exit "ssh-keygen was not found on the system"
+
+        if [ -z "$SSH_KEY_DIR" ] && [ ${#SSH_KEYGEN_ARGS[*]} -eq 0 ]; then
+            echo "ERROR: refusing to create new images without ssh keys. Please use the -d option"
+            echo "       or supply ssh-keygen arguments on the command line."
+            usage
+            exit 1
+        fi
+
+        if [ -n "$KEYTYPE" ]; then
+            SSH_KEYGEN_ARGS+=("-f $KEY_SOURCE/id_$KEYTYPE")
+        fi
+
     fi
 }
-
 
 function verify_and_unsquash() {
     local squash
@@ -295,7 +314,6 @@ function verify_and_unsquash() {
     done
 }
 
-
 function update_etc_shadow() {
     local squashfs_root=$1
     local seconds_per_day=$(( 60*60*24 ))
@@ -303,7 +321,6 @@ function update_etc_shadow() {
 
     sed -i "/^root:/c\root:$SUPPLIED_HASH:$days_since_1970::::::" "$squashfs_root"/etc/shadow
 }
-
 
 function set_timezone() {
     local squashfs_root
@@ -331,7 +348,7 @@ function set_timezone() {
     fi
 }
 
-
+# Technically, setup ssh and passwords
 function setup_ssh() {
     local name
     local squash
@@ -374,7 +391,6 @@ function setup_ssh() {
     done
 }
 
-
 function create_new_squashfs() {
     local name
     local new_name
@@ -413,7 +429,11 @@ fi
 preflight_sanity
 process_args "$@"
 verify_and_unsquash
-setup_ssh
+
+if ! tz_only; then
+    setup_ssh
+fi
+
 set_timezone
 create_new_squashfs
 cleanup

--- a/scripts/operations/node_management/ncn-image-modification.sh
+++ b/scripts/operations/node_management/ncn-image-modification.sh
@@ -127,14 +127,14 @@ function usage() {
 
 }
 
-function usage_exit
+function usage_exit()
 {
     echo "ERROR: $*" >&2
     usage
     exit 1
 }
 
-function err_exit
+function err_exit()
 {
     echo "ERROR: $*" >&2
     exit 1

--- a/scripts/operations/node_management/ncn-ims-image-upload.sh
+++ b/scripts/operations/node_management/ncn-ims-image-upload.sh
@@ -28,20 +28,20 @@ set -eo pipefail
 
 unset CRAY_FORMAT
 
-function err_exit
+function err_exit()
 {
     echo "ERROR: $*" >&2
     exit 1
 }
 
-function nonblank_arg_required
+function nonblank_arg_required()
 {
     # $1 $2 ... current command line arguments
     [[ $# -ge 2 ]] || err_exit "'$1' parameter requires an argument"
     [[ -n $2 ]] || err_exit "Argument to '$1' parameter may not be empty"
 }
 
-function file_exists_nonempty
+function file_exists_nonempty()
 {
     # $1 $2 ... current command line arguments
     nonblank_arg_required "$@"

--- a/scripts/operations/node_management/ncn-ims-image-upload.sh
+++ b/scripts/operations/node_management/ncn-ims-image-upload.sh
@@ -28,21 +28,18 @@ set -eo pipefail
 
 unset CRAY_FORMAT
 
-function err_exit()
-{
+function err_exit() {
     echo "ERROR: $*" >&2
     exit 1
 }
 
-function nonblank_arg_required()
-{
+function nonblank_arg_required() {
     # $1 $2 ... current command line arguments
     [[ $# -ge 2 ]] || err_exit "'$1' parameter requires an argument"
     [[ -n $2 ]] || err_exit "Argument to '$1' parameter may not be empty"
 }
 
-function file_exists_nonempty()
-{
+function file_exists_nonempty() {
     # $1 $2 ... current command line arguments
     nonblank_arg_required "$@"
     [[ -e $2 ]] || err_exit "File argument to '$1' does not exist: '$2'"

--- a/scripts/operations/node_management/ncn-ims-image-upload.sh
+++ b/scripts/operations/node_management/ncn-ims-image-upload.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+test -n "${DEBUG}" && set -x
+set -eo pipefail
+
+unset CRAY_FORMAT
+
+function err_exit
+{
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+function nonblank_arg_required
+{
+    # $1 $2 ... current command line arguments
+    [[ $# -ge 2 ]] || err_exit "'$1' parameter requires an argument"
+    [[ -n $2 ]] || err_exit "Argument to '$1' parameter may not be empty"
+}
+
+function file_exists_nonempty
+{
+    # $1 $2 ... current command line arguments
+    nonblank_arg_required "$@"
+    [[ -e $2 ]] || err_exit "File argument to '$1' does not exist: '$2'"
+    [[ -f $2 ]] || err_exit "File argument to '$1' exists but is not a regular file: '$2'"
+    [[ -s $2 ]] || err_exit "File argument to '$1' exists but is zero size: '$2'"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -i)         file_exists_nonempty  "$@" ; IMS_INITRD_FILENAME=$2 ; shift ;;
+        -k)         file_exists_nonempty  "$@" ; IMS_KERNEL_FILENAME=$2 ; shift ;;
+        -n)         nonblank_arg_required "$@" ; IMS_IMAGE_NAME=$2      ; shift ;;
+        -s)         file_exists_nonempty  "$@" ; IMS_ROOTFS_FILENAME=$2 ; shift ;;
+        --no-cpc)   ;; # This argument is implemented in future versions of the script, so we allow it to be
+                       # passed here, even though it is the default behavior for this version of the script.
+        *)          err_exit "Unknown argument: '$1'" ;;
+    esac
+    shift
+done
+
+[[ -n ${IMS_KERNEL_FILENAME} ]] || err_exit "Required option (-k) is missing"
+[[ -n ${IMS_INITRD_FILENAME} ]] || err_exit "Required option (-i) is missing"
+[[ -n ${IMS_ROOTFS_FILENAME} ]] || err_exit "Required option (-s) is missing"
+
+IMS_ROOTFS_MD5SUM=$(md5sum "${IMS_ROOTFS_FILENAME}" | awk '{ print $1 }')
+IMS_INITRD_MD5SUM=$(md5sum "${IMS_INITRD_FILENAME}" | awk '{ print $1 }')
+IMS_KERNEL_MD5SUM=$(md5sum "${IMS_KERNEL_FILENAME}" | awk '{ print $1 }')
+
+# Use default value for IMS image name if one was not passed in
+[[ -n ${IMS_IMAGE_NAME} ]] || IMS_IMAGE_NAME=$(basename "${IMS_ROOTFS_FILENAME}")
+
+IMS_IMAGE_ID=$(cray ims images create --name "${IMS_IMAGE_NAME}" --format json | jq -r .id)
+cray artifacts create boot-images "${IMS_IMAGE_ID}/rootfs" "${IMS_ROOTFS_FILENAME}" > /dev/null
+cray artifacts create boot-images "${IMS_IMAGE_ID}/kernel" "${IMS_KERNEL_FILENAME}" > /dev/null
+cray artifacts create boot-images "${IMS_IMAGE_ID}/initrd" "${IMS_INITRD_FILENAME}" > /dev/null
+
+ROOTFS_ETAG=$( cray artifacts describe boot-images "${IMS_IMAGE_ID}/rootfs" --format json | jq -r .artifact.ETag  | tr -d '"' )
+KERNEL_ETAG=$( cray artifacts describe boot-images "${IMS_IMAGE_ID}/kernel" --format json | jq -r .artifact.ETag  | tr -d '"' )
+INITRD_ETAG=$( cray artifacts describe boot-images "${IMS_IMAGE_ID}/initrd" --format json | jq -r .artifact.ETag  | tr -d '"' )
+
+IMS_MANIFEST_JSON=$(mktemp -p . ims_manifest_XXX.json)
+
+cat <<EOF> "${IMS_MANIFEST_JSON}"
+{
+  "created": "$(date '+%Y-%m-%d %H:%M:%S')",
+  "version": "1.0",
+  "artifacts": [
+    {
+      "link": {
+        "etag": "${ROOTFS_ETAG}",
+        "path": "s3://boot-images/${IMS_IMAGE_ID}/rootfs",
+        "type": "s3"
+      },
+      "md5": "${IMS_ROOTFS_MD5SUM}",
+      "type": "application/vnd.cray.image.rootfs.squashfs"
+    },
+    {
+      "link": {
+        "etag": "${KERNEL_ETAG}",
+        "path": "s3://boot-images/${IMS_IMAGE_ID}/kernel",
+        "type": "s3"
+      },
+      "md5": "${IMS_KERNEL_MD5SUM}",
+      "type": "application/vnd.cray.image.kernel"
+    },
+    {
+      "link": {
+        "etag": "${INITRD_ETAG}",
+        "path": "s3://boot-images/${IMS_IMAGE_ID}/initrd",
+        "type": "s3"
+      },
+      "md5": "${IMS_INITRD_MD5SUM}",
+      "type": "application/vnd.cray.image.initrd"
+    }
+  ]
+}
+EOF
+
+cray artifacts create boot-images "${IMS_IMAGE_ID}/manifest.json" "${IMS_MANIFEST_JSON}" > /dev/null
+MANIFEST_ETAG=$( cray artifacts describe boot-images "${IMS_IMAGE_ID}/manifest.json" --format json | jq -r .artifact.ETag  | tr -d '"' )
+
+cray ims images update "${IMS_IMAGE_ID}" \
+        --link-type s3 \
+        --link-etag "${MANIFEST_ETAG}" \
+        --link-path "s3://boot-images/${IMS_IMAGE_ID}/manifest.json" > /dev/null
+
+echo "${IMS_IMAGE_ID}"


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/docs-csm/pull/3299

This includes backporting just the IMS upload portion of the ncn-ims-image-upload.sh script (and not the cray-product-catalog part of it), so that it can be used to simplify some of the procedures.