### PR TITLE
CASMSEC-388: Document Kyverno Tooling to Report Audit Violations

### DIFF
--- a/operations/kubernetes/Kyverno.md
+++ b/operations/kubernetes/Kyverno.md
@@ -322,6 +322,73 @@ Also, it generates the report of policy violation in respective workloads. The f
     This shows that the mutation policy for the workload was enforced properly.
 
     If there are any discrepancies, look at the detailed policy report to triage the issue.
+## What is new in HPE CSM v1.4
+
+As part of HPE CSM v1.4, the upstream Baseline profile is made available for the customer.
+
+The Baseline profile is a collection of policies which implement the various levels of Kubernetes [Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/).
+
+The Baseline profile is minimally restrictive and denies the most common vulnerabilities. It also follows many of the common security best practices for Pods.
+
+[Baseline profile](https://github.com/kyverno/policies/tree/main/pod-security/baseline) consists of 12 policies as listed below. 
+
+    ```bash
+    kubectl get clusterpolicy -A
+    ```
+
+    Example output:
+
+    ```text
+    NAME                             BACKGROUND   ACTION   READY
+    cluster-job-ttl                  true         audit    true
+    disallow-capabilities            true         audit    true
+    disallow-host-namespaces         true         audit    true
+    disallow-host-path               true         audit    true
+    disallow-host-ports              true         audit    true
+    disallow-host-process            true         audit    true
+    disallow-privileged-containers   true         audit    true
+    disallow-proc-mount              true         audit    true
+    disallow-selinux                 true         audit    true
+    restrict-apparmor-profiles       true         audit    true
+    restrict-seccomp                 true         audit    true
+    restrict-sysctls                 true         audit    true
+    ```
+The violations for each of the baseline policy is logged in policyreport, similar to other policies as mentioned in Validation section above.
+In order to give more insights towards each violation use below mentioned command.
+
+### Example to list policy violations at pod level.
+
+    ```bash
+    kubectl get polr -A -o json | jq -r -c '["Name","kind","Namespace","policy","message"],(.items[].results // [] | map(select(.result=="fail")) | select(. | length > 0) | .[] | select (.resources[0].kind == "Pod") | [.resources[0].name,.resources[0].kind,.resources[0].namespace,.policy,.message]) | @csv'
+    ```
+
+    Example output: 
+
+    ```text
+    "Name","kind","Namespace","policy","message"
+    "hms-discovery-28031310-lnvtf","Pod","services","disallow-capabilities","Any capabilities added beyond the allowed list (AUDIT_WRITE, CHOWN, DAC_OVERRIDE, FOWNER, FSETID, KILL, MKNOD, NET_BIND_SERVICE, SETFCAP, SETGID, SETPCAP, SETUID, SYS_CHROOT) are disallowed."
+    "etcd-backup-pvc-snapshots-to-s3-28031285-ssjfc","Pod","services","disallow-capabilities","Any capabilities added beyond the allowed list (AUDIT_WRITE, CHOWN, DAC_OVERRIDE, FOWNER, FSETID, KILL, MKNOD, NET_BIND_SERVICE, SETFCAP, SETGID, SETPCAP, SETUID, SYS_CHROOT) are disallowed."
+    "cray-dns-unbound-manager-28031310-wrhvj","Pod","services","disallow-capabilities","Any capabilities added beyond the allowed list (AUDIT_WRITE, CHOWN, DAC_OVERRIDE, FOWNER, FSETID, KILL, MKNOD, NET_BIND_SERVICE, SETFCAP, SETGID, SETPCAP, SETUID, SYS_CHROOT) are disallowed."
+    "cray-console-data-postgres-1","Pod","services","disallow-capabilities","Any capabilities added beyond the allowed list (AUDIT_WRITE, CHOWN, DAC_OVERRIDE, FOWNER, FSETID, KILL, MKNOD, NET_BIND_SERVICE, SETFCAP, SETGID, SETPCAP, SETUID, SYS_CHROOT) are disallowed."
+    "hms-discovery-28031292-6cxmz","Pod","services","disallow-capabilities","Any capabilities added beyond the allowed list (AUDIT_WRITE, CHOWN, DAC_OVERRIDE, FOWNER, FSETID, KILL, MKNOD, NET_BIND_SERVICE, SETFCAP, SETGID, SETPCAP, SETUID, SYS_CHROOT) are disallowed."
+    ```
+
+### Example to list all the policy violations.
+	
+    ```bash
+    kubectl get polr -A -o json | jq -r -c '["Name","kind","Namespace","policy","message"],(.items[].results // [] | map(select(.result=="fail")) | select(. | length > 0) | .[] | select (.resources[0].kind) | [.resources[0].name,.resources[0].kind,.resources[0].namespace,.policy,.message]) | @csv'
+    ```
+
+    Example output: 
+
+    ```text
+    "Name","kind","Namespace","policy","message"
+    "cray-nls","Deployment","argo","disallow-host-path","validation error: HostPath volumes are forbidden. The field spec.volumes[*].hostPath must be unset. Rule autogen-host-path failed at path /spec/template/spec/volumes/4/hostPath/"
+    "cray-ceph-csi-cephfs-nodeplugin","DaemonSet","ceph-cephfs","disallow-host-ports","validation error: Use of host ports is disallowed. The fields spec.containers[*].ports[*].hostPort , spec.initContainers[*].ports[*].hostPort, and spec.ephemeralContainers[*].ports[*].hostPort must either be unset or set to `0`. Rule autogen-host-ports-none failed at path /spec/template/spec/containers/2/ports/0/hostPort/"
+    "cray-ceph-csi-cephfs-nodeplugin","DaemonSet","ceph-cephfs","disallow-host-namespaces","validation error: Sharing the host namespaces is disallowed. The fields spec.hostNetwork, spec.hostIPC, and spec.hostPID must be unset or set to `false`. Rule autogen-host-namespaces failed at path /spec/template/spec/hostNetwork/"
+    "cray-ceph-csi-cephfs-nodeplugin","DaemonSet","ceph-cephfs","disallow-capabilities","Any capabilities added beyond the allowed list (AUDIT_WRITE, CHOWN, DAC_OVERRIDE, FOWNER, FSETID, KILL, MKNOD, NET_BIND_SERVICE, SETFCAP, SETGID, SETPCAP, SETUID, SYS_CHROOT) are disallowed."
+    "cray-ceph-csi-cephfs-nodeplugin","DaemonSet","ceph-cephfs","disallow-privileged-containers","validation error: Privileged mode is disallowed. The fields spec.containers[*].securityContext.privileged and spec.initContainers[*].securityContext.privileged must be unset or set to `false`. Rule autogen-privileged-containers failed at path /spec/template/spec/containers/0/securityContext/privileged/"
+    ```
 
 ## Known issues
 

--- a/operations/kubernetes/Kyverno.md
+++ b/operations/kubernetes/Kyverno.md
@@ -322,7 +322,7 @@ Also, it generates the report of policy violation in respective workloads. The f
     This shows that the mutation policy for the workload was enforced properly.
 
     If there are any discrepancies, look at the detailed policy report to triage the issue.
-    
+
 ## What is new in HPE CSM v1.4
 
 As part of HPE CSM v1.4, the upstream Baseline profile is made available for the customer.
@@ -331,7 +331,7 @@ The Baseline profile is a collection of policies which implement the various lev
 
 The Baseline profile is minimally restrictive and denies the most common vulnerabilities. It also follows many of the common security best practices for Pods.
 
-[Baseline profile](https://github.com/kyverno/policies/tree/main/pod-security/baseline) consists of 12 policies as listed below. 
+[Baseline profile](https://github.com/kyverno/policies/tree/main/pod-security/baseline) consists of 12 policies as listed below.
 
     ```bash
     kubectl get clusterpolicy -A
@@ -357,7 +357,7 @@ The Baseline profile is minimally restrictive and denies the most common vulnera
 The violations for each of the baseline policy is logged in policy report, similar to other policies as mentioned in Validation section above.
 In order to give more insights towards each violation use below mentioned command.
 
-### Example to list policy violations at pod level.
+### Example to list policy violations at pod level
 
     ```bash
     kubectl get polr -A -o json | jq -r -c '["Name","kind","Namespace","policy","message"],(.items[].results // [] | map(select(.result=="fail")) | select(. | length > 0) | .[] | select (.resources[0].kind == "Pod") | [.resources[0].name,.resources[0].kind,.resources[0].namespace,.policy,.message]) | @csv'
@@ -374,8 +374,8 @@ In order to give more insights towards each violation use below mentioned comman
     "hms-discovery-28031292-6cxmz","Pod","services","disallow-capabilities","Any capabilities added beyond the allowed list (AUDIT_WRITE, CHOWN, DAC_OVERRIDE, FOWNER, FSETID, KILL, MKNOD, NET_BIND_SERVICE, SETFCAP, SETGID, SETPCAP, SETUID, SYS_CHROOT) are disallowed."
     ```
 
-### Example to list all the policy violations.
-	
+### Example to list all the policy violations
+
     ```bash
     kubectl get polr -A -o json | jq -r -c '["Name","kind","Namespace","policy","message"],(.items[].results // [] | map(select(.result=="fail")) | select(. | length > 0) | .[] | select (.resources[0].kind) | [.resources[0].name,.resources[0].kind,.resources[0].namespace,.policy,.message]) | @csv'
     ```
@@ -390,7 +390,7 @@ In order to give more insights towards each violation use below mentioned comman
     "cray-ceph-csi-cephfs-nodeplugin","DaemonSet","ceph-cephfs","disallow-capabilities","Any capabilities added beyond the allowed list (AUDIT_WRITE, CHOWN, DAC_OVERRIDE, FOWNER, FSETID, KILL, MKNOD, NET_BIND_SERVICE, SETFCAP, SETGID, SETPCAP, SETUID, SYS_CHROOT) are disallowed."
     "cray-ceph-csi-cephfs-nodeplugin","DaemonSet","ceph-cephfs","disallow-privileged-containers","validation error: Privileged mode is disallowed. The fields spec.containers[*].securityContext.privileged and spec.initContainers[*].securityContext.privileged must be unset or set to `false`. Rule autogen-privileged-containers failed at path /spec/template/spec/containers/0/securityContext/privileged/"
     ```
-    
+
 ## Known issues
 
 * [False positive audit logs are generated for Validation policy](https://github.com/kyverno/kyverno/issues/3970)

--- a/operations/kubernetes/Kyverno.md
+++ b/operations/kubernetes/Kyverno.md
@@ -336,9 +336,9 @@ The Baseline profile is minimally restrictive and denies the most common vulnera
 ```bash
 kubectl get clusterpolicy -A
 ```
-    
+
 Example output:
-    
+
 ```text
 NAME                             BACKGROUND   ACTION   READY
 cluster-job-ttl                  true         audit    true
@@ -363,9 +363,9 @@ In order to give more insights towards each violation use below mentioned comman
 ```bash
 kubectl get polr -A -o json | jq -r -c '["Name","kind","Namespace","policy","message"],(.items[].results // [] | map(select(.result=="fail")) | select(. | length > 0) | .[] | select (.resources[0].kind == "Pod") | [.resources[0].name,.resources[0].kind,.resources[0].namespace,.policy,.message]) | @csv'
 ```
-    
+
 Example output:
-    
+
 ```text
 "Name","kind","Namespace","policy","message"
 "hms-discovery-28031310-lnvtf","Pod","services","disallow-capabilities","Any capabilities added beyond the allowed list (AUDIT_WRITE, CHOWN, DAC_OVERRIDE, FOWNER, FSETID, KILL, MKNOD, NET_BIND_SERVICE, SETFCAP, SETGID, SETPCAP, SETUID, SYS_CHROOT) are disallowed."
@@ -380,9 +380,9 @@ Example output:
 ```bash
 kubectl get polr -A -o json | jq -r -c '["Name","kind","Namespace","policy","message"],(.items[].results // [] | map(select(.result=="fail")) | select(. | length > 0) | .[] | select (.resources[0].kind) | [.resources[0].name,.resources[0].kind,.resources[0].namespace,.policy,.message]) | @csv'
 ```
-    
+
 Example output:
-    
+
 ```text
 "Name","kind","Namespace","policy","message"
 "cray-nls","Deployment","argo","disallow-host-path","validation error: HostPath volumes are forbidden. The field spec.volumes[*].hostPath must be unset. Rule autogen-host-path failed at path /spec/template/spec/volumes/4/hostPath/"

--- a/operations/kubernetes/Kyverno.md
+++ b/operations/kubernetes/Kyverno.md
@@ -323,13 +323,13 @@ Also, it generates the report of policy violation in respective workloads. The f
 
     If there are any discrepancies, look at the detailed policy report to triage the issue.
 
-## What is new in HPE CSM v1.4
+## What is new in the HPE CSM 1.4 release
 
-As part of HPE CSM v1.4, the upstream Baseline profile is made available for the customer.
+The upstream Baseline profile is now available for customers as part of the HPE CSM 1.4 release.
 
 The Baseline profile is a collection of policies which implement the various levels of Kubernetes [Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/).
 
-The Baseline profile is minimally restrictive and denies the most common vulnerabilities. It also follows many of the common security best practices for Pods.
+The Baseline profile is minimally restrictive and denies the most common vulnerabilities. It also follows many of the common security best practices for Kubernetes pods.
 
 [Baseline profile](https://github.com/kyverno/policies/tree/main/pod-security/baseline) consists of 12 policies as listed below.
 
@@ -355,8 +355,8 @@ restrict-seccomp                 true         audit    true
 restrict-sysctls                 true         audit    true
 ```
 
-The violations for each of the baseline policy is logged in policy report, similar to other policies as mentioned in Validation section above.
-In order to give more insights towards each violation use below mentioned command.
+The violations for each of the Baseline policies is logged in a policy report, similar to the other policies mentioned in Validation section above.
+To get more information on each violation, use the following command.
 
 ### Example to list policy violations at pod level
 

--- a/operations/kubernetes/Kyverno.md
+++ b/operations/kubernetes/Kyverno.md
@@ -322,6 +322,7 @@ Also, it generates the report of policy violation in respective workloads. The f
     This shows that the mutation policy for the workload was enforced properly.
 
     If there are any discrepancies, look at the detailed policy report to triage the issue.
+    
 ## What is new in HPE CSM v1.4
 
 As part of HPE CSM v1.4, the upstream Baseline profile is made available for the customer.
@@ -353,7 +354,7 @@ The Baseline profile is minimally restrictive and denies the most common vulnera
     restrict-seccomp                 true         audit    true
     restrict-sysctls                 true         audit    true
     ```
-The violations for each of the baseline policy is logged in policyreport, similar to other policies as mentioned in Validation section above.
+The violations for each of the baseline policy is logged in policy report, similar to other policies as mentioned in Validation section above.
 In order to give more insights towards each violation use below mentioned command.
 
 ### Example to list policy violations at pod level.
@@ -389,7 +390,7 @@ In order to give more insights towards each violation use below mentioned comman
     "cray-ceph-csi-cephfs-nodeplugin","DaemonSet","ceph-cephfs","disallow-capabilities","Any capabilities added beyond the allowed list (AUDIT_WRITE, CHOWN, DAC_OVERRIDE, FOWNER, FSETID, KILL, MKNOD, NET_BIND_SERVICE, SETFCAP, SETGID, SETPCAP, SETUID, SYS_CHROOT) are disallowed."
     "cray-ceph-csi-cephfs-nodeplugin","DaemonSet","ceph-cephfs","disallow-privileged-containers","validation error: Privileged mode is disallowed. The fields spec.containers[*].securityContext.privileged and spec.initContainers[*].securityContext.privileged must be unset or set to `false`. Rule autogen-privileged-containers failed at path /spec/template/spec/containers/0/securityContext/privileged/"
     ```
-
+    
 ## Known issues
 
 * [False positive audit logs are generated for Validation policy](https://github.com/kyverno/kyverno/issues/3970)

--- a/operations/kubernetes/Kyverno.md
+++ b/operations/kubernetes/Kyverno.md
@@ -336,9 +336,9 @@ The Baseline profile is minimally restrictive and denies the most common vulnera
     ```bash
     kubectl get clusterpolicy -A
     ```
-
+    
     Example output:
-
+    
     ```text
     NAME                             BACKGROUND   ACTION   READY
     cluster-job-ttl                  true         audit    true
@@ -354,6 +354,7 @@ The Baseline profile is minimally restrictive and denies the most common vulnera
     restrict-seccomp                 true         audit    true
     restrict-sysctls                 true         audit    true
     ```
+    
 The violations for each of the baseline policy is logged in policy report, similar to other policies as mentioned in Validation section above.
 In order to give more insights towards each violation use below mentioned command.
 
@@ -362,9 +363,9 @@ In order to give more insights towards each violation use below mentioned comman
     ```bash
     kubectl get polr -A -o json | jq -r -c '["Name","kind","Namespace","policy","message"],(.items[].results // [] | map(select(.result=="fail")) | select(. | length > 0) | .[] | select (.resources[0].kind == "Pod") | [.resources[0].name,.resources[0].kind,.resources[0].namespace,.policy,.message]) | @csv'
     ```
-
-    Example output: 
-
+    
+    Example output:
+    
     ```text
     "Name","kind","Namespace","policy","message"
     "hms-discovery-28031310-lnvtf","Pod","services","disallow-capabilities","Any capabilities added beyond the allowed list (AUDIT_WRITE, CHOWN, DAC_OVERRIDE, FOWNER, FSETID, KILL, MKNOD, NET_BIND_SERVICE, SETFCAP, SETGID, SETPCAP, SETUID, SYS_CHROOT) are disallowed."
@@ -379,9 +380,9 @@ In order to give more insights towards each violation use below mentioned comman
     ```bash
     kubectl get polr -A -o json | jq -r -c '["Name","kind","Namespace","policy","message"],(.items[].results // [] | map(select(.result=="fail")) | select(. | length > 0) | .[] | select (.resources[0].kind) | [.resources[0].name,.resources[0].kind,.resources[0].namespace,.policy,.message]) | @csv'
     ```
-
-    Example output: 
-
+    
+    Example output:
+    
     ```text
     "Name","kind","Namespace","policy","message"
     "cray-nls","Deployment","argo","disallow-host-path","validation error: HostPath volumes are forbidden. The field spec.volumes[*].hostPath must be unset. Rule autogen-host-path failed at path /spec/template/spec/volumes/4/hostPath/"

--- a/operations/kubernetes/Kyverno.md
+++ b/operations/kubernetes/Kyverno.md
@@ -333,64 +333,64 @@ The Baseline profile is minimally restrictive and denies the most common vulnera
 
 [Baseline profile](https://github.com/kyverno/policies/tree/main/pod-security/baseline) consists of 12 policies as listed below.
 
-    ```bash
-    kubectl get clusterpolicy -A
-    ```
+```bash
+kubectl get clusterpolicy -A
+```
     
-    Example output:
+Example output:
     
-    ```text
-    NAME                             BACKGROUND   ACTION   READY
-    cluster-job-ttl                  true         audit    true
-    disallow-capabilities            true         audit    true
-    disallow-host-namespaces         true         audit    true
-    disallow-host-path               true         audit    true
-    disallow-host-ports              true         audit    true
-    disallow-host-process            true         audit    true
-    disallow-privileged-containers   true         audit    true
-    disallow-proc-mount              true         audit    true
-    disallow-selinux                 true         audit    true
-    restrict-apparmor-profiles       true         audit    true
-    restrict-seccomp                 true         audit    true
-    restrict-sysctls                 true         audit    true
-    ```
-    
+```text
+NAME                             BACKGROUND   ACTION   READY
+cluster-job-ttl                  true         audit    true
+disallow-capabilities            true         audit    true
+disallow-host-namespaces         true         audit    true
+disallow-host-path               true         audit    true
+disallow-host-ports              true         audit    true
+disallow-host-process            true         audit    true
+disallow-privileged-containers   true         audit    true
+disallow-proc-mount              true         audit    true
+disallow-selinux                 true         audit    true
+restrict-apparmor-profiles       true         audit    true
+restrict-seccomp                 true         audit    true
+restrict-sysctls                 true         audit    true
+```
+
 The violations for each of the baseline policy is logged in policy report, similar to other policies as mentioned in Validation section above.
 In order to give more insights towards each violation use below mentioned command.
 
 ### Example to list policy violations at pod level
 
-    ```bash
-    kubectl get polr -A -o json | jq -r -c '["Name","kind","Namespace","policy","message"],(.items[].results // [] | map(select(.result=="fail")) | select(. | length > 0) | .[] | select (.resources[0].kind == "Pod") | [.resources[0].name,.resources[0].kind,.resources[0].namespace,.policy,.message]) | @csv'
-    ```
+```bash
+kubectl get polr -A -o json | jq -r -c '["Name","kind","Namespace","policy","message"],(.items[].results // [] | map(select(.result=="fail")) | select(. | length > 0) | .[] | select (.resources[0].kind == "Pod") | [.resources[0].name,.resources[0].kind,.resources[0].namespace,.policy,.message]) | @csv'
+```
     
-    Example output:
+Example output:
     
-    ```text
-    "Name","kind","Namespace","policy","message"
-    "hms-discovery-28031310-lnvtf","Pod","services","disallow-capabilities","Any capabilities added beyond the allowed list (AUDIT_WRITE, CHOWN, DAC_OVERRIDE, FOWNER, FSETID, KILL, MKNOD, NET_BIND_SERVICE, SETFCAP, SETGID, SETPCAP, SETUID, SYS_CHROOT) are disallowed."
-    "etcd-backup-pvc-snapshots-to-s3-28031285-ssjfc","Pod","services","disallow-capabilities","Any capabilities added beyond the allowed list (AUDIT_WRITE, CHOWN, DAC_OVERRIDE, FOWNER, FSETID, KILL, MKNOD, NET_BIND_SERVICE, SETFCAP, SETGID, SETPCAP, SETUID, SYS_CHROOT) are disallowed."
-    "cray-dns-unbound-manager-28031310-wrhvj","Pod","services","disallow-capabilities","Any capabilities added beyond the allowed list (AUDIT_WRITE, CHOWN, DAC_OVERRIDE, FOWNER, FSETID, KILL, MKNOD, NET_BIND_SERVICE, SETFCAP, SETGID, SETPCAP, SETUID, SYS_CHROOT) are disallowed."
-    "cray-console-data-postgres-1","Pod","services","disallow-capabilities","Any capabilities added beyond the allowed list (AUDIT_WRITE, CHOWN, DAC_OVERRIDE, FOWNER, FSETID, KILL, MKNOD, NET_BIND_SERVICE, SETFCAP, SETGID, SETPCAP, SETUID, SYS_CHROOT) are disallowed."
-    "hms-discovery-28031292-6cxmz","Pod","services","disallow-capabilities","Any capabilities added beyond the allowed list (AUDIT_WRITE, CHOWN, DAC_OVERRIDE, FOWNER, FSETID, KILL, MKNOD, NET_BIND_SERVICE, SETFCAP, SETGID, SETPCAP, SETUID, SYS_CHROOT) are disallowed."
-    ```
+```text
+"Name","kind","Namespace","policy","message"
+"hms-discovery-28031310-lnvtf","Pod","services","disallow-capabilities","Any capabilities added beyond the allowed list (AUDIT_WRITE, CHOWN, DAC_OVERRIDE, FOWNER, FSETID, KILL, MKNOD, NET_BIND_SERVICE, SETFCAP, SETGID, SETPCAP, SETUID, SYS_CHROOT) are disallowed."
+"etcd-backup-pvc-snapshots-to-s3-28031285-ssjfc","Pod","services","disallow-capabilities","Any capabilities added beyond the allowed list (AUDIT_WRITE, CHOWN, DAC_OVERRIDE, FOWNER, FSETID, KILL, MKNOD, NET_BIND_SERVICE, SETFCAP, SETGID, SETPCAP, SETUID, SYS_CHROOT) are disallowed."
+"cray-dns-unbound-manager-28031310-wrhvj","Pod","services","disallow-capabilities","Any capabilities added beyond the allowed list (AUDIT_WRITE, CHOWN, DAC_OVERRIDE, FOWNER, FSETID, KILL, MKNOD, NET_BIND_SERVICE, SETFCAP, SETGID, SETPCAP, SETUID, SYS_CHROOT) are disallowed."
+"cray-console-data-postgres-1","Pod","services","disallow-capabilities","Any capabilities added beyond the allowed list (AUDIT_WRITE, CHOWN, DAC_OVERRIDE, FOWNER, FSETID, KILL, MKNOD, NET_BIND_SERVICE, SETFCAP, SETGID, SETPCAP, SETUID, SYS_CHROOT) are disallowed."
+"hms-discovery-28031292-6cxmz","Pod","services","disallow-capabilities","Any capabilities added beyond the allowed list (AUDIT_WRITE, CHOWN, DAC_OVERRIDE, FOWNER, FSETID, KILL, MKNOD, NET_BIND_SERVICE, SETFCAP, SETGID, SETPCAP, SETUID, SYS_CHROOT) are disallowed."
+```
 
 ### Example to list all the policy violations
 
-    ```bash
-    kubectl get polr -A -o json | jq -r -c '["Name","kind","Namespace","policy","message"],(.items[].results // [] | map(select(.result=="fail")) | select(. | length > 0) | .[] | select (.resources[0].kind) | [.resources[0].name,.resources[0].kind,.resources[0].namespace,.policy,.message]) | @csv'
-    ```
+```bash
+kubectl get polr -A -o json | jq -r -c '["Name","kind","Namespace","policy","message"],(.items[].results // [] | map(select(.result=="fail")) | select(. | length > 0) | .[] | select (.resources[0].kind) | [.resources[0].name,.resources[0].kind,.resources[0].namespace,.policy,.message]) | @csv'
+```
     
-    Example output:
+Example output:
     
-    ```text
-    "Name","kind","Namespace","policy","message"
-    "cray-nls","Deployment","argo","disallow-host-path","validation error: HostPath volumes are forbidden. The field spec.volumes[*].hostPath must be unset. Rule autogen-host-path failed at path /spec/template/spec/volumes/4/hostPath/"
-    "cray-ceph-csi-cephfs-nodeplugin","DaemonSet","ceph-cephfs","disallow-host-ports","validation error: Use of host ports is disallowed. The fields spec.containers[*].ports[*].hostPort , spec.initContainers[*].ports[*].hostPort, and spec.ephemeralContainers[*].ports[*].hostPort must either be unset or set to `0`. Rule autogen-host-ports-none failed at path /spec/template/spec/containers/2/ports/0/hostPort/"
-    "cray-ceph-csi-cephfs-nodeplugin","DaemonSet","ceph-cephfs","disallow-host-namespaces","validation error: Sharing the host namespaces is disallowed. The fields spec.hostNetwork, spec.hostIPC, and spec.hostPID must be unset or set to `false`. Rule autogen-host-namespaces failed at path /spec/template/spec/hostNetwork/"
-    "cray-ceph-csi-cephfs-nodeplugin","DaemonSet","ceph-cephfs","disallow-capabilities","Any capabilities added beyond the allowed list (AUDIT_WRITE, CHOWN, DAC_OVERRIDE, FOWNER, FSETID, KILL, MKNOD, NET_BIND_SERVICE, SETFCAP, SETGID, SETPCAP, SETUID, SYS_CHROOT) are disallowed."
-    "cray-ceph-csi-cephfs-nodeplugin","DaemonSet","ceph-cephfs","disallow-privileged-containers","validation error: Privileged mode is disallowed. The fields spec.containers[*].securityContext.privileged and spec.initContainers[*].securityContext.privileged must be unset or set to `false`. Rule autogen-privileged-containers failed at path /spec/template/spec/containers/0/securityContext/privileged/"
-    ```
+```text
+"Name","kind","Namespace","policy","message"
+"cray-nls","Deployment","argo","disallow-host-path","validation error: HostPath volumes are forbidden. The field spec.volumes[*].hostPath must be unset. Rule autogen-host-path failed at path /spec/template/spec/volumes/4/hostPath/"
+"cray-ceph-csi-cephfs-nodeplugin","DaemonSet","ceph-cephfs","disallow-host-ports","validation error: Use of host ports is disallowed. The fields spec.containers[*].ports[*].hostPort , spec.initContainers[*].ports[*].hostPort, and spec.ephemeralContainers[*].ports[*].hostPort must either be unset or set to `0`. Rule autogen-host-ports-none failed at path /spec/template/spec/containers/2/ports/0/hostPort/"
+"cray-ceph-csi-cephfs-nodeplugin","DaemonSet","ceph-cephfs","disallow-host-namespaces","validation error: Sharing the host namespaces is disallowed. The fields spec.hostNetwork, spec.hostIPC, and spec.hostPID must be unset or set to `false`. Rule autogen-host-namespaces failed at path /spec/template/spec/hostNetwork/"
+"cray-ceph-csi-cephfs-nodeplugin","DaemonSet","ceph-cephfs","disallow-capabilities","Any capabilities added beyond the allowed list (AUDIT_WRITE, CHOWN, DAC_OVERRIDE, FOWNER, FSETID, KILL, MKNOD, NET_BIND_SERVICE, SETFCAP, SETGID, SETPCAP, SETUID, SYS_CHROOT) are disallowed."
+"cray-ceph-csi-cephfs-nodeplugin","DaemonSet","ceph-cephfs","disallow-privileged-containers","validation error: Privileged mode is disallowed. The fields spec.containers[*].securityContext.privileged and spec.initContainers[*].securityContext.privileged must be unset or set to `false`. Rule autogen-privileged-containers failed at path /spec/template/spec/containers/0/securityContext/privileged/"
+```
 
 ## Known issues
 


### PR DESCRIPTION
The documentation change will be used by HPE internally and customers. This helps to identify the policy violations. There is no functionality impact with this documentation change.
