### PR TITLE
CASMINST-6317 delete of temp json res files should be a best effort a…

### DIFF
--- a/upgrade/scripts/common/upgrade-state.sh
+++ b/upgrade/scripts/common/upgrade-state.sh
@@ -158,7 +158,7 @@ function argo_err_report() {
     echo "${cmd}"
 
     # in case we have left over temp files
-    rm -f /tmp/argo-res.* > /dev/null 2>&1 
+    rm -f /tmp/argo-res.* > /dev/null 2>&1 || true
 
     echo
     echo "[ERROR] - Unexpected errors"

--- a/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh
+++ b/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh
@@ -252,11 +252,11 @@ function getUnsucceededRebuildWorkflows() {
     if [[ ${http_code} -ne 200 ]]; then
         echo "Request Failed, Response code: ${http_code}"
         cat "${res_file}"
-        rm -f "${res_file}" > /dev/null 2>&1 
+        rm -f "${res_file}" > /dev/null 2>&1 || true
         exit 1
     fi
     jq -r ".[]? | .name?" < "${res_file}"
-    rm -f "${res_file}" > /dev/null 2>&1 
+    rm -f "${res_file}" > /dev/null 2>&1 || true
 }
 
 function createRebuildWorkflow() {
@@ -265,13 +265,13 @@ function createRebuildWorkflow() {
     if [[ ${http_code} -ne 200 ]]; then
         echo "Request Failed, Response code: ${http_code}"
         cat "${res_file}"
-        rm -f "${res_file}" > /dev/null 2>&1 
+        rm -f "${res_file}" > /dev/null 2>&1 || true
         exit 1
     fi
     local workflow
     workflow=$(grep -o 'ncn-lifecycle-rebuild-[a-z0-9]*' < "${res_file}" )
     echo "${workflow}"
-    rm -f "${res_file}" > /dev/null 2>&1 
+    rm -f "${res_file}" > /dev/null 2>&1  || true
 }
 
 function deleteRebuildWorkflow() {
@@ -280,10 +280,10 @@ function deleteRebuildWorkflow() {
     if [[ ${http_code} -ne 200 ]]; then
         echo "Request Failed, Response code: ${http_code}"
         cat "${res_file}"
-        rm -f "${res_file}" > /dev/null 2>&1 
+        rm -f "${res_file}" > /dev/null 2>&1 || true 
         exit 1
     fi
-    rm -f "${res_file}" > /dev/null 2>&1 
+    rm -f "${res_file}" > /dev/null 2>&1 || true 
 }
 
 function retryRebuildWorkflow() {
@@ -293,7 +293,7 @@ function retryRebuildWorkflow() {
         echo "Request Failed, Response code: ${http_code}"
         cat "${res_file}"
     fi
-    rm -f "${res_file}" > /dev/null 2>&1 
+    rm -f "${res_file}" > /dev/null 2>&1 || true 
 }
 
 printCmdArgs
@@ -380,5 +380,5 @@ while true; do
         echo "INFO - ${runningSteps}"  | awk -F'.' '{print $2" -  "$3}'
         sleep 10
     fi
-    rm -f "${res_file}" > /dev/null 2>&1 
+    rm -f "${res_file}" > /dev/null 2>&1 || true
 done

--- a/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh
+++ b/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh
@@ -365,11 +365,13 @@ while true; do
         if [[ "${phase}" == "Failed" ]]; then
             echo "WARNING - Workflow in Failed state, Retry ..."
             retryRebuildWorkflow "$workflow"
+            continue
         fi
 
         if [[ "${phase}" == "Error" ]]; then
             echo "WARNING - Workflow in Error state, Retry ..."
             retryRebuildWorkflow "$workflow"
+            continue
         fi
         runningSteps=$(jq -jr ".[] | select(.name==\"${workflow}\") | .status.nodes[] | select(.type==\"Retry\")| select(.phase==\"Running\")  | .name + \"\n  \" " < "${res_file}")
         succeededSteps=$(jq -jr ".[] | select(.name==\"${workflow}\") | .status.nodes[] | select(.type==\"Retry\")| select(.phase==\"Succeeded\")  | .name +\"\n  \" " < "${res_file}")


### PR DESCRIPTION
…ction that doesn't fail the script

<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
