### PR TITLE
Refactor rebuild links to avoid following next step if not rebuilding (CASMINST-6001)

### DIFF
--- a/operations/node_management/Rebuild_NCNs/Final_Validation_Steps.md
+++ b/operations/node_management/Rebuild_NCNs/Final_Validation_Steps.md
@@ -35,6 +35,6 @@ Use this procedure to finish validating the success of a rebuilt NCN(s).
    /opt/cray/platform-utils/ncnPostgresHealthChecks.sh
    ```
 
-## Next step
+## Next Step
 
 Return to the main [Rebuild NCNs](Rebuild_NCNs.md) page.

--- a/operations/node_management/Rebuild_NCNs/Identify_Nodes_and_Update_Metadata.md
+++ b/operations/node_management/Rebuild_NCNs/Identify_Nodes_and_Update_Metadata.md
@@ -59,4 +59,4 @@ This section applies to all node types. The commands in this section assume the 
 
 ## Next Step
 
-Proceed to the next step to [Power Cycle and Rebuild Nodes](Power_Cycle_and_Rebuild_Nodes.md). Otherwise, return to the main [Rebuild NCNs](Rebuild_NCNs.md) page.
+If executing this procedure as part of an NCN rebuild, return to the main [Rebuild NCNs](Rebuild_NCNs.md#storage-node) page and proceed with the next step.

--- a/operations/node_management/Rebuild_NCNs/Post_Rebuild_Storage_Node_Validation.md
+++ b/operations/node_management/Rebuild_NCNs/Post_Rebuild_Storage_Node_Validation.md
@@ -87,4 +87,4 @@ Skip this section if a master or worker node was rebuilt.
 
 ## Next Step
 
-Return to the main [Rebuild NCNs](Rebuild_NCNs.md#validation) page.
+If executing this procedure as part of an NCN rebuild, return to the main [Rebuild NCNs](Rebuild_NCNs.md#storage-node) page and proceed with the next step.

--- a/operations/node_management/Rebuild_NCNs/Power_Cycle_and_Rebuild_Nodes.md
+++ b/operations/node_management/Rebuild_NCNs/Power_Cycle_and_Rebuild_Nodes.md
@@ -199,4 +199,4 @@ This section applies to all node types. The commands in this section assume the 
 
 ## Next Step
 
-Proceed to the next step to [Validate Boot Loader](Validate_Boot_Loader.md). Otherwise, return to the main [Rebuild NCNs](Rebuild_NCNs.md) page.
+If executing this procedure as part of an NCN rebuild, return to the main [Rebuild NCNs](Rebuild_NCNs.md#storage-node) page and proceed with the next step.

--- a/operations/node_management/Rebuild_NCNs/Prepare_Storage_Nodes.md
+++ b/operations/node_management/Rebuild_NCNs/Prepare_Storage_Nodes.md
@@ -256,4 +256,4 @@ Check the status of Ceph.
 
 ## Next Step
 
-Proceed to the next step to [Identify Nodes and Update Metadata](Identify_Nodes_and_Update_Metadata.md). Otherwise, return to the main [Rebuild NCNs](Rebuild_NCNs.md) page.
+If executing this procedure as part of an NCN rebuild, return to the main [Rebuild NCNs](Rebuild_NCNs.md#storage-node) page and proceed with the next step.

--- a/operations/node_management/Rebuild_NCNs/Re-add_Storage_Node_to_Ceph.md
+++ b/operations/node_management/Rebuild_NCNs/Re-add_Storage_Node_to_Ceph.md
@@ -123,4 +123,4 @@ This is automated as part of the install, but administrators may have to regener
 
 ## Next Step
 
-Proceed to the next step to perform [Storage Node Validation](Post_Rebuild_Storage_Node_Validation.md). Otherwise, return to the main [Rebuild NCNs](Rebuild_NCNs.md) page.
+If executing this procedure as part of an NCN rebuild, return to the main [Rebuild NCNs](Rebuild_NCNs.md#storage-node) page and proceed with the next step.

--- a/operations/node_management/Rebuild_NCNs/Rebuild_NCNs.md
+++ b/operations/node_management/Rebuild_NCNs/Rebuild_NCNs.md
@@ -69,7 +69,14 @@ make sure that the following conditions are met:
 
 ### Storage node
 
-See [Prepare storage nodes](Prepare_Storage_Nodes.md) to begin storage node rebuild.
+Follow each step below:
+
+1. [Prepare storage nodes](Prepare_Storage_Nodes.md)
+1. [Identify Nodes and Update Metadata](Identify_Nodes_and_Update_Metadata.md)
+1. [Power Cycle and Rebuild Nodes](Power_Cycle_and_Rebuild_Nodes.md)
+1. [Validate Boot Loader](Validate_Boot_Loader.md)
+1. [Re-add Storage Node to Ceph](Re-add_Storage_Node_to_Ceph.md)
+1. [Storage Node Validation](Post_Rebuild_Storage_Node_Validation.md)
 
 ## Validation
 

--- a/operations/node_management/Rebuild_NCNs/Validate_Boot_Loader.md
+++ b/operations/node_management/Rebuild_NCNs/Validate_Boot_Loader.md
@@ -12,4 +12,4 @@ Perform the following steps **on `ncn-m001`**.
 
 ## Next Step
 
-If this is a storage node rebuild, proceed to the next step to [Re-add Storage Node to Ceph](Re-add_Storage_Node_to_Ceph.md). Otherwise, return to the main [Rebuild NCNs](Rebuild_NCNs.md) page.
+If executing this procedure as part of an NCN rebuild, return to the main [Rebuild NCNs](Rebuild_NCNs.md#storage-node) page and proceed with the next step.


### PR DESCRIPTION
# Description

Redirect back to main rebuild page instead of directly to next step.

Resolves [CASMINST-6001](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-6001)

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

