### PR TITLE
CASMPET-6440 change storage upgrade to deploy daemons with nexus image after node reboots

### DIFF
--- a/upgrade/scripts/upgrade/ncn-upgrade-ceph-nodes.sh
+++ b/upgrade/scripts/upgrade/ncn-upgrade-ceph-nodes.sh
@@ -163,7 +163,7 @@ if [[ $state_recorded == "0" ]]; then
             done
         fi
     done
-    sleep 90
+    sleep 120
     } >> ${LOG_FILE} 2>&1
     record_state "${state_name}" ${target_ncn}
 else

--- a/upgrade/scripts/upgrade/ncn-upgrade-ceph-nodes.sh
+++ b/upgrade/scripts/upgrade/ncn-upgrade-ceph-nodes.sh
@@ -108,6 +108,8 @@ if [[ $state_recorded == "0" ]]; then
     {
     ssh_keygen_keyscan "${target_ncn}"
     ssh_keys_done=1
+    # remove old ceph daemons
+    ssh ${target_ncn} podman rmi --all --force
     scp ./${target_ncn}-ceph.tgz $target_ncn:/
     ssh ${target_ncn} 'cd /; tar -xvf ./$(hostname)-ceph.tgz; rm /$(hostname)-ceph.tgz'
     # pull container images from nexus

--- a/workflows/ncn/storage/storage.upgrade.yaml
+++ b/workflows/ncn/storage/storage.upgrade.yaml
@@ -230,7 +230,7 @@ spec:
                     chmod +x /tmp/${ts}.sh
                     scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null /tmp/${ts}.sh {{$value}}:/tmp/${ts}.sh
                     ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null {{$value}} "/tmp/${ts}.sh"
-          - name: pull-ceph-image-in-nexus
+          - name: pull-ceph-image-in-nexus-all-storage-nodes
             templateRef:
               name: ssh-template
               template: shell-script
@@ -243,17 +243,10 @@ spec:
                 - name: scriptContent
                   value: |
                     nexus_image=$(cat /tmp/ceph_global_container_image.txt)
-                    pdsh -w $(ceph orch host ls --format=json|jq -r '.[].hostname' | sort -u |  tr -t '\n' ',') "podman pull $nexus_image"
-          {{ end }}
+                    pdsh -S -w $(ceph orch host ls --format=json|jq -r '.[].hostname' | sort -u |  tr -t '\n' ',') "podman pull $nexus_image"
           - name: enter-ceph-orch-maintenance-mode-{{$value}}
             dependencies:
-              {{ if eq $index 0 }}
-              - pull-ceph-image-in-nexus
-              {{ end }}
-              # each upgrade depends on previous upgrade action and success
-              {{ if ne $index 0 }}
-              - check-ceph-health-{{ index $.TargetNcns (add $index -1) }}
-              {{ end }}
+              - pull-ceph-image-in-nexus-all-storage-nodes
             templateRef:
               name: ssh-template
               template: shell-script
@@ -289,7 +282,7 @@ spec:
                     # remove local images on target_ncn
                     echo "Removing local images on $TARGET_NCN"
                     ssh $TARGET_NCN podman rmi --all -f
-          - name: pull-ceph-images-from-nexus-{{$value}}
+          - name: save-sha-value-from-nexus-{{$value}}
             templateRef:
               name: ssh-template
               template: shell-script
@@ -302,6 +295,30 @@ spec:
                 - name: scriptContent
                   value: |
                     target_ncn={{$value}}
+                    image=$"$(cat /tmp/ceph_global_container_image.txt)"
+                    ssh ${target_ncn} podman pull $image
+                    image_with_sha=$(ssh ${target_ncn} podman inspect $image | jq '.[] | .RepoDigests' | \
+                        grep -o "registry.local/artifactory.algol60.net/csm-docker/stable/quay.io/ceph/ceph@sha256.*" | tr -d '"')
+                    if [[ $(echo $image_with_sha | wc -w) -gt 1 ]]; then
+                       echo " ERROR The podman image: $image on $target_ncn should only have a single RepoDigest entry which cooresponds to image in nexus."
+                       exit 1
+                    else
+                       echo $image_with_sha > /tmp/ceph_global_container_image_with_sha.txt
+                    fi
+          - name: load-images-{{$value}}
+            templateRef:
+              name: ssh-template
+              template: shell-script
+            dependencies: 
+              - save-sha-value-from-nexus-{{$value}}
+            arguments:
+              parameters:
+                - name: dryRun
+                  value: "{{$.DryRun}}"
+                - name: scriptContent
+                  value: |
+                    target_ncn={{$value}}
+                    ssh ${target_ncn} /srv/cray/scripts/common/pre-load-images.sh
                     for container in "container_image_prometheus" "container_image_node_exporter" "container_image_alertmanager" "container_image_grafana"; do
                         image=$(ceph config get mgr mgr/cephadm/${container})
                         ssh ${target_ncn} podman pull $image
@@ -309,7 +326,7 @@ spec:
                     ssh ${target_ncn} podman pull "$(cat /tmp/ceph_global_container_image.txt)"
           - name: "exit-ceph-orch-maintenance-mode-{{$value}}"
             dependencies:
-              - pull-ceph-images-from-nexus-{{$value}}
+              - load-images-{{$value}}
             templateRef:
               name: ssh-template
               template: shell-script
@@ -330,44 +347,6 @@ spec:
                     else
                       echo "$TARGET_NCN is not in maintenance mode. Nothing to do."
                     fi
-          {{ if eq $index 0 }}
-          - name: repoint-ceph-to-nexus
-            templateRef:
-              name: ssh-template
-              template: shell-script
-            dependencies:
-              - exit-ceph-orch-maintenance-mode-{{$value}}
-            arguments:
-              parameters:
-                - name: dryRun
-                  value: "{{$.DryRun}}"  
-                - name: scriptContent
-                  value: |
-                    echo "This step repoints ceph to use the image stored in Nexus. It runs the command 'ceph orch upgrade' to do this."
-                    nexus_location=$(cat /tmp/ceph_global_container_image.txt)
-                    ceph orch upgrade start --image $nexus_location
-                    echo "Waiting for upgrade to complete..."
-                    sleep 10
-                    int=0
-                    success=false
-                    while [[ $int -lt 100 ]] && ! $success; do
-                        if [[ -n $(ceph orch upgrade status --format json | jq '.message' | grep Error) ]]; then
-                          echo "Error: there was an issue with the upgrade. Run 'ceph orch upgrade status' from ncn-s00[1/2/3]."
-                          exit 1
-                        fi
-                        if [[ $(ceph orch upgrade status --format json | jq '.in_progress') != "true" ]]; then
-                          echo "Upgrade complete"
-                          success=true
-                          break
-                        else
-                          int=$(( $int + 1 ))
-                          sleep 10
-                        fi
-                    done
-                    if ! $success; then
-                      echo "Error completing 'ceph orch upgrade'. Check upgrade status by running 'ceph orch upgrade status' from ncn-s00[1/2/3]."
-                      exit 1
-                    fi
           {{ end }}
           - name: upgrade-{{$value}}
             templateRef:
@@ -375,10 +354,10 @@ spec:
               template: shell-script
             dependencies: 
               {{ if eq $index 0 }}
-              - repoint-ceph-to-nexus
+              - exit-ceph-orch-maintenance-mode-{{$value}}
               {{ end }}
               {{ if ne $index 0 }}
-              - exit-ceph-orch-maintenance-mode-{{$value}}
+              - check-ceph-health-{{ index $.TargetNcns (add $index -1) }}
               {{ end }}
             arguments:
               parameters:
@@ -438,30 +417,6 @@ spec:
                       echo "BSS metadata was not successfully updated. Output:"
                       echo "$RESULT"
                       exit 7
-                    fi
-          - name: check-ceph-config
-            templateRef:
-              name: ssh-template
-              template: shell-script
-            arguments:
-              parameters:
-                - name: dryRun
-                  value: "{{$.DryRun}}"  
-                - name: scriptContent
-                  value: |
-                    if [[ $(ceph config dump --format json-pretty|jq '.[]|select(.name == "container_image")|.value' | wc -l) -gt 1 ]]; then
-                      echo "ERROR  the ceph config has more that one value for container_image set."
-                      echo "Look at the following output from ceph config dump --format json-pretty|jq '.[]|select(.name == "container_image")'"
-                      ceph config dump --format json-pretty|jq '.[]|select(.name == "container_image")'
-                      echo "There should only be one item and its section should be 'global'"
-                      echo
-                      echo "Troubleshoot this failure by investigating following items."
-                      echo "Run 'ceph -s' and 'ceph health detail'"
-                      echo "All ceph mon,mgr,mds,crash,rgw,osd daemons should be running the same image. Check this by running 'podman ps' on storage nodes."
-                      echo "Look at the ceph upgrade status by running 'ceph orch upgrade status' and check that it is not running and does not have an error."
-                      exit 1
-                    else
-                      echo "Ceph config check succeeded."
                     fi
           - name: ceph-health-check
             templateRef:


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

The storage node upgrade previously was performing the following steps:
1. push local running ceph container images to nexus
2. point ceph daemons to use nexus image by doing a ceph orch upgrade nexus_image 
3. reboot node to upgrade node image
4. redeploy daemons
The upgrade was having trouble with step 2.

This PR changes the storage node upgrade to do the following steps:
1. push local running ceph container images to nexus
2. reboot node to upgrade node image
3. redeploy daemons explicitly telling them to use the nexus_image
Note: this new upgrade will not run pre-load-images.sh once the node has been upgraded. This makes it so after the upgrade, the ceph daemons will be running off of the ceph container images in nexus and do not need to have any local containers.

This has been tested on an upgrade on Drax.

There is a cosmetic bug/behavior we are seeing with upgrading storage nodes like this. The functionality and the upgrade work correctly. However, when looking at the the 'ceph config' we see a container_image entry for every daemon where usually there is just one global container_image in the config. This is something that may have to be investigated more. But again, this is just cosmetic.

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
