### PR TITLE
CASMTRIAGE-5114 Update Slingshot fabric step after EPO event

### DIFF
--- a/operations/power_management/Recover_from_a_Liquid_Cooled_Cabinet_EPO_Event.md
+++ b/operations/power_management/Recover_from_a_Liquid_Cooled_Cabinet_EPO_Event.md
@@ -100,8 +100,8 @@ If a Cray EX liquid-cooled cabinet or cooling group experiences an EPO event, th
     err_msg = ""
     ```
 
-7. Bring up the Slingshot Fabric.
-    Refer to the following documentation for more information on how to bring up the Slingshot Fabric:
+7. Verify the Slingshot fabric is up and healthy.
+    Refer to the following documentation for more information on how to verify the health of the Slingshot Fabric:
     * The *Slingshot Administration Guide* PDF for HPE Cray EX systems.
     * The *Slingshot Troubleshooting Guide* PDF.
 


### PR DESCRIPTION
# Description
Documentation for recovery from EPO indicated a need to bring up the Slingshot fabric. That is not needed as the Slingshot fabric will automatically come up after hms-discovery powers the Colorado switches back On. The step has been reworked to indicate the admin needs to validate the health of the fabric instead.

Relates to:
- CASMTRIAGE-5114

# Checklist
- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
