### PR TITLE
CASMINST-6249 Correct management rollout procedure

### DIFF
--- a/upgrade/Stage_2.md
+++ b/upgrade/Stage_2.md
@@ -241,6 +241,10 @@ Complete the Kubernetes upgrade. This script will restart several pods on each m
 
 > **`NOTE`**: `kubelet` has been upgraded already, ignore the warning to upgrade it.
 
+If the previous three steps were executed as part of the IUF [Management rollout](../operations/iuf/workflows/management_rollout.md)
+procedure, return to the IUF [Management rollout](../operations/iuf/workflows/management_rollout.md) procedure and
+complete the remaining steps. Otherwise, proceed to the following topic.
+
 ### Stop typescript on `ncn-m002`
 
 For any typescripts that were started during this stage on `ncn-m002`, stop them with the `exit` command.


### PR DESCRIPTION
# Description

Added text to Stage 2 to refer the reader back to IUF when appropriate.

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
