### PR TITLE
CASMPET-6400: Update update-customizations.sh for keycloak 20.0.5

### DIFF
--- a/upgrade/scripts/upgrade/util/update-customizations.sh
+++ b/upgrade/scripts/upgrade/util/update-customizations.sh
@@ -88,11 +88,21 @@ yq w -i "$c" 'spec.kubernetes.services.cray-opa.ingresses.ingressgateway-hmn.iss
 yq w -i "$c" 'spec.kubernetes.services.cray-istio.services.istio-ingressgateway-hmn.serviceAnnotations.[external-dns.alpha.kubernetes.io/hostname]' 'api.hmnlb.{{ network.dns.external }},auth.hmnlb.{{ network.dns.external }},hmcollector.hmnlb.{{ network.dns.external }}'
 
 # cray-keycloak
-if [[ -n "$(yq3 r "$c" "spec.kubernetes.services.cray-keycloak.keycloak.keycloak")" ]]; then
-  yq r "$c" 'spec.kubernetes.services.cray-keycloak.keycloak.keycloak' | yq p - keycloak | yq m -i "$c" -
+if [[ -n "$(yq r "$c" "spec.kubernetes.services.cray-keycloak.keycloak.keycloak")" ]]; then
+  yq r "$c" 'spec.kubernetes.services.cray-keycloak.keycloak.keycloak' | yq p - 'spec.kubernetes.services.cray-keycloak.keycloak' | yq m -i "$c" -
   yq d -i "$c" 'spec.kubernetes.services.cray-keycloak.keycloak.keycloak'
-  yq w -i "$c" 'spec.kubernetes.services.cray-keycloak.keycloak.contextPath' "$(yq r "$c" 'spec.kubernetes.services.cray-keycloak.keycloak.basepath')"
-  yq d -i "$c" 'spec.kubernetes.services.cray-keycloak.keycloak.basepath'
+  if [[ -n "$(yq r "$c" "spec.kubernetes.services.cray-keycloak.keycloak.basepath")" ]]; then
+    yq w -i "$c" 'spec.kubernetes.services.cray-keycloak.keycloak.contextPath' "$(yq r "$c" 'spec.kubernetes.services.cray-keycloak.keycloak.basepath')"
+    yq d -i "$c" 'spec.kubernetes.services.cray-keycloak.keycloak.basepath'
+  fi
+fi
+if [[ -n "$(yq r "$c" "spec.kubernetes.services.cray-keycloak.keycloak")" ]]; then
+  yq r "$c" 'spec.kubernetes.services.cray-keycloak.keycloak' | yq p - 'spec.kubernetes.services.cray-keycloak.keycloakx' | yq m -i "$c" -
+  yq d -i "$c" 'spec.kubernetes.services.cray-keycloak.keycloak'
+  if [[ -n "$(yq r "$c" "spec.kubernetes.services.cray-keycloak.keycloakx.contextPath")" ]]; then
+    yq w -i "$c" 'spec.kubernetes.services.cray-keycloak.keycloakx.http.relativePath' "$(yq r "$c" 'spec.kubernetes.services.cray-keycloak.keycloak.contextPath')"
+    yq d -i "$c" 'spec.kubernetes.services.cray-keycloak.keycloakx.contextPath'
+  fi
 fi
 
 #


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->
Update the update-customizations.sh script to change the values for keycloak from keycloak to keycloakx to adjust for new values in updated chart.
# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
