### PR TITLE
CASMINST-6033 explicitly skipping output parameters to maintain whate…

### DIFF
--- a/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh
+++ b/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh
@@ -342,8 +342,6 @@ fi
 sleep 20
 
 # poll
-declare -A alreadyInProgress
-declare -A alreadySucceeded
 while true; do
     labelSelector="node-type=${nodeType}"
     res_file="$(mktemp)"

--- a/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh
+++ b/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh
@@ -342,6 +342,8 @@ fi
 sleep 20
 
 # poll
+declare -A alreadyInProgress
+declare -A alreadySucceeded
 while true; do
     labelSelector="node-type=${nodeType}"
     res_file="$(mktemp)"

--- a/workflows/iuf/operations/prepare-images/prepare-managed-images-template.yaml
+++ b/workflows/iuf/operations/prepare-images/prepare-managed-images-template.yaml
@@ -74,7 +74,7 @@ spec:
                     BOOTPREP_FILE_PATH="{{=jsonpath(inputs.parameters.global_params, '$.input_params.bootprep_config_managed')}}"
                     if [[ -z "$BOOTPREP_FILE_PATH" ]]; then
                       echo "INFO No bootprep file provided. Skipping operation." 1>&2
-                      echo "{}"
+                      echo "skipped"
                       exit 0
                     fi
 

--- a/workflows/iuf/operations/prepare-images/prepare-management-images-template.yaml
+++ b/workflows/iuf/operations/prepare-images/prepare-management-images-template.yaml
@@ -74,7 +74,7 @@ spec:
                     BOOTPREP_FILE_PATH="{{=jsonpath(inputs.parameters.global_params, '$.input_params.bootprep_config_management')}}"
                     if [[ -z "$BOOTPREP_FILE_PATH" ]]; then
                       echo "INFO No bootprep file provided. Skipping operation." 1>&2
-                      echo "{}"
+                      echo "skipped"
                       exit 0
                     fi
 

--- a/workflows/iuf/operations/update-cfs-config/update-managed-cfs-config.yaml
+++ b/workflows/iuf/operations/update-cfs-config/update-managed-cfs-config.yaml
@@ -74,7 +74,7 @@ spec:
                     BOOTPREP_FILE_PATH="{{=jsonpath(inputs.parameters.global_params, '$.input_params.bootprep_config_managed')}}"
                     if [[ -z "$BOOTPREP_FILE_PATH" ]]; then
                       echo "INFO No bootprep file provided. Skipping operation." 1>&2
-                      echo "{}"
+                      echo "skipped"
                       exit 0
                     fi
 

--- a/workflows/iuf/operations/update-cfs-config/update-management-cfs-config.yaml
+++ b/workflows/iuf/operations/update-cfs-config/update-management-cfs-config.yaml
@@ -74,7 +74,7 @@ spec:
                     BOOTPREP_FILE_PATH="{{=jsonpath(inputs.parameters.global_params, '$.input_params.bootprep_config_management')}}"
                     if [[ -z "$BOOTPREP_FILE_PATH" ]]; then
                       echo "INFO No bootprep file provided. Skipping operation." 1>&2
-                      echo "{}"
+                      echo "skipped"
                       exit 0
                     fi
 

--- a/workflows/iuf/stages.yaml
+++ b/workflows/iuf/stages.yaml
@@ -78,6 +78,8 @@ stages:
 
   - name: update-vcs-config
     type: product
+    process-product-variants-sequentially: true # this stage wants to make sure all products with the same name (but different versions)
+                                                #  are processed sequentially, not in parallel, to avoid operational race conditions
     operations:
       - name: vcs-update-working-branch
         static-parameters: {} # any parameters that will be supplied statically to this operation.


### PR DESCRIPTION
…ver already exists in the activity

<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
