### PR TITLE
CASMINST-6128 Copy the RPMs to `/root`

### DIFF
--- a/update_product_stream/README.md
+++ b/update_product_stream/README.md
@@ -150,40 +150,35 @@ Acquire the latest documentation RPM. This may include updates, corrections, and
 
 1. Download and upgrade the latest documentation RPM and CSM library.
 
-   - Without proxy:
+    - Without proxy:
 
-     ```bash
-     rpm -Uvh --force https://release.algol60.net/csm-1.3/docs-csm/docs-csm-latest.noarch.rpm
-     ```
+        ```bash
+        wget "https://release.algol60.net/$(awk -F. '{print "csm-"$1"."$2}' <<< ${CSM_RELEASE})/docs-csm/docs-csm-latest.noarch.rpm" -O /root/docs-csm-latest.noarch.rpm
+        wget "https://release.algol60.net/lib/sle-$(awk -F= '/VERSION=/{gsub(/["-]/, "") ; print tolower($NF)}' /etc/os-release)/libcsm-latest.noarch.rpm" -O libcsm-latest.noarch.rpm 
+        ```
 
-   - With https proxy:
+    - With https proxy:
 
-     ```bash
-     rpm -Uvh --force --httpproxy https://example.proxy.net --httpport 443 https://release.algol60.net/csm-1.3/docs-csm/docs-csm-latest.noarch.rpm
-     ```
+        ```bash
+        https_proxy=https://example.proxy.net:443 wget "https://release.algol60.net/$(awk -F. '{print "csm-"$1"."$2}' <<< ${CSM_RELEASE})/docs-csm/docs-csm-latest.noarch.rpm" \
+            -O /root/docs-csm-latest.noarch.rpm
+        https_proxy=https://example.proxy.net:443 wget "https://release.algol60.net/lib/sle-$(awk -F= '/VERSION=/{gsub(/["-]/, "") ; print tolower($NF)}' /etc/os-release)/libcsm-latest.noarch.rpm" \
+            -O /root/libcsm-latest.noarch.rpm
+        ```
 
-   If this machine does not have internet access with or without a proxy, then this RPM will need to be externally downloaded and copied to the system. This example copies it to `ncn-m001`.
+    - If this machine does not have direct internet access, then this RPM will need to be externally downloaded and copied to the system. This example copies it to `ncn-m001`.
+
+        ```bash
+        curl -O "https://release.algol60.net/$(awk -F. '{print "csm-"$1"."$2}' <<< ${CSM_RELEASE})/docs-csm/docs-csm-latest.noarch.rpm"
+        SLES_VERSION=$(ssh ncn-m001 'awk -F= '\''/VERSION=/{gsub(/["-]/, "") ; print tolower($NF)}'\'' /etc/os-release')
+        curl -O "https://release.algol60.net/lib/sle-${SLES_VERSION}/libcsm-latest.noarch.rpm"
+        scp docs-csm-latest.noarch.rpm libcsm-latest.noarch.rpm ncn-m001:/root
+        ssh ncn-m001
+        ```
+
+1. Install the documentation RPM and CSM library.
 
    ```bash
-   rpm -Uvh --force "https://release.algol60.net/$(awk -F. '{print "csm-"$1"."$2}' <<< ${CSM_RELEASE})/docs-csm/docs-csm-latest.noarch.rpm"
-   rpm -Uvh --force "https://release.algol60.net/lib/sle-$(awk -F= '/VERSION=/{gsub(/["-]/, "") ; print tolower($NF)}' /etc/os-release)/libcsm-latest.noarch.rpm"
-   ```
-
-   With https proxy:
-
-   ```bash
-   rpm -Uvh --force --httpproxy https://example.proxy.net --httpport 443 "https://release.algol60.net/$(awk -F. '{print "csm-"$1"."$2}' <<< ${CSM_RELEASE})/docs-csm/docs-csm-latest.noarch.rpm"
-   rpm -Uvh --force --httpproxy https://example.proxy.net --httpport 443 "https://release.algol60.net/lib/sle-$(awk -F= '/VERSION=/{gsub(/["-]/, "") ; print tolower($NF)}' /etc/os-release)/libcsm-latest.noarch.rpm"
-   ```
-
-   If this machine does not have direct internet access, then this RPM will need to be externally downloaded and copied to the system. This example copies it to `ncn-m001`.
-
-   ```bash
-   curl -O "https://release.algol60.net/$(awk -F. '{print "csm-"$1"."$2}' <<< ${CSM_RELEASE})/docs-csm/docs-csm-latest.noarch.rpm"
-   SLES_VERSION=$(ssh ncn-m001 'awk -F= '\''/VERSION=/{gsub(/["-]/, "") ; print tolower($NF)}'\'' /etc/os-release')
-   curl -O "https://release.algol60.net/lib/sle-${SLES_VERSION}/libcsm-latest.noarch.rpm"
-   scp docs-csm-latest.noarch.rpm libcsm-latest.noarch.rpm ncn-m001:/root
-   ssh ncn-m001
    rpm -Uvh --force /root/docs-csm-latest.noarch.rpm /root/libcsm-latest.noarch.rpm
    ```
 


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->
The consolidation of the RPM fetching step in the upgrade into caused a gap where the fetched RPMs are not available for the `prereqs` script.

There also was some duplication of steps in fetch RPM steps.

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
