### PR TITLE
CASMINST-6209: don't toggle metal.no-wipe when associating new images with IMS

### DIFF
--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -711,7 +711,6 @@ if [[ ${state_recorded} == "0" && $(hostname) == "ncn-m001" ]]; then
         NEW_METAL_SERVER="s3://boot-images/${K8S_IMS_IMAGE_ID}/rootfs"
         PARAMS=$(cray bss bootparameters list --hosts "${xname}" --format json | jq '.[] |."params"' | \
             sed "/metal.server/ s|${METAL_SERVER}|${NEW_METAL_SERVER}|" | \
-            sed "s/metal.no-wipe=1/metal.no-wipe=0/" | \
             tr -d \")
 
         cray bss bootparameters update --hosts "${xname}" \
@@ -726,7 +725,6 @@ if [[ ${state_recorded} == "0" && $(hostname) == "ncn-m001" ]]; then
         NEW_METAL_SERVER="s3://boot-images/${STORAGE_IMS_IMAGE_ID}/rootfs"
         PARAMS=$(cray bss bootparameters list --hosts "${xname}" --format json | jq '.[] |."params"' | \
             sed "/metal.server/ s|${METAL_SERVER}|${NEW_METAL_SERVER}|" | \
-            sed "s/metal.no-wipe=1/metal.no-wipe=0/" | \
             tr -d \")
 
         cray bss bootparameters update --hosts "${xname}" \


### PR DESCRIPTION
This toggle is handled by various scripts (argo and otherwise) at the time of the individual/group NCN upgrade(s). There is no need to set it at the time we associate images with IMS and update the boot parameters.

<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
