### PR TITLE
CASMNET-2056 Update CANU in 1.3.2 Patch Docs

### DIFF
--- a/upgrade/1.3.2/README.md
+++ b/upgrade/1.3.2/README.md
@@ -119,6 +119,14 @@ to resolve potential problems and then try running `setup-nexus.sh` again. Note 
 report `FAIL` when uploading duplicate assets. This is okay as long as `setup-nexus.sh` outputs `setup-nexus.sh: OK` and exits
 with status code `0`.
 
+## Upgrade CANU
+
+CANU must be at version `1.7.1` or greater for this CSM patch release. New features were delivered in [CANU 1.7.0](https://github.com/Cray-HPE/canu/releases/tag/1.7.0) and a critical bug fixed in [CANU 1.7.1](https://github.com/Cray-HPE/canu/releases/tag/1.7.1).  Update CANU, adjusting the `pdsh` node ranges for the node type and counts on your system.
+
+```bash
+pdsh -f 1 -w ncn-m00[1-3],ncn-w00[1-3] "zypper install -y canu
+```
+
 ## Upgrade services
 
 Run `upgrade.sh` to deploy upgraded CSM applications and services:

--- a/upgrade/1.3.2/README.md
+++ b/upgrade/1.3.2/README.md
@@ -121,7 +121,9 @@ with status code `0`.
 
 ## Upgrade CANU
 
-CANU must be at version `1.7.1` or greater for this CSM patch release. New features were delivered in [CANU 1.7.0](https://github.com/Cray-HPE/canu/releases/tag/1.7.0) and a critical bug fixed in [CANU 1.7.1](https://github.com/Cray-HPE/canu/releases/tag/1.7.1).  Update CANU, adjusting the `pdsh` node ranges for the node type and counts on your system.
+CANU must be at version `1.7.1` or greater for this CSM patch release.
+New features were delivered in [CANU 1.7.0](https://github.com/Cray-HPE/canu/releases/tag/1.7.0) and a critical bug fixed in [CANU 1.7.1](https://github.com/Cray-HPE/canu/releases/tag/1.7.1).
+Update CANU, adjusting the `pdsh` node ranges for the node type and counts on your system.
 
 ```bash
 pdsh -f 1 -w ncn-m00[1-3],ncn-w00[1-3] "zypper install -y canu


### PR DESCRIPTION
# Description:

Add guidance to 1.3.2 patch release to upgrade CANU to 1.7.1.

Relates to:
- CASMNET-2056

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
