### PR TITLE
CASMINST-6338: Add missing terms to glossary; add missing links to operations index

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -18,6 +18,7 @@ Glossary of terms used in CSM documentation.
 * [Content Projection Service (CPS)](#content-projection-service-cps)
 * [Cray Advanced Platform Monitoring and Control (CAPMC)](#cray-advanced-platform-monitoring-and-control-capmc)
 * [Cray CLI (`cray`)](#cray-cli-cray)
+* [Cray Security Token Service (STS)](#cray-security-token-service-sts)
 * [Cray Site Init (CSI)](#cray-site-init-csi)
 * [Cray System Management (CSM)](#cray-system-management-csm)
 * [Customer Access Network (CAN)](#customer-access-network-can)
@@ -25,6 +26,7 @@ Glossary of terms used in CSM documentation.
 * [EX Compute Cabinet](#ex-compute-cabinet)
 * [EX TDS Cabinet](#ex-tds-cabinet)
 * [Fabric](#fabric)
+* [Firmware Action Service (FAS)](#firmware-action-service-fas)
 * [Floor Standing CDU](#floor-standing-cdu)
 * [Hardware Management Network (HMN)](#hardware-management-network-hmn)
 * [Hardware Management Notification Fanout Daemon (HMNFD)](#hardware-management-notification-fanout-daemon-hmnfd)
@@ -58,6 +60,7 @@ Glossary of terms used in CSM documentation.
 * [Shasta Cabling Diagram (SHCD)](#shasta-cabling-diagram)
 * [Supply/Return Cutoff Valves](#supply-return-cutoff-valves)
 * [System Admin Toolkit (SAT)](#system-admin-toolkit)
+* [System Configuration Service (SCSD)](#system-configuration-service-scsd)
 * [System Layout Service (SLS)](#system-layout-service)
 * [System Management Network (SMNet)](#system-management-network)
 * [System Management Services (SMS)](#system-management-services-sms)
@@ -193,7 +196,7 @@ The Compute Rolling Upgrade Service (CRUS) upgrades sets of [compute nodes](#com
 set of nodes to be out of service at once. CRUS manages the workload management status of nodes, handling each of the steps
 required to upgrade compute nodes.
 
-See [Compute Rolling Upgrades](operations/index.md#compute-rolling-upgrades).
+For more information, see [Compute Rolling Upgrades](operations/index.md#compute-rolling-upgrades).
 
 **Note:** CRUS is deprecated in CSM 1.2.0 and it will be removed in CSM 1.5.0. It will be replaced with [BOS](#boot-orchestration-service-bos) V2,
 which will provide similar functionality. See [Deprecated features](introduction/differences.md#deprecated_features).
@@ -243,6 +246,10 @@ For more information, see [Cray Advanced Platform Monitoring and Control](operat
 
 The `cray` command line interface (CLI) is a framework created to integrate all of the system management
 REST APIs into easily usable commands.
+
+## Cray Security Token Service (STS)
+
+The Cray Security Token Service (STS) generates short-lived Ceph S3 credentials.
 
 <a name="cray-site-init"></a>
 
@@ -305,16 +312,6 @@ with the [Content Projection Service (CPS)](#content-projection-service-cps).
 This Liquid-Cooled [Olympus cabinet](#olympus-cabinet) is a dense compute cabinet that supports 64 compute blades and 64
 [High Speed Network (HSN)](#high-speed-network-hsn) switches.
 
-<a name="image-management-service"></a>
-
-## Image Management Service (IMS)
-
-The Image Management Service (IMS) uses the open source Kiwi-NG tool to build image roots from
-recipes. IMS also uses [CFS](#configuration-framework-service-cfs) to apply image customization for pre-boot
-configuration of the image root. These images are bootable on [compute nodes](#compute-node-cn) and [application nodes](#application-node-an).
-
-For more information, see [Image Management](operations/image_management/Image_Management.md).
-
 ## EX TDS Cabinet
 
 A Liquid-Cooled TDS cabinet is a dense compute cabinet that supports 2-chassis, 16
@@ -325,6 +322,14 @@ compute blades and 16 [High Speed Network (HSN)](#high-speed-network-hsn) switch
 
 The [Slingshot](#slingshot) fabric consists of the switches, cables, ports, topology policy, and
 configuration settings for the Slingshot [High-Speed Network](#high-speed-network-hsn).
+
+## Firmware Action Service (FAS)
+
+The Firmware Action Service (FAS) provides an interface for managing firmware versions of Redfish-enabled hardware in the system.
+FAS interacts with the [Hardware State Manager (HSM)](#hardware-state-manager-hsm), device data, and image data in order to update
+firmware.
+
+For more information, see [Update firmware with FAS](operations/firmware/Update_Firmware_with_FAS.md).
 
 ## Floor Standing CDU
 
@@ -373,6 +378,16 @@ It tracks changes in heartbeats and conveys changes to the [HSM](#hardware-state
 ## High Speed Network (HSN)
 
 The High Speed Network (HSN) in an HPE Cray EX system is based on the [Slingshot](#slingshot) switches.
+
+<a name="image-management-service"></a>
+
+## Image Management Service (IMS)
+
+The Image Management Service (IMS) uses the open source Kiwi-NG tool to build image roots from
+recipes. IMS also uses [CFS](#configuration-framework-service-cfs) to apply image customization for pre-boot
+configuration of the image root. These images are bootable on [compute nodes](#compute-node-cn) and [application nodes](#application-node-an).
+
+For more information, see [Image Management](operations/image_management/Image_Management.md).
 
 ## Kubernetes NCNs
 
@@ -606,6 +621,12 @@ valves are closed during operation, the action automatically causes the [CMMs](#
 ## System Admin Toolkit (SAT)
 
 The System Admin Toolkit (SAT) product provides the `sat` command line interface which interacts with the REST APIs of many services to perform more complex system management tasks.
+
+## System Configuration Service (SCSD)
+
+The System Configuration Service (SCSD) allows administrators to set various [BMC](#baseboard-management-controller-bmc) and
+controller parameters. These parameters are typically set during discovery, but this tool enables parameters to be set before or
+after discovery.
 
 <a name="system-layout-service"></a>
 

--- a/index.md
+++ b/index.md
@@ -1,6 +1,10 @@
 # Cray System Management Documentation
 
-## Scope and Audience
+* [Scope and audience](#scope-and-audience)
+* [Table of contents](#table-of-contents)
+* [Copyright and license](#copyright-and-license)
+
+## Scope and audience
 
 The documentation included here describes the Cray System Management (CSM) software, how to install
 or upgrade CSM software, and related supporting operational procedures to manage an HPE Cray EX system.
@@ -20,7 +24,7 @@ This information is intended for system installers, system administrators, and n
 of the system. It assumes some familiarity with standard Linux and open source tools, such as shell
 scripts, revision control with git, configuration management with Ansible, YAML, JSON, and TOML file formats, etc.
 
-## Table of Contents
+## Table of contents
 
 1. [Introduction to CSM Installation](introduction/index.md)
 
@@ -105,26 +109,6 @@ scripts, revision control with git, configuration management with Ansible, YAML,
 
    This chapter provides explanations of terms and acronyms used throughout the rest of this documentation.
 
-## Copyright and License
+## Copyright and license
 
-MIT License
-
-(C) Copyright [2020-2022] Hewlett Packard Enterprise Development LP
-
-Permission is hereby granted, free of charge, to any person obtaining a
-copy of this software and associated documentation files (the "Software"),
-to deal in the Software without restriction, including without limitation
-the rights to use, copy, modify, merge, publish, distribute, sublicense,
-and/or sell copies of the Software, and to permit persons to whom the
-Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included
-in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
+See [LICENSE](LICENSE).

--- a/operations/index.md
+++ b/operations/index.md
@@ -627,7 +627,7 @@ Spire provides the ability to authenticate nodes and workloads, and to securely 
 ## Update firmware with FAS
 
 The Firmware Action Service (FAS) provides an interface for managing firmware versions of Redfish-enabled hardware in the system. FAS interacts with the Hardware State
-Managers (HSM), device data, and image data in order to update firmware.
+Manager (HSM), device data, and image data in order to update firmware.
 
 See [Update Firmware with FAS](firmware/Update_Firmware_with_FAS.md) for a list components that are upgradable with FAS. Refer to the HPC Firmware Pack (HFP) product
 stream to update firmware on other components.
@@ -639,6 +639,8 @@ stream to update firmware on other components.
 - [FAS Admin Procedures](firmware/FAS_Admin_Procedures.md)
 - [FAS Use Cases](firmware/FAS_Use_Cases.md)
 - [Upload Olympus BMC Recovery Firmware into TFTP Server](firmware/Upload_Olympus_BMC_Recovery_Firmware_into_TFTP_Server.md)
+- [Updating Firmware on `m001`](firmware/Updating_Firmware_m001.md)
+- [Updating Firmware without FAS](firmware/Updating_Firmware_without_FAS.md)
 
 ## User Access Service (UAS)
 


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/docs-csm/pull/3777