### PR TITLE
CASM-4137 Improving iuf messages for management-nodes-rollout stage

### DIFF
--- a/workflows/iuf/operations/management-nodes-rollout/info-to-read.yaml
+++ b/workflows/iuf/operations/management-nodes-rollout/info-to-read.yaml
@@ -76,9 +76,9 @@ spec:
                   value: "{{$.DryRun}}"
                 - name: scriptContent
                   value: |
-                    echo "NOTICE  this stage will not rollout storage nodes or ncn-m001. This will have to be done manually if rolling-out these nodes is desired."
-                    echo "NOTICE  this stage will rollout workers and master nodes according to --limit-management-rollout and the node label iuf-prevent-rollout=true."
-                    echo "NOTICE  check the argo pod logs from each step in the workflow to see what the step is doing."
+                    echo "NOTICE This stage will not rollout storage nodes or ncn-m001. This will have to be done manually if rolling-out these nodes is desired"
+                    echo "NOTICE This stage will rollout workers and master nodes according to --limit-management-rollout and the node label iuf-prevent-rollout=true"
+                    echo "NOTICE Check the argo pod logs from each step in the workflow to see what the step is doing"
           - name: end-operation
             dependencies:
               - INFO-to-read

--- a/workflows/iuf/operations/management-nodes-rollout/management-two-master-nodes-rollout.yaml
+++ b/workflows/iuf/operations/management-nodes-rollout/management-two-master-nodes-rollout.yaml
@@ -64,80 +64,7 @@ spec:
             templateRef:
               name: workflow-template-record-time-template
               template: record-time-template
-          - name: verify-images-and-configuration
-            dependencies:
-              - start-operation
-            templateRef:
-              name: ssh-template
-              template: shell-script
-            arguments:
-              parameters:
-                - name: dryRun
-                  value: "{{$.DryRun}}"
-                - name: scriptContent
-                  value: |
-                    rebuild_workers=false
-                    rebuild_masters=false
-                    limit_management_nodes=$(echo '{{inputs.parameters.global_params}}' | jq -r '.input_params.limit_management_nodes[]')
-                    if [[ -n $(echo $limit_management_nodes | grep 'Management_Worker') ]]; then rebuild_workers=true; fi
-                    if [[ -n $(echo $limit_management_nodes | grep 'Management_Master') ]]; then rebuild_masters=true; fi
-
-                    prepare_images_ouput=$(echo '{{inputs.parameters.global_params}}' | jq -r '.stage_params["prepare-images"].global["prepare-management-images"]["sat-bootprep-run"].script_stdout')
-
-                    if $rebuild_workers; then
-                      # Check config exists
-                      config=$(echo $prepare_images_ouput | jq '.images | map(select(.configuration_group_names[] == "Management_Worker")) | .[].configuration' | tr -d '"')
-                      if [[ -z $config ]]; then echo "ERROR  no CFS configuration was received for 'Management_Worker' from prepare images stage"; exit 1; fi
-                      cray cfs configurations describe "$config" > /dev/null
-                      if [[ $? -ne 0 ]]; then
-                        exit 1 # could not find the desired cfs configuration
-                      else
-                        echo "NOTICE found CFS configuration:$config in CFS for 'Management_Worker' nodes"
-                      fi
-
-                      # Check image exists
-                      image=$(echo $prepare_images_ouput | jq '.images | map(select(.configuration_group_names[] == "Management_Worker")) | .[].final_image_id' | tr -d '"')
-                      if [[ -z $image ]]; then echo "ERROR  no image was received for 'Management_Worker' from prepare images stage"; exit 1; fi
-                      if [[ $(echo $image | wc -l) -gt 1 ]]; then 
-                        echo "ERROR  more than 1 image was received for Management_Worker nodes. Must be exactly 1 image to rebuild"
-                        echo "ERROR  Images received: $image"; exit 1
-                      fi
-                      cray ims images describe "$image" > /dev/null
-                      if [[ $? -ne 0 ]]; then
-                        exit 1 # could not find the image in IMS
-                      else
-                        echo "NOTICE found image:$image in IMS for Management_Worker rebuild"
-                      fi
-                    fi
-
-                    if $rebuild_masters; then
-                      # Check config exists
-                      config=$(echo $prepare_images_ouput | jq '.images | map(select(.configuration_group_names[] == "Management_Master")) | .[].configuration' | tr -d '"')
-                      if [[ -z $config ]]; then echo "ERROR  no CFS configuration was received for 'Management_Master' from prepare images stage"; exit 1; fi
-                      cray cfs configurations describe "$config" > /dev/null
-                      if [[ $? -ne 0 ]]; then
-                        exit 1 # could not find the desired cfs configuration
-                      else
-                        echo "NOTICE found CFS configuration:$config in CFS for 'Management_Master' nodes"
-                      fi
-
-                      # Check image exists
-                      image=$(echo $prepare_images_ouput | jq '.images | map(select(.configuration_group_names[] == "Management_Master")) | .[].final_image_id' | tr -d '"')
-                      if [[ -z $image ]]; then echo "ERROR  no image was received for 'Management_Master' from prepare images stage"; exit 1; fi
-                      if [[ $(echo $image | wc -l) -gt 1 ]]; then 
-                        echo "ERROR  more than 1 image was received for Management_Master nodes. Must be exactly 1 image to rebuild"
-                        echo "ERROR  Images received: $image"; exit 1
-                      fi
-                      cray ims images describe "$image" > /dev/null
-                      if [[ $? -ne 0 ]]; then
-                        exit 1 # could not find the image in IMS
-                      else
-                        echo "NOTICE found image:$image in IMS for Management_Master rebuild"
-                      fi
-                    fi
           - name: upgrade-m002
-            dependencies:
-              - verify-images-and-configuration
             templateRef:
               name: ssh-template
               template: shell-script
@@ -147,32 +74,43 @@ spec:
                   value: "{{$.DryRun}}"
                 - name: scriptContent
                   value: |
-                    export TOKEN=$(curl -k -s -S -d grant_type=client_credentials \
+                    TOKEN=$(curl -k -s -S -d grant_type=client_credentials \
                     -d client_id=admin-client \
                     -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
                     https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
+                    if [[ $? -ne 0 ]]; then
+                      echo "ERROR Could not retrieve the access token from keycloak"
+                    else
+                      export TOKEN=$TOKEN
+                    fi
 
+                    TARGET_NCN=ncn-m002
                     limit_management_nodes=$(echo '{{inputs.parameters.global_params}}' | jq -r '.input_params.limit_management_nodes[]')
                     if [[ -z $(echo $limit_management_nodes | grep 'Management_Master') ]]; then 
-                      echo "NOTICE  Not upgrading ncn-m002 nodes because 'Management_Master' was not in --limit-management-rollout"
+                      echo "NOTICE Not upgrading $TARGET_NCN nodes because 'Management_Master' was not in --limit-management-rollout"
                       exit 0
                     fi
                     labeled_nodes=$(kubectl get nodes --selector='iuf-prevent-rollout=true' -o jsonpath='{range .items[*]}{@.metadata.name}{" "}')
-                    if [[ -n $(echo $labeled_nodes | grep ncn-m002) ]]; then
-                      echo "NOTICE  ncn-m002 is labeled with 'iuf-prevent-rollout=true' which means it will not be rebuilt"
+                    if [[ -n $(echo $labeled_nodes | grep $TARGET_NCN) ]]; then
+                      echo "NOTICE $TARGET_NCN will not be rebuilt as it is labeled with 'iuf-prevent-rollout=true'"
                       exit 0
                     fi
 
-                    echo "NOTICE  updating CFS config on ncn-m002"
-                    TARGET_NCN=ncn-m002
                     TARGET_XNAME=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management" | \
                       jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"$TARGET_NCN\")) | .Xname")
-                    prepare_images_ouput=$(echo '{{inputs.parameters.global_params}}' | jq -r '.stage_params["prepare-images"].global["prepare-management-images"]["sat-bootprep-run"].script_stdout')
-                    config=$(echo $prepare_images_ouput | jq '.images | map(select(.configuration_group_names[] == "Management_Master")) | .[].configuration' | tr -d '"')
-                    cray cfs components update ${TARGET_XNAME} --enabled false --desired-config "${config}"
+                    prepare_images_output=$(echo '{{inputs.parameters.global_params}}' | jq -r '.stage_params["prepare-images"].global["prepare-management-images"]["sat-bootprep-run"].script_stdout')
+                    config=$(echo $prepare_images_output | jq '.images | map(select(.configuration_group_names[] == "Management_Master")) | .[].configuration' | tr -d '"')
 
-                    echo "NOTICE  updating boot-image in BSS on ncn-m002"
-                    IMAGE_ID=$(echo $prepare_images_ouput | jq '.images | map(select(.configuration_group_names[] == "Management_Master")) | .[].final_image_id' | tr -d '"')
+                    echo "DEBUG Updating CFS config $config on $TARGET_NCN ($TARGET_XNAME)"
+                    result=$(cray cfs components update ${TARGET_XNAME} --enabled false --desired-config "${config}" 2>&1)
+                    if [[ $? -ne 0 ]]; then
+                      result=$(echo "$result" | sed -e 's/^/DEBUG /')
+                      echo "ERROR Could not update CFS config $config on $TARGET_NCN"
+                      echo -e "DEBUG <cray cfs components update ${TARGET_XNAME} --enabled false --desired-config "${config}"> failed with -\n\n$result"
+                    fi
+
+                    IMAGE_ID=$(echo $prepare_images_output | jq '.images | map(select(.configuration_group_names[] == "Management_Master")) | .[].final_image_id' | tr -d '"')
+                    echo "DEBUG Updating boot-image $IMAGE_ID in BSS on $TARGET_NCN ($TARGET_XNAME)"
                     image_manifest_str=$(cray ims images describe $IMAGE_ID --format json | jq '.link.path')
                     image_manifest_str=${image_manifest_str#*s3://}
                     bucket="$( cut -d '/' -f 1 <<< "$image_manifest_str" )"
@@ -180,15 +118,32 @@ spec:
                     path=${image_manifest_str#*${bucket_rm}}
                     path=${path%?}
                     temp_file="/tmp/$(echo $RANDOM | md5sum | head -c 21; echo).json"
-                    cray artifacts get $bucket $path $temp_file
+                    result=$(cray artifacts get $bucket $path $temp_file 2>&1)
+                    if [ ! -s "$temp_file" ]; then
+                      result=$(echo "$result" | sed -e 's/^/DEBUG /')
+                      echo "ERROR Failed to get artifacts from bucket - $bucket, path - $path"
+                      echo -e "DEBUG File $temp_file is empty after command <cray artifacts get $bucket $path $temp_file>. Output from command is -\n\n$result"
+                    fi
                     metal_image=$(jq '.artifacts | map({"path": .link.path, "type": .type}) | .[] | select( .type == "application/vnd.cray.image.rootfs.squashfs") | .path ' < $temp_file)
-                    echo "INFO  Setting metal.server image to: $metal_image"
+                    if [ -z "$metal_image" ]; then
+                      echo "ERROR Metal image (rootfs.squashfs image) is not present in the output of <cray artifacts get $bucket $path>"
+                    else
+                      echo "DEBUG Setting metal.server image to: $metal_image"
+                    fi
                     kernel_image=$(jq '.artifacts | map({"path": .link.path, "type": .type}) | .[] | select( .type == "application/vnd.cray.image.kernel") | .path ' < $temp_file)
                     kernel_image=$(echo "$kernel_image" | tr -d '"')
-                    echo "INFO Setting kernel image to: $kernel_image"
+                    if [ -z "$kernel_image" ]; then
+                      echo "ERROR Kernel image is not present in the output of <cray artifacts get $bucket $path>"
+                    else
+                      echo "DEBUG Setting kernel image to: $kernel_image"
+                    fi
                     initrd_image=$(jq '.artifacts | map({"path": .link.path, "type": .type}) | .[] | select( .type == "application/vnd.cray.image.initrd") | .path ' < $temp_file)
                     initrd_image=$(echo "$initrd_image" | tr -d '"')
-                    echo "INFO  Setting initrd image to: $initrd_image"
+                    if [ -z "$initrd_image" ]; then
+                      echo "ERROR initrd image is not present in the output of <cray artifacts get $bucket $path>"
+                    else
+                      echo "DEBUG Setting initrd image to: $initrd_image"
+                    fi
                     METAL_SERVER=$(cray bss bootparameters list --hosts "${TARGET_XNAME}" --format json | jq '.[] |."params"' \
                     | awk -F 'metal.server=' '{print $2}' \
                     | awk -F ' ' '{print $1}')
@@ -196,14 +151,18 @@ spec:
                     PARAMS=$(cray bss bootparameters list --hosts "${TARGET_XNAME}" --format json | jq '.[] |."params"' | \
                         sed "/metal.server/ s|${METAL_SERVER}|${NEW_METAL_SERVER}|" | \
                         tr -d \")
-                    cray bss bootparameters update --hosts "${TARGET_XNAME}" \
+                    result=$(cray bss bootparameters update --hosts "${TARGET_XNAME}" \
                       --kernel $kernel_image \
                       --initrd $initrd_image \
-                      --params "${PARAMS}"
-
+                      --params "${PARAMS}" 2>&1)
+                    if[ $? != 0 ]; then
+                      result=$(echo "$result" | sed -e 's/^/DEBUG /')
+                      echo "ERROR Failed to update BSS boot parameters on $TARGET_NCN ($TARGET_XNAME)"
+                      echo -e "DEBUG <cray bss bootparameters update --hosts "${TARGET_XNAME}" --kernel $kernel_image --initrd $initrd_image --params "${PARAMS}"> with error -\n\n$result"
+                    fi
                     export TERM=linux
-                    echo "NOTICE  upgrading ncn-m002"
-                    /usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-master-nodes.sh ncn-m002
+                    echo "DEBUG Upgrading $TARGET_NCN"
+                    /usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-master-nodes.sh $TARGET_NCN
           - name: upgrade-m003
             dependencies:
               - upgrade-m002
@@ -216,32 +175,43 @@ spec:
                   value: "{{$.DryRun}}"
                 - name: scriptContent
                   value: |
-                    export TOKEN=$(curl -k -s -S -d grant_type=client_credentials \
+                    TOKEN=$(curl -k -s -S -d grant_type=client_credentials \
                     -d client_id=admin-client \
                     -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
                     https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
-                    
+                    if [[ $? -ne 0 ]]; then
+                      echo "ERROR Could not retrieve the access token from keycloak"
+                    else
+                      export TOKEN=$TOKEN
+                    fi
+
+                    TARGET_NCN=ncn-m003
                     limit_management_nodes=$(echo '{{inputs.parameters.global_params}}' | jq -r '.input_params.limit_management_nodes[]')
                     if [[ -z $(echo $limit_management_nodes | grep 'Management_Master') ]]; then 
-                      echo "NOTICE  Not upgrading ncn-m003 nodes because 'Management_Master' was not in --limit-management-rollout"
+                      echo "NOTICE Not upgrading $TARGET_NCN nodes because 'Management_Master' was not in --limit-management-rollout"
                       exit 0
                     fi
                     labeled_nodes=$(kubectl get nodes --selector='iuf-prevent-rollout=true' -o jsonpath='{range .items[*]}{@.metadata.name}{" "}')
-                    if [[ -n $(echo $labeled_nodes | grep ncn-m003) ]]; then
-                      echo "NOTICE  ncn-m003 is labeled with 'iuf-prevent-rollout=true' which means it will not be rebuilt"
+                    if [[ -n $(echo $labeled_nodes | grep $TARGET_NCN) ]]; then
+                      echo "NOTICE $TARGET_NCN will not be rebuilt as it is labeled with 'iuf-prevent-rollout=true'"
                       exit 0
                     fi
-                    
-                    echo "NOTICE  updating CFS config on ncn-m003"
-                    TARGET_NCN=ncn-m003
+
                     TARGET_XNAME=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management" | \
                       jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"$TARGET_NCN\")) | .Xname")
-                    prepare_images_ouput=$(echo '{{inputs.parameters.global_params}}' | jq -r '.stage_params["prepare-images"].global["prepare-management-images"]["sat-bootprep-run"].script_stdout')
-                    config=$(echo $prepare_images_ouput | jq '.images | map(select(.configuration_group_names[] == "Management_Master")) | .[].configuration' | tr -d '"')
-                    cray cfs components update ${TARGET_XNAME} --enabled false --desired-config "${config}"
+                    prepare_images_output=$(echo '{{inputs.parameters.global_params}}' | jq -r '.stage_params["prepare-images"].global["prepare-management-images"]["sat-bootprep-run"].script_stdout')
+                    config=$(echo $prepare_images_output | jq '.images | map(select(.configuration_group_names[] == "Management_Master")) | .[].configuration' | tr -d '"')
 
-                    echo "NOTICE  updating boot-image in BSS on ncn-m003"
-                    IMAGE_ID=$(echo $prepare_images_ouput | jq '.images | map(select(.configuration_group_names[] == "Management_Master")) | .[].final_image_id' | tr -d '"')
+                    echo "DEBUG Updating CFS config $config on $TARGET_NCN ($TARGET_XNAME)"
+                    result=$(cray cfs components update ${TARGET_XNAME} --enabled false --desired-config "${config}" 2>&1)
+                    if [[ $? -ne 0 ]]; then
+                      result=$(echo "$result" | sed -e 's/^/DEBUG /')
+                      echo "ERROR Could not update CFS config $config on $TARGET_NCN"
+                      echo -e "DEBUG <cray cfs components update ${TARGET_XNAME} --enabled false --desired-config "${config}"> failed with -\n\n$result"
+                    fi
+
+                    IMAGE_ID=$(echo $prepare_images_output | jq '.images | map(select(.configuration_group_names[] == "Management_Master")) | .[].final_image_id' | tr -d '"')
+                    echo "DEBUG Updating boot-image $IMAGE_ID in BSS on $TARGET_NCN ($TARGET_XNAME)"
                     image_manifest_str=$(cray ims images describe $IMAGE_ID --format json | jq '.link.path')
                     image_manifest_str=${image_manifest_str#*s3://}
                     bucket="$( cut -d '/' -f 1 <<< "$image_manifest_str" )"
@@ -249,15 +219,32 @@ spec:
                     path=${image_manifest_str#*${bucket_rm}}
                     path=${path%?}
                     temp_file="/tmp/$(echo $RANDOM | md5sum | head -c 21; echo).json"
-                    cray artifacts get $bucket $path $temp_file
+                    result=$(cray artifacts get $bucket $path $temp_file 2>&1)
+                    if [ ! -s "$temp_file" ]; then
+                      result=$(echo "$result" | sed -e 's/^/DEBUG /')
+                      echo "ERROR Failed to get artifacts from bucket - $bucket, path - $path"
+                      echo -e "DEBUG File $temp_file is empty after command <cray artifacts get $bucket $path $temp_file>. Output from command is -\n\n$result"
+                    fi
                     metal_image=$(jq '.artifacts | map({"path": .link.path, "type": .type}) | .[] | select( .type == "application/vnd.cray.image.rootfs.squashfs") | .path ' < $temp_file)
-                    echo "INFO  Setting metal.server image to: $metal_image"
+                    if [ -z "$metal_image" ]; then
+                      echo "ERROR Metal image (rootfs.squashfs image) is not present in the output of <cray artifacts get $bucket $path>"
+                    else
+                      echo "DEBUG Setting metal.server image to: $metal_image"
+                    fi
                     kernel_image=$(jq '.artifacts | map({"path": .link.path, "type": .type}) | .[] | select( .type == "application/vnd.cray.image.kernel") | .path ' < $temp_file)
                     kernel_image=$(echo "$kernel_image" | tr -d '"')
-                    echo "INFO Setting kernel image to: $kernel_image"
+                    if [ -z "$kernel_image" ]; then
+                      echo "ERROR Kernel image is not present in the output of <cray artifacts get $bucket $path>"
+                    else
+                      echo "DEBUG Setting kernel image to: $kernel_image"
+                    fi
                     initrd_image=$(jq '.artifacts | map({"path": .link.path, "type": .type}) | .[] | select( .type == "application/vnd.cray.image.initrd") | .path ' < $temp_file)
                     initrd_image=$(echo "$initrd_image" | tr -d '"')
-                    echo "INFO  Setting initrd image to: $initrd_image"
+                    if [ -z "$initrd_image" ]; then
+                      echo "ERROR initrd image is not present in the output of <cray artifacts get $bucket $path>"
+                    else
+                      echo "DEBUG Setting initrd image to: $initrd_image"
+                    fi
                     METAL_SERVER=$(cray bss bootparameters list --hosts "${TARGET_XNAME}" --format json | jq '.[] |."params"' \
                     | awk -F 'metal.server=' '{print $2}' \
                     | awk -F ' ' '{print $1}')
@@ -265,14 +252,18 @@ spec:
                     PARAMS=$(cray bss bootparameters list --hosts "${TARGET_XNAME}" --format json | jq '.[] |."params"' | \
                         sed "/metal.server/ s|${METAL_SERVER}|${NEW_METAL_SERVER}|" | \
                         tr -d \")
-                    cray bss bootparameters update --hosts "${TARGET_XNAME}" \
+                    result=$(cray bss bootparameters update --hosts "${TARGET_XNAME}" \
                       --kernel $kernel_image \
                       --initrd $initrd_image \
-                      --params "${PARAMS}"
-
+                      --params "${PARAMS}" 2>&1)
+                    if[ $? != 0 ]; then
+                      result=$(echo "$result" | sed -e 's/^/DEBUG /')
+                      echo "ERROR Failed to update BSS boot parameters on $TARGET_NCN ($TARGET_XNAME)"
+                      echo -e "DEBUG <cray bss bootparameters update --hosts "${TARGET_XNAME}" --kernel $kernel_image --initrd $initrd_image --params "${PARAMS}"> with error -\n\n$result"
+                    fi
                     export TERM=linux
-                    echo "NOTICE  upgrading ncn-m003"
-                    /usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-master-nodes.sh ncn-m003
+                    echo "DEBUG Upgrading $TARGET_NCN"
+                    /usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-master-nodes.sh $TARGET_NCN
           - name: end-operation
             dependencies:
               - upgrade-m003

--- a/workflows/iuf/operations/management-nodes-rollout/management-two-master-nodes-rollout.yaml
+++ b/workflows/iuf/operations/management-nodes-rollout/management-two-master-nodes-rollout.yaml
@@ -106,7 +106,7 @@ spec:
                     if [[ $? -ne 0 ]]; then
                       result=$(echo "$result" | sed -e 's/^/DEBUG /')
                       echo "ERROR Could not update CFS config $config on $TARGET_NCN"
-                      echo -e "DEBUG <cray cfs components update ${TARGET_XNAME} --enabled false --desired-config "${config}"> failed with -\n\n$result"
+                      echo -e "DEBUG <cray cfs components update ${TARGET_XNAME} --enabled false --desired-config ${config}> failed with -\n\n$result"
                     fi
 
                     IMAGE_ID=$(echo $prepare_images_output | jq '.images | map(select(.configuration_group_names[] == "Management_Master")) | .[].final_image_id' | tr -d '"')
@@ -158,7 +158,9 @@ spec:
                     if[ $? != 0 ]; then
                       result=$(echo "$result" | sed -e 's/^/DEBUG /')
                       echo "ERROR Failed to update BSS boot parameters on $TARGET_NCN ($TARGET_XNAME)"
-                      echo -e "DEBUG <cray bss bootparameters update --hosts "${TARGET_XNAME}" --kernel $kernel_image --initrd $initrd_image --params "${PARAMS}"> with error -\n\n$result"
+                      echo -e "DEBUG <cray bss bootparameters update --hosts ${TARGET_XNAME} --kernel $kernel_image --initrd $initrd_image --params ${PARAMS}> with error -\n\n$result"
+                    else
+                      echo "INFO Successfully updated BSS boot parameters on $TARGET_NCN ($TARGET_XNAME) with --kernel $kernel_image --initrd $initrd_image --params ${PARAMS}"
                     fi
                     export TERM=linux
                     echo "DEBUG Upgrading $TARGET_NCN"
@@ -207,7 +209,7 @@ spec:
                     if [[ $? -ne 0 ]]; then
                       result=$(echo "$result" | sed -e 's/^/DEBUG /')
                       echo "ERROR Could not update CFS config $config on $TARGET_NCN"
-                      echo -e "DEBUG <cray cfs components update ${TARGET_XNAME} --enabled false --desired-config "${config}"> failed with -\n\n$result"
+                      echo -e "DEBUG <cray cfs components update ${TARGET_XNAME} --enabled false --desired-config ${config}> failed with -\n\n$result"
                     fi
 
                     IMAGE_ID=$(echo $prepare_images_output | jq '.images | map(select(.configuration_group_names[] == "Management_Master")) | .[].final_image_id' | tr -d '"')
@@ -259,7 +261,9 @@ spec:
                     if[ $? != 0 ]; then
                       result=$(echo "$result" | sed -e 's/^/DEBUG /')
                       echo "ERROR Failed to update BSS boot parameters on $TARGET_NCN ($TARGET_XNAME)"
-                      echo -e "DEBUG <cray bss bootparameters update --hosts "${TARGET_XNAME}" --kernel $kernel_image --initrd $initrd_image --params "${PARAMS}"> with error -\n\n$result"
+                      echo -e "DEBUG <cray bss bootparameters update --hosts ${TARGET_XNAME} --kernel $kernel_image --initrd $initrd_image --params ${PARAMS}> with error -\n\n$result"
+                    else
+                      echo "INFO Successfully updated BSS boot parameters on $TARGET_NCN ($TARGET_XNAME) with --kernel $kernel_image --initrd $initrd_image --params ${PARAMS}"
                     fi
                     export TERM=linux
                     echo "DEBUG Upgrading $TARGET_NCN"

--- a/workflows/iuf/operations/management-nodes-rollout/management-worker-nodes-rollout.yaml
+++ b/workflows/iuf/operations/management-nodes-rollout/management-worker-nodes-rollout.yaml
@@ -171,7 +171,7 @@ spec:
                 value: |
                   limit_management_nodes=$(echo '{{inputs.parameters.global_params}}' | jq -r '.input_params.limit_management_nodes[]')
                   if [[ -z $(echo $limit_management_nodes | grep 'Management_Worker') ]]; then
-                    echo "NOTICE  Not rebuilding worker nodes because 'Management_Worker' was not in --limit-management-rollout"
+                    echo "NOTICE Not rebuilding worker nodes because 'Management_Worker' was not in --limit-management-rollout"
                     exit 0
                   fi
                   sets="{{inputs.parameters.sets}}"
@@ -179,7 +179,7 @@ spec:
                   current_count="{{inputs.parameters.counter}}"
                   rebuild_set=${set_array[$current_count]}
                   if [[ -z $rebuild_set ]]; then
-                    echo "NOTICE  this step received no nodes to rebuild. Continuing without rebuilding any worker nodes"
+                    echo "NOTICE This step received no nodes to rebuild. Continuing without rebuilding any worker nodes"
                     exit 0
                   fi
                   prepare_images_ouput=$(echo '{{inputs.parameters.global_params}}' | jq -r '.stage_params["prepare-images"].global["prepare-management-images"]["sat-bootprep-run"].script_stdout')
@@ -187,9 +187,7 @@ spec:
                   configuration=$(echo $prepare_images_ouput | jq '.images | map(select(.configuration_group_names[] == "Management_Worker")) | .[].configuration' | tr -d '"')
 
                   export TERM=linux
-                  echo "NOTICE  starting rebuild of $rebuild_set"
-                  echo "INFO  using image: $image"
-                  echo "INFO  using cfs-configuration: $configuration"
+                  echo "DEBUG Starting rebuild of $rebuild_set using image: $image and cfs-configuration: $configuration"
                   /usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh $rebuild_set --image-id $image --desired-cfs-conf $configuration --labels "{activity:{{workflow.labels.activity}},session:{{workflow.labels.session}}}"
           - name: move-to-next-set
             template: move-to-next-set

--- a/workflows/iuf/operations/management-nodes-rollout/verify-images-and-configuration.yaml
+++ b/workflows/iuf/operations/management-nodes-rollout/verify-images-and-configuration.yaml
@@ -80,57 +80,76 @@ spec:
                     if [[ -n $(echo $limit_management_nodes | grep 'Management_Worker') ]]; then rebuild_workers=true; fi
                     if [[ -n $(echo $limit_management_nodes | grep 'Management_Master') ]]; then rebuild_masters=true; fi
 
-                    prepare_images_ouput=$(echo '{{inputs.parameters.global_params}}' | jq -r '.stage_params["prepare-images"].global["prepare-management-images"]["sat-bootprep-run"].script_stdout')
+                    prepare_images_output=$(echo '{{inputs.parameters.global_params}}' | jq -r '.stage_params["prepare-images"].global["prepare-management-images"]["sat-bootprep-run"].script_stdout')
 
                     if $rebuild_workers; then
                       # Check config exists
-                      config=$(echo $prepare_images_ouput | jq '.images | map(select(.configuration_group_names[] == "Management_Worker")) | .[].configuration' | tr -d '"')
-                      if [[ -z $config ]]; then echo "ERROR  no CFS configuration was received for 'Management_Worker' from prepare images stage"; exit 1; fi
-                      cray cfs configurations describe "$config" > /dev/null
+                      config=$(echo $prepare_images_output | jq '.images | map(select(.configuration_group_names[] == "Management_Worker")) | .[].configuration' | tr -d '"')
+                      if [[ -z $config ]]; then
+                        echo "ERROR No CFS configuration was received for 'Management_Worker' from 'prepare-images' stage. Retry by running from 'prepare-images' stage"
+                        exit 1
+                      fi
+                      result=$(cray cfs configurations describe "$config" 2>&1)
                       if [[ $? -ne 0 ]]; then
-                        exit 1 # could not find the desired cfs configuration
+                        result=$(echo "$result" | sed -e 's/^/DEBUG /')
+                        echo "ERROR Could not find the desired configuration $configuration in CFS for Management_Worker nodes"
+                        echo -e "DEBUG Command <cray cfs configurations describe $configuration> produced -\n\n$result"
+                        exit 1
                       else
-                        echo "NOTICE found CFS configuration:$config in CFS for 'Management_Worker' nodes"
+                        echo "DEBUG Found CFS configuration:$config in CFS for Management_Worker nodes"
                       fi
 
                       # Check image exists
-                      image=$(echo $prepare_images_ouput | jq '.images | map(select(.configuration_group_names[] == "Management_Worker")) | .[].final_image_id' | tr -d '"')
-                      if [[ -z $image ]]; then echo "ERROR  no image was received for 'Management_Worker' from prepare images stage"; exit 1; fi
-                      if [[ $(echo $image | wc -l) -gt 1 ]]; then 
-                        echo "ERROR  more than 1 image was received for Management_Worker nodes. Must be exactly 1 image to rebuild"
-                        echo "ERROR  Images received: $image"; exit 1
+                      image=$(echo $prepare_images_output | jq '.images | map(select(.configuration_group_names[] == "Management_Worker")) | .[].final_image_id' | tr -d '"')
+                      if [[ -z $image ]]; then
+                        echo "ERROR No image was received for 'Management_Worker' from 'prepare-images' stage. Retry by running from 'prepare-images' stage"
+                        exit 1
                       fi
-                      cray ims images describe "$image" > /dev/null
+                      if [[ $(echo $image | wc -l) -gt 1 ]]; then 
+                        echo "ERROR More than 1 image was received for Management_Worker nodes. Must be exactly 1 image to rebuild"
+                        echo "ERROR Images received: $image"
+                        exit 1
+                      fi
+                      result=$(cray ims images describe "$image" 2>&1)
                       if [[ $? -ne 0 ]]; then
-                        exit 1 # could not find the image in IMS
+                        result=$(echo "$result" | sed -e 's/^/DEBUG /')
+                        echo "ERROR Could not find the required image $image in IMS for Management_Worker rebuild"
+                        echo -e "DEBUG Command <cray ims images describe $image> produced -\n\n$result"
+                        exit 1
                       else
-                        echo "NOTICE found image:$image in IMS for Management_Worker rebuild"
+                        echo "DEBUG Found image:$image in IMS for Management_Worker rebuild"
                       fi
                     fi
 
                     if $rebuild_masters; then
                       # Check config exists
-                      config=$(echo $prepare_images_ouput | jq '.images | map(select(.configuration_group_names[] == "Management_Master")) | .[].configuration' | tr -d '"')
-                      if [[ -z $config ]]; then echo "ERROR  no CFS configuration was received for 'Management_Master' from prepare images stage"; exit 1; fi
-                      cray cfs configurations describe "$config" > /dev/null
+                      config=$(echo $prepare_images_output | jq '.images | map(select(.configuration_group_names[] == "Management_Master")) | .[].configuration' | tr -d '"')
+                      if [[ -z $config ]]; then echo "ERROR No CFS configuration was received for 'Management_Master' from 'prepare-images' stage"; exit 1; fi
+                      result=$(cray cfs configurations describe "$config" 2>&1)
                       if [[ $? -ne 0 ]]; then
-                        exit 1 # could not find the desired cfs configuration
+                        result=$(echo "$result" | sed -e 's/^/DEBUG /')
+                        echo "ERROR Could not find the desired configuration $configuration in CFS for Management_Master nodes"
+                        echo -e "DEBUG Command <cray cfs configurations describe $configuration> produced -\n\n$result"
+                        exit 1
                       else
-                        echo "NOTICE found CFS configuration:$config in CFS for 'Management_Master' nodes"
+                        echo "DEBUG Found CFS configuration:$config in CFS for Management_Master nodes"
                       fi
 
                       # Check image exists
-                      image=$(echo $prepare_images_ouput | jq '.images | map(select(.configuration_group_names[] == "Management_Master")) | .[].final_image_id' | tr -d '"')
-                      if [[ -z $image ]]; then echo "ERROR  no image was received for 'Management_Master' from prepare images stage"; exit 1; fi
+                      image=$(echo $prepare_images_output | jq '.images | map(select(.configuration_group_names[] == "Management_Master")) | .[].final_image_id' | tr -d '"')
+                      if [[ -z $image ]]; then echo "ERROR No image was received for 'Management_Master' from prepare images stage"; exit 1; fi
                       if [[ $(echo $image | wc -l) -gt 1 ]]; then 
-                        echo "ERROR  more than 1 image was received for Management_Master nodes. Must be exactly 1 image to rebuild"
-                        echo "ERROR  Images received: $image"; exit 1
+                        echo "ERROR More than 1 image was received for Management_Master nodes. Must be exactly 1 image to rebuild"
+                        echo "ERROR Images received: $image"; exit 1
                       fi
-                      cray ims images describe "$image" > /dev/null
+                      result=$(cray ims images describe "$image" 2>&1)
                       if [[ $? -ne 0 ]]; then
-                        exit 1 # could not find the image in IMS
+                        result=$(echo "$result" | sed -e 's/^/DEBUG /')
+                        echo "ERROR Could not find the required image $image in IMS for Management_Master rebuild"
+                        echo -e "DEBUG Command <cray ims images describe $image> produced -\n\n$result"
+                        exit 1
                       else
-                        echo "NOTICE found image:$image in IMS for Management_Master rebuild"
+                        echo "DEBUG Found image:$image in IMS for Management_Master rebuild"
                       fi
                     fi
           - name: end-operation


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
Improve contextual logging information for management-nodes-rollout operation
Changes in this PR address the following use cases for IUF -

As an admin, I want to have more contextual information from the result of prepare-images stage so I can do deployments manually
As an admin, I want to have better logging information about what failed and what I need to fix
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
