### PR TITLE
CASMINST-6399: UPGRADE: update_customization error for sysmgmt-health

### DIFF
--- a/upgrade/scripts/upgrade/util/update-customizations.sh
+++ b/upgrade/scripts/upgrade/util/update-customizations.sh
@@ -135,7 +135,9 @@ fi
 
 # Kube-prometheus-stack
 if [ "$(yq4 eval '.spec.kubernetes.services.cray-sysmgmt-health.prometheus-operator' $c)" != null ]; then
-        yq4 eval '.spec.kubernetes.services.cray-sysmgmt-health.prometheus-operator = (.spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-stack * .spec.kubernetes.services.cray-sysmgmt-health.prometheus-operator)' -i $c
+        if [ "$(yq4 eval '.spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-stack' $c)" != null ]; then
+                yq4 eval '.spec.kubernetes.services.cray-sysmgmt-health.prometheus-operator = (.spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-stack * .spec.kubernetes.services.cray-sysmgmt-health.prometheus-operator)' -i $c
+        fi        
         yq4 eval ".spec.proxiedWebAppExternalHostnames.customerManagement[3] = \"{{ kubernetes.services['cray-sysmgmt-health']['kube-prometheus-stack'].prometheus.prometheusSpec.externalAuthority }}\"" -i $c
         yq4 eval ".spec.proxiedWebAppExternalHostnames.customerManagement[4] = \"{{ kubernetes.services['cray-sysmgmt-health']['kube-prometheus-stack'].alertmanager.alertmanagerSpec.externalAuthority }}\"" -i $c
         yq4 eval ".spec.proxiedWebAppExternalHostnames.customerManagement[5] = \"{{ kubernetes.services['cray-sysmgmt-health']['kube-prometheus-stack'].grafana.externalAuthority }}\"" -i $c


### PR DESCRIPTION
# Description
yq4 to handle handle when there is no kube-prometheus-stack section in customizations.yaml in case of bare-metal systems. 


Relates to:

https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-6399

Tested:

Mug

![image](https://github.com/Cray-HPE/docs-csm/assets/53111642/9446969f-1b15-404e-b7c3-6734f437ab53)
