### PR TITLE
CASMCMS-8593: Update to reflect BOS v1 removal in CSM 1.6, BOS CLI default change in CSM 1.4

### DIFF
--- a/introduction/deprecated_features/README.md
+++ b/introduction/deprecated_features/README.md
@@ -8,7 +8,7 @@ version for their planned removal, customers are still strongly encouraged to ma
 
 * [Removals](#removals)
   * [Removals in CSM 1.5](#removals-in-csm-15)
-  * [Removals in CSM 1.9](#removals-in-csm-19)
+  * [Removals in CSM 1.6](#removals-in-csm-16)
 * [Deprecations](#deprecations)
   * [Deprecated in CSM 1.3](#deprecated-in-csm-13)
   * [Deprecated in CSM 1.2](#deprecated-in-csm-12)
@@ -28,7 +28,7 @@ in chronological order.
 
 * [Compute Rolling Upgrade Service (CRUS)](../../glossary.md#compute-rolling-upgrade-service-crus)
 
-### Removals in CSM 1.9
+### Removals in CSM 1.6
 
 * [Boot Orchestration Service (BOS)](../../glossary.md#boot-orchestration-service-bos) v1
 
@@ -40,10 +40,8 @@ features are listed first).
 ### Deprecated in CSM 1.3
 
 * [Boot Orchestration Service (BOS)](../../glossary.md#boot-orchestration-service-bos) v1
-  * BOS v1 will be removed in CSM 1.9.
-  * It is likely that even prior to BOS v1 being removed from CSM, the [Cray CLI](../../glossary.md#cray-cli-cray) will change its behavior when no
-    version is explicitly specified in BOS commands. Currently it defaults to BOS v1, but it may change to default to BOS v2 even before BOS v1
-    is removed from CSM.
+  * BOS v1 will be removed in CSM 1.6.
+  * The [Cray CLI](../../glossary.md#cray-cli-cray) changed in CSM 1.4 so that it defaults to BOS v2 when no version is explicitly specified in BOS commands.
 
 ### Deprecated in CSM 1.2
 

--- a/operations/UAS_user_and_admin_topics/Customize_End-User_UAI_Images.md
+++ b/operations/UAS_user_and_admin_topics/Customize_End-User_UAI_Images.md
@@ -35,7 +35,7 @@ See [Configure the Cray CLI](../configure_cray_cli.md).
     Identify the `sessiontemplate` name to use. A full list may be found with the following command:
 
     ```bash
-    cray bos sessiontemplate list --format yaml
+    cray bos v1 sessiontemplate list --format yaml
     ```
 
     Example output:
@@ -73,7 +73,7 @@ See [Configure the Cray CLI](../configure_cray_cli.md).
     Use the `sessiontemplate` name to download a compute node SquashFS from a BOS `sessiontemplate` name:
 
     ```bash
-    ST_ID=$(cray bos sessiontemplate describe $ST_NAME --format json | jq -r '.boot_sets.compute.path' | awk -F/ '{print $4}')
+    ST_ID=$(cray bos v1 sessiontemplate describe $ST_NAME --format json | jq -r '.boot_sets.compute.path' | awk -F/ '{print $4}')
 
     cray artifacts get boot-images $ST_ID/rootfs rootfs.squashfs
     ```

--- a/operations/UAS_user_and_admin_topics/Troubleshoot_Common_Mistakes_when_Creating_a_Custom_End-User_UAI_Image.md
+++ b/operations/UAS_user_and_admin_topics/Troubleshoot_Common_Mistakes_when_Creating_a_Custom_End-User_UAI_Image.md
@@ -1,11 +1,11 @@
 # Troubleshoot Common Mistakes when Creating a Custom End-User UAI Image
 
-There a several problems that may occur while making or working with a custom End-User UAI images. The following are some basic troubleshooting questions to ask:
+There a several problems that may occur while making or working with a custom end-user UAI images. The following are some basic troubleshooting questions to ask:
 
-* Does SESSION_NAME match an actual entry in `cray bos v1 sessiontemplate list`?
-* Is the SESSION_ID set to an appropriate uuid format? Did the `awk` command not parse the uuid correctly?
+* Does `SESSION_NAME` match an actual entry in `cray bos v1 sessiontemplate list`?
+* Is the `SESSION_ID` set to an appropriate UUID format? Did the `awk` command not parse the UUID correctly?
 * Did the file `/etc/security/limits.d/99-slingshot-network.conf` get removed from the tarball correctly?
-* Does the ENTRYPOINT `/usr/bin/uai-ssh.sh` exist?
+* Does the `ENTRYPOINT` `/usr/bin/uai-ssh.sh` exist?
 * Did the container image get pushed and registered with UAS?
 * Did the creation process run from a real worker or master node as opposed to a LiveCD node?
 

--- a/operations/UAS_user_and_admin_topics/Troubleshoot_Common_Mistakes_when_Creating_a_Custom_End-User_UAI_Image.md
+++ b/operations/UAS_user_and_admin_topics/Troubleshoot_Common_Mistakes_when_Creating_a_Custom_End-User_UAI_Image.md
@@ -2,7 +2,7 @@
 
 There a several problems that may occur while making or working with a custom End-User UAI images. The following are some basic troubleshooting questions to ask:
 
-* Does SESSION_NAME match an actual entry in `cray bos sessiontemplate list`?
+* Does SESSION_NAME match an actual entry in `cray bos v1 sessiontemplate list`?
 * Is the SESSION_ID set to an appropriate uuid format? Did the `awk` command not parse the uuid correctly?
 * Did the file `/etc/security/limits.d/99-slingshot-network.conf` get removed from the tarball correctly?
 * Does the ENTRYPOINT `/usr/bin/uai-ssh.sh` exist?

--- a/operations/boot_orchestration/Check_the_Progress_of_BOS_Session_Operations.md
+++ b/operations/boot_orchestration/Check_the_Progress_of_BOS_Session_Operations.md
@@ -17,7 +17,7 @@ When a Boot Orchestration Service \(BOS\) session is created, it will return a j
 (`ncn-mw#`) For example:
 
 ```bash
-cray bos session create --template-uuid SESSIONTEMPLATE_NAME --operation Boot --format toml
+cray bos v1 session create --template-uuid SESSIONTEMPLATE_NAME --operation Boot --format toml
 ```
 
 Example output:

--- a/operations/boot_orchestration/Clean_Up_After_a_BOS-BOA_Job_is_Completed_or_Cancelled.md
+++ b/operations/boot_orchestration/Clean_Up_After_a_BOS-BOA_Job_is_Completed_or_Cancelled.md
@@ -26,7 +26,7 @@ When a session is launched, the following items are created:
     Describe the BOS session to find the name of the BOA job under the attribute `boa_job_name`.
 
     ```bash
-    cray bos session describe --format json BOS_SESSION_ID
+    cray bos v1 session describe --format json BOS_SESSION_ID
     ```
 
     Example output:
@@ -72,7 +72,7 @@ When a session is launched, the following items are created:
 1. (`ncn-mw#`) Delete the etcd entry for the BOS session.
 
     ```bash
-    cray bos session delete BOS_SESSION_ID
+    cray bos v1 session delete BOS_SESSION_ID
     ```
 
 1. Stop CFS from configuring nodes.

--- a/operations/boot_orchestration/Manage_a_BOS_Session.md
+++ b/operations/boot_orchestration/Manage_a_BOS_Session.md
@@ -46,7 +46,7 @@ V2 Sessions also support several other optional arguments:
 
 Creating a new BOS V1 session requires the following command-line options:
 
-* `--template-name`: Use this option to specify the name value returned in the `cray bos sessiontemplate list` command.
+* `--template-name`: Use this option to specify the name value returned in the `cray bos v1 sessiontemplate list` command.
 * `--operation`: Use this option to indicate if a `boot`, `reboot`, `configure`, or `shutdown` action is being taken.
 
 (`ncn-mw#`): The following is a boot operation:
@@ -176,8 +176,8 @@ Example output:
 }
 ```
 
-**Troubleshooting:** There is a known issue in BOS V1 where some sessions cannot be described using the `cray bos session describe` command.
-The issue with the describe action results in a 404 error, despite the session existing in the output of `cray bos session list` command.
+**Troubleshooting:** There is a known issue in BOS V1 where some sessions cannot be described using the `cray bos v1 session describe` command.
+The issue with the describe action results in a 404 error, despite the session existing in the output of `cray bos v1 session list` command.
 
 ## Delete a Session
 

--- a/operations/image_management/Create_UAN_Boot_Images.md
+++ b/operations/image_management/Create_UAN_Boot_Images.md
@@ -710,7 +710,7 @@ and the HPE Cray Programming Environment\) that must be configured on the UANs.
     The following command uses the JSON session template file to save a session template in BOS. This step allows administrators to boot UANs by referring to the session template name.
 
     ```bash
-    cray bos sessiontemplate create \
+    cray bos v1 sessiontemplate create \
             --name uan-sessiontemplate-PRODUCT_VERSION \
             --file uan-sessiontemplate-PRODUCT_VERSION.json
     ```

--- a/operations/node_management/Add_a_Standard_Rack_Node.md
+++ b/operations/node_management/Add_a_Standard_Rack_Node.md
@@ -516,7 +516,7 @@ Follow the [Added Hardware](../network/management_network/added_hardware.md) pro
     Use the appropriate BOS template for the node type.
 
     ```bash
-    cray bos session create --template-uuid cle-VERSION \
+    cray bos v1 session create --template-uuid cle-VERSION \
         --operation reboot --limit x3000c0s27b0n0,x3000c0s27b0n1,x3000c0s27b0n2,x3000c0s27b00n3
     ```
 

--- a/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System.md
+++ b/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System.md
@@ -449,7 +449,7 @@ Use boot orchestration to power on and boot the nodes. Specify the appropriate B
 
     ```bash
     BOS_TEMPLATE=cos-2.0.30-slurm-healthy-compute
-    cray bos sessiontemplate describe $BOS_TEMPLATE --format json|jq '.boot_sets[] | select(.node_list)'
+    cray bos v1 sessiontemplate describe $BOS_TEMPLATE --format json|jq '.boot_sets[] | select(.node_list)'
     ```
 
     * If this query returns empty, then skip to booting the nodes.
@@ -461,7 +461,7 @@ Use boot orchestration to power on and boot the nodes. Specify the appropriate B
        1. Dump the current Session template.
 
           ```bash
-          cray bos sessiontemplate describe $BOS_TEMPLATE --format json > tmp.txt
+          cray bos v1 sessiontemplate describe $BOS_TEMPLATE --format json > tmp.txt
           ```
 
        1. Edit the `tmp.txt` file, adding the new nodes to the `node_list`.
@@ -483,19 +483,19 @@ Use boot orchestration to power on and boot the nodes. Specify the appropriate B
        1. Create the Session template.
 
           ```bash
-          cray bos sessiontemplate create --file tmp.txt --name $BOS_TEMPLATE
+          cray bos v1 sessiontemplate create --file tmp.txt --name $BOS_TEMPLATE
           ```
 
        1. Verify that the Session template contains the additional nodes and the proper name.
 
            ```bash
-           cray bos sessiontemplate describe $BOS_TEMPLATE --format json
+           cray bos v1 sessiontemplate describe $BOS_TEMPLATE --format json
            ```
 
     1. (`ncn#`) Boot the nodes.
 
        ```bash
-       cray bos session create --template-uuid $BOS_TEMPLATE \
+       cray bos v1 session create --template-uuid $BOS_TEMPLATE \
             --operation reboot --limit x1005c3s0b0n0,x1005c3s0b0n1,x1005c3s0b1n0,x1005c3s0b1n1
        ```
 

--- a/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System_Using_SAT.md
+++ b/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System_Using_SAT.md
@@ -89,7 +89,7 @@ This procedure will add a liquid-cooled blade to an HPE Cray EX system.
       If it is unclear which session template is in use, proceed to the next substep.
 
       ```bash
-      cray bos sessiontemplate list
+      cray bos v1 sessiontemplate list
       ```
 
    1. Find the node xnames with `sat status`. In this example, the target blade is in slot `x9000c3s0`.
@@ -126,7 +126,7 @@ This procedure will add a liquid-cooled blade to an HPE Cray EX system.
    1. Find the required `templateName` value with BOS.
 
       ```bash
-      cray bos session describe BOS_SESSION | grep templateName
+      cray bos v1 session describe BOS_SESSION | grep templateName
       ```
 
       Example output:
@@ -138,7 +138,7 @@ This procedure will add a liquid-cooled blade to an HPE Cray EX system.
    1. Determine the list of xnames associated with the desired session template.
 
       ```bash
-      cray bos sessiontemplate describe SESSION_TEMPLATE_NAME | grep node_list
+      cray bos v1 sessiontemplate describe SESSION_TEMPLATE_NAME | grep node_list
       ```
 
       Example output:

--- a/operations/node_management/Move_a_Standard_Rack_Node_SameRack_SameHSNPorts.md
+++ b/operations/node_management/Move_a_Standard_Rack_Node_SameRack_SameHSNPorts.md
@@ -364,7 +364,7 @@ This procedure works with both application and compute nodes. This example moves
     Specify the appropriate BOS template for the node type.
 
     ```bash
-    cray bos session create --template-uuid cle-VERSION \
+    cray bos v1 session create --template-uuid cle-VERSION \
     --operation reboot --limit x3000c0s27b1n0,x3000c0s27b2n0,x3000c0s27b3n0,x3000c0s27b4n0
     ```
 

--- a/operations/node_management/Move_a_Standard_Rack_Node_SameRack_SameHSNPorts.md
+++ b/operations/node_management/Move_a_Standard_Rack_Node_SameRack_SameHSNPorts.md
@@ -6,81 +6,104 @@ Update the location-based component name (xname) for a standard rack node within
 
 If a node has an incorrect component name (xname) based on its physical location, then this procedure can be used to correct the component name (xname) of the node without the need to physically move the node.
 
-### Prerequisites
+## Prerequisites
 
--   An authentication token has been retrieved.
+- An authentication token has been retrieved.
 
-    ```bash
-    function get_token () {
-        curl -s -S -d grant_type=client_credentials \
-            -d client_id=admin-client \
-            -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
-            https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token'
-    }
-    ```
+   ```bash
+   function get_token () {
+       curl -s -S -d grant_type=client_credentials \
+           -d client_id=admin-client \
+           -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
+           https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token'
+   }
+   ```
 
--   The Cray command line interface \(CLI\) tool is initialized and configured on the system.
--   This procedure applies only to standard rack nodes. Liquid-cooled compute blades do not require the use of the `MgmtSwitchConnector` object in the System Layout Service \(SLS\) to perform discovery.
--   This procedure moves an application node or compute node to a different location in an HPE Cray standard rack.
--   The node must use the **same Slingshot switch switch ports**.
--   The node must use the **same management network switch ports**.
+- The Cray command line interface \(CLI\) tool is initialized and configured on the system. See [configure the Cray CLI](../configure_cray_cli.md).
+- This procedure applies only to standard rack nodes. Liquid-cooled compute blades do not require the use of the `MgmtSwitchConnector` object in the System Layout Service \(SLS\) to perform discovery.
+- This procedure moves an application node or compute node to a different location in an HPE Cray standard rack.
+- The node must use the **same Slingshot switch switch ports**.
+- The node must use the **same management network switch ports**.
 
-### Limitations
+## Limitations
 
 This procedure assumes there are no changes to the node high-speed network switch port or management network ports.
 
-### Procedure
+## Procedure
 
 This procedure works with both application and compute nodes. This example moves a compute node in rack 3000 at U17 to U27 in the same rack.
 
-1.  Shut down software and power off the node.
+1. Shut down software and power off the node.
 
-2.  Disconnect the power cables, management network cables, and high-speed network \(HSN\) cables.
+1. Disconnect the power cables, management network cables, and high-speed network \(HSN\) cables.
+
     > If this procedure is being followed to correct a node's component name (xname), then this step can be skipped.
 
-3.  Move the node to the new location in the rack \(U27\), connect the management cables and HSN cables, but do not connect the power cables.
+1. Move the node to the new location in the rack \(U27\), connect the management cables and HSN cables, but do not connect the power cables.
+
     > If this procedure is being followed to correct a node's component name (xname), then this step can be skipped.
 
-#### Update Node in the System Layout Service \(SLS\)
+### Update Node in the System Layout Service \(SLS\)
 
-4.  Setup environment variables for the original node and node BMC component names (xnames):
+1. (`ncn-mw#`) Set up environment variables for the original node and node BMC component names (xnames).
 
     ```bash
     OLD_NODE_XNAME=x3000c0s17b1n0
     echo $OLD_NODE_XNAME
+    ```
+
+    Example output:
+
+    ```text
     x3000c0s17b1n0
     ```
 
     ```bash
     OLD_BMC_XNAME=$(echo $OLD_NODE_XNAME | egrep -o 'x[0-9]+c[0-9]+s[0-9]+b[0-9]+')
     echo $OLD_BMC_XNAME
+    ```
+
+    Example output:
+
+    ```text
     x3000c0s17b1
     ```
 
-5.  Setup environment variables for the new node and node BMC component names (xnames):
+1. (`ncn-mw#`) Set up environment variables for the new node and node BMC component names (xnames).
 
     ```bash
     NEW_NODE_XNAME=x3000c0s27b1n0
     echo $NEW_NODE_XNAME
+    ```
+
+    Example output:
+
+    ```text
     x3000c0s27b1n0
     ```
 
     ```bash
     NEW_BMC_XNAME=$(echo $NEW_NODE_XNAME | egrep -o 'x[0-9]+c[0-9]+s[0-9]+b[0-9]+')
     echo $NEW_BMC_XNAME
+    ```
+
+    Example output:
+
+    ```text
     x3000c0s27b1
     ```
 
-6.  Update SLS with the node's new component name (xname).
-	1.  Get Node from SLS:
+1. (`ncn-mw#`) Update SLS with the node's new component name (xname).
 
-       ```bash
-       cray sls hardware describe "$OLD_NODE_XNAME" --format json > sls_node.original.json
-       ```
+    1. Get node from SLS:
 
-       Sample contents of `sls_node.original.json`
+        ```bash
+        cray sls hardware describe "$OLD_NODE_XNAME" --format json > sls_node.original.json
+        ```
 
-       ```json
+        Example contents of `sls_node.original.json`
+
+        ```json
         {
           "Parent": "x3000c0s17b1",
           "Xname": "x3000c0s17b1n0",
@@ -97,9 +120,9 @@ This procedure works with both application and compute nodes. This example moves
             "Role": "Compute"
           }
         }
-       ```
+        ```
 
-    2.  Update the SLS Node object with the new component names (xnames):
+    1. Update the SLS node object with the new component names (xnames):
 
         ```bash
         jq --arg NODE_XNAME "$NEW_NODE_XNAME" --arg BMC_XNAME "$NEW_BMC_XNAME" \
@@ -107,7 +130,7 @@ This procedure works with both application and compute nodes. This example moves
             > sls_node.json
         ```
 
-        Expected content of `sls_node.original.json`:
+        Expected contents of `sls_node.original.json`:
 
         ```json
         {
@@ -127,19 +150,21 @@ This procedure works with both application and compute nodes. This example moves
           }
         }
         ```
+
         > Only the fields `Parent` and `Xname` should have been updated.
 
-    3.  Create new Node object in SLS:
+    1. Create new node object in SLS:
 
         ```bash
         curl -i -X POST -H "Authorization: Bearer $(get_token)" \
             https://api-gw-service-nmn.local/apis/sls/v1/hardware -d @sls_node.json
         ```
-        > **`NOTE`** If a 503 is returned, verify that get_token function has been defined.
+
+        > **`NOTE`** If a 503 is returned, verify that `get_token` function has been defined.
 
         Expected output:
 
-        ```
+        ```text
         HTTP/2 200
         content-type: application/json
         date: Mon, 18 Oct 2021 20:30:02 GMT
@@ -150,28 +175,28 @@ This procedure works with both application and compute nodes. This example moves
         {"code":0,"message":"inserted new entry"}
         ```
 
-    4.  Delete old Node object from SLS:
+    1. Delete old node object from SLS:
 
         ```bash
-        cray sls hardware delete $OLD_NODE_XNAME
+        cray sls hardware delete $OLD_NODE_XNAME --format toml
         ```
 
         Expected output:
 
-        ```
+        ```toml
         code = 0
         message = "deleted entry and its descendants"
         ```
 
-7.  Update `MgmtSwitchConnector` in SLS with the node BMC's new component name (xname):
+1. (`ncn-mw#`) Update `MgmtSwitchConnector` in SLS with the node BMC's new component name (xname):
 
-    1.  Get MgmtSwitchConnector object from SLS:
+    1. Get `MgmtSwitchConnector` object from SLS:
 
         ```bash
         cray sls search hardware list --node-nics "$OLD_BMC_XNAME" --format json > sls_MgmtSwitchConnector.original.json
         ```
 
-        Sample contents of `sls_MgmtSwitchConnector.original.json`
+        Example contents of `sls_MgmtSwitchConnector.original.json`:
 
         ```json
         [
@@ -193,7 +218,7 @@ This procedure works with both application and compute nodes. This example moves
         ]
         ```
 
-    2.  Update `MgmtSwitchConnector` object with the new node BMC component name (xname):
+    1. Update `MgmtSwitchConnector` object with the new node BMC component name (xname):
 
         ```bash
         jq --arg BMC_XNAME "$NEW_BMC_XNAME" \
@@ -201,7 +226,7 @@ This procedure works with both application and compute nodes. This example moves
             > sls_MgmtSwitchConnector.json
         ```
 
-        Expected content of `sls_MgmtSwitchConnector.json`:
+        Expected contents of `sls_MgmtSwitchConnector.json`:
 
         ```json
         {
@@ -220,17 +245,23 @@ This procedure works with both application and compute nodes. This example moves
           }
         }
         ```
+
         > Only the `NodeNics` field should have been updated.
 
-    3.  Determine the component name (xname) of the `MgmtSwitchConnector`:
+    1. Determine the component name (xname) of the `MgmtSwitchConnector`:
 
         ```bash
         MGMT_SWITCH_CONNECTOR_XNAME=$(jq -r .Xname sls_MgmtSwitchConnector.json)
         echo $MGMT_SWITCH_CONNECTOR_XNAME
+        ```
+
+        Example output:
+
+        ```text
         x3000c0w22j36
         ```
 
-    4.  Update the `MgmtSwitchConnector` in SLS:
+    1. Update the `MgmtSwitchConnector` in SLS:
 
         ```bash
         curl -i -X PUT -H "Authorization: Bearer $(get_token)" \
@@ -239,7 +270,7 @@ This procedure works with both application and compute nodes. This example moves
 
         Expected output:
 
-        ```
+        ```text
         HTTP/2 200
         content-type: application/json
         date: Mon, 18 Oct 2021 20:33:36 GMT
@@ -250,32 +281,32 @@ This procedure works with both application and compute nodes. This example moves
         {"Parent":"x3000c0w22","Xname":"x3000c0w22j36","Type":"comptype_mgmt_switch_connector","Class":"River","TypeString":"MgmtSwitchConnector","LastUpdated":1631829089,"LastUpdatedTime":"2021-09-16 21:51:29.997834 +0000 +0000","ExtraProperties":{"NodeNics":["x3000c0s21b4"],"VendorName":"ethernet1/1/36"}}
         ```
 
-#### Remove previously discovered node data from HSM
+### Remove previously discovered node data from HSM
 
-8.  Remove previously discovered components from HSM:
+1. (`ncn-mw#`) Remove previously discovered components from HSM:
 
-    Remove Node component from HSM:
+    1. Remove Node component from HSM:
 
-    ```bash
-    cray hsm state components delete $OLD_NODE_XNAME
-    ```
+        ```bash
+        cray hsm state components delete $OLD_NODE_XNAME
+        ```
 
-    Remove NodeBMC component from HSM:
+    1. Remove `NodeBMC` component from HSM:
 
-    ```bash
-    cray hsm state components delete $OLD_BMC_XNAME
-    ```
+        ```bash
+        cray hsm state components delete $OLD_BMC_XNAME
+        ```
 
-    Remove NodeEnclosure component form HSM. The component name (xname) for a NodeEnclosure is similar to the node BMC component name (xname), but the `b` is replaced with a `e`.
+    1. Remove `NodeEnclosure` component from HSM. The component name (xname) for a `NodeEnclosure` is similar to the node BMC component name (xname), but the `b` is replaced with a `e`.
 
-    ```bash
-    OLD_NODE_ENCLOSURE_XNAME=x3000c0s17e0
-    cray hsm state components delete $OLD_NODE_ENCLOSURE_XNAME
-    ```
+        ```bash
+        OLD_NODE_ENCLOSURE_XNAME=x3000c0s17e0
+        cray hsm state components delete $OLD_NODE_ENCLOSURE_XNAME
+        ```
 
-9.  Delete the `NodeBMC`, `Node` NIC MAC addresses, and the Redfish endpoint for the U17 node from th HSM.
+1. (`ncn-mw#`) Delete the `NodeBMC`, Node NIC MAC addresses, and the Redfish endpoint for the U17 node from the HSM.
 
-    1.  Delete the `Node` MAC addresses from the HSM.
+    1. Delete the Node MAC addresses from the HSM.
 
         ```bash
         for ID in $(cray hsm inventory ethernetInterfaces list --component-id $OLD_NODE_XNAME --format json | jq -r .[].ID); do
@@ -284,7 +315,7 @@ This procedure works with both application and compute nodes. This example moves
         done
         ```
 
-    2.  Delete each `NodeBMC` MAC address from the Hardware State Manager \(HSM\) Ethernet interfaces table.
+    1. Delete each `NodeBMC` MAC address from the Hardware State Manager \(HSM\) Ethernet interfaces table.
 
         ```bash
         for ID in $(cray hsm inventory ethernetInterfaces list --component-id $OLD_BMC_XNAME --format json | jq -r .[].ID); do
@@ -293,25 +324,27 @@ This procedure works with both application and compute nodes. This example moves
         done
         ```
 
-    3.  Delete the Redfish endpoint for the removed node.
+    1. Delete the Redfish endpoint for the removed node.
 
         ```bash
         cray hsm inventory redfishEndpoints delete $OLD_BMC_XNAME
         ```
 
-10. Connect the power cables to the node to power on the BMC.
+1. Connect the power cables to the node to power on the BMC.
+
     > If this procedure is being followed to correct a node's component name (xname), then this step can be skipped.
 
-11. Wait for 5 minutes for power on and the node BMCs to be discovered.
+1. Wait for 5 minutes for the BMC to power on and the node BMCs to be discovered.
 
-    ```bash
-    sleep 300
-    ```
-
-12. Verify the node BMC has been discovered by the HSM.
+1. (`ncn-mw#`) Verify the node BMC has been discovered by the HSM.
 
     ```bash
     cray hsm inventory redfishEndpoints describe $NEW_BMC_XNAME --format json
+    ```
+
+    Example output:
+
+    ```json
     {
         "ID": "x3000c0s27b1",
         "Type": "NodeBMC",
@@ -332,39 +365,42 @@ This procedure works with both application and compute nodes. This example moves
     }
     ```
 
-    -   When `LastDiscoveryStatus` displays as `DiscoverOK`, the node BMC has been successfully discovered.
-    -   If the last discovery state is `DiscoveryStarted` then the BMC is currently being inventoried by HSM.
-    -   If the last discovery state is `HTTPsGetFailed` or `ChildVerificationFailed` then an error occurred during the discovery process.
-        -   For `HTTPsGetFailed`, verify that the BMC is pingable by its component name (xname). If the component name (xname) of the BMC is not resolvable, then more time may be needed for DNS to update.
-
-            If hostname it does resolve, issue a discovery request to HSM:
+    - When `LastDiscoveryStatus` displays as `DiscoverOK`, then the node BMC has been successfully discovered.
+    - If the last discovery state is `DiscoveryStarted` then the BMC is currently being inventoried by HSM.
+    - If the last discovery state is `HTTPsGetFailed` or `ChildVerificationFailed` then an error occurred during the discovery process.
+      - For `HTTPsGetFailed`, verify that the BMC is pingable by its component name (xname).
+        - If the component name (xname) of the BMC is not resolvable, then more time may be needed for DNS to update.
+        - If hostname does resolve, then issue a discovery request to HSM:
 
             ```bash
             cray hsm inventory discover create --xnames $NEW_BMC_XNAME
             ```
 
-13. Verify that the nodes are enabled in the HSM.
+1. (`ncn-mw#`) Verify that the nodes are enabled in the HSM.
 
     ```bash
-    cray hsm state components describe $NEW_NODE_XNAME
+    cray hsm state components describe $NEW_NODE_XNAME --format toml
+    ```
+
+    Beginning of example output:
+
+    ```toml
     Type = "Node"
     Enabled = true
     State = "Off"
-    . . .
     ```
 
-14. If necessary, enable the nodes in the HSM database \(in this example, the nodes are `x3000c0s27b[1-4]n0`\).
+1. (`ncn-mw#`) If necessary, enable the nodes in the HSM database \(in this example, the nodes are `x3000c0s27b[1-4]n0`\).
 
     ```bash
     cray hsm state components bulkEnabled update --enabled true --component-ids x3000c0s27b1n0,x3000c0s27b2n0,x3000c0s27b3n0,x3000c0s27b4n0
     ```
 
-15. Use boot orchestration to power on and boot the nodes.
+1. (`ncn-mw#`) Use boot orchestration to power on and boot the nodes.
 
     Specify the appropriate BOS template for the node type.
 
     ```bash
     cray bos v1 session create --template-uuid cle-VERSION \
-    --operation reboot --limit x3000c0s27b1n0,x3000c0s27b2n0,x3000c0s27b3n0,x3000c0s27b4n0
+        --operation reboot --limit x3000c0s27b1n0,x3000c0s27b2n0,x3000c0s27b3n0,x3000c0s27b4n0
     ```
-

--- a/operations/node_management/Removing_a_Liquid-cooled_blade_from_a_System.md
+++ b/operations/node_management/Removing_a_Liquid-cooled_blade_from_a_System.md
@@ -33,7 +33,7 @@ This procedure will remove a liquid-cooled blades from an HPE Cray EX system.
 
     ```bash
     BOS_TEMPLATE=cos-2.0.30-slurm-healthy-compute
-    cray bos session create --template-uuid $BOS_TEMPLATE --operation shutdown --limit x9000c3s0b0n0,x9000c3s0b0n1,x9000c3s0b1n0,x9000c3s0b1n1
+    cray bos v1 session create --template-uuid $BOS_TEMPLATE --operation shutdown --limit x9000c3s0b0n0,x9000c3s0b0n1,x9000c3s0b1n0,x9000c3s0b1n1
     ```
 
 ### Step 2: Disable the Redfish endpoints for the nodes

--- a/operations/node_management/Removing_a_Liquid-cooled_blade_from_a_System_Using_SAT.md
+++ b/operations/node_management/Removing_a_Liquid-cooled_blade_from_a_System_Using_SAT.md
@@ -35,7 +35,7 @@ This procedure will remove a liquid-cooled blade from an HPE Cray EX system.
       If it is unclear which session template is in use, proceed to the next substep.
 
       ```bash
-      cray bos sessiontemplate list
+      cray bos v1 sessiontemplate list
       ```
 
    1. Find the node xnames with `sat status`. In this example, the target blade is in slot `x9000c3s0`.
@@ -72,7 +72,7 @@ This procedure will remove a liquid-cooled blade from an HPE Cray EX system.
    1. Find the required `templateName` value with BOS.
 
       ```bash
-      cray bos session describe BOS_SESSION | grep templateName
+      cray bos v1 session describe BOS_SESSION | grep templateName
       ```
 
       Example output:
@@ -84,7 +84,7 @@ This procedure will remove a liquid-cooled blade from an HPE Cray EX system.
    1. Determine the list of xnames associated with the desired boot session template.
 
       ```bash
-      cray bos sessiontemplate describe SESSION_TEMPLATE_NAME | grep node_list
+      cray bos v1 sessiontemplate describe SESSION_TEMPLATE_NAME | grep node_list
       ```
 
       Example output:

--- a/operations/node_management/Removing_a_Standard_Node_from_a_System.md
+++ b/operations/node_management/Removing_a_Standard_Node_from_a_System.md
@@ -42,7 +42,7 @@ This procedure is applicable for the following types of standard rack nodes:
 
     ```bash
     BOS_TEMPLATE=cos-2.0.30-slurm-healthy-compute
-    cray bos session create --template-uuid $BOS_TEMPLATE --operation shutdown --limit x9000c3s0b0n0,x9000c3s0b0n1,x9000c3s0b1n0,x9000c3s0b1n1
+    cray bos v1 session create --template-uuid $BOS_TEMPLATE --operation shutdown --limit x9000c3s0b0n0,x9000c3s0b0n1,x9000c3s0b1n0,x9000c3s0b1n1
     ```
 
 ### Step 3: Remove Data from SLS and HSM

--- a/operations/node_management/Replace_a_Compute_Blade.md
+++ b/operations/node_management/Replace_a_Compute_Blade.md
@@ -33,7 +33,7 @@ Replace an HPE Cray EX liquid-cooled compute blade.
 1. Use Boot Orchestration Services (BOS) to shut down the affected nodes. Specify the appropriate BOS template for the node type.
 
    ```bash
-   cray bos session create --template-uuid BOS_TEMPLATE \
+   cray bos v1 session create --template-uuid BOS_TEMPLATE \
    --operation shutdown --limit x1000c3s0b0n0,x1000c3s0b0n1,x1000c3s0b1n0,x1000c3s0b1n1
    ```
 
@@ -273,6 +273,6 @@ Replace an HPE Cray EX liquid-cooled compute blade.
     Specify the appropriate BOS template for the node type.
 
     ```bash
-    cray bos session create --template-uuid BOS_TEMPLATE --operation reboot \
+    cray bos v1 session create --template-uuid BOS_TEMPLATE --operation reboot \
     --limit x1000c3s0b0n0,x1000c3s0b0n1,x1000c3s0b1n0,x1000c3s0b1n1
     ```

--- a/operations/node_management/Replace_a_Compute_Blade_Using_SAT.md
+++ b/operations/node_management/Replace_a_Compute_Blade_Using_SAT.md
@@ -34,7 +34,7 @@ Replace an HPE Cray EX liquid-cooled compute blade.
       If it is unclear which session template is in use, proceed to the next substep.
 
       ```bash
-      cray bos sessiontemplate list
+      cray bos v1 sessiontemplate list
       ```
 
    1. Find the node xnames with `sat status`. In this example, the target blade is in slot `x9000c3s0`.
@@ -71,7 +71,7 @@ Replace an HPE Cray EX liquid-cooled compute blade.
    1. Find the required `templateName` value with BOS.
 
       ```bash
-      cray bos session describe BOS_SESSION | grep templateName
+      cray bos v1 session describe BOS_SESSION | grep templateName
       ```
 
       Example output:
@@ -83,7 +83,7 @@ Replace an HPE Cray EX liquid-cooled compute blade.
    1. Determine the list of xnames associated with the desired boot session template.
 
       ```bash
-      cray bos sessiontemplate describe SESSION_TEMPLATE_NAME | grep node_list
+      cray bos v1 sessiontemplate describe SESSION_TEMPLATE_NAME | grep node_list
       ```
 
       Example output:

--- a/operations/node_management/Swap_a_Compute_Blade_with_a_Different_System.md
+++ b/operations/node_management/Swap_a_Compute_Blade_with_a_Different_System.md
@@ -94,7 +94,7 @@ Swap an HPE Cray EX liquid-cooled compute blade between two systems.
 
    ```bash
    BOS_TEMPLATE=cos-2.0.30-slurm-healthy-compute
-   cray bos session create --template-uuid $BOS_TEMPLATE --operation shutdown --limit x9000c3s0b0n0,x9000c3s0b0n1,x9000c3s0b1n0,x9000c3s0b1n1
+   cray bos v1 session create --template-uuid $BOS_TEMPLATE --operation shutdown --limit x9000c3s0b0n0,x9000c3s0b0n1,x9000c3s0b1n0,x9000c3s0b1n1
    ```
 
 ### Source: Disable the Redfish endpoints for the nodes
@@ -269,7 +269,7 @@ The hardware management network MAC and IP addresses are assigned algorithmicall
 
     ```bash
     BOS_TEMPLATE=cos-2.0.30-slurm-healthy-compute
-    cray bos session create --template-uuid $BOS_TEMPLATE --operation shutdown \
+    cray bos v1 session create --template-uuid $BOS_TEMPLATE --operation shutdown \
             --limit x1005c3s0b0n0,x1005c3s0b0n1,x1005c3s0b1n0,x1005c3s0b1n1
     ```
 
@@ -709,7 +709,7 @@ The hardware management network NIC MAC addresses for liquid-cooled blades are a
 
     ```bash
     BOS_TEMPLATE=cos-2.0.30-slurm-healthy-compute
-    cray bos session create --template-uuid $BOS_TEMPLATE \
+    cray bos v1 session create --template-uuid $BOS_TEMPLATE \
             --operation reboot --limit x1005c3s0b0n0,x1005c3s0b0n1,x1005c3s0b1n0,x1005c3s0b1n1
     ```
 

--- a/operations/node_management/Swap_a_Compute_Blade_with_a_Different_System_Using_SAT.md
+++ b/operations/node_management/Swap_a_Compute_Blade_with_a_Different_System_Using_SAT.md
@@ -44,7 +44,7 @@ Swap an HPE Cray EX liquid-cooled compute blade between two systems.
       If it is unclear which session template is in use, proceed to the next substep.
 
       ```bash
-      cray bos sessiontemplate list
+      cray bos v1 sessiontemplate list
       ```
 
    1. (`ncn#`) Find the node xnames with `sat status`.
@@ -83,7 +83,7 @@ Swap an HPE Cray EX liquid-cooled compute blade between two systems.
    1. (`ncn#`) Find the required `templateName` value with BOS.
 
       ```bash
-      cray bos session describe BOS_SESSION --format toml | grep templateName
+      cray bos v1 session describe BOS_SESSION --format toml | grep templateName
       ```
 
       Example output:
@@ -95,7 +95,7 @@ Swap an HPE Cray EX liquid-cooled compute blade between two systems.
    1. (`ncn#`) Determine the list of xnames associated with the desired boot session template.
 
       ```bash
-      cray bos sessiontemplate describe SESSION_TEMPLATE_NAME --format toml | grep node_list
+      cray bos v1 sessiontemplate describe SESSION_TEMPLATE_NAME --format toml | grep node_list
       ```
 
       Example output:

--- a/operations/node_management/Update_Compute_Node_Mellanox_HSN_NIC_Firmware.md
+++ b/operations/node_management/Update_Compute_Node_Mellanox_HSN_NIC_Firmware.md
@@ -1,29 +1,30 @@
 # Update Compute Node Mellanox HSN NIC Firmware
 
-This procedure updates liquid-cooled or standard rack compute node NIC mezzanine cards \(NMC\) firmware for Slingshot 10 Mellanox ConnectX-5 NICs. The deployed RPM on compute nodes contains the scripts and firmware images required to perform the firmware and configuration updates.
+This procedure updates liquid-cooled or standard rack compute node NIC mezzanine cards \(NMC\) firmware for Slingshot 10 Mellanox ConnectX-5 NICs. The deployed RPM on compute nodes contains the scripts and firmware images
+required to perform the firmware and configuration updates.
 
 **Attention:** The NIC firmware update is performed while the node is running the compute image \(in-band\). Use the CX-5 NIC firmware that is deployed with the compute node RPMs and not from some other repository.
 
 See [Update Firmware with FAS](../firmware/Update_Firmware_with_FAS.md) for information about automated firmware updates using Redfish.
 
-### Time Required
+## Time Required
 
 2-5 minutes for a firmware update and 1-3 minutes for a configuration update.
 
-### Procedure
+## Procedure
 
-1.  SSH to the node as root.
+1. SSH to the node as root.
 
-2.  Load the module.
+1. (`nid#`) Load the module.
 
     ```bash
-    nid000001:~ # module load cray-shasta-mlnx-firmware
-    nid000001:~ # module show cray-shasta-mlnx-firmware
+    module load cray-shasta-mlnx-firmware
+    module show cray-shasta-mlnx-firmware
     ```
 
     Example output:
 
-    ```
+    ```text
     -------------------------------------------------------------------
     /opt/cray/modulefiles/cray-shasta-mlnx-firmware/1.0.5:
     module-whatis   "This module adds cray-shasta-mlnx-firmware v1.0.5 to the environment"
@@ -31,19 +32,45 @@ See [Update Firmware with FAS](../firmware/Update_Firmware_with_FAS.md) for info
     -------------------------------------------------------------------
     ```
 
-3.  List the contents of the firmware directory.
+1. (`nid#`) List the contents of the firmware directories.
 
     ```bash
-    nid000001:~ # ls /opt/cray/cray-shasta-mlnx-firmware/1.0.5/share/firmware/*
+    ls /opt/cray/cray-shasta-mlnx-firmware/1.0.5/share/firmware/*
+    ```
+
+    Example output:
+
+    ```text
     apply_mlnx_configs  generate_mlnx_configs  update_mlnx_firmware
+    ```
 
-    nid000001:~ # ls /opt/cray/cray-shasta-mlnx-firmware/1.0.5/share/firmware/
+    ```bash
+    ls /opt/cray/cray-shasta-mlnx-firmware/1.0.5/share/firmware/
+    ```
+
+    Example output:
+
+    ```text
     CRAY000000001/ MT_0000000011/ images/
+    ```
 
-    nid000001:~ # ls /opt/cray/cray-shasta-mlnx-firmware/1.0.5/share/firmware/
+    ```bash
+    ls /opt/cray/cray-shasta-mlnx-firmware/1.0.5/share/firmware/
+    ```
+
+    Example output:
+
+    ```text
     CRAY000000001/ MT_0000000011/ images/
+    ```
 
-    nid000001:~ # ls /opt/cray/cray-shasta-mlnx-firmware/1.0.5/share/firmware/*
+    ```bash
+    ls /opt/cray/cray-shasta-mlnx-firmware/1.0.5/share/firmware/*
+    ```
+
+    Example output:
+
+    ```text
     /opt/cray/cray-shasta-mlnx-firmware/1.0.5/share/firmware/CRAY000000001:
     config.xml  fw-ConnectX5-rel-16_26_4012-Cray_Timms_mezz_100G_1P-UEFI-14.19.17-FlexBoot-3.5.805.bin
 
@@ -54,27 +81,27 @@ See [Update Firmware with FAS](../firmware/Update_Firmware_with_FAS.md) for info
     CRAY000000001.bin  MT_0000000011.bin
     ```
 
-4.  Update the firmware on the node.
+1. (`nid#`) Update the firmware on the node.
 
     ```bash
-    nid000001:~ # update_mlnx_firmware
+    update_mlnx_firmware
     ```
 
-5.  Apply the configuration settings.
+1. (`nid#`) Apply the configuration settings.
 
     ```bash
-    nid000001:~ # apply_mlnx_configs
+    apply_mlnx_configs
     ```
 
-6.  Determine the prepend pathname.
+1. (`nid#`) Determine the prepend pathname.
 
     ```bash
-    nid000001:~ # module show cray-shasta-mlnx-firmware
+    module show cray-shasta-mlnx-firmware
     ```
 
     Example output:
 
-    ```
+    ```text
     -------------------------------------------------------------------
     /opt/cray/modulefiles/cray-shasta-mlnx-firmware/1.0.5:
     module-whatis   "This module adds cray-shasta-mlnx-firmware v1.0.5 to the environment"
@@ -82,22 +109,20 @@ See [Update Firmware with FAS](../firmware/Update_Firmware_with_FAS.md) for info
     -------------------------------------------------------------------
     ```
 
-7.  Log in to ncn-m001 and use `pdsh` to update the firmware.
+1. (`ncn-m001#`) Log in to `ncn-m001` and use `pdsh` to update the firmware.
 
     ```bash
     pdsh -w NODE_LIST /opt/cray/cray-shasta-mlnx-firmware/1.0.5/sbin/update_mlnx_firmware
     ```
 
-8.  Apply the configuration settings.
+1. (`ncn-m001#`) Apply the configuration settings.
 
     ```bash
     pdsh -w NODE_LIST /opt/cray/cray-shasta-mlnx-firmware/1.0.5/sbin/apply_mlnx_configs
     ```
 
-9.  Use the Boot Orchestration Service \(BOS\) to reboot all the affected nodes.
+1. (`ncn-m001#`) Use the Boot Orchestration Service \(BOS\) to reboot all the affected nodes.
 
     ```bash
-    cray bos v1 session create --template-uuid SESSION_TEMPLATE \
-    --operation reboot
+    cray bos v1 session create --template-uuid SESSION_TEMPLATE --operation reboot
     ```
-

--- a/operations/node_management/Update_Compute_Node_Mellanox_HSN_NIC_Firmware.md
+++ b/operations/node_management/Update_Compute_Node_Mellanox_HSN_NIC_Firmware.md
@@ -97,7 +97,7 @@ See [Update Firmware with FAS](../firmware/Update_Firmware_with_FAS.md) for info
 9.  Use the Boot Orchestration Service \(BOS\) to reboot all the affected nodes.
 
     ```bash
-    cray bos session create --template-uuid SESSION_TEMPLATE \
+    cray bos v1 session create --template-uuid SESSION_TEMPLATE \
     --operation reboot
     ```
 

--- a/operations/power_management/Power_On_and_Boot_Compute_Nodes_and_User_Access_Nodes.md
+++ b/operations/power_management/Power_On_and_Boot_Compute_Nodes_and_User_Access_Nodes.md
@@ -104,7 +104,7 @@ This procedure boots all compute nodes and user access nodes \(UANs\) in the con
     Identify the BOS session template names (such as `"cos-2.0.x"`, `slurm`, or `uan-slurm`), and choose the appropriate compute and UAN node templates for the power on and boot.
 
     ```bash
-    cray bos sessiontemplate list
+    cray bos v1 sessiontemplate list
     ```
 
     Example output:
@@ -124,7 +124,7 @@ This procedure boots all compute nodes and user access nodes \(UANs\) in the con
 1. (`ncn-m001#`) To display more information about a session template, for example `cos-2.0.0`, use the `describe` option.
 
     ```bash
-    cray bos sessiontemplate describe cos-2.0.x
+    cray bos v1 sessiontemplate describe cos-2.0.x
     ```
 
 1. (`ncn-m001#`) Use `sat bootsys boot` to power on and boot UANs and compute nodes.

--- a/operations/power_management/Prepare_the_System_for_Power_Off.md
+++ b/operations/power_management/Prepare_the_System_for_Power_Off.md
@@ -34,7 +34,7 @@ HPE Cray EX System Admin Toolkit (SAT) product stream documentation (`S-8031`) f
        If it is unclear what session template is in use, proceed to the next substep.
 
        ```bash
-       cray bos sessiontemplate list
+       cray bos v1 sessiontemplate list
        ```
 
     1. Find the xname with `sat status`.
@@ -68,7 +68,7 @@ HPE Cray EX System Admin Toolkit (SAT) product stream documentation (`S-8031`) f
     1. Find the required `templateUuid` value with BOS.
 
        ```bash
-       cray bos session describe BOS_SESSION | grep templateUuid
+       cray bos v1 session describe BOS_SESSION | grep templateUuid
        ```
 
        Example output:
@@ -80,7 +80,7 @@ HPE Cray EX System Admin Toolkit (SAT) product stream documentation (`S-8031`) f
     1. Determine the list of xnames associated with the desired boot session template.
 
        ```bash
-       cray bos sessiontemplate describe SESSION_TEMPLATE_NAME | egrep "node_list|node_roles_groups|node_groups"
+       cray bos v1 sessiontemplate describe SESSION_TEMPLATE_NAME | egrep "node_list|node_roles_groups|node_groups"
        ```
 
        Example output(s):
@@ -345,13 +345,13 @@ HPE Cray EX System Admin Toolkit (SAT) product stream documentation (`S-8031`) f
         string. Use the following command to delete the BOS database entry.
 
         ```bash
-        cray bos session delete <session ID>
+        cray bos v1 session delete <session ID>
         ```
 
         Example:
 
         ```bash
-        cray bos session delete 0216d2d9-b2bc-41b0-960d-165d2af7a742
+        cray bos v1 session delete 0216d2d9-b2bc-41b0-960d-165d2af7a742
         ```
 
 1. Coordinate with the site to prevent new sessions from starting in the services listed.

--- a/operations/power_management/Shut_Down_and_Power_Off_Compute_and_User_Access_Nodes.md
+++ b/operations/power_management/Shut_Down_and_Power_Off_Compute_and_User_Access_Nodes.md
@@ -15,7 +15,7 @@ System Admin Toolkit (SAT) (S-8031)* product stream documentation for instructio
    Identify the BOS session template names such as `cos-2.0.x`, `uan-slurm`, and choose the appropriate compute and UAN node templates for the shutdown.
 
    ```bash
-   cray bos sessiontemplate list
+   cray bos v1 sessiontemplate list
    ```
 
    Example output:
@@ -39,7 +39,7 @@ System Admin Toolkit (SAT) (S-8031)* product stream documentation for instructio
 1. To display more information about a session template, for example `cos-2.0.x`, use the `describe` option.
 
    ```bash
-   cray bos sessiontemplate describe cos-2.0.x
+   cray bos v1 sessiontemplate describe cos-2.0.x
    ```
 
 1. Use `sat bootsys shutdown` to shut down and power off UANs and compute nodes.

--- a/operations/resiliency/Resiliency_Testing_Procedure.md
+++ b/operations/resiliency/Resiliency_Testing_Procedure.md
@@ -1,75 +1,74 @@
 # Resiliency Testing Procedure
 
-This document and the procedures contained within it are for the purposes of communicating the kind of testing done by the internal Cray System Management (CSM) team to ensure a basic level of system resiliency in the event of the loss of a single non-compute node (NCN).
+This document and the procedures contained within it are for the purposes of communicating the kind of testing done by the internal Cray System Management (CSM) team to ensure a basic level of system resiliency in the event of
+the loss of a single non-compute node (NCN).
 
-It is assumed that some procedures are already known by admins and thus does not go into great detail or attempt to encompass every command necessary for execution. It is intended to be higher level guidance (with some command examples) to inform internal users and customers about our process.
+It is assumed that some procedures are already known by admins and thus does not go into great detail or attempt to encompass every command necessary for execution. It is intended to be higher level guidance (with some command
+examples) to inform internal users and customers about our process.
 
-## High Level Procedure Summary
+* [Prepare for resiliency testing](#prepare-for-resiliency-testing)
+* [Establish system health before beginning](#establish-system-health-before-beginning)
+* [Monitor for changes](#monitor-for-changes)
+* [Launch a non-interactive batch job](#launch-a-non-interactive-batch-job)
+* [Shut down an NCN](#shut-down-an-ncn)
+* [Conduct testing](#conduct-testing)
+* [Power on the downed NCN](#power-on-the-downed-ncn)
+* [Execute post-boot health checks](#execute-post-boot-health-checks)
 
-   - [Prepare for Resiliency Testing](#prepare-for-resiliency-testing)
-   - [Establish System Health Before Beginning](#establish-system-health-before-beginning)
-   - [Monitor for Changes](#monitor-for-changes)
-   - [Launch a Non-Interactive Batch Job](#launch-a-non-interactive-batch-job)
-   - [Shut Down an NCN](#shut-down-an-ncn)
-   - [Conduct Testing](#conduct-testing)
-   - [Power on the Downed NCN](#power-on-the-downed-ncn)
-   - [Execute Post-Boot Health Checks](#execute-post-boot-health-checks)
+## Prepare for resiliency testing
 
-### Prepare for Resiliency Testing
-
-* Confirm the component name (xname) mapping for each node on the system. This get dumped out by execution of the `/opt/cray/platform-utils/ncnGetXnames.sh` script.
+* Confirm the component name (xname) mapping for each node on the system by running the `/opt/cray/platform-utils/ncnGetXnames.sh` script on each node.
 
 * Verify that `metal.no-wipe=1` is set for each of the NCNs using output from running the `ncnGetXnames.sh` script.
 
-* Ensure the user account in use is an authorized user on the Cray CLI.
+* (`ncn-mw#`) Ensure the user account in use is an authorized user on the Cray CLI.
 
   Log in as a user account where the credentials are known:
 
    ```bash
    export CRAY_CONFIG_DIR=$(mktemp -d); echo $CRAY_CONFIG_DIR; cray init --configuration default --hostname https://api-gw-service-nmn.local
-   /tmp/tmp.ShkBrUfhsJ
-   Username: username
-   Password:
-   Success!
    ```
 
    Then, validate the authorization by executing the `cray uas list` command, for example. For more information, see the `Validate UAI Creation` section of [Validate CSM Health](../validate_csm_health.md).
 
-* Verify that `kubectl get nodes` reports all master and worker nodes are `Ready`.
+* (`ncn-mw#`) Verify that `kubectl get nodes` reports all master and worker nodes are `Ready`.
 
    ```bash
    kubectl get nodes -o wide
    ```
 
-* Get a current list of pods that have a status of anything other than `Running` or `Completed`. Investigate any of concern. Save the list of pods for comparison once resiliency testing is completed and the system has been restored.
+* (`ncn-mw#`) Get a current list of pods that have a status of anything other than `Running` or `Completed`. Investigate any of concern.
+  Save the list of pods for comparison once resiliency testing is completed and the system has been restored.
 
    ```bash
    kubectl get pods -o wide -A | grep -Ev 'Running|Completed'
    ```
 
-* Note which pods are running on an NCN that will be taken down (as well as the total number of pods running). The following is an example that shows the listing of pods running on `ncn-w001`:
+* (`ncn-mw#`) Note which pods are running on an NCN that will be taken down (as well as the total number of pods running). The following is an example that shows the listing of pods running on `ncn-w001`:
 
    ```bash
    kubectl get pods -o wide -A | grep ncn-w001 | awk '{print $2}'
    ```
 
-   Note that the above would only apply to Kubernetes nodes, such as master and worker nodes (ncn-m00x and ncn-w00x).
+   Note that the above would only apply to Kubernetes nodes, such as master and worker nodes.
 
-* Verify `ipmitool` can report power status for the NCN to be shutdown.
+* (`linux#`) Verify `ipmitool` can report power status for the NCN to be shut down.
 
    ```bash
    ipmitool -I lanplus -U root -P <password> -H <ncn-node-name> chassis power status
    ```
 
-   If `ncn-m001` is the node to be brought down, note that it has the external network connection. Therefore it is important to establish that `ipmitool` commands are able to be run from a node external to the system, in order to get the power status of `ncn-m001`.
+   If `ncn-m001` is the node to be brought down, then note that it has the external network connection. Therefore it is important to establish that `ipmitool` commands are able to be run from a node external to the system, in
+   order to get the power status of `ncn-m001`.
 
-* If `ncn-m001` is the node to take down, establish Customer Access Network (CAN) links to bypass `ncn-m001` (because it will be down) in order to enable an external connection to one of the other master NCNs before, during, and after `ncn-m001` is brought down.
+* If `ncn-m001` is the node to be brought down, then establish Customer Access Network (CAN) links to bypass `ncn-m001` (because it will be down) in order to enable an external connection to one of the other master NCNs before,
+  during, and after `ncn-m001` is brought down.
 
-* Verify Boot Orchestration Service (BOS) templates and create a new one(s) if needed (to be set-up for booting a specific compute node(s) after the targeted NCN has been shutdown).
+* Verify Boot Orchestration Service (BOS) templates and create a new one if needed (to be set-up for booting a specific compute nodes after the targeted NCN has been shutdown).
 
-   Ahead of shutting down the NCN and beginning resiliency testing, verify that compute nodes identified for reboot validation can be successfully rebooted and configured.
+   Before shutting down the NCN and beginning resiliency testing, verify that compute nodes identified for reboot validation can be successfully rebooted and configured.
 
-   To see a list of BOS templates that exist on the system:
+   (`ncn-mw#`) To see a list of BOS templates that exist on the system:
 
    ```bash
    cray bos v1 sessiontemplate list
@@ -79,31 +78,42 @@ It is assumed that some procedures are already known by admins and thus does not
 
 * If a UAN is present on the system, log onto it and verify that the workload manager (WLM) is configured by running a command.
 
-   The following is an example for Slurm:
+   (`uan#`) The following is an example for Slurm:
 
    ```bash
    srun -N 4 hostname | sort
    ```
 
-### Establish System Health Before Beginning
+## Establish system health before beginning
 
 In order to ensure that the system is healthy before taking an NCN node down, run the `Platform Health Checks` section of [Validate CSM Health](../validate_csm_health.md).
 
-If health issues are noted, it is best to address those before proceeding with the resiliency testing procedure. If it is believed (in the case of an internal Cray-HPE testing environment) that the issue is known/understood and will not impact the testing to be performed, then those health issues just need to be noted (so that it does not appear that they were caused by inducing the fault, in this case, powering off the NCN). There is an optional section of the platform health validation that deals with using the System Management monitoring tools to survey system health. If that optional validation is included, please note that the prometheus alert manager may show various alerts that would not prevent or block moving forward with this testing. For more information about Prometheus alerts (and some that can be safely ignored), reference [Troubleshooting Prometheus Alerts](../system_management_health/Troubleshoot_Prometheus_Alerts.md).
+If health issues are noted, it is best to address those before proceeding with the resiliency testing procedure. If it is believed (in the case of an internal Cray-HPE testing environment) that the issue is known/understood
+and will not impact the testing to be performed, then those health issues just need to be noted (so that it does not appear that they were caused by inducing the fault, in this case, powering off the NCN). There is an optional
+section of the platform health validation that deals with using the System Management monitoring tools to survey system health. If that optional validation is included, note that the Prometheus alert manager may show
+various alerts that would not prevent or block moving forward with this testing. For more information about Prometheus alerts (and some that can be safely ignored), see
+[Troubleshooting Prometheus Alerts](../system_management_health/Troubleshoot_Prometheus_Alerts.md).
 
-Part of the data being returned via execution of the `Platform Health Checks` includes patronictl info for each Postgres cluster. Each of the Postgres clusters has a leader pod, and in the case of a resiliency test that involves bringing an NCN worker node down, it may be useful to take note of the Postgres clusters that have their leader pods running on the NCN worker targeted for shutdown. The postgres-operator should handle re-establishment of a leader on another pod running in the cluster, but it is worth taking note of where leader re-elections are expected to occur so special attention can be given to those Postgres clusters. The Postgres health check is included in [Validate CSM Health](../validate_csm_health.md), but the script for dumping Postgres data can be run at any time:
+Part of the data being returned via execution of the `Platform Health Checks` includes `patronictl` information for each Postgres cluster. Each of the Postgres clusters has a leader pod, and in the case of a resiliency test
+that involves bringing an NCN worker node down, it may be useful to take note of the Postgres clusters that have their leader pods running on the NCN worker targeted for shutdown. The `postgres-operator` should handle
+re-establishment of a leader on another pod running in the cluster, but it is worth taking note of where leader re-elections are expected to occur so special attention can be given to those Postgres clusters.
 
-   ```bash
-   /opt/cray/platform-utils/ncnPostgresHealthChecks.sh
-   ```
+(`ncn-mw#`) The Postgres health check is included in [Validate CSM Health](../validate_csm_health.md), but the script for dumping Postgres data can be run at any time:
 
-### Monitor for Changes
+```bash
+/opt/cray/platform-utils/ncnPostgresHealthChecks.sh
+```
 
-In order to keep watch on various items during and after the fault has been introduced (in this case, the shutdown of a single NCN node), the steps listed below can help give insight into changing health conditions. It is an eventual goal to strive for a monitoring dashboard which would help track these sort of things in a single or few automated views. Until that can be incorporated, these kinds of command prompt sessions can be useful.
+## Monitor for changes
 
-1. Set up a `watch` command to repeatedly run with the Cray CLI (that will hit the service API) to ensure that critical services can ride through a fault. Note that there is not more than a window of 5-10 minutes where a service would, intermittently, fail to respond.
+In order to keep watch on various items during and after the fault has been introduced (in this case, the shutdown of a single NCN), the steps listed below can help give insight into changing health conditions.
 
-   In the examples below, the CLI commands are checking the `bos` and `cps` APIs. It may be desired to choose additional Cray CLI commands to run in this manner. The ultimate proof of system resiliency lies in the ability to perform system level use cases and to, further, prove that can be done at scale. If there are errors being returned, consistently (and without recovery), with respect to these commands, it is likely that business critical use cases (that utilize the same APIs) will also fail.
+1. (`ncn-mw#`) Set up a `watch` command to repeatedly run with the Cray CLI (that will hit the service API) to ensure that critical services can ride through a fault. Note that there is not more than a window of 5-10 minutes where a
+   service would intermittently fail to respond.
+
+   In the examples below, the CLI commands are checking the BOS and CPS APIs. It may be desired to choose additional Cray CLI commands to run in this manner. The ultimate proof of system resiliency lies in the ability to
+   perform system level use cases and to, further, prove that can be done at scale. If there are errors being returned consistently (and without recovery) with respect to these commands, then it is likely that business critical
+   use cases (that utilize the same APIs) will also fail.
 
    It may be useful to reference instructions for [Configuring the Cray CLI](../configure_cray_cli.md).
 
@@ -121,11 +131,16 @@ In order to keep watch on various items during and after the fault has been intr
    watch -n 5 "date; ceph -s"
    ```
 
-1. Identify when pods on a downed master or worker NCN are no longer responding.
+1. (`ncn-mw#`) Identify when pods on a downed master or worker NCN are no longer responding.
 
-   This takes around 5-6 minutes, and Kubernetes will begin terminating pods so that new pods to replace them can start-up on another NCN. Pods that had been running on the downed NCN will remain in `Terminated` state until the NCN is back up. Pods that need to start-up on other nodes will be `Pending` until they start-up. Some pods that have anti-affinity configurations or that run as daemonsets will not be able to start up on another NCN. Those pods will remain in Pending state until the NCN is back up.
+   This takes around 5-6 minutes, and Kubernetes will begin terminating pods so that new pods to replace them can start-up on another NCN. Pods that had been running on the downed NCN will remain in `Terminated` state until
+   the NCN is back up. Pods that need to start-up on other nodes will be `Pending` until they start-up. Some pods that have anti-affinity configurations or that run as `daemonsets` will not be able to start up on another NCN.
+   Those pods will remain in Pending state until the NCN is back up.
 
-   Finally, it is helpful to have a window tracking the list of pods that are not in `Completed` or `Running` state to be able to determine how that list is changing once the NCN is downed and pods begin shifting around. This step offers a view of what is going on at the time that the NCN is brought down and once Kubernetes detects an issue and begins remediation. It is not so important to capture everything that is happening during this step. It may be helpful for debugging. The output of these windows/commands becomes more interesting once the NCN is down for a period of time and then it is brought back up. At that point, the expectation is that everything can recover.
+   Finally, it is helpful to have a window tracking the list of pods that are not in `Completed` or `Running` state to be able to determine how that list is changing once the NCN is downed and pods begin shifting around. This
+   step offers a view of what is going on at the time that the NCN is brought down and once Kubernetes detects an issue and begins remediation. It is not so important to capture everything that is happening during this step. It
+   may be helpful for debugging. The output of these windows/commands becomes more interesting once the NCN is down for a period of time and then it is brought back up. At that point, the expectation is that everything can
+   recover.
 
    Run the following commands in separate windows:
 
@@ -141,7 +156,7 @@ In order to keep watch on various items during and after the fault has been intr
    watch -n 5 "date; kubectl get pods -o wide -A | grep -v Completed | grep -v Running"
    ```
 
-1. Detect the change in state of the various Postgres instances running.
+1. (`ncn-mw#`) Detect the change in state of the various Postgres instances running.
 
    Run the following in a separate window:
 
@@ -151,15 +166,18 @@ In order to keep watch on various items during and after the fault has been intr
 
    If Postgres reports a status that deviates from `Running`, that would require further investigation and possibly remediation via [Troubleshooting the Postgres Database](../kubernetes/Troubleshoot_Postgres_Database.md).
 
-### Launch a Non-Interactive Batch Job
+## Launch a non-interactive batch job
 
-The purpose of this procedure is to launch a non-interactive, long-running batch job across computes via a UAI (or the UAN, if present) in order to ensure that even though the UAI pod used to launch the job is running on the NCN worker node being taken down, it will start up on another NCN worker (once Kubernetes begins terminating pods).
+The purpose of this procedure is to launch a non-interactive, long-running batch job across computes via a UAI (or the UAN, if present) in order to ensure that even though the UAI pod used to launch the job is running on the
+worker NCN being taken down, it will start up on another worker NCN (once Kubernetes begins terminating pods).
 
-Additionally, it is important to verify that the batch job continued to run, uninterrupted through that process. If the target NCN for shutdown is not a worker node (where a UAI would be running), then there is no need to pay attention to the steps, below, that discuss ensuring the UAI can only be created on the NCN worker node that is targeted for shutdown. If executing a shut down of a master or storage NCN, the procedure can begin at creating a UAI. It is still good to ensure that non-interactive batch jobs are uninterrupted, even with the UAI they are launched from is not being disrupted.
+Additionally, it is important to verify that the batch job continued to run, uninterrupted through that process. If the target NCN for shutdown is not a worker node (where a UAI would be running), then there is no need to pay
+attention to the steps, below, that discuss ensuring the UAI can only be created on the NCN worker node that is targeted for shutdown. If executing a shut down of a master or storage NCN, the procedure can begin at creating a
+UAI. It is still good to ensure that non-interactive batch jobs are uninterrupted, even with the UAI they are launched from is not being disrupted.
 
-#### Launch on a UAI
+### Launch on a UAI
 
-1. Create a UAI.
+1. (`ncn-mw#`) Create a UAI.
 
    To create a UAI, see the `Validate UAI Creation` section of [Validate CSM Health](../validate_csm_health.md) and/or [Create a UAI](../UAS_user_and_admin_topics/Create_a_UAI.md).
 
@@ -184,7 +202,7 @@ Additionally, it is important to verify that the batch job continued to run, uni
 
       Example output:
 
-      ```
+      ```text
       NAME       STATUS   ROLES    AGE     VERSION
       ncn-w001   Ready    <none>   4d19h   v1.18.2
       ncn-w003   Ready    <none>   4d19h   v1.18.2
@@ -201,15 +219,15 @@ Additionally, it is important to verify that the batch job continued to run, uni
 
 1. Verify that WLM is configured with the appropriate workload manager within the created UAI.
 
-   1. Verify the connection string of the created UAI.
+   1. (`ncn-mw#`) Verify the connection string of the created UAI.
 
       ```bash
-      cray uas list
+      cray uas list --format toml
       ```
 
       Example output:
 
-      ```
+      ```toml
       [[results]]
       uai_age = "2m"
       uai_connect_string = "ssh vers@10.103.8.170"
@@ -222,7 +240,7 @@ Additionally, it is important to verify that the batch job continued to run, uni
       username = "vers"
       ```
 
-   1. Log in to the created UAI.
+   1. (`ncn-mw#`) Log in to the created UAI.
 
       For example:
 
@@ -230,15 +248,15 @@ Additionally, it is important to verify that the batch job continued to run, uni
       ssh vers@10.103.8.170
       ```
 
-   1. Verify the configuration of Slurm, for example, within the UAI:
+   1. (`uai#`) Verify the configuration of Slurm, for example, within the UAI:
 
       ```bash
-      vers@uai-vers-f8fa541f-5c5c9f5b75-vsb2k:/lus> srun -N 4 hostname | sort
+      srun -N 4 hostname | sort
       ```
 
       Example output:
 
-      ```
+      ```text
       nid000001
       nid000002
       nid000003
@@ -249,17 +267,19 @@ Additionally, it is important to verify that the batch job continued to run, uni
 
 1. Compile an MPI application with the UAI. Launch application as batch job (not interactive) on compute node(s) that have not been designated, already, for reboots once an NCN is shut down.
 
-   1. Verify that batch job is running and that application output is streaming to a file. Streaming output will be used to verify that the batch job is still running during resiliency testing. A batch job, when submitted, will designate a log file location. This log file can be accessed to be able to verify that the batch job is continuing to run after an NCN is brought down and once it is back online. Additionally, the `squeue` command can be used to verify that the job continues to run (for Slurm).
+   1. Verify that batch job is running and that application output is streaming to a file. Streaming output will be used to verify that the batch job is still running during resiliency testing. A batch job, when submitted, will
+      designate a log file location. This log file can be accessed to be able to verify that the batch job is continuing to run after an NCN is brought down and once it is back online. Additionally, the `squeue` command can be
+      used to verify that the job continues to run (for Slurm).
 
-   1. Delete the UAI session when all of the testing is complete.
+   1. (`ncn-mw#`) Delete the UAI session when all of the testing is complete.
 
       ```bash
       cray uas delete --uai-list uai-vers-f8fa541f
       ```
 
-#### Launch on a UAN
+### Launch on a UAN
 
-1. Login to the UAN and verify that a WLM has been properly configured.
+1. (`uan#`) Log in to the UAN and verify that a WLM has been properly configured.
 
    In this example, Slurm will be used.
 
@@ -269,7 +289,7 @@ Additionally, it is important to verify that the batch job continued to run, uni
 
    Example output:
 
-   ```
+   ```text
    nid000001
    nid000002
    nid000003
@@ -278,11 +298,14 @@ Additionally, it is important to verify that the batch job continued to run, uni
 
 1. Copy an MPI application source and WLM batch job files to UAN.
 
-1. Compile an MPI application within the UAN. Launch the application as interactive on compute node(s)that have not been designated, already, for either reboots (once an NCN is shut down) or that are not already running an MPI job via a UAI.
+1. Compile an MPI application within the UAN. Launch the application as interactive on compute node(s)that have not been designated, already, for either reboots (once an NCN is shut down) or that are not already running an MPI
+   job via a UAI.
 
-1. Verify that the job launched on the UAN is running and that application output is streaming to a file. Streaming output will be used to verify that the batch job is still running during resiliency testing. A batch job, when submitted, will designate a log file location. This log file can be accessed to be able to verify that the batch job is continuing to run after an NCN is brought down and once it is back online. Additionally, the `squeue` command can be used to verify that the job continues to run (for Slurm).
+1. Verify that the job launched on the UAN is running and that application output is streaming to a file. Streaming output will be used to verify that the batch job is still running during resiliency testing. A batch job, when
+   submitted, will designate a log file location. This log file can be accessed to be able to verify that the batch job is continuing to run after an NCN is brought down and once it is back online. Additionally, the `squeue`
+   command can be used to verify that the job continues to run (for Slurm).
 
-### Shut Down an NCN
+## Shut down an NCN
 
 1. Establish a console session to the NCN targeted for shutdown by executing the steps in [Establish a Serial Connection to NCNs](../conman/Establish_a_Serial_Connection_to_NCNs.md).
 
@@ -290,72 +313,88 @@ Additionally, it is important to verify that the batch job continued to run, uni
 
    1. Take note of the timestamp of the power off in the target node's console output.
 
-   1. Once the target node is reported as being powered off, verify that the node's power status with the `ipmitool` is reported as off.
+   1. (`linux#`) Once the target node is reported as being powered off, verify that the node's power status with the `ipmitool` is reported as off.
 
       ```bash
       ipmitool -I lanplus -U root -P <password> -H <ncn-node-name> chassis power status
       ```
 
-      **`NOTE`** In previous releases, an `ipmitool` command has been used to simply yank the power to an NCN. There have been times where this resulted in a longer recovery procedure under Shasta 1.5 (mostly due to issues with getting nodes physically booted up again), so the preference has been to simply use the `shutdown` command.
+      **`NOTE`** In previous releases, an `ipmitool` command has been used to simply yank the power to an NCN. There have been times where this resulted in a longer recovery procedure under Shasta 1.5 (mostly due to issues with
+      getting nodes physically booted up again), so the preference has been to simply use the `shutdown` command.
 
-      If the NCN shutdown is a master or worker node, within 5-6 minutes of the node being shut down, Kubernetes will begin reporting `Terminating` pods on the target node and start rescheduling pods to other NCN nodes. New pending pods will be created for pods that can not be relocated off of the NCN shut down. Pods reported as `Terminating` will remain in that state until the NCN has been powered back up.
+      If the NCN shutdown is a master or worker node, within 5-6 minutes of the node being shut down, Kubernetes will begin reporting `Terminating` pods on the target node and start rescheduling pods to other NCN nodes. New
+      pending pods will be created for pods that can not be relocated off of the NCN shut down. Pods reported as `Terminating` will remain in that state until the NCN has been powered back up.
 
 1. Take note of changes in the data being reported out of the many monitoring windows that were set-up in a previous step.
 
-### Conduct Testing
+## Conduct testing
 
-After the target NCN was shut down, assuming the command line windows that were set-up for ensuring API responsiveness are not encountering persistent failures, the next step will be to use a BOS template to boot a pre-designated set of compute nodes. The timing of this test is recommended to be around 10 minutes after the NCN has gone down. That should give ample time for Kubernetes to have terminated pods on the downed node (in the case of a master or worker NCN) and for them to have been rescheduled and in a healthy state on another NCN. Going too much earlier than 10 minutes runs the risk that there are still some critical pods that are settling out to reach a healthy state.
+After the target NCN was shut down, assuming the command line windows that were set up for ensuring API responsiveness are not encountering persistent failures, the next step will be to use a BOS template to boot a
+pre-designated set of compute nodes. The timing of this test is recommended to be around 10 minutes after the NCN has gone down. That should give ample time for Kubernetes to have terminated pods on the downed node (in the case
+of a master or worker NCN) and for them to have been rescheduled and in a healthy state on another NCN. Going too much earlier than 10 minutes runs the risk that there are still some critical pods that are settling out to reach
+a healthy state.
 
-1. Reboot a pre-designated set of compute node(s) and watch the reboot.
+1. (`ncn-mw#`) Reboot a pre-designated set of compute nodes and watch the reboot.
 
-   1. Use BOS to reboot the designated compute node(s).
+   1. Use BOS to reboot the designated compute nodes.
 
       ```bash
       cray bos v1 session create --template-uuid boot-nids-1-4 --operation reboot
       ```
 
-      Issuing this reboot command will spit out a Boot Orchestration Agent (BOA) "jobId", which can be used to find the new BOA pod that has been created for the boot. Then, the logs can be tailed to watch the compute boot proceed.
+      Issuing this reboot command will output a Boot Orchestration Agent (BOA) `jobId`, which can be used to find the new BOA pod that has been created for the boot. Then, the logs can be tailed to watch the compute boot proceed.
 
-   1. Find the BOA job name using the returned BOA "jobID".
+   1. Find the BOA job name using the returned BOA `jobID`.
 
-      ```
+      ```bash
       kubectl get pods -o wide -A | grep <boa-job-id>
       ```
 
-   1. Watch the progress of the reboot of the compute(s).
+   1. Watch the progress of the reboot of the compute nodes.
 
-      ```
+      ```bash
       kubectl logs -n services <boa-job-pod-name> -c boa -f
       ```
 
-      Failures or a timeout being reached in either the boot or CFS (post-boot configuration) phase will need investigation. For more information around accessing logs for the BOS operations, see [Check the Progress of BOS Session Operations](../boot_orchestration/Check_the_Progress_of_BOS_Session_Operations.md).
+      Failures or a timeout being reached in either the boot or CFS (post-boot configuration) phase will need investigation. For more information around accessing logs for the BOS operations, see
+      [Check the Progress of BOS Session Operations](../boot_orchestration/Check_the_Progress_of_BOS_Session_Operations.md).
 
 1. If the target node for shutdown was a worker NCN, verify that the UAI launched on that node still exists. It should be running on another worker NCN.
 
-   * Any prior SSH session established with the UAI while it was running on the downed NCN worker node will be unresponsive. A new SSH session will need to be established once the UAI pods has been successfully relocated to another worker NCN.
-   * Log back into the UAI and verify that the WLM batch job is still running and streaming output. The log file created with the kick-off of the batch job should still be accessible and the `squeue` command can be used to verify that the job continues to run (for Slurm).
+   * Any prior SSH session established with the UAI while it was running on the downed NCN worker node will be unresponsive. A new SSH session will need to be established once the UAI pods has been successfully relocated to
+     another worker NCN.
+   * Log back into the UAI and verify that the WLM batch job is still running and streaming output. The log file created with the kick-off of the batch job should still be accessible and the `squeue` command can be used to
+     verify that the job continues to run (for Slurm).
 
-1. If the WLM batch job was launched on a UAN, log back into it and verify that the batch job is still running and streaming output via the log file created with the batch job and/or the `squeue` command (if Slurm is used as the WLM).
+1. If the WLM batch job was launched on a UAN, log back into it and verify that the batch job is still running and streaming output via the log file created with the batch job and/or the `squeue` command (if Slurm is used as
+   the WLM).
 
 1. Verify that new WLM jobs can be started on a compute node after the NCN is down (either via a UAI or the UAN node).
 
-1. Look at any pods that, are at this point, in a state other than `Running`, `Completed`, `Pending`, or `Terminating`:
+1. (`ncn-mw#`) Look for any pods that are in a state other than `Running`, `Completed`, `Pending`, or `Terminating`:
 
    ```bash
    kubectl get pods -o wide -A | grep -Ev "Running|Completed|Pending|Termin"
    ```
 
-   Compare what comes up in this list to the pod list that was collected before. If there are new pods that are in status `ImagePullBackOff` or `CrashLoopBackOff`, a `kubectl describe` as well as `kubectl logs` command should be run against them to collect additional data about what happened. Obviously, if there were pods in a bad state before the procedure started, then it should not be expected that bringing one of the NCNs down is going to fix that.
+   Compare what comes up in this list to the pod list that was collected before. If there are new pods that are in status `ImagePullBackOff` or `CrashLoopBackOff`, a `kubectl describe` as well as `kubectl logs` command should
+   be run against them to collect additional data about what happened. Obviously, if there were pods in a bad state before the procedure started, then it should not be expected that bringing one of the NCNs down is going to fix
+   that.
 
-   Ignore anything that was already in a bad state before (that was deemed to be ok). It is also worth taking note of any pods in a bad state at this stage as this should be checked again after bringing the NCN back up - to see if those pods remain in a bad state or if they are cleared. Noting behaviors, collecting logs, and opening tickets throughout this process is recommended when behavior occurs that is not expected. When we see an issue that has not been encountered before, it may not be immediately clear if code changes/regressions are at fault or if it is simply an intermittent/timing kind of issue that has not previously surfaced. The recommendation at that point, given time/resources is to repeat the test to gain a sense of the repeatability of the behavior (in the case that the issue is not directly tied to a code-change).
+   Ignore anything that was already in a bad state before (that was deemed to be okay). It is also worth taking note of any pods in a bad state at this stage as this should be checked again after bringing the NCN back up - to
+   see if those pods remain in a bad state or if they are cleared. Noting behaviors, collecting logs, and opening tickets throughout this process is recommended when behavior occurs that is not expected. When we see an issue
+   that has not been encountered before, it may not be immediately clear if code changes/regressions are at fault or if it is simply an intermittent/timing kind of issue that has not previously surfaced. The recommendation at
+   that point, given time/resources is to repeat the test to gain a sense of the repeatability of the behavior (in the case that the issue is not directly tied to a code change).
 
-   Additionally, it is as important to understand (and document) any work-around procedures needed to fix issues encountered. In addition to filing a bug for a permanent fix, work-around documentation can be very useful when written up - for both internal and external customers to access.
+   Additionally, it is as important to understand (and document) any work-around procedures needed to fix issues encountered. In addition to filing a bug for a permanent fix, workaround documentation can be very useful when
+   written up - for both internal and external customers to access.
 
-### Power on the Downed NCN
+## Power on the downed NCN
 
-1. Use the `ipmitool` command to power up the NCN.
+1. (`linux#`) Use the `ipmitool` command to power up the NCN.
 
-   It will take several minutes for the NCN to reboot. Progress can be monitored over the connected serial console session. Wait to begin execution of the next steps until after it can be determined that the NCN has booted up and is back at the login prompt (when viewing the serial console log).
+   It will take several minutes for the NCN to reboot. Progress can be monitored over the connected serial console session. Wait to begin execution of the next steps until after it can be determined that the NCN has booted
+   up and is back at the login prompt (when viewing the serial console log).
 
    ```bash
    ipmitool -I lanplus -U root -P <password> -H <hostname> chassis power on   #example hostname is ncn-w003-mgmt
@@ -364,17 +403,20 @@ After the target NCN was shut down, assuming the command line windows that were 
    Check the following depending on the NCN type powered on:
 
    * If the NCN being powered on is a master or worker, verify that `Terminating` pods on that NCN clear up. It may take several minutes. Watch the command prompt, previously set-up, that is displaying the `Terminating` pod list.
-   * If the NCN being powered on is a storage node, wait for Ceph to recover and again report a "HEALTH_OK" status. It may take several minutes for Ceph to resolve clock skew. This can be noted in the previously set-up window to watch Ceph status.
+   * If the NCN being powered on is a storage node, wait for Ceph to recover and again report a `HEALTH_OK` status. It may take several minutes for Ceph to resolve clock skew. This can be noted in the previously set-up window
+     to watch Ceph status.
 
-1. Check that pod statuses have returned to the state that they were in at the beginning of this procedure, paying particular attention to any pods that were previously noted to be in a bad state while the NCN was down. Additionally, there is no concern if pods that were in a bad state at the beginning of the procedure, are still in a bad state. What is important to note is anything that is different from either the beginning of the test or from the time that the NCN was down.
+1. Check that pod statuses have returned to the state that they were in at the beginning of this procedure, paying particular attention to any pods that were previously noted to be in a bad state while the NCN was down.
+   Additionally, there is no concern if pods that were in a bad state at the beginning of the procedure, are still in a bad state. What is important to note is anything that is different from either the beginning of the test or
+   from the time that the NCN was down.
 
-### Execute Post-Boot Health Checks
+## Execute post-boot health checks
 
-1. Re-run the `Platform Health Checks` section of [Validate CSM Health](../validate_csm_health.md) noting any output that indicates output is not as expected. Note that in a future version of CSM, these checks will be further automated for better efficiency and pass/fail clarity.
+1. Re-run the `Platform Health Checks` section of [Validate CSM Health](../validate_csm_health.md) noting any output that indicates output is not as expected.
 
-1. Ensure that after a downed NCN worker node (can ignore if not a worker node) has been powered up, a new UAI can be created on that NCN. It may be necessary to label the nodes again, to ensure the UAI gets created on the worker node that was just powered on. Refer to the section above for `Launch a Non-Interactive Batch Job` for the procedure.
+1. Ensure that after a downed NCN worker node (can ignore if not a worker node) has been powered up, a new UAI can be created on that NCN. It may be necessary to label the nodes again, to ensure the UAI gets created on the
+   worker node that was just powered on. Refer to the section above for `Launch a Non-Interactive Batch Job` for the procedure.
 
    > **IMPORTANT:** Do not forget to remove the labels after the UAI has been created. Once the UAI has been created, log into it and ensure a new workload manager job can be launched.
 
 1. Ensure tickets have been opened for any unexpected behavior along with associated logs and notes on workarounds, if any were executed.
-

--- a/operations/resiliency/Resiliency_Testing_Procedure.md
+++ b/operations/resiliency/Resiliency_Testing_Procedure.md
@@ -72,7 +72,7 @@ It is assumed that some procedures are already known by admins and thus does not
    To see a list of BOS templates that exist on the system:
 
    ```bash
-   cray bos sessiontemplate list
+   cray bos v1 sessiontemplate list
    ```
 
    For more information regarding management of BOS session templates, refer to [Manage a Session Template](../boot_orchestration/Manage_a_Session_Template.md).
@@ -112,7 +112,7 @@ In order to keep watch on various items during and after the fault has been intr
    ```
 
    ```bash
-   watch -n 5 "date; cray bos session list"
+   watch -n 5 "date; cray bos v1 session list"
    ```
 
 1. Monitor Ceph health, in a window, during and after a single NCN is taken down.
@@ -311,7 +311,7 @@ After the target NCN was shut down, assuming the command line windows that were 
    1. Use BOS to reboot the designated compute node(s).
 
       ```bash
-      cray bos session create --template-uuid boot-nids-1-4 --operation reboot
+      cray bos v1 session create --template-uuid boot-nids-1-4 --operation reboot
       ```
 
       Issuing this reboot command will spit out a Boot Orchestration Agent (BOA) "jobId", which can be used to find the new BOA pod that has been created for the boot. Then, the logs can be tailed to watch the compute boot proceed.

--- a/operations/security_and_authentication/Add_LDAP_User_Federation.md
+++ b/operations/security_and_authentication/Add_LDAP_User_Federation.md
@@ -709,7 +709,7 @@ LDAP user federation is not currently configured in Keycloak. For example, if it
    1. Reboot with the Boot Orchestration Service (BOS).
 
       ```bash
-      cray bos session create --template-uuid BOS_TEMPLATE --operation reboot
+      cray bos v1 session create --template-uuid BOS_TEMPLATE --operation reboot
       ```
 
 1. Validate that LDAP integration was added successfully.

--- a/operations/security_and_authentication/Resync_Keycloak_Users_to_Compute_Nodes.md
+++ b/operations/security_and_authentication/Resync_Keycloak_Users_to_Compute_Nodes.md
@@ -70,5 +70,5 @@ The Slurm or PBS product must be installed.
     Or, reboot the compute nodes with the Boot Orchestration Service \(BOS\).
 
     ```bash
-    cray bos session create --template-uuid BOS_TEMPLATE --operation reboot
+    cray bos v1 session create --template-uuid BOS_TEMPLATE --operation reboot
     ```

--- a/troubleshooting/cms_barebones_image_boot.md
+++ b/troubleshooting/cms_barebones_image_boot.md
@@ -227,7 +227,7 @@ As noted below, make sure the S3 path for the manifest matches the S3 path shown
 1. Create the BOS session template using the following file as input:
 
    ```bash
-   cray bos sessiontemplate create --file sessiontemplate.json --name shasta-csm-bare-bones-image
+   cray bos v1 sessiontemplate create --file sessiontemplate.json --name shasta-csm-bare-bones-image
    ```
 
    The expected output is:
@@ -289,7 +289,7 @@ As noted below, make sure the S3 path for the manifest matches the S3 path shown
 (`ncn-mw#`) Create a BOS session to reboot the chosen node using the BOS session template that was just created.
 
 ```bash
-cray bos session create --template-uuid shasta-csm-bare-bones-image --operation reboot --limit "${XNAME}" --format toml
+cray bos v1 session create --template-uuid shasta-csm-bare-bones-image --operation reboot --limit "${XNAME}" --format toml
 ```
 
 Expected output looks similar to the following:


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
- Update the deprecations page to specify the removal of BOSv1 in CSM 1.6.
- Since the CLI default is changed to BOS v2 in CSM 1.4, update all of the commands in the docs that were relying on v1 as the default, instead having them explicitly specify the version.
- Linting unrelated to this PR to fix pre-existing problems on the pages being edited.

Backports:
- [1.4](https://github.com/Cray-HPE/docs-csm/pull/3747)
- [1.3](https://github.com/Cray-HPE/docs-csm/pull/3748)
- [1.2](https://github.com/Cray-HPE/docs-csm/pull/3749) -- just the linting part
- [1.0](https://github.com/Cray-HPE/docs-csm/pull/3750) -- just the linting part

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
