### PR TITLE
Add call to set enable_multiple to true for cephfs share (CASMPET-6385)

### DIFF
--- a/scripts/mount-cephfs-share.sh
+++ b/scripts/mount-cephfs-share.sh
@@ -88,6 +88,8 @@ function wait_for_running_daemons() {
 
 function create-admin-tools-cephfs-share {
   if [[ "$(ceph fs status admin-tools --format json-pretty 2>/dev/null|jq -r .clients[].fs)" != "admin-tools" ]]; then
+    echo "Setting cephfs 'enable_multiple' flag to true..."
+    ceph fs flag set enable_multiple true
     echo "Creating admin-tools ceph fs share..."
     ceph config generate-minimal-conf > /etc/ceph/new_ceph.conf
     cp /etc/ceph/new_ceph.conf /etc/ceph/ceph.conf


### PR DESCRIPTION
### Summary and Scope

- Fixes: https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6385

surtur:

```
ncn-m001:~ # /usr/share/doc/csm/scripts/mount-cephfs-share.sh
Didn't find previous CSM release rbd mount, proceeding...
Didn't find s3fs mount at /var/lib/admin-tools, proceeding...
Creating admin-tools ceph fs share...
Sleeping for five seconds waiting for 3 running mds.admin-tools daemons...
Sleeping for five seconds waiting for 3 running mds.admin-tools daemons...
Sleeping for five seconds waiting for 3 running mds.admin-tools daemons...
Found 3 running mds.admin-tools daemons -- continuing...
Creating admin-tools keyring...
[client.admin-tools]
	key = AQAfnQdkPM0iLBAAE8aYOsH8aLMc1w5xOtuCuA==
export auth(key=AQAfnQdkPM0iLBAAE8aYOsH8aLMc1w5xOtuCuA==)
fstab entry for cephfs already present...
Done! /etc/cray/upgrade/csm is mounted as a cephfs share!
```
#### Issue Type

- Bug Pull Request

### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
- [ ] I tested this on a vagrant environment (if yes, please include results or a description of the test)
 
### Idempotency
 
Yes
 
### Risks and Mitigations
 
Low
