### PR TITLE
CASMCMS-8503: Update IMS import/export script to handle new IMS recipe fields

### DIFF
--- a/scripts/operations/configuration/ims-import-export.py
+++ b/scripts/operations/configuration/ims-import-export.py
@@ -433,6 +433,16 @@ def import_ims_recipe(recipe, recipes_path):
                 '--linux-distribution', recipe['linux_distribution'],
                 '--format', 'json'
             ]
+            # In CSM 1.5, IMS recipes added support for different architectures.
+            # Older recipes may not contain "arch" and "require_dkms" fields. For recipes
+            # which do contain these fields, we need to add these arguments as well.
+            # If the recipe does not contain these fields, we will not specify them, which will
+            # result in them being assigned default values (which is what would have happened to
+            # these recipes had they existed on the system when it was updated to CSM 1.5).
+            if 'arch' in recipe:
+                command.extend(['--arch'], recipe['arch'])
+            if 'require_dkms' in recipe:
+                command.extend(['--require-dkms'], recipe['require_dkms'])
             LOGGER.debug(' '.join(command))
             new_recipe = json.loads(subprocess.check_output(command))
             LOGGER.debug(new_recipe)


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
In CSM 1.5, two new fields are being added to IMS recipes to allow support for other hardware architectures. This breaks the existing IMS import/export disaster recovery script -- or worse, the script actually still works, but it would just ignore those fields in the recipes it was importing, causing them to take on their default values. This small change to the script just adds logic to look at the recipes being imported and, if they contain these fields, adding the appropriate arguments to the command being used to create them. 

This change handles both importing older recipes (which don't have these fields) and newer ones (which do).

Eventually it would be good to convert the IMS import/export tool to use the API instead of the CLI, because had it been doing that, this change would not have been needed. However, such a change would be much more extensive and require a lot more testing -- at the moment, that's not the best use of time.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
