### PR TITLE
CASMPET-6315 : DOCS : Cert renewal - update kubeadm [alpha] kubeconifg user

### DIFF
--- a/operations/kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md
+++ b/operations/kubernetes/Cert_Renewal_for_Kubernetes_and_Bare_Metal_EtcD.md
@@ -374,27 +374,32 @@ Run the following steps on each master node.
                /root/kubelet_certs.tar /etc/kubernetes/kubelet.conf /var/lib/kubelet/pki/
    ```
 
-2. Log into the master node where the other certificates were updated.
+2. Log into the master node that has the `kubeadm` configuration file to generate new `kubelet.conf` files.
 
-   1. Get the current `apiserver-advertise-address`.
+   1. Find the master node with the `/etc/cray/kubernetes/kubeadmin.yaml` file.
 
       ```bash
-      kubectl config view|grep server
+      ncn# MASTERNODE=$(for node in ncn-m00{1..3}; do ssh root@$node test -f /etc/cray/kubernetes/kubeadm.yaml && echo $node && break; done)
+      ncn# echo $MASTERNODE
       ```
 
       Example output:
 
       ```text
-      server: https://10.252.120.2:6442
+      ncn-m002
       ```
 
-   1. Generate a new `kubelet.conf` file in the `/root/` directory with the IP address from the previous command.
-
-      **`NOTE`** The `apiserver-advertise-address` may vary, so do not copy and paste without verifying.
+   1. Log into the master
 
       ```bash
-      for node in $(kubectl get nodes -o json|jq -r '.items[].metadata.name'); do kubeadm alpha kubeconfig user --org system:nodes \
-                               --client-name system:node:$node --apiserver-advertise-address 10.252.120.2 --apiserver-bind-port 6442 > /root/$node.kubelet.conf; done
+      ncn# ssh $MASTERNODE
+      ```
+
+   1. Generate a new `kubelet.conf` file in the `/root/` directory.
+
+      ```bash
+      ncn-m# for node in $(kubectl get nodes -o json|jq -r '.items[].metadata.name'); do kubeadm kubeconfig user --org system:nodes \
+                               --client-name system:node:$node --config /etc/cray/kubernetes/kubeadm.yaml | sed "/WARNING/d" > /root/$node.kubelet.conf; done
       ```
 
       There should be a new `kubelet.conf` file per node running Kubernetes.


### PR DESCRIPTION
# Description
Update the "kubeadm [alpha] kubeconfig user" command to use the --config argument.  The --apiserver-advertise-address and --apiserver-bind-port arguments are no longer supported.  In CSM 1.3+ the 'alpha' portion of the 'kubeadm' command is optional so this is being removed in the CSM 1.3+ versions of the doc.

Resolves [CASMPET-6315](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6315) for CSM 1.3
Backports of this change for CSM 1.4 and main branch are in progress.

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
