### PR TITLE
CAST-32234: Fix typo in BOS staging docs

### DIFF
--- a/operations/boot_orchestration/Stage_Changes_with_BOS.md
+++ b/operations/boot_orchestration/Stage_Changes_with_BOS.md
@@ -2,7 +2,7 @@
 
 In BOS V2 it is possible to stage changes when creating a session.  These changes will not immediately take effect, and will instead be applied when the `applystaged` endpoint is called.
 
-This is a BOS V2 feature only.  For suggestions on working around this in V1, see [Stage Changes Without BOS](#Stage-Changes-Without-BOS).
+This is a BOS V2 feature only.  For suggestions on working around this in V1, see [Stage Changes Without BOS](#stage-changes-without-bos).
 
 ## Creating a staged session
 
@@ -11,7 +11,7 @@ Creating a staged session is no different than creating a normal session, with o
 (`ncn-mw#`)
 
 ```bash
-cray bos v2 sessions create --template-name TEMPLATE_NAME --operation Boot --staged True --format json
+cray bos v2 sessions create --template-name TEMPLATE_NAME --operation boot --stage True --format json
 ```
 
 This creates a new BOS session that can be managed and monitored as normal, but rather than updating the component's desired state, the desired state information will be stored in a `staged_state` field.


### PR DESCRIPTION
# Description
Fixes a typo in the command to stage a boot with BOS v2

Relates to: CAST-32234
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
