### PR TITLE
CASMCMS-8660: Make CFS import tool able to handle layers with branch field

### DIFF
--- a/scripts/operations/configuration/import_cfs_data.py
+++ b/scripts/operations/configuration/import_cfs_data.py
@@ -280,6 +280,14 @@ def create_configs(configs_map: NameObjectMap, config_names_to_create: List[str]
     print("")
     for config_name in config_names_to_create:
         print(f"Importing configuration '{config_name}'")
+        # First, check for any layers which contain both "branch" and "commit" fields. It is not legal to
+        # specify both for a layer when creating a configuration. In these cases, we omit the
+        # "commit" field when recreating the layer, as it will be automatically populated by CFS.
+        # The alternative (omitting the "branch" field) means that information is lost, since the
+        # "branch" field is only present if it is specified when creating the configuration.
+        for layer in configs_map[config_name]["layers"]:
+            if "commit" in layer and "branch" in layer:
+                del layer["commit"]
         cfs.create_configuration(config_name, configs_map[config_name]["layers"])
 
 def update_components(comps_map: NameObjectMap, comp_ids_to_update: List[str]) -> None:


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
CFS doesn't let you create a configuration layer that has both a branch and a commit field. However, configurations with such layers can exist in CFS. This is because when creating a configuration layer that has a branch field, CFS automatically populates the commit field (and can later be told to update it, if desired). 

The import tool did not take this into account, and tries to create layers with both fields. This PR modifies it so that for layers with both fields, the commit field is deleted, allowing CFS to repopulate it on import.

I found this bug during the import testing on wasp, and I also tested this PR fix on there to verify that it solved the problem.

[1.4 backport](https://github.com/Cray-HPE/docs-csm/pull/3861)
[1.3 backport](https://github.com/Cray-HPE/docs-csm/pull/3862)

No other backports needed.

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
