### PR TITLE
CASMPET-6594 1.2 : Update Disaster Recovery Postgres for keycloak oath2 change

### DIFF
--- a/operations/kubernetes/Disaster_Recovery_Postgres.md
+++ b/operations/kubernetes/Disaster_Recovery_Postgres.md
@@ -91,24 +91,38 @@ recreated.
       job.batch/keycloak-users-localize-1 condition met
       ```
 
-1. Restart `keycloak-gatekeeper` to pick up the newly generated client ID.
+1. Restart the ingress `oauth2-proxies`.
 
-   1. Restart the `keycloak-gatekeeper` pods.
+   1. Restart the deployments.
 
       ```bash
-      ncn-mw# kubectl rollout restart deployment -n services cray-keycloak-gatekeeper-ingress
+      ncn-mw# kubectl rollout restart -n services deployment/cray-oauth2-proxies-customer-access-ingress && \
+      kubectl rollout restart -n services deployment/cray-oauth2-proxies-customer-high-speed-ingress && \
+      kubectl rollout restart -n services deployment/cray-oauth2-proxies-customer-management-ingress
       ```
 
      Expected output:
 
       ```text
-      deployment.apps/cray-keycloak-gatekeeper-ingress restarted
+      deployment.apps/cray-oauth2-proxies-customer-access-ingress restarted
+      deployment.apps/cray-oauth2-proxies-customer-high-speed-ingress restarted
+      deployment.apps/cray-oauth2-proxies-customer-management-ingress restarte
       ```
 
    1. Wait for the restart to complete.
 
       ```bash
-      ncn-mw# kubectl rollout status deployment -n services cray-keycloak-gatekeeper-ingress
+      ncn-mw# kubectl rollout status -n services deployment/cray-oauth2-proxies-customer-access-ingress && \
+      kubectl rollout status -n services deployment/cray-oauth2-proxies-customer-high-speed-ingress && \
+      kubectl rollout status -n services deployment/cray-oauth2-proxies-customer-management-ingress
+      ```
+
+     Expected output:
+
+      ```text
+      deployment "cray-oauth2-proxies-customer-access-ingress" successfully rolled out
+      deployment "cray-oauth2-proxies-customer-high-speed-ingress" successfully rolled out
+      deployment "cray-oauth2-proxies-customer-management-ingress" successfully rolled out
       ```
 
 Any other changes made to Keycloak, such as local users that have been created, will have to be manually re-applied.


### PR DESCRIPTION
# Description
Updated the restart of the ingress gateway to the oauth2-proxies.
TBD : Backport to 1.3, 1.4 and 1.5

# Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
