### PR TITLE
CASMINST-6150: Update Cray Product Catalog after IMS import

### DIFF
--- a/scripts/operations/configuration/python_lib/api_requests.py
+++ b/scripts/operations/configuration/python_lib/api_requests.py
@@ -39,8 +39,8 @@ from .types import JSONDecodeError
 
 ADMIN_CLIENT_SECRET_NAME = "admin-client-auth"
 ADMIN_CLIENT_SECRET_NAMESPACE = "default"
-AUTH_TOKEN_URL = ("https://api-gw-service-nmn.local/"
-                  "keycloak/realms/shasta/protocol/openid-connect/token")
+API_GW_BASE_URL = "https://api-gw-service-nmn.local"
+AUTH_TOKEN_URL = f"{API_GW_BASE_URL}/keycloak/realms/shasta/protocol/openid-connect/token"
 
 # For type hints
 ApiResponse = requests.models.Response
@@ -111,7 +111,8 @@ def get_api_token(k8s_client: k8s.CoreV1API = None) -> str:
 
 
 def make_api_request_with_retries(request_method: Callable, url: str, add_api_token: bool = False,
-                                  k8s_client: k8s.CoreV1API = None, **request_kwargs) -> ApiResponse:
+                                  k8s_client: k8s.CoreV1API = None,
+                                  **request_kwargs) -> ApiResponse:
     """
     Makes request with specified method to specified URL with specified keyword arguments (if any).
     If a 5xx status code is returned, the request will be retried after a brief wait, a limited

--- a/scripts/operations/configuration/python_lib/api_requests.py
+++ b/scripts/operations/configuration/python_lib/api_requests.py
@@ -26,7 +26,9 @@
 import logging
 import time
 import traceback
-from typing import Callable
+from typing import Callable, Container, Union
+
+import requests
 
 from . import common
 
@@ -48,21 +50,17 @@ def log_error_raise_exception(msg: str, parent_exception: Exception = None) -> N
 
 def make_api_request_with_retries(request_method: Callable,
                                   url: str,
-                                  expected_status_code: int,
-                                  **request_kwargs):
+                                  **request_kwargs) -> requests.models.Response:
     """
     Makes request with specified method to specified URL with specified keyword arguments (if any).
-    If the expected status code is returned, then the response body is returned (or None, if empty).
     If a 5xx status code is returned, the request will be retried after a brief wait, a limited
-    number of times.
-    If the expected status code is never returned (or an unexpected and non-5xx status code is
-    ever returned), then raise an exception
+    number of times. If this persists, an exception is raised. Otherwise, the response is returned.
     """
     try:
         method_name = request_method.__name__.upper()
-    except Exception as e:
+    except Exception as exc:
         log_error_raise_exception(
-            "Unexpected error determining API request method name", e)
+            "Unexpected error determining API request method name", exc)
 
     count = 0
     max_attempts = 6
@@ -71,31 +69,38 @@ def make_api_request_with_retries(request_method: Callable,
         logging.info(f"Making {method_name} request to {url}")
         try:
             resp = request_method(url, **request_kwargs)
-        except Exception as e:
+        except Exception as exc:
             log_error_raise_exception(
-                f"Error making {method_name} request to {url}", e)
+                f"Error making {method_name} request to {url}", exc)
         logging.debug(f"Response status code = {resp.status_code}")
-        if resp.status_code == expected_status_code:
-            if resp.text:
-                try:
-                    return resp.json()
-                except Exception as e:
-                    logging.debug(f"Response reason = {resp.reason}")
-                    logging.debug(f"Response text = {resp.text}")
-                    log_error_raise_exception(
-                        f"Error parsing {url} {method_name} response as JSON", e)
-            else:
-                return None
+        if not 500 <= resp.status_code <= 599:
+            return resp
         logging.debug(f"Response reason = {resp.reason}")
         logging.debug(f"Response text = {resp.text}")
-        if not 500 <= resp.status_code <= 599:
-            log_error_raise_exception(
-                "Unexpected status code received in response to API request."
-                f"Received {resp.status_code}, expecting {expected_status_code}")
-        elif count >= max_attempts:
+        if count >= max_attempts:
             log_error_raise_exception(
                 f"API request unsuccessful even after {max_attempts} attempts")
         logging.info("Sleeping 3 seconds before retrying..")
         time.sleep(3)
     log_error_raise_exception(
         "PROGRAMMING LOGIC ERROR: make_api_request_with_retries function should get here")
+
+
+def retry_request_validate_status(expected_status_codes: Union[int, Container[int]],
+                                  **kwargs_to_make_api_request_with_retries
+                                 ) -> requests.models.Response:
+    """
+    Wrapper function for make_api_request_with_retries that validates the status code of the
+    response.
+    expected_status_codes specifies the expected status code(s) for the API request.
+    It can be a single int, or a collection of ints. If the response status code does not match,
+    an exception is raised. Otherwise, the response is returned.
+    """
+    if isinstance(expected_status_codes, int):
+        expected_status_codes = {expected_status_codes}
+    response = make_api_request_with_retries(
+        **kwargs_to_make_api_request_with_retries)
+    if response.status_code not in expected_status_codes:
+        log_error_raise_exception(f"Response status code ({response.status_code}) does not match"
+                                  f" any expected status codes ({expected_status_codes})")
+    return response

--- a/scripts/operations/configuration/python_lib/args.py
+++ b/scripts/operations/configuration/python_lib/args.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/scripts/operations/configuration/python_lib/args.py
+++ b/scripts/operations/configuration/python_lib/args.py
@@ -1,0 +1,156 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""Shared Python function library: argument parsing"""
+
+import argparse
+import getpass
+import logging
+import os
+
+from typing import Callable, List
+
+
+TEXT_FILE_TYPE = argparse.FileType('rt', encoding="utf-8")
+
+
+def get_text_file_contents(file_name: str,
+                           value_validator: Callable = None) -> str:
+    """
+    Reads in the contents of the specified file as a string.
+
+    If value_validator is set, it is called with the file contents string as the only argument.
+    The return of the call is not examined -- the expectation is that the call will raise an
+    ArgumentTypeError if there is a problem.
+
+    Returns the file contents string if there are no errors.
+    """
+    # Use the built-in argparse FileType to open the file for reading.
+    # This will automatically raise appropriate errors if there are any issues.
+    file_contents = TEXT_FILE_TYPE(file_name).read()
+
+    if value_validator is not None:
+        try:
+            value_validator(file_contents)
+        except argparse.ArgumentTypeError as exc:
+            raise argparse.ArgumentTypeError(
+                f"Contents of '{file_name}' file failed validation: {exc}") from exc
+
+    return file_contents
+
+
+def get_env_var_value(env_var_name: str,
+                      value_validator: Callable = None,
+                      unset_ok: bool = False) -> str:
+    """
+    Looks up the value of the specified environment variable.
+
+    If unset_ok is False and the variable is not set, an ArgumentTypeError is raised.
+
+    NOTE that the variable may be set to an empty string, which is not the same as being unset.
+    If that condition needs to be caught, then the value_validator parameter must be used.
+
+    If value_validator is set, it is called with the variable value as the only argument.
+    The return of the call is not examined -- the expectation is that the call will raise an
+    ArgumentTypeError if there is a problem.
+
+    If there are no errors, the value of the variable is returned (or an empty string, if
+    the variable is unset and unset_ok is True).
+    """
+    env_var_value = os.getenv(env_var_name)
+    if env_var_value is None:
+        msg = f"Environment variable {env_var_name} is not set"
+        if unset_ok:
+            logging.debug(f"{msg}; unset_ok is True")
+            env_var_value = ""
+        else:
+            logging.error(msg)
+            raise argparse.ArgumentTypeError(msg)
+
+    if value_validator is not None:
+        try:
+            value_validator(env_var_value)
+        except argparse.ArgumentTypeError as exc:
+            raise argparse.ArgumentTypeError(
+                f"Value of environment variable {env_var_name} failed validation: {exc}") from exc
+
+    return env_var_value
+
+
+def validate_string(string_to_validate: str,
+                    min_length: int = None,
+                    max_length: int = None,
+                    required_prefix: str = None) -> None:
+    """
+    If the specified string fails to meet any of the requirements, raise an
+    argparse.ArgumentTypeError.
+    """
+    string_length = len(string_to_validate)
+
+    if min_length is not None and string_length < min_length:
+        raise argparse.ArgumentTypeError(
+            f"Length {string_length} is less than minimum permitted length {min_length}")
+
+    if max_length is not None and string_length > max_length:
+        raise argparse.ArgumentTypeError(
+            f"Length {string_length} is greater than maximum permitted length {max_length}")
+
+    if required_prefix is not None and string_to_validate.find(required_prefix) != 0:
+        raise argparse.ArgumentTypeError(
+            f"Does not begin with required prefix: '{required_prefix}'")
+
+
+class PasswordPromptAction(argparse.Action):
+    """
+    Custom argparse action to prompt user for a password, have them re-enter it to verify,
+    and then validate that it meets the minimum and maximum length requirements (if any).
+    """
+
+    def __init__(self, option_strings: List, dest: str, nargs=0,
+                 min_length: int = None, max_length: int = None, **kwargs):
+        """
+        Initialize the custom action, storing the length requirements for later use
+        """
+        if nargs != 0:
+            raise ValueError("nargs must be 0")
+        self.min_length, self.max_length = min_length, max_length
+        super().__init__(option_strings, dest, nargs=nargs, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        """
+        Prompt the user for the password, making sure that it meets the length requirements (if any)
+        and that it is entered correctly a second time
+        """
+        logging.debug("Prompting user for password")
+        while True:
+            pw_text = getpass.getpass("Enter desired password: ")
+            try:
+                validate_string(pw_text, min_length=self.min_length,
+                                max_length=self.max_length)
+            except argparse.ArgumentTypeError as exc:
+                logging.error(exc)
+                continue
+            if pw_text == getpass.getpass("Verify password: "):
+                break
+            logging.error("Passwords do not match. Please try again.")
+        setattr(namespace, self.dest, pw_text)

--- a/scripts/operations/configuration/python_lib/bss.py
+++ b/scripts/operations/configuration/python_lib/bss.py
@@ -1,0 +1,190 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""Shared Python function library: BSS"""
+
+import traceback
+
+import logging
+
+from typing import Dict, List, Union
+
+from . import api_requests
+from . import common
+from .types import JSONDecodeError
+
+BSS_BASE_URL = f"{api_requests.API_GW_BASE_URL}/apis/bss"
+BSS_BOOTPARAMS_URL = f"{BSS_BASE_URL}/boot/v1/bootparameters"
+
+
+def log_error_raise_exception(msg: str, parent_exception: Union[Exception, None] = None) -> None:
+    """
+    1) If a parent exception is passed in, make a debug log entry with its stack trace.
+    2) Log an error with the specified message.
+    3) Raise a ScriptException with the specified message (from the parent exception, if
+       specified)
+    """
+    if parent_exception is not None:
+        logging.debug(traceback.format_exc())
+    logging.error(msg)
+    if parent_exception is None:
+        raise common.ScriptException(msg)
+    raise common.ScriptException(msg) from parent_exception
+
+
+def get_bootparameters(xname_list: Union[List[str], None] = None,
+                       expected_to_exist: bool = True) -> List[dict]:
+    """
+    Queries BSS for all bootparameters for the specified xnames (or all bootparameters, if
+    no xnames are specified). Returns the list of these bootparameters.
+    common.ScriptException is raised on error.
+
+    By default, if any xnames are specified, and bootparameters are not found for one or more of
+    them, then an exception is raised. This behavior can be overridden with the expected_to_exist
+    argument. If no xnames are specified, then the expected_to_exist argument has no effect.
+    """
+    request_kwargs = {"url": BSS_BOOTPARAMS_URL, "add_api_token": True,
+                      "expected_status_codes": {200}}
+
+    if xname_list:
+        request_kwargs["json"] = {"hosts": xname_list}
+        if not expected_to_exist:
+            request_kwargs["expected_status_codes"].add(404)
+
+    resp = api_requests.get_retry_validate(**request_kwargs)
+    if resp.status_code == 404:
+        # This will only happen if expected_to_exist is set to False and no host entries
+        # were found for the query. In this case, return an empty list.
+        return []
+
+    try:
+        bootparams_list = list(resp.json())
+    except (JSONDecodeError, TypeError) as exc:
+        log_error_raise_exception("Response from BSS has unexpected format", exc)
+
+    if not xname_list or not expected_to_exist:
+        # If no xnames were specified, or if we are not validating that the xnames all were found,
+        # then whatever list we got back is what we return
+        return bootparams_list
+
+    # Reaching here means that we did specify xname(s) and we do expect them to exist. We
+    # got a 200 status code from the request, but this does NOT ensure that every xname
+    # was found. It means that at least one was found. In this case, we must manually check
+    # that all xnames were found.
+
+    logging.debug("Validating that all specified xnames are present in BSS response")
+    missing_xnames = set(xname_list)
+    for bootparam in bootparams_list:
+        try:
+            missing_xnames.difference_update(bootparam["hosts"])
+        except (KeyError, TypeError) as exc:
+            # KeyError - if bootparam does not have a hosts field. This should always be the case,
+            #   since we sent a request with an explicit host list.
+            # TypeError - To cover the case where bootparam is not a mapping-type object, or where
+            #   bootparam["hosts"] is not a list, both of which should be the case.
+            log_error_raise_exception("Response from BSS has unexpected format", exc)
+
+    if missing_xnames:
+        missing_xnames_str = ", ".join(sorted(list(missing_xnames)))
+        log_error_raise_exception("One or more queried xnames were not found in BSS"
+                                  f" bootparameters: {missing_xnames_str}")
+
+    logging.debug("No xnames missing from BSS response")
+    return bootparams_list
+
+
+def get_bootparameters_map(xname_list: List[str]) -> Dict[str, dict]:
+    """
+    Queries BSS for all bootparameters for the specified xnames. Returns a dictionary mapping
+    every xname to its corresponding bootparameters. An exception is raised if bootparameters
+    are not found for any of the xnames. common.ScriptException is raised on error.
+    """
+    bootparams_list = get_bootparameters(xname_list=xname_list, expected_to_exist=True)
+    bootparams_map = {}
+    for xname in xname_list:
+        for bootparam in bootparams_list:
+            # Not protecting the following with try...except because that is handled inside
+            # get_bootparameters()
+            if xname in bootparam["hosts"]:
+                bootparams_map[xname] = bootparam
+                break
+
+    if len(bootparams_map) != len(xname_list):
+        log_error_raise_exception(f"Number of xnames {len(xname_list)} does not match corresponding"
+                                  f" number of BSS bootparameters {len(bootparams_map)}")
+    return bootparams_map
+
+
+def update_bootparameters_artifacts(xname_list: List[str], kernel: str, initrd: str,
+                                    rootfs: str) -> None:
+    """
+    For the specified host xnames, updates the BSS bootparameters to use the specified kernel,
+    initrd, and rootfs artifacts. The artifacts are expected to be full S3 paths (i.e.
+    "s3://boot-images/k8s/0.3.49/rootfs").
+    The rootfs artifact is updated in the "params" string field.
+    The kernel and initrd artifacts are updated in their corresponding string fields.
+    Nothing is returned on success.
+    common.ScriptException is raised on error.
+    """
+    bootparameters_map = get_bootparameters_map(xname_list)
+    # In order to avoid leaving BSS in an inconsistent state, first we make sure that all of the
+    # specified xnames have "params" fields and that we can find a metal.server link in them. While
+    # we're at it, go ahead and generate the updated params field.
+    updated_params_field = {}
+    for xname in xname_list:
+        logging.debug(f"Generating updated params string for {xname}")
+        try:
+            current_params = bootparameters_map[xname]["params"]
+        except KeyError as exc:
+            # The KeyError should be from "params", since the get_bootparameters_map function should
+            # have raised an exception if the xname itself was not found.
+            log_error_raise_exception(f"No 'params' field found in BSS bootparameters for {xname}",
+                                      exc)
+
+        new_params_list = []
+        found = False
+        for current_param in current_params.split():
+            if current_param.find("metal.server=") == 0:
+                new_params_list.append(f"metal.server={rootfs}")
+                found = True
+                continue
+            new_params_list.append(current_param)
+        if not found:
+            log_error_raise_exception("No metal.server string found in 'params' field of BSS"
+                                      f" bootparameters for {xname}")
+        updated_params = " ".join(new_params_list)
+        logging.debug(f"Updated BSS bootparameters 'params' field for {xname}: {updated_params}")
+        updated_params_field[xname] = updated_params
+
+    # Now do the updates for each xname
+    request_kwargs = {"url": BSS_BOOTPARAMS_URL, "add_api_token": True,
+                      "expected_status_codes": 200}
+
+    for xname, updated_params in updated_params_field.items():
+        logging.info(f"Updating BSS bootparameters for {xname} with kernel '{kernel}', initrd "
+                     f"{initrd}, and rootfs {rootfs}")
+        request_json = {"hosts": [xname], "params": updated_params, "kernel": kernel,
+                        "initrd": initrd}
+        api_requests.patch_retry_validate(json=request_json, **request_kwargs)
+
+    logging.info("BSS bootparameters updated for all specified xnames")

--- a/scripts/operations/configuration/python_lib/cfs.py
+++ b/scripts/operations/configuration/python_lib/cfs.py
@@ -1,0 +1,150 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""Shared Python function library: CFS"""
+
+import traceback
+
+import logging
+
+from typing import Dict, List, Union
+
+from . import api_requests
+from . import common
+from .types import JSONDecodeError
+
+CFS_BASE_URL = f"{api_requests.API_GW_BASE_URL}/apis/cfs"
+CFS_V2_BASE_URL = f"{CFS_BASE_URL}/v2"
+CFS_V2_CONFIGS_URL = f"{CFS_V2_BASE_URL}/configurations"
+CFS_V2_SESSIONS_URL = f"{CFS_V2_BASE_URL}/sessions"
+
+
+def log_error_raise_exception(msg: str, parent_exception: Union[Exception, None] = None) -> None:
+    """
+    1) If a parent exception is passed in, make a debug log entry with its stack trace.
+    2) Log an error with the specified message.
+    3) Raise a ScriptException with the specified message (from the parent exception, if
+       specified)
+    """
+    if parent_exception is not None:
+        logging.debug(traceback.format_exc())
+    logging.error(msg)
+    if parent_exception is None:
+        raise common.ScriptException(msg)
+    raise common.ScriptException(msg) from parent_exception
+
+
+def get_session(session_name: str, expected_to_exist: bool = True) -> Union[dict, None]:
+    """
+    Queries CFS for the specified session and returns it. Throws an exception if it
+    is not found, unless expected_to_exist is set to False, in which case None is
+    returned.
+    """
+    request_kwargs = {"url": f"{CFS_V2_SESSIONS_URL}/{session_name}",
+                      "add_api_token": True,
+                      "expected_status_codes": {200}}
+
+    if not expected_to_exist:
+        request_kwargs["expected_status_codes"].add(404)
+
+    resp = api_requests.get_retry_validate(**request_kwargs)
+    if resp.status_code == 404:
+        # This will only happen if expected_to_exist is set to False and the session
+        # was not found. In this case, return None.
+        return None
+
+    try:
+        return resp.json()
+    except JSONDecodeError as exc:
+        log_error_raise_exception("Response from CFS has unexpected format", exc)
+
+
+def create_dynamic_session(session_name: str, config_name: str,
+                           xname_limit: Union[List[str], None] = None) -> dict:
+    """
+    Creates a CFS session of dynamic type with the specified name, running the specified
+    CFS configuration. By default this will be run on all applicable nodes, based on
+    the Ansible inventory and the node types defined in the Ansible play. This can be
+    limited by specifying a list of xnames.
+
+    The CFS session entry is returned if successful. Otherwise an exception is raised.
+    """
+    request_kwargs = {"url": CFS_V2_SESSIONS_URL,
+                      "json": {"name": session_name, "configurationName": config_name},
+                      "add_api_token": True,
+                      "expected_status_codes": {200}}
+    if xname_limit:
+        request_kwargs["json"]["ansibleLimit"] = ",".join(xname_limit)
+
+    resp = api_requests.post_retry_validate(**request_kwargs)
+
+    try:
+        return resp.json()
+    except JSONDecodeError as exc:
+        log_error_raise_exception("Response from CFS has unexpected format", exc)
+
+
+def get_configuration(config_name: str, expected_to_exist: bool = True) -> Union[dict, None]:
+    """
+    Queries CFS for the specified configuration and returns it. Throws an exception if it
+    is not found, unless expected_to_exist is set to False, in which case None is
+    returned.
+    """
+    request_kwargs = {"url": f"{CFS_V2_CONFIGS_URL}/{config_name}",
+                      "add_api_token": True,
+                      "expected_status_codes": {200}}
+
+    if not expected_to_exist:
+        request_kwargs["expected_status_codes"].add(404)
+
+    resp = api_requests.get_retry_validate(**request_kwargs)
+    if resp.status_code == 404:
+        # This will only happen if expected_to_exist is set to False and it
+        # was not found. In this case, return None.
+        return None
+
+    try:
+        return resp.json()
+    except JSONDecodeError as exc:
+        log_error_raise_exception("Response from CFS has unexpected format", exc)
+
+
+def create_configuration(config_name: str, layers: List[Dict[str, str]]) -> dict:
+    """
+    Creates a CFS configuration with the specified name and layers.
+    The layers should be dictionaries with the following fields set:
+        cloneUrl, commit, name, playbook
+
+    The CFS configuration is returned if successful. Otherwise an exception is raised.
+    """
+    request_kwargs = {"url": f"{CFS_V2_CONFIGS_URL}/{config_name}",
+                      "json": {"layers": layers},
+                      "add_api_token": True,
+                      "expected_status_codes": {200}}
+
+    resp = api_requests.put_retry_validate(**request_kwargs)
+
+    try:
+        return resp.json()
+    except JSONDecodeError as exc:
+        log_error_raise_exception("Response from CFS has unexpected format", exc)

--- a/scripts/operations/configuration/python_lib/common.py
+++ b/scripts/operations/configuration/python_lib/common.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/scripts/operations/configuration/python_lib/common.py
+++ b/scripts/operations/configuration/python_lib/common.py
@@ -1,0 +1,38 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""Shared Python function library"""
+
+import sys
+
+def stdout_write_flush(msg):
+    sys.stdout.write(msg)
+    sys.stdout.flush()
+
+def err(msg):
+    sys.stderr.write("ERROR: {}\n".format(msg))
+    sys.stderr.flush()
+
+def err_exit(msg):
+    err(msg)
+    sys.exit(1)

--- a/scripts/operations/configuration/python_lib/hsm.py
+++ b/scripts/operations/configuration/python_lib/hsm.py
@@ -58,7 +58,7 @@ def get_management_ncn_xnames() -> List[str]:
     """
     params = {"type": "Node", "role": "Management"}
     resp = api_requests.get_retry_validate(url=SMD_HSM_COMPONENTS_URL, expected_status_codes=200,
-                                           add_api_token=True, verify=False, params=params)
+                                           add_api_token=True, params=params)
     try:
         component_list = resp.json()["Components"]
         return sorted([comp["ID"] for comp in component_list])

--- a/scripts/operations/configuration/python_lib/hsm.py
+++ b/scripts/operations/configuration/python_lib/hsm.py
@@ -1,0 +1,66 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""Shared Python function library: HSM"""
+
+import traceback
+
+import logging
+
+from typing import List
+
+from . import api_requests
+from . import common
+from .types import JSONDecodeError
+
+SMD_BASE_URL = f"{api_requests.API_GW_BASE_URL}/apis/smd"
+SMD_HSM_COMPONENTS_URL = f"{SMD_BASE_URL}/hsm/v2/State/Components"
+
+
+def log_error_raise_exception(msg: str, parent_exception: Exception = None) -> None:
+    """
+    1) If a parent exception is passed in, make a debug log entry with its stack trace.
+    2) Log an error with the specified message.
+    3) Raise a ScriptException with the specified message (from the parent exception, if
+       specified)
+    """
+    if parent_exception is not None:
+        logging.debug(traceback.format_exc())
+    logging.error(msg)
+    if parent_exception is None:
+        raise common.ScriptException(msg)
+    raise common.ScriptException(msg) from parent_exception
+
+
+def get_management_ncn_xnames() -> List[str]:
+    """
+    Return a sorted list of the xnames of the management NCNs
+    """
+    params = {"type": "Node", "role": "Management"}
+    resp = api_requests.get_retry_validate(url=SMD_HSM_COMPONENTS_URL, expected_status_codes=200,
+                                           add_api_token=True, verify=False, params=params)
+    try:
+        component_list = resp.json()["Components"]
+        return sorted([comp["ID"] for comp in component_list])
+    except (JSONDecodeError, KeyError, TypeError) as exc:
+        log_error_raise_exception("Response from SMD has unexpected format", exc)

--- a/scripts/operations/configuration/python_lib/k8s.py
+++ b/scripts/operations/configuration/python_lib/k8s.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -32,9 +32,14 @@ import kubernetes.client.api
 import kubernetes.config
 
 from . import common
+from .types import JSONObject
 
-K8S_CONFIGURATION = None
-K8S_API_CLIENT = None
+# To help for type hinting in other modules
+CoreV1API = kubernetes.client.api.core_v1_api.CoreV1Api
+V1ClientConfiguration = kubernetes.client.configuration.Configuration
+V1ConfigMap = kubernetes.client.models.v1_config_map.V1ConfigMap
+V1Secret = kubernetes.client.models.v1_secret.V1Secret
+V1Service = kubernetes.client.models.v1_service.V1Service
 
 
 def log_error_raise_exception(msg: str, parent_exception: Exception = None) -> None:
@@ -52,70 +57,107 @@ def log_error_raise_exception(msg: str, parent_exception: Exception = None) -> N
     raise common.ScriptException(msg) from parent_exception
 
 
-def get_configuration() -> kubernetes.client.configuration.Configuration:
+def get_configuration() -> V1ClientConfiguration:
     """
     Creates a default Kubernetes configuration and returns it.
     """
-    global K8S_CONFIGURATION
-    if K8S_CONFIGURATION is None:
-        logging.debug("Loading Kubernetes configuration")
-        try:
-            kubernetes.config.load_kube_config()
-        except Exception as exc:
-            log_error_raise_exception(
-                "Error loading Kubernetes configuration", exc)
-        logging.debug("Getting default copy of Kubernetes configuration")
-        try:
-            K8S_CONFIGURATION = kubernetes.client.Configuration().get_default_copy()
-        except Exception as exc:
-            log_error_raise_exception(
-                "Error getting default copy of Kubernetes configuration", exc)
-    return K8S_CONFIGURATION
+    logging.debug("Loading Kubernetes configuration")
+    try:
+        kubernetes.config.load_kube_config()
+    except Exception as exc:
+        log_error_raise_exception(
+            "Error loading Kubernetes configuration", exc)
+    logging.debug("Getting default copy of Kubernetes configuration")
+    try:
+        return kubernetes.client.Configuration().get_default_copy()
+    except Exception as exc:
+        log_error_raise_exception(
+            "Error getting default copy of Kubernetes configuration", exc)
 
 
-def get_api_client() -> kubernetes.client.api.core_v1_api.CoreV1Api:
+def get_api_client() -> CoreV1API:
     """
     Creates a Kubernetes API client and returns it.
     """
-    global K8S_API_CLIENT
-    if K8S_API_CLIENT is None:
-        logging.info("Initializing Kubernetes client")
-        k8s_config = get_configuration()
-        logging.debug("Setting client default Kubernetes configuration")
+    logging.info("Initializing Kubernetes client")
+    k8s_config = get_configuration()
+    logging.debug("Setting client default Kubernetes configuration")
+    try:
+        kubernetes.client.Configuration.set_default(k8s_config)
+    except Exception as exc:
+        log_error_raise_exception(
+            "Error setting default Kubernetes configuration", exc)
+    try:
+        return kubernetes.client.api.core_v1_api.CoreV1Api()
+    except Exception as exc:
+        log_error_raise_exception("Error obtaining Kubernetes API client", exc)
+
+
+def get_data_field(k8s_object, label: str) -> JSONObject:
+    """
+    Returns the data field from the specified object. Raises an exception (using the
+    provided label) if there is a problem.
+    """
+    try:
+        return k8s_object.data
+    except AttributeError as exc:
+        log_error_raise_exception(
+            f"Error accessing data field in {label}", exc)
+
+
+class Client:
+    """
+    Kubernetes API client object. Takes care of the setup steps and provides simplified API calls.
+    """
+    def __init__(self):
+        self.client = get_api_client()
+
+    def get_config_map(self, name: str, namespace: str) -> V1ConfigMap:
+        """
+        Wrapper for read_namespaced_config_map function
+        """
+        configmap_label = f"{namespace}/{name} Kubernetes configmap"
+        logging.debug(f"Getting {configmap_label}")
         try:
-            kubernetes.client.Configuration.set_default(k8s_config)
+            return self.client.read_namespaced_config_map(name=name, namespace=namespace)
         except Exception as exc:
             log_error_raise_exception(
-                "Error setting default Kubernetes configuration", exc)
+                f"Error retrieving {configmap_label}", exc)
+
+    def get_config_map_data(self, name: str, namespace: str) -> JSONObject:
+        """
+        Calls get_config_map function, then extracts the data field from the response.
+        """
+        configmap_label = f"{namespace}/{name} Kubernetes configmap"
+        configmap = self.get_config_map(name=name, namespace=namespace)
+        return get_data_field(configmap, label=configmap_label)
+
+    def get_secret(self, name: str, namespace: str) -> V1Secret:
+        """
+        Wrapper for read_namespaced_secret function
+        """
+        secret_label = f"{namespace}/{name} Kubernetes secret"
+        logging.debug(f"Getting {secret_label}")
         try:
-            K8S_API_CLIENT = kubernetes.client.api.core_v1_api.CoreV1Api()
+            return self.client.read_namespaced_secret(name=name, namespace=namespace)
         except Exception as exc:
-            log_error_raise_exception(
-                "Error obtaining Kubernetes API client", exc)
-    return K8S_API_CLIENT
+            log_error_raise_exception(f"Error retrieving {secret_label}", exc)
 
+    def get_secret_data(self, name: str, namespace: str) -> JSONObject:
+        """
+        Calls get_secret function, then extracts the data field from the response.
+        """
+        secret_label = f"{namespace}/{name} Kubernetes secret"
+        secret = self.get_secret(name=name, namespace=namespace)
+        return get_data_field(secret, label=secret_label)
 
-def get_secret(name: str, namespace: str) -> kubernetes.client.models.v1_secret.V1Secret:
-    """
-    Wrapper for read_namespaced_secret function
-    """
-    api_client = get_api_client()
-    secret_label = f"{namespace}/{name} Kubernetes secret"
-    logging.debug(f"Getting {secret_label}")
-    try:
-        return api_client.read_namespaced_secret(name=name, namespace=namespace)
-    except Exception as exc:
-        log_error_raise_exception(f"Error retrieving {secret_label}", exc)
-
-
-def get_service(name: str, namespace: str) -> kubernetes.client.models.v1_service.V1Service:
-    """
-    Wrapper for read_namespaced_service function
-    """
-    api_client = get_api_client()
-    service_label = f"{namespace}/{name} Kubernetes service"
-    logging.debug(f"Getting {service_label}")
-    try:
-        return api_client.read_namespaced_service(name=name, namespace=namespace)
-    except Exception as exc:
-        log_error_raise_exception(f"Error retrieving {service_label}", exc)
+    def get_service(self, name: str, namespace: str) -> V1Service:
+        """
+        Wrapper for read_namespaced_service function
+        """
+        service_label = f"{namespace}/{name} Kubernetes service"
+        logging.debug(f"Getting {service_label}")
+        try:
+            return self.client.read_namespaced_service(name=name, namespace=namespace)
+        except Exception as exc:
+            log_error_raise_exception(f"Error retrieving {service_label}", exc)

--- a/scripts/operations/configuration/python_lib/k8s.py
+++ b/scripts/operations/configuration/python_lib/k8s.py
@@ -1,0 +1,121 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""Shared Python function library: Kubernetes"""
+
+import logging
+import traceback
+
+import kubernetes
+import kubernetes.client
+import kubernetes.client.api
+import kubernetes.config
+
+from . import common
+
+K8S_CONFIGURATION = None
+K8S_API_CLIENT = None
+
+
+def log_error_raise_exception(msg: str, parent_exception: Exception = None) -> None:
+    """
+    1) If a parent exception is passed in, make a debug log entry with its stack trace.
+    2) Log an error with the specified message.
+    3) Raise a ScriptException with the specified message (from the parent exception, if
+       specified)
+    """
+    if parent_exception is not None:
+        logging.debug(traceback.format_exc())
+    logging.error(msg)
+    if parent_exception is None:
+        raise common.ScriptException(msg)
+    raise common.ScriptException(msg) from parent_exception
+
+
+def get_configuration() -> kubernetes.client.configuration.Configuration:
+    """
+    Creates a default Kubernetes configuration and returns it.
+    """
+    global K8S_CONFIGURATION
+    if K8S_CONFIGURATION is None:
+        logging.debug("Loading Kubernetes configuration")
+        try:
+            kubernetes.config.load_kube_config()
+        except Exception as e:
+            log_error_raise_exception(
+                "Error loading Kubernetes configuration", e)
+        logging.debug("Getting default copy of Kubernetes configuration")
+        try:
+            K8S_CONFIGURATION = kubernetes.client.Configuration().get_default_copy()
+        except Exception as e:
+            log_error_raise_exception(
+                "Error getting default copy of Kubernetes configuration", e)
+    return K8S_CONFIGURATION
+
+
+def get_api_client() -> kubernetes.client.api.core_v1_api.CoreV1Api:
+    """
+    Creates a Kubernetes API client and returns it.
+    """
+    global K8S_API_CLIENT
+    if K8S_API_CLIENT is None:
+        logging.info("Initializing Kubernetes client")
+        k8s_config = get_configuration()
+        logging.debug("Setting client default Kubernetes configuration")
+        try:
+            kubernetes.client.Configuration.set_default(k8s_config)
+        except Exception as e:
+            log_error_raise_exception(
+                "Error setting default Kubernetes configuration", e)
+        try:
+            K8S_API_CLIENT = kubernetes.client.api.core_v1_api.CoreV1Api()
+        except Exception as e:
+            log_error_raise_exception(
+                "Error obtaining Kubernetes API client", e)
+    return K8S_API_CLIENT
+
+
+def get_secret(name: str, namespace: str) -> kubernetes.client.models.v1_secret.V1Secret:
+    """
+    Wrapper for read_namespaced_secret function
+    """
+    api_client = get_api_client()
+    secret_label = f"{namespace}/{name} Kubernetes secret"
+    logging.debug(f"Getting {secret_label}")
+    try:
+        return api_client.read_namespaced_secret(name=name, namespace=namespace)
+    except Exception as e:
+        log_error_raise_exception(f"Error retrieving {secret_label}", e)
+
+
+def get_service(name: str, namespace: str) -> kubernetes.client.models.v1_service.V1Service:
+    """
+    Wrapper for read_namespaced_service function
+    """
+    api_client = get_api_client()
+    service_label = f"{namespace}/{name} Kubernetes service"
+    logging.debug(f"Getting {service_label}")
+    try:
+        return api_client.read_namespaced_service(name=name, namespace=namespace)
+    except Exception as e:
+        log_error_raise_exception(f"Error retrieving {service_label}", e)

--- a/scripts/operations/configuration/python_lib/k8s.py
+++ b/scripts/operations/configuration/python_lib/k8s.py
@@ -61,15 +61,15 @@ def get_configuration() -> kubernetes.client.configuration.Configuration:
         logging.debug("Loading Kubernetes configuration")
         try:
             kubernetes.config.load_kube_config()
-        except Exception as e:
+        except Exception as exc:
             log_error_raise_exception(
-                "Error loading Kubernetes configuration", e)
+                "Error loading Kubernetes configuration", exc)
         logging.debug("Getting default copy of Kubernetes configuration")
         try:
             K8S_CONFIGURATION = kubernetes.client.Configuration().get_default_copy()
-        except Exception as e:
+        except Exception as exc:
             log_error_raise_exception(
-                "Error getting default copy of Kubernetes configuration", e)
+                "Error getting default copy of Kubernetes configuration", exc)
     return K8S_CONFIGURATION
 
 
@@ -84,14 +84,14 @@ def get_api_client() -> kubernetes.client.api.core_v1_api.CoreV1Api:
         logging.debug("Setting client default Kubernetes configuration")
         try:
             kubernetes.client.Configuration.set_default(k8s_config)
-        except Exception as e:
+        except Exception as exc:
             log_error_raise_exception(
-                "Error setting default Kubernetes configuration", e)
+                "Error setting default Kubernetes configuration", exc)
         try:
             K8S_API_CLIENT = kubernetes.client.api.core_v1_api.CoreV1Api()
-        except Exception as e:
+        except Exception as exc:
             log_error_raise_exception(
-                "Error obtaining Kubernetes API client", e)
+                "Error obtaining Kubernetes API client", exc)
     return K8S_API_CLIENT
 
 
@@ -104,8 +104,8 @@ def get_secret(name: str, namespace: str) -> kubernetes.client.models.v1_secret.
     logging.debug(f"Getting {secret_label}")
     try:
         return api_client.read_namespaced_secret(name=name, namespace=namespace)
-    except Exception as e:
-        log_error_raise_exception(f"Error retrieving {secret_label}", e)
+    except Exception as exc:
+        log_error_raise_exception(f"Error retrieving {secret_label}", exc)
 
 
 def get_service(name: str, namespace: str) -> kubernetes.client.models.v1_service.V1Service:
@@ -117,5 +117,5 @@ def get_service(name: str, namespace: str) -> kubernetes.client.models.v1_servic
     logging.debug(f"Getting {service_label}")
     try:
         return api_client.read_namespaced_service(name=name, namespace=namespace)
-    except Exception as e:
-        log_error_raise_exception(f"Error retrieving {service_label}", e)
+    except Exception as exc:
+        log_error_raise_exception(f"Error retrieving {service_label}", exc)

--- a/scripts/operations/configuration/python_lib/logger.py
+++ b/scripts/operations/configuration/python_lib/logger.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/scripts/operations/configuration/python_lib/logger.py
+++ b/scripts/operations/configuration/python_lib/logger.py
@@ -1,0 +1,90 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""Shared Python function library: logging"""
+
+import logging
+import logging.config
+import sys
+
+
+class _ExcludeErrorsFilter(logging.Filter):
+    def filter(self, record):
+        """Allow through the filter if the log level is less than ERROR"""
+        return record.levelno < logging.ERROR
+
+
+def configure_logging(filename):
+    """
+    Configures logging, with file logging going to the specified filename
+    """
+    config = {
+        'version': 1,
+        'filters': {
+            'exclude_errors': {
+                '()': _ExcludeErrorsFilter
+            }
+        },
+        'formatters': {
+            'file_formatter': {
+                'format': ('%(asctime)s.%(msecs)03d | %(process)d | %(name)s | %(pathname)s |'
+                           ' %(lineno)s | %(funcName)s | %(levelname)s | %(message)s'),
+                'datefmt': '%Y%m%d_%H%M%S'
+            },
+            'stream_formatter': {
+                'format': '%(message)s'
+            }
+        },
+        'handlers': {
+            'console_stderr': {
+                # Sends log messages with log level ERROR or higher to stderr
+                'class': 'logging.StreamHandler',
+                'level': 'ERROR',
+                'formatter': 'stream_formatter',
+                'stream': sys.stderr
+            },
+            'console_stdout': {
+                # Sends log messages with log level INFO or higher, but lower than ERROR, to stdout
+                'class': 'logging.StreamHandler',
+                'level': 'INFO',
+                'formatter': 'stream_formatter',
+                'filters': ['exclude_errors'],
+                'stream': sys.stdout
+            },
+            'file': {
+                # Sends all log messages to a file
+                'class': 'logging.FileHandler',
+                'level': 'DEBUG',
+                'formatter': 'file_formatter',
+                'filename': filename,
+                'encoding': 'utf8'
+            }
+        },
+        'root': {
+            # In general, this should be kept at 'NOTSET'.
+            # Otherwise it would interfere with the log levels set for each handler.
+            'level': 'NOTSET',
+            'handlers': ['console_stderr', 'console_stdout', 'file']
+        },
+    }
+    logging.config.dictConfig(config)

--- a/scripts/operations/configuration/python_lib/product_catalog.py
+++ b/scripts/operations/configuration/python_lib/product_catalog.py
@@ -237,7 +237,7 @@ class ProductCatalog:
         Verifies that the specified product and version are in the product catalog.
         Updates the 'images' and 'recipes' fields of the specified version of the specified product,
         using the latest version of the cray-product-catalog-update tool.
-        """       
+        """
         installed_product_map = self.get_installed_products()
         if product_name not in installed_product_map:
             log_error_raise_exception(

--- a/scripts/operations/configuration/python_lib/product_catalog.py
+++ b/scripts/operations/configuration/python_lib/product_catalog.py
@@ -1,0 +1,210 @@
+#
+# MIT License
+#
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""Shared Python function library: Cray product catalog"""
+
+import traceback
+from typing import Dict, ItemsView
+
+import logging
+import packaging.version
+import yaml
+
+from . import common
+from . import k8s
+
+from .types import JSONObject
+
+K8S_NAMESPACE = "services"
+K8S_CONFIG_MAP_NAME = "cray-product-catalog"
+
+# Used for type hinting
+ProductVersionMap = Dict[str, JSONObject]
+ProductCatalogMap = Dict[str, ProductVersionMap]
+
+
+def log_error_raise_exception(msg: str, parent_exception: Exception = None) -> None:
+    """
+    1) If a parent exception is passed in, make a debug log entry with its stack trace.
+    2) Log an error with the specified message.
+    3) Raise a ScriptException with the specified message (from the parent exception, if
+       specified)
+    """
+    if parent_exception is not None:
+        logging.debug(traceback.format_exc())
+    logging.error(msg)
+    if parent_exception is None:
+        raise common.ScriptException(msg)
+    raise common.ScriptException(msg) from parent_exception
+
+
+def parse_product_yaml(label: str, yaml_string: str) -> JSONObject:
+    """
+    Converts the YAML string for a product catalog product entry into its
+    dictionary form. Raises an exception if there are problems.
+    """
+    try:
+        decoded_yaml = yaml.safe_load(yaml_string)
+    except (AttributeError, yaml.scanner.ScannerError) as exc:
+        log_error_raise_exception(
+            f"Error decoding YAML data from {label}", exc)
+    # Ensure that we are actually returning a dictionary
+    try:
+        return {key: value for key, value in decoded_yaml.items()}
+    except (AttributeError, TypeError) as exc:
+        # Attribute error if 'items' attribute does not exist
+        # Type error if 'items' is not callable
+        log_error_raise_exception(
+            f"YAML data from {label} has an unexpected format", exc)
+
+
+def get_latest_version(product_version_map: ProductVersionMap,
+                       strict_versioning: bool = False,
+                       ignore_invalid_versions: bool = True) -> str:
+    """
+    Given a product version map from the product catalog, sort the version strings
+    and return the latest one.
+
+    If strict_versioning is false, then the generic packaging.version.parse() function will be
+    used to parse the version strings. Otherwise the packaging.versions.Version() constructor will
+    be used. The latter is more strict about what it considers to be a valid version.
+
+    If ignore_invalid_versions is true, any version string keys that are not valid will be excluded
+    from the sorting. Otherwise, invalid version strings will raise an exception.
+
+    Returns None if there are no valid version strings.
+    """
+    all_version_strings = list(product_version_map.keys())
+    logging.debug("get_latest_version: strict_versioning = %s, ignore_invalid_versions=%s, "
+                  "all_version_strings=%s", strict_versioning, ignore_invalid_versions,
+                  all_version_strings)
+    version_object_to_string = dict()
+    for version_string in all_version_strings:
+        try:
+            if strict_versioning:
+                version_object = packaging.version.Version(version_string)
+            else:
+                version_object = packaging.version.parse(version_string)
+            version_object_to_string[version_object] = version_string
+        except packaging.version.InvalidVersion as exc:
+            if ignore_invalid_versions:
+                logging.debug("get_latest_version: Ignoring invalid version string '%s'",
+                              version_string)
+                continue
+            log_error_raise_exception(
+                f"Invalid product version string in Cray product catalog: '{version_string}'", exc)
+    if not version_object_to_string:
+        logging.debug("get_latest_version: No valid version strings found")
+        return None
+    sorted_version_objects = sorted(version_object_to_string.keys())
+    latest_version_object = sorted_version_objects[-1]
+    # return corresponding string
+    latest_version_string = version_object_to_string[latest_version_object]
+    logging.debug(
+        "get_latest_version: latest_version_string = '%s'", latest_version_string)
+    return latest_version_string
+
+
+class ProductCatalog:
+    """
+    A snapshot of the current Cray product catalog configmap in Kubernetes.
+    """
+    def __init__(self, k8s_client: k8s.CoreV1API = None):
+        """
+        Retrieves the Cray Product Catalog configmap and returns its data field.
+        """
+        if k8s_client is None:
+            k8s_client = k8s.Client()
+        self.data = k8s_client.get_config_map_data(name=K8S_CONFIG_MAP_NAME,
+                                                   namespace=K8S_NAMESPACE)
+
+    def get_items(self) -> ItemsView:
+        """
+        Returns an item listing of the data field.
+        Raises an exception if there are any problems.
+        """
+        try:
+            return self.data.items()
+        except (AttributeError, TypeError) as exc:
+            # Attribute error if 'items' attribute does not exist
+            # Type error if 'items' is not callable
+            log_error_raise_exception(f"{K8S_NAMESPACE}/{K8S_CONFIG_MAP_NAME} Kubernetes configmap"
+                                      " has an unexpected format", exc)
+
+    def get_installed_products(self) -> ProductCatalogMap:
+        """
+        Returns the product mapping from the Cray Product Catalog configmap.
+        Parses the YAML of each product listing. Raises an exception if there
+        are any problems.
+        """
+        label = f"{K8S_NAMESPACE}/{K8S_CONFIG_MAP_NAME} Kubernetes configmap"
+        # This could be done in a single return / dictionary construction, but the following is
+        # more readable for those unfamiliar with the code, I think.
+        installed_products_map = dict()
+        for product_name, product_yaml in self.get_items():
+            installed_products_map[product_name] = parse_product_yaml(
+                label=f"'{product_name}' entry in {label}", yaml_string=product_yaml)
+        return installed_products_map
+
+    def get_installed_product_versions(self, requested_product_name: str) -> ProductVersionMap:
+        """
+        Returns just the specified product entry from the Cray Product Catalog configmap,
+        after parsing its YAML. Raises an exception if there are any problems.
+        Note that this will not examine other product entries in the configmap (if there
+        are any).
+        """
+        label = f"{K8S_NAMESPACE}/{K8S_CONFIG_MAP_NAME} Kubernetes configmap"
+        for product_name, product_yaml in self.get_items():
+            if product_name == requested_product_name:
+                return parse_product_yaml(label=f"'{requested_product_name}' entry in {label}",
+                                          yaml_string=product_yaml)
+        # Return an empty mapping if no versions are installed
+        return dict()
+
+    def get_installed_csm_versions(self) -> ProductVersionMap:
+        """
+        CSM-specific wrapper for get_installed_product_versions
+        """
+        return self.get_installed_product_versions("csm")
+
+    def get_latest_cfs_information(self, product_name: str) -> Dict[str, str]:
+        """
+        Returns the configuration data mapping from the latest installed version of the specified
+        product
+        """
+        label = (f"'{product_name}' entry in {K8S_NAMESPACE}/{K8S_CONFIG_MAP_NAME} "
+                 "Kubernetes configmap")
+        installed_version_map = self.get_installed_product_versions(
+            product_name)
+        latest_version_string = get_latest_version(installed_version_map)
+        try:
+            return installed_version_map[latest_version_string]["configuration"]
+        except KeyError as exc:
+            log_error_raise_exception(
+                f"No 'configuration' field found in {label}", exc)
+
+    def get_latest_csm_cfs_information(self) -> Dict[str, str]:
+        """
+        CSM-specific wrapper for get_latest_cfs_information
+        """
+        return self.get_latest_cfs_information("csm")

--- a/scripts/operations/configuration/python_lib/types.py
+++ b/scripts/operations/configuration/python_lib/types.py
@@ -1,0 +1,29 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""Shared Python function library: Type hints"""
+
+from typing import Any, Dict
+
+# A simplified type hint to use for JSON objects
+JSONObject = Dict[str, Any]

--- a/scripts/operations/configuration/python_lib/types.py
+++ b/scripts/operations/configuration/python_lib/types.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -23,7 +23,16 @@
 #
 """Shared Python function library: Type hints"""
 
-from typing import Any, Dict
+from typing import Any, Dict, Union
+
+from packaging.version import LegacyVersion, Version
+import simplejson.errors
 
 # A simplified type hint to use for JSON objects
 JSONObject = Dict[str, Any]
+
+# A generic version type that covers both Version and LegacyVersion
+GenericVersion = Union[LegacyVersion, Version]
+
+# So we can catch exceptions decoding JSON
+JSONDecodeError = simplejson.errors.JSONDecodeError

--- a/scripts/operations/configuration/python_lib/vault.py
+++ b/scripts/operations/configuration/python_lib/vault.py
@@ -1,0 +1,210 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""Shared Python function library: Vault"""
+
+import traceback
+
+import base64
+import logging
+import requests
+
+from . import api_requests
+from . import common
+from . import k8s
+
+SECRET_FIELD_NAMES = ["password", "ssh_private_key", "ssh_public_key"]
+
+K8S_NAMESPACE = "vault"
+K8S_SECRET_NAME = "cray-vault-unseal-keys"
+K8S_SERVICE_NAME = "cray-vault"
+
+TOKEN_STRING = None
+API_URL = None
+
+
+def log_error_raise_exception(msg: str, parent_exception: Exception = None) -> None:
+    """
+    1) If a parent exception is passed in, make a debug log entry with its stack trace.
+    2) Log an error with the specified message.
+    3) Raise a ScriptException with the specified message (from the parent exception, if
+       specified)
+    """
+    if parent_exception is not None:
+        logging.debug(traceback.format_exc())
+    logging.error(msg)
+    if parent_exception is None:
+        raise common.ScriptException(msg)
+    raise common.ScriptException(msg) from parent_exception
+
+
+def get_token_string() -> str:
+    """
+    Retrieve the Vault Kubernetes secret, extract the token string from it,
+    decode it from base-64, and return it as a string.
+    """
+    global TOKEN_STRING
+    if TOKEN_STRING is None:
+        # Obtain Vault token string from Kubernetes secret
+        secret_label = f"{K8S_NAMESPACE}/{K8S_SECRET_NAME} Kubernetes secret"
+        logging.info(f"Getting Vault token from {secret_label}")
+        vault_secret = k8s.get_secret(
+            name=K8S_SECRET_NAME, namespace=K8S_NAMESPACE)
+        try:
+            encoded_vault_token = vault_secret.data["vault-root"]
+        except (AttributeError, KeyError, TypeError) as e:
+            log_error_raise_exception(
+                f"{secret_label} has an unexpected format", e)
+        # return decoded bytes as a string
+        try:
+            TOKEN_STRING = base64.standard_b64decode(
+                encoded_vault_token).decode()
+        except Exception as e:
+            log_error_raise_exception(
+                f"Error decoding token in {secret_label}", e)
+    return TOKEN_STRING
+
+
+def get_api_url() -> str:
+    """
+    1. Looks up the vault/cray-vault service in Kubernetes
+    2. Retrieves the cluster IP address of the service
+    3. Retrieves the port list of the service
+    4. Finds the API port.
+    5. Assembles the base URL for the Vault API
+    """
+    global API_URL
+    if API_URL is None:
+        logging.debug("Finding Vault API URL")
+        service_label = f"{K8S_NAMESPACE}/{K8S_SERVICE_NAME} Kubernetes service"
+        vault_service = k8s.get_service(
+            name=K8S_SERVICE_NAME, namespace=K8S_NAMESPACE)
+
+        try:
+            vault_ip = vault_service.spec.cluster_ip
+            for vault_port in vault_service.spec.ports:
+                if vault_port.name == 'http-api-port':
+                    API_URL = f"http://{vault_ip}:{vault_port.port}"
+                    break
+        except (AttributeError, KeyError, TypeError) as e:
+            log_error_raise_exception(
+                f"{service_label} has an unexpected format", e)
+
+        if API_URL is None:
+            log_error_raise_exception(
+                f"No 'http-api-port' port found for {service_label}")
+        logging.debug(f"API_URL = {API_URL}")
+    return API_URL
+
+
+def get_csm_root_secret_api_url() -> str:
+    """
+    Returns the Vault API endpoint URL for the secret/csm/users/root Vault entry
+    """
+    api_url_base = get_api_url()
+    return f"{api_url_base}/v1/secret/csm/users/root"
+
+
+def write_root_secrets(ssh_private_key: str,
+                       ssh_public_key: str,
+                       password_hash: str,
+                       verify: bool = True) -> None:
+    """
+    Write the SSH keys and passwords to the csm root secret in Vault.
+    If verify is true, read them back to verify that they were set to the desired values.
+    """
+
+    secrets_to_write = {
+        "ssh_private_key": ssh_private_key,
+        "ssh_public_key": ssh_public_key,
+        "password": password_hash}
+
+    csm_root_secret_url = get_csm_root_secret_api_url()
+    logging.debug(f"csm_root_secret_url = {csm_root_secret_url}")
+    request_headers = {
+        "X-Vault-Request": "true",
+        "X-Vault-Token": get_token_string()}
+
+    # Create API request session
+    with requests.Session() as session:
+        # The same headers are used for all requests we'll be making
+        session.headers.update(request_headers)
+
+        # Write secrets to Vault
+        logging.info(
+            "Writing SSH keys and root password hash to secret/csm/users/root in Vault")
+        # We do not expect or care about any output of the write request,
+        # so no need to save the function return
+        try:
+            api_requests.make_api_request_with_retries(request_method=session.post,
+                                                       url=csm_root_secret_url,
+                                                       expected_status_code=204,
+                                                       json=secrets_to_write)
+        except Exception as e:
+            log_error_raise_exception(
+                f"Error making POST request to {csm_root_secret_url}", e)
+
+        if not verify:
+            logging.info("Vault write completed successfully")
+            return
+
+        # Read secrets back from Vault
+        logging.info(
+            "Read back secrets from Vault to verify that the values were correctly saved")
+        try:
+            resp_body = api_requests.make_api_request_with_retries(request_method=session.get,
+                                                                   url=csm_root_secret_url,
+                                                                   expected_status_code=200)
+        except Exception as e:
+            log_error_raise_exception(
+                f"Error making GET request to {csm_root_secret_url}", e)
+
+        if resp_body is None:
+            log_error_raise_exception(
+                "Empty body in response to Vault API read request")
+
+        try:
+            retrieved_vault_secrets = {
+                field: resp_body["data"][field] for field in SECRET_FIELD_NAMES}
+        except (KeyError, TypeError) as e:
+            log_error_raise_exception(
+                "Vault API read response has unexpected format", e)
+
+    # Validate that Vault values match what we wrote
+    logging.debug(
+        "Validating that Vault contents match what was written to it")
+    if retrieved_vault_secrets == secrets_to_write:
+        logging.info(
+            "Secrets read back from Vault match desired values -- "
+            "all secrets successfully written to Vault")
+        return
+
+    # Print summary of differences
+    for field in SECRET_FIELD_NAMES:
+        if secrets_to_write[field] == retrieved_vault_secrets[field]:
+            logging.debug(f"Vault value for {field} matches what was written")
+        else:
+            logging.error(
+                f"Vault value for {field} DOES NOT MATCH what was written")
+    raise common.ScriptException(
+        "Secrets read back from Vault do not all match what was written")

--- a/scripts/operations/configuration/python_lib/vault.py
+++ b/scripts/operations/configuration/python_lib/vault.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -27,25 +27,18 @@ import traceback
 
 import base64
 import logging
-import requests
-
-# So we can catch exceptions decoding JSON
-import simplejson.errors
 
 from . import api_requests
 from . import common
 from . import k8s
 
-from .types import JSONObject
+from .types import JSONDecodeError, JSONObject
 
 K8S_NAMESPACE = "vault"
 K8S_SECRET_NAME = "cray-vault-unseal-keys"
 K8S_SERVICE_NAME = "cray-vault"
 
 CSM_ROOT_SECRET_KEY = "csm/users/root"
-
-TOKEN_STRING = None
-API_URL = None
 
 API_STATUS_OK_WITH_DATA = 200
 API_STATUS_OK_EMPTY = 204
@@ -67,34 +60,36 @@ def log_error_raise_exception(msg: str, parent_exception: Exception = None) -> N
     raise common.ScriptException(msg) from parent_exception
 
 
-def get_token_string() -> str:
+def get_token_string(k8s_client: k8s.CoreV1API) -> str:
     """
     Retrieve the Vault Kubernetes secret, extract the token string from it,
     decode it from base-64, and return it as a string.
     """
-    global TOKEN_STRING
-    if TOKEN_STRING is None:
-        # Obtain Vault token string from Kubernetes secret
-        secret_label = f"{K8S_NAMESPACE}/{K8S_SECRET_NAME} Kubernetes secret"
-        logging.info(f"Getting Vault token from {secret_label}")
-        vault_secret = k8s.get_secret(
-            name=K8S_SECRET_NAME, namespace=K8S_NAMESPACE)
-        try:
-            encoded_vault_token = vault_secret.data["vault-root"]
-        except (AttributeError, KeyError, TypeError) as exc:
-            log_error_raise_exception(
-                f"{secret_label} has an unexpected format", exc)
-        # return decoded bytes as a string
-        try:
-            TOKEN_STRING = base64.standard_b64decode(
-                encoded_vault_token).decode()
-        except Exception as exc:
-            log_error_raise_exception(
-                f"Error decoding token in {secret_label}", exc)
-    return TOKEN_STRING
+    # Retrieve the Vault Kubernetes secret
+    secret_label = f"{K8S_NAMESPACE}/{K8S_SECRET_NAME} Kubernetes secret"
+    logging.debug("Getting Vault token from %s", secret_label)
+    vault_secret_data = k8s_client.get_secret_data(
+        name=K8S_SECRET_NAME, namespace=K8S_NAMESPACE)
+
+    # Extract the token string from it,
+    try:
+        encoded_vault_token = vault_secret_data["vault-root"]
+    except (KeyError, TypeError) as exc:
+        log_error_raise_exception(
+            f"{secret_label} has an unexpected format", exc)
+
+    # Decode it from base-64
+    try:
+        token_bytes = base64.standard_b64decode(encoded_vault_token)
+    except Exception as exc:
+        log_error_raise_exception(
+            f"Error decoding token in {secret_label}", exc)
+
+    # Return it as a string.
+    return token_bytes.decode()
 
 
-def get_api_url() -> str:
+def get_api_url(k8s_client: k8s.CoreV1API) -> str:
     """
     1. Looks up the vault/cray-vault service in Kubernetes
     2. Retrieves the cluster IP address of the service
@@ -102,50 +97,37 @@ def get_api_url() -> str:
     4. Finds the API port.
     5. Assembles the base URL for the Vault API
     """
-    global API_URL
-    if API_URL is None:
-        logging.debug("Finding Vault API URL")
-        service_label = f"{K8S_NAMESPACE}/{K8S_SERVICE_NAME} Kubernetes service"
-        vault_service = k8s.get_service(
-            name=K8S_SERVICE_NAME, namespace=K8S_NAMESPACE)
+    logging.debug("Finding Vault API URL")
+    service_label = f"{K8S_NAMESPACE}/{K8S_SERVICE_NAME} Kubernetes service"
+    vault_service = k8s_client.get_service(name=K8S_SERVICE_NAME, namespace=K8S_NAMESPACE)
 
-        try:
-            vault_ip = vault_service.spec.cluster_ip
-            for vault_port in vault_service.spec.ports:
-                if vault_port.name == 'http-api-port':
-                    API_URL = f"http://{vault_ip}:{vault_port.port}"
-                    break
-        except (AttributeError, KeyError, TypeError) as exc:
-            log_error_raise_exception(
-                f"{service_label} has an unexpected format", exc)
+    try:
+        vault_ip = vault_service.spec.cluster_ip
+        for vault_port in vault_service.spec.ports:
+            if vault_port.name == 'http-api-port':
+                api_url = f"http://{vault_ip}:{vault_port.port}"
+                logging.debug(f"API URL = {api_url}")
+                return api_url
+    except (AttributeError, KeyError, TypeError) as exc:
+        log_error_raise_exception(
+            f"{service_label} has an unexpected format", exc)
 
-        if API_URL is None:
-            log_error_raise_exception(
-                f"No 'http-api-port' port found for {service_label}")
-        logging.debug(f"API_URL = {API_URL}")
-    return API_URL
+    log_error_raise_exception(
+        f"No 'http-api-port' port found for {service_label}")
 
 
-def get_secret_api_url(secret_key: str) -> str:
-    """
-    Given the key for a Vault secret, returns the API URL for that secret.
-    Essentially this is just appending the secret key to the base API URL.
-    """
-    api_url_base = get_api_url()
-    return f"{api_url_base}/v1/secret/{secret_key}"
-
-
-def get_secret_data_from_response(api_response: requests.models.Response) -> JSONObject:
+def get_secret_data_from_response(api_response: api_requests.ApiResponse) -> JSONObject:
     """
     This is used to parse an API response to a Vault read request and extract the
     secret data (a JSON object). That data is returned. An exception is raised if
     anything goes wrong with this. The status code of the response is not validated.
     """
     if not api_response.text:
-        log_error_raise_exception("Vault response to read secret request has empty body")
+        log_error_raise_exception(
+            "Vault response to read secret request has empty body")
     try:
         resp_body = api_response.json()
-    except simplejson.errors.JSONDecodeError as exc:
+    except JSONDecodeError as exc:
         log_error_raise_exception(
             "Error decoding JSON in Vault response to read secret request", exc)
     try:
@@ -155,134 +137,153 @@ def get_secret_data_from_response(api_response: requests.models.Response) -> JSO
             "Vault response to read secret request is not in expected format", exc)
 
 
-def get_api_request_headers(additional_headers: JSONObject = None) -> JSONObject:
+class Vault():
     """
-    Return the headers to use for Vault API requests. If additional_headers are
-    provided, the function returns a dictionary of the default headers updated using
-    the additional headers.
-    """
-    default_headers = {"X-Vault-Request": "true", "X-Vault-Token": get_token_string()}
-    if additional_headers is None:
-        return default_headers
-    default_headers.update(additional_headers)
-    return default_headers
-
-
-def vault_api_delete(**kwargs) -> requests.models.Response:
-    """
-    Just a function wrapper to simplify making DELETE requests to Vault
-    using api_requests.retry_request_validate_status()
-    It specifies the request_method argument. If the caller
-    specifies headers, the default headers (from delete_api_request_headers())
-    will be updated with those values.
+    Used as an interface into Vault.
+    This object assumes that the Vault secret token is not
+    being changed over the lifetime of this object. If that becomes a problem, changes
+    will need to be made to handle it. The same is true of the service IP addresses and ports.
     """
 
-    # Get additional headers, if any, and remove them from the keyword arguments
-    additional_headers = kwargs.pop("headers", None)
-    # Generate request headers, combining additional ones, if any
-    request_headers = get_api_request_headers(additional_headers)
-    return api_requests.retry_request_validate_status(request_method=requests.delete,
-                                                      headers=request_headers, **kwargs)
+    def __init__(self, k8s_client: k8s.CoreV1API = None):
+        """
+        Obtains and stores the Vault token from the Kubernetes secret.
+        Obtains and stores the service IP address and port from Kubernetes, and saves
+        the API base URL constructed from them.
+        """
+        if k8s_client is None:
+            k8s_client = k8s.Client()
+        self.token_string = get_token_string(k8s_client)
+        self.api_url = get_api_url(k8s_client)
 
+    def get_secret_api_url(self, secret_key: str) -> str:
+        """
+        Given the key for a Vault secret, returns the API URL for that secret.
+        Essentially this is just appending the secret key to the base API URL.
+        """
+        return f"{self.api_url}/v1/secret/{secret_key}"
 
-def vault_api_get(**kwargs) -> requests.models.Response:
-    """
-    Just a function wrapper to simplify making GET requests to Vault
-    using api_requests.retry_request_validate_status()
-    It specifies the request_method argument. If the caller
-    specifies headers, the default headers (from get_api_request_headers())
-    will be updated with those values.
-    """
+    def get_api_request_headers(self, additional_headers: JSONObject = None) -> JSONObject:
+        """
+        Return the headers to use for Vault API requests. If additional_headers are
+        provided, the function returns a dictionary of the default headers updated using
+        the additional headers.
+        """
+        headers = {"X-Vault-Request": "true",
+                   "X-Vault-Token": self.token_string}
+        if additional_headers is not None:
+            headers.update(additional_headers)
+        return headers
 
-    # Get additional headers, if any, and remove them from the keyword arguments
-    additional_headers = kwargs.pop("headers", None)
-    # Generate request headers, combining additional ones, if any
-    request_headers = get_api_request_headers(additional_headers)
-    return api_requests.retry_request_validate_status(request_method=requests.get,
-                                                      headers=request_headers, **kwargs)
+    def api_delete(self, **kwargs) -> api_requests.ApiResponse:
+        """
+        Just a function wrapper to simplify making DELETE requests to Vault
+        using api_requests.retry_request_validate_status()
+        It specifies the request_method argument. If the caller
+        specifies headers, the default headers (from delete_api_request_headers())
+        will be updated with those values.
+        """
 
+        # Get additional headers, if any, and remove them from the keyword arguments
+        additional_headers = kwargs.pop("headers", None)
+        # Generate request headers, combining additional ones, if any
+        request_headers = self.get_api_request_headers(additional_headers)
+        return api_requests.delete_retry_validate(headers=request_headers, **kwargs)
 
-def vault_api_post(**kwargs) -> requests.models.Response:
-    """
-    Just a function wrapper to simplify making POST requests to Vault
-    using api_requests.retry_request_validate_status()
-    It specifies the request_method argument. If the caller
-    specifies headers, the default headers (from post_api_request_headers())
-    will be updated with those values.
-    """
+    def api_get(self, **kwargs) -> api_requests.ApiResponse:
+        """
+        Just a function wrapper to simplify making GET requests to Vault
+        using api_requests.retry_request_validate_status()
+        It specifies the request_method argument. If the caller
+        specifies headers, the default headers (from get_api_request_headers())
+        will be updated with those values.
+        """
 
-    # Get additional headers, if any, and remove them from the keyword arguments
-    additional_headers = kwargs.pop("headers", None)
-    # Generate request headers, combining additional ones, if any
-    request_headers = get_api_request_headers(additional_headers)
-    return api_requests.retry_request_validate_status(request_method=requests.post,
-                                                      headers=request_headers, **kwargs)
+        # Get additional headers, if any, and remove them from the keyword arguments
+        additional_headers = kwargs.pop("headers", None)
+        # Generate request headers, combining additional ones, if any
+        request_headers = self.get_api_request_headers(additional_headers)
+        return api_requests.get_retry_validate(headers=request_headers, **kwargs)
 
+    def api_post(self, **kwargs) -> api_requests.ApiResponse:
+        """
+        Just a function wrapper to simplify making POST requests to Vault
+        using api_requests.retry_request_validate_status()
+        It specifies the request_method argument. If the caller
+        specifies headers, the default headers (from post_api_request_headers())
+        will be updated with those values.
+        """
 
-def delete_secret(secret_key: str) -> None:
-    """
-    Deletes the specified secret key from Vault. This is also required in the case where the last
-    field of data in a secret is being removed, because Vault does not allow for empty secrets.
-    Raises an exception if anything goes wrong.
-    """
-    secret_url = get_secret_api_url(secret_key)
-    logging.debug(f"{secret_key} secret URL = {secret_url}")
-    logging.debug(f"Deleting {secret_key} secret from Vault")
-    vault_api_delete(url=secret_url, expected_status_codes=API_STATUS_OK_EMPTY)
+        # Get additional headers, if any, and remove them from the keyword arguments
+        additional_headers = kwargs.pop("headers", None)
+        # Generate request headers, combining additional ones, if any
+        request_headers = self.get_api_request_headers(additional_headers)
+        return api_requests.post_retry_validate(headers=request_headers, **kwargs)
 
+    def delete_secret(self, secret_key: str) -> None:
+        """
+        Deletes the specified secret key from Vault. This is also required in the case where the
+        last field of data in a secret is being removed, because Vault does not allow for empty
+        secrets.
+        Raises an exception if anything goes wrong.
+        """
+        secret_url = self.get_secret_api_url(secret_key)
+        logging.debug(f"{secret_key} secret URL = {secret_url}")
+        logging.debug(f"Deleting {secret_key} secret from Vault")
+        self.api_delete(
+            url=secret_url, expected_status_codes=API_STATUS_OK_EMPTY)
 
-def get_secret(secret_key: str, must_exist: bool = False) -> JSONObject:
-    """
-    Retrieves the Vault secret with the specified key and returns its contents.
-    The must_exist argument governs whether a 404 response status code results
-    in an exception or not. If must_exist is False and the response is 404, then
-    None is returned.
-    An exception is raised if any problems occur
-    """
-    secret_url = get_secret_api_url(secret_key)
-    logging.debug(f"{secret_key} secret URL = {secret_url}")
-    if must_exist:
-        expected_status_codes = {API_STATUS_OK_WITH_DATA}
-    else:
-        expected_status_codes = {API_STATUS_OK_WITH_DATA, API_STATUS_NOT_FOUND}
+    def get_secret(self, secret_key: str, must_exist: bool = False) -> JSONObject:
+        """
+        Retrieves the Vault secret with the specified key and returns its contents.
+        The must_exist argument governs whether a 404 response status code results
+        in an exception or not. If must_exist is False and the response is 404, then
+        None is returned.
+        An exception is raised if any problems occur
+        """
+        secret_url = self.get_secret_api_url(secret_key)
+        logging.debug(f"{secret_key} secret URL = {secret_url}")
+        if must_exist:
+            expected_status_codes = {API_STATUS_OK_WITH_DATA}
+        else:
+            expected_status_codes = {
+                API_STATUS_OK_WITH_DATA, API_STATUS_NOT_FOUND}
 
-    logging.debug(f"Reading {secret_key} secret from Vault")
-    resp = vault_api_get(url=secret_url, expected_status_codes=expected_status_codes)
-    if resp.status_code == API_STATUS_NOT_FOUND:
-        # Since an exception was not raised, this must mean we are in the case where this is okay.
-        # So return None.
-        return None
-    # Return the secret data from the response
-    return get_secret_data_from_response(resp)
+        logging.debug(f"Reading {secret_key} secret from Vault")
+        resp = self.api_get(
+            url=secret_url, expected_status_codes=expected_status_codes)
+        if resp.status_code == API_STATUS_NOT_FOUND:
+            # Since an exception was not raised, this must mean we are in the case where
+            #  this is okay. So return None.
+            return None
+        # Return the secret data from the response
+        return get_secret_data_from_response(resp)
 
+    def write_secret(self, secret_key: str, secret_data: JSONObject) -> None:
+        """
+        Writes the specified secret data to Vault using the specified secret key.
+        Raises an exception if anything goes wrong.
+        """
+        secret_url = self.get_secret_api_url(secret_key)
+        logging.debug(f"{secret_key} secret URL = {secret_url}")
+        logging.debug(f"Writing {secret_key} secret to Vault")
+        self.api_post(
+            url=secret_url, expected_status_codes=API_STATUS_OK_EMPTY, json=secret_data)
 
-def write_secret(secret_key: str, secret_data: JSONObject) -> None:
-    """
-    Writes the specified secret data to Vault using the specified secret key.
-    Raises an exception if anything goes wrong.
-    """
-    secret_url = get_secret_api_url(secret_key)
-    logging.debug(f"{secret_key} secret URL = {secret_url}")
-    logging.debug(f"Writing {secret_key} secret to Vault")
-    vault_api_post(url=secret_url, expected_status_codes=API_STATUS_OK_EMPTY, json=secret_data)
+    def delete_csm_root_secret(self, **kwargs) -> None:
+        """
+        Wrapper function that supplies the CSM root secret key to delete_secret()
+        """
+        self.delete_secret(secret_key=CSM_ROOT_SECRET_KEY)
 
+    def get_csm_root_secret(self, **kwargs) -> JSONObject:
+        """
+        Wrapper function that supplies the CSM root secret key to get_secret()
+        """
+        return self.get_secret(secret_key=CSM_ROOT_SECRET_KEY, **kwargs)
 
-def delete_csm_root_secret(**kwargs) -> None:
-    """
-    Wrapper function that supplies the CSM root secret key to delete_secret()
-    """
-    delete_secret(secret_key=CSM_ROOT_SECRET_KEY, **kwargs)
-
-
-def get_csm_root_secret(**kwargs) -> JSONObject:
-    """
-    Wrapper function that supplies the CSM root secret key to get_secret()
-    """
-    return get_secret(secret_key=CSM_ROOT_SECRET_KEY, **kwargs)
-
-
-def write_csm_root_secret(**kwargs) -> None:
-    """
-    Wrapper function that supplies the CSM root secret key to write_secret()
-    """
-    write_secret(secret_key=CSM_ROOT_SECRET_KEY, **kwargs)
+    def write_csm_root_secret(self, **kwargs) -> None:
+        """
+        Wrapper function that supplies the CSM root secret key to write_secret()
+        """
+        self.write_secret(secret_key=CSM_ROOT_SECRET_KEY, **kwargs)

--- a/scripts/operations/configuration/python_lib/vault.py
+++ b/scripts/operations/configuration/python_lib/vault.py
@@ -270,7 +270,7 @@ class Vault():
         self.api_post(
             url=secret_url, expected_status_codes=API_STATUS_OK_EMPTY, json=secret_data)
 
-    def delete_csm_root_secret(self, **kwargs) -> None:
+    def delete_csm_root_secret(self) -> None:
         """
         Wrapper function that supplies the CSM root secret key to delete_secret()
         """

--- a/scripts/operations/configuration/python_lib/vcs.py
+++ b/scripts/operations/configuration/python_lib/vcs.py
@@ -1,0 +1,87 @@
+#
+# MIT License
+#
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""Shared Python function library: VCS"""
+
+import traceback
+
+import base64
+import logging
+
+from typing import Tuple
+
+from . import common
+from . import k8s
+
+
+K8S_NAMESPACE = "services"
+K8S_SECRET_NAME = "vcs-user-credentials"
+
+
+def log_error_raise_exception(msg: str, parent_exception: Exception = None) -> None:
+    """
+    1) If a parent exception is passed in, make a debug log entry with its stack trace.
+    2) Log an error with the specified message.
+    3) Raise a ScriptException with the specified message (from the parent exception, if
+       specified)
+    """
+    if parent_exception is not None:
+        logging.debug(traceback.format_exc())
+    logging.error(msg)
+    if parent_exception is None:
+        raise common.ScriptException(msg)
+    raise common.ScriptException(msg) from parent_exception
+
+
+def get_vcs_credentials(k8s_client: k8s.CoreV1API = None) -> Tuple[str, str]:
+    """
+    Retrieve and decode the vcs_username and vcs_password from the VCS Kubernetes secret
+    """
+    if k8s_client is None:
+        k8s_client = k8s.Client()
+    secret_label = f"{K8S_NAMESPACE}/{K8S_SECRET_NAME} Kubernetes secret"
+    vcs_secret = k8s_client.get_secret(
+        name=K8S_SECRET_NAME, namespace=K8S_NAMESPACE)
+    try:
+        vcs_secret_data = vcs_secret.data
+    except AttributeError as exc:
+        log_error_raise_exception(
+            f"{secret_label} has an unexpected format", exc)
+    try:
+        encoded_username = vcs_secret_data["vcs_username"]
+        logging.debug("Encoded VCS username obtained")
+        encoded_password = vcs_secret_data["vcs_password"]
+        logging.debug("Encoded VCS password obtained")
+    except (KeyError, TypeError) as exc:
+        log_error_raise_exception(
+            f"{secret_label} has an unexpected format", exc)
+    # decode bytes to strings
+    try:
+        decoded_username = base64.standard_b64decode(encoded_username).decode()
+        logging.debug("VCS username decoded")
+        decoded_password = base64.standard_b64decode(encoded_password).decode()
+        logging.debug("VCS password decoded")
+    except Exception as exc:
+        log_error_raise_exception(
+            f"Error decoding credentials in {secret_label}", exc)
+    return decoded_username, decoded_password

--- a/scripts/operations/configuration/update_product_catalog_ims_ids.py
+++ b/scripts/operations/configuration/update_product_catalog_ims_ids.py
@@ -1,0 +1,156 @@
+#! /usr/bin/env python3
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+"""
+Search the Cray Product Catalog for specified IMS IDs and replace them with specified new IDs.
+Used both as a standalone script and as a module imported by other modules.
+"""
+
+import argparse
+import logging
+from typing import Dict, Tuple
+
+from python_lib import product_catalog
+from python_lib.types import JSONObject
+
+LOGGER = logging.getLogger(__name__)
+ch = logging.StreamHandler()
+ch.setLevel(logging.ERROR)
+LOGGER.addHandler(ch)
+
+IdChangeMap = Dict[str, str]
+
+class UpdateProductCatalogImsIdsBaseError(Exception):
+    pass
+
+def parse_args() -> Tuple[IdChangeMap, IdChangeMap]:
+    """
+    Parses the command line arguments.
+    Returns a tuple of IMS image ID old-to-new map and IMS recipe ID old-to-new map
+    """
+    parser = argparse.ArgumentParser(description="Searches Cray Product Catalog for instances of "
+        "specified old IMS image or recipe ID and replaces them with the specified new ID.")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('-i', '--image-id', dest='ims_type', action='store_const', const='image',
+                       help='Replace IMS image IDs')
+    group.add_argument('-r', '--recipe-id', dest='ims_type', action='store_const', const='recipe',
+                       help='Replace IMS recipe IDs')
+    parser.add_argument('old_ims_id', type=str, help='Old IMS ID to be replaced')
+    parser.add_argument('new_ims_id', type=str, help='New IMS ID to replace the old one with')
+    parsed_args = parser.parse_args()
+    old_new_map = { parsed_args.old_ims_id: parsed_args.new_ims_id }
+    if parsed_args.ims_type == 'image':
+        return old_new_map, {}
+    if parsed_args.ims_type == 'recipe':
+        return {}, old_new_map
+    # This should never happen, but just in case
+    raise UpdateProductCatalogImsIdsBaseError(
+        "PROGRAMMING LOGIC ERROR: Unable to determine type of IMS ID to replace")
+
+def get_name_id_replacements(product_name: str, product_version: str,
+                             product_version_details: JSONObject, images_or_recipes: str,
+                             id_change_map: IdChangeMap) -> product_catalog.NameIdTupleList:
+    """
+    Looks at the specified product version entry from the Cray Product Catalog.
+    Based on the 'images_or_recipes' parameter, looks at the 'images' or 'recipes' field of the
+    entry. If no such field exists, then there are no IDs to be updated. If the field exists,
+    its contents are scanned for IDs that match ones in the specified id_change_map.
+    Returns a list of tuples: (image_or_recipe_name, new_ims_id_for_this_image_or_recipe)
+    """
+    name_id_list = []
+    if not id_change_map:
+        # Nothing to do
+        return name_id_list
+    if not images_or_recipes in product_version_details:
+        # No field for images or recipes
+        return name_id_list
+    prod_ver_imgrec_map = product_version_details[images_or_recipes]
+
+    # The contents of this field should be a dictionary
+    if not isinstance(prod_ver_imgrec_map, dict):
+        LOGGER.debug("Product catalog entry for '%s' version '%s' contains '%s' field which is "
+                     "type %s instead of dict", product_name, product_version, images_or_recipes,
+                     str(type(prod_ver_imgrec_map)))
+        return name_id_list
+
+    # This dictionary should map image/recipe names to another dictionary, and that
+    # second dictionary should include an id field, which maps to the IMS ID for that image/recipe
+    # So parse through this and look for any IDs that need to be replaced.
+
+    for imgrec_name, imgrec_data in prod_ver_imgrec_map.items():
+        if not isinstance(imgrec_data, dict):
+            LOGGER.debug("Product catalog entry for '%s' version '%s' contains %s '%s' with "
+                         "unexpected data format: %s", product_name, product_version,
+                         images_or_recipes, imgrec_name, str(imgrec_data))
+            continue
+        if "id" not in imgrec_data:
+            LOGGER.debug("Product catalog entry for '%s' version '%s' contains %s '%s' with no "
+                         "'id' data: %s", product_name, product_version, images_or_recipes,
+                         imgrec_name, str(imgrec_data))
+            continue
+        imgrec_id = imgrec_data["id"]
+        if imgrec_id in id_change_map:
+            # This means that this ID was changed during the import
+            name_id_list.append((imgrec_name, id_change_map[imgrec_id]))
+
+    return name_id_list
+
+def update_product_catalog(image_id_change_map: IdChangeMap,
+                           recipe_id_change_map: IdChangeMap) -> None:
+    """
+    Update the Cray Product Catalog configmap, replacing any old IMS image or recipe IDs with the
+    corresponding new ones.
+
+    This function is intended to be used by other modules that import this one, as well as being
+    used within this module.
+    """
+    if not image_id_change_map and not recipe_id_change_map:
+        # No ID changes, so nothing to do
+        return
+    cpc = product_catalog.ProductCatalog()
+    for product_name, product_version_map in cpc.get_installed_products().items():
+        for product_version, product_version_details in product_version_map.items():
+            image_name_ids = get_name_id_replacements(product_name, product_version,
+                                                      product_version_details, "images",
+                                                      image_id_change_map)
+            recipe_name_ids = get_name_id_replacements(product_name, product_version,
+                                                       product_version_details, "recipes",
+                                                       recipe_id_change_map)
+            # If no IDs changed, we're done with this product version
+            if not image_name_ids and not recipe_name_ids:
+                continue
+            # Update the product catalog accordingly.
+            cpc.update_product_images_recipes(product_name=product_name,
+                                              product_version=product_version,
+                                              image_name_ids=image_name_ids,
+                                              recipe_name_ids=recipe_name_ids)
+
+def main() -> None:
+    """ Main function """
+    image_id_map, recipe_id_map = parse_args()
+    update_product_catalog(image_id_map, recipe_id_map)
+    LOGGER.info('DONE!')
+
+if __name__ == "__main__":
+    main()

--- a/scripts/operations/configuration/write_root_secrets_to_vault.py
+++ b/scripts/operations/configuration/write_root_secrets_to_vault.py
@@ -47,19 +47,9 @@ import requests
 import sys
 import time
 
+from python_lib.common import err, err_exit, stdout_write_flush
+
 VAULT_SECRET_FIELD_NAMES = [ "password", "ssh_private_key", "ssh_public_key" ]
-
-def stdout_write_flush(msg):
-    sys.stdout.write(msg)
-    sys.stdout.flush()
-
-def err(msg):
-    sys.stderr.write("ERROR: {}\n".format(msg))
-    sys.stderr.flush()
-
-def err_exit(msg):
-    err(msg)
-    sys.exit(1)
 
 def read_file(filename):
     """

--- a/scripts/operations/configuration/write_root_secrets_to_vault.py
+++ b/scripts/operations/configuration/write_root_secrets_to_vault.py
@@ -23,120 +23,66 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-# Reads in:
-# - the hashed root user password from /etc/shadow
-# - the root user SSH private key from /root/.ssh/id_rsa
-# - the root user SSH public key from /root/.ssh/id_rsa.pub
-#
-# Writes these to the secret/csm/users/root in Vault, and then
-# reads them back to verify that they match what was written.
-#
-# Beyond validating the inputs, currently this script does minimal error-checking.
-# This is because it is desirable for any errors to be fatal, so catching the
-# Python exceptions is only useful inasmuch as it gives the opportunity to translate
-# the error into a more user-friendly format. This is certainly something that should
-# eventually be implemented, but for the initial version of this tool, it is not
-# necessary.
+"""
+Reads in:
+- the hashed root user password from /etc/shadow
+- the root user SSH private key from /root/.ssh/id_rsa
+- the root user SSH public key from /root/.ssh/id_rsa.pub
 
-import base64
-import kubernetes
-import kubernetes.client
-import kubernetes.client.api
-import kubernetes.config
-import requests
-import sys
-import time
+Writes these to the secret/csm/users/root in Vault, and then
+reads them back to verify that they match what was written.
+"""
 
-from python_lib.common import err, err_exit, stdout_write_flush
+import logging
+import traceback
 
-VAULT_SECRET_FIELD_NAMES = [ "password", "ssh_private_key", "ssh_public_key" ]
+from python_lib import common
+from python_lib import logger
+from python_lib import vault
 
-def read_file(filename):
+
+def log_error_raise_exception(msg: str, parent_exception: Exception = None) -> None:
     """
-    Reads contents of text file, verifies it is more than a few characters long,
-    and returns it as a string. The length check could be refined to be
-    more precise, but this will suffice.
+    1) If a parent exception is passed in, make a debug log entry with its stack trace.
+    2) Log an error with the specified message.
+    3) Raise a ScriptException with the specified message (from the parent exception, if
+       specified)
     """
+    if parent_exception is not None:
+        logging.debug(traceback.format_exc())
+    logging.error(msg)
+    if parent_exception is None:
+        raise common.ScriptException(msg)
+    raise common.ScriptException(msg) from parent_exception
 
-    print("Reading in file '%s'" % filename, flush=True)
-    try:
-        with open(filename, "rt") as textfile:
-            contents = textfile.read()
-    except FileNotFoundError:
-        err_exit("File '%s' does not exist" % filename)
-    if len(contents) < 4:
-        err_exit("File '%s' only contains %d characters" % (filename, len(contents)))
-    return contents
 
-def get_root_hash_from_etc_shadow():
+def get_root_hash_from_etc_shadow() -> str:
     """
     Find the line in /etc/shadow for the root user and return the
     hashed password field from that line.
     """
 
-    for etc_shadow_line in read_file("/etc/shadow").splitlines():
-        line_fields = etc_shadow_line.split(":")
-        if line_fields[0] != "root":
-            continue
-        print("Found root user line in /etc/shadow", flush=True)
-        # Hash is in the second field of this line
-        root_password_hash = line_fields[1]
-        if not root_password_hash:
-            err_exit("No password hash found on root user line")
-        return root_password_hash
-    err_exit("No root user line found in /etc/shadow file")
+    etc_shadow_lines = common.read_file("/etc/shadow")
 
-def get_vault_api_endpoint_url(k8s_core_v1_api):
-    """
-    1. Looks up the vault/cray-vault service in Kubernetes
-    2. Retrieves the cluster IP address of the service
-    3. Retrieves the port list of the service
-    4. Finds the API port.
-    5. Assembles the URL for the Vault API endpoint URL for the secret/csm/users/root Vault entry
-       and returns it as a string.
-    """
-    vault_service = k8s_core_v1_api.read_namespaced_service(name="cray-vault", namespace="vault")
-    vault_ip = vault_service.spec.cluster_ip
-    for vault_port in vault_service.spec.ports:
-        if vault_port.name == 'http-api-port':
-            return "http://{ip}:{port}/v1/secret/csm/users/root".format(ip=vault_ip, port=vault_port.port)
-    err_exit("No 'http-api-port' port found for vault/cray-vault Kubernetes service")
+    try:
+        for etc_shadow_line in etc_shadow_lines.splitlines():
+            line_fields = etc_shadow_line.split(":")
+            if line_fields[0] != "root":
+                continue
+            logging.info("Found root user line in /etc/shadow")
+            # Hash is in the second field of this line
+            root_password_hash = line_fields[1]
+            if not root_password_hash:
+                common.print_err_exit(
+                    "No password hash found on root user line")
+            return root_password_hash
+    except Exception as e:
+        common.log_error_raise_exception(
+            "Unexpected error parsing /etc/shadow file contents", e)
+    common.print_err_exit("No root user line found in /etc/shadow file")
 
-def make_api_request_with_retries(request_method, url, expected_status_code, **request_kwargs):
-    """
-    Makes request with specified method to specified URL with specified keyword arguments (if any).
-    If the expected status code is returned, then the response body is returned (or None, if empty).
-    If a 5xx status code is returned, the request will be retried after a brief wait, a limited number
-    of times.
-    If the expected status code is never returned (or an unexpected and non-5xx status code is
-    ever returned), then exit in error.
-    """
-    count=0
-    max_attempts=6
-    while count < max_attempts:
-        count+=1
-        print("Making {method} request to {url}".format(method=request_method.__name__.upper(), url=url), flush=True)
-        resp = request_method(url, **request_kwargs)
-        print("Response status code = {}".format(resp.status_code), flush=True)
-        if resp.status_code == expected_status_code:
-            if resp.text:
-                return resp.json()
-            else:
-                return None
-        print("Response reason = {}".format(resp.reason), flush=True)
-        print("Response text = {}".format(resp.text), flush=True)
-        if not 500 <= resp.status_code <= 599:
-            err_exit("Unexpect status code received in response to API request")
-        elif count >= max_attempts:
-            err_exit("API request unsuccessful even after {} attempts".format(max_attempts))
-        stdout_write_flush("Sleeping 3 seconds before retrying..")
-        for x in range(3):
-            stdout_write_flush(".")
-            time.sleep(1)
-        stdout_write_flush("\n\n")
-    err_exit("PROGRAMMING LOGIC ERROR: Should never reach this point in the make_api_request_with_retries function")
 
-def main():
+def main() -> None:
     """
     1. Read in the SSH keys and hashed root password from the system.
     2. Initialize the Kubernetes API client.
@@ -147,63 +93,21 @@ def main():
     """
 
     # Read in secrets from the system
-    system_secrets = {
-        "ssh_private_key": read_file("/root/.ssh/id_rsa"),
-        "ssh_public_key": read_file("/root/.ssh/id_rsa.pub"),
-        "password": get_root_hash_from_etc_shadow() }
+    try:
+        ssh_private_key = common.read_file("/root/.ssh/id_rsa")
+        ssh_public_key = common.read_file("/root/.ssh/id_rsa.pub")
+        password_hash = get_root_hash_from_etc_shadow()
+        vault.write_root_secrets(ssh_private_key=ssh_private_key,
+                                 ssh_public_key=ssh_public_key,
+                                 password_hash=password_hash,
+                                 verify=True)
+    except common.ScriptException as e:
+        common.print_err_exit(f"{e}")
 
-    # Initialize our Kubernetes API client
-    print("\nInitializing Kubernetes client", flush=True)
-    kubernetes.config.load_kube_config()
-    k8s_configuration = kubernetes.client.Configuration().get_default_copy()
-    kubernetes.client.Configuration.set_default(k8s_configuration)
-    k8s_core_v1_api = kubernetes.client.api.core_v1_api.CoreV1Api()
+    print("SUCCESS", flush=True)
 
-    # Obtain Vault token string from Kubernetes secret
-    print("\nGetting Vault token from vault/cray-vault-unseal-keys Kubernetes secret", flush=True)
-    vault_secret = k8s_core_v1_api.read_namespaced_secret(name="cray-vault-unseal-keys", namespace="vault")
-    encoded_vault_token = vault_secret.data["vault-root"]
-    decoded_token_bytes = base64.standard_b64decode(encoded_vault_token)
-    # Convert from bytes to string for API request header
-    vault_api_request_headers = { 
-        "X-Vault-Request": "true", 
-        "X-Vault-Token": decoded_token_bytes.decode() }
-
-    # Obtain Vault API IP address and port from Kubernetes cray-vault service
-    print("\nExamining Kubernetes cray-vault service to determine URL for Vault API endpoint of secret/csm/users/root", flush=True)
-    vault_api_url = get_vault_api_endpoint_url(k8s_core_v1_api)
-
-    # Create API request session
-    with requests.Session() as session:
-        # The same headers are used for all requests we'll be making
-        session.headers.update(vault_api_request_headers)
-
-        # Write secrets to Vault
-        print("\nWriting SSH keys and root password hash to secret/csm/users/root in Vault", flush=True)
-        # We do not expect or care about any output of the write request, so no need to save the function return
-        make_api_request_with_retries(request_method=session.post, url=vault_api_url, expected_status_code=204, json=system_secrets)
-
-        # Read secrets back from Vault
-        print("\nRead back secrets from Vault to verify that the values were correctly saved", flush=True)
-        resp_body = make_api_request_with_retries(request_method=session.get, url=vault_api_url, expected_status_code=200)
-        if resp_body == None:
-            err_exit("Empty body in response to Vault API request")
-        vault_secrets = { field: resp_body["data"][field] for field in VAULT_SECRET_FIELD_NAMES }
-
-    # Validate that Vault values match what we wrote
-    print("\nValidating that Vault contents match what was written to it", flush=True)
-    if vault_secrets == system_secrets:
-        print("All secrets successfully written to Vault\n", flush=True)
-        print("SUCCESS", flush=True)
-        sys.exit(0)
-
-    # Print summary of differences
-    for field in VAULT_SECRET_FIELD_NAMES:
-        if system_secrets[field] == vault_secrets[field]:
-            print("Vault value for {} matches what was written".format(field), flush=True)
-        else:
-            err("Vault value for {} DOES NOT MATCH what was written".format(field))
-    err_exit("Not all secrets successfully written to Vault")
 
 if __name__ == '__main__':
+    logger.configure_logging(
+        filename='/var/log/write_root_secrets_to_vault.log')
     main()

--- a/scripts/operations/configuration/write_root_secrets_to_vault.py
+++ b/scripts/operations/configuration/write_root_secrets_to_vault.py
@@ -33,12 +33,29 @@ Writes these to the secret/csm/users/root in Vault, and then
 reads them back to verify that they match what was written.
 """
 
+import argparse
+import copy
+import crypt
 import logging
+import sys
 import traceback
 
+from python_lib import args
 from python_lib import common
 from python_lib import logger
 from python_lib import vault
+
+from python_lib.types import JSONObject
+
+# Default values
+PRI_KEY_PATH = "/root/.ssh/id_rsa"
+PUB_KEY_PATH = "/root/.ssh/id_rsa.pub"
+MINIMUM_PW_LENGTH = 8
+
+# Constants
+PASSWORD_HASH_FIELD_NAME = "password"
+PRIVATE_KEY_FIELD_NAME = "ssh_private_key"
+PUBLIC_KEY_FIELD_NAME = "ssh_public_key"
 
 
 def log_error_raise_exception(msg: str, parent_exception: Exception = None) -> None:
@@ -61,7 +78,6 @@ def get_root_hash_from_etc_shadow() -> str:
     Find the line in /etc/shadow for the root user and return the
     hashed password field from that line.
     """
-
     etc_shadow_lines = common.read_file("/etc/shadow")
 
     try:
@@ -76,38 +92,284 @@ def get_root_hash_from_etc_shadow() -> str:
                 common.print_err_exit(
                     "No password hash found on root user line")
             return root_password_hash
-    except Exception as e:
+    except Exception as exc:
         common.log_error_raise_exception(
-            "Unexpected error parsing /etc/shadow file contents", e)
-    common.print_err_exit("No root user line found in /etc/shadow file")
+            "Unexpected error parsing /etc/shadow file contents", exc)
+    common.log_error_raise_exception(
+        "No root user line found in /etc/shadow file")
 
 
-def main() -> None:
+def pw_env_var(env_var_name: str) -> str:
     """
-    1. Read in the SSH keys and hashed root password from the system.
-    2. Initialize the Kubernetes API client.
-    3. Get the Vault token from the cray-vault-unseal-keys secret in Kubernetes.
-    4. Write the SSH keys and hashed password into Vault.
-    5. Read the SSH keys and hashed password from Vault.
-    6. Verify that what was read matches what was written.
+    Wrapper for args.get_env_var_value with appropriate arguments for password environment
+    variables. This will require passwords to be at least 8 characters long.
+    """
+    logging.info(
+        f"Reading in plaintext password from {env_var_name} environment variable")
+    return args.get_env_var_value(
+        env_var_name=env_var_name,
+        value_validator=lambda s: args.validate_string(s, min_length=MINIMUM_PW_LENGTH))
+
+
+def pw_hash_env_var(env_var_name: str) -> str:
+    """
+    Wrapper for args.get_env_var_value with appropriate arguments for password hash
+    environment variables.
+
+    The minimum length of the password hash will depend on the algorithm that is used.
+    For our purposes, we will look for an 8 character minimum, and make sure that it
+    begins with a $ character.
+    """
+    logging.info(
+        f"Reading in password hash from {env_var_name} environment variable")
+    return args.get_env_var_value(
+        env_var_name=env_var_name,
+        value_validator=lambda s: args.validate_string(s, min_length=8, required_prefix='$'))
+
+
+def pri_ssh_key_file(file_name: str) -> str:
+    """
+    Wrapper for args.get_text_file_contents with appropriate arguments for SSH key files.
+    At this point, we just make sure that the files are at least 256 characters long.
+    """
+    logging.info(
+        f"Reading in SSH private key from '{file_name}' file")
+    return args.get_text_file_contents(
+        file_name=file_name,
+        value_validator=lambda s: args.validate_string(s, min_length=256))
+
+
+def pub_ssh_key_file(file_name: str) -> str:
+    """
+    Wrapper for args.get_text_file_contents with appropriate arguments for SSH key files.
+    At this point, we just make sure that the files are at least 256 characters long.
+    """
+    logging.info(
+        f"Reading in SSH public key from '{file_name}' file")
+    return args.get_text_file_contents(
+        file_name=file_name,
+        value_validator=lambda s: args.validate_string(s, min_length=256))
+
+
+def update_secret_fields(secret: JSONObject, field_changes: JSONObject) -> JSONObject:
+    """
+    Takes the current CSM root secret values (secret) and determines the desired new CSM root secret
+    values. Returns a dictionary of the new values.
+    """
+    updated_secret = copy.deepcopy(secret)
+    for field_name, new_field_value in field_changes.items():
+        if new_field_value is None:
+            # This means the field should be removed, if it is set
+            try:
+                del updated_secret[field_name]
+                logging.debug(f"CSM root secret {field_name} in Vault will be deleted")
+            except KeyError:
+                # Not a problem, but let's note it for the log
+                logging.debug(
+                    f"Asked to delete CSM root secret {field_name} in Vault, but it isn't set")
+            continue
+        # Record the new value
+        updated_secret[field_name] = new_field_value
+    return updated_secret
+
+
+def compare_root_secrets(secret_written: JSONObject, secret_read: JSONObject) -> None:
+    """
+    Compare the secret we wrote to what we read back. If there are any differences,
+    log them and raise an exception.
+    """
+    secrets_match = True
+
+    # Validate that Vault values match what we wrote
+    logging.debug("Validating that Vault contents match what was written to it")
+
+    fields_not_written = secret_written.keys() - secret_read.keys()
+    extra_fields = secret_read.keys() - secret_written.keys()
+    common_fields = secret_read.keys() & secret_written.keys()
+
+    if fields_not_written:
+        secrets_match = False
+        logging.error("Fields were written to the CSM root secret, but were not present"
+                      f" when it was read back: {fields_not_written}")
+    else:
+        logging.debug(
+            "All written secret fields were present when read back")
+
+    if extra_fields:
+        secrets_match = False
+        logging.error("Fields were not written to the CSM root secret, but were present"
+                      f" when it was read back: {extra_fields}")
+    else:
+        logging.debug("All read secret fields were present when written")
+
+    for field in common_fields:
+        if secret_read[field] == secret_written[field]:
+            logging.debug(f"Vault value for {field} matches what was written")
+        else:
+            secrets_match = False
+            logging.error(f"Vault value for {field} DOES NOT MATCH what was written")
+
+    if not secrets_match:
+        raise common.ScriptException("Secret read back from Vault does not match what was written")
+
+    logging.info("Secrets read back from Vault match desired values")
+
+
+def update_root_secret_in_vault(field_changes: JSONObject) -> None:
+    """
+    Write the SSH keys and passwords to the csm root secret in Vault.
+    If the result is that the secret no longer contains any data, it is deleted from Vault.
+    Then read secret the back to verify it matches what was written (or verify that it
+    no longer exists in Vault, if applicable).
     """
 
-    # Read in secrets from the system
-    try:
-        ssh_private_key = common.read_file("/root/.ssh/id_rsa")
-        ssh_public_key = common.read_file("/root/.ssh/id_rsa.pub")
-        password_hash = get_root_hash_from_etc_shadow()
-        vault.write_root_secrets(ssh_private_key=ssh_private_key,
-                                 ssh_public_key=ssh_public_key,
-                                 password_hash=password_hash,
-                                 verify=True)
-    except common.ScriptException as e:
-        common.print_err_exit(f"{e}")
+    # Get the current CSM root secrets from Vault. It is possible that the secret is not in Vault.
+    csm_root_secret_before = vault.get_csm_root_secret(must_exist=False)
+    if csm_root_secret_before is None:
+        logging.debug("CSM root secret does not currently exist in Vault")
+        csm_root_secret_before = dict()
 
-    print("SUCCESS", flush=True)
+    # Generate the new desired root secret based on the current secret contents and the
+    # arguments to this function
+    csm_root_secret_to_write = update_secret_fields(secret=csm_root_secret_before,
+                                                    field_changes=field_changes)
+
+    if not csm_root_secret_to_write:
+        logging.info("Based on inputs, the desired CSM root secret is empty")
+        if not csm_root_secret_before:
+            logging.info("The CSM root secret in Vault is already empty, so nothing to do.")
+            return
+
+        # Vault does not allow empty secrets do be written. Instead, they must be deleted.
+        logging.info("Deleting CSM root secret from Vault")
+        vault.delete_csm_root_secret()
+
+        # Now attempt to read the CSM root secret from Vault.
+        csm_root_secret_after = vault.get_csm_root_secret(must_exist=False)
+        if csm_root_secret_after is not None:
+            common.log_error_raise_exception(
+                "CSM root secret appears to exist in Vault even after deleting it")
+        logging.info("CSM root secret deleted from Vault")
+        return
+
+    # We are left with the case where we are writing secret data to Vault
+    logging.info("Writing updated CSM root secret to Vault")
+    vault.write_csm_root_secret(secret_data=csm_root_secret_to_write)
+
+    # Read back CSM root secret from Vault. It should exist, since we just wrote it.
+    csm_root_secret_after = vault.get_csm_root_secret(must_exist=True)
+
+    # Compare what we wrote to what we read back
+    compare_root_secrets(csm_root_secret_to_write, csm_root_secret_after)
+    return
+
+
+def parse_args() -> JSONObject:
+    """
+    Parses the command line arguments.
+    Returns a dictionary mapping secret field names to the value they should be
+    set to, or None if they should be deleted from Vault. Any fields not
+    included in the dictionary will be left unchanged from their current value
+    in Vault (if any).
+
+    [--pw-env-var VAR_NAME | --pw-hash-env-var VAR_NAME | --pw-no-change |
+     --pw-prompt | --pw-remove | --pw-sys]
+    [--pri-key-file FILEPATH | --pri-key-no-change | --pri-key-remove]
+    [--pub-key-file FILEPATH | --pub-key-no-change | --pub-key-remove]
+    """
+    logging.debug(f"Command line arguments: {sys.argv}")
+
+    parser = argparse.ArgumentParser(
+        description="Update CSM root secrets in Vault with specified SSH keys and password hash")
+
+    # Password source arguments are mutually exclusive
+    pw_group = parser.add_mutually_exclusive_group()
+    pw_group.add_argument("--pw-env-var", type=pw_env_var,
+                          metavar="VAR_NAME",
+                          help="Read plaintext password from specified variable")
+    pw_group.add_argument("--pw-hash-env-var", type=pw_hash_env_var,
+                          metavar="VAR_NAME",
+                          help="Read shadow password hash string from specified variable")
+    pw_group.add_argument("--pw-no-change", action='store_true',
+                          help="Do not change saved password (if any) in Vault")
+    pw_group.add_argument("--pw-prompt", action=args.PasswordPromptAction,
+                          min_length=MINIMUM_PW_LENGTH,
+                          help="Prompt user to enter plaintext password")
+    pw_group.add_argument("--pw-remove", action='store_true',
+                          help="Remove saved password (if any) from Vault")
+    pw_group.add_argument("--pw-sys", action='store_true',
+                          help="Read password hash from /etc/shadow file on the system (default)")
+
+    # Private key source arguments are mutually exclusive
+    pri_key_group = parser.add_mutually_exclusive_group()
+    pri_key_group.add_argument("--pri-key-no-change", action='store_true',
+                               help="Do not change saved private key (if any) in Vault")
+    pri_key_group.add_argument("--pri-key-file", type=pri_ssh_key_file,
+                               metavar='private_key_file', default=PRI_KEY_PATH, dest='pri_key',
+                               help=f"Path to private key file (default: {PRI_KEY_PATH})")
+    pri_key_group.add_argument("--pri-key-remove", action='store_true',
+                               help="Remove saved private key (if any) from Vault")
+
+    # Public key source arguments are mutually exclusive
+    pub_key_group = parser.add_mutually_exclusive_group()
+    pub_key_group.add_argument("--pub-key-no-change", action='store_true',
+                               help="Do not change saved public key (if any) in Vault")
+    pub_key_group.add_argument("--pub-key-file", type=pub_ssh_key_file,
+                               metavar='public_key_file', default=PUB_KEY_PATH, dest='pub_key',
+                               help=f"Path to public key file (default: {PUB_KEY_PATH})")
+    pub_key_group.add_argument("--pub-key-remove", action='store_true',
+                               help="Remove saved public key (if any) from Vault")
+
+    parsed_args = parser.parse_args()
+
+    field_changes = dict()
+
+    if parsed_args.pw_remove:
+        # Clear the field in Vault, if it is set
+        field_changes[PASSWORD_HASH_FIELD_NAME] = None
+    elif parsed_args.pw_hash_env_var is not None:
+        # We have already read in the hashed value from the environment variable
+        field_changes[PASSWORD_HASH_FIELD_NAME] = parsed_args.pw_hash_env_var
+    elif parsed_args.pw_env_var is not None:
+        # Generate the hash
+        logging.debug("Generating password hash")
+        field_changes[PASSWORD_HASH_FIELD_NAME] = crypt.crypt(parsed_args.pw_env_var)
+    elif parsed_args.pw_prompt is not None:
+        # Generate the hash
+        logging.debug("Generating password hash")
+        field_changes[PASSWORD_HASH_FIELD_NAME] = crypt.crypt(parsed_args.pw_prompt)
+    elif not parsed_args.pw_no_change:
+        # Default is to read it from the system
+        field_changes[PASSWORD_HASH_FIELD_NAME] = get_root_hash_from_etc_shadow()
+
+    if parsed_args.pri_key_remove:
+        # Clear the field in Vault, if it is set
+        field_changes[PRIVATE_KEY_FIELD_NAME] = None
+    elif not parsed_args.pri_key_no_change:
+        field_changes[PRIVATE_KEY_FIELD_NAME] = parsed_args.pri_key
+
+    if parsed_args.pub_key_remove:
+        # Clear the field in Vault, if it is set
+        field_changes[PUBLIC_KEY_FIELD_NAME] = None
+    elif not parsed_args.pub_key_no_change:
+        field_changes[PUBLIC_KEY_FIELD_NAME] = parsed_args.pub_key
+
+    return field_changes
+
+
+def main():
+    """
+    Parses the command line arguments, read in the secrets, write them to Vault.
+    """
+    field_changes = parse_args()
+    update_root_secret_in_vault(field_changes)
 
 
 if __name__ == '__main__':
     logger.configure_logging(
         filename='/var/log/write_root_secrets_to_vault.log')
-    main()
+    try:
+        main()
+    except common.ScriptException as script_exc:
+        common.print_err_exit(f"{script_exc}")
+    print("SUCCESS", flush=True)

--- a/scripts/operations/system_recovery/ims-import-export.py
+++ b/scripts/operations/system_recovery/ims-import-export.py
@@ -32,7 +32,14 @@ import sys
 import tempfile
 import uuid
 from os import path
+from typing import Dict
 from urllib.parse import urlparse
+
+# Ugly temporary hack to get the product_catalog module from a different path.
+# This will go away as the helper modules make their way into libcsm
+sys.path.insert(1, os.path.join(os.path.dirname(os.path.abspath(__file__)),"..","configuration"))
+
+import update_product_catalog_ims_ids
 
 LOGGER = logging.getLogger(__name__)
 ch = logging.StreamHandler()
@@ -675,6 +682,12 @@ def import_ims_artifacts(args):
                 outfile)
         LOGGER.info(f'Recorded mapping from old to new IMS IDs and S3 etags in {id_map_file}')
         LOGGER.info(f'IMS data imported from {args.import_export_root}')
+
+        # If any image or recipe IDs changed, update the product catalog if needed
+        if image_map or recipe_map:
+            LOGGER.info('Updating IMS IDs in Cray Product Catalog')
+            update_product_catalog_ims_ids.update_product_catalog(image_map, recipe_map)
+
     except ImsImportExportBaseError as ims_exc:
         LOGGER.warning('Error importing IMS data', exc_info=ims_exc)
         return False


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/docs-csm/pull/3564

This also includes some other cherry-picked commits for Python code dependencies that had not previously been backported to CSM 1.3.

This also handles the product catalog update slightly differently than the main/1.4 PRs. For those, only the changed image data is put into the Cray Product Catalog updater. That is because in CSM 1.4+, the updater is smart enough to merge the existing CPC data with the changes. There is some question as to whether this was the case in CSM 1.3. To be on the safe side, for this 1.3 version of the PR I did the merging inside my tool, rather than relying on the updater to handle it.

This should not merge [until this PR merges](https://github.com/Cray-HPE/docs-csm/pull/3536).