### PR TITLE
CASMHMS-5565: Add NID defragmentation script and procedure CSM 1.4

### DIFF
--- a/operations/README.md
+++ b/operations/README.md
@@ -547,6 +547,7 @@ Monitor and manage compute nodes (CNs) and non-compute nodes (NCNs) used in the 
 - [Replace a Compute Blade Using SAT](node_management/Replace_a_Compute_Blade_Using_SAT.md)
 - [Update the Gigabyte Node BIOS Time](node_management/Update_the_Gigabyte_Node_BIOS_Time.md)
 - [S3FS Usage Guidelines](node_management/S3FS_Usage_and_Guidelines.md)
+- [Defragment NID Numbering](node_management/Defragment_NID_Numbering.md)
 
 ## Network
 

--- a/operations/node_management/Defragment_NID_Numbering.md
+++ b/operations/node_management/Defragment_NID_Numbering.md
@@ -1,0 +1,341 @@
+# Defragment NID Numbering
+
+This procedure will rearrange NIDs for specified compute nodes to create a numerically (NID) and lexicographically (xname) contiguous block of NIDs at the specified start point.
+
+It is recommended that the system be taken down for maintenance while performing this procedure.
+
+This procedure should only be performed if absolutely required. Some reasons for needing to perform this procedure include:
+
+1. Compute nodes were added to SLS with incorrect NID numbering, missing node entries, and/or extra node entries.
+
+2. Compute nodes were permanently moved, removed, or re-provisioned and there is a desire to remove NID numbering gaps.
+
+The example in this procedure removes NID gaps from 2 cabinets of compute nodes that were a result of incorrect numbering in SLS.
+
+## Topics
+
+* [Prerequisites](#prerequisites)
+* [Defragment NID Script Functionality and Limitations](#defragment-nid-script-functionality-and-limitations)
+* [NID Defragmentation Procedure](#nid-defragmentation-procedure)
+  * [Step 1: Run the Defragmentation Script](#step-1-run-the-defragmentation-script)
+  * [Step 2: Perform Reload of DVS/LNet Service](#step-2-perform-reload-of-dvslnet-service)
+* [Troubleshooting](#troubleshooting)
+  * [Discovery Errors](#discovery-errors)
+  * [Invalid NID Range](#invalid-nid-range)
+
+## Prerequisites
+
+* Hardware State Manager's (HSM) inventory data is up to date (Hardware has not changed since the previous discovery).
+* Chassis-level entries exist in the System Layout Service (SLS) and are correct for all Mountain and Hill chassis.
+* All compute nodes are powered off.
+
+## Defragment NID Script Functionality and Limitations
+
+In the process of defragmenting NIDs, the `defragment_nids.py` script will:
+
+* Update the NID numbers for compute node entries in HSM.
+* Update/create SLS compute node entries with correct NID numbering and aliases.
+* Remove node entries from HSM that were not previously removed due to missed blade swap procedure steps. This includes associated entries under `/State/Components`, `/Inventory/ComponentEndpoints`, `/Inventory/Hardware`, and `/Inventory/EthernetInterfaces`.
+* Remove SLS node entries with conflicting NIDs that are not in HSM.
+* Correct the _Class_ designation of compute nodes in HSM.
+
+Limitations of the `defragment_nids.py` script:
+
+* Only affects compute nodes.
+* HSM node entries are only removed if the "leftover" nodes are of a different model than the existing nodes in the same slot.
+* SLS node entries that don't exist in HSM are only removed if their NID falls within the specified NID block.
+
+## NID Defragmentation Procedure
+
+### Step 1: Run the Defragmentation Script
+
+1. Choose the starting NID for the NID block (e.g., 1000).
+
+    ```bash
+        export NID_START=1000
+    ```
+
+2. Choose the components to include in the NID block (e.g., `x1000`,`x3000`). This can be specified at cabinet (`x#`), chassis (`x#c#`), slot (`x#c#s#`), or even node level (`x#c#s#b#n#`).
+This list always gets expanded to include all compute nodes contained by the specified parent components.
+
+    ```bash
+        export INCLUDE_LIST=x1000,x3000
+    ```
+
+3. Run `defragment_nids.py`.
+**NOTE:** You can do a dryrun of `defragment_nids.py` to print out a report of what will happen without affecting the system's NID numbering by specifying `--dryrun`.
+
+    ```bash
+        /usr/share/doc/csm/scripts/operations/node_management/defragment_nids.py --start ${NID_START} --include ${INCLUDE_LIST} | jq .
+    ```
+
+    Example (summarized) output:
+
+    ```json
+    {
+      "Description": "NID Defragmentation Report",
+      "StartingNID": 1000,
+      "Include": [
+        "x1000",
+        "x3000"
+      ],
+      "HSMChanges": [
+        {
+          "ID": "x1000c0s0b0n0",
+          "OldNID": 1000,
+          "NewNID": 1000
+        },
+        {
+          "ID": "x1000c0s0b0n1",
+          "OldNID": 1001,
+          "NewNID": 1001
+        },
+        {
+          "ID": "x1000c0s0b1n0",
+          "OldNID": 1002,
+          "NewNID": 1002
+        },
+        ...
+        {
+          "ID": "x1000c0s2b1n0",
+          "OldNID": 1010,
+          "NewNID": 1009
+        },
+        {
+          "ID": "x1000c0s3b0n0",
+          "OldNID": 1012,
+          "NewNID": 1010
+        },
+        {
+          "ID": "x1000c0s3b0n1",
+          "OldNID": 1013,
+          "NewNID": 1011
+        },
+        {
+          "ID": "x3001c0s1b1n0",
+          "OldNID": 1,
+          "NewNID": 1012
+        },
+        ...
+        {
+          "ID": "x3000c0s6b0n0",
+          "OldNID": 20,
+          "NewNID": 1020
+        }
+      ],
+      "SLSEntries": [
+        {
+          "Xname": "x1000c0s0b0n0",
+          "Class": "Hill",
+          "ExtraProperties": {
+            "Aliases": [
+              "nid001000"
+            ],
+            "NID": 1000,
+            "Role": "Compute"
+          }
+        },
+        {
+          "Xname": "x1000c0s0b0n1",
+          "Class": "Hill",
+          "ExtraProperties": {
+            "Aliases": [
+              "nid001001"
+            ],
+            "NID": 1001,
+            "Role": "Compute"
+          }
+        },
+        {
+          "Xname": "x1000c0s0b1n0",
+          "Class": "Hill",
+          "ExtraProperties": {
+            "Aliases": [
+              "nid001002"
+            ],
+            "NID": 1002,
+            "Role": "Compute"
+          }
+        },
+        ...
+        {
+          "Xname": "x1000c0s2b1n0",
+          "Class": "Hill",
+          "ExtraProperties": {
+            "Aliases": [
+              "nid001009"
+            ],
+            "NID": 1009,
+            "Role": "Compute"
+          }
+        },
+        {
+          "Xname": "x1000c0s3b0n0",
+          "Class": "Hill",
+          "ExtraProperties": {
+            "Aliases": [
+              "nid001010"
+            ],
+            "NID": 1010,
+            "Role": "Compute"
+          }
+        },
+        {
+          "Xname": "x1000c0s3b0n1",
+          "Class": "Hill",
+          "ExtraProperties": {
+            "Aliases": [
+              "nid001011"
+            ],
+            "NID": 1011,
+            "Role": "Compute"
+          }
+        },
+        {
+          "Xname": "x3000c0s1b1n0",
+          "Class": "River",
+          "ExtraProperties": {
+            "Aliases": [
+              "nid001012"
+            ],
+            "NID": 1012,
+            "Role": "Compute"
+          }
+        },
+        ...
+        {
+          "Xname": "x3000c0s6b0n0",
+          "Class": "River",
+          "ExtraProperties": {
+            "Aliases": [
+              "nid001020"
+            ],
+            "NID": 1020,
+            "Role": "Compute"
+          }
+        }
+      ],
+      "NodesRemovedFromHSM": [],
+      "NodesRemovedFromSLS": [
+        "x1000c0s2b0n1",
+        "x1000c0s2b1n1"
+      ],
+      "Errors": []
+    }
+    ```
+
+    Example output if `--output text` is specified:
+
+    ```text
+    NID Defragmentation Report
+    =================
+    Starting NID: 1000
+    Include: ['x1000', 'x3000']
+    =================
+    HSM Changes:
+    x1000c0s0b0n0 1000 -> 1000
+    x1000c0s0b0n1 1001 -> 1001
+    x1000c0s0b1n0 1002 -> 1002
+    x1000c0s0b1n1 1003 -> 1003
+    x1000c0s1b0n0 1004 -> 1004
+    x1000c0s1b0n1 1005 -> 1005
+    x1000c0s1b1n0 1006 -> 1006
+    x1000c0s1b1n1 1007 -> 1007
+    x1000c0s2b0n0 1008 -> 1008
+    x1000c0s2b1n0 1010 -> 1009
+    x1000c0s3b0n0 1012 -> 1010
+    x1000c0s3b0n1 1013 -> 1011
+    x3000c0s1b1n0 1 -> 1012
+    x3000c0s1b2n0 2 -> 1013
+    x3000c0s1b3n0 3 -> 1014
+    x3000c0s1b4n0 4 -> 1015
+    x3000c0s3b1n0 11 -> 1016
+    x3000c0s3b2n0 12 -> 1017
+    x3000c0s3b3n0 13 -> 1018
+    x3000c0s3b4n0 14 -> 1019
+    x3000c0s6b0n0 20 -> 1020
+
+    SLS Entries:
+    {"Xname": "x1000c0s0b0n0", "Class": "Hill", "ExtraProperties": {"Aliases": ["nid001000"], "NID": 1000, "Role": "Compute"}}
+    {"Xname": "x1000c0s0b0n1", "Class": "Hill", "ExtraProperties": {"Aliases": ["nid001001"], "NID": 1001, "Role": "Compute"}}
+    {"Xname": "x1000c0s0b1n0", "Class": "Hill", "ExtraProperties": {"Aliases": ["nid001002"], "NID": 1002, "Role": "Compute"}}
+    {"Xname": "x1000c0s0b1n1", "Class": "Hill", "ExtraProperties": {"Aliases": ["nid001003"], "NID": 1003, "Role": "Compute"}}
+    {"Xname": "x1000c0s1b0n0", "Class": "Hill", "ExtraProperties": {"Aliases": ["nid001004"], "NID": 1004, "Role": "Compute"}}
+    {"Xname": "x1000c0s1b0n1", "Class": "Hill", "ExtraProperties": {"Aliases": ["nid001005"], "NID": 1005, "Role": "Compute"}}
+    {"Xname": "x1000c0s1b1n0", "Class": "Hill", "ExtraProperties": {"Aliases": ["nid001006"], "NID": 1006, "Role": "Compute"}}
+    {"Xname": "x1000c0s1b1n1", "Class": "Hill", "ExtraProperties": {"Aliases": ["nid001007"], "NID": 1007, "Role": "Compute"}}
+    {"Xname": "x1000c0s2b0n0", "Class": "Hill", "ExtraProperties": {"Aliases": ["nid001008"], "NID": 1008, "Role": "Compute"}}
+    {"Xname": "x1000c0s2b1n0", "Class": "Hill", "ExtraProperties": {"Aliases": ["nid001009"], "NID": 1009, "Role": "Compute"}}
+    {"Xname": "x1000c0s3b0n0", "Class": "Hill", "ExtraProperties": {"Aliases": ["nid001010"], "NID": 1010, "Role": "Compute"}}
+    {"Xname": "x1000c0s3b0n1", "Class": "Hill", "ExtraProperties": {"Aliases": ["nid001011"], "NID": 1011, "Role": "Compute"}}
+    {"Xname": "x3000c0s1b1n0", "Class": "River", "ExtraProperties": {"Aliases": ["nid001012"], "NID": 1012, "Role": "Compute"}}
+    {"Xname": "x3000c0s1b2n0", "Class": "River", "ExtraProperties": {"Aliases": ["nid001013"], "NID": 1013, "Role": "Compute"}}
+    {"Xname": "x3000c0s1b3n0", "Class": "River", "ExtraProperties": {"Aliases": ["nid001014"], "NID": 1014, "Role": "Compute"}}
+    {"Xname": "x3000c0s1b4n0", "Class": "River", "ExtraProperties": {"Aliases": ["nid001015"], "NID": 1015, "Role": "Compute"}}
+    {"Xname": "x3000c0s3b1n0", "Class": "River", "ExtraProperties": {"Aliases": ["nid001016"], "NID": 1016, "Role": "Compute"}}
+    {"Xname": "x3000c0s3b2n0", "Class": "River", "ExtraProperties": {"Aliases": ["nid001017"], "NID": 1017, "Role": "Compute"}}
+    {"Xname": "x3000c0s3b3n0", "Class": "River", "ExtraProperties": {"Aliases": ["nid001018"], "NID": 1018, "Role": "Compute"}}
+    {"Xname": "x3000c0s3b4n0", "Class": "River", "ExtraProperties": {"Aliases": ["nid001019"], "NID": 1019, "Role": "Compute"}}
+    {"Xname": "x3000c0s6b0n0", "Class": "River", "ExtraProperties": {"Aliases": ["nid001020"], "NID": 1020, "Role": "Compute"}}
+
+    Nodes Removed From SLS:
+        x1000c0s2b0n1,x1000c0s2b1n1
+    ```
+
+### Step 2: Perform Reload of DVS/LNet Service
+
+DVS node maps on NCN worker nodes and gateway nodes have entries of compute nodes that include their NIDs. Thus, the NID defragmentation process will impact the NCN worker and gateway nodes.
+
+Carry out the _Procedure To Perform After CSM Defragmentation of Compute Node Identifiers_ documented in publication _HPE Cray Operating System Administration Guide: CSM on HPE Cray EX Systems_.
+
+## Troubleshooting
+
+### Discovery Errors
+
+The `defragment_nids.py` script checks for HSM discovery errors on the specified nodes before proceeding. It will return an error if any are found. For example:
+
+```json
+{
+    "Message": "Discovery errors detected.",
+    "Severity": "Error",
+    "IDs": ["x1000c0s1b1", "x3000c0s6b0"]
+}
+```
+
+To continue with the NID defragmentation you must first debug any discovery errors such that all specified components have a discovery status of `DiscoverOK` in HSM.
+
+See [Troubleshoot Issues with Redfish Endpoint Discovery](Troubleshoot_Issues_with_Redfish_Endpoint_Discovery.md) for debugging discovery issues.
+
+Alternately, if these issues are known and will not affect the desired resulting NID numbering, the `--ignore-discovery-errors` option may be specified with `defragment_nids.py` to continue through these errors.
+
+**Warning:** Continuing through discovery errors may result in incorrect NID numbering if HSM's inventory data for those nodes is missing or incorrect.
+
+### Invalid NID Range
+
+The `defragment_nids.py` script checks for nodes with NIDs that fall within the specified NID block that are not specified in the include list. An example of this error is:
+
+```json
+{
+    "Message": "There is an unexpected node NID in the requested NID range, 1000-1100",
+    "Severity": "Error",
+    "IDs": ["x3001c0s0b0n0", "x3001c0s0b0n1"]
+}
+```
+
+These might be NCNs and UANs or compute nodes that were not covered by the specified include list. Here are some scenarios and how to fix them:
+
+1. Computes nodes in cabinets `x1000` and `x1002` where specified in the include list so the new NID block is 1000-1100 but the compute nodes in cabinet `x1001` have NIDs 1090-1140. This would create a conflict so `defragment_nids.py` will return an error.
+This can be fixed by:
+
+    * Changing the starting NID for the new NID block (e.g., 1200).
+    * Include `x1001` in the include list to include it in the new NID block.
+    * Run `defragment_nids.py` to first move the computes nodes in `x1001` to another NID block then rerun `defragment_nids.py` for the compute nodes in cabinets `x1000` and `x1002`.
+
+2. Computes nodes in cabinet `x1000` where specified in the include list so the new NID block is 1000-1100 but `x1000c1b0n0` is a UAN that was given the NID 1000. This would create a conflict so `defragment_nids.py` will return an error.
+This can be fixed by:
+
+    * Changing the starting NID for the new NID block (e.g., 1001).
+    * Manually change the NID of the UAN in HSM and SLS then rerun `defragment_nids.py` for the nodes in `x1000`.
+
+3. Computes nodes in cabinet `x1000` where specified in the include list so the new NID block is 1000-1100 but `x3000c0b0n0` is an NCN that was given the NID 1000. This would create a conflict so `defragment_nids.py` will return an error.
+It is not recommended to try and change the NID of an NCN. The best course of action is to change the starting NID for the new NID block.

--- a/scripts/operations/node_management/defragment_nids.py
+++ b/scripts/operations/node_management/defragment_nids.py
@@ -1,0 +1,728 @@
+#!/usr/bin/python3
+
+# MIT License
+#
+# (C) Copyright [2023] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+"""
+	Attempt to rearrange NIDs for specified nodes to create a numerically (NID)
+	and lexicographically (xname) contiguous block of NIDs at the specified start.
+	
+	This script makes a few assumptions:
+	1) Inventory data is up to date (nothing has changed since the last HSM discovery).
+	2) Chassis entries in SLS are correct and exist for all Mountain and Hill hardware.
+	3) HSM's view of nodes is more correct than SLS's and will delete SLS entries with
+	   conflicting NIDs and create new SLS entries for nodes found by HSM that are not
+	   in SLS.
+	4) HSM may have node information for non-existent nodes left behind by a blade swap
+	   where procedure wasn't followed. The script will delete these.
+"""
+
+import json
+from base64 import b64decode
+import sys,getopt
+import requests
+from kubernetes import client, config
+
+hsmURL = "https://api-gw-service-nmn.local/apis/smd/hsm/v2"
+slsURL = "https://api-gw-service-nmn.local/apis/sls/v1"
+
+dryrun = False
+debugLevel = 0
+outputFormat = "json"
+simMode = False
+
+# MaxComponentQuery is the maximum number of components that we can safely allow
+# in URI parameters before it might get too long for some buffer somewhere.
+MaxComponentQuery = 2048
+
+def getK8sClient():
+	"""Create a k8s client object for use in getting auth tokens."""
+	config.load_kube_config()
+	k8sClient = client.CoreV1Api()
+	return k8sClient
+
+def getAuthenticationToken():
+	"""Fetch auth token for HMS REST API calls."""
+	URL = "https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token"
+
+	kSecret = getK8sClient().read_namespaced_secret("admin-client-auth", "default")
+	secret = b64decode(kSecret.data['client-secret']).decode("utf-8")
+
+	DATA = {
+		"grant_type": "client_credentials",
+		"client_id": "admin-client",
+		"client_secret": secret
+	}
+
+	try:
+		r = requests.post(url=URL, data=DATA)
+	except OSError:
+		return ""
+
+	result = json.loads(r.text)
+	return result['access_token']
+
+def doRest(uri, authToken, op, payload=None):
+	"""
+		Func to get a JSON payload from a URL. It's assumed to be a full URL.
+		Also note that we'll only ever be contacting HMS services.
+	"""
+	restHeaders = {}
+	if not simMode:
+		restHeaders['Authorization'] = 'Bearer %s' % authToken
+	if op == "get":
+		r = requests.get(url=uri, headers=restHeaders)
+	elif op == "delete":
+		r = requests.delete(url=uri, headers=restHeaders)
+	elif op == "post" and not payload is None:
+		r = requests.post(url=uri, headers=restHeaders, data=json.dumps(payload))
+	elif op == "put" and not payload is None:
+		r = requests.put(url=uri, headers=restHeaders, data=json.dumps(payload))
+	elif op == "patch" and not payload is None:
+		r = requests.patch(url=uri, headers=restHeaders, data=json.dumps(payload))
+	else:
+		return 1
+
+	retJSON = r.text
+
+	if r.status_code >= 300:
+		stat = 1
+	else:
+		stat = 0
+
+	respData = None
+	if len(retJSON) > 2:
+		respData = json.loads(retJSON)
+	return respData, stat
+
+def doRestGet(uri, authToken):
+	"""Wrapper for doRest() for GET operations"""
+	return doRest(uri, authToken, "get")
+
+def doRestPost(uri, authToken, payload):
+	"""Wrapper for doRest() for POST operations"""
+	return doRest(uri, authToken, "post", payload)
+
+def doRestPatch(uri, authToken, payload):
+	"""Wrapper for doRest() for PATCH operations"""
+	return doRest(uri, authToken, "patch", payload)
+
+def doRestPut(uri, authToken, payload):
+	"""Wrapper for doRest() for PUT operations"""
+	return doRest(uri, authToken, "put", payload)
+
+def doRestDelete(uri, authToken):
+	"""Wrapper for doRest() for DELETE operations"""
+	return doRest(uri, authToken, "delete")
+
+def getHSMComps(authToken, fltr):
+	"""Get HSM Component data"""
+	url = hsmURL + "/State/Components" + fltr
+	return doRestGet(url, authToken)
+
+def getHSMCompQuery(authToken, compFilter):
+	"""Expand a list of components based on a filter"""
+	url = hsmURL + "/State/Components/Query"
+	return doRestPost(url, authToken, compFilter)
+
+def getHSMRFEndpoints(authToken, fltr):
+	"""Get RedfishEndpoint information from HSM"""
+	url = hsmURL + "/Inventory/RedfishEndpoints" + fltr
+	return doRestGet(url, authToken)
+
+def getHSMHWInv(authToken, xname, fltr):
+	"""Get hardware inventory information from HSM"""
+	url = hsmURL + "/Inventory/Hardware/Query/" + xname + fltr
+	return doRestGet(url, authToken)
+
+def patchHSMNIDs(authToken, nidList):
+	"""Update component NID information in HSM"""
+	url = hsmURL + "/State/Components/BulkNID"
+	payload = {
+		'Components': nidList
+	}
+	return doRestPatch(url, authToken, payload)
+
+def patchHSMClass(authToken, hmsClass, compList):
+	"""Update component NID information in HSM"""
+	url = hsmURL + "/State/Components/BulkClass"
+	payload = {
+		'ComponentIDs': compList,
+		'Class': hmsClass
+	}
+	return doRestPatch(url, authToken, payload)
+
+def deleteHSMComp(authToken, xname):
+	"""Delete HSM component data"""
+	url = hsmURL + "/State/Components/" + xname
+	return doRESTDelete(url, authToken)
+
+def deleteHSMCompEP(authToken, xname):
+	"""Delete HSM component endpoint data"""
+	url = hsmURL + "/Inventory/ComponentEndpoints/" + xname
+	return doRESTDelete(url, authToken)
+
+def deleteHSMHwLoc(authToken, xname):
+	"""Delete HSM hardware location data (detach FRU data from the empty location)"""
+	url = hsmURL + "/Inventory/Hardware/" + xname
+	return doRESTDelete(url, authToken)
+
+def getHSMEth(authToken, fltr):
+	"""Get HSM ethernet interfaces data"""
+	url = hsmURL + "/Inventory/EthernetInterface" + fltr
+	return doRestGet(url, authToken)
+
+def deleteHSMEth(authToken, id):
+	"""Delete HSM ethernet interface data"""
+	url = hsmURL + "/Inventory/EthernetInterface/" + id
+	return doRESTDelete(url, authToken)
+
+def postHSMComps(authToken, compList):
+	"""Expand a list of components based on a filter"""
+	url = hsmURL + "/State/Components"
+	payload = {
+		'Components': compList,
+		'force': True
+	}
+	return doRestPost(url, authToken, payload)
+
+def getChassisClass(authToken, chassis):
+	"""Get the hardware class of the specified chassis from SLS"""
+	slsComps, stat = getSLSComps(authToken, "?xname=" + chassis)
+	if stat != 0:
+		return slsComps, stat
+	if slsComps == None or slsComps == "":
+		return "River", stat
+	return slsComps[0]['Class'], stat
+
+def getSLSComps(authToken, fltr):
+	"""Get component information from SLS"""
+	url = slsURL + "/search/hardware" + fltr
+	return doRestGet(url, authToken)
+
+def putSLSComp(authToken, slsEntry):
+	"""Update/Create component entries in SLS"""
+	url = slsURL + "/hardware/" + slsEntry['Xname']
+	return doRestPut(url, authToken, slsEntry)
+
+def deleteSLSComp(authToken, xname):
+	"""Delete a component from SLS"""
+	url = slsURL + "/hardware/" + xname
+	return doRestDelete(url, authToken)
+
+def compSort(comp):
+  return comp['ID']
+
+def printReport(report):
+	if outputFormat == "text":
+		printReportText(report)
+	else:
+		printReportJson(report)
+
+def printReportText(report):
+	"""Print a text report comparing what was with what will be."""
+	print(report['Description'])
+	print("=================")
+	print("Starting NID: %d" % report['StartingNID'])
+	print("Include: %s" % report['Include'])
+	print("=================")
+	print("HSM Changes:")
+	for node in report['HSMChanges']:
+		print("%s %d -> %d" % (node['ID'], node['OldNID'], node['NewNID']))
+	print("")
+	print("SLS Entries:")
+	for entry in report['SLSEntries']:
+		print(json.dumps(entry))
+	if len(report['NodesRemovedFromHSM']) > 0:
+		print("")
+		print("Nodes Removed From HSM:")
+		print("    " + ','.join(report['NodesRemovedFromHSM']))
+	if len(report['NodesRemovedFromSLS']) > 0:
+		print("")
+		print("Nodes Removed From SLS:")
+		print("    " + ','.join(report['NodesRemovedFromSLS']))
+	if len(report['Errors']) > 0:
+		print("")
+		print("Errors:")
+		for err in report['Errors']:
+			if 'IDs' in err:
+				print("%s: %s - IDs: %s" % (err['Severity'], err['Message'], ','.join(err['IDs'])))
+			else:
+				print("%s: %s" % (err['Severity'], err['Message']))
+
+def printReportJson(report):
+	"""Print a JSON report comparing what was with what will be."""
+	print(json.dumps(report))
+
+def usage():
+	print("Usage: %s [options]" % sys.argv[0])
+	print(" ")
+	print("   --debug=level    Set debug level")
+	print("   --dryrun         Gather all info but don't change anything.")
+	print("   --start=NID      The desired starting point for the new block of NIDs.")
+	print("   --include=list   Comma-separated list of XNames. This list will be expanded")
+	print("                    to a list of compute nodes to act upon.")
+	print("                    Example: --include=x1000 includes all compute nodes in cabinet x1000.")
+	print("   --output=format  Format of the output. The options are:")
+	print("                      - json (default)")
+	print("                      - text")
+	print("   --ignore-discovery-errors  Specify to ignore HSM discovery errors.")
+	print("   --sim-mode       Specify to run in a simulation environment without kubernetes auth.")
+	print(" ")
+
+def main():
+	"""Entry point"""
+	global dryrun
+	global debugLevel
+	global outputFormat
+	global simMode
+	global hsmURL
+	global slsURL
+
+	startingNID = None
+	includeList = None
+	includes = []
+	ignoreDiscoveryErrors = False
+	errors = []
+	report = {
+		'Description': 'NID Defragmentation Report',
+		'StartingNID': 1,
+		'Include': [],
+		'HSMChanges': [],
+		'SLSEntries': [],
+		'NodesRemovedFromHSM': [],
+		'NodesRemovedFromSLS': [],
+		'Errors': []
+	}
+
+	try:
+		opts,args = getopt.getopt(sys.argv[1:],"",["start=","include=","debug=","dryrun","output=","ignore-discovery-errors","sim-mode"])
+	except getopt.GetoptError:
+		usage()
+		return 1
+
+	for opt,arg in opts:
+		if opt == '-h':
+			usage()
+			return 0
+		elif opt in ("--start"):
+			startingNID = int(arg)
+		elif opt in ("--include"):
+			includeList = arg
+		elif opt in ("--dryrun"):
+			dryrun = True
+		elif opt in ("--debug"):
+			debugLevel = int(arg)
+		elif opt in ("--output"):
+			if arg == "text":
+				outputFormat = arg
+			else:
+				outputFormat = "json"
+		elif opt in ("--ignore-discovery-errors"):
+			ignoreDiscoveryErrors = True
+		elif opt in ("--sim-mode"):
+			simMode = True
+			hsmURL = "http://localhost:27779/hsm/v2"
+			slsURL = "http://localhost:8376/v1"
+
+	if startingNID == None:
+		startingNID = 1
+
+	if not includeList == None:
+		includes = includeList.split(',',-1)
+
+	report['StartingNID'] = startingNID
+	report['Include'] = includes
+
+	authToken = ""
+	if not simMode:
+		authToken = getAuthenticationToken()
+		if authToken == "":
+			err = {
+				'Message': 'No/empty auth token, cannot continue. For troubleshooting and manual steps, see https://github.com/Cray-HPE/docs-csm/blob/main/operations/security_and_authentication/Retrieve_an_Authentication_Token.md.',
+				'Severity': 'Error'
+			}
+			report['Errors'].append(err)
+			printReport(report)
+			return 1
+
+	compFilter = {
+		'ComponentIDs': includes,
+		'type': ['Node'],
+		'role': ['Compute']
+	}
+
+	# Expand to a list of nodes
+	nodes, stat = getHSMCompQuery(authToken, compFilter)
+	if stat != 0:
+		err = {
+			'Message': 'HSM Components Query returned non-zero. %s' % nodes,
+			'Severity': 'Error'
+		}
+		report['Errors'].append(err)
+		printReport(report)
+		return 1
+
+	# Get the RedfishEndpoint data for the NodeBMCs of those nodes
+	bmcSet = set()
+	allowedNodes = []
+	for node in nodes['Components']:
+		fields = node['ID'].split('n')
+		bmcSet.add(fields[0])
+		allowedNodes.append(node['ID'])
+	bmcList = list(bmcSet)
+	rfEPs = []
+	start = 0
+	end = len(bmcList)
+	if end > MaxComponentQuery:
+		end = MaxComponentQuery
+	while start < len(bmcList):
+		rfEpData, stat = getHSMRFEndpoints(authToken, "?type=nodebmc&id=" + '&id='.join(bmcList[start:end]))
+		if stat != 0:
+			err = {
+				'Message': 'HSM RedfishEndpoints returned non-zero. %s' % rfEpData,
+				'Severity': 'Error'
+			}
+			report['Errors'].append(err)
+			printReport(report)
+			return 1
+		rfEPs.extend(rfEpData['RedfishEndpoints'])
+		start = end
+		end = end + MaxComponentQuery
+		if end > len(bmcList):
+			end = len(bmcList)
+
+	discoveryErrList = []
+	slotSet = set()
+	for rfEp in rfEPs:
+		if rfEp['Enabled']:
+			fields = rfEp['ID'].split('b')
+			slotSet.add(fields[0])
+			if not rfEp['DiscoveryInfo']['LastDiscoveryStatus'] == "DiscoverOK":
+				discoveryErrList.append(rfEp['ID'])
+	if len(discoveryErrList) != 0:
+		err = {
+			'Message': 'Discovery errors detected.',
+			'Severity': 'Error',
+			'IDs': discoveryErrList
+		}
+		if not ignoreDiscoveryErrors:
+			report['Errors'].append(err)
+			printReport(report)
+			return 1
+		# Still report even if we're ignoring discovery errors
+		err['Severity'] = 'Warning'
+		report['Errors'].append(err)
+
+	nodeList = []
+	mismatchList = []
+	for slot in slotSet:
+		# Retrieve FRU information for all nodes in the slot so we can just compare nodes we expect to be the same.
+		hwInv, stat = getHSMHWInv(authToken, slot, "?type=node&children=false")
+		if stat != 0:
+			err = {
+				'Message': 'HSM Hardware Inventory returned non-zero. %s' % hwInv,
+				'Severity': 'Error'
+			}
+			report['Errors'].append(err)
+			printReport(report)
+			return 1
+
+		nodeType = ""
+		mismatch = False
+		node0Type = ""
+		tempNodeList = []
+		# Make sure all node types match. If they don't, try to determine which
+		# one is correct using the type of b0n0 or b1n0 since one of them should
+		# always be there.
+		for nodeFRU in hwInv['Nodes']:
+			newNodeType = nodeFRU['PopulatedFRU']['NodeFRUInfo']['Model']
+			if nodeFRU['ID'].endswith("b0n0"):
+				node0Type = nodeFRU['PopulatedFRU']['NodeFRUInfo']['Model']
+			if nodeFRU['ID'].endswith("b1n0") and node0Type == "":
+				# River multi-node compute modules start at b1 instead of b0.
+				node0Type = nodeFRU['PopulatedFRU']['NodeFRUInfo']['Model']
+			if nodeType == "":
+				nodeType = newNodeType
+			if not nodeType == newNodeType:
+				mismatch = True
+			tempNodeList.append(nodeFRU['ID'])
+		if mismatch:
+			for nodeFRU in hwInv['Nodes']:
+				if not nodeFRU['ID'] in allowedNodes:
+					continue
+				newNodeType = nodeFRU['PopulatedFRU']['NodeFRUInfo']['Model']
+				if node0Type == newNodeType:
+					nodeList.append(nodeFRU['ID'])
+				else:
+					mismatchList.append(nodeFRU['ID'])
+		else:
+			for xname in tempNodeList:
+				if xname in allowedNodes:
+					nodeList.append(xname)
+	if len(mismatchList) > 0:
+		err = {
+			'Message': 'Node does not match the hardware type of other nodes in the same slot and will be deleted.',
+			'Severity': 'Info',
+			'IDs': mismatchList
+		}
+		report['Errors'].append(err)
+
+
+	# Retrieve new list of nodes based off of our filtered list of nodes
+	compFilter = {
+		'ComponentIDs': nodeList,
+		'type': ['Node'],
+		'role': ['Compute']
+	}
+	nodesFiltered, stat = getHSMCompQuery(authToken, compFilter)
+	if stat != 0:
+		err = {
+			'Message': 'HSM Components query returned non-zero. %s' % nodesFiltered,
+			'Severity': 'Error'
+		}
+		report['Errors'].append(err)
+		printReport(report)
+		return 1
+
+	workingNodeList = []
+	for node in nodesFiltered['Components']:
+		workingNodeList.append(node['ID'])
+
+	# Get the nodes in our NID range and make sure there isn't anything we're not allowed to touch.
+	nodesRange, stat = getHSMComps(authToken, "?nid_start=%d&nid_end=%d" % (startingNID, startingNID+len(workingNodeList)-1))
+	if stat != 0:
+		err = {
+			'Message': 'HSM Components returned non-zero. %s' % nodesRange,
+			'Severity': 'Error'
+		}
+		report['Errors'].append(err)
+		printReport(report)
+		return 1
+	nidErrList = []
+	for node in nodesRange['Components']:
+		if node['ID'] not in allowedNodes:
+			nidErrList.append(node['ID'])
+	if len(nidErrList) != 0:
+		err = {
+			'Message': 'There is an unexpected node NID in the requested NID range, %d-%d' % (startingNID, startingNID+len(workingNodeList)-1),
+			'Severity': 'Error',
+			'IDs': nidErrList
+		}
+		report['Errors'].append(err)
+		printReport(report)
+		return 1
+
+	# Look for entries in SLS with conflicting NIDs. We'll delete these later.
+	slsDeleteList = []
+	for nid in range(startingNID, startingNID+len(workingNodeList)):
+		slsNodes, stat = getSLSComps(authToken, "?extra_properties.NID=%d" % nid)
+		if stat != 0:
+			err = {
+				'Message': 'SLS hardware search returned non-zero. %s' % slsNodes,
+				'Severity': 'Error'
+			}
+			report['Errors'].append(err)
+			printReport(report)
+			return 1
+		if slsNodes is None:
+			continue
+		for slsNode in slsNodes:
+			if slsNode['Xname'] not in allowedNodes:
+				slsDeleteList.append(slsNode['Xname'])
+
+	report['NodesRemovedFromSLS'] = slsDeleteList
+
+	# Look for entries in our "allowed" list that aren't in our working list.
+	# These entries are leftovers from removed hardware. We'll delete these later.
+	hsmDeleteList = []
+	for id in allowedNodes:
+		if id not in workingNodeList:
+			hsmDeleteList.append(id)
+
+	nodesFiltered['Components'].sort(key = compSort)
+	currentNID = startingNID
+	chassisClass = ""
+	myChassis = ""
+	newNIDList = []
+	newSLSList = []
+	for node in nodesFiltered['Components']:
+		fields = node['ID'].split('s')
+		if chassisClass == "" or myChassis != fields[0]:
+			myChassis = fields[0]
+			chassisClass, stat = getChassisClass(authToken, myChassis)
+			if stat != 0:
+				err = {
+					'Message': 'Failed to get Chassis class from SLS.',
+					'Severity': 'Error'
+				}
+				report['Errors'].append(err)
+				printReport(report)
+				return 1
+
+		newNID = node.copy()
+		newNID['NID'] = currentNID
+		# The class designation for nodes that are in HSM but not SLS may be
+		# incorrect. We'll want to update them too.
+		newNID['Class'] = chassisClass
+
+		newSLS = {
+			'Xname': node['ID'],
+			'Class': chassisClass,
+			'ExtraProperties': {
+				'Aliases': ["nid%06d" % currentNID],
+				'NID': currentNID,
+				'Role': "Compute"
+			}
+		}
+		currentNID += 1
+		newNIDList.append(newNID)
+		newSLSList.append(newSLS)
+
+	# Add the plan to the report
+	for i in range(len(nodesFiltered['Components'])):
+		node = {
+			'ID': nodesFiltered['Components'][i]['ID'],
+			'OldNID': nodesFiltered['Components'][i]['NID'],
+			'NewNID': newNIDList[i]['NID']
+		}
+		report['HSMChanges'].append(node)
+	report['SLSEntries'] = newSLSList
+
+	if dryrun:
+		printReport(report)
+		return 0
+
+	# Delete conflicting SLS entries
+	for xname in slsDeleteList:
+		resp, stat = deleteSLSComp(authToken, xname)
+		if stat != 0:
+			err = {
+				'Message': 'Failed to delete entry from SLS. %s' % resp,
+				'Severity': 'Warning',
+				'IDs': [xname]
+			}
+			report['Errors'].append(err)
+
+	failedEthDels = {
+		'Message': 'Failed to delete ethernet interface data entries from HSM for dead nodes',
+		'Severity': 'Warning',
+		'IDs': []
+	}
+
+	# Cleanup dead HSM entries
+	for xname in hsmDeleteList:
+		resp, stat = deleteHSMComp(authToken, xname)
+		if stat != 0:
+			err = {
+				'Message': 'Failed to delete component data from HSM. %s' % resp,
+				'Severity': 'Warning',
+				'IDs': [xname]
+			}
+			report['Errors'].append(err)
+			continue
+		resp, stat = deleteHSMCompEP(authToken, xname)
+		if stat != 0:
+			err = {
+				'Message': 'Failed to delete component endpoint data from HSM. %s' % resp,
+				'Severity': 'Warning',
+				'IDs': [xname]
+			}
+			report['Errors'].append(err)
+			continue
+		resp, stat = deleteHSMHwLoc(authToken, xname)
+		if stat != 0:
+			err = {
+				'Message': 'Failed to delete hardware locational data from HSM. %s' % resp,
+				'Severity': 'Warning',
+				'IDs': [xname]
+			}
+			report['Errors'].append(err)
+			continue
+		compEthList, stat = getHSMEth(authToken, "?ComponentID=" + xname)
+		if stat != 0:
+			err = {
+				'Message': 'Failed to get ethernet interface data from HSM. %s' % compEthList,
+				'Severity': 'Warning',
+				'IDs': [xname]
+			}
+			report['Errors'].append(err)
+			continue
+		for compEth in compEthList:
+			resp, stat = deleteHSMEth(authToken, compEth['ID'])
+			if stat != 0:
+				err = {
+					'Message': 'Failed to delete ethernet interface data from HSM. %s' % resp,
+					'Severity': 'Warning',
+					'IDs': [compEth['ID']]
+				}
+				report['Errors'].append(err)
+				continue
+
+	# Update SLS entries
+	for entry in newSLSList:
+		resp, stat = putSLSComp(authToken, entry)
+		if stat != 0:
+			err = {
+				'Message': 'Failed to create/update entry in SLS. %s' % resp,
+				'Severity': 'Error',
+				'IDs': [entry['Xname']]
+			}
+			report['Errors'].append(err)
+			printReport(report)
+			return 1
+
+	# Update HSM NIDs
+	resp, stat = patchHSMNIDs(authToken, newNIDList)
+	if stat != 0:
+		err = {
+			'Message': 'Failed to update NIDs in HSM. %s' % resp,
+			'Severity': 'Error',
+			'IDs': []
+		}
+		for node in newNIDList:
+			err['IDs'].append(node['ID'])
+		report['Errors'].append(err)
+		printReport(report)
+		return 1
+
+	# Only updates Class because POST /State/Components doesn't check for changes in NID to apply it.
+	resp, stat = postHSMComps(authToken, newNIDList)
+	if stat != 0:
+		print("HSM POST /State/Components returned non-zero.")
+		err = {
+			'Message': 'Failed to update HSM component data. %s' % resp,
+			'Severity': 'Error',
+			'IDs': []
+		}
+		for node in newNIDList:
+			err['IDs'].append(node['ID'])
+		report['Errors'].append(err)
+		printReport(report)
+		return 1
+
+	printReport(report)
+	return 0
+
+if __name__ == "__main__":
+	ret = main()
+	sys.exit(ret)

--- a/troubleshooting/known_issues/antero_node_NID_allocation.md
+++ b/troubleshooting/known_issues/antero_node_NID_allocation.md
@@ -10,7 +10,7 @@ SLS has NIDS only allocated for nodes `b0n0`, `b0n1`, `b1n0`, `b1n1` on a comput
 
 It is important to note the nodes `b0n2` and `b0n3` on a Antero blade are functional, but do not have NIDs in contiguous range with its peers.
 
-## How to identity NIDs on Antero blades
+## How to identify NIDs on Antero blades
 
 To work around this issue the appropriate NID values for nodes `b0n2` and `n0n3` on Antero blades need to be supplied to Work Load Manager (WLM) when launch jobs. The following commands are some examples to determine the NIDs in use for Antero blades.
 
@@ -90,3 +90,7 @@ To work around this issue the appropriate NID values for nodes `b0n2` and `n0n3`
     | x9000c3s0b0n3 | Compute | 147474595 |
     +---------------+---------+-----------+
     ```
+
+## Correcting the NID Numbering
+
+Optionally, during a system maintenance window, the Antero node NID numbering can be corrected by following the [Defragment NID Numbering](../../operations/node_management/Defragment_NID_Numbering.md) procedure.


### PR DESCRIPTION
# Description

This adds the defragment_nids.py script and the `Defragment NID Numbering` procedure to docs-csm for CSM 1.4.

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
