### PR TITLE
CASMINST-6403 Avoid creating new VMs for each Jenkinsfile matrix axis

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -87,11 +87,12 @@ pipeline {
                         steps {
                             withCredentials([gitUsernamePassword(credentialsId: 'jenkins-algol60-cray-hpe-github-integration')]) {
                                 sh "cp ${env.NAME}.spec ${env.SPEC_FILE}"
-                                runLibraryScript("addRpmMetaData.sh", env.SPEC_FILE)
-                                // sh "git update-index --assume-unchanged ${env.SPEC_FILE}"
                                 sh "echo ${env.BRANCH_NAME}"
                                 sh "env"
                                 sh "make prepare"
+                                dir("${env.BUILD_DIR}/SPECS/") {
+                                    runLibraryScript("addRpmMetaData.sh", "${env.SPEC_FILE}")
+                                }
                             }
                         }
                     }

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -61,9 +61,11 @@ pipeline {
             matrix {
 
                 agent {
-                    node {
-                        label "metal-gcp-builder"
-                        customWorkspace "${env.WORKSPACE}/${sleVersion}"
+                    docker {
+                        label 'docker'
+                        reuseNode true
+                        image "${sleImage}:${sleVersion}"
+                        args "-v /home/jenkins/.ssh:/home/jenkins/.ssh"
                     }
                 }
 
@@ -74,20 +76,19 @@ pipeline {
                     }
                 }
 
+                environment{
+                    BUILD_DIR = "${env.WORKSPACE}/dist/rpmbuild/${sleVersion}"
+                    SPEC_FILE = "${env.NAME}-${sleVersion}.spec"
+                }
+
                 stages {
 
                     stage('Prepare: RPMs') {
-                        agent {
-                            docker {
-                                label 'docker'
-                                reuseNode true
-                                image "${sleImage}:${sleVersion}"
-                            }
-                        }
                         steps {
                             withCredentials([gitUsernamePassword(credentialsId: 'jenkins-algol60-cray-hpe-github-integration')]) {
-                                runLibraryScript("addRpmMetaData.sh", "${env.NAME}.spec")
-                                sh "git update-index --assume-unchanged ${env.NAME}.spec"
+                                sh "cp ${env.NAME}.spec ${env.SPEC_FILE}"
+                                runLibraryScript("addRpmMetaData.sh", env.SPEC_FILE)
+                                // sh "git update-index --assume-unchanged ${env.SPEC_FILE}"
                                 sh "echo ${env.BRANCH_NAME}"
                                 sh "env"
                                 sh "make prepare"
@@ -96,13 +97,6 @@ pipeline {
                     }
 
                     stage('Build: RPMs') {
-                        agent {
-                            docker {
-                                label 'docker'
-                                reuseNode true
-                                image "${sleImage}:${sleVersion}"
-                            }
-                        }
                         steps {
                             withCredentials([gitUsernamePassword(credentialsId: 'jenkins-algol60-cray-hpe-github-integration')]) {
                                 sh "make rpm"
@@ -128,7 +122,7 @@ pipeline {
                                         component: env.NAME + RELEASE_FOLDER,
                                         isStable: isStable,
                                         os: "sle-${sles_major}sp${sles_minor}",
-                                        pattern: "dist/rpmbuild/RPMS/noarch/*.rpm",
+                                        pattern: "dist/rpmbuild/${sleVersion}/RPMS/noarch/*.rpm",
                                 )
                                 publishCsmRpms(
                                         additionalVersions: ADDITIONAL_VERSIONS,
@@ -136,7 +130,7 @@ pipeline {
                                         component: env.NAME + RELEASE_FOLDER,
                                         isStable: isStable,
                                         os: "sle-${sles_major}sp${sles_minor}",
-                                        pattern: "dist/rpmbuild/SRPMS/*.rpm",
+                                        pattern: "dist/rpmbuild/${sleVersion}/SRPMS/*.rpm",
                                 )
                             }
                         }

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ rpm_package_source:
 	tar --transform 'flags=r;s,^,/${NAME}-${VERSION}/,' -cvjf $(SOURCE_PATH) $(SPEC_FILE) --exclude .git --exclude "*.spec" --exclude dist .
 
 rpm_build_source:
-	rpmbuild -ts $(SOURCE_PATH) --define "_topdir $(BUILD_DIR)"
+	rpmbuild -bs $(BUILD_DIR)/SPECS/$(SPEC_FILE) --define "_topdir $(BUILD_DIR)"
 
 rpm_build:
-	rpmbuild -ba $(SPEC_FILE) --define "_topdir $(BUILD_DIR)"
+	rpmbuild -ba $(BUILD_DIR)/SPECS/$(SPEC_FILE) --define "_topdir $(BUILD_DIR)"

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ prepare:
 	cp $(SPEC_FILE) $(BUILD_DIR)/SPECS/
 
 rpm_package_source:
-	tar --transform 'flags=r;s,^,/${NAME}-${VERSION}/,' --exclude .git --exclude dist -cvjf $(SOURCE_PATH) .
+	tar --transform 'flags=r;s,^,/${NAME}-${VERSION}/,' -cvjf $(SOURCE_PATH) $(SPEC_FILE) --exclude .git --exclude "*.spec" --exclude dist .
 
 rpm_build_source:
 	rpmbuild -ts $(SOURCE_PATH) --define "_topdir $(BUILD_DIR)"


### PR DESCRIPTION
# Description

Reduce amount of Google Compute VMs needed to build docs-csm RPMs down to 1. Currently, it takes 3 VMs for each build. It takes a lot of time and resources to spin up all 3 VMs and do a fresh git clone onto each of them. This change uses docker container with mounted cone directory instead of 2 VMs.