### PR TITLE
Add success output to validate-bss-ntp (CASMTRIAGE-5164)

### DIFF
--- a/workflows/ncn/worker/worker.post-rebuild.yaml
+++ b/workflows/ncn/worker/worker.post-rebuild.yaml
@@ -36,6 +36,7 @@ tasks:
             ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null {{ `{{inputs.parameters.targetNcn}}` }} \
               -t "SW_ADMIN_PASSWORD='{{.SwitchPassword}}' \
                   GOSS_BASE=/opt/cray/tests/install/ncn \
+                  TARGET_NCN={{ `{{inputs.parameters.targetNcn}}` }} \
                   goss -g /opt/cray/tests/install/ncn/suites/ncn-upgrade-tests-worker.yaml \
                     --vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml validate \
                     --retry-timeout 1h"

--- a/workflows/ncn/worker/worker.wipe-and-reboot.yaml
+++ b/workflows/ncn/worker/worker.wipe-and-reboot.yaml
@@ -38,6 +38,8 @@ tasks:
             if ! cray bss bootparameters list --hosts $TARGET_XNAME --format json | jq '.[] |."cloud-init"."user-data".ntp' | grep -q '/etc/chrony.d/cray.conf'; then
               echo "${TARGET_NCN} is missing NTP data in BSS. Please see the procedure which can be found in the 'Known Issues and Bugs' section titled 'Fix BSS Metadata' on the 'Configure NTP on NCNs' page of the CSM documentation."
               exit 1
+            else
+              echo "Successfully found ${TARGET_NCN} NTP data is present in BSS."
             fi
   - name: "get-bootscript-last-access-timestamp"
     dependencies:


### PR DESCRIPTION
### Summary and Scope

Change bgp test when run after worker rebuild to only check that worker.

### Issues and Related PRs

* https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5164

### Testing

* `surtur`

```
ncn-w003:~ # TARGET_NCN=ncn-w003 GOSS_BASE=/opt/cray/tests/install/ncn SW_ADMIN_PASSWORD='!nitial0' /opt/cray/tests/install/ncn/scripts/check_bgp_neighbors_established_brad.sh
NAME      DATA   AGE
metallb   1      3d5h
CAN
Running: canu validate network bgp --verbose --network all --password XXXXXXXX
PASS
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
