### PR TITLE
CASMTRIAGE-5102: Add note for password prompt during the yapl execute command

### DIFF
--- a/install/install_csm_services.md
+++ b/install/install_csm_services.md
@@ -39,6 +39,7 @@ This procedure will install CSM applications and services into the CSM Kubernete
    >
    > * This command may take up to 90 minutes to complete.
    > * If any errors are encountered, then potential fixes should be displayed where the error occurred.
+   > * If you are prompted for a password, this is the password for the PIT node (ncn-m001). Enter the password to continue.
    > * Output is redirected to `/usr/share/doc/csm/install/scripts/csm_services/yapl.log` . To show the output in the terminal, append
    >   the `--console-output execute` argument to the `yapl` command.
    > * The `yapl` command can safely be rerun. By default, it will skip any steps which were previously completed successfully. To force it to


### PR DESCRIPTION
# Description

Adds a note that the user may be prompted for a password during the execution of the `yapl execute`, to indicate that this will be a prompt for the password of the `pit` nodes (`ncn-m001`)

# Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
