### PR TITLE
CASMINST-5994 create new loop for rebuild-worker-nodes due to argo bug

### DIFF
--- a/workflows/iuf/operations/management-nodes-rollout/management-nodes-rollout.yaml
+++ b/workflows/iuf/operations/management-nodes-rollout/management-nodes-rollout.yaml
@@ -436,6 +436,8 @@ spec:
                   value: "{{tasks.move-to-next-set.outputs.result}}"
                 - name: limit
                   value: "{{inputs.parameters.limit}}"
+                - name: global_params
+                  value: "{{inputs.parameters.global_params}}"
     - name: process-sets
       inputs:
         parameters:

--- a/workflows/iuf/operations/management-nodes-rollout/management-nodes-rollout.yaml
+++ b/workflows/iuf/operations/management-nodes-rollout/management-nodes-rollout.yaml
@@ -35,8 +35,6 @@ spec:
   entrypoint: main
   templates:
     - name: main
-      parallelism: 1
-      failFast: true
       metrics:
         prometheus:
         - name: operation_counter
@@ -184,29 +182,40 @@ spec:
                         index=$(( $index + 1 ))
                         set="${set},""$node"
                         if [[ $index -eq $rebuild_set_size ]]; then
-                          output="${output},"$(printf '{"set":"%s"}' "${set#?}")
+                          output="${output} ${set#?}"
                           index=0
                           set=""
                         fi
                       done
                       if [[ -n $set ]]; then
-                        output="${output},""$(printf {"set":"%s"} "${set#?}")"
+                        output="${output} ${set#?}"
                       fi
-                      echo "[""${output#?}""]"
+                      echo "${output#?}"
                     else
-                      echo '[{"INFO":  "Not rebuilding worker nodes because Management_Worker was not in --limit-management-rollout"}]'
+                      echo 'none'
                     fi
-          - name: rebuild-worker-nodes
+          - name: process-worker-rebuild-sets
             dependencies:
               - get-worker-rebuild-sets
+            template: process-sets
+            arguments:
+              parameters:
+                - name: sets
+                  value: "{{tasks.get-worker-rebuild-sets.outputs.result}}"
+          - name: rebuild-worker-nodes
+            dependencies:
+              - process-worker-rebuild-sets
             template: rebuild-set-of-workers
             arguments:
               parameters:
-                - name: nodes
-                  value: "{{item}}"
+                - name: sets
+                  value: "{{tasks.process-worker-rebuild-sets.outputs.parameters.sets}}"
+                - name: counter
+                  value: "0"
+                - name: limit
+                  value: "{{tasks.process-worker-rebuild-sets.outputs.parameters.num_sets}}"
                 - name: global_params
                   value: "{{inputs.parameters.global_params}}"
-            withParam: "{{tasks.get-worker-rebuild-sets.outputs.result}}"
           - name: rebuild-m002
             dependencies:
               - rebuild-worker-nodes
@@ -367,7 +376,9 @@ spec:
     - name: rebuild-set-of-workers
       inputs:
         parameters:
-          - name: nodes
+          - name: sets
+          - name: counter
+          - name: limit
           - name: global_params
       dag:
         tasks:
@@ -386,10 +397,10 @@ spec:
                     echo "NOTICE  Not rebuilding worker nodes because 'Management_Worker' was not in --limit-management-rollout"
                     exit 0
                   fi
-                  echo "NOTICE  rebuild: {{inputs.parameters.nodes}}"
-                  rebuild_set="{{inputs.parameters.nodes}}"
-                  rebuild_set=${rebuild_set#"{set:"}
-                  rebuild_set=${rebuild_set%"}"}
+                  sets="{{inputs.parameters.sets}}"
+                  set_array=($sets)
+                  current_count="{{inputs.parameters.counter}}"
+                  rebuild_set=${set_array[$current_count]}
                   if [[ -z $rebuild_set ]]; then
                     echo "NOTICE  this step recieved no nodes to rebuild. Continuing without rebuilding any worker nodes"
                     exit 0
@@ -404,6 +415,60 @@ spec:
                   echo "INFO  using image: $image"
                   echo "INFO  using cfs-configuration: $configuration"
                   /usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh $rebuild_set --image-id $image --desired-cfs-conf $configuration
+          - name: move-to-next-set
+            template: move-to-next-set
+            dependencies:
+              - rebuild-set
+            arguments:
+              parameters:
+                - name: count
+                  value: "{{inputs.parameters.counter}}"
+          - name: continue
+            dependencies:
+              - move-to-next-set
+            template: rebuild-set-of-workers
+            when: "{{tasks.move-to-next-set.outputs.result}} < {{inputs.parameters.limit}}"
+            arguments:
+              parameters:
+                - name: sets
+                  value: "{{inputs.parameters.sets}}"
+                - name: counter
+                  value: "{{tasks.move-to-next-set.outputs.result}}"
+                - name: limit
+                  value: "{{inputs.parameters.limit}}"
+    - name: process-sets
+      inputs:
+        parameters:
+          - name: sets
+      script:
+        image: artifactory.algol60.net/csm-docker/stable/docker.io/alpine/git:2.32.0
+        command: [sh]
+        source: |
+          #!/bin/sh
+          sets="{{inputs.parameters.sets}}"
+          echo $sets > /tmp/sets
+          num_sets=$(echo $sets | wc -w)
+          echo $num_sets > /tmp/num_sets
+      outputs:
+        parameters:
+          - name: sets
+            valueFrom:
+              path: "/tmp/sets"
+          - name: num_sets
+            valueFrom:
+              path: "/tmp/num_sets"
+    - name: move-to-next-set
+      inputs:
+        parameters:
+          - name: count
+      script:
+        image: artifactory.algol60.net/csm-docker/stable/docker.io/alpine/git:2.32.0
+        command: [sh]
+        source: |
+          #!/bin/sh
+          current_count="{{inputs.parameters.count}}"
+          counter=$(($current_count + 1 ))
+          echo $counter
     - name: prom-metrics
       inputs:
         parameters:


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->
CASMINST-5994 create new loop for rebuild-worker-nodes due to argo bug.
This prevents the workflow getting into a bad state if a step was to fail.

This has been tested on Gamora.
# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
