### PR TITLE
CASMTRIAGE-5324-revert revert changes from CASMINST-6286

### DIFF
--- a/upgrade/Stage_1.md
+++ b/upgrade/Stage_1.md
@@ -7,7 +7,6 @@
   - [Start typescript](#start-typescript)
   - [Run Ceph Latency Repair Script](#run-ceph-latency-repair-script)
   - [Apply boot order workaround](#apply-boot-order-workaround)
-  - [Upload Ceph container images to Nexus](#upload-ceph-container-images-to-nexus)
   - [Argo workflows](#argo-workflows)
   - [CSM Upgrade requirement for upgrades staying within a CSM release version](#csm-upgrade-requirement-for-upgrades-staying-within-a-csm-release-version)
   - [Storage node image upgrade](#storage-node-image-upgrade)
@@ -48,79 +47,20 @@ Note that the progress for the current stage will not show up in Argo before the
 
 For more information, see [Using the Argo UI](../operations/argo/Using_the_Argo_UI.md) and [Using Argo Workflows](../operations/argo/Using_Argo_Workflows.md).
 
-## CSM Upgrade requirement for upgrades to a new CSM release version
-
-**IMPORTANT:**
-
-> If the upgrade is to a new CSM release, e.g. `CSM-1.2.0` to `CSM-1.3.0`, then you will need to run the following to upgrade Ceph. This will upgrade Ceph from `v15.2.15` to `v16.2.9`.
-
-1. (`ncn-m001#`) Check that Ceph version `16.2.9` is in Nexus.
-
-    ```bash
-    ceph orch upgrade check registry.local/artifactory.algol60.net/csm-docker/stable/quay.io/ceph/ceph:v16.2.9
-    ```
-  
-    Expected output for a successful check should contain `target_digest`, `target_id`, `target_name`. The following is an example :
-
-    ```bash
-    "target_digest": "registry.local/artifactory.algol60.net/csm-docker/stable/quay.io/ceph/ceph@sha256:a960130143d4feb952d6afc205ffcc0d7d033f78839a38339e46c122646910d5",
-    "target_id": "87b249bff032ea26a91e455c43b7b2feb07e03c1b10bc32885ca9d583fc08236",
-    "target_name": "registry.local/artifactory.algol60.net/csm-docker/stable/quay.io/ceph/ceph:v16.2.9"
-    ```
-
-    A failed check will provide the following error:
-
-    ```bash
-    Error EINVAL: host ncn-s001 `cephadm pull` failed: cephadm exited with an error code: 1, stderr:Pulling container image registry.local/artifactory.algol60.net/csm-docker/stable/quay.io/ceph/ceph:v16.2.9...
-    ```
-
-    This failure means that the Ceph image with version `16.2.9` is not in Nexus. Verify that the upgrade `prerequisites.sh` script completed successfully. This script uploads images to Nexus.
-
-1. (`ncn-m001#`) Upgrade Ceph to `16.2.9`.
-
-   ```bash
-   ceph orch upgrade start registry.local/artifactory.algol60.net/csm-docker/stable/quay.io/ceph/ceph:v16.2.9
-   ```
-
-1. (`ncn-m001, ncn-s00[1/2/3]#`) Monitor the upgrade.
-
-    ```bash
-    watch ceph orch upgrade status
-    ```
-
-    Other helpful commands for monitoring the status of the upgrade are below.
-
-    ```bash
-    watch ceph orch ps
-    ceph -W cephadm
-    ```
-
-1. Wait for the upgrade to complete. Expected output after a successful upgrade:
-
-    ```bash
-    ncn-s001:~ # ceph orch upgrade status
-    {
-        "target_image": null,
-        "in_progress": false,
-        "services_complete": [],
-        "progress": null,
-        "message": ""
-    }
-    ```
-
 ## CSM Upgrade requirement for upgrades staying within a CSM release version
 
 **IMPORTANT:**
 
-> If the upgrade is staying with a CSM release, e.g. `CSM-1.3.0-rc1` to `CSM-1.3.0-rc2`, then you will need to run the following to point the Ceph cluster to use the Ceph container image stored in Nexus.
+> If the upgrade is staying within a CSM release, e.g. `CSM-1.3.0-rc1` to `CSM-1.3.0-rc2`, then you will need to run the following to point the Ceph cluster to use the Ceph container image stored in Nexus.
 > The issue stems from slightly different `sha` values for the Ceph containers for in-family CSM storage node images which will prevent the Ceph containers from starting.
+> This script uploads local Ceph container images to nexus and restarts all Ceph daemons so they are using the image in Nexus.
 
-(`ncn-s001#`) Upload Ceph container images into Nexus and restart daemons so that they use the image in Nexus.
+(`ncn-s00[1/2/3]#`) Copy `upload_ceph_images_to_nexus.sh` from `ncn-m001` and execute it.
 
-```bash
-scp ncn-m001:/usr/share/doc/csm/scripts/upload_ceph_images_to_nexus.sh /srv/cray/scripts/common/upload_ceph_images_to_nexus.sh
-/srv/cray/scripts/common/upload_ceph_images_to_nexus.sh
-```
+   ```bash
+   scp ncn-m001:/usr/share/doc/csm/scripts/upload_ceph_images_to_nexus.sh /srv/cray/scripts/common/upload_ceph_images_to_nexus.sh
+   /srv/cray/scripts/common/upload_ceph_images_to_nexus.sh
+   ```
 
 ### Troubleshooting `upload_ceph_images_to_nexus.sh`
 

--- a/upgrade/Stage_3.md
+++ b/upgrade/Stage_3.md
@@ -74,6 +74,4 @@ For any typescripts that were started during this stage, stop them with the `exi
 
 ## Stage completed
 
-**DO NOT** proceed past this point if the upgrade has not completed and been verified. Contact support for in-depth troubleshooting.
-
-This stage is completed. Proceed to [Validate CSM health](README.md#3-validate-csm-health) on the main upgrade page.
+This stage is completed. Continue to [Stage 4](Stage_4.md).

--- a/upgrade/Stage_4.md
+++ b/upgrade/Stage_4.md
@@ -1,0 +1,242 @@
+# Stage 4 - Ceph Upgrade
+
+**Important:** Ceph does not need to be upgraded if this is an upgrade is staying within a CSM release, e.g. `CSM-1.3.0-rc1` to `CSM-1.3.0-rc2`.
+If this is an upgrade starying within a CSM release, then Ceph is already running `v16.2.9`. See instructions in [stage completed](#stage-completed) for next steps.
+
+**Reminder:** If any problems are encountered and the procedure or command output does not provide relevant guidance, then see
+[Relevant troubleshooting links for upgrade-related issues](Upgrade_Management_Nodes_and_CSM_Services.md#relevant-troubleshooting-links-for-upgrade-related-issues).
+
+- [Ceph upgrade contents](#ceph-upgrade-contents)
+- [Start typescript](#start-typescript)
+- [Procedure](#procedure)
+  - [Initiate upgrade](#initiate-upgrade)
+  - [Diagnose a stalled upgrade](#diagnose-a-stalled-upgrade)
+    - [`UPGRADE_FAILED_PULL: Upgrade: failed to pull target image`](#upgrade_failed_pull-upgrade-failed-to-pull-target-image)
+  - [Troubleshoot a failed upgrade](#troubleshoot-a-failed-upgrade)
+- [Stop typescript](#stop-typescript)
+- [Stage completed](#stage-completed)
+
+## Ceph upgrade contents
+
+The upgrade includes all fixes from `v15.2.15` through `v16.2.9`. See the [Ceph version index](https://docs.ceph.com/en/latest/releases/pacific/) for details.
+
+## Start typescript
+
+1. (`ncn-m002#`) If a typescript session is already running in the shell, then first stop it with the `exit` command.
+
+1. (`ncn-m002#`) Start a typescript.
+
+    ```bash
+    script -af /root/csm_upgrade.$(date +%Y%m%d_%H%M%S).stage_4.txt
+    export PS1='\u@\H \D{%Y-%m-%d} \t \w # '
+    ```
+
+If additional shells are opened during this procedure, then record those with typescripts as well. When resuming a procedure
+after a break, always be sure that a typescript is running before proceeding.
+
+## Procedure
+
+- This upgrade is performed using the `cubs_tool`.
+- The `cubs_tool.py` can be found on `ncn-s00[1-3]` in `/srv/cray/script/common/`
+- Unless otherwise noted, all `ceph` commands that may need to be used in this stage may be run on any master node or any of the first three storage
+  nodes (`ncn-s001`, `ncn-s002`, or `ncn-s003`).
+
+### Initiate upgrade
+
+1. (`ncn-s001#`) Check to ensure that the upgrade is possible.
+
+   On :
+
+   ```bash
+   /srv/cray/scripts/common/cubs_tool.py --version 16.2.9 --registry localhost
+   ```
+
+   Example output:
+
+   ```text
+   Upgrade Available!!  The specified version v16.2.9 has been found in the registry
+   ```
+
+   **Note:** If the output does not match what is expected, then this can indicate that a previous step has failed.
+   Review the output from [Stage 1](Stage_1.md) for errors or contact support.
+
+1. (`ncn-s001#`) Start the upgrade.
+
+   ```bash
+   /srv/cray/scripts/common/cubs_tool.py --version v16.2.9 --registry localhost --upgrade
+   ```
+
+   Example output:
+
+   ```text
+   Upgrade Available!!  The specified version v16.2.9 has been found in the registry
+   Initiating Ceph upgrade from v16.2.7 to v16.2.9
+   ```
+
+   The source version in the output may vary, but the target version should match what is shown above.
+
+   If this is an in family upgrade and the Ceph upgrade was completed during [Stage 1](Stage_1.md), then the upgrade will not run again. The expected output is stated below.
+
+   ```text
+   Your current version is the same as the proposed version 16.2.9
+   ```
+
+1. Monitor the upgrade.
+
+   The `cubs_tool` will automatically watch the upgrade.
+   As services are upgraded, they will move from the `Total Current` column to the `Total Upgraded` column.
+
+   ```text
+   +---------+---------------+----------------+
+   | Service | Total Current | Total Upgraded |
+   +---------+---------------+----------------+
+   |   MGR   |       0       |       2        |
+   |   MON   |       3       |       0        |
+   |  Crash  |       3       |       0        |
+   |   OSD   |       9       |       0        |
+   |   MDS   |       3       |       0        |
+   |   RGW   |       3       |       0        |
+   +---------+---------------+----------------+
+   ```
+
+   The final result should have `0` for every service in the `Total Current` column.
+
+   ```text
+   +---------+---------------+----------------+
+   | Service | Total Current | Total Upgraded |
+   +---------+---------------+----------------+
+   |   MGR   |       0       |       3        |
+   |   MON   |       0       |       3        |
+   |  Crash  |       0       |       3        |
+   |   OSD   |       0       |       9        |
+   |   MDS   |       0       |       3        |
+   |   RGW   |       0       |       3        |
+   +---------+---------------+----------------+
+   ```
+
+1. (`ncn-s001#`) Verify that the upgrade completed successfully.
+
+   ```bash
+   /srv/cray/scripts/common/cubs_tool.py --report
+   ```
+
+   Expected output:
+
+   ```text
+   +----------+-------------+-----------------+---------+---------+
+   |   Host   | Daemon Type |        ID       | Version |  Status |
+   +----------+-------------+-----------------+---------+---------+
+   | ncn-s001 |     mgr     | ncn-s001.antgnu |  16.2.9 | running |
+   | ncn-s002 |     mgr     | ncn-s002.jhwgup |  16.2.9 | running |
+   | ncn-s003 |     mgr     | ncn-s003.wzoivk |  16.2.9 | running |
+   +----------+-------------+-----------------+---------+---------+
+   +----------+-------------+----------+---------+---------+
+   |   Host   | Daemon Type |    ID    | Version |  Status |
+   +----------+-------------+----------+---------+---------+
+   | ncn-s001 |     mon     | ncn-s001 |  16.2.9 | running |
+   | ncn-s002 |     mon     | ncn-s002 |  16.2.9 | running |
+   | ncn-s003 |     mon     | ncn-s003 |  16.2.9 | running |
+   +----------+-------------+----------+---------+---------+
+   +----------+-------------+----------+---------+---------+
+   |   Host   | Daemon Type |    ID    | Version |  Status |
+   +----------+-------------+----------+---------+---------+
+   | ncn-s001 |    crash    | ncn-s001 |  16.2.9 | running |
+   | ncn-s002 |    crash    | ncn-s002 |  16.2.9 | running |
+   | ncn-s003 |    crash    | ncn-s003 |  16.2.9 | running |
+   +----------+-------------+----------+---------+---------+
+   +----------+-------------+----+---------+---------+
+   |   Host   | Daemon Type | ID | Version |  Status |
+   +----------+-------------+----+---------+---------+
+   | ncn-s001 |     osd     | 0  |  16.2.9 | running |
+   | ncn-s001 |     osd     | 3  |  16.2.9 | running |
+   | ncn-s001 |     osd     | 7  |  16.2.9 | running |
+   | ncn-s002 |     osd     | 1  |  16.2.9 | running |
+   | ncn-s002 |     osd     | 5  |  16.2.9 | running |
+   | ncn-s002 |     osd     | 8  |  16.2.9 | running |
+   | ncn-s003 |     osd     | 2  |  16.2.9 | running |
+   | ncn-s003 |     osd     | 4  |  16.2.9 | running |
+   | ncn-s003 |     osd     | 6  |  16.2.9 | running |
+   +----------+-------------+----+---------+---------+
+   +----------+-------------+------------------------+---------+---------+
+   |   Host   | Daemon Type |           ID           | Version |  Status |
+   +----------+-------------+------------------------+---------+---------+
+   | ncn-s001 |     mds     | cephfs.ncn-s001.sbtjip |  16.2.9 | running |
+   | ncn-s002 |     mds     | cephfs.ncn-s002.gywfal |  16.2.9 | running |
+   | ncn-s003 |     mds     | cephfs.ncn-s003.emebxe |  16.2.9 | running |
+   +----------+-------------+------------------------+---------+---------+
+   +----------+-------------+-----------------------+---------+---------+
+   |   Host   | Daemon Type |           ID          | Version |  Status |
+   +----------+-------------+-----------------------+---------+---------+
+   | ncn-s001 |     rgw     | site1.ncn-s001.rrfbvo |  16.2.9 | running |
+   | ncn-s002 |     rgw     | site1.ncn-s002.axqnca |  16.2.9 | running |
+   | ncn-s003 |     rgw     | site1.ncn-s003.pxhahp |  16.2.9 | running |
+   +----------+-------------+-----------------------+---------+---------+
+   ```
+
+   **NOTE:** This is an example only and is showing only the core Ceph components.
+
+### Diagnose a stalled upgrade
+
+The processes running the Ceph container image will go through the upgrade process. This involves stopping the old process
+and restarting the process with the new version `16.2.9` container image.
+
+**IMPORTANT:** Only processes running the `15.2.15` image will be upgraded. This includes `crash`, `mds`, `mgr`, `mon`, `osd`, and `rgw` processes only.
+
+#### `UPGRADE_FAILED_PULL: Upgrade: failed to pull target image`
+
+If `ceph -s` shows a warning with `UPGRADE_FAILED_PULL: Upgrade: failed to pull target image` as the description, then perform the following procedure
+on any of the first three storage nodes (`ncn-s001`, `ncn-s002`, or `ncn-s003`).
+
+1. (`ncn-s#`) Check the upgrade status.
+
+    ```bash
+    ceph orch upgrade status
+    ```
+
+    Example output:
+
+    ```json
+    {
+       "target_image": "registry.local/artifactory.algol60.net/csm-docker/stable/quay.io/ceph/ceph:v15.2.15",
+       "in_progress": true,
+       "services_complete": [],
+       "message": "Error: UPGRADE_FAILED_PULL: Upgrade: failed to pull target image"
+     }
+     ```
+
+1. (`ncn-s#`) Pause and resume the upgrade.
+
+    ```bash
+    ceph orch upgrade pause
+    ceph orch upgrade resume
+    ```
+
+1. (`ncn-s#`) Watch `cephadm`.
+
+    This command watches the `cephadm` logs. If the issue occurs again, then it will give more details about which node may be having an issue.
+
+    ```bash
+    ceph -W cephadm
+    ```
+
+1. (`ncn-s#`) If the issue occurs again, then log into each of the storage nodes and perform a `podman` pull of the image.
+
+    ```bash
+    podman pull localhost/quay.io/ceph/ceph:v16.2.9
+    ```
+
+If these steps do not resolve the issue, then contact support for further assistance.
+
+### Troubleshoot a failed upgrade
+
+See [Ceph Orchestrator Usage](../operations/utility_storage/Ceph_Orchestrator_Usage.md) for additional usage and troubleshooting.
+
+## Stop typescript
+
+For any typescripts that were started during this stage, stop them with the `exit` command.
+
+## Stage completed
+
+**DO NOT** proceed past this point if the upgrade has not completed and been verified. Contact support for in-depth troubleshooting.
+
+This stage is completed. Proceed to [Validate CSM health](README.md#3-validate-csm-health) on the main upgrade page.

--- a/upgrade/Stage_4.md
+++ b/upgrade/Stage_4.md
@@ -1,7 +1,7 @@
 # Stage 4 - Ceph Upgrade
 
 **Important:** Ceph does not need to be upgraded if this is an upgrade is staying within a CSM release, e.g. `CSM-1.3.0-rc1` to `CSM-1.3.0-rc2`.
-If this is an upgrade starying within a CSM release, then Ceph is already running `v16.2.9`. See instructions in [stage completed](#stage-completed) for next steps.
+If this is an upgrade staying within a CSM release, then Ceph is already running `v16.2.9`. See instructions in [stage completed](#stage-completed) for next steps.
 
 **Reminder:** If any problems are encountered and the procedure or command output does not provide relevant guidance, then see
 [Relevant troubleshooting links for upgrade-related issues](Upgrade_Management_Nodes_and_CSM_Services.md#relevant-troubleshooting-links-for-upgrade-related-issues).

--- a/upgrade/Upgrade_Management_Nodes_and_CSM_Services.md
+++ b/upgrade/Upgrade_Management_Nodes_and_CSM_Services.md
@@ -28,6 +28,7 @@ mentioned explicitly on this page, see [resource material](resource_material/REA
 - [Stage 1 - Ceph Node Image Upgrade](Stage_1.md)
 - [Stage 2 - Kubernetes Upgrade](Stage_2.md)
 - [Stage 3 - CSM Services Upgrade](Stage_3.md)
+- [Stage 4 - Ceph Upgrade](Stage_4.md)
 - [Validate CSM health](../operations/validate_csm_health.md)
 
 **Important:** Take note of the below content for troubleshooting purposes, in the event that issues are encountered during the upgrade process.


### PR DESCRIPTION
Upload_ceph_images_to_nexus script to only run when staying in CSM release version

<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
Detailed description:
Original problem was upload_ceph_images_to_nexus script was added to the 1.3 storage upgrade. This script does not work when upgrade from CSM-1.2 to CSM-1.3 because of the Ceph version. Ticket to track this was CASMINST-6268. What should have been done here is move that script to only run during upgrades staying within the 1.3 release version.
Instead, CASMINST-6268 moved the Ceph upgrade from Stage_4 of the upgrade to Stage_1. This was done to avoid sha issues that might occur because upload_ceph_images_to_nexus was not being run. However, this change failed because the Ceph upgrade cannot be completed on CSM-1.2 storage nodes because the Ceph upgrade requires images to be pullable from a local registry and CSM-1.2 did not have a local registry. To resolve this issue, we are doing what should've been done in the first place which is moving the upload_ceph_images_to_nexus script to only run during upgrades staying within the 1.3 release version.

This PR reverts changes from CASMINST-6286 and moves the upload_ceph_images_to_nexus script to only run during upgrades staying within the 1.3 release version.

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
