### PR TITLE
MTL-2112 remove `libcsm` from upgrade

### DIFF
--- a/upgrade/Stage_0_Prerequisites.md
+++ b/upgrade/Stage_0_Prerequisites.md
@@ -44,8 +44,45 @@ after a break, always be sure that a typescript is running before proceeding.
    CSM_REL_NAME=csm-${CSM_RELEASE}
    ```
 
-1. (`ncn-m001#`) Install the latest `docs-csm` and `libcsm` RPMs. See the short procedure in
-   [Check for latest documentation](../update_product_stream/README.md#check-for-latest-documentation).
+1. Acquire the latest documentation RPM. This may include updates, corrections, and enhancements that were not available until after the software release.
+
+    > ***NOTE:*** CSM does NOT support the use of proxy servers for anything other than downloading artifacts from external endpoints. Using http proxies in any way other than the following examples will cause many failures in subsequent steps.
+
+   1. Check the version of the currently installed CSM documentation and CSM library.
+
+      ```bash
+      rpm -q docs-csm
+      ```
+
+   1. Download and upgrade the latest documentation RPM and CSM library.
+
+       - Without proxy:
+
+           ```bash
+           wget "https://release.algol60.net/$(awk -F. '{print "csm-"$1"."$2}' <<< ${CSM_RELEASE})/docs-csm/docs-csm-latest.noarch.rpm" -O /root/docs-csm-latest.noarch.rpm
+           ```
+
+       - With https proxy:
+
+           ```bash
+           https_proxy=https://example.proxy.net:443 wget "https://release.algol60.net/$(awk -F. '{print "csm-"$1"."$2}' <<< ${CSM_RELEASE})/docs-csm/docs-csm-latest.noarch.rpm" \
+               -O /root/docs-csm-latest.noarch.rpm
+           ```
+
+       - If this machine does not have direct internet access, then this RPM will need to be externally downloaded and
+         copied to the system.
+
+           ```bash
+           curl -O "https://release.algol60.net/$(awk -F. '{print "csm-"$1"."$2}' <<< ${CSM_RELEASE})/docs-csm/docs-csm-latest.noarch.rpm"
+           scp docs-csm-latest.noarch.rpm ncn-m001:/root
+           ssh ncn-m001
+           ```
+
+   1. Install the documentation RPM.
+
+      ```bash
+      rpm -Uvh --force /root/docs-csm-latest.noarch.rpm
+      ```
 
 1. (`ncn-m001#`) Create and mount an `rbd` device where the CSM release tarball can be stored.
 

--- a/upgrade/Stage_2.md
+++ b/upgrade/Stage_2.md
@@ -192,32 +192,14 @@ For any typescripts that were started earlier on `ncn-m001`, stop them with the 
    echo "${CSM_REL_NAME}"
    ```
 
-1. (`ncn-m002#`) Copy artifacts from `ncn-m001`.
+1. (`ncn-m002#`) Copy artifacts from `ncn-m001` and install them.
 
-    > A later stage of the upgrade expects the `docs-csm` and `libcsm` RPMs to be located at `/root/` on `ncn-m002`;
-    > that is why this command copies them there.
-
-   - Install `csi` and `docs-csm`.
-
-       ```bash
-       scp ncn-m001:/root/csm_upgrade.pre_m001_reboot_artifacts.*.tgz /root
-       zypper --plus-repo="/etc/cray/upgrade/csm/csm-${CSM_RELEASE}/tarball/csm-${CSM_RELEASE}/rpm/cray/csm/sle-$(awk -F= '/VERSION=/{gsub(/["-]/, "") ; print tolower($NF)}' /etc/os-release)" --no-gpg-checks install -y cray-site-init
-       scp ncn-m001:/root/*.noarch.rpm /root/
-       rpm -Uvh --force /root/docs-csm-latest.noarch.rpm
-       ```
-
-   - Install `libcsm`.
-
-       > ***NOTE*** Since `libcsm` depends on versions of Python relative to what is included in the SLES service packs,
-       > then in the event that `ncn-m002` is running a newer SLES distro a new `libcsm` must be downloaded. This will
-       > often be the case when jumping to a new CSM minor version (e.g. CSM 1.3 to CSM 1.4).
-       > e.g. if `ncn-m001` is running SLES15SP3, and `ncn-m002` is running SLES15SP4 then the SLES15SP4 `libcsm` is needed.
-       > Follow the [Check for latest documentation](../update_product_stream/README.md#check-for-latest-documentation)
-       > guide again, but from `ncn-m002`.
-
-       ```bash
-       rpm -Uvh --force /root/libcsm-latest.noarch.rpm
-       ```
+   ```bash
+   scp ncn-m001:/root/csm_upgrade.pre_m001_reboot_artifacts.*.tgz /root
+   zypper --plus-repo="/etc/cray/upgrade/csm/csm-${CSM_RELEASE}/tarball/csm-${CSM_RELEASE}/rpm/cray/csm/sle-$(awk -F= '/VERSION=/{gsub(/["-]/, "") ; print tolower($NF)}' /etc/os-release)" --no-gpg-checks install -y cray-site-init
+   scp ncn-m001:/root/*.noarch.rpm /root/
+   rpm -Uvh --force /root/docs-csm-latest.noarch.rpm
+   ```
 
 ### Upgrade `ncn-m001`
 

--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -374,13 +374,13 @@ if [[ $state_recorded == "0" ]]; then
     echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
     {
     error=0
-    packages=( docs-csm libcsm )
+    packages=( docs-csm )
     for package in "${packages[@]}"; do
         if [[ ! -f /root/${package}-latest.noarch.rpm ]]; then
             echo >&2 "ERROR: ${package}-latest.noarch.rpm is missing under: /root"
             error=1
         else
-            cp "/root/${package}-latest.noarch.rpm" "${CSM_ARTI_DIR}/rpm/cray/csm/sle-15sp2/"
+            cp "/root/${package}-latest.noarch.rpm" "${CSM_ARTI_DIR}/rpm/cray/csm/sle-$(awk -F= '/VERSION=/{gsub(/["-]/, "") ; print tolower($NF)}' /etc/os-release)/"
         fi
     done
     if [ "${error}" -ne 0 ]; then


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->
`libcsm` does not support CSM 1.2, and therefore upgrades to 1.3 should not refer to libcsm. CSM's SP2 environments only have Python 3.6, which `libcsm` will not support.

`libcsm` can still be used for fresh installs of 1.3, when an SP3 environment is used.

This will fix this error message [during 1.2->1.3 upgrades](https://cray.slack.com/archives/CHG1MQB6E/p1681181934754239):
```bash
# rpm -Uvh --force libcsm-0.0.4-1.noarch.rpm
error: Failed dependencies:
        python39-base is needed by libcsm-0.0.4-1.noarch
```
# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
