### PR TITLE
CASMHMS-5956 CAPMC deprecation update

### DIFF
--- a/operations/power_management/Cray_Advanced_Platform_Monitoring_and_Control_CAPMC.md
+++ b/operations/power_management/Cray_Advanced_Platform_Monitoring_and_Control_CAPMC.md
@@ -19,15 +19,20 @@ documentation for detailed information about API options and features.
 The `cray capmc` command (see `--help`) can be used to control power to
 specific components by specifying the component NID, component name (xname), or group.
 
-- [Power control and query by xname](#power-control-and-query-by-xname)
-  - [Controllable components](#controllable components)
-  - [Power capping](#power-capping)
-  - [Power control and query by NID](#power-control-and-query-by-nid)
-  - [Power control and query by group](#power-control-and-query-by-group)
-- [Node energy](#node-energy)
-  - [System monitor](#system-monitor)
-  - [Others](#others)
-- [Deprecated interfaces](#deprecated-interfaces)
+- [Cray Advanced Platform Monitoring and Control (CAPMC)](#cray-advanced-platform-monitoring-and-control-capmc)
+  - [Power control and query by xname](#power-control-and-query-by-xname)
+    - [Controllable components](#controllable-components)
+      - [Air-cooled cabinets](#air-cooled-cabinets)
+      - [Liquid-cooled cabinets](#liquid-cooled-cabinets)
+      - [Naming convention](#naming-convention)
+        - [Examples of valid xnames](#examples-of-valid-xnames)
+    - [Power capping](#power-capping)
+  - [Deprecated interfaces](#deprecated-interfaces)
+    - [Power control and query by NID](#power-control-and-query-by-nid)
+    - [Power control and query by group](#power-control-and-query-by-group)
+  - [Node energy](#node-energy)
+    - [System monitor](#system-monitor)
+    - [Others](#others)
 
 ## Power control and query by xname
 
@@ -105,6 +110,13 @@ node type has its own power capping capabilities.
 modules, compute blades, and any non-compute nodes (NCNs) in air-cooled
 cabinets.
 
+## Deprecated interfaces
+
+The following APIs have been deprecated.
+
+See the [CAPMC Deprecation Notice](../../introduction/deprecated_features/CAPMC_Deprecation_Notice.md) for
+more information
+
 ### Power control and query by NID
 
 Use the interfaces from [Power control and query by xname](#power-control-and-query-by-xname):
@@ -144,8 +156,3 @@ Use the System Monitoring Application (SMA) Grafana instance:
 - `get_node_rules`
 - `emergency_power_off`
 - `get_nid_map`
-
-## Deprecated interfaces
-
-See the [CAPMC Deprecation Notice](../../introduction/deprecated_features/CAPMC_Deprecation_Notice.md) for
-more information

--- a/operations/power_management/Cray_Advanced_Platform_Monitoring_and_Control_CAPMC.md
+++ b/operations/power_management/Cray_Advanced_Platform_Monitoring_and_Control_CAPMC.md
@@ -115,7 +115,7 @@ cabinets.
 The following APIs have been deprecated.
 
 See the [CAPMC Deprecation Notice](../../introduction/deprecated_features/CAPMC_Deprecation_Notice.md) for
-more information
+more information.
 
 ### Power control and query by NID
 


### PR DESCRIPTION
# Description
The deprecated interfaces of CAPMC were not under the deprecation heading. Moved the heading to include the deprecated interfaces.

- [CASMHMS-5956](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5956)

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
