### PR TITLE
CASMINST-6060: add the embedded repo to csm-config-management

### DIFF
--- a/operations/package_repository_management/Nexus_Import_Embedded_Repo.md
+++ b/operations/package_repository_management/Nexus_Import_Embedded_Repo.md
@@ -40,3 +40,28 @@ In order to access the packages in the embedded repo, it is necessary to add the
 ```bash
 zypper ar https://packages.local/repository/csm-${CSM_RELEASE}-embedded csm-embedded
 ```
+
+## Using the Embedded Repo for NCN image customization and node personalization
+
+In order to make the embedded repo available during NCN image customization and node personalization the `csm-config-management`
+repository in Gitea needs a modification.
+
+(`ncn-m#`)
+
+1. Clone the `csm-config-management` repository
+
+    ```bash
+    VCS_USER=$(kubectl get secret -n services vcs-user-credentials --template={{.data.vcs_username}} | base64 --decode)
+    VCS_PASS=$(kubectl get secret -n services vcs-user-credentials --template={{.data.vcs_password}} | base64 --decode)
+    git clone "https://${VCS_USER}:${VCS_PASS}@api-gw-service-nmn.local/vcs/cray/csm-config-management.git"
+    ```
+
+1. Add the following lines to the `vars/csm_repos.yml` file in the `csm-config-management` repository:
+
+    ```yaml
+    - name: csm-embedded
+      description: "CSM Embedded NCN Packages (added by Ansible)"
+      repo: https://packages.local/repository/csm-embedded
+    ```
+
+1. Commit and push the change.


### PR DESCRIPTION


<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

This commit amends Nexus_Import_Embedded_Repo.md to include adding the embedded repo to the list of repos csm-config-management adds via ansible during image customization and/or node personalization.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
