### PR TITLE
CASMINST-6196-1.4 copy latest files for storage rebuild from ncn-m001 before executing

### DIFF
--- a/operations/node_management/Rebuild_NCNs/Prepare_Storage_Nodes.md
+++ b/operations/node_management/Rebuild_NCNs/Prepare_Storage_Nodes.md
@@ -50,9 +50,10 @@ When rebuilding a node, make sure that `/srv/cray/scripts/common/storage-ceph-cl
 
 Upload Ceph container images into nexus.
 
-1. Logged into one of (`ncn-s00[1/2/3]`), execute the `upload_ceph_images_to_nexus.sh`.
+1. Logged into one of (`ncn-s00[1/2/3]`), copy `upload_ceph_images_to_nexus.sh` from `ncn-m001` and execute it.
 
    ```bash
+   scp ncn-m001:/usr/share/doc/csm/scripts/upload_ceph_images_to_nexus.sh /srv/cray/scripts/common/upload_ceph_images_to_nexus.sh
    /srv/cray/scripts/common/upload_ceph_images_to_nexus.sh
    ```
 

--- a/operations/node_management/Rebuild_NCNs/Re-add_Storage_Node_to_Ceph.md
+++ b/operations/node_management/Rebuild_NCNs/Re-add_Storage_Node_to_Ceph.md
@@ -14,9 +14,10 @@ Watch `ceph -s` and run the `ceph_join_cluster.sh` script.
    watch ceph -s
    ```
 
-1. (`ncn-s#`) **On the node being rebuilt**, execute the `ceph_join_cluster.sh` script.
+1. (`ncn-s#`) **On the node being rebuilt**, copy `ceph_join_cluster.sh` from `ncn-m001` and execute it.
 
    ```bash
+   scp ncn-m001:/usr/share/doc/csm/scripts/join_ceph_cluster.sh /srv/cray/scripts/common/join_ceph_cluster.sh
    /srv/cray/scripts/common/join_ceph_cluster.sh
    ```
 


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
This is necessary because for CSM-1.4 we are using the sp3 version of storage nodes. So storage nodes will not have the latest scripts in their image so they should be copied from ncn-m001.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
