### PR TITLE
CASMINST-6257 remove check to make sure master node is in k8s cluster in management-nodes-rollout

### DIFF
--- a/workflows/iuf/operations/management-nodes-rollout/management-nodes-rollout.yaml
+++ b/workflows/iuf/operations/management-nodes-rollout/management-nodes-rollout.yaml
@@ -177,12 +177,7 @@ spec:
                       echo "NOTICE  ncn-m002 is labeled with 'iuf-prevent-rollout=true' which means it will not be rebuilt"
                       exit 0
                     fi
-                    master_nodes=$(kubectl get node --selector='node-role.kubernetes.io/master' --no-headers=true | awk '{print $1}' | tr "\n", " ")
-                    if [[ -z $(echo $master_nodes | grep ncn-m002) ]]; then 
-                      echo "ERROR  ncn-m002 was not found in kubernetes master nodes. The search was via kubectl get node --selector='node-role.kubernetes.io/master'"
-                      exit 1
-                    fi
-                    
+
                     echo "NOTICE  updating CFS config on ncn-m002"
                     TARGET_NCN=ncn-m002
                     TARGET_XNAME=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management" | \
@@ -250,11 +245,6 @@ spec:
                     if [[ -n $(echo $labeled_nodes | grep ncn-m003) ]]; then
                       echo "NOTICE  ncn-m003 is labeled with 'iuf-prevent-rollout=true' which means it will not be rebuilt"
                       exit 0
-                    fi
-                    master_nodes=$(kubectl get node --selector='node-role.kubernetes.io/master' --no-headers=true | awk '{print $1}' | tr "\n", " ")
-                    if [[ -z $(echo $master_nodes | grep ncn-m003) ]]; then 
-                      echo "ERROR  ncn-m003 was not found in kubernetes master nodes. The search was via kubectl get node --selector='node-role.kubernetes.io/master'"
-                      exit 1
                     fi
                     
                     echo "NOTICE  updating CFS config on ncn-m003"


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

Remove check to make sure master nodes is in k8s cluster in management-nodes-rollout. This check creates a bug when a master node has been partially upgraded. For example, if a master node has been removed from the cluster and power cycled and the workflow has been stopped. Then, if the workflow is restarted, this check will fail because the node is not part of the cluster and it will prevent the workflow from continuing.

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
