### PR TITLE
CASMINST-6056: Linting of IMS import/export procedure

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -463,7 +463,6 @@ dropdown
 dryrun
 eBGP
 eC
-etag
 etcd
 ex2500
 exascale
@@ -893,6 +892,10 @@ Lorem
 # To allow Site Init
 Init
 
+- operations/image_management/IMS_export_import.md
+etag
+etags
+
 - operations/iuf/IUF.md
 sessionid
 SESSIONID
@@ -909,6 +912,12 @@ rollouts
 rollout
 unlabeled
 userspace
+
+- operations/network/dns/DNS.md
+ExternalDNS
+
+- operations/network/dns/Manage_the_DNS_Unbound_Resolver.md
+ExternalDNS
 
 - operations/network/external_dns/Update_the_cmn-external-dns_Value_Post-Installation.md
 LoadBalancer
@@ -947,12 +956,6 @@ Admin
 
 - operations/system_management_health/Configure_Prometheus_Alerta_Alert_Notifications.md
 Alerta
-
-- operations/network/dns/DNS.md
-ExternalDNS
-
-- operations/network/dns/Manage_the_DNS_Unbound_Resolver.md
-ExternalDNS
 
 - RELEASE_NOTES.md
 5.x

--- a/operations/image_management/IMS_export_import.md
+++ b/operations/image_management/IMS_export_import.md
@@ -165,7 +165,7 @@ either using an automated script, or manually one at a time.
       }
       ```
 
-   1. Download each of the images referenced in the manifest file.
+   1. Download each of the artifacts referenced in the manifest file.
 
       ```bash
       cray artifacts get boot-images "${IMAGE_ID}/rootfs" "images/${IMAGE_ID}/rootfs"

--- a/operations/image_management/IMS_export_import.md
+++ b/operations/image_management/IMS_export_import.md
@@ -24,7 +24,7 @@ either using an automated script, or manually one at a time.
 
 ### Automated export procedure
 
-1. (`ncn-mw`) The `ims-import-export.py`script will create a subdirectory of the current directory named `ims-import-export-data` 
+1. (`ncn-mw`) The `ims-import-export.py`script will create a subdirectory of the current directory named `ims-import-export-data`
    containing information about the recipes and images that are registered with IMS.
 
    ```bash

--- a/operations/image_management/IMS_export_import.md
+++ b/operations/image_management/IMS_export_import.md
@@ -3,21 +3,32 @@
 IMS recipe and image data, including associated artifacts stored in Ceph S3, can be exported and imported
 either using an automated script, or manually one at a time.
 
+- [Prerequisites](#prerequisites)
+- [Exporting images and recipes](#exporting-images-and-recipes)
+  - [Automated export procedure](#automated-export-procedure)
+  - [Manual recipe export procedure](#manual-recipe-export-procedure)
+  - [Manual image export procedure](#manual-image-export-procedure)
+- [Importing images and recipes](#importing-images-and-recipes)
+  - [Automated import procedure](#automated-import-procedure)
+  - [Manual recipe import procedure](#manual-recipe-import-procedure)
+  - [Manual image import procedure](#manual-image-import-procedure)
+
+## Prerequisites
+
+- Ensure that the `cray` command line interface (CLI) is authenticated and configured to talk to system management services.
+  - See [Configure the Cray CLI](../configure_cray_cli.md).
+- In order to use the automated procedures, the latest CSM documentation RPM must be installed on the node where the procedure is being performed.
+  - See [Check for latest documentation](../../update_product_stream/README.md#check-for-latest-documentation).
+
 ## Exporting Images and Recipes
 
-### Prerequisites
+### Automated export procedure
 
-* Ensure that the `cray` command line interface (CLI) is authenticated and configured to talk to
-system management services.
-
-### Automated Exporting Procedure
-
-1. (`ncn-mw`) Run the `ims-import-export.py` script located [here](../../scripts/operations/system_recovery). The `ims-import-export.py`
-   script will create a directory named `ims-import-export-data` containing information about the recipes and images
-   that are registered with IMS.
+1. (`ncn-mw`) The `ims-import-export.py`script will create a subdirectory of the current directory named `ims-import-export-data` 
+   containing information about the recipes and images that are registered with IMS.
 
    ```bash
-   ims-import-export.py --export --include-linked-artifacts
+   /usr/share/doc/csm/scripts/operations/system_recovery/ims-import-export.py --export --include-linked-artifacts
    ```
 
    Expected output:
@@ -30,18 +41,17 @@ system management services.
    INFO:__main__:DONE!!
    ```
 
-### Manual Recipe Exporting Procedure
+### Manual recipe export procedure
 
-1. (`ncn-mw`) Identify the recipes that you wish to manually export.
+1. (`ncn-mw`) Identify the recipes to be manually exported.
 
    ```bash
    cray ims recipes list --format json | jq
    ```
 
-   Expected output:
+   The expected output is a list of IMS recipe entries. An example of one such entry is:
 
-   ```text
-     [
+   ```json
        {
          "created": "2021-03-29T15:22:50.039151+00:00",
          "id": "1dd47f2f-aa37-4f17-9e9c-4e17a3675a92",
@@ -53,38 +63,36 @@ system management services.
          "linux_distribution": "sles15",
          "name": "cray-shasta-csm-sles15sp1-barebones.x86_64-shasta-1.4",
          "recipe_type": "kiwi-ng"
-       },
-       ...
-     ]
+       }
    ```
 
-   For each recipe that you wish to export, make note of the recipe details including:
-   * Recipe ID
-   * Recipe Type
-   * Recipe Linux Distribution
-   * Recipe Name
-   * Recipe Link Path
+   For each recipe to be exported, make note of the recipe details including:
 
-1. (`ncn-mw`) For each recipe that you wish to export, use the `cray artifacts` CLI to download the recipe archive from Ceph S3.
+   - Recipe ID
+   - Recipe Type
+   - Recipe Linux Distribution
+   - Recipe Name
+   - Recipe Link Path
+
+1. (`ncn-mw`) For each recipe to be export, use the `cray artifacts` CLI to download the recipe archive from Ceph S3.
 
    ```bash
-   export RECIPE_ID=1dd47f2f-aa37-4f17-9e9c-4e17a3675a92
-   mkdir -p recipes/$RECIPE_ID
-   cray artifacts get ims recipes/$RECIPE_ID/recipe.tar.gz recipes/$RECIPE_ID/recipe.tar.gz
+   RECIPE_ID=1dd47f2f-aa37-4f17-9e9c-4e17a3675a92
+   mkdir -pv "recipes/${RECIPE_ID}"
+   cray artifacts get ims "recipes/${RECIPE_ID}/recipe.tar.gz" "recipes/${RECIPE_ID}/recipe.tar.gz"
    ```
 
-### Manual Image Exporting Procedure
+### Manual image export procedure
 
-1. (`ncn-mw`) Identify the images that you wish to manually export.
+1. (`ncn-mw`) Identify the images to be manually exported.
 
    ```bash
    cray ims images list --format json | jq
    ```
 
-   Expected output:
+   The expected output is a list of IMS image entries. An example of one such entry is:
 
-   ```text
-     [
+   ```json
        {
          "created": "2021-04-28T20:48:44.007816+00:00",
          "id": "0f1acea4-2bf1-4931-ac19-ce3c484af540",
@@ -94,95 +102,90 @@ system management services.
            "type": "s3"
          },
          "name": "cray-shasta-csm-sles15sp1-barebones.x86_64-shasta-1.4"
-       },
-       ...
-     ]
-   ```
-
-   For each image that you wish to export, make note of the image details including:
-   * Image ID
-   * Image Name
-   * Recipe Link Path
-
-1. (`ncn-mw`) For each image that you wish to export, use the `cray artifacts` CLI to download the image manifest from Ceph S3.
-
-   ```bash
-   export IMAGE_ID=0f1acea4-2bf1-4931-ac19-ce3c484af540
-   mkdir -p images/$IMAGE_ID
-   cray artifacts get boot-images $IMAGE_ID/manifest.json images/$IMAGE_ID/manifest.json
-   ```
-
-   Review the image manifest and download any linked artifacts
-
-   ```bash
-   cat images/$IMAGE_ID/manifest.json | jq
-   ```
-
-   Expected output:
-
-   ```text
-   {
-     "version": "1.0",
-     "created": "2021-04-01 21:24:23.161422",
-     "artifacts": [
-       {
-         "md5": "6e784dc8519baffc2177b0b70f3f8f89",
-         "type": "application/vnd.cray.image.rootfs.squashfs",
-         "link": {
-           "etag": "f99dcad6c55a52904a8fee283b0dad22-204",
-           "path": "s3://boot-images/0f1acea4-2bf1-4931-ac19-ce3c484af540/rootfs",
-           "type": "s3"
-         }
-       },
-       {
-         "md5": "175f0c1363c9e3a4840b08570a923bc5",
-         "type": "application/vnd.cray.image.kernel",
-         "link": {
-           "etag": "175f0c1363c9e3a4840b08570a923bc5",
-           "path": "s3://boot-images/0f1acea4-2bf1-4931-ac19-ce3c484af540/kernel",
-           "type": "s3"
-         }
-       },
-       { 
-         "md5": "2e8fadafab28081d6018ecfd479206d8",
-         "type": "application/vnd.cray.image.initrd",
-         "link": {
-           "etag": "cad6c356f72e3dc65b6a28610629cba5-5",
-           "path": "s3://boot-images/0f1acea4-2bf1-4931-ac19-ce3c484af540/initrd",
-           "type": "s3"
-         }
        }
-     ]
-   }
    ```
 
-   Export each of the images referenced in the manifest file:
+   For each image to be exported, make note of the image details including:
+
+   - Image ID
+   - Image Name
+   - Recipe Link Path
+
+1. (`ncn-mw`) For each image to be exported, use the `cray artifacts` CLI to download the image artifacts from Ceph S3.
+
+   1. Download the image manifest from Ceph S3.
+
+      ```bash
+      IMAGE_ID=0f1acea4-2bf1-4931-ac19-ce3c484af540
+      mkdir -pv "images/${IMAGE_ID}"
+      cray artifacts get boot-images "${IMAGE_ID}/manifest.json" "images/${IMAGE_ID}/manifest.json"
+      ```
+
+   1. Review the image manifest.
+
+      ```bash
+      cat "images/${IMAGE_ID}/manifest.json" | jq
+      ```
+
+      Example output:
+
+      ```json
+      {
+        "version": "1.0",
+        "created": "2021-04-01 21:24:23.161422",
+        "artifacts": [
+          {
+            "md5": "6e784dc8519baffc2177b0b70f3f8f89",
+            "type": "application/vnd.cray.image.rootfs.squashfs",
+            "link": {
+              "etag": "f99dcad6c55a52904a8fee283b0dad22-204",
+              "path": "s3://boot-images/0f1acea4-2bf1-4931-ac19-ce3c484af540/rootfs",
+              "type": "s3"
+            }
+          },
+          {
+            "md5": "175f0c1363c9e3a4840b08570a923bc5",
+            "type": "application/vnd.cray.image.kernel",
+            "link": {
+              "etag": "175f0c1363c9e3a4840b08570a923bc5",
+              "path": "s3://boot-images/0f1acea4-2bf1-4931-ac19-ce3c484af540/kernel",
+              "type": "s3"
+            }
+          },
+          { 
+            "md5": "2e8fadafab28081d6018ecfd479206d8",
+            "type": "application/vnd.cray.image.initrd",
+            "link": {
+              "etag": "cad6c356f72e3dc65b6a28610629cba5-5",
+              "path": "s3://boot-images/0f1acea4-2bf1-4931-ac19-ce3c484af540/initrd",
+              "type": "s3"
+            }
+          }
+        ]
+      }
+      ```
+
+   1. Download each of the images referenced in the manifest file.
+
+      ```bash
+      cray artifacts get boot-images "${IMAGE_ID}/rootfs" "images/${IMAGE_ID}/rootfs"
+      cray artifacts get boot-images "${IMAGE_ID}/kernel" "images/${IMAGE_ID}/kernel"
+      cray artifacts get boot-images "${IMAGE_ID}/initrd" "images/${IMAGE_ID}/initrd"
+      ```
+
+## Importing images and recipes
+
+NOTE: Recipes and images imported using these procedures will have their IMS ID and S3 location of linked artifacts
+changed during the import process. Any BOS Session templates, or other references to recipes, images, or their
+artifacts will need to be updated to use the new identifiers.
+
+### Automated import procedure
+
+1. (`ncn-mw`) If IMS data was previously exported using the `ims-import-export.py` script, then the same script can be used to
+   import IMS recipes and images that are missing after an upgrade.
 
    ```bash
-   cray artifacts get boot-images $IMAGE_ID/rootfs images/$IMAGE_ID/rootfs
-   cray artifacts get boot-images $IMAGE_ID/kernel images/$IMAGE_ID/kernel
-   cray artifacts get boot-images $IMAGE_ID/initrd images/$IMAGE_ID/initrd
-   ```
-
-## Importing Images and Recipes
-
-NOTE: recipes and images imported using these procedures will have their IMS ID and S3 location of linked artifacts
-      changed during the import process. Any BOS Session templates, or other references to recipes, images or their
-      artifacts will need to be updated to use the new identifiers.
-
-### Importing Prerequisites
-
-* Ensure that the `cray` command line interface (CLI) is authenticated and configured to talk to
-system management services.
-
-### Automated Importing Procedure
-
-1. (`ncn-mw`) If IMS data was previously exported using the `ims-import-export.py` script, the same script can be used to
-   import IMS recipes and images that are missing after an upgrade. To do so, run the `ims-import-export.py` script
-   located [here](../../scripts/operations/system_recovery).
-
-   ```bash
-   ims-import-export.py --import
+   /usr/share/doc/csm/scripts/operations/system_recovery/ims-import-export.py --import
    ```
 
    Expected output:
@@ -195,22 +198,29 @@ system management services.
    INFO:__main__:DONE!!
    ```
 
-### Manual Recipe Importing Procedure
+### Manual recipe import procedure
 
-Using the recipe information previously noted, for each recipe that you wish to restore, perform the following steps:
+Using the recipe information previously noted, for each recipe to be restored, perform the following steps:
 
-Note: In the example below, we are creating a new IMS recipe record for the recipe previously known as IMS recipe
-      ID `1dd47f2f-aa37-4f17-9e9c-4e17a3675a92`.
+1. (`ncn-mw#`) Record the old IMS ID of the recipe to be restored.
+
+   This ID is obtained from the exported data. For example:
+
+   ```bash
+   OLD_RECIPE_ID=1dd47f2f-aa37-4f17-9e9c-4e17a3675a92
+   ```
 
 1. (`ncn-mw`) Create a new IMS recipe record.
+
+   > Be sure to modify the example command to specify the appropriate recipe type and Linux distribution for the recipe being imported.
 
    ```bash
    cray ims recipes create --name <name> --recipe-type <type> --linux-distribution <linux-distribution> --format json
    ```
 
-   Expected output:
+   Example output:
 
-   ```text
+   ```json
    {
      "name": "cray-shasta-csm-sles15sp1-barebones.x86_64-shasta-1.4",
      "linux_distribution": "sles15",
@@ -221,28 +231,29 @@ Note: In the example below, we are creating a new IMS recipe record for the reci
    }
    ```
 
-   Note the new and old recipe IDs:
+1. (`ncn-mw`) Note the new IMS ID.
+
+   This ID is found in the output of the command in the previous step.
 
    ```bash
-   export NEW_RECIPE_ID=e5b9a5f9-cd75-4cb2-870a-48c42c009d4b
-   export OLD_RECIPE_ID=1dd47f2f-aa37-4f17-9e9c-4e17a3675a92
+   NEW_RECIPE_ID=e5b9a5f9-cd75-4cb2-870a-48c42c009d4b   
    ```
 
-1. (`ncn-mw`) Upload the IMS Recipe archive to Ceph S3
+1. (`ncn-mw`) Upload the IMS recipe archive to Ceph S3.
 
    ```bash
-   cray artifacts create ims recipes/$NEW_RECIPE_ID/recipe.tar.gz recipes/$OLD_RECIPE_ID/recipe.tar.gz
+   cray artifacts create ims "recipes/${NEW_RECIPE_ID}/recipe.tar.gz" "recipes/${OLD_RECIPE_ID}/recipe.tar.gz"
    ```
 
-1. (`ncn-mw`) Determine the S3 etag for the recipe archive
+1. (`ncn-mw`) View the new S3 recipe archive.
 
    ```bash
-   cray artifacts describe ims recipes/$NEW_RECIPE_ID/recipe.tar.gz --format json
+   cray artifacts describe ims "recipes/${NEW_RECIPE_ID}/recipe.tar.gz" --format json
    ```
 
-   Expected output:
+   Example output:
 
-   ```text
+   ```json
    {
      "artifact": {
        "AcceptRanges": "bytes",
@@ -254,33 +265,47 @@ Note: In the example below, we are creating a new IMS recipe record for the reci
          "md5sum": "dd95e38bf328dd31d83d661877df8fcf"
        }
      }
-   } 
+   }
+   ```
+
+1. (`ncn-mw#`) Record the S3 etag of the new recipe archive.
+
+   This value is found in the output of the command in the previous step.
+
+   ```bash
+   RECIPE_ETAG=dd95e38bf328dd31d83d661877df8fcf
    ```
 
 1. (`ncn-mw`) Update the IMS recipe record with the Ceph S3 location of the recipe archive
 
    ```bash
-   cray ims recipes update $NEW_RECIPE_ID \
-     --link-type s3 --link-path s3://ims/recipes/$NEW_RECIPE_ID/recipe.tar.gz \
-     --link-etag dd95e38bf328dd31d83d661877df8fcf
+   cray ims recipes update "${NEW_RECIPE_ID}" --link-type s3 --link-etag "${RECIPE_ETAG}" \
+     --link-path "s3://ims/recipes/${NEW_RECIPE_ID}/recipe.tar.gz"
    ```
 
-### Manual Image Importing Procedure
+### Manual image import procedure
 
-Using the image information previously noted, for each image that you wish to restore, perform the following steps:
+Using the image information previously noted, for each image to be restored, perform the following steps:
 
-Note: In the example below, we are creating a new IMS image record for the image previously known as IMS image
-      ID `0f1acea4-2bf1-4931-ac19-ce3c484af540`.
+1. (`ncn-mw#`) Record the old IMS ID of the image to be restored.
+
+   This ID is obtained from the exported data. For example:
+
+   ```bash
+   ${OLD_IMAGE_ID}=0f1acea4-2bf1-4931-ac19-ce3c484af540
+   ```
 
 1. (`ncn-mw`) Create a new IMS image record.
+
+   > Be sure to modify the example command to specify the desired name for the image.
 
    ```bash
    cray ims images create --name <name> --format json
    ```
 
-   Expected output:
+   Example output:
 
-   ```text
+   ```json
    {
      "name": "cray-shasta-csm-sles15sp1-barebones.x86_64-shasta-1.4",
      "link": null,
@@ -289,96 +314,127 @@ Note: In the example below, we are creating a new IMS image record for the image
    }
    ```
 
-   Note the old and new image ID:
+1. (`ncn-mw`) Note the new IMS ID.
+
+   This ID is found in the output of the command in the previous step.
 
    ```bash
-   export OLD_IMAGE_ID=0f1acea4-2bf1-4931-ac19-ce3c484af540
-   export NEW_IMAGE_ID=b5ac5d8a-0fac-470f-88a5-26c1276961e7
+   NEW_IMAGE_ID=b5ac5d8a-0fac-470f-88a5-26c1276961e7
    ```
 
-1. (`ncn-mw`) Upload each associated image artifact to Ceph S3
+1. (`ncn-mw`) Upload each associated image artifact to Ceph S3.
 
    ```bash
-   cray artifacts create boot-images $NEW_IMAGE_ID/rootfs images/$OLD_IMAGE_ID/rootfs
-   cray artifacts create boot-images $NEW_IMAGE_ID/kernel images/$OLD_IMAGE_ID/kernel
-   cray artifacts create boot-images $NEW_IMAGE_ID/initrd images/$OLD_IMAGE_ID/initrd
+   cray artifacts create boot-images "${NEW_IMAGE_ID}/rootfs" "images/${OLD_IMAGE_ID}/rootfs"
+   cray artifacts create boot-images "${NEW_IMAGE_ID}/kernel" "images/${OLD_IMAGE_ID}/kernel"
+   cray artifacts create boot-images "${NEW_IMAGE_ID}/initrd" "images/${OLD_IMAGE_ID}/initrd"
    ```
 
-1. (`ncn-mw`) Determine the S3 etag for each associated image artifact
+1. (`ncn-mw`) Collect the S3 etags of the new S3 image artifacts.
 
-   ```bash
-   cray artifacts describe boot-images $NEW_IMAGE_ID/rootfs --format json
-   ```
+   1. View the new `rootfs` artifact in S3.
 
-   Expected output:
+      ```bash
+      cray artifacts describe boot-images "${NEW_IMAGE_ID}/rootfs" --format json
+      ```
 
-   ```text
-   {
-     "artifact": {
-       "AcceptRanges": "bytes",
-       "LastModified": "2021-03-29T15:22:50+00:00",
-       "ContentLength": 11799,
-       "ETag": "\"17574f7ce0d7b5e2b35913669347afca\"",
-       "ContentType": "binary/octet-stream",
-       "Metadata": {
-         "md5sum": "dd95e38bf328dd31d83d661877df8fcf"
-       }
-     }
-   }
-   ```
+      Example output:
 
-   ```bash
-   cray artifacts describe boot-images $NEW_IMAGE_ID/kernel --format json
-   ```
+      ```json
+      {
+        "artifact": {
+          "AcceptRanges": "bytes",
+          "LastModified": "2021-03-29T15:22:50+00:00",
+          "ContentLength": 11799,
+          "ETag": "\"17574f7ce0d7b5e2b35913669347afca\"",
+          "ContentType": "binary/octet-stream",
+          "Metadata": {
+            "md5sum": "dd95e38bf328dd31d83d661877df8fcf"
+          }
+        }
+      }
+      ```
 
-   Expected output:
+   1. Record the S3 etag of the new `rootfs` artifact.
 
-   ```text
-   {
-     "artifact": {
-       "AcceptRanges": "bytes",
-       "LastModified": "2021-03-29T15:22:50+00:00",
-       "ContentLength": 11799,
-       "ETag": "\"d2572e79e99bdf408bb2f65cd4b209f3\"",
-       "ContentType": "binary/octet-stream",
-       "Metadata": {
-         "md5sum": "dd95e38bf328dd31d83d661877df8fcf"
-       }
-     }
-   }
-   ```
+      This value is found in the output of the command in the previous step.
 
-   ```bash
-   cray artifacts describe boot-images $NEW_IMAGE_ID/initrd --format json
-   ```
+      ```bash
+      ROOTFS_ETAG=17574f7ce0d7b5e2b35913669347afca
+      ```
 
-   Expected output:
+   1. View the new kernel artifact in S3.
 
-   ```text
-   {
-     "artifact": {
-       "AcceptRanges": "bytes",
-       "LastModified": "2021-03-29T15:22:50+00:00",
-       "ContentLength": 11799,
-       "ETag": "\"87adf3df69224d1b5f1449d21999ab52\"",
-       "ContentType": "binary/octet-stream",
-       "Metadata": {
-         "md5sum": "dd95e38bf328dd31d83d661877df8fcf"
-       }
-     }
-   }
-   ```
+      ```bash
+      cray artifacts describe boot-images "${NEW_IMAGE_ID}/kernel" --format json
+      ```
+
+      Example output:
+
+      ```json
+      {
+        "artifact": {
+          "AcceptRanges": "bytes",
+          "LastModified": "2021-03-29T15:22:50+00:00",
+          "ContentLength": 11799,
+          "ETag": "\"d2572e79e99bdf408bb2f65cd4b209f3\"",
+          "ContentType": "binary/octet-stream",
+          "Metadata": {
+            "md5sum": "dd95e38bf328dd31d83d661877df8fcf"
+          }
+        }
+      }
+      ```
+
+   1. Record the S3 etag of the new kernel artifact.
+
+      This value is found in the output of the command in the previous step.
+
+      ```bash
+      KERNEL_ETAG=d2572e79e99bdf408bb2f65cd4b209f3
+      ```
+
+   1. View the new `initrd` artifact in S3.
+
+      ```bash
+      cray artifacts describe boot-images "${NEW_IMAGE_ID}/initrd" --format json
+      ```
+
+      Example output:
+
+      ```json
+      {
+        "artifact": {
+          "AcceptRanges": "bytes",
+          "LastModified": "2021-03-29T15:22:50+00:00",
+          "ContentLength": 11799,
+          "ETag": "\"87adf3df69224d1b5f1449d21999ab52\"",
+          "ContentType": "binary/octet-stream",
+          "Metadata": {
+            "md5sum": "dd95e38bf328dd31d83d661877df8fcf"
+          }
+        }
+      }
+      ```
+
+   1. Record the S3 etag of the new `initrd` artifact.
+
+      This value is found in the output of the command in the previous step.
+
+      ```bash
+      INITRD_ETAG=87adf3df69224d1b5f1449d21999ab52
+      ```
 
 1. (`ncn-mw`) Make a copy of the original IMS `manifest.json` and update with the new S3 link and etag values.
 
    ```bash
-   cp images/$OLD_IMAGE_ID/manifest.json images/$OLD_IMAGE_ID/manifest-new.json
-   vi images/$OLD_IMAGE_ID/manifest-new.json
+   cp -v "images/${OLD_IMAGE_ID}/manifest.json" "images/${OLD_IMAGE_ID}/manifest-new.json"
+   vi "images/${OLD_IMAGE_ID}/manifest-new.json"
    ```
 
-   Expected file contents:
+   Example file contents after editing:
 
-   ```text
+   ```json
    {
      "version": "1.0",
      "created": "2021-04-01 21:24:23.161422",
@@ -414,21 +470,21 @@ Note: In the example below, we are creating a new IMS image record for the image
    }
    ```
 
-1. (`ncn-mw`) Upload the IMS image manifest to Ceph S3
+1. (`ncn-mw`) Upload the IMS image manifest to Ceph S3.
 
    ```bash
-   cray artifacts create boot-images $NEW_IMAGE_ID/manifest.json images/$OLD_IMAGE_ID/manifest-new.json
+   cray artifacts create boot-images "${NEW_IMAGE_ID}/manifest.json" "images/${OLD_IMAGE_ID}/manifest-new.json"
    ```
 
-1. (`ncn-mw`) Determine the S3 etag for the `manifest.json`
+1. (`ncn-mw`) View the manifest in S3.
 
    ```bash
-   cray artifacts describe ims $NEW_IMAGE_ID/manifest.json --format json
+   cray artifacts describe ims ${NEW_IMAGE_ID}/manifest.json --format json
    ```
 
-   Expected output:
+   Example output:
 
-   ```text
+   ```json
    {
      "artifact": {
        "AcceptRanges": "bytes",
@@ -443,10 +499,17 @@ Note: In the example below, we are creating a new IMS image record for the image
    }
    ```
 
-1. (`ncn-mw`) Update the IMS image record with the Ceph S3 location of the `manifest.json`
+1. (`ncn-mw#`) Record the new S3 etag of the manifest in S3.
+
+   This value is found in the output of the command in the previous step.
 
    ```bash
-   cray ims images update $NEW_IMAGE_ID \
-     --link-type s3 --link-path s3://ims/$NEW_IMAGE_ID/manifest.json \
-     --link-etag ab3ffecdd1299bbda6c373824c9d0870
+   MANIFEST_ETAG=ab3ffecdd1299bbda6c373824c9d0870
+   ```
+
+1. (`ncn-mw`) Update the IMS image record with the Ceph S3 location of the manifest.
+
+   ```bash
+   cray ims images update "${NEW_IMAGE_ID}" --link-etag "${MANIFEST_ETAG}" \
+     --link-type s3 --link-path "s3://ims/${NEW_IMAGE_ID}/manifest.json"
    ```

--- a/operations/image_management/IMS_export_import.md
+++ b/operations/image_management/IMS_export_import.md
@@ -109,7 +109,7 @@ either using an automated script, or manually one at a time.
 
    - Image ID
    - Image Name
-   - Recipe Link Path
+   - Image Link Path
 
 1. (`ncn-mw`) For each image to be exported, use the `cray artifacts` CLI to download the image artifacts from Ceph S3.
 
@@ -479,7 +479,7 @@ Using the image information previously noted, for each image to be restored, per
 1. (`ncn-mw`) View the manifest in S3.
 
    ```bash
-   cray artifacts describe ims ${NEW_IMAGE_ID}/manifest.json --format json
+   cray artifacts describe boot-images ${NEW_IMAGE_ID}/manifest.json --format json
    ```
 
    Example output:
@@ -511,5 +511,5 @@ Using the image information previously noted, for each image to be restored, per
 
    ```bash
    cray ims images update "${NEW_IMAGE_ID}" --link-etag "${MANIFEST_ETAG}" \
-     --link-type s3 --link-path "s3://ims/${NEW_IMAGE_ID}/manifest.json"
+     --link-type s3 --link-path "s3://boot-images/${NEW_IMAGE_ID}/manifest.json"
    ```


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->
In upcoming work for [CASMINST-6054](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-6054), there will be a number of changes made to the IMS import/export procedure. In order to make those changes easier to review, I've tried to do as much of my usual linting as possible up front. That is what is being done in this PR. It is not intending to make true content changes to the page -- it is just correcting some issues, making minor improvements, and doing some minor reorganization.

- [1.4 backport](https://github.com/Cray-HPE/docs-csm/pull/3411)
- [1.3 backport](https://github.com/Cray-HPE/docs-csm/pull/3412)

Backports to earlier releases are not needed, as the IMS import/export procedure does not exist in them.

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
