### PR TITLE
CASMTRIAGE-5069 add upload-rebuild-templates.sh to install workflow

### DIFF
--- a/install/scripts/csm_services/steps/7.docs_csm_upload_rebuild_templates.yaml
+++ b/install/scripts/csm_services/steps/7.docs_csm_upload_rebuild_templates.yaml
@@ -21,16 +21,34 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-kind: pipeline
+kind: step
 metadata:
-  name: CSM Services Install Pipeline
-  description: ../../install_csm_services.md
+  name: Deploy Argo templates from docs-csm
+  description: |-
+    # Deploy Argo templates from docs-csm
+
+    Upload the Argo templates needed for IUF and NLS.
+
 spec:
-  steps:
-    - ./steps/1.initialize_bootstrap_registry.yaml
-    - ./steps/2.create_site_init_secret.yaml
-    - ./steps/3.deploy_sealed_secret_decryption_key.yaml
-    - ./steps/4.deploy_csm_application_and_services.yaml
-    - ./steps/5.setup_nexus.yaml
-    - ./steps/6.set_management_NCN_to_use_unbound.yaml
-    - ./steps/7.docs_csm_upload_rebuild_templates.yaml
+  jobs:
+    - preCondition:
+        description: |-
+          Nothing
+        command: |-
+          true
+        troubleshooting: |-
+          Nothing
+      action:
+        description: |-
+          Upload the Argo templates needed for IUF and NLS.
+        command: |-
+          ../../../workflows/scripts/upload-rebuild-templates.sh
+        troubleshooting: |-
+          Nothing
+      postValidation:
+        description: |-
+          Nothing
+        command: |-
+          true
+        troubleshooting: |-
+          Nothing


### PR DESCRIPTION
# Description

## Symptom 
IUF workflows are not starting up

## Problem
IUF workflow templates are not uploaded

## Root Cause
The root cause here is that the fresh-install path does not ever install the Argo workflow templates from docs-csm (using the script in /usr/share/doc/csm/workflows/script/upload-rebuild-templates.sh) 

Note that for the upgrade path, it does this through the prerequisites.sh, but we never run prerequisites.sh on a fresh install.

One solution here is to add an instruction to run upload-rebuild-templates.sh once kubernetes is up and running.

Note that we want to move away from having these templates part of docs-csm for 1.6.0 so this is a temporary measure (i.e. IUF backend will install these templates itself when it boots up).

# Tested

Tested on gamora

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
