### PR TITLE
CASMHMS-5968 Improve verbiage for restarting orca when recovering HMNFD ETCD

### DIFF
--- a/operations/kubernetes/Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md
+++ b/operations/kubernetes/Repopulate_Data_in_etcd_Clusters_When_Rebuilding_Them.md
@@ -3,17 +3,18 @@
 When an etcd cluster is not healthy, it needs to be rebuilt. During that process, the pods that rely on etcd clusters lose data.
 That data needs to be repopulated in order for the cluster to go back to a healthy state.
 
-- [Applicable services](#applicable-services)
-- [Prerequisites](#prerequisites)
-- [Procedures](#procedures)
-  - [BOS](#bos)
-  - [BSS](#bss)
-  - [CPS](#cps)
-  - [CRUS](#crus)
-  - [FAS](#fas)
-  - [HMNFD](#hmnfd)
-  - [MEDS](#meds)
-  - [REDS](#reds)
+- [Repopulate Data in etcd Clusters When Rebuilding Them](#repopulate-data-in-etcd-clusters-when-rebuilding-them)
+  - [Applicable services](#applicable-services)
+  - [Prerequisites](#prerequisites)
+  - [Procedures](#procedures)
+    - [BOS](#bos)
+    - [BSS](#bss)
+    - [CPS](#cps)
+    - [CRUS](#crus)
+    - [FAS](#fas)
+    - [HMNFD](#hmnfd)
+    - [MEDS](#meds)
+    - [REDS](#reds)
 
 ## Applicable services
 
@@ -34,14 +35,18 @@ An etcd cluster was rebuilt. See [Rebuild Unhealthy etcd Clusters](Rebuild_Unhea
 
 ## Procedures
 
-- [BOS](#bos)
-- [BSS](#bss)
-- [CPS](#cps)
-- [CRUS](#crus)
-- [FAS](#fas)
-- [HMNFD](#hmnfd)
-- [MEDS](#meds)
-- [REDS](#reds)
+- [Repopulate Data in etcd Clusters When Rebuilding Them](#repopulate-data-in-etcd-clusters-when-rebuilding-them)
+  - [Applicable services](#applicable-services)
+  - [Prerequisites](#prerequisites)
+  - [Procedures](#procedures)
+    - [BOS](#bos)
+    - [BSS](#bss)
+    - [CPS](#cps)
+    - [CRUS](#crus)
+    - [FAS](#fas)
+    - [HMNFD](#hmnfd)
+    - [MEDS](#meds)
+    - [REDS](#reds)
 
 ### BOS
 
@@ -188,13 +193,12 @@ Resubscribe the compute nodes and any NCNs that use the ORCA daemon for their St
     rm -rf "${TMPFILE}"
     ```
 
-1. (`ncn-m#`) Resubscribe the NCNs.
+1. (`ncn-m#`) Resubscribe all worker nodes.
 
-    **NOTE:** Modify the `-w` arguments in the following commands to reflect the number of worker and storage nodes in the system.
+    **NOTE:** Modify the `-w` arguments in the following commands to reflect the number of worker nodes in the system.
 
     ```bash
     pdsh -w ncn-w00[1-4]-can.local "systemctl restart cray-orca"
-    pdsh -w ncn-s00[1-4]-can.local "systemctl restart cray-orca"
     ```
 
 ### MEDS


### PR DESCRIPTION
# Description
Instructions for restarting the cray-orca system daemon were including nodes that did not run the cray-orca system daemon. Cleaned up the verbiage and commands to execute.

Relates to:
- [CASMHMS-5968](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5968)

# Checklist
- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
