### PR TITLE
CASMCMS-8608: Update link in CRUS CLI known issue to use API spec inside this repo

### DIFF
--- a/troubleshooting/known_issues/CRUS_Subcommands_Missing_From_Cray_CLI.md
+++ b/troubleshooting/known_issues/CRUS_Subcommands_Missing_From_Cray_CLI.md
@@ -56,8 +56,9 @@ ERROR (run tag KPEqc-crus): CLI command failed (and does not look like a CLI con
 
 ## Workaround
 
-Until the update Cray CLI RPM is installed, the only workaround is to access CRUS directly using its API. For details on how to use the API,
-see its [Swagger specification](https://github.com/Cray-HPE/cray-crus/blob/v1.11.2/api/openapi.yaml).
+Until the update Cray CLI RPM is installed, the only workaround is to access CRUS directly using its API.
+For details on how to use the API, see
+[Compute Rolling Upgrade Service v1](../../api/crus.md).
 
 ## Fix
 

--- a/troubleshooting/known_issues/CRUS_Subcommands_Missing_From_Cray_CLI.md
+++ b/troubleshooting/known_issues/CRUS_Subcommands_Missing_From_Cray_CLI.md
@@ -58,7 +58,7 @@ ERROR (run tag KPEqc-crus): CLI command failed (and does not look like a CLI con
 
 Until the update Cray CLI RPM is installed, the only workaround is to access CRUS directly using its API.
 For details on how to use the API, see
-[Compute Rolling Upgrade Service v1](../../api/crus.md).
+[Compute Rolling Upgrade Service API](../../api/crus.md).
 
 ## Fix
 


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
Now that the API docs are being auto-generated and included in this repository, this PR updates the "CRUS CLI is missing" workaround doc to link to the CRUS API doc inside the docs-csm repository, rather than an external repository. That way on the off chance that the 1.4 CRUS API spec does end up changing, we won't have to update the link, because the auto-generation will take care of it for us.

No backports are needed. This is specific to 1.4 only.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
