### PR TITLE
CASMINST-5981 add log headers so IUF cli can show progress

### DIFF
--- a/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh
+++ b/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh
@@ -321,22 +321,22 @@ fi
 # shellcheck disable=SC2046
 if $retry && [ "${numOfUnsucceededWorkflows}" -eq 1 ]; then
     workflow=$(echo "${unsucceededWorkflows[0]}" | grep -o 'ncn-lifecycle-rebuild-[a-z0-9]*')
-    echo "Retry workflow: ${workflow}"
+    echo "DEBUG - Retry workflow: ${workflow}"
     retryRebuildWorkflow "${workflow}"
 fi
 
 if [ "${numOfUnsucceededWorkflows}" -eq 0 ]; then
     # create a new workflow
     workflow=$(createRebuildWorkflow)
-    echo "Create workflow: ${workflow}"
+    echo "NOTICE - Create workflow: ${workflow}"
 fi
 
 if [[ -z "${workflow}" ]]; then
     echo
-    echo "No workflow to pull, something is wrong"
+    echo "ERROR - No workflow to pull, something is wrong"
 else 
     echo
-    echo "Poll status of: ${workflow}"
+    echo "DEBUG - Poll status of: ${workflow}"
 fi
 
 sleep 20
@@ -364,21 +364,21 @@ while true; do
         fi
 
         if [[ "${phase}" == "Failed" ]]; then
-            echo "Workflow in Failed state, Retry ..."
+            echo "WARNING - Workflow in Failed state, Retry ..."
             retryRebuildWorkflow "$workflow"
         fi
 
         if [[ "${phase}" == "Error" ]]; then
-            echo "Workflow in Error state, Retry ..."
+            echo "WARNING - Workflow in Error state, Retry ..."
             retryRebuildWorkflow "$workflow"
         fi
         runningSteps=$(jq -jr ".[] | select(.name==\"${workflow}\") | .status.nodes[] | select(.type==\"Retry\")| select(.phase==\"Running\")  | .name + \"\n  \" " < "${res_file}")
         succeededSteps=$(jq -jr ".[] | select(.name==\"${workflow}\") | .status.nodes[] | select(.type==\"Retry\")| select(.phase==\"Succeeded\")  | .name +\"\n  \" " < "${res_file}")
         clear
-        printf "\n%s\n" "Succeeded:"
-        echo "  ${succeededSteps}" | awk -F'.' '{print $2" -  "$3}'
-        printf "%s\n" "${phase}:"
-        echo "  ${runningSteps}"  | awk -F'.' '{print $2" -  "$3}'
+        printf "\n%s\n" "INFO - Succeeded:"
+        echo "INFO - ${succeededSteps}" | awk -F'.' '{print $2" -  "$3}'
+        printf "%s\n" "INFO - ${phase}:"
+        echo "INFO - ${runningSteps}"  | awk -F'.' '{print $2" -  "$3}'
         sleep 10
     fi
 done

--- a/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh
+++ b/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh
@@ -328,7 +328,7 @@ fi
 if [ "${numOfUnsucceededWorkflows}" -eq 0 ]; then
     # create a new workflow
     workflow=$(createRebuildWorkflow)
-    echo "NOTICE - Create workflow: ${workflow}"
+    echo "NOTICE - Create workflow: ${workflow}. Please see the workflow ${workflow} in the Argo UI to see detailed logs"
 fi
 
 if [[ -z "${workflow}" ]]; then


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
