### PR TITLE
CASMINST-6431 Ignore spell and style checks in docs-csm api/ folder

### DIFF
--- a/.github/workflows/link-check.yaml
+++ b/.github/workflows/link-check.yaml
@@ -43,7 +43,9 @@ jobs:
       uses: tj-actions/changed-files@v36
       with:
         files: "**/*.md"
-        files_ignore: ".github/**/*"
+        files_ignore: |
+          .github/**/*
+          api/*
 
     # Newer versions of markdown-link-checker do not work with anchors - https://github.com/tcort/markdown-link-check/issues/225
     - name: Check links in changed files

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -36,7 +36,9 @@ jobs:
       uses: tj-actions/changed-files@v36
       with:
         files: "**/*.sh"
-        files_ignore: ".github/**/*"
+        files_ignore: |
+          .github/**/*
+          api/*
 
     - uses: docker://koalaman/shellcheck:stable
       if: ${{ steps.changed-files.outputs.all_changed_files }}

--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -37,7 +37,9 @@ jobs:
       uses: tj-actions/changed-files@v36
       with:
         files: "**/*.md"
-        files_ignore: ".github/**/*"
+        files_ignore: |
+          .github/**/*
+          api/*
 
     - uses: docker://tmaier/markdown-spellcheck:latest
       env:

--- a/.github/workflows/style-check.yaml
+++ b/.github/workflows/style-check.yaml
@@ -37,7 +37,9 @@ jobs:
       uses: tj-actions/changed-files@v36
       with:
         files: "**/*.md"
-        files_ignore: ".github/**/*"
+        files_ignore: |
+          .github/**/*
+          api/*
 
     - uses: docker://ghcr.io/igorshubovych/markdownlint-cli:v0.32.0
       with:


### PR DESCRIPTION
# Description
Sometimes files in `api/` are listed as changed in the PR (when last commit in the PR is a rebase, for example: https://github.com/Cray-HPE/docs-csm/pull/3820). Spell and style checking is applied to these files and causes confusion. These files are very specific and should not undergo style/spell checks.

# Checklist
- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
