### PR TITLE
CASMPET-6524 add function to check if ceph daemons are currently running the image in nexus

### DIFF
--- a/scripts/upload_ceph_images_to_nexus.sh
+++ b/scripts/upload_ceph_images_to_nexus.sh
@@ -32,6 +32,8 @@ nexus_username=$(ssh ncn-m001 'kubectl get secret -n nexus nexus-admin-credentia
 nexus_password=$(ssh ncn-m001 'kubectl get secret -n nexus nexus-admin-credential --template={{.data.password}} | base64 --decode')
 ssh_options="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
 
+ceph_nexus_digest_file="/tmp/ceph_nexus_digest"
+
 function wait_for_health_ok() {
   cnt=0
   cnt2=0
@@ -197,6 +199,20 @@ function check_mon_daemon() {
   fi
 }
 
+function check_currently_running_nexus_image() {
+  node=$1
+  nexus_sha=$(cat ${ceph_nexus_digest_file})
+  for daemon in "mon" "mgr" "osd" "mds" "crash" "rgw"; do
+    for each in $(ssh ${node} "podman ps --filter name=$daemon --format {{.Image}}" ); do
+      if [[ -z $(echo $each | grep "$nexus_sha" ) && -z $(echo $each | grep $nexus_location) ]]; then
+        echo "false"
+        return 0
+      fi
+    done
+  done
+  echo "true"
+}
+
 function redeploy_monitoring_stack() {
 # restart daemons
 for daemon in "prometheus" "node-exporter" "alertmanager" "grafana"; do
@@ -232,7 +248,12 @@ function upload_image() {
     echo "Pushing image: $local_image to $nexus_location"
     podman pull "$local_image"
     podman tag "$local_image" "$nexus_location"
-    podman push --creds "$nexus_username":"$nexus_password" "$nexus_location"
+    if [[ $name == "mgr" ]]; then
+      # save the digestfile of the mgr image, this contains the sha in nexus
+      podman push --creds "$nexus_username":"$nexus_password" "$nexus_location" --digestfile=${ceph_nexus_digest_file}
+    else
+      podman push --creds "$nexus_username":"$nexus_password" "$nexus_location"
+    fi
     for storage_node in "ncn-s001" "ncn-s002" "ncn-s003"; do
         # shellcheck disable=SC2086
         # shellcheck disable=SC2029
@@ -249,27 +270,33 @@ function upload_image() {
 }
 
 function redeploy_ceph_services(){
-# restart daemons
-for node in $(ceph orch host ls -f json |jq -r '.[].hostname'); do
-  enter_maintenance_mode
-  # shellcheck disable=SC2086
-  ssh ${node} ${ssh_options} "podman rmi --all --force"
-  exit_maintenance_mode
-  for daemon in "mon" "mgr" "osd" "mds" "crash" "rgw"; do
-    daemons_to_restart=$(ceph --name client.ro orch ps "$node"| awk '{print $1}' | grep $daemon)
-    for each in $daemons_to_restart; do
-      #shellcheck disable=SC2086
-      if [[ $(hostname) = @("ncn-s001"|"ncn-s002"|"ncn-s003") ]]; then
-	 ceph config set global container_image ${nexus_location}
-	 ceph orch daemon redeploy "$each" --image "$nexus_location"
-      else
-	echo "This script can only be run from ncn-s001/2/3."
-	exit 1
-      fi
-    done
+  # restart daemons
+  for node in $(ceph orch host ls -f json |jq -r '.[].hostname'); do
+    running_nexus_image=$(check_currently_running_nexus_image $node)
+    if ! $running_nexus_image; then
+      echo "$node is not running all ceph services using the image in nexus. Redeploying these daemons using the nexus image."
+      enter_maintenance_mode
+      # shellcheck disable=SC2086
+      ssh ${node} ${ssh_options} "podman rmi --all --force"
+      exit_maintenance_mode
+      for daemon in "mon" "mgr" "osd" "mds" "crash" "rgw"; do
+        daemons_to_restart=$(ceph --name client.ro orch ps "$node"| awk '{print $1}' | grep $daemon)
+        for each in $daemons_to_restart; do
+          #shellcheck disable=SC2086
+          if [[ $(hostname) = @("ncn-s001"|"ncn-s002"|"ncn-s003") ]]; then
+            ceph config set global container_image ${nexus_location}
+            ceph orch daemon redeploy "$each" --image "$nexus_location"
+          else
+            echo "This script can only be run from ncn-s001/2/3."
+            exit 1
+          fi
+        done
+      done
+      wait_for_health_ok
+    else
+      echo "$node is already running all ceph services using the image in nexus."
+    fi
   done
-  wait_for_health_ok
-done
 }
 
 function enter_maintenance_mode() {

--- a/scripts/upload_ceph_images_to_nexus.sh
+++ b/scripts/upload_ceph_images_to_nexus.sh
@@ -314,7 +314,7 @@ function enter_maintenance_mode() {
   ceph orch host maintenance enter "$node" --force
   counter=0
   # shellcheck disable=SC2086
-  until [[ "$(ceph orch host ls $node --format json-pretty|jq -r '.[].status')" == "maintenance" ]]; do
+  until [[ "$(ceph orch host ls --host_pattern $node --format json-pretty|jq -r '.[].status')" == "maintenance" ]]; do
     echo "Waiting for node $node to enter maintenance mode."
     (( counter ++ ))
     if [[ $counter -ge 5 ]]; then
@@ -330,7 +330,7 @@ function exit_maintenance_mode() {
   # shellcheck disable=SC2086
   if [[ "$(ceph orch host maintenance exit $node)" ]]; then
     # shellcheck disable=SC2086
-    until [[ "$(ceph orch host ls $node --format json-pretty|jq -r '.[].status')" != "maintenance" ]]; do
+    until [[ "$(ceph orch host ls --host_pattern $node --format json-pretty|jq -r '.[].status')" != "maintenance" ]]; do
       echo "Waiting for node $node to exit maintenance mode."
       sleep 15
     done


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
Add function to check if ceph daemons are currently running the image in nexus. The ceph_upload_image_to_nexus script restarts all ceph daemons so that they use the image in nexus. This can take 40 minutes and the script will do this even if the daemons are already running the image in nexus. This PR adds a function to check if the daemons are already running the image in nexus and it doesn't restart them unless necessary.

Tested on Beau.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
