### PR TITLE
CASMINST-6135: IMS import/export: Record S3 etag changes on import

### DIFF
--- a/scripts/operations/system_recovery/ims-import-export.py
+++ b/scripts/operations/system_recovery/ims-import-export.py
@@ -308,9 +308,10 @@ def export_ims_artifacts(args):
     # TODO Verify path doesn't exist
     try:
         os.makedirs(args.import_export_root)
-
+        LOGGER.info(f'Exporting IMS data to {args.import_export_root}')
         export_ims_recipes(args)
         export_ims_images(args)
+        LOGGER.info(f'IMS data exported to {args.import_export_root}')
     except ImsImportExportBaseError as ims_exc:
         LOGGER.warning('Error exporting IMS data', exc_info=ims_exc)
         return False
@@ -459,7 +460,7 @@ def import_ims_recipe(recipe, recipes_path):
             result = json.loads(subprocess.check_output(command))
             LOGGER.debug(result)
 
-            return new_recipe['id']
+            return new_recipe['id'], new_recipe_link_etag
 
     except ImsImportExportRecoverableError:
         # TODO
@@ -467,16 +468,18 @@ def import_ims_recipe(recipe, recipes_path):
     except subprocess.CalledProcessError as call_proc_exc:
         LOGGER.warning(f'An error was encountered while importing IMS image {recipe["id"]}.', exc_info=call_proc_exc)
 
-    return None
+    return None, None
 
 
-def import_ims_recipes(args):
+def import_ims_recipes(args, etag_map):
     def _import_v1_0_recipes(recipes):
-
         for recipe in recipes:
-            new_recipe_id = import_ims_recipe(recipe, recipes_path)
+            old_recipe_etag = recipe['link']['etag']
+            new_recipe_id, new_recipe_etag = import_ims_recipe(recipe, recipes_path)
             if new_recipe_id and new_recipe_id != recipe['id']:
                 imported_recipes[recipe['id']] = new_recipe_id
+                if old_recipe_etag and new_recipe_etag != old_recipe_etag:
+                    etag_map[old_recipe_etag] = new_recipe_etag
 
     imported_recipes = {}
     LOGGER.info(f'Importing recipes')
@@ -506,10 +509,11 @@ def image_exists(image):
     return artifact_exists(image['link'])
 
 
-def import_ims_image(image, images_path):
+def import_ims_image(image, images_path, etag_map):
     def _upload_1_0_linked_artifacts(artifacts):
         ret_value = []
         for artifact in artifacts:
+            artifact_etag = artifact['link']['etag']
             artifact_url = S3Url(artifact['link']['path'])
             artifact_file = path.join(images_path, image['id'], artifact_url.filename)
             if path.isfile(artifact_file):
@@ -519,6 +523,9 @@ def import_ims_image(image, images_path):
                 _, new_artifact_link_etag = artifact_upload(image['link']['type'],
                                                             new_artifact_link_path,
                                                             artifact_file)
+
+                if artifact_etag and artifact_etag != new_artifact_link_etag:
+                    etag_map[artifact_etag] = new_artifact_link_etag
 
                 ret_value.append({
                     'md5': artifact['md5'],
@@ -602,7 +609,7 @@ def import_ims_image(image, images_path):
                 result = json.loads(subprocess.check_output(command))
                 LOGGER.debug(result)
 
-                return new_image['id']
+                return new_image['id'], new_image_manifest_json_link_etag
             finally:
                 os.remove(tmp_manifest_path)
 
@@ -612,15 +619,18 @@ def import_ims_image(image, images_path):
     except subprocess.CalledProcessError as call_proc_exc:
         LOGGER.warning(f'An error was encountered while importing IMS image {image["id"]}.', exc_info=call_proc_exc)
 
-    return None
+    return None, None
 
 
-def import_ims_images(args):
+def import_ims_images(args, etag_map):
     def _import_v1_0_images(images):
         for image in images:
-            new_image_id = import_ims_image(image, images_path)
+            old_image_etag = image['link']['etag']
+            new_image_id, new_image_etag = import_ims_image(image, images_path, etag_map=etag_map)
             if new_image_id and new_image_id != image['id']:
                 imported_images[image['id']] = new_image_id
+                if old_image_etag and new_image_etag != old_image_etag:
+                    etag_map[old_image_etag] = new_image_etag
 
     imported_images = {}
     LOGGER.info(f'Importing images')
@@ -636,29 +646,35 @@ def import_ims_images(args):
 
 def import_ims_artifacts(args):
     try:
-        recipe_map = import_ims_recipes(args)
-        image_map = import_ims_images(args)
+        LOGGER.info(f'Importing IMS data from {args.import_export_root}')
+        etag_map = {}
+        recipe_map = import_ims_recipes(args, etag_map=etag_map)
+        image_id_map = import_ims_images(args, etag_map=etag_map)
 
         for old_recipe_id, new_recipe_id in recipe_map.items():
             LOGGER.info(f'The IMS recipe {old_recipe_id} was imported as {new_recipe_id}')
 
-        for old_image_id, new_image_id in image_map.items():
+        for old_image_id, new_image_id in image_id_map.items():
             LOGGER.info(f'The IMS image {old_image_id} was imported as {new_image_id}')
 
-        # Record mappings of old IMS IDs to new ones
+        for old_etag, new_etag in etag_map.items():
+            LOGGER.info(f'The S3 artifact with etag {old_etag} was imported with etag {new_etag}')
+
+        # Record mappings of old IMS IDs and S3 etags to new ones
         id_map_file = path.join(os.getcwd(), f'ims-id-maps-post-import-{uuid.uuid4().hex}.json')
         with open(id_map_file, 'w') as outfile:
             json.dump(
                 {
-                    'timestamp': get_timestamp_string(),
+                    'etag_map': etag_map,
                     'id_maps': {
-                        "images": image_map,
+                        "images": image_id_map,
                         "recipes": recipe_map
-                    }
+                    },
+                    'timestamp': get_timestamp_string()
                 },
                 outfile)
-        LOGGER.info(f'Recorded mapping from old IMS image and recipe IDs to new IDs in {id_map_file}')
-
+        LOGGER.info(f'Recorded mapping from old to new IMS IDs and S3 etags in {id_map_file}')
+        LOGGER.info(f'IMS data imported from {args.import_export_root}')
     except ImsImportExportBaseError as ims_exc:
         LOGGER.warning('Error importing IMS data', exc_info=ims_exc)
         return False

--- a/scripts/operations/system_recovery/ims-import-export.py
+++ b/scripts/operations/system_recovery/ims-import-export.py
@@ -649,12 +649,12 @@ def import_ims_artifacts(args):
         LOGGER.info(f'Importing IMS data from {args.import_export_root}')
         etag_map = {}
         recipe_map = import_ims_recipes(args, etag_map=etag_map)
-        image_id_map = import_ims_images(args, etag_map=etag_map)
+        image_map = import_ims_images(args, etag_map=etag_map)
 
         for old_recipe_id, new_recipe_id in recipe_map.items():
             LOGGER.info(f'The IMS recipe {old_recipe_id} was imported as {new_recipe_id}')
 
-        for old_image_id, new_image_id in image_id_map.items():
+        for old_image_id, new_image_id in image_map.items():
             LOGGER.info(f'The IMS image {old_image_id} was imported as {new_image_id}')
 
         for old_etag, new_etag in etag_map.items():
@@ -667,7 +667,7 @@ def import_ims_artifacts(args):
                 {
                     'etag_map': etag_map,
                     'id_maps': {
-                        "images": image_id_map,
+                        "images": image_map,
                         "recipes": recipe_map
                     },
                     'timestamp': get_timestamp_string()


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
When importing IMS images and recipes, not only does the IMS ID change, but the etag will change as well. For images in particular, BOS session templates may refer to these etag values for the image manifest. Accordingly, the import procedure needs to record these changes just as it does for the IMS IDs.

This PR just adds that data to what is collected during the IMS import procedure. I tested this on wasp and verified that the information is correctly recorded. 

- [1.4 backport](https://github.com/Cray-HPE/docs-csm/pull/3533)
- [1.3 backport](https://github.com/Cray-HPE/docs-csm/pull/3532)

No backports needed for pre-1.3 as the procedure did not exist then.

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
