### PR TITLE
CASMINST-6354:  Adjustments to run on vshasta

### DIFF
--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -182,6 +182,12 @@ function is_vshasta_node {
     return $?
 }
 
+if is_vshasta_node; then
+    vshasta="true"
+else
+    vshasta="false"
+fi
+
 # Make a backup copy of select pre-upgrade information, just in case it is needed for later reference.
 # This is only run on the primary upgrade node
 state_name="BACKUP_SNAPSHOT"
@@ -625,7 +631,7 @@ fi
 
 state_name="UPLOAD_NEW_NCN_IMAGE"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
-if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" && ${vshasta} == "false" ]]; then
     echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
     {
     artdir=${CSM_ARTI_DIR}/images
@@ -833,7 +839,7 @@ fi
 
 state_name="UPGRADE_PRECACHE_CHART"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
-if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}1" ]]; then
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
     echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
     {
     tmp_current_configmap=/tmp/precache-current-configmap.yaml
@@ -969,7 +975,7 @@ fi
 
 state_name="TDS_LOWER_CPU_REQUEST"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
-if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" && ${vshasta} == "false" ]]; then
     echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
     {
 
@@ -987,9 +993,10 @@ else
     echo "====> ${state_name} has been completed" | tee -a "${LOG_FILE}"
 fi
 
+# This is not run on vshasta because it doesn't have HSM
 state_name="CHECK_BMC_NCN_LOCKS"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
-if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" && ${vshasta} == "false" ]]; then
     echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
     {
     # install the hpe-csm-scripts rpm early to get lock_management_nodes.py
@@ -1015,9 +1022,10 @@ fi
 # new sessions from being scheduled. It will also not prevent current sessions from updating
 # the status of the component when they complete. However, that update will not re-enable
 # the component.
+# This is not run on vshasta because it doesn't have HSM
 state_name="DISABLE_CFS_ON_NCNS"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
-if [[ $state_recorded == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
+if [[ $state_recorded == "0" && $(hostname) == "${PRIMARY_NODE}" && ${vshasta} == "false" ]]; then
     echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
     {
         echo "Retrieving a list of all management node component names (xnames)"

--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -24,14 +24,6 @@
 #
 
 set -e
-# CASMPET-6390 - detect unexpected hostname before continuing
-if [[ $(hostname) == "ncn-m002" ]]; then
-    echo "WARN: running prerequisites.sh on ncn-m002..."
-elif [[ $(hostname) != "ncn-m001" ]]; then
-    echo "ERROR: unexpected hostname $(hostname)"
-    echo "You should only run prerequisites.sh from ncn-m001 or ncn-m002"
-    exit 1
-fi
 
 locOfScript=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 . "${locOfScript}/../common/upgrade-state.sh"
@@ -40,6 +32,8 @@ trap 'err_report' ERR INT TERM HUP EXIT
 # array for paths to unmount after chrooting images
 # shellcheck disable=SC2034
 declare -a UNMOUNTS=()
+
+PRIMARY_NODE="ncn-m001"
 
 while [[ $# -gt 0 ]]
 do
@@ -52,12 +46,25 @@ case ${key} in
     shift # past argument
     shift # past value
     ;;
+    --primary-node)
+    PRIMARY_NODE=$2
+    shift # past argument
+    shift # past value
+    ;;
     *)    # unknown option
     echo "[ERROR] - unknown options"
     exit 1
     ;;
 esac
 done
+
+# CASMPET-6390 - detect unexpected hostname before continuing
+if [[ $(hostname) != "${PRIMARY_NODE}" ]]; then
+    echo "ERROR: unexpected hostname $(hostname)"
+    echo "You should only run prerequisites.sh from ${PRIMARY_NODE}"
+    exit 1
+fi
+
 
 if [[ -z ${CSM_RELEASE} ]]; then
     echo "CSM RELEASE is not specified"
@@ -165,11 +172,21 @@ function upgrade_csm_chart
     loftsman ship --manifest-path "${TMP_MANIFEST_CUSTOMIZED}"
 }
 
+function is_vshasta_node {
+    # This is the best check for an image specifically booted to vshasta
+    [[ -f /etc/google_system ]] && return 0
+
+    # metal images can still be booted on GCP, so check if there are any disks vendored by Google
+    # if not, we conclude that this is not GCP
+    lsblk --noheadings -o vendor | grep -q Google
+    return $?
+}
+
 # Make a backup copy of select pre-upgrade information, just in case it is needed for later reference.
-# This is only run on ncn-m001 (not when it is run from ncn-m002 during the upgrade)
+# This is only run on the primary upgrade node
 state_name="BACKUP_SNAPSHOT"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
-if [[ ${state_recorded} == "0" && $(hostname) == "ncn-m001" ]]; then
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
     echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
     {
 
@@ -201,7 +218,7 @@ fi
 
 state_name="CHECK_WEAVE"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
-if [[ ${state_recorded} == "0" && $(hostname) == "ncn-m001" ]]; then
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
     echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
     {
     SLEEVE_MODE="yes"
@@ -258,55 +275,53 @@ fi
 
 state_name="REPAIR_AND_VERIFY_CHRONY_CONFIG"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
-TOKEN=$(curl -s -S -d grant_type=client_credentials \
-                   -d client_id=admin-client \
-                   -d client_secret="$(kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d)" \
-                   https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
-export TOKEN
-if [[ ${state_recorded} == "0" ]]; then
+
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
     echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
     {
-    if [[ "$(hostname)" == "ncn-m002" ]]; then
-        # we already did this from ncn-m001
-        echo "====> ${state_name} has been completed" | tee -a "${LOG_FILE}"
-    else
-      for target_ncn in $(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u); do
+    for target_ncn in $(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u); do
 
-        # ensure host is accessible, skip it if not
-        if ! ssh "${target_ncn}" hostname > /dev/null; then
-            continue
-        fi
+      if is_vshasta_node; then
+          if [ "${target_ncn}" == "ncn-m001" ]; then
+              echo "Skipping ncn-m001 because we are running on vshasta"
+              continue
+          fi
+      fi
 
-        # ensure the directory exists
-        ssh "${target_ncn}" mkdir -p /srv/cray/scripts/common/
+      # ensure host is accessible, skip it if not
+      if ! ssh "${target_ncn}" hostname > /dev/null; then
+          continue
+      fi
 
-        # copy the NTP script and template to the target ncn
-        rsync -aq "${CSM_ARTI_DIR}"/chrony "${target_ncn}":/srv/cray/scripts/common/
+      # ensure the directory exists
+      ssh "${target_ncn}" mkdir -p /srv/cray/scripts/common/
 
-        # shellcheck disable=SC2029 # it is intentional that ${TOKEN} expands on the client side
-        # run the script
-        if ! ssh "${target_ncn}" "TOKEN=${TOKEN} /srv/cray/scripts/common/chrony/csm_ntp.py"; then
-            echo "${target_ncn} csm_ntp failed"
-            exit 1
-        fi
+      # copy the NTP script and template to the target ncn
+      rsync -aq "${CSM_ARTI_DIR}"/chrony "${target_ncn}":/srv/cray/scripts/common/
 
-        ssh "${target_ncn}" chronyc makestep
-        loop_idx=0
-        in_sync=$(ssh "${target_ncn}" timedatectl | awk /synchronized:/'{print $NF}')
-        # wait up to 90s for the node to be in sync
-        while [[ ${loop_idx} -lt 18 && ${in_sync} == "no" ]]; do
-            sleep 5
-            in_sync=$(ssh "${target_ncn}" timedatectl | awk /synchronized:/'{print $NF}')
-            loop_idx=$(( loop_idx+1 ))
-        done
+      # shellcheck disable=SC2029 # it is intentional that ${TOKEN} expands on the client side
+      # run the script
+      if ! ssh "${target_ncn}" "TOKEN=${TOKEN} /srv/cray/scripts/common/chrony/csm_ntp.py"; then
+          echo "${target_ncn} csm_ntp failed"
+          exit 1
+      fi
 
-        if [[ ${in_sync} == "no" ]]; then
-            echo "The clock for ${target_ncn} is not in sync.  Wait a bit more or try again."
-            exit 1
-        fi
+      ssh "${target_ncn}" chronyc makestep
+      loop_idx=0
+      in_sync=$(ssh "${target_ncn}" timedatectl | awk /synchronized:/'{print $NF}')
+      # wait up to 90s for the node to be in sync
+      while [[ ${loop_idx} -lt 18 && ${in_sync} == "no" ]]; do
+          sleep 5
+          in_sync=$(ssh "${target_ncn}" timedatectl | awk /synchronized:/'{print $NF}')
+          loop_idx=$(( loop_idx+1 ))
       done
-      record_state "${state_name}" "$(hostname)" | tee -a "${LOG_FILE}"
-    fi
+
+      if [[ ${in_sync} == "no" ]]; then
+          echo "The clock for ${target_ncn} is not in sync.  Wait a bit more or try again."
+          exit 1
+      fi
+    done
+    record_state "${state_name}" "$(hostname)" | tee -a "${LOG_FILE}"
     } >> "${LOG_FILE}" 2>&1
 else
     echo "====> ${state_name} has been completed" | tee -a "${LOG_FILE}"
@@ -314,7 +329,7 @@ fi
 
 state_name="CHECK_CLOUD_INIT_PREREQ"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
-if [[ ${state_recorded} == "0" && $(hostname) == "ncn-m001" ]]; then
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
     echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
     {
     echo "Ensuring cloud-init is healthy"
@@ -395,7 +410,7 @@ fi
 
 state_name="UPDATE_CUSTOMIZATIONS"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
-if [[ ${state_recorded} == "0" && $(hostname) == "ncn-m001" ]]; then
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
     echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
     {
 
@@ -430,7 +445,7 @@ fi
 
 state_name="SETUP_NEXUS"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
-if [[ ${state_recorded} == "0" && $(hostname) == "ncn-m001" ]]; then
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
     echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
     {
 
@@ -456,7 +471,7 @@ fi
 
 state_name="UPGRADE_NLS"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
-if [[ ${state_recorded} == "0" && $(hostname) == "ncn-m001" ]]; then
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
     echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
     {
         "${locOfScript}/util/upgrade-cray-nls.sh"
@@ -487,7 +502,7 @@ fi
 
 state_name="UPGRADE_SPIRE"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
-if [[ ${state_recorded} == "0" && $(hostname) == "ncn-m001" ]]; then
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
     echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
     {
 
@@ -501,7 +516,7 @@ fi
 
 state_name="UPGRADE_SYSMGMT_HEALTH"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
-if [[ ${state_recorded} == "0" && $(hostname) == "ncn-m001" ]]; then
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
     echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
     {
 
@@ -515,7 +530,7 @@ fi
 
 state_name="UPGRADE_CSM_CONFIG"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
-if [[ ${state_recorded} == "0" && $(hostname) == "ncn-m001" ]]; then
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
     echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
     {
 
@@ -529,7 +544,7 @@ fi
 
 state_name="UPGRADE_DRYDOCK"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
-if [[ ${state_recorded} == "0" && $(hostname) == "ncn-m001" ]]; then
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
     echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
     {
 
@@ -543,7 +558,7 @@ fi
 
 state_name="UPGRADE_KYVERNO"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
-if [[ ${state_recorded} == "0" && $(hostname) == "ncn-m001" ]]; then
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
     echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
     {
 
@@ -557,7 +572,7 @@ fi
 
 state_name="UPGRADE_KYVERNO_POLICY"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
-if [[ ${state_recorded} == "0" && $(hostname) == "ncn-m001" ]]; then
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
     echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
     {
 
@@ -571,7 +586,7 @@ fi
 
 state_name="UPGRADE_CRAY_KYVERNO_POLICIES_UPSTREAM"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
-if [[ ${state_recorded} == "0" && $(hostname) == "ncn-m001" ]]; then
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
     echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
     {
     upgrade_csm_chart cray-kyverno-policies-upstream platform.yaml
@@ -583,7 +598,7 @@ fi
 
 state_name="UPGRADE_TFTP"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
-if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
+if [[ $state_recorded == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
     echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
     {
 
@@ -596,7 +611,7 @@ else
 fi
 state_name="UPGRADE_TFTP_PVC"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
-if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
+if [[ $state_recorded == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
     echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
     {
 
@@ -610,7 +625,7 @@ fi
 
 state_name="UPLOAD_NEW_NCN_IMAGE"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
-if [[ ${state_recorded} == "0" && $(hostname) == "ncn-m001" ]]; then
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
     echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
     {
     artdir=${CSM_ARTI_DIR}/images
@@ -722,7 +737,7 @@ fi
 
 state_name="UPDATE_CLOUD_INIT_RECORDS"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
-if [[ ${state_recorded} == "0" && $(hostname) == "ncn-m001" ]]; then
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
     echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
     {
 
@@ -760,14 +775,9 @@ fi
 
 state_name="UPDATE_NCN_KERNEL_PARAMETERS"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
-if [[ ${state_recorded} == "0" && $(hostname) == "ncn-m001" ]]; then
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
     echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
     {
-    TOKEN=$(curl -k -s -S -d grant_type=client_credentials \
-        -d client_id=admin-client \
-        -d client_secret="$(kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d)" \
-        https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
-    export TOKEN
 
     # As boot parameters are added or removed, update these arrays.
     # NOTE: bootparameters_to_delete should contain keys only, nothing should have "=<value>" appended to it.
@@ -808,6 +818,10 @@ if [[ ${state_recorded} == "0" ]]; then
       exit 1
     fi
 
+    if is_vshasta_node; then
+        sed -i 's/vshasta: false/vshasta: true/g' /opt/cray/tests/install/ncn/vars/variables-ncn.yaml
+    fi
+
     GOSS_BASE=/opt/cray/tests/install/ncn goss -g /opt/cray/tests/install/ncn/suites/ncn-upgrade-preflight-tests.yaml \
         --vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml validate
 
@@ -819,7 +833,7 @@ fi
 
 state_name="UPGRADE_PRECACHE_CHART"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
-if [[ ${state_recorded} == "0" && $(hostname) == "ncn-m001" ]]; then
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}1" ]]; then
     echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
     {
     tmp_current_configmap=/tmp/precache-current-configmap.yaml
@@ -862,7 +876,7 @@ fi
 
 state_name="UPGRADE_TRUSTEDCERTS_OPERATOR"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
-if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
+if [[ $state_recorded == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
     echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
     {
 
@@ -876,7 +890,7 @@ fi
 
 state_name="CREATE_CEPH_RO_KEY"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
-if [[ ${state_recorded} == "0" && $(hostname) == "ncn-m001" ]]; then
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
     echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
     {
 
@@ -894,7 +908,7 @@ fi
 
 state_name="BACKUP_BSS_DATA"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
-if [[ ${state_recorded} == "0" && $(hostname) == "ncn-m001" ]]; then
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
     echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
     {
 
@@ -913,7 +927,7 @@ fi
 
 state_name="BACKUP_VCS_DATA"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
-if [[ ${state_recorded} == "0" && $(hostname) == "ncn-m001" ]]; then
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
     echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
     {
 
@@ -955,7 +969,7 @@ fi
 
 state_name="TDS_LOWER_CPU_REQUEST"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
-if [[ ${state_recorded} == "0" && $(hostname) == "ncn-m001" ]]; then
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
     echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
     {
 
@@ -975,7 +989,7 @@ fi
 
 state_name="CHECK_BMC_NCN_LOCKS"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
-if [[ ${state_recorded} == "0" && $(hostname) == "ncn-m001" ]]; then
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
     echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
     {
     # install the hpe-csm-scripts rpm early to get lock_management_nodes.py
@@ -1003,7 +1017,7 @@ fi
 # the component.
 state_name="DISABLE_CFS_ON_NCNS"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
-if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
+if [[ $state_recorded == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
     echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
     {
         echo "Retrieving a list of all management node component names (xnames)"
@@ -1034,7 +1048,7 @@ fi
 # CRUS is being removed as part of this upgrade
 state_name="UNINSTALL_CRUS"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
-if [[ $state_recorded == "0" && $(hostname) == "ncn-m001" ]]; then
+if [[ $state_recorded == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
     echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
     {
         # If CRUS is installed, uninstall it


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

These are changes to allow prerequisites to run properly on vshasta.   vshasta currently cannot deploy m001 so we need to run prerequisites.sh from m002.    However, most of the stages in prerequisites are skipped if it is not run on m001.

This introduces a --primary-node option to allow specifying a different primary node.   Otherwise, it defaults the primary node to m001 to allow it to run the same way on baremetal systems.

This also now detects if it is running on vshasta and 
* sets the vshasta goss variable to true to skip tests that are not relevent to (and will fail on) vshasta.   
* skips m001 in REPAIR_AND_VERIFY_CHRONY_CONFIG
* skips stages UPLOAD_NEW_NCN_IMAGE, CHECK_BMC_NCN_LOCKS, DISABLE_CFS_ON_NCNS, and TDS_LOWER_CPU_REQUEST

Finally, I pulled out a couple of redundant token retrievals.  We get the token at the very beginning of prerequisites.   Then I found that we do it again within a couple of the stages.    I verified that it is the same token so it should not be necessary to get the token three times.

Testing:

I ran this prerequisites.sh on the cilium cluster both with and without the --primary-node option to make sure it is getting the correct default and that it is hitting the vshasta conditionals correctly.   Made sure that it skipped the right tests when run on vshasta.

I also ran it on drax to make sure that it detects baremetal correctly.

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
