### PR TITLE
CASMPET-6516 - disable registry and fix podman aliases on ncn-s nodes

### DIFF
--- a/scripts/upload_ceph_images_to_nexus.sh
+++ b/scripts/upload_ceph_images_to_nexus.sh
@@ -23,14 +23,28 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-m001_ip=$(host ncn-m001 | awk '{ print $NF }')
-ssh-keygen -R ncn-m001 -f ~/.ssh/known_hosts > /dev/null 2>&1
-ssh-keygen -R "${m001_ip}" -f ~/.ssh/known_hosts > /dev/null 2>&1
-ssh-keyscan -H "ncn-m001,${m001_ip}" >> ~/.ssh/known_hosts
+# File name is a bit of a historical misnomer, this does upload executable
+# ceph container images from a storage node to nexus, but it also changes what
+# is running (so that those pushed images are actually used). It does this by
+# modifying the /etc/containers/registry.conf file on the storage node to point
+# to the nexus registry and then restarting the services.
 
-nexus_username=$(ssh ncn-m001 'kubectl get secret -n nexus nexus-admin-credential --template={{.data.username}} | base64 --decode')
-nexus_password=$(ssh ncn-m001 'kubectl get secret -n nexus nexus-admin-credential --template={{.data.password}} | base64 --decode')
+m002_ip=$(host ncn-m002 | awk '{ print $NF }')
+ssh-keygen -R ncn-m002 -f ~/.ssh/known_hosts > /dev/null 2>&1
+ssh-keygen -R "${m002_ip}" -f ~/.ssh/known_hosts > /dev/null 2>&1
+ssh-keyscan -H "ncn-m002,${m002_ip}" >> ~/.ssh/known_hosts
+
+nexus_username=$(ssh ncn-m002 'kubectl get secret -n nexus nexus-admin-credential --template={{.data.username}} | base64 --decode')
+nexus_password=$(ssh ncn-m002 'kubectl get secret -n nexus nexus-admin-credential --template={{.data.password}} | base64 --decode')
 ssh_options="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+
+function oneshot_health_check() {
+  ceph_status=$(ceph health -f json-pretty | jq -r .status)
+  if [[ $ceph_status != "HEALTH_OK" ]]; then
+    echo "ERROR: Ceph is not healthy!"
+    return 1
+  fi
+}
 
 function wait_for_health_ok() {
   cnt=0
@@ -63,7 +77,7 @@ function wait_for_health_ok() {
       cnt2=0
     fi
   done
-}
+} # end wait_for_health_ok()
 
 function wait_for_running_daemons() {
   daemon_type=$1
@@ -136,7 +150,7 @@ function wait_for_osd() {
     echo "Sleeping for five seconds waiting for osd.$osd running daemon..."
     cnt=$((cnt+1))
   done
-}
+} # end wait_for_osd()
 
 function wait_for_osds() {
   for host in $(ceph node ls| jq -r '.osd|keys[]'); do
@@ -246,7 +260,7 @@ function upload_image() {
           break
         fi
     done
-}
+} # end of upload_image()
 
 function redeploy_ceph_services(){
 # restart daemons
@@ -287,7 +301,7 @@ function enter_maintenance_mode() {
   ceph orch host maintenance enter "$node" --force
   counter=0
   # shellcheck disable=SC2086
-  until [[ "$(ceph orch host ls $node --format json-pretty|jq -r '.[].status')" == "maintenance" ]]; do
+  until [[ "$(ceph orch host ls --host_pattern $node --format json-pretty|jq -r '.[].status')" == "maintenance" ]]; do
     echo "Waiting for node $node to enter maintenance mode."
     (( counter ++ ))
     if [[ $counter -ge 5 ]]; then
@@ -300,23 +314,117 @@ function enter_maintenance_mode() {
 
 function exit_maintenance_mode() {
   echo "exiting maintenance mode for ${node}"
+  counter=0
   # shellcheck disable=SC2086
   if [[ "$(ceph orch host maintenance exit $node)" ]]; then
     # shellcheck disable=SC2086
-    until [[ "$(ceph orch host ls $node --format json-pretty|jq -r '.[].status')" != "maintenance" ]]; do
+    until [[ "$(ceph orch host ls --host_pattern $node --format json-pretty|jq -r '.[].status')" != "maintenance" ]]; do
       echo "Waiting for node $node to exit maintenance mode."
       sleep 15
+      counter=$(( counter + 1 ))
+      if [[ $counter -ge 5 ]]; then
+        echo "$node is still in maintenance mode. Failing the Ceph mgr process to another node to force $node to exit maintenance mode."
+        ceph mgr fail
+        counter=0
+      fi
     done
   else
     echo "Could not exit maintenance mode on $node.  Please check ceph services on $node and ensure they are started."
   fi
 }
 
+function disable_local_registries() {
+  echo "Disabling local docker registries"
+  systemctl_force="--now"
+
+  for storage_node in $(ceph orch host ls -f json |jq -r '.[].hostname'); do
+    #shellcheck disable=SC2029
+    if ssh "${storage_node}" "${ssh_options}" "systemctl disable registry.container.service ${systemctl_force}"; then
+       if ! ssh "${storage_node}" "${ssh_options}" "systemctl is-enabled registry.container.service"; then
+         echo "Docker registry service on ${storage_node} has been disabled"
+       fi
+    fi
+  done
+}
+
+function fix_registries_conf() {
+  HEREFILE=$(mktemp)
+  cat > "${HEREFILE}" <<'EOF'
+# For more information on this configuration file, see containers-registries.conf(5).
+#
+# Registries to search for images that are not fully-qualified.
+# i.e. foobar.com/my_image:latest vs my_image:latest
+[registries.search]
+registries = []
+unqualified-search-registries = ["registry.local", "localhost"]
+
+# Registries that do not use TLS when pulling images or uses self-signed
+# certificates.
+[registries.insecure]
+registries = []
+unqualified-search-registries = ["localhost", "registry.local"]
+
+# Blocked Registries, blocks the  from pulling from the blocked registry.  If you specify
+# "*", then the docker daemon will only be allowed to pull from registries listed above in the search
+# registries.  Blocked Registries is deprecated because other container runtimes and tools will not use it.
+# It is recommended that you use the trust policy file /etc/containers/policy.json to control which
+# registries you want to allow users to pull and push from.  policy.json gives greater flexibility, and
+# supports all container runtimes and tools including the docker daemon, cri-o, buildah ...
+[registries.block]
+registries = []
+
+## ADD BELOW
+
+[[registry]]
+prefix = "registry.local"
+location = "registry.local"
+insecure = true
+
+[[registry.mirror]]
+prefix = "registry.local"
+location = "localhost:5000"
+insecure = true
+
+[[registry]]
+location = "localhost:5000"
+insecure = true
+
+[[registry]]
+prefix = "localhost"
+location = "localhost:5000"
+insecure = true
+
+[[registry]]
+prefix = "artifactory.algol60.net/csm-docker/stable/quay.io"
+location = "artifactory.algol60.net/csm-docker/stable/quay.io"
+insecure = true
+
+[[registry.mirror]]
+prefix = "artifactory.algol60.net/csm-docker/stable/quay.io"
+location = "registry.local/artifactory.algol60.net/csm-docker/stable/quay.io"
+insecure = true
+
+EOF
+
+  for storage_node in $(ceph orch host ls -f json |jq -r '.[].hostname'); do
+    scp "${ssh_options}" "${HEREFILE}" "${storage_node}":/etc/containers/registries.conf
+  done
+} #end fix_registries_conf()
+
+#First check to make sure ceph is healthy prior to making any changes
+if ! oneshot_health_check; then
+  echo "Ceph is not healthy.  Please check ceph status and try again."
+  exit 1
+fi
+
+
 # Begin upload of local images into nexus
 #prometheus, node-exporter, and alertmanager have this prefix
 ceph_prefix="registry.local/artifactory.algol60.net/csm-docker/stable/quay.io/ceph/"
 ceph_grafana_prefix="registry.local/artifactory.algol60.net/csm-docker/stable/quay.io/ceph/ceph-grafana/"
 prometheus_prefix="registry.local/artifactory.algol60.net/csm-docker/stable/quay.io/prometheus/"
+disable_local_registries
+fix_registries_conf
 upload_image "prometheus" $prometheus_prefix "mgr/cephadm/container_image_prometheus"
 upload_image "node-exporter" $prometheus_prefix "mgr/cephadm/container_image_node_exporter"
 upload_image "alertmanager" $prometheus_prefix "mgr/cephadm/container_image_alertmanager"


### PR DESCRIPTION
Addressed:
- disable docker registry on each storage node that is used for ceph bootstrap
- fix podman registries.conf to a post internal build version

To do:
- Add a check and restart for any containers that did not restart (typically node-exporter)

Refactor the here file and shellcheck cleanup

One shot health_check near the beginning

Create description and function(){} cleanup

Flesh out description

CASMPET-6348 style ceph mgr fail to force service movement

Add --host_pattern  in more recent versions of ceph


# Description
1.4 based version of CASMPET-6516 to address insecure registry on utility storage nodes

# Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

# Notes
- [x] Validated on Fanta for both 1.3 branch and subsequently 1.4 branch (after full reinstall of Fanta)
