### PR TITLE
CASMINST-6346: UPGRADE: cray-sysmgmt-health upgrade error

### DIFF
--- a/upgrade/scripts/upgrade/util/update-customizations.sh
+++ b/upgrade/scripts/upgrade/util/update-customizations.sh
@@ -132,6 +132,10 @@ if [[ "$(yq r "$c" "spec.kubernetes.services.cray-sysmgmt-health.prometheus-snmp
       temp=$(( temp+1 ))
     done
 fi
+
+# Kube-prometheus-stack
+sed -i 's/prometheus-operator/kube-prometheus-stack/g' "$c"
+
 if [[ "$inplace" == "yes" ]]; then
     cp "$c" "$customizations"
 else


### PR DESCRIPTION
# Description
Replace all occurrences of Prometheus-operator to kube-prometheus-operator as part of version update from 9.3.1 to 45.1.1.
Note: Here using sed instead of yq calls since this is simply a string search/replace.

Relates to:
- https://github.com/Cray-HPE/csm/pull/1913/files

## Test

Tested on 
- Gamora

## Logs

cat customizations.yaml | grep kube-prometheus-stack
      - '{{ kubernetes.services[''cray-sysmgmt-health''][''kube-prometheus-stack''].prometheus.prometheusSpec.externalAuthority }}'
      - '{{ kubernetes.services[''cray-sysmgmt-health''][''kube-prometheus-stack''].alertmanager.alertmanagerSpec.externalAuthority }}'
      - '{{ kubernetes.services[''cray-sysmgmt-health''][''kube-prometheus-stack''].grafana.externalAuthority }}'
                  url: https://{{ kubernetes.services['cray-sysmgmt-health']['kube-prometheus-stack'].grafana.externalAuthority }}/
        kube-prometheus-stack:
              externalUrl: https://{{ kubernetes.services['cray-sysmgmt-health']['kube-prometheus-stack'].prometheus.prometheusSpec.externalAuthority }}/
              externalUrl: https://{{ kubernetes.services['cray-sysmgmt-health']['kube-prometheus-stack'].alertmanager.alertmanagerSpec.externalAuthority }}/
