### PR TITLE
CASMINST-6062 Do a full link-checker scan if files were deleted/renamed [main]

### DIFF
--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -25,6 +25,12 @@ name: Check Links
 
 on:
   pull_request:
+  workflow_dispatch:
+    inputs:
+      force_full_scan:
+        description: 'Enforce link checking on all files'
+        required: false
+        type: boolean
 
 jobs:
   markdown-link-check:
@@ -34,11 +40,35 @@ jobs:
 
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@v18.7
+      uses: tj-actions/changed-files@v35
       with:
         files: "**/*.md"
         files_ignore: ".github/**/*"
 
-    - uses: docker://ghcr.io/tcort/markdown-link-check:3.9.3
+    # Newer versions of markdown-link-checker do not work with anchors - https://github.com/tcort/markdown-link-check/issues/225
+    - name: Check links in changed files
+      uses: docker://ghcr.io/tcort/markdown-link-check:3.9.3
+      if: ${{ steps.changed-files.outputs.deleted_files == '' && steps.changed-files.outputs.renamed_files == '' }}
       with:
         args: "--config .github/config/markdown_link.json ${{ steps.changed-files.outputs.all_changed_files }}"
+
+    # In case if any files were renamed or deleted, other files may still have references - need a full scan
+    - name: Full scan
+      uses: docker://ghcr.io/tcort/markdown-link-check:3.9.3
+      if: ${{ steps.changed-files.outputs.deleted_files != '' || steps.changed-files.outputs.renamed_files != '' || inputs.force_full_scan }}
+      with:
+        entrypoint: find
+        args: -name "*.md" -not -path "./.github/*" -exec sh -c "set -o pipefail; markdown-link-check --config .github/config/markdown_link.json {} 2>&1 | tee output.txt || cat output.txt >> error.txt" ";"
+
+    - name: Report errors
+      if: ${{ steps.changed-files.outputs.deleted_files != '' || steps.changed-files.outputs.renamed_files != '' || inputs.force_full_scan }}
+      uses: actions/github-script@v6
+      with:
+        script: |
+            const fs = require('fs');
+            if (fs.existsSync('error.txt')) {
+              fs.readFile('error.txt', 'utf8', (err, data) => {
+                console.log(data);
+              });
+              core.setFailed('Unsatisfied links found')
+            }


### PR DESCRIPTION
# Description
If one or more `*.md` files were deleted or renamed, references to these files may have not been updated. Currently, link checker does not catch such errors, because it only verifies changed files, and the files where reference are originating from may be unchanged. To catch this type of issue, full re-scan (all `*.md` files) is needed.

This PR also adds `workflow_dispatch` trigger to `Check Links` workflow, with optional `Enforce Full Scan` flag. This allows to run full scan manually.

# Testing
Temporarily renamed one file to trigger full re-scan. It was successfully triggered, and uncovered the following broken links (filtered for readility, and removing temporary filename change):
https://github.com/Cray-HPE/docs-csm/actions/runs/4449788607/jobs/7814442768

    FILE: ./operations/network/management_network/generate_switch_configs.md
      [✖] https://github.com/Cray-HPE/canu/blob/develop/docs/network_configuration_and_upgrade/custom_config.md

    FILE: ./operations/network/customer_accessible_networks/can_to_chn/network/network_upgrade_1.2_to_1.3.md
      [✖] https://github.com/Cray-HPE/canu/blob/main/docs/generate_network_config.md

    FILE: ./operations/security_and_authentication/Add_Root_Service_Account_for_Gigabyte_Controllers.md
      [✖] ../node_management/Add_Remove_Replace_NCNs.md#add-worker-storage-or-master-ncns

    FILE: ./operations/security_and_authentication/Configure_root_user_on_HPE_iLO_BMCs.md
      [✖] ../node_management/Add_Remove_Replace_NCNs.md#add-worker-storage-or-master-ncns

    FILE: ./operations/node_management/Reboot_NCNs.md
      [✖] ../configuration_management/Troubleshoot_Ansible_Play_Failures_in_CFS_Sessions.md

    FILE: ./operations/node_management/Enable_ipmi_access_on_HPE_iLO_BMCs.md
      [✖] Add_Remove_Replace_NCNs.md#add-worker-storage-or-master-ncns

    FILE: ./background/ncn_boot_workflow.md
      [✖] https://github.com/Cray-HPE/node-image-build/blob/lts/csm-1.0/boxes/ncn-common/files/scripts/metal/set-efi-bbs.sh

# Checklist
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.