### PR TITLE
CASMINST-6288 update cf-gitea-import version

### DIFF
--- a/workflows/iuf/operations/vcs-upload/vcs-upload-content.yaml
+++ b/workflows/iuf/operations/vcs-upload/vcs-upload-content.yaml
@@ -233,7 +233,7 @@ spec:
               path: /results/records.yaml
               default: "{}"
       container:
-        image: artifactory.algol60.net/csm-docker/stable/cf-gitea-import:1.9.1
+        image: artifactory.algol60.net/csm-docker/stable/cf-gitea-import:1.9.4
         command:
           - "/bin/sh"
         args: ["-c", "/opt/csm/cf-gitea-import/argo_entrypoint.sh"]


### PR DESCRIPTION
# Description

Update the IUF operation to use the version of `cf-gitea-import` (1.9.4) that is [specified in the CSM manifest for release/1.4](https://github.com/Cray-HPE/csm/blob/release/1.4/docker/index.yaml#L57-L58)

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
