### PR TITLE
CASMINST-6150: Update Cray Product Catalog after IMS import

### DIFF
--- a/scripts/operations/configuration/python_lib/product_catalog.py
+++ b/scripts/operations/configuration/python_lib/product_catalog.py
@@ -23,13 +23,15 @@
 #
 """Shared Python function library: Cray product catalog"""
 
+import subprocess
 import traceback
-from typing import Dict, ItemsView
+from typing import Dict, ItemsView, List, Tuple
 
 import logging
 import packaging.version
 import yaml
 
+from . import api_requests
 from . import common
 from . import k8s
 
@@ -37,11 +39,12 @@ from .types import JSONObject
 
 K8S_NAMESPACE = "services"
 K8S_CONFIG_MAP_NAME = "cray-product-catalog"
+CPC_UPDATE_IMAGE = "artifactory.algol60.net/csm-docker/stable/cray-product-catalog-update"
 
 # Used for type hinting
 ProductVersionMap = Dict[str, JSONObject]
 ProductCatalogMap = Dict[str, ProductVersionMap]
-
+NameIdTupleList = List[Tuple[str, str]]
 
 def log_error_raise_exception(msg: str, parent_exception: Exception = None) -> None:
     """
@@ -78,12 +81,11 @@ def parse_product_yaml(label: str, yaml_string: str) -> JSONObject:
             f"YAML data from {label} has an unexpected format", exc)
 
 
-def get_latest_version(product_version_map: ProductVersionMap,
-                       strict_versioning: bool = False,
-                       ignore_invalid_versions: bool = True) -> str:
+def get_latest_version_from_list(version_string_list: List[str],
+                                 strict_versioning: bool = False,
+                                 ignore_invalid_versions: bool = True) -> str:
     """
-    Given a product version map from the product catalog, sort the version strings
-    and return the latest one.
+    Given a list of version strings, sort them and return the latest one.
 
     If strict_versioning is false, then the generic packaging.version.parse() function will be
     used to parse the version strings. Otherwise the packaging.versions.Version() constructor will
@@ -94,12 +96,11 @@ def get_latest_version(product_version_map: ProductVersionMap,
 
     Returns None if there are no valid version strings.
     """
-    all_version_strings = list(product_version_map.keys())
-    logging.debug("get_latest_version: strict_versioning = %s, ignore_invalid_versions=%s, "
-                  "all_version_strings=%s", strict_versioning, ignore_invalid_versions,
-                  all_version_strings)
-    version_object_to_string = dict()
-    for version_string in all_version_strings:
+    logging.debug("get_latest_version_from_list: strict_versioning = %s, "
+                  "ignore_invalid_versions=%s, version_string_list=%s", strict_versioning,
+                  ignore_invalid_versions, version_string_list)
+    version_object_to_string = {}
+    for version_string in version_string_list:
         try:
             if strict_versioning:
                 version_object = packaging.version.Version(version_string)
@@ -108,21 +109,30 @@ def get_latest_version(product_version_map: ProductVersionMap,
             version_object_to_string[version_object] = version_string
         except packaging.version.InvalidVersion as exc:
             if ignore_invalid_versions:
-                logging.debug("get_latest_version: Ignoring invalid version string '%s'",
+                logging.debug("get_latest_version_from_list: Ignoring invalid version string '%s'",
                               version_string)
                 continue
-            log_error_raise_exception(
-                f"Invalid product version string in Cray product catalog: '{version_string}'", exc)
+            log_error_raise_exception(f"Invalid product version string: '{version_string}'", exc)
     if not version_object_to_string:
-        logging.debug("get_latest_version: No valid version strings found")
+        logging.debug("get_latest_version_from_list: No valid version strings found")
         return None
     sorted_version_objects = sorted(version_object_to_string.keys())
     latest_version_object = sorted_version_objects[-1]
     # return corresponding string
     latest_version_string = version_object_to_string[latest_version_object]
     logging.debug(
-        "get_latest_version: latest_version_string = '%s'", latest_version_string)
+        "get_latest_version_from_list: latest_version_string = '%s'", latest_version_string)
     return latest_version_string
+
+
+def get_latest_version(product_version_map: ProductVersionMap, *args, **kwargs) -> str:
+    """
+    Given a product version map from the product catalog, sort the version strings
+    and return the latest one, using the get_latest_version_from_list function.
+    All additional arguments are passed on to the get_latest_version_from_list function.
+    """
+    return get_latest_version_from_list(version_string_list=list(product_version_map.keys()),
+                                        *args, **kwargs)
 
 
 class ProductCatalog:
@@ -135,8 +145,17 @@ class ProductCatalog:
         """
         if k8s_client is None:
             k8s_client = k8s.Client()
-        self.data = k8s_client.get_config_map_data(name=K8S_CONFIG_MAP_NAME,
-                                                   namespace=K8S_NAMESPACE)
+        self.k8s_client = k8s_client
+        self.refresh_data()
+
+
+    def refresh_data(self):
+        """
+        Load the config map data from K8s
+        """
+        self.data = self.k8s_client.get_config_map_data(name=K8S_CONFIG_MAP_NAME,
+                                                        namespace=K8S_NAMESPACE)
+
 
     def get_items(self) -> ItemsView:
         """
@@ -160,7 +179,7 @@ class ProductCatalog:
         label = f"{K8S_NAMESPACE}/{K8S_CONFIG_MAP_NAME} Kubernetes configmap"
         # This could be done in a single return / dictionary construction, but the following is
         # more readable for those unfamiliar with the code, I think.
-        installed_products_map = dict()
+        installed_products_map = {}
         for product_name, product_yaml in self.get_items():
             installed_products_map[product_name] = parse_product_yaml(
                 label=f"'{product_name}' entry in {label}", yaml_string=product_yaml)
@@ -179,7 +198,7 @@ class ProductCatalog:
                 return parse_product_yaml(label=f"'{requested_product_name}' entry in {label}",
                                           yaml_string=product_yaml)
         # Return an empty mapping if no versions are installed
-        return dict()
+        return {}
 
     def get_installed_csm_versions(self) -> ProductVersionMap:
         """
@@ -208,3 +227,98 @@ class ProductCatalog:
         CSM-specific wrapper for get_latest_cfs_information
         """
         return self.get_latest_cfs_information("csm")
+
+
+    def update_product_images_recipes(self, product_name: str, product_version: str,
+                                      image_name_ids: NameIdTupleList = None,
+                                      recipe_name_ids: NameIdTupleList = None) -> None:
+        """
+        Verifies that the specified product and version are in the product catalog.
+        Updates the 'images' and 'recipes' fields of the specified version of the specified product,
+        using the latest version of the cray-product-catalog-update tool.
+        """
+        installed_product_map = self.get_installed_products()
+        if product_name not in installed_product_map:
+            log_error_raise_exception(
+                f"update_product_images_recipes: Product '{product_name}' not in product catalog")
+        if product_version not in installed_product_map[product_name]:
+            log_error_raise_exception(f"update_product_images_recipes: Version '{product_version}'"
+                                      f" of product '{product_name}' not in product catalog")
+        latest_cpc_update_version = get_latest_cpc_update_version()
+        update_content = {}
+        if image_name_ids:
+            update_content["images"] = { image_name: { "id": image_id }
+                                       for image_name, image_id in image_name_ids }
+        if recipe_name_ids:
+            update_content["recipes"] = { recipe_name: { "id": recipe_id }
+                                       for recipe_name, recipe_id in recipe_name_ids }
+        # rstrip is to remove trailing newline that yaml adds
+        yaml_content_string = yaml.dump(update_content, default_flow_style=True).rstrip()
+        podman_cmd = ("podman run --rm --name ncn-cpc --user root -e KUBECONFIG=/.kube/admin.conf "
+                      "-e VALIDATE_SCHEMA=true -v /etc/kubernetes:/.kube:ro").split()
+        podman_cmd.extend(["-e", f"PRODUCT={product_name}",
+                           "-e", f"PRODUCT_VERSION={product_version}",
+                           "-e", f"YAML_CONTENT_STRING={yaml_content_string}",
+                           f"registry.local/{CPC_UPDATE_IMAGE}:{latest_cpc_update_version}"])
+        subprocess.run(podman_cmd, check=True)
+        self.refresh_data()
+
+
+def get_latest_cpc_update_version() -> str:
+    """
+    Queries Nexus to find the latest version of the following Docker image:
+    artifactory.algol60.net/csm-docker/stable/cray-product-catalog-update
+
+    Returns a string with the latest version.
+    Returns None if no versions are found.
+    Raises an exception if there are errors.
+    """
+    nexus_search_url = "https://packages.local/service/rest/v1/search"
+    search_params = { "repository": "registry", "format": "docker", "name": CPC_UPDATE_IMAGE }
+    version_list = []
+
+    while True:
+        resp = api_requests.get_retry_validate(expected_status_codes=200, url=nexus_search_url,
+                                               add_api_token=False, params=search_params)
+        if not resp.text:
+            log_error_raise_exception("Nexus search response had 200 status but empty body")
+        response_object = resp.json()
+        try:
+            items = response_object["items"]
+        except KeyError as exc:
+            log_error_raise_exception(
+                f"Nexus search response had 200 status but no 'items' field: {response_object}",
+                exc)
+        except TypeError as exc:
+            log_error_raise_exception(
+                f"Nexus search response had 200 status but unexpected type: {exc}", exc)
+        if not isinstance(items, list):
+            log_error_raise_exception("Nexus search response had 200 status but 'items' field is "
+                                      f"type {type(items)}, not list")
+
+        for item in items:
+            try:
+                item_version = item["version"]
+            except KeyError as exc:
+                log_error_raise_exception(f"Nexus component has no 'version' field: {item}", exc)
+            if not isinstance(item_version, str):
+                log_error_raise_exception(
+                    f"Nexus component has non-string (type {type(item)}) 'version' field: {item}",
+                    exc)
+            version_list.append(item_version)
+
+        try:
+            continuation_token = response_object["continuationToken"]
+        except KeyError:
+            continuation_token = None
+        if continuation_token:
+            # Make another request to get the next page of responses
+            search_params["continuationToken"] = continuation_token
+            continue
+        # Continuation token is None or not set, so no more responses to get
+        break
+
+    if not version_list:
+        # No versions found
+        return None
+    return get_latest_version_from_list(version_list)

--- a/scripts/operations/configuration/update_product_catalog_ims_ids.py
+++ b/scripts/operations/configuration/update_product_catalog_ims_ids.py
@@ -1,0 +1,156 @@
+#! /usr/bin/env python3
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+"""
+Search the Cray Product Catalog for specified IMS IDs and replace them with specified new IDs.
+Used both as a standalone script and as a module imported by other modules.
+"""
+
+import argparse
+import logging
+from typing import Dict, Tuple
+
+from python_lib import product_catalog
+from python_lib.types import JSONObject
+
+LOGGER = logging.getLogger(__name__)
+ch = logging.StreamHandler()
+ch.setLevel(logging.ERROR)
+LOGGER.addHandler(ch)
+
+IdChangeMap = Dict[str, str]
+
+class UpdateProductCatalogImsIdsBaseError(Exception):
+    pass
+
+def parse_args() -> Tuple[IdChangeMap, IdChangeMap]:
+    """
+    Parses the command line arguments.
+    Returns a tuple of IMS image ID old-to-new map and IMS recipe ID old-to-new map
+    """
+    parser = argparse.ArgumentParser(description="Searches Cray Product Catalog for instances of "
+        "specified old IMS image or recipe ID and replaces them with the specified new ID.")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('-i', '--image-id', dest='ims_type', action='store_const', const='image',
+                       help='Replace IMS image IDs')
+    group.add_argument('-r', '--recipe-id', dest='ims_type', action='store_const', const='recipe',
+                       help='Replace IMS recipe IDs')
+    parser.add_argument('old_ims_id', type=str, help='Old IMS ID to be replaced')
+    parser.add_argument('new_ims_id', type=str, help='New IMS ID to replace the old one with')
+    parsed_args = parser.parse_args()
+    old_new_map = { parsed_args.old_ims_id: parsed_args.new_ims_id }
+    if parsed_args.ims_type == 'image':
+        return old_new_map, {}
+    if parsed_args.ims_type == 'recipe':
+        return {}, old_new_map
+    # This should never happen, but just in case
+    raise UpdateProductCatalogImsIdsBaseError(
+        "PROGRAMMING LOGIC ERROR: Unable to determine type of IMS ID to replace")
+
+def get_name_id_replacements(product_name: str, product_version: str,
+                             product_version_details: JSONObject, images_or_recipes: str,
+                             id_change_map: IdChangeMap) -> product_catalog.NameIdTupleList:
+    """
+    Looks at the specified product version entry from the Cray Product Catalog.
+    Based on the 'images_or_recipes' parameter, looks at the 'images' or 'recipes' field of the
+    entry. If no such field exists, then there are no IDs to be updated. If the field exists,
+    its contents are scanned for IDs that match ones in the specified id_change_map.
+    Returns a list of tuples: (image_or_recipe_name, new_ims_id_for_this_image_or_recipe)
+    """
+    name_id_list = []
+    if not id_change_map:
+        # Nothing to do
+        return name_id_list
+    if not images_or_recipes in product_version_details:
+        # No field for images or recipes
+        return name_id_list
+    prod_ver_imgrec_map = product_version_details[images_or_recipes]
+
+    # The contents of this field should be a dictionary
+    if not isinstance(prod_ver_imgrec_map, dict):
+        LOGGER.debug("Product catalog entry for '%s' version '%s' contains '%s' field which is "
+                     "type %s instead of dict", product_name, product_version, images_or_recipes,
+                     str(type(prod_ver_imgrec_map)))
+        return name_id_list
+
+    # This dictionary should map image/recipe names to another dictionary, and that
+    # second dictionary should include an id field, which maps to the IMS ID for that image/recipe
+    # So parse through this and look for any IDs that need to be replaced.
+
+    for imgrec_name, imgrec_data in prod_ver_imgrec_map.items():
+        if not isinstance(imgrec_data, dict):
+            LOGGER.debug("Product catalog entry for '%s' version '%s' contains %s '%s' with "
+                         "unexpected data format: %s", product_name, product_version,
+                         images_or_recipes, imgrec_name, str(imgrec_data))
+            continue
+        if "id" not in imgrec_data:
+            LOGGER.debug("Product catalog entry for '%s' version '%s' contains %s '%s' with no "
+                         "'id' data: %s", product_name, product_version, images_or_recipes,
+                         imgrec_name, str(imgrec_data))
+            continue
+        imgrec_id = imgrec_data["id"]
+        if imgrec_id in id_change_map:
+            # This means that this ID was changed during the import
+            name_id_list.append((imgrec_name, id_change_map[imgrec_id]))
+
+    return name_id_list
+
+def update_product_catalog(image_id_change_map: IdChangeMap,
+                           recipe_id_change_map: IdChangeMap) -> None:
+    """
+    Update the Cray Product Catalog configmap, replacing any old IMS image or recipe IDs with the
+    corresponding new ones.
+
+    This function is intended to be used by other modules that import this one, as well as being
+    used within this module.
+    """
+    if not image_id_change_map and not recipe_id_change_map:
+        # No ID changes, so nothing to do
+        return
+    cpc = product_catalog.ProductCatalog()
+    for product_name, product_version_map in cpc.get_installed_products().items():
+        for product_version, product_version_details in product_version_map.items():
+            image_name_ids = get_name_id_replacements(product_name, product_version,
+                                                      product_version_details, "images",
+                                                      image_id_change_map)
+            recipe_name_ids = get_name_id_replacements(product_name, product_version,
+                                                       product_version_details, "recipes",
+                                                       recipe_id_change_map)
+            # If no IDs changed, we're done with this product version
+            if not image_name_ids and not recipe_name_ids:
+                continue
+            # Update the product catalog accordingly.
+            cpc.update_product_images_recipes(product_name=product_name,
+                                              product_version=product_version,
+                                              image_name_ids=image_name_ids,
+                                              recipe_name_ids=recipe_name_ids)
+
+def main() -> None:
+    """ Main function """
+    image_id_map, recipe_id_map = parse_args()
+    update_product_catalog(image_id_map, recipe_id_map)
+    LOGGER.info('DONE!')
+
+if __name__ == "__main__":
+    main()

--- a/scripts/operations/system_recovery/ims-import-export.py
+++ b/scripts/operations/system_recovery/ims-import-export.py
@@ -32,7 +32,14 @@ import sys
 import tempfile
 import uuid
 from os import path
+from typing import Dict
 from urllib.parse import urlparse
+
+# Ugly temporary hack to get the product_catalog module from a different path.
+# This will go away as the helper modules make their way into libcsm
+sys.path.insert(1, os.path.join(os.path.dirname(os.path.abspath(__file__)),"..","configuration"))
+
+import update_product_catalog_ims_ids
 
 LOGGER = logging.getLogger(__name__)
 ch = logging.StreamHandler()
@@ -675,6 +682,12 @@ def import_ims_artifacts(args):
                 outfile)
         LOGGER.info(f'Recorded mapping from old to new IMS IDs and S3 etags in {id_map_file}')
         LOGGER.info(f'IMS data imported from {args.import_export_root}')
+
+        # If any image or recipe IDs changed, update the product catalog if needed
+        if image_map or recipe_map:
+            LOGGER.info('Updating IMS IDs in Cray Product Catalog')
+            update_product_catalog_ims_ids.update_product_catalog(image_map, recipe_map)
+
     except ImsImportExportBaseError as ims_exc:
         LOGGER.warning('Error importing IMS data', exc_info=ims_exc)
         return False


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
Starting in CSM 1.4, the Cray Product Catalog contained pointers to IMS image and recipe IDs. This PR modifies the IMS import script so that after import, if any IDs have changed, the Product Catalog will be updated if necessary.

I also provide a standalone script that will just update a specified IMS ID in the Cray Product Catalog. It uses the same backend code, but is intended for use in the docs when a user is manually importing just a single image or recipe, and wants to update the product catalog with the changed ID.

This involved writing code to find the latest version of the product catalog updater image. Code had already been written for parsing the product catalog. This makes use of that, searching each entry in the product catalog for images and recipes. And then if there are any changes for a given CPC entry, the aforementioned CPC updater is used to make the changes (same as is done to set them initially in the NCN image upload script).

I tested the code to update the cray product catalog on wasp, and verified that all of the desired updates were made, and no additional undesired changes were made.

In addition,[this PR relies in [code changes in this PR](https://github.com/Cray-HPE/docs-csm/pull/3585). ***This PR should not merge until that PR merges.***
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
- - [ ] https://github.com/Cray-HPE/docs-csm/pull/3512 has merged

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
