### PR TITLE
CASMTRIAGE-5184 Adding section in upgrade for the nexus upload

### DIFF
--- a/upgrade/Stage_1.md
+++ b/upgrade/Stage_1.md
@@ -5,8 +5,9 @@
 
 - [Stage 1 - Ceph image upgrade](#stage-1---ceph-image-upgrade)
   - [Start typescript](#start-typescript)
-  - [Run Ceph Latency Repair Script](#run-ceph-latency-repair-script)
+    - [Run Ceph Latency Repair Script](#run-ceph-latency-repair-script)
   - [Apply boot order workaround](#apply-boot-order-workaround)
+  - [Upload Ceph container images to Nexus](#upload-ceph-container-images-to-nexus)
   - [Argo workflows](#argo-workflows)
   - [CSM Upgrade requirement for upgrades staying within a CSM release version](#csm-upgrade-requirement-for-upgrades-staying-within-a-csm-release-version)
   - [Storage node image upgrade](#storage-node-image-upgrade)
@@ -39,6 +40,17 @@ Ceph can begin to exhibit latency over time when upgrading the cluster from prev
 ```bash
 /usr/share/doc/csm/scripts/workarounds/boot-order/run.sh
 ```
+
+## Upload Ceph container images to Nexus
+
+Upload Ceph container images into nexus.
+
+1. Logged into one of (`ncn-s00[1/2/3]`), copy `upload_ceph_images_to_nexus.sh` from `ncn-m001` and execute it.
+
+   ```bash
+   scp ncn-m001:/usr/share/doc/csm/scripts/upload_ceph_images_to_nexus.sh /srv/cray/scripts/common/upload_ceph_images_to_nexus.sh
+   /srv/cray/scripts/common/upload_ceph_images_to_nexus.sh
+   ```
 
 ## Argo workflows
 

--- a/upgrade/Stage_1.md
+++ b/upgrade/Stage_1.md
@@ -5,7 +5,7 @@
 
 - [Stage 1 - Ceph image upgrade](#stage-1---ceph-image-upgrade)
   - [Start typescript](#start-typescript)
-    - [Run Ceph Latency Repair Script](#run-ceph-latency-repair-script)
+  - [Run Ceph Latency Repair Script](#run-ceph-latency-repair-script)
   - [Apply boot order workaround](#apply-boot-order-workaround)
   - [Upload Ceph container images to Nexus](#upload-ceph-container-images-to-nexus)
   - [Argo workflows](#argo-workflows)


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->
This was put into rebuild but not referenced in the upgrade section

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
