### PR TITLE
CASM-3496: Highly available Prometheus setup with long term storage with Thanos

### DIFF
--- a/upgrade/scripts/upgrade/util/update-customizations.sh
+++ b/upgrade/scripts/upgrade/util/update-customizations.sh
@@ -143,10 +143,12 @@ if [ "$(yq4 eval '.spec.kubernetes.services.cray-sysmgmt-health.prometheus-opera
         yq4 eval ".spec.proxiedWebAppExternalHostnames.customerManagement[3] = \"{{ kubernetes.services['cray-sysmgmt-health']['kube-prometheus-stack'].prometheus.prometheusSpec.externalAuthority }}\"" -i $c
         yq4 eval ".spec.proxiedWebAppExternalHostnames.customerManagement[4] = \"{{ kubernetes.services['cray-sysmgmt-health']['kube-prometheus-stack'].alertmanager.alertmanagerSpec.externalAuthority }}\"" -i $c
         yq4 eval ".spec.proxiedWebAppExternalHostnames.customerManagement[5] = \"{{ kubernetes.services['cray-sysmgmt-health']['kube-prometheus-stack'].grafana.externalAuthority }}\"" -i $c
+        yq4 eval ".spec.proxiedWebAppExternalHostnames.customerManagement[6] = \"{{ kubernetes.services['cray-sysmgmt-health']['kube-prometheus-stack'].thanos.thanosSpec.externalAuthority }}\"" -i $c
         yq4 eval ".spec.kubernetes.services.cray-kiali.kiali-operator.cr.spec.external_services.grafana.url = \"https://{{ kubernetes.services['cray-sysmgmt-health']['kube-prometheus-stack'].grafana.externalAuthority }}/\"" -i $c
         yq4 eval ".spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-stack = .spec.kubernetes.services.cray-sysmgmt-health.prometheus-operator | del(.spec.kubernetes.services.cray-sysmgmt-health.prometheus-operator)" -i $c
         yq4 eval ".spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-stack.prometheus.prometheusSpec.externalUrl = \"https://{{ kubernetes.services['cray-sysmgmt-health']['kube-prometheus-stack'].prometheus.prometheusSpec.externalAuthority }}/\"" -i $c
         yq4 eval ".spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-stack.alertmanager.alertmanagerSpec.externalUrl = \"https://{{ kubernetes.services['cray-sysmgmt-health']['kube-prometheus-stack'].alertmanager.alertmanagerSpec.externalAuthority }}/\"" -i $c
+        yq4 eval ".spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-stack.thanos.thanosSpec.externalUrl = \"https://{{ kubernetes.services['cray-sysmgmt-health']['kube-prometheus-stack'].thanos.thanosSpec.externalAuthority }}/\"" -i $c
 fi
 
 # When upgrading to CSM 1.5 or later, ensure that we remove obsolete cray-service.sqlCluster entries (CASMPET-6584).


### PR DESCRIPTION
#### CASM-3496: Highly available Prometheus setup with long-term storage with Thanos

## Summary and Scope

This PR includes Prometheus scalability and high availability with Thanos.  It has several components such as Querier, Compactor, StoreAPI, Ruler, etc.

## Issues and Related PRs

_List and characterize the relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves - https://jira-pro.it.hpe.com:8443/browse/CASM-3496


## Testing

### Tested on:

Gamora
Mug
Starlord

### Test description:

#### Pods (shards and replicas) and services

ncn-m001:~ # kubectl get pods -n sysmgmt-health | grep prom-
prometheus-cray-sysmgmt-health-kube-p-prom-0                    3/3     Running             0          2d23h
prometheus-cray-sysmgmt-health-kube-p-prom-1                    3/3     Running             0          2d23h
prometheus-cray-sysmgmt-health-kube-p-prom-shard-1-0            3/3     Running             0          2d23h
prometheus-cray-sysmgmt-health-kube-p-prom-shard-1-1            3/3     Running             0          2d23h

ncn-m001:~ # kubectl get pods -n sysmgmt-health | grep thanos
cray-sysmgmt-health-thanos-compactor-0                          1/1     Running             0          2d23h
cray-sysmgmt-health-thanos-query-0                              1/1     Running             2          2d23h
cray-sysmgmt-health-thanos-store-0                              1/1     Running             0          2d23h
thanos-ruler-kube-prometheus-stack-thanos-ruler-0               2/2     Running             0          2d23h

ncn-m001:~ # kubectl get svc -n sysmgmt-health | grep thanos
cray-sysmgmt-health-kube-p-thanos-discovery    ClusterIP      10.17.84.55     <none>        10901/TCP,10902/TCP              2d23h
cray-sysmgmt-health-thanos-compactor           ClusterIP      10.23.88.249    <none>        10902/TCP                        2d23h
cray-sysmgmt-health-thanos-query               LoadBalancer   10.16.19.238    10.94.100.0   9090:30285/TCP,10901:31499/TCP   2d23h
cray-sysmgmt-health-thanos-store               ClusterIP      None            <none>        10901/TCP,10902/TCP              2d23h
kube-prometheus-stack-thanos-ruler             ClusterIP      10.20.215.195   <none>        10902/TCP                        2d23h
thanos-ruler-operated                          ClusterIP      None            <none>        10902/TCP,10901/TCP              2d23h

#### Thanos sidecar logs:

`ncn-m001:~ # kubectl logs -n sysmgmt-health prometheus-cray-sysmgmt-health-kube-p-prom-0 -c thanos-sidecar
level=info ts=2023-05-31T09:53:39.555645995Z caller=options.go:26 protocol=gRPC msg="disabled TLS, key and cert must be set to enable"
level=info ts=2023-05-31T09:53:39.556600389Z caller=factory.go:52 msg="loading bucket configuration"
level=info ts=2023-05-31T09:53:39.556999515Z caller=sidecar.go:363 msg="starting sidecar"
level=info ts=2023-05-31T09:53:39.557187854Z caller=reloader.go:199 component=reloader msg="nothing to be watched"
level=info ts=2023-05-31T09:53:39.557268028Z caller=intrumentation.go:56 msg="changing probe status" status=ready
level=info ts=2023-05-31T09:53:39.557895248Z caller=grpc.go:131 service=gRPC/server component=sidecar msg="listening for serving gRPC" address=:10901
level=info ts=2023-05-31T09:53:39.558031647Z caller=intrumentation.go:75 msg="changing probe status" status=healthy
level=info ts=2023-05-31T09:53:39.558058345Z caller=http.go:73 service=http/server component=sidecar msg="listening for requests and metrics" address=:10902
level=info ts=2023-05-31T09:53:39.558150604Z caller=tls_config.go:232 service=http/server component=sidecar msg="Listening on" address=[::]:10902
level=info ts=2023-05-31T09:53:39.558202523Z caller=tls_config.go:235 service=http/server component=sidecar msg="TLS is disabled." http2=false address=[::]:10902
level=info ts=2023-05-31T09:53:39.564861146Z caller=sidecar.go:179 msg="successfully loaded prometheus version"
level=info ts=2023-05-31T09:53:39.629825807Z caller=sidecar.go:201 msg="successfully loaded prometheus external labels" external_labels="{prometheus=\"sysmgmt-health/cray-sysmgmt-health-kube-p-prom\", prometheus_replica=\"prometheus-cray-sysmgmt-health-kube-p-prom-0\"}"
level=warn ts=2023-05-31T09:53:41.559417402Z caller=shipper.go:239 msg="reading meta file failed, will override it" err="failed to read /prometheus/thanos.shipper.json: open /prometheus/thanos.shipper.json: no such file or directory"
level=info ts=2023-05-31T12:54:11.58930768Z caller=shipper.go:334 msg="upload new block" id=01H1RXY320N1B01DSQ66AC6YXJ
level=info ts=2023-05-31T13:00:41.572204111Z caller=shipper.go:334 msg="upload new block" id=01H1RY9MJPFYMEJ5HQA0FXC85B
level=info ts=2023-05-31T15:00:41.57989417Z caller=shipper.go:334 msg="upload new block" id=01H1S55BRZ3VJCYCDRDGXAARAQ
level=info ts=2023-05-31T17:00:41.572876242Z caller=shipper.go:334 msg="upload new block" id=01H1SC139PZZNNWHMAGWWE8Y72
level=info ts=2023-05-31T19:00:41.573873878Z caller=shipper.go:334 msg="upload new block" id=01H1SJWT8VHDETYQXMJ4HRDC7M
level=info ts=2023-05-31T21:00:41.574223443Z caller=shipper.go:334 msg="upload new block" id=01H1SSRHH2DRJYE1T44H6CJ3ZF
level=info ts=2023-05-31T23:00:41.572233724Z caller=shipper.go:334 msg="upload new block" id=01H1T0M8RX4TCYER983FY7XHR6
level=info ts=2023-06-01T01:00:41.57328052Z caller=shipper.go:334 msg="upload new block" id=01H1T7FZXBM6NFCMMNY9HKA7VJ
level=info ts=2023-06-01T03:00:41.575309697Z caller=shipper.go:334 msg="upload new block" id=01H1TEBQ8RRFXF2GJFR2QSP7VQ
level=info ts=2023-06-01T05:00:41.57343274Z caller=shipper.go:334 msg="upload new block" id=01H1TN7EGT74F0W1VHPBFVMPXW
`

#### Thanos Querier
![image](https://github.com/Cray-HPE/cray-sysmgmt-health/assets/110656037/8ac04ab7-e347-4178-8bd4-2cd8906a8a49)

#### Thanos Dashboards
![image](https://github.com/Cray-HPE/cray-sysmgmt-health/assets/110656037/e3b328d0-7ee5-4847-99e6-12eee4f72e4b)
![image](https://github.com/Cray-HPE/cray-sysmgmt-health/assets/110656037/69581afd-3975-4b3e-846d-684080e90dc7)
![image](https://github.com/Cray-HPE/cray-sysmgmt-health/assets/110656037/44da6f42-5f87-4059-9846-850de3262165)