### PR TITLE
CASMCMS-8481: Make BOS V2 the default

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,7 +4,8 @@
 
 ## New
 
-v1 of Power Control Service (PCS) is active.  
+* v1 of Power Control Service (PCS) is active.
+* Cray CLI will default to version 2 (v2) for BOS, if a version is not specified.
 
 ### Monitoring
 

--- a/operations/boot_orchestration/BOS_API_Versions.md
+++ b/operations/boot_orchestration/BOS_API_Versions.md
@@ -40,7 +40,6 @@ These operators monitor nodes individually, not as a group, allowing each node t
 
 ## The CLI
 
-If no version is specified, the BOS CLI defaults to the `v1` endpoints. `cray bos <command>` defaults to `cray bos v1 <command>`.
-However, this will not always be the case and the default version will be switched to `v2` in the future.
+If no version is specified, the BOS CLI defaults to the `v2` endpoints. `cray bos <command>` defaults to `cray bos v2 <command>`. This is a change from the previous release.
 To avoid compatibility issues when the CLI's default version changes, scripts using the CLI should always explicitly specify a version.
 The behavior of defaulting to a version when the version parameter is omitted is a convenience to users and is not intended for scripts.

--- a/operations/boot_orchestration/Boot_Orchestration.md
+++ b/operations/boot_orchestration/Boot_Orchestration.md
@@ -20,7 +20,7 @@ BOS depends on each of the following services to complete its tasks:
 ## Use the BOS Cray CLI commands
 
 BOS commands are available using the Cray CLI.
-For ease of use, BOS can be used without specifying the version and will default to v1. However, explicitly specifying the version in scripts or documentation
+For ease of use, BOS can be used without specifying the version and will default to v2. However, explicitly specifying the version in scripts or documentation
 is **highly recommended**, because the default BOS version for the CLI may change in the future.
 
 (`ncn-mw#`) API information, including the default API version, can be found with the following command:


### PR DESCRIPTION
When no version is specified for a cray bos <command>, the default BOS version is V2. Previously, it was V1.

<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
