### PR TITLE
Change ceph latency script to always restart osds (CASMTRIAGE-5138)

### DIFF
--- a/scripts/repair-ceph-latency.sh
+++ b/scripts/repair-ceph-latency.sh
@@ -23,35 +23,8 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-max_latency="${1:-100}"
-seconds_sustained_latency="${2:-10}"
-osd_memory_target_gb="${3:-6}"
+osd_memory_target_gb="${1:-6}"
 osd_memory_target_bytes=$((osd_memory_target_gb * 1024 * 1024 * 1024))
-max_total_latency=$((max_latency * seconds_sustained_latency))
-num_osds_with_latency=0
-max_osds_with_latency=2
-
-function check_osd_for_sustained_latency() {
-  local osd=$1
-  local cnt=0
-  local total_latency=0
-  while true; do
-    if [[ "$cnt" -lt "$seconds_sustained_latency" ]]; then
-      tmp_latency=$(ceph osd perf | awk '{print $1,$2}' | grep "^${osd}[[:space:]]" | awk '{print $2}')
-      total_latency=$((total_latency+tmp_latency))
-      sleep 1
-    else
-      if [[ "$total_latency" -gt "$max_total_latency" ]]; then
-         echo "WARNING: osd.${osd} average latency exceeds ${max_latency}ms over ${seconds_sustained_latency} seconds"
-         num_osds_with_latency=$((num_osds_with_latency+1))
-      else
-         echo "INFO: no latency detected for osd.${osd}"
-      fi
-      break
-    fi
-    cnt=$((cnt+1))
-  done
-}
 
 function wait_for_health_ok() {
   local num_attempts=$1
@@ -148,27 +121,13 @@ function set_memory_target_settings() {
   ceph config set osd osd_memory_target ${osd_memory_target_bytes}
 }
 
-function check_osds_for_latency() {
+function repair_ceph_latency() {
   set_memory_target_settings
-  for osd in $(ceph osd ls)
-  do
-    check_osd_for_sustained_latency ${osd}
-    if [ $num_osds_with_latency -ge $max_osds_with_latency ]; then
-      echo "WARNING: found ${max_osds_with_latency} osds with latency, proceeding with restarts..."
-      restart_osds
-      break
-    fi
-  done
-
+  restart_osds
   echo "INFO: failing active manager to another node one final time."
   ceph mgr fail
-
-  if [ $num_osds_with_latency -lt $max_osds_with_latency ]; then
-    echo "SUCCESS: found fewer than ${max_osds_with_latency} osds with latency exceeding ${max_latency}ms over ${seconds_sustained_latency} seconds."
-  else
-    echo "SUCCESS: all restarts complete."
-  fi
+  echo "SUCCESS: all restarts complete."
 }
 
 wait_for_health_ok 60 # 5 minutes max
-check_osds_for_latency
+repair_ceph_latency


### PR DESCRIPTION
### Summary and Scope

Refactor latency script to simply set rocksdb options and restart osds without checking if the cluster is currently exhibiting latency.

### Issues and Related PRs

* https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5138

### Testing

* `ashton`

```
ncn-m002:~/brad # ./repair-ceph-latency.sh
Ceph is healthy -- continuing...
INFO: beginning restart of daemons on ncn-s001.
INFO: failing active manager to another node (from ncn-s001).
Sleeping for 30 seconds waiting for mgr to fail over...
noout is set
norecover is set
nobackfill is set
Daemons for Ceph cluster 7dd7193a-cb42-11ed-af07-42010afc0104 stopped on host ncn-s001. Host ncn-s001 moved to maintenance mode
Sleeping for ten seconds waiting for daemons to stop...
All daemons stopped, continuing...
Ceph cluster 7dd7193a-cb42-11ed-af07-42010afc0104 on ncn-s001 has exited maintenance mode
Sleeping for thirty seconds waiting for osds to be up (be patient)...
Sleeping for thirty seconds waiting for osds to be up (be patient)...
All osds up, continuing...
noout is unset
norecover is unset
nobackfill is unset
Sleeping for five seconds waiting ceph to be healthy...
Sleeping for five seconds waiting ceph to be healthy...
Sleeping for five seconds waiting ceph to be healthy...
Sleeping for five seconds waiting ceph to be healthy...
Sleeping for five seconds waiting ceph to be healthy...
Sleeping for five seconds waiting ceph to be healthy...
Sleeping for five seconds waiting ceph to be healthy...
Sleeping for five seconds waiting ceph to be healthy...
Ceph is healthy -- continuing...
INFO: done with restart of daemons on ncn-s001.
INFO: beginning restart of daemons on ncn-s001.
INFO: active manager is not running on ncn-s001, no need to fail over to another node.
noout is set
norecover is set
nobackfill is set
Daemons for Ceph cluster 7dd7193a-cb42-11ed-af07-42010afc0104 stopped on host ncn-s001. Host ncn-s001 moved to maintenance mode
Sleeping for ten seconds waiting for daemons to stop...
All daemons stopped, continuing...
Ceph cluster 7dd7193a-cb42-11ed-af07-42010afc0104 on ncn-s001 has exited maintenance mode
Sleeping for thirty seconds waiting for osds to be up (be patient)...
All osds up, continuing...
noout is unset
norecover is unset
nobackfill is unset
Sleeping for five seconds waiting ceph to be healthy...
Sleeping for five seconds waiting ceph to be healthy...
Sleeping for five seconds waiting ceph to be healthy...
Ceph is healthy -- continuing...
INFO: done with restart of daemons on ncn-s001.
INFO: beginning restart of daemons on ncn-s002.
INFO: failing active manager to another node (from ncn-s002).
Sleeping for 30 seconds waiting for mgr to fail over...
noout is set
norecover is set
nobackfill is set
Daemons for Ceph cluster 7dd7193a-cb42-11ed-af07-42010afc0104 stopped on host ncn-s002. Host ncn-s002 moved to maintenance mode
Sleeping for ten seconds waiting for daemons to stop...
All daemons stopped, continuing...
Ceph cluster 7dd7193a-cb42-11ed-af07-42010afc0104 on ncn-s002 has exited maintenance mode
Sleeping for thirty seconds waiting for osds to be up (be patient)...
Sleeping for thirty seconds waiting for osds to be up (be patient)...
All osds up, continuing...
noout is unset
norecover is unset
nobackfill is unset
Sleeping for five seconds waiting ceph to be healthy...
Sleeping for five seconds waiting ceph to be healthy...
Sleeping for five seconds waiting ceph to be healthy...
Sleeping for five seconds waiting ceph to be healthy...
Sleeping for five seconds waiting ceph to be healthy...
Ceph is healthy -- continuing...
INFO: done with restart of daemons on ncn-s002.
INFO: beginning restart of daemons on ncn-s002.
INFO: active manager is not running on ncn-s002, no need to fail over to another node.
noout is set
norecover is set
nobackfill is set
Daemons for Ceph cluster 7dd7193a-cb42-11ed-af07-42010afc0104 stopped on host ncn-s002. Host ncn-s002 moved to maintenance mode
Sleeping for ten seconds waiting for daemons to stop...
All daemons stopped, continuing...
Ceph cluster 7dd7193a-cb42-11ed-af07-42010afc0104 on ncn-s002 has exited maintenance mode
Sleeping for thirty seconds waiting for osds to be up (be patient)...
All osds up, continuing...
noout is unset
norecover is unset
nobackfill is unset
Sleeping for five seconds waiting ceph to be healthy...
Sleeping for five seconds waiting ceph to be healthy...
Ceph is healthy -- continuing...
INFO: done with restart of daemons on ncn-s002.
INFO: beginning restart of daemons on ncn-s003.
INFO: failing active manager to another node (from ncn-s003).
Sleeping for 30 seconds waiting for mgr to fail over...
noout is set
norecover is set
nobackfill is set
Daemons for Ceph cluster 7dd7193a-cb42-11ed-af07-42010afc0104 stopped on host ncn-s003. Host ncn-s003 moved to maintenance mode
Sleeping for ten seconds waiting for daemons to stop...
All daemons stopped, continuing...
Ceph cluster 7dd7193a-cb42-11ed-af07-42010afc0104 on ncn-s003 has exited maintenance mode
Sleeping for thirty seconds waiting for osds to be up (be patient)...
Sleeping for thirty seconds waiting for osds to be up (be patient)...
All osds up, continuing...
noout is unset
norecover is unset
nobackfill is unset
Sleeping for five seconds waiting ceph to be healthy...
Sleeping for five seconds waiting ceph to be healthy...
Sleeping for five seconds waiting ceph to be healthy...
Sleeping for five seconds waiting ceph to be healthy...
Ceph is healthy -- continuing...
INFO: done with restart of daemons on ncn-s003.
INFO: beginning restart of daemons on ncn-s003.
INFO: active manager is not running on ncn-s003, no need to fail over to another node.
noout is set
norecover is set
nobackfill is set
Daemons for Ceph cluster 7dd7193a-cb42-11ed-af07-42010afc0104 stopped on host ncn-s003. Host ncn-s003 moved to maintenance mode
Sleeping for ten seconds waiting for daemons to stop...
All daemons stopped, continuing...
Ceph cluster 7dd7193a-cb42-11ed-af07-42010afc0104 on ncn-s003 has exited maintenance mode
Sleeping for thirty seconds waiting for osds to be up (be patient)...
All osds up, continuing...
noout is unset
norecover is unset
nobackfill is unset
Sleeping for five seconds waiting ceph to be healthy...
Ceph is healthy -- continuing...
INFO: done with restart of daemons on ncn-s003.
INFO: failing active manager to another node one final time.
SUCCESS: all restarts complete.
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
