### PR TITLE
CASMINST-6039: fix PITDATA logic. Again.

### DIFF
--- a/scripts/operations/node_management/ncn-ims-image-upload.sh
+++ b/scripts/operations/node_management/ncn-ims-image-upload.sh
@@ -72,7 +72,7 @@ done
 if update_cpc; then
 
     [[ -n ${CSM_RELEASE} ]] || err_exit "\$CSM_RELEASE is not specified"
-    if [[ -n ${PITDATA} ]] && [[ -f /etc/pit-release ]]; then
+    if [[ -z ${PITDATA} ]] && [[ -f /etc/pit-release ]]; then
         err_exit "\$PITDATA is not specified"
     fi
     [[ -n ${CSM_ARTI_DIR} || -n ${CSM_PATH} ]] || err_exit "One of \$CSM_ARTI_DIR or \$CSM_PATH must be set to the path of unpacked CSM tarball"


### PR DESCRIPTION
# Description

The previous fix to this conditional missed changing `-n` (variable set) to `-z` (variable empty) when the logic was restructured.

<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
