### PR TITLE
CASMINST-6074 main : Backup and Restore: Drax - No LDAP users after backup and restore

### DIFF
--- a/operations/kubernetes/Restore_Postgres.md
+++ b/operations/kubernetes/Restore_Postgres.md
@@ -314,6 +314,8 @@ In the event that the Keycloak Postgres cluster must be rebuilt and the data res
     These will be needed in the steps below. List the files in the `postgres-backup` S3 bucket and if the files exist, download the dump and secrets out of the S3 bucket.
     The `cray artifacts` CLI can be used list and download the files. Note that the `.psql` file contains the database dump and the .manifest file contains the secrets.
 
+    1. Setup the `CRAY_CREDENTIALS` environment variable to permit simple CLI operations needed while restoring the Keycloak database. See [Authenticate an Account with the Command Line](../security_and_authentication/Authenticate_an_Account_with_the_Command_Line.md).
+
     1. List the available backups.
 
         ```bash
@@ -344,6 +346,12 @@ In the event that the Keycloak Postgres cluster must be rebuilt and the data res
         cray artifacts get postgres-backup "${DUMPFILE_SRC}" "${DUMPFILE}"
         cray artifacts get postgres-backup "${MANIFEST}" "${MANIFEST}"
         ```
+
+    1. Unset the `CRAY_CREDENTIALS` environment variable:
+
+        ```bash
+        unset CRAY_CREDENTIALS
+        rm /tmp/setup-token.json
 
 1. (`ncn-mw#`) Set helper variables.
 


### PR DESCRIPTION
# Description
This issue was fixed previously in CASMINST-5362 but later removed as part of lint cleanup (CASMINST-5663)
This resolves [CASMINST-6074](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-6074) Backup and Restore: Drax - No LDAP users after backup and restore for main
Backport to 1.4, 1.3 and 1.2

# Checklist

- [ x If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
