### PR TITLE
Fix cephfs storage class config map for add'l pool (CASMTRIAGE-5144)

### DIFF
--- a/upgrade/scripts/upgrade/csm-upgrade.sh
+++ b/upgrade/scripts/upgrade/csm-upgrade.sh
@@ -63,6 +63,8 @@ if [[ $state_recorded == "0" ]]; then
     echo "====> ${state_name} ..."
     {
     scp ncn-s001:/srv/cray/scripts/common/csi-configuration.sh /tmp/csi-configuration.sh
+    pool=$(ceph fs ls --format json-pretty|jq -r '.[] | select(. "name" == "cephfs") | .data_pools[]')
+    sed -i "s/.*ceph fs ls.*/         pool: $pool/" /tmp/csi-configuration.sh
     mkdir -p /srv/cray/tmp
     . /tmp/csi-configuration.sh
     create_ceph_rbd_1.2_csi_configmap


### PR DESCRIPTION
### Summary and Scope

Add pool fix to csi script if pulling from older version.

### Issues and Related PRs

* https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5144

### Testing

* `tyr`

Kurt is re-running with this change on tyr.

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
