### PR TITLE
CASMCMS-8473: Add note to cmsdev test details page about tftp file transfer subtest

### DIFF
--- a/troubleshooting/known_issues/sms_health_check.md
+++ b/troubleshooting/known_issues/sms_health_check.md
@@ -12,7 +12,12 @@
 This test requires that the Cray CLI is configured on nodes where the test is executed.
 See [Cray command line interface](../../operations/validate_csm_health.md#0-cray-command-line-interface).
 
-The following test can be run on any Kubernetes node (any master or worker node, but **not** on the PIT node).
+This test can be run on any Kubernetes NCN (any master or worker NCN, but **not** the PIT node).
+When run on a Kubernetes master NCN, the TFTP file transfer subtest is omitted. However, that TFTP subtest is
+run on a worker NCN as part of the Goss NCN health checks.
+
+(`ncn-mw#`) The following command runs the entire SMS test suite (with the possible exception of the TFTP file
+transfer subtest, as noted in the previous paragraph).
 
 ```bash
 /usr/local/bin/cmsdev test -q all


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->
Add a short note in the `cmsdev` test details page explaining that the tftp file transfer subtest is omitted on master nodes, but that it's run automatically on a worker node as part of the Goss tests.

- Resolves [CASMCMS-8473](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8473)
- Problem created by the change made in [CASMCMS-8450](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8450)
- Problem reported by [CASMTRIAGE-5071](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5071)
- [cmsdev test tool PR](https://github.com/Cray-HPE/cms-tools/pull/73)
- [csm-testing PR](https://github.com/Cray-HPE/csm-testing/pull/458)

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
