### PR TITLE
CASMINST-5962 - Update Docs to Indicate Ceph Latency Repair is Mandatory

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -205,8 +205,8 @@ For a list of all features with an announced removal target, see [Removals](intr
 
 * UAIs use a default route that sends outbound packets over the CMN, this will be addressed in a future release so that the default route uses the CAN/CHN.
 
-* On some systems, Ceph can begin to exhibit latency over time, and if this occurs it can eventually cause services like `slurm` and services that are backed by `etcd` clusters to exhibit slowness and possible timeouts.
-See [Known Issue: Ceph OSD latency](troubleshooting/known_issues/ceph_osd_latency.md) for a workaround.
+* On some systems, Ceph can begin to exhibit latency over time, and if this occurs it can eventually cause services like `slurm` and services that are backed by `etcd` clusters to exhibit slowness and possible timeouts.  It can also cause nexus to start up slowly or fail to initialize properly.
+See [Known Issue: Ceph OSD latency](troubleshooting/known_issues/ceph_osd_latency.md) to execute a repair script which is mandatory toward prevention of this latency condition. 
 
 ### Security vulnerability exceptions in CSM 1.3
 

--- a/install/deploy_non-compute_nodes.md
+++ b/install/deploy_non-compute_nodes.md
@@ -278,7 +278,7 @@ for all nodes, the Ceph storage will have been initialized and the Kubernetes cl
 
 ### 2.4 Run Ceph Latency Repair Script
 
-Ceph can begin to exhibit latency over time unless OSDs are restarted and some OSD memory settings are changed. It is recommended to run the `/usr/share/doc/csm/scripts/repair-ceph-latency.sh` script at [Known Issue: Ceph OSD latency](../troubleshooting/known_issues/ceph_osd_latency.md).
+Ceph can begin to exhibit latency over time unless OSDs are restarted and some OSD memory settings are changed. It is mandatory to run the `/usr/share/doc/csm/scripts/repair-ceph-latency.sh` script at [Known Issue: Ceph OSD latency](../troubleshooting/known_issues/ceph_osd_latency.md) in order to prevent a Ceph latency condition from occurring.
 
 ### 2.5 Check LVM on Kubernetes NCNs
 

--- a/troubleshooting/known_issues/ceph_osd_latency.md
+++ b/troubleshooting/known_issues/ceph_osd_latency.md
@@ -1,7 +1,8 @@
 # Known Issue: Ceph OSD latency
 
-On some systems, Ceph can begin to exhibit latency over time, and if this occurs it can eventually cause services like `slurm` and services that are backed by `etcd` clusters to exhibit slowness and possible timeouts.
-In order to determine if this is occurring, run the `ceph osd perf` command on a master node over a period of about ten seconds, and if an OSD consistently shows latency of above `100ms` (as follows), the OSDs exhibiting this latency should be restarted:
+On some systems, Ceph can begin to exhibit latency over time, and if this occurs it can eventually cause services like `slurm` and services that are backed by `etcd` clusters to exhibit slowness and possible timeouts.  It can also cause nexus to start up slowly or fail to initialize properly.
+Please note that though this procedure gives guidance on determining if the system is exhibiting ceph latency, it is absolutely necessary that the repair script referenced in the `Fix` section below be run - even if Ceph latency is not detected with the command listed below.   The repair script will correct settings to prevent entry into the Ceph latency state.  It does no harm to run the repair script even if it has been run previously.  There was an earlier version of the repair script that only executed settings if the ceph-latency condition was detected at the time of execution of the script.  This has, since, been corrected.  Re-running the script may be necessary.  Once it has been run, it should not need to be run again.
+In order to determine if the system is experiencing the latency condition, run the `ceph osd perf` command on a master node over a period of about ten seconds, and if an OSD consistently shows latency of above `100ms` (as follows), the OSDs exhibiting this latency should be restarted:
 
 (`ncn-m#`) Run the following command:
 
@@ -108,4 +109,4 @@ ags set
  pgs degraded
 ```
 
-Once the script is complete, `ceph osd perf` should no longer report higher sustained latency numbers.
+Once the script is complete, `ceph osd perf` should no longer report higher sustained latency numbers and settings should be in place to prevent future latency.

--- a/upgrade/README.md
+++ b/upgrade/README.md
@@ -23,8 +23,8 @@ sections, but there is also a general troubleshooting topic.
 
 - If IMS image creation CFS jobs fail, see [Known Issue: IMS image creation failure](../troubleshooting/known_issues/ims_image_creation_failure.md) for a possible workaround.
 
-- On some systems, Ceph can begin to exhibit latency over time, and if this occurs it can eventually cause services like `slurm` and services that are backed by `etcd` clusters to exhibit slowness and possible timeouts.
-See [Known Issue: Ceph OSD latency](../troubleshooting/known_issues/ceph_osd_latency.md) for a workaround.
+- On some systems, Ceph can begin to exhibit latency over time, and if this occurs it can eventually cause services like `slurm` and services that are backed by `etcd` clusters to exhibit slowness and possible timeouts.  It can also cause nexus to start up slowly or fail to initialize properly.
+Please see [Known Issue: Ceph OSD latency](../troubleshooting/known_issues/ceph_osd_latency.md) for a mandatory one-time workaround needed to correct settings, so as to avoid this latency condition.
 
 ## 1. Prepare for upgrade
 

--- a/upgrade/Stage_1.md
+++ b/upgrade/Stage_1.md
@@ -31,7 +31,7 @@ after a break, always be sure that a typescript is running before proceeding.
 
 ### Run Ceph Latency Repair Script
 
-Ceph can begin to exhibit latency over time when upgrading the cluster from previous versions. It is recommended to run the `/usr/share/doc/csm/scripts/repair-ceph-latency.sh` script at [Known Issue: Ceph OSD latency](../troubleshooting/known_issues/ceph_osd_latency.md).
+Ceph can begin to exhibit latency over time when upgrading the cluster from previous versions. It is mandatory to run the `/usr/share/doc/csm/scripts/repair-ceph-latency.sh` script at [Known Issue: Ceph OSD latency](../troubleshooting/known_issues/ceph_osd_latency.md) in order to prevent a Ceph latency condition from occurring.
 
 ## Apply boot order workaround
 


### PR DESCRIPTION

<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->
Updating various docs for install and upgrade where we discuss latency and the repair script - so as to make it clear that it is not a suggestion or optional to run it - we need to ensure that it reads as being a mandatory step so that users will be sure to execute it.

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->



<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
