### PR TITLE
CASMTRIAGE-5077 set environment variables before master node rebuild

### DIFF
--- a/operations/node_management/Rebuild_NCNs/Rebuild_NCNs.md
+++ b/operations/node_management/Rebuild_NCNs/Rebuild_NCNs.md
@@ -74,7 +74,17 @@ make sure that the following conditions are met:
 
 ### Master node
 
-(`ncn-m#`) Run `ncn-rebuild-master-nodes.sh`:
+Master node rebuilds require that the environment varaibles `CSM_RELEASE`,  `CSM_REL_NAME`, and `CSM_ARTI_DIR` be set on the node where the rebuild script is executed.
+
+(`ncn-m#`) Set `CSM_RELEASE`,  `CSM_REL_NAME`, and `CSM_ARTI_DIR` environment variables. Replace `1.4.0` with the correct CSM release version:
+
+```bash
+CSM_RELEASE=1.4.0
+CSM_REL_NAME=csm-${CSM_RELEASE}
+CSM_ARTI_DIR="/etc/cray/upgrade/csm/${CSM_REL_NAME}/tarball/${CSM_REL_NAME}"
+```
+
+(`ncn-m#`) Rebuild the desired master node. Replace `ncn-m002` with the desired node to rebuild:
 
 ```bash
 /usr/share/doc/csm/upgrade/scripts/rebuild/ncn-rebuild-master-nodes.sh ncn-m002


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

Set environment variables before master node rebuild. Specifically setting `CSM_RELEASE`,  `CSM_REL_NAME`, and `CSM_ARTI_DIR`
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
