### PR TITLE
CASMNET-2127 | qlogic driver crash known issue doc

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -885,8 +885,6 @@ twinax
 USR SFP-10G
 vcs-user-credentials
 Xcvr
-Qlogic
-qlogic
 Canu
 VSX-pair
 vlan

--- a/.spelling
+++ b/.spelling
@@ -885,6 +885,11 @@ twinax
 USR SFP-10G
 vcs-user-credentials
 Xcvr
+Qlogic
+qlogic
+Canu
+VSX-pair
+vlan
 
 # Per-file spelling exceptions. Please keep this section sorted in order by filepath, to help make it easier to
 # see if a file already is listed.

--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -43,6 +43,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 * [Antero node NID allocation](known_issues/antero_node_NID_allocation.md)
 * [HPE nodes not properly transitioning power state](known_issues/hpe_systems_not_transitioning_power_state.md)
 * [Software Management Services health check](known_issues/sms_health_check.md)
+* [Qlogic driver crash on storage nodes](known_issues/qlogic_driver_crash.md)
 
 ## Booting
 

--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -43,7 +43,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 * [Antero node NID allocation](known_issues/antero_node_NID_allocation.md)
 * [HPE nodes not properly transitioning power state](known_issues/hpe_systems_not_transitioning_power_state.md)
 * [Software Management Services health check](known_issues/sms_health_check.md)
-* [Qlogic driver crash on storage nodes](known_issues/qlogic_driver_crash.md)
+* [QLogic driver crash on storage nodes](known_issues/qlogic_driver_crash.md)
 
 ## Booting
 

--- a/troubleshooting/known_issues/qlogic_driver_crash.md
+++ b/troubleshooting/known_issues/qlogic_driver_crash.md
@@ -85,7 +85,7 @@ interface lag 14 multi-chassis
     spanning-tree port-type admin-edge
 ```
 
-Too correct the issue, please login to both the VSX pair switches and correct the configuration of these lags to use "vlan trunk native 10":
+Too correct the issue, please login to both the VSX pair switches and correct the configuration of these lags to use `vlan trunk native 10`:
 
 ```text
 interface lag 10 multi-chassis

--- a/troubleshooting/known_issues/qlogic_driver_crash.md
+++ b/troubleshooting/known_issues/qlogic_driver_crash.md
@@ -87,7 +87,7 @@ interface lag 14 multi-chassis
 
 Too correct the issue, please login to both the VSX pair switches and correct the configuration of these lags to use "vlan trunk native 10":
 
-```bash
+```text
 interface lag 10 multi-chassis
     description ncn-s001:ocp:2<==sw-spine-001
     no shutdown

--- a/troubleshooting/known_issues/qlogic_driver_crash.md
+++ b/troubleshooting/known_issues/qlogic_driver_crash.md
@@ -10,7 +10,7 @@ The configuration is fixed in Canu versions 2.3 and above.
 
 Signature of the driver crash:
 
-```bash
+```text
 [72201.473386] CPU: 28 PID: 1380762 Comm: sadc Kdump: loaded Tainted: G        W           5.14.21-150400.24.38.1.25440.1.PTF.1204911-default #1 SLE15-SP4 a183b387d1d6082da7a867507e6a04161f95b2be
 [72201.491487] Hardware name: HPE ProLiant DL325 Gen10 Plus/ProLiant DL325 Gen10 Plus, BIOS A43 11/17/2022
 [72201.501809] RIP: 0010:qed_get_current_link+0x11/0xe0 [qed]

--- a/troubleshooting/known_issues/qlogic_driver_crash.md
+++ b/troubleshooting/known_issues/qlogic_driver_crash.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-In some failover/maintenance scenarios users may experience Qlogic driver crash on the storage nodes. This issue is usually tied to network event's such as an reboot of a switch in the VSX pair but can happen with out user intervention as well albeit rarely.
+In some failover/maintenance scenarios users may experience Qlogic driver crash on the storage nodes. This issue is usually tied to network events, such as a reboot of a switch in the VSX pair, but can also occur without user intervention in rare events.
 
 Issue seems to be aggravated by incorrect configuration for storage node back-channel links and per internal testing correcting the configuration on switch greatly reduces the risk of running into this issue.
 

--- a/troubleshooting/known_issues/qlogic_driver_crash.md
+++ b/troubleshooting/known_issues/qlogic_driver_crash.md
@@ -53,7 +53,7 @@ Upgrade Canu to 2.3 or above, regenerate the configuration and apply it the VSX-
 
 Or manually correct the configuration.
 
-In this example of the problem you can see that the lags 10,12,14 which are the lags for the storage back channel communication have applied configuration of "vlan trunk native 1". Which is wrong.
+In this example of the problem you can see that the lags 10,12,14 which are the lags for the storage back channel communication have applied configuration of `vlan trunk native 1`. Which is wrong.
 
 ```text
 interface lag 10 multi-chassis

--- a/troubleshooting/known_issues/qlogic_driver_crash.md
+++ b/troubleshooting/known_issues/qlogic_driver_crash.md
@@ -119,4 +119,4 @@ interface lag 14 multi-chassis
 
 ## Fix
 
-Working with vendor to fix qlogic driver code, once fix is released we will add the new qlogic driver to our firmware pack.
+The vendor is working to fix the Qlogic driver code. Once a fix is released, the new Qlogic driver will be added to the firmware pack.

--- a/troubleshooting/known_issues/qlogic_driver_crash.md
+++ b/troubleshooting/known_issues/qlogic_driver_crash.md
@@ -6,7 +6,7 @@ In some failover/maintenance scenarios users may experience Qlogic driver crash 
 
 Issue seems to be aggravated by incorrect configuration for storage node back-channel links and per internal testing correcting the configuration on switch greatly reduces the risk of running into this issue.
 
-The configuration is fixed in Canu versions 2.3 and above.
+The configuration is fixed in CANU versions 2.3 and above.
 
 Signature of the driver crash:
 

--- a/troubleshooting/known_issues/qlogic_driver_crash.md
+++ b/troubleshooting/known_issues/qlogic_driver_crash.md
@@ -1,10 +1,17 @@
-# Qlogic driver crash
+# QLogic driver crash
+
+- [Description](#description)
+- [Workaround](#workaround)
+- [Fix](#fix)
 
 ## Description
 
-In some failover/maintenance scenarios users may experience Qlogic driver crash on the storage nodes. This issue is usually tied to network events, such as a reboot of a switch in the VSX pair, but can also occur without user intervention in rare events.
+In some failover/maintenance scenarios users may experience QLogic driver crash on the storage nodes. This issue is
+usually tied to network events, such as a reboot of a switch in the VSX pair, but can also occur without user
+intervention in rare events.
 
-Issue seems to be aggravated by incorrect configuration for storage node back-channel links and per internal testing correcting the configuration on switch greatly reduces the risk of running into this issue.
+Issue seems to be aggravated by incorrect configuration for storage node back-channel links and per internal testing
+correcting the configuration on switch greatly reduces the risk of running into this issue.
 
 The configuration is fixed in CANU versions 2.3 and above.
 
@@ -49,11 +56,13 @@ Signature of the driver crash:
 
 ## Workaround
 
-Upgrade CANU to version 2.3 or above, regenerate the configuration, and then apply it the VSX-pair that hosts the storage nodes.
+Upgrade CANU to version 2.3 or above, regenerate the configuration, and then apply it the VSX-pair that hosts the
+storage nodes.
 
 Or manually correct the configuration.
 
-In this example of the problem you can see that the lags 10,12,14 which are the lags for the storage back channel communication have applied configuration of `vlan trunk native 1`. Which is wrong.
+In this example of the problem you can see that the lags 10,12,14 which are the lags for the storage back channel
+communication have applied configuration of `vlan trunk native 1`. Which is wrong.
 
 ```text
 interface lag 10 multi-chassis
@@ -85,7 +94,8 @@ interface lag 14 multi-chassis
     spanning-tree port-type admin-edge
 ```
 
-Too correct the issue, please login to both the VSX pair switches and correct the configuration of these lags to use `vlan trunk native 10`:
+Too correct the issue, please login to both the VSX pair switches and correct the configuration of these lags to
+use `vlan trunk native 10`:
 
 ```text
 interface lag 10 multi-chassis
@@ -119,4 +129,5 @@ interface lag 14 multi-chassis
 
 ## Fix
 
-The vendor is working to fix the Qlogic driver code. Once a fix is released, the new Qlogic driver will be added to the firmware pack.
+The vendor is working to fix the QLogic driver code. Once a fix is released, the new QLogic driver will be added to the
+firmware pack.

--- a/troubleshooting/known_issues/qlogic_driver_crash.md
+++ b/troubleshooting/known_issues/qlogic_driver_crash.md
@@ -49,7 +49,7 @@ Signature of the driver crash:
 
 ## Workaround
 
-Upgrade Canu to 2.3 or above, regenerate the configuration and apply it the VSX-pair that hosts the storage nodes.
+Upgrade CANU to version 2.3 or above, regenerate the configuration, and then apply it the VSX-pair that hosts the storage nodes.
 
 Or manually correct the configuration.
 

--- a/troubleshooting/known_issues/qlogic_driver_crash.md
+++ b/troubleshooting/known_issues/qlogic_driver_crash.md
@@ -55,7 +55,7 @@ Or manually correct the configuration.
 
 In this example of the problem you can see that the lags 10,12,14 which are the lags for the storage back channel communication have applied configuration of "vlan trunk native 1". Which is wrong.
 
-```bash
+```text
 interface lag 10 multi-chassis
     description ncn-s001:ocp:2<==sw-spine-001
     no shutdown

--- a/troubleshooting/known_issues/qlogic_driver_crash.md
+++ b/troubleshooting/known_issues/qlogic_driver_crash.md
@@ -1,0 +1,122 @@
+# Qlogic driver crash
+
+## Description
+
+In some failover/maintenance scenarios users may experience Qlogic driver crash on the storage nodes. This issue is usually tied to network event's such as an reboot of a switch in the VSX pair but can happen with out user intervention as well albeit rarely.
+
+Issue seems to be aggravated by incorrect configuration for storage node back-channel links and per internal testing correcting the configuration on switch greatly reduces the risk of running into this issue.
+
+The configuration is fixed in Canu versions 2.3 and above.
+
+Signature of the driver crash:
+
+```bash
+[72201.473386] CPU: 28 PID: 1380762 Comm: sadc Kdump: loaded Tainted: G        W           5.14.21-150400.24.38.1.25440.1.PTF.1204911-default #1 SLE15-SP4 a183b387d1d6082da7a867507e6a04161f95b2be
+[72201.491487] Hardware name: HPE ProLiant DL325 Gen10 Plus/ProLiant DL325 Gen10 Plus, BIOS A43 11/17/2022
+[72201.501809] RIP: 0010:qed_get_current_link+0x11/0xe0 [qed]
+[72201.508225] Code: 48 81 c7 d0 00 00 00 e8 f8 c1 e8 e6 e9 d7 fe ff ff e8 43 18 e9 e6 0f 1f 00 0f 1f 44 00 00 41 55 41 54 49 89 fc 55 53 48 89 f5 <80> bf 54 43 00 00 00 48 8d 9f 90 00 00 00 75 3f 48 89 df e8 f7 f9
+[72201.527984] RSP: 0018:ffffb4e18a3dfba8 EFLAGS: 00010246
+[72201.534113] RAX: ffffffffc09a6810 RBX: ffffb4e18a3dfc68 RCX: 0000000000000000
+[72201.542163] RDX: ffff9cbae6868000 RSI: ffffb4e18a3dfbd0 RDI: 0000000000000000
+[72201.550212] RBP: ffffb4e18a3dfbd0 R08: ffff9cbae6868000 R09: ffff9ca69e9e1a40
+[72201.558262] R10: ffffb4e18a3dfc68 R11: 0000000000000000 R12: 0000000000000000
+[72201.566311] R13: ffff9ca4caa90940 R14: 0000000000000001 R15: 0000000000000001
+[72201.574360] FS:  00007f4a2dc1ab80(0000) GS:ffff9cc33f100000(0000) knlGS:0000000000000000
+[72201.583370] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+[72201.590023] CR2: 0000000000004354 CR3: 000000120fabc000 CR4: 0000000000350ee0
+[72201.598073] Call Trace:
+[72201.601409]  <TASK>
+[72201.604393]  qede_get_link_ksettings+0x75/0x120 [qede ec51249dd817fa184d2346562f8d1f5661029c7c]
+[72201.614025]  ? duplex_show+0x8b/0xe0
+[72201.618497]  duplex_show+0x8b/0xe0
+[72201.622793]  dev_attr_show+0x18/0x50
+[72201.627267]  sysfs_kf_seq_show+0x9b/0x110
+[72201.632177]  seq_read_iter+0xd9/0x440
+[72201.636735]  new_sync_read+0x11c/0x1b0
+[72201.641382]  vfs_read+0x16f/0x190
+[72201.645591]  ksys_read+0xa5/0xe0
+[72201.649713]  do_syscall_64+0x5b/0x80
+[72201.654186]  ? vfs_read+0x16f/0x190
+[72201.658569]  ? exit_to_user_mode_prepare+0xbb/0x230
+[72201.664350]  ? syscall_exit_to_user_mode+0x18/0x40
+[72201.670044]  ? do_syscall_64+0x67/0x80
+[72201.674690]  ? do_syscall_64+0x67/0x80
+[72201.679335]  ? do_syscall_64+0x67/0x80
+[72201.683978]  ? exit_to_user_mode_prepare+0x1dc/0x230
+[72201.689845]  entry_SYSCALL_64_after_hwframe+0x61/0xcb
+[72201.695800] RIP: 0033:0x7f4a2d503a3e 
+```
+
+## Workaround
+
+Upgrade Canu to 2.3 or above, regenerate the configuration and apply it the VSX-pair that hosts the storage nodes.
+
+Or manually correct the configuration.
+
+In this example of the problem you can see that the lags 10,12,14 which are the lags for the storage back channel communication have applied configuration of "vlan trunk native 1". Which is wrong.
+
+```bash
+interface lag 10 multi-chassis
+    description ncn-s001:ocp:2<==sw-spine-001
+    no shutdown
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+interface lag 12 multi-chassis
+    description ncn-s002:ocp:2<==sw-spine-001
+    no shutdown
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+interface lag 14 multi-chassis
+    description ncn-s003:ocp:2<==sw-spine-001
+    no shutdown
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+```
+
+Too correct the issue, please login to both the VSX pair switches and correct the configuration of these lags to use "vlan trunk native 10":
+
+```bash
+interface lag 10 multi-chassis
+    description ncn-s001:ocp:2<==sw-spine-001
+    no shutdown
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+interface lag 12 multi-chassis
+    description ncn-s002:ocp:2<==sw-spine-001
+    no shutdown
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+interface lag 14 multi-chassis
+    description ncn-s003:ocp:2<==sw-spine-001
+    no shutdown
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+```
+
+## Fix
+
+Working with vendor to fix qlogic driver code, once fix is released we will add the new qlogic driver to our firmware pack.

--- a/troubleshooting/known_issues/qlogic_driver_crash.md
+++ b/troubleshooting/known_issues/qlogic_driver_crash.md
@@ -94,7 +94,7 @@ interface lag 14 multi-chassis
     spanning-tree port-type admin-edge
 ```
 
-Too correct the issue, please login to both the VSX pair switches and correct the configuration of these lags to
+Too correct the issue, log in to both the VSX pair switches and correct the configuration of these lags to
 use `vlan trunk native 10`:
 
 ```text


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

Known  issue documentation for Qlogic driver crash triaged in CASMTRIAGE-5033

Relates to:
- https://jira-pro.it.hpe.com:8443/browse/CASMNET-2127
- https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5033

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
