### PR TITLE
Clarify which cephfs share steps are required for upgrade (CASMINST-6029)

### DIFF
--- a/upgrade/Stage_0_Prerequisites.md
+++ b/upgrade/Stage_0_Prerequisites.md
@@ -119,6 +119,8 @@ If a previous `rbd` mount is detected at `/etc/cray/upgrade/csm`, that content w
      Done! /etc/cray/upgrade/csm is mounted as a cephfs share!
      ```
 
+   **NOTE**: ***The following steps are not part of the upgrade procedure**, but rather informative about how to access data from previous upgrades stored on an `rbd` device*:
+
    - After completing the CSM upgrade, all master nodes will automatically mount the new `cephfs` file share at `/etc/cray/upgrade/csm`.
 The content from a previous `rbd` device is still available, and can be accessed by executing the following steps:
 


### PR DESCRIPTION
# Description

Clarify which cephfs share steps are required for upgrade

Fixes: https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-6029

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.