### PR TITLE
CASMINST-6470: Update chart redeploy procedure

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -992,6 +992,12 @@ Admin
 # To allow Site Init
 Init
 
+- operations/security_and_authentication/Update_Default_Air-Cooled_BMC_and_Leaf_BMC_Switch_SNMP_Credentials.md
+SNMP-backed
+
+- operations/security_and_authentication/Update_Default_ServerTech_PDU_Credentials_used_by_the_Redfish_Translation_Service.md
+SNMP-backed
+
 - operations/security_and_authentication/Updating_the_Liquid-Cooled_EX_Cabinet_Default_Credentials_after_a_CEC_Password_Change.md
 # To allow Site Init
 Init

--- a/operations/CSM_product_management/Post_Install_Customizations.md
+++ b/operations/CSM_product_management/Post_Install_Customizations.md
@@ -132,22 +132,10 @@ Use Grafana to investigate and analyze CPU throttling and memory usage.
 
 ### Prerequisites
 
-In order to apply post-install customizations to a system, the affected Helm chart must exist on the system so that the same chart version can be redeployed with the desired customizations.
-
-This example unpacks the `csm-1.0.0` tarball under `/root` and lists the Helm charts that are now on the system.
-Set `PATH_TO_RELEASE` to the release directory where the `helm` directory exists.
-`PATH_TO_RELEASE` will be used below when deploying a customization.
-
-(`ncn-mw#`) These unpacked files can be safely removed after the customizations are deployed through `loftsman ship` in the examples below.
-
-```bash
-## This example assumes the csm-1.0.0 release is currently running and the csm-1.0.0.tar.gz has been pulled down under /root
-cd /root
-tar -xzf csm-1.0.0.tar.gz
-rm csm-1.0.0.tar.gz
-PATH_TO_RELEASE=/root/csm-1.0.0
-ls $PATH_TO_RELEASE/helm
-```
+Most of these procedures instruct the administrator to perform the [Redeploying a Chart](Redeploying_a_Chart.md)
+procedure for a specific chart. In these cases, the section on this page provides the administrator with the
+information necessary in order to carry out that procedure. It is recommended to keep both pages open
+in different browser windows for easy reference.
 
 ### Prometheus pod is `OOMKilled` or CPU throttled
 
@@ -155,134 +143,77 @@ Update resources associated with Prometheus in the `sysmgmt-health` namespace.
 This example is based on what was needed for a system with 4000 compute nodes.
 Trial and error may be needed to determine what is best for a given system at scale.
 
-1. (`ncn-mw#`) Get the current cached customizations.
+Follow the [Redeploying a Chart](Redeploying_a_Chart.md) procedure **with the following specifications**:
 
-   ```bash
-   kubectl get secrets -n loftsman site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d > customizations.yaml
-   ```
+* Chart name: `cray-sysmgmt-health`
+* Base manifest name: `platform`
+* (`ncn-mw#`) When reaching the step to update the customizations, perform the following steps:
 
-1. (`ncn-mw#`) Get the current cached platform manifest.
+    **Only follow these steps as part of the previously linked chart redeploy procedure.**
 
-   ```bash
-   kubectl get cm -n loftsman loftsman-platform -o jsonpath='{.data.manifest\.yaml}'  > platform.yaml
-   ```
+    1. Edit the customizations by adding or updating `spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-stack.prometheus.prometheusSpec.resources`.
 
-1. (`ncn-mw#`) Edit the customizations as desired by adding or updating `spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-stack.prometheus.prometheusSpec.resources`.
+        * If the number of NCNs is less than 20, then:
 
-   * If the number of NCNs is less than 20, then:
+            ```bash
+            yq write -i customizations.yaml 'spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-stack.prometheus.prometheusSpec.resources.requests.cpu' --style=double '2'
+            yq write -i customizations.yaml 'spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-stack.prometheus.prometheusSpec.resources.requests.memory' '15Gi'
+            yq write -i customizations.yaml 'spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-stack.prometheus.prometheusSpec.resources.limits.cpu' --style=double '6'
+            yq write -i customizations.yaml 'spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-stack.prometheus.prometheusSpec.resources.limits.memory' '30Gi'
+            ```
 
-      ```bash
-      yq write -i customizations.yaml 'spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-stack.prometheus.prometheusSpec.resources.requests.cpu' --style=double '2'
-      yq write -i customizations.yaml 'spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-stack.prometheus.prometheusSpec.resources.requests.memory' '15Gi'
-      yq write -i customizations.yaml 'spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-stack.prometheus.prometheusSpec.resources.limits.cpu' --style=double '6'
-      yq write -i customizations.yaml 'spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-stack.prometheus.prometheusSpec.resources.limits.memory' '30Gi'
-      ```
+        * If the number of NCNs is 20 or more, then:
 
-   * If the number of NCNs is 20 or more, then:
+            ```bash
+            yq write -i customizations.yaml 'spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-stack.prometheus.prometheusSpec.resources.requests.cpu' --style=double '6'
+            yq write -i customizations.yaml 'spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-stack.prometheus.prometheusSpec.resources.requests.memory' '50Gi'
+            yq write -i customizations.yaml 'spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-stack.prometheus.prometheusSpec.resources.limits.cpu' --style=double '12'
+            yq write -i customizations.yaml 'spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-stack.prometheus.prometheusSpec.resources.limits.memory' '60Gi'
+            ```
 
-      ```bash
-      yq write -i customizations.yaml 'spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-stack.prometheus.prometheusSpec.resources.requests.cpu' --style=double '6'
-      yq write -i customizations.yaml 'spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-stack.prometheus.prometheusSpec.resources.requests.memory' '50Gi'
-      yq write -i customizations.yaml 'spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-stack.prometheus.prometheusSpec.resources.limits.cpu' --style=double '12'
-      yq write -i customizations.yaml 'spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-stack.prometheus.prometheusSpec.resources.limits.memory' '60Gi'
-      ```
+    1. Check that the customization file has been updated.
 
-1. (`ncn-mw#`) Check that the customization file has been updated.
+        ```bash
+        yq read customizations.yaml 'spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-stack.prometheus.prometheusSpec.resources'
+        ```
 
-   ```bash
-   yq read customizations.yaml 'spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-stack.prometheus.prometheusSpec.resources'
-   ```
+        Example output:
 
-   Example output:
+        ```yaml
+        requests:
+          cpu: "3"
+          memory: 15Gi
+        limits:
+          cpu: "6"
+          memory: 30Gi
+        ```
 
-   ```yaml
-   requests:
-     cpu: "3"
-     memory: 15Gi
-   limits:
-     cpu: "6"
-     memory: 30Gi
-   ```
+* (`ncn-mw#`) When reaching the step to validate the redeployed chart, perform the following steps:
 
-1. (`ncn-mw#`) Edit the `platform.yaml` to only include the `cray-sysmgmt-health` chart and all its current data, and change the `metadata.name`
-   field to `syshealth`.
+    **Only follow these steps as part of the previously linked chart redeploy procedure.**
 
-   > **NOTE:** If you leave the `metadata.name` field unchanged, it will override the existing cached product manifest so please make sure
-   > to change it to `syshealth` before proceeding.
+    1. Verify that the pod restarts and that the desired resources have been applied.
 
-   The resources specified above will be updated in the next step. The version may differ, because this is an example.
+        Watch the `prometheus-cray-sysmgmt-health-kube-p-prometheus-0` pod restart.
 
-   ```yaml
-   apiVersion: manifests/v1beta1
-   metadata:
-     name: syshealth
-   spec:
-     charts:
-     - name: cray-sysmgmt-health
-       namespace: sysmgmt-health
-       values:
-       - "..."
-       version: 0.12.0
-   ```
+        ```bash
+        watch "kubectl get pods -n sysmgmt-health -l prometheus=cray-sysmgmt-health-kube-p-prometheus"
+        ```
 
-1. (`ncn-mw#`) Generate the manifest that will be used to redeploy the chart with the modified resources.
+        It may take about 10 minutes for the `prometheus-cray-sysmgmt-health-kube-p-prometheus-0` pod to terminate.
+        It can be forced deleted if it remains in the terminating state:
 
-   ```bash
-   manifestgen -c customizations.yaml -i platform.yaml -o manifest.yaml
-   ```
+        ```bash
+        kubectl delete pod prometheus-cray-sysmgmt-health-kube-p-prometheus-0 --force --grace-period=0 -n sysmgmt-health
+        ```
 
-1. (`ncn-mw#`) Check that the manifest file contains the desired resource settings.
+    1. Verify that the resource changes are in place.
 
-   ```bash
-   yq read manifest.yaml 'spec.charts.(name==cray-sysmgmt-health).values.kube-prometheus-stack.prometheus.prometheusSpec.resources'
-   ```
+        ```bash
+        kubectl get pod prometheus-cray-sysmgmt-health-kube-p-prometheus-0 -n sysmgmt-health -o json | jq -r '.spec.containers[] | select(.name == "prometheus").resources'
+        ```
 
-   Example output:
-
-   ```yaml
-   requests:
-     cpu: "3"
-     memory: 15Gi
-   limits:
-     cpu: "6"
-     memory: 30Gi
-   ```
-
-1. (`ncn-mw#`) Redeploy the same chart version but with the desired resource settings.
-
-   ```bash
-   loftsman ship --charts-path ${PATH_TO_RELEASE}/helm --manifest-path ${PWD}/manifest.yaml
-   ```
-
-1. (`ncn-mw#`) Verify that the pod restarts and that the desired resources have been applied.
-
-   1. Watch the `prometheus-cray-sysmgmt-health-kube-p-prometheus-0` pod restart.
-
-      ```bash
-      watch "kubectl get pods -n sysmgmt-health -l prometheus=cray-sysmgmt-health-kube-p-prometheus"
-      ```
-
-      It may take about 10 minutes for the `prometheus-cray-sysmgmt-health-kube-p-prometheus-0` pod to terminate.
-      It can be forced deleted if it remains in the terminating state:
-
-      ```bash
-      kubectl delete pod prometheus-cray-sysmgmt-health-kube-p-prometheus-0 --force --grace-period=0 -n sysmgmt-health
-      ```
-
-   1. Verify that the resource changes are in place.
-
-      ```bash
-      kubectl get pod prometheus-cray-sysmgmt-health-kube-p-prometheus-0 -n sysmgmt-health -o json | jq -r '.spec.containers[] | select(.name == "prometheus").resources'
-      ```
-
-1. (`ncn-mw#`) **This step is critical.** Store the modified `customizations.yaml` file in the `site-init` repository in the customer-managed location.
-
-   If this is not done, these changes will not persist in future installs or upgrades.
-
-   ```bash
-   kubectl delete secret -n loftsman site-init
-   kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
-   ```
+* **Make sure to perform the entire linked procedure, including the step to save the updated customizations.**
 
 ### Postgres pods are `OOMKilled` or CPU throttled
 
@@ -291,153 +222,96 @@ This example is based on what was needed for a system with 4000 compute nodes.
 Trial and error may be needed to determine what is best for a given system at scale.
 
 A similar flow can be used to update the resources for `cray-sls-postgres`, `cray-smd-postgres`, or `gitea-vcs-postgres`.
-Refer to the note at the end of this section for more details.
 
-1. (`ncn-mw#`) Get the current cached customizations.
+The following table provides values the administrator will need based on which pods are
+experiencing problems.
 
-   ```bash
-   kubectl get secrets -n loftsman site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d > customizations.yaml
-   ```
+| Chart name           | Base manifest name   | Resource path name | Kubernetes namespace |
+| -------------------- | -------------------- | ------------------ | -------------------- |
+| `cray-sls-postgres`  | `core-services`      | `cray-hms-sls`     | `services`           |
+| `cray-smd-postgres`  | `core-services`      | `cray-hms-smd`     | `services`           |
+| `gitea-vcs-postgres` | `sysmgmt`            | `gitea`            | `services`           |
+| `spire-postgres`     | `sysmgmt`            | `spire`            | `spire`              |
 
-1. (`ncn-mw#`) Get the current cached `sysmgmt` manifest.
+Using the values from the above table, follow the [Redeploying a Chart](Redeploying_a_Chart.md) **with the following specifications**:
 
-   ```bash
-   kubectl get cm -n loftsman loftsman-sysmgmt -o jsonpath='{.data.manifest\.yaml}'  > sysmgmt.yaml
-   ```
+* (`ncn-mw#`) When reaching the step to update the customizations, perform the following steps:
 
-1. (`ncn-mw#`) Edit the customizations as desired by adding or updating `spec.kubernetes.services.spire.cray-postgresql.sqlCluster.resources`.
+    **Only follow these steps as part of the previously linked chart redeploy procedure.**
 
-   ```bash
-   yq write -i customizations.yaml 'spec.kubernetes.services.spire.cray-postgresql.sqlCluster.resources.requests.cpu' --style=double '4'
-   yq write -i customizations.yaml 'spec.kubernetes.services.spire.cray-postgresql.sqlCluster.resources.requests.memory' '4Gi'
-   yq write -i customizations.yaml 'spec.kubernetes.services.spire.cray-postgresql.sqlCluster.resources.limits.cpu' --style=double '8'
-   yq write -i customizations.yaml 'spec.kubernetes.services.spire.cray-postgresql.sqlCluster.resources.limits.memory' '8Gi'
-   ```
+    1. Set the `rpname` variable to the appropriate resource path name from the table above.
 
-1. (`ncn-mw#`) Check that the customization file has been updated.
+        ```bash
+        rpname=<put resource path name from table here>
+        ```
 
-   ```bash
-   yq read customizations.yaml 'spec.kubernetes.services.spire.cray-postgresql.sqlCluster.resources'
-   ```
+    1. Edit the customizations by adding or updating `spec.kubernetes.services.${rpname}.cray-postgresql.sqlCluster.resources`.
 
-   Example output:
+        ```bash
+        yq write -i customizations.yaml "spec.kubernetes.services.${rpname}.cray-postgresql.sqlCluster.resources.requests.cpu" --style=double '4'
+        yq write -i customizations.yaml "spec.kubernetes.services.${rpname}.cray-postgresql.sqlCluster.resources.requests.memory" '4Gi'
+        yq write -i customizations.yaml "spec.kubernetes.services.${rpname}.cray-postgresql.sqlCluster.resources.limits.cpu" --style=double '8'
+        yq write -i customizations.yaml "spec.kubernetes.services.${rpname}.cray-postgresql.sqlCluster.resources.limits.memory" '8Gi'
+        ```
 
-   ```yaml
-   requests:
-     cpu: "4"
-     memory: 4Gi
-   limits:
-     cpu: "8"
-     memory: 8Gi
-   ```
+    1. Check that the customization file has been updated.
 
-1. (`ncn-mw#`) Edit the `sysmgmt.yaml` to only include the `spire` chart and all its current data, and change the `metadata.name` field to `spirepg`.
+        ```bash
+        yq read customizations.yaml "spec.kubernetes.services.${rpname}.cray-postgresql.sqlCluster.resources"
+        ```
 
-   > **NOTE:** If you leave the `metadata.name` field unchanged, it will override the existing cached product manifest so please make sure
-   > to change it to `spirepg` before proceeding.
+        Example output:
 
-   The resources specified above will be updated in the next step. The version may differ, because this is an example.
+        ```yaml
+        requests:
+          cpu: "4"
+          memory: 4Gi
+        limits:
+          cpu: "8"
+          memory: 8Gi
+        ```
 
-   ```yaml
-   apiVersion: manifests/v1beta1
-   metadata:
-     name: spirepg
-   spec:
-     charts:
-     - name: spire
-       namespace: spire
-       values:
-       - "..."
-       version: 0.9.1
-   ```
+* (`ncn-mw#`) When reaching the step to validate the redeployed chart, perform the following steps:
 
-1. (`ncn-mw#`) Generate the manifest that will be used to redeploy the chart with the modified resources.
+    **Only follow these steps as part of the previously linked chart redeploy procedure.**
 
-   ```bash
-   manifestgen -c customizations.yaml -i sysmgmt.yaml -o manifest.yaml
-   ```
+    Verify that the pods restart and that the desired resources have been applied. Commands in this section  use the
+    `$CHART_NAME` variable which should have been set as part of the [Redeploying a Chart](Redeploying_a_Chart.md) procedure.
 
-1. (`ncn-mw#`) Check that the manifest file contains the desired resource settings.
+    1. Set the `ns` variable to the name of the appropriate Kubernetes namespace from the earlier table.
 
-   ```bash
-   yq read manifest.yaml 'spec.charts.(name==spire).values.cray-postgresql.sqlCluster.resources'
-   ```
+        ```bash
+        ns=<put kubernetes namespace here>
+        ```
 
-   Example output:
+    1. Watch the pod restart.
 
-   ```yaml
-   requests:
-     cpu: "4"
-     memory: 4Gi
-   limits:
-     cpu: "8"
-     memory: 8Gi
-   ```
+        ```bash
+        watch "kubectl get pods -n ${ns} -l application=spilo,cluster-name=${CHART_NAME}"
+        ```
 
-1. (`ncn-mw#`) Redeploy the same chart version but with the desired resource settings.
+    1. Verify that the desired resources have been applied.
 
-   ```bash
-   loftsman ship --charts-path ${PATH_TO_RELEASE}/helm --manifest-path ${PWD}/manifest.yaml
-   ```
+        ```bash
+        kubectl get pod ${CHART_NAME}-0 -n "${ns}" -o json | jq -r '.spec.containers[] | select(.name == "postgres").resources'
+        ```
 
-1. (`ncn-mw#`) Verify the pods restart and that the desired resources have been applied.
+        Example output:
 
-   1. Watch the pod restart.
+        ```json
+        {
+        "limits": {
+           "cpu": "8",
+           "memory": "8Gi"
+        },
+        "requests": {
+           "cpu": "4",
+           "memory": "4Gi"
+        }
+        }
+        ```
 
-      ```bash
-      watch "kubectl get pods -n spire -l application=spilo,cluster-name=spire-postgres"
-      ```
-
-   1. Verify that the desired resources have been applied.
-
-      ```bash
-      kubectl get pod spire-postgres-0 -n spire -o json | jq -r '.spec.containers[] | select(.name == "postgres").resources'
-      ```
-
-      Example output:
-
-      ```json
-      {
-      "limits": {
-         "cpu": "8",
-         "memory": "8Gi"
-      },
-      "requests": {
-         "cpu": "4",
-         "memory": "4Gi"
-      }
-      }
-      ```
-
-1. (`ncn-mw#`) **This step is critical.** Store the modified `customizations.yaml` file in the `site-init` repository in the customer-managed location.
-
-   If this is not done, these changes will not persist in future installs or upgrades.
-
-   ```bash
-   kubectl delete secret -n loftsman site-init
-   kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
-   ```
-
-**IMPORTANT:** If `cray-sls-postgres`, `cray-smd-postgres`, or `gitea-vcs-postgres` resources need to be adjusted,
-the same procedure as above can be used with the following changes:
-
-> **NOTE:** When copying bash commands from the above section, please use a YAML file name that matches the corresponding
-> cached manifest ConfigMap to avoid accidentally using a wrong YAML file.
-
-* `cray-sls-postgres`
-
-  * Get the current cached manifest ConfigMap from: `loftsman-core-services`
-  * Resource path: `spec.kubernetes.services.cray-hms-sls.cray-postgresql.sqlCluster.resources`
-
-* `cray-smd-postgres`
-
-  * Get the current cached manifest ConfigMap from: `loftsman-core-services`
-  * Resource path: `spec.kubernetes.services.cray-hms-smd.cray-postgresql.sqlCluster.resources`
-
-* `gitea-vcs-postgres`
-
-  * Get the current cached manifest ConfigMap from: `loftsman-sysmgmt`
-  * Resource path: `spec.kubernetes.services.gitea.cray-postgresql.sqlCluster.resources`
+* **Make sure to perform the entire linked procedure, including the step to save the updated customizations.**
 
 ### Scale `cray-bss` service
 
@@ -445,115 +319,64 @@ Scale the replica count associated with the `cray-bss` service in the `services`
 This example is based on what was needed for a system with 4000 compute nodes.
 Trial and error may be needed to determine what is best for a given system at scale.
 
-1. (`ncn-mw#`) Get the current cached customizations.
+Follow the [Redeploying a Chart](Redeploying_a_Chart.md) procedure **with the following specifications**:
 
-   ```bash
-   kubectl get secrets -n loftsman site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d > customizations.yaml
-   ```
+* Chart name: `cray-hms-bss`
+* Base manifest name: `sysmgmt`
+* (`ncn-mw#`) When reaching the step to update the customizations, perform the following steps:
 
-1. (`ncn-mw#`) Get the current cached `sysmgmt` manifest.
+    **Only follow these steps as part of the previously linked chart redeploy procedure.**
 
-   ```bash
-   kubectl get cm -n loftsman loftsman-sysmgmt -o jsonpath='{.data.manifest\.yaml}' > sysmgmt.yaml
-   ```
+    1. Edit the customizations by adding or updating `spec.kubernetes.services.cray-hms-bss.cray-service.replicaCount`.
 
-1. (`ncn-mw#`) Edit the customizations as desired by adding or updating `spec.kubernetes.services.cray-hms-bss.cray-service.replicaCount`.
+        ```bash
+        yq write -i customizations.yaml 'spec.kubernetes.services.cray-hms-bss.cray-service.replicaCount' '5'
+        ```
 
-   ```bash
-   yq write -i customizations.yaml 'spec.kubernetes.services.cray-hms-bss.cray-service.replicaCount' '5'
-   ```
+    1. Check that the customization file has been updated.
 
-1. (`ncn-mw#`) Check that the customization file has been updated.
+        ```bash
+        yq read customizations.yaml 'spec.kubernetes.services.cray-hms-bss.cray-service.replicaCount'
+        ```
 
-   ```bash
-   yq read customizations.yaml 'spec.kubernetes.services.cray-hms-bss.cray-service.replicaCount'
-   ```
+        Example output:
 
-   Example output:
+        ```text
+        5
+        ```
 
-   ```text
-   5
-   ```
+* (`ncn-mw#`) When reaching the step to validate the redeployed chart, perform the following steps:
 
-1. Edit the `sysmgmt.yaml` to only include the `cray-hms-bss` chart and all its current data, and change the `metadata.name` field to `bssrep`.
+    **Only follow these steps as part of the previously linked chart redeploy procedure.**
 
-   > **NOTE:** If you leave the `metadata.name` field unchanged, it will override the existing cached product manifest so please make sure
-   > to change it to `bssrep` before proceeding.
+    Verify the `cray-bss` pods scale.
 
-   The `replicaCount` specified above will be updated in the next step. The version may differ, because this is an example.
+    1. Watch the `cray-bss` pods scale to the desired number (in this example, 5), with each pod reaching a `2/2` ready state.
 
-   ```yaml
-   apiVersion: manifests/v1beta1
-   metadata:
-     name: bssrep
-   spec:
-     charts:
-     - name: cray-hms-bss
-       namespace: services
-       values:
-       - "..."
-       version: 1.5.8
-   ```
+        ```bash
+        watch "kubectl get pods -l app.kubernetes.io/instance=cray-hms-bss -n services"
+        ```
 
-1. (`ncn-mw#`) Generate the manifest that will be used to redeploy the chart with the modified resources.
+        Example output:
 
-   ```bash
-   manifestgen -c customizations.yaml -i sysmgmt.yaml -o manifest.yaml
-   ```
+        ```text
+        NAME                       READY   STATUS    RESTARTS   AGE
+        cray-bss-fccbc9f7d-7jw2q   2/2     Running   0          82m
+        cray-bss-fccbc9f7d-l524g   2/2     Running   0          93s
+        cray-bss-fccbc9f7d-qwzst   2/2     Running   0          93s
+        cray-bss-fccbc9f7d-sw48b   2/2     Running   0          82m
+        cray-bss-fccbc9f7d-xr26l   2/2     Running   0          82m
+        ```
 
-1. (`ncn-mw#`) Check that the manifest file contains the desired resource settings.
+    1. Verify that the replicas change is present in the Kubernetes `cray-bss` deployment.
 
-   ```bash
-   yq read manifest.yaml 'spec.charts.(name==cray-hms-bss).values.cray-service.replicaCount'
-   ```
+        ```bash
+        kubectl get deployment cray-bss -n services -o json | jq -r '.spec.replicas'
+        ```
 
-   Example output:
+        In this example, `5` will be the returned value.
 
-   ```text
-   5
-   ```
-
-1. (`ncn-mw#`) Redeploy the same chart version but with the desired resource settings.
-
-   ```bash
-   loftsman ship --charts-path ${PATH_TO_RELEASE}/helm --manifest-path ${PWD}/manifest.yaml
-   ```
-
-1. Verify the `cray-bss` pods scale.
-
-   1. (`ncn-mw#`) Watch the `cray-bss` pods scale to 5, with each pod reaching a `2/2` ready state.
-
-      ```bash
-      watch "kubectl get pods -l app.kubernetes.io/instance=cray-hms-bss -n services"
-      ```
-
-      Example output:
-
-      ```text
-      NAME                       READY   STATUS    RESTARTS   AGE
-      cray-bss-fccbc9f7d-7jw2q   2/2     Running   0          82m
-      cray-bss-fccbc9f7d-l524g   2/2     Running   0          93s
-      cray-bss-fccbc9f7d-qwzst   2/2     Running   0          93s
-      cray-bss-fccbc9f7d-sw48b   2/2     Running   0          82m
-      cray-bss-fccbc9f7d-xr26l   2/2     Running   0          82m
-      ```
-
-   1. (`ncn-mw#`) Verify that the replicas change is present in the Kubernetes `cray-bss` deployment.
-
-      ```bash
-      kubectl get deployment cray-bss -n services -o json | jq -r '.spec.replicas'
-      ```
-
-      In this example, `5` will be the returned value.
-
-1. (`ncn-mw#`) **This step is critical.** Store the modified `customizations.yaml` in the `site-init` repository in the customer-managed location.
-
-   If this is not done, these changes will not persist in future installs or upgrades.
-
-   ```bash
-   kubectl delete secret -n loftsman site-init
-   kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
-   ```
+* **Make sure to perform the entire linked procedure, including the step to save the updated customizations.**
 
 ### Postgres PVC resize
 
@@ -561,360 +384,218 @@ Increase the PVC volume size associated with `cray-smd-postgres` cluster in the 
 This example is based on what was needed for a system with 4000 compute nodes.
 Trial and error may be needed to determine what is best for a given system at scale. The PVC size can only ever be increased.
 
-A similar flow can be used to update the volume size for `cray-sls-postgres`, `gitea-vcs-postgres`, or `spire-postgres`.
-Refer to the note at the end of this section for more details.
+A similar flow can be used to update the resources for `cray-sls-postgres`, `gitea-vcs-postgres`, or `spire-postgres`.
 
-1. (`ncn-mw#`) Get the current cached customizations.
+The following table provides values the administrator will need based on which pods are
+experiencing problems.
 
-   ```bash
-   kubectl get secrets -n loftsman site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d > customizations.yaml
-   ```
+| Chart name           | Base manifest name   | Resource path name | Kubernetes namespace |
+| -------------------- | -------------------- | ------------------ | -------------------- |
+| `cray-sls-postgres`  | `core-services`      | `cray-hms-sls`     | `services`           |
+| `cray-smd-postgres`  | `core-services`      | `cray-hms-smd`     | `services`           |
+| `gitea-vcs-postgres` | `sysmgmt`            | `gitea`            | `services`           |
+| `spire-postgres`     | `sysmgmt`            | `spire`            | `spire`              |
 
-1. (`ncn-mw#`) Get the current cached `core-services` manifest.
+Using the values from the above table, follow the [Redeploying a Chart](Redeploying_a_Chart.md) **with the following specifications**:
 
-   ```bash
-   kubectl get cm -n loftsman loftsman-core-services -o jsonpath='{.data.manifest\.yaml}'  > core-services.yaml
-   ```
+* (`ncn-mw#`) When reaching the step to update the customizations, perform the following steps:
 
-1. (`ncn-mw#`) Edit the customizations as desired by adding or updating `spec.kubernetes.services.cray-hms-smd.cray-postgresql.sqlCluster.volumeSize`.
+    **Only follow these steps as part of the previously linked chart redeploy procedure.**
 
-   ```bash
-   yq write -i customizations.yaml 'spec.kubernetes.services.cray-hms-smd.cray-postgresql.sqlCluster.volumeSize' '100Gi'
-   ```
+    1. Set the `rpname` variable to the appropriate resource path name from the table above.
 
-1. (`ncn-mw#`) Check that the customization file has been updated.
+        ```bash
+        rpname=<put resource path name from table here>
+        ```
 
-   ```bash
-   yq read customizations.yaml 'spec.kubernetes.services.cray-hms-smd.cray-postgresql.sqlCluster.volumeSize'
-   ```
+    1. Edit the customizations by adding or updating `spec.kubernetes.services.${rpname}.cray-postgresql.sqlCluster.volumeSize`.
 
-   Example output:
+        ```bash
+        yq write -i customizations.yaml "spec.kubernetes.services.${rpname}.cray-postgresql.sqlCluster.volumeSize" '100Gi'
+        ```
 
-   ```text
-   100Gi
-   ```
+    1. Check that the customization file has been updated.
 
-1. (`ncn-mw#`) Edit the `core-services.yaml` to only include the `cray-hms-smd` chart and all its current data, and change the `metadata.name` field to `smdpvc`.
+        ```bash
+        yq read customizations.yaml "spec.kubernetes.services.${rpname}.cray-postgresql.sqlCluster.volumeSize"
+        ```
 
-   > **NOTE:** If you leave the `metadata.name` field unchanged, it will override the existing cached product manifest so please make sure
-   > to change it to `smdpvc` before proceeding.
+        Example output:
 
-   The `volumeSize` specified above will be updated in the next step. The version may differ, because this is an example.
+        ```text
+        100Gi
+        ```
 
-   ```yaml
-   apiVersion: manifests/v1beta1
-   metadata:
-     name: smdpvc
-   spec:
-     charts:
-     - name: cray-hms-smd
-       namespace: service
-       values:
-       - "..."
-       version: 1.26.20
-   ```
+* (`ncn-mw#`) When reaching the step to validate the redeployed chart, perform the following steps:
 
-1. (`ncn-mw#`) Generate the manifest that will be used to redeploy the chart with the modified volume size.
+    **Only follow these steps as part of the previously linked chart redeploy procedure.**
 
-   ```bash
-   manifestgen -c customizations.yaml -i core-services.yaml -o manifest.yaml
-   ```
+    Verify that the pods restart and that the desired resources have been applied. Commands in this section  use the
+    `$CHART_NAME` variable which should have been set as part of the [Redeploying a Chart](Redeploying_a_Chart.md) procedure.
 
-1. (`ncn-mw#`) Check that the manifest file contains the desired volume size setting.
+    1. Set the `ns` variable to the name of the appropriate Kubernetes namespace from the earlier table.
 
-   ```bash
-   yq read manifest.yaml 'spec.charts.(name==cray-hms-smd).values.cray-postgresql.sqlCluster.volumeSize'
-   ```
+        ```bash
+        ns=<put kubernetes namespace here>
+        ```
 
-   Example output:
+    1. Verify that the increased volume size has been applied.
 
-   ```text
-   100Gi
-   ```
+        ```bash
+        watch "kubectl get postgresql ${CHART_NAME} -n $ns"
+        ```
 
-1. (`ncn-mw#`) Redeploy the same chart version but with the desired volume size setting.
+        Example output:
 
-   ```bash
-   loftsman ship --charts-path ${PATH_TO_RELEASE}/helm --manifest-path ${PWD}/manifest.yaml
-   ```
+        ```text
+        NAME                TEAM       VERSION   PODS   VOLUME   CPU-REQUEST   MEMORY-REQUEST   AGE   STATUS
+        cray-smd-postgres   cray-smd   11        3      100Gi     500m          8Gi              45m  Running
+        ```
 
-1. (`ncn-mw#`) Verify that the increased volume size has been applied.
+    1. If the status on the above command is `SyncFailed` instead of `Running`, refer to *Case 1* in the
+       `SyncFailed` section of [Troubleshoot Postgres Database](../kubernetes/Troubleshoot_Postgres_Database.md#postgres-status-syncfailed).
 
-   ```bash
-   watch "kubectl get postgresql cray-smd-postgres -n services"
-   ```
+        At this point the Postgres cluster is healthy, but additional steps are required to complete the resize of the Postgres PVCs.
 
-   Example output:
-
-   ```text
-   NAME                TEAM       VERSION   PODS   VOLUME   CPU-REQUEST   MEMORY-REQUEST   AGE   STATUS
-   cray-smd-postgres   cray-smd   11        3      100Gi     500m          8Gi              45m  Running
-   ```
-
-1. If the status on the above command is `SyncFailed` instead of `Running`, refer to *Case 1* in the
-   `SyncFailed` section of [Troubleshoot Postgres Database](../kubernetes/Troubleshoot_Postgres_Database.md#postgres-status-syncfailed).
-
-   At this point the Postgres cluster is healthy, but additional steps are required to complete the resize of the Postgres PVCs.
-
-1. (`ncn-mw#`) **This step is critical.** Store the modified `customizations.yaml` in the `site-init` repository in the customer-managed location.
-
-   If this is not done, these changes will not persist in future installs or upgrades.
-
-   ```bash
-   kubectl delete secret -n loftsman site-init
-   kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
-   ```
-
-**IMPORTANT:** If the volume sizes of `cray-sls-postgres`, `gitea-vcs-postgres`, or `spire-postgres` need to be adjusted, the same procedure as above can be used with the following changes:
-
-> **NOTE:** When copying bash commands from the above section, please use a YAML file name that matches the corresponding
-> cached manifest ConfigMap to avoid accidentally using a wrong YAML file.
-
-* `cray-sls-postgres`
-
-  * Get the current cached manifest ConfigMap from: `loftsman-core-services`
-  * Resource path: `spec.kubernetes.services.cray-hms-sls.cray-postgresql.sqlCluster.volumeSize`
-
-* `gitea-vcs-postgres`
-
-  * Get the current cached manifest ConfigMap from: `loftsman-sysmgmt`
-  * Resource path: `spec.kubernetes.services.gitea.cray-postgresql.sqlCluster.volumeSize`
-
-* `spire-postgres`
-
-  * Get the current cached manifest ConfigMap from: `loftsman-sysmgmt`
-  * Resource path: `spec.kubernetes.services.spire.cray-postgresql.sqlCluster.volumeSize`
+* **Make sure to perform the entire linked procedure, including the step to save the updated customizations.**
 
 ### Prometheus PVC resize
 
 Increase the PVC volume size associated with `prometheus-cray-sysmgmt-health-kube-p-prometheus` cluster in the `sysmgmt-health` namespace.
 This example is based on what was needed for a system with more than 20 non compute nodes (NCNs). The PVC size can only ever be increased.
 
-1. (`ncn-mw#`) Get the current cached customizations.
+Follow the [Redeploying a Chart](Redeploying_a_Chart.md) procedure **with the following specifications**:
 
-   ```bash
-   kubectl get secrets -n loftsman site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d > customizations.yaml
-   ```
+* Chart name: `cray-sysmgmt-health`
+* Base manifest name: `platform`
+* (`ncn-mw#`) When reaching the step to update the customizations, perform the following steps:
 
-1. (`ncn-mw#`) Get the current cached platform manifest.
+    **Only follow these steps as part of the previously linked chart redeploy procedure.**
 
-   ```bash
-   kubectl get cm -n loftsman loftsman-platform -o jsonpath='{.data.manifest\.yaml}'  > platform.yaml
-   ```
+    1. Edit the customizations by adding or updating `spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-stack.prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage`.
 
-1. (`ncn-mw#`) Edit the customizations as desired by adding or updating `spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-stack.prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage`.
+        ```bash
+        yq write -i customizations.yaml  'spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-stack.prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage' '300Gi'
+        ```
 
-   ```bash
-   yq write -i customizations.yaml  'spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-stack.prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage' '300Gi'
-   ```
+    1. Check that the customization file has been updated.
 
-1. (`ncn-mw#`) Check that the customization file has been updated.
+        ```bash
+        yq read customizations.yaml  'spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-stack.prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage'
+        ```
 
-   ```bash
-   yq read customizations.yaml  'spec.kubernetes.services.cray-sysmgmt-health.kube-prometheus-stack.prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage'
-   ```
+        Example output:
 
-   Example output:
+        ```text
+        300Gi
+        ```
 
-   ```text
-   300Gi
-   ```
+* (`ncn-mw#`) When reaching the step to validate the redeployed chart, perform the following step:
 
-1. (`ncn-mw#`) Edit the `platform.yaml` to only include the `cray-sysmgmt-health` chart and all its current data.
+    **Only follow this step as part of the previously linked chart redeploy procedure.**
 
-   The `storage` specified above will be updated in the next step. The version may differ, because this is an example.
+    Verify that the increased volume size has been applied.
 
-   ```yaml
-   apiVersion: manifests/v1beta1
-   metadata:
-     name: platform
-   spec:
-     charts:
-     - name: cray-sysmgmt-health
-       namespace: sysmgmt-health
-       values:
-       - "..."
-       version: 0.12.0
-   ```
+    ```bash
+    watch "kubectl get pvc -n sysmgmt-health prometheus-cray-sysmgmt-health-kube-p-prometheus-db-prometheus-cray-sysmgmt-health-kube-p-prometheus-0"
+    ```
 
-1. (`ncn-mw#`) Generate the manifest that will be used to redeploy the chart with the modified volume size.
+    Example output:
 
-   ```bash
-   manifestgen -c customizations.yaml -i platform.yaml -o manifest.yaml
-   ```
+    ```text
+    NAME                                                                                                     STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS           AGE
+    prometheus-cray-sysmgmt-health-kube-p-prometheus-db-prometheus-cray-sysmgmt-health-kube-p-prometheus-0   Bound    pvc-bcb8f4f1-fb84-4b48-95c7-63508ef18962   200Gi      RWO            k8s-block-replicated   3d2h
+    ```
 
-1. (`ncn-mw#`) Check that the manifest file contains the desired storage size setting.
+    At this point the Prometheus cluster is healthy, but additional steps are required to complete the resize of the Prometheus PVCs.
 
-   ```bash
-   yq read manifest.yaml 'spec.charts.(name==cray-sysmgmt-health).values.kube-prometheus-stack.prometheus.prometheusSpec.storageSpec.resources'
-   ```
-
-   Example output:
-
-   ```yaml
-   volumeClaimTemplate:
-   spec:
-    resources:
-      requests:
-        storage: 250Gi
-   ```
-
-1. (`ncn-mw#`) Redeploy the same chart version but with the desired volume size setting.
-
-   ```bash
-   loftsman ship --charts-path ${PATH_TO_RELEASE}/helm --manifest-path ${PWD}/manifest.yaml
-   ```
-
-1. (`ncn-mw#`) Verify that the increased volume size has been applied.
-
-   ```bash
-   watch "kubectl get pvc -n sysmgmt-health prometheus-cray-sysmgmt-health-kube-p-prometheus-db-prometheus-cray-sysmgmt-health-kube-p-prometheus-0"
-   ```
-
-   Example output:
-
-   ```text
-   NAME                                                                                                     STATUS   VOLUME
-   CAPACITY   ACCESS MODES   STORAGECLASS           AGE
-   prometheus-cray-sysmgmt-health-kube-p-prometheus-db-prometheus-cray-sysmgmt-health-kube-p-prometheus-0   Bound    pvc-bcb8f4f1-fb84-4b48-95c7-63508ef18962
-   200Gi      RWO            k8s-block-replicated   3d2h
-   ```
-
-   At this point the Prometheus cluster is healthy, but additional steps are required to complete the resize of the Prometheus PVCs.
-
-1. (`ncn-mw#`) **This step is critical.** Store the modified `customizations.yaml` in the `site-init` repository in the customer-managed location.
-
-   If this is not done, these changes will not persist in future installs or upgrades.
-
-   ```bash
-   kubectl delete secret -n loftsman site-init
-   kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
-   ```
+* **Make sure to perform the entire linked procedure, including the step to save the updated customizations.**
 
 ### `cray-hms-hmcollector` pods are `OOMKilled`
 
 Update resources associated with `cray-hms-hmcollector` in the `services` namespace.
 Trial and error may be needed to determine what is best for a given system at scale.
-
-* [Adjust HM Collector Ingress Replicas and Resource Limits](../hmcollector/adjust_hmcollector_resource_limits_requests.md)
+See [Adjust HM Collector Ingress Replicas and Resource Limits](../hmcollector/adjust_hmcollector_resource_limits_requests.md).
 
 ### `cray-cfs-api` pods are `OOMKilled`
 
-Increase the memory requests and limits associated with `cray-cfs-api` deployment in the `services` namespace.
+Increase the memory requests and limits associated with the `cray-cfs-api` deployment in the `services` namespace.
 
-1. (`ncn-mw#`) Get the current cached customizations.
+Follow the [Redeploying a Chart](Redeploying_a_Chart.md) procedure **with the following specifications**:
 
-   ```bash
-   kubectl get secrets -n loftsman site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d > customizations.yaml
-   ```
+* Chart name: `cray-cfs-api`
+* Base manifest name: `sysmgmt`
+* (`ncn-mw#`) When reaching the step to update the customizations, perform the following steps:
 
-1. (`ncn-mw#`) Get the current cached CSM `sysmgmt` manifest.
+    **Only follow these steps as part of the previously linked chart redeploy procedure.**
 
-   ```bash
-   kubectl get cm -n loftsman loftsman-sysmgmt -o jsonpath='{.data.manifest\.yaml}'  > sysmgmt.yaml
-   ```
+    1. Edit the customizations by adding or updating `spec.kubernetes.services.cray-cfs-api.cray-service.containers.cray-cfs-api.resources`.
 
-1. (`ncn-mw#`) Edit the customizations as desired by adding or updating `spec.kubernetes.services.cray-cfs-api.cray-service.containers.cray-cfs-api.resources`.
+        ```bash
+        yq4 -i '.spec.kubernetes.services.cray-cfs-api.cray-service.containers.cray-cfs-api.resources.requests.memory="200Mi"' customizations.yaml
+        yq4 -i '.spec.kubernetes.services.cray-cfs-api.cray-service.containers.cray-cfs-api.resources.limits.memory="500Mi"' customizations.yaml
+        ```
 
-   ```bash
-   yq4 -i '.spec.kubernetes.services.cray-cfs-api.cray-service.containers.cray-cfs-api.resources.requests.memory="200Mi"' customizations.yaml
-   yq4 -i '.spec.kubernetes.services.cray-cfs-api.cray-service.containers.cray-cfs-api.resources.limits.memory="500Mi"' customizations.yaml
-   ```
+    1. Check that the customization file has been updated.
 
-1. (`ncn-mw#`) Check that the customization file has been updated.
+        * Check the memory request value.
 
-   ```bash
-   yq4 '.spec.kubernetes.services.cray-cfs-api.cray-service.containers.cray-cfs-api.resources.requests.memory' customizations.yaml
-   ```
+            ```bash
+            yq4 '.spec.kubernetes.services.cray-cfs-api.cray-service.containers.cray-cfs-api.resources.requests.memory' customizations.yaml
+            ```
 
-   Expected output:
+            Expected output:
 
-   ```text
-   200Mi
-   ```
+            ```text
+            200Mi
+            ```
 
-   ```bash
-   yq4 '.spec.kubernetes.services.cray-cfs-api.cray-service.containers.cray-cfs-api.resources.limits.memory' customizations.yaml
-   ```
+        * Check the memory limit value.
 
-   Expected output:
+            ```bash
+            yq4 '.spec.kubernetes.services.cray-cfs-api.cray-service.containers.cray-cfs-api.resources.limits.memory' customizations.yaml
+            ```
 
-   ```text
-   500Mi
-   ```
+            Expected output:
 
-1. (`ncn-mw#`) Edit the `sysmgmt.yaml` to only include the `cray-cfs-api` chart and all its current data.
+            ```text
+            500Mi
+            ```
 
-   The version may differ, because this is an example.
+* (`ncn-mw#`) When reaching the step to validate the redeployed chart, perform the following steps:
 
-   ```yaml
-    apiVersion: manifests/v1beta1
-    metadata:
-      name: sysmgmt
-    spec:
-      charts:
-        - name: cray-cfs-api
-          namespace: services
-          source: csm-algol60
-          version: 1.12.1
-   ```
+    **Only follow these steps as part of the previously linked chart redeploy procedure.**
 
-1. (`ncn-mw#`) Generate the manifest that will be used to redeploy the chart with the modified volume size.
+    1. Verify that the increased memory request and limit have been applied.
 
-   ```bash
-   manifestgen -c customizations.yaml -i sysmgmt.yaml -o manifest.yaml
-   ```
+        ```bash
+        kubectl get deployment -n services cray-cfs-api -o json | jq .spec.template.spec.containers[0].resources
+        ```
 
-1. (`ncn-mw#`) Check that the manifest file contains the desired memory settings.
+        Example output:
 
-   ```bash
-   yq4 eval '.spec.charts.[] | select(.name=="cray-cfs-api") | .values.cray-service.containers.cray-cfs-api.resources'
-   ```
+        ```json
+        {
+          "limits": {
+            "cpu": "500m",
+            "memory": "500Mi"
+          },
+          "requests": {
+            "cpu": "150m",
+            "memory": "200Mi"
+          }
+        }
+        ```
 
-   Example output:
+    1. Run a CFS health check.
 
-   ```yaml
-   limits:
-     memory: 500Mi
-   requests:
-     memory: 200Mi
-   ```
+        ```bash
+        /usr/local/bin/cmsdev test -q cfs
+        ```
 
-1. (`ncn-mw#`) Redeploy the same chart version but with the desired volume size setting.
+        For more details on this test, including known issues and other command line options, see [Software Management Services health checks](../../troubleshooting/known_issues/sms_health_check.md).
 
-   ```bash
-   loftsman ship --charts-path ${PATH_TO_RELEASE}/helm --manifest-path ${PWD}/manifest.yaml
-   ```
-
-1. (`ncn-mw#`) Verify that the increased memory request and limit have been applied.
-
-   ```bash
-   kubectl get deployment -n services cray-cfs-api -o json | jq .spec.template.spec.containers[0].resources
-   ```
-
-   Example output:
-
-   ```json
-   {
-     "limits": {
-       "cpu": "500m",
-       "memory": "500Mi"
-     },
-     "requests": {
-       "cpu": "150m",
-       "memory": "200Mi"
-     }
-   }
-   ```
-
-1. (`ncn-mw#`) **This step is critical.** Store the modified `customizations.yaml` in the `site-init` repository in the customer-managed location.
-
-   If this is not done, these changes will not persist in future installs or upgrades.
-
-   ```bash
-   kubectl delete secret -n loftsman site-init
-   kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
-   ```
+* **Make sure to perform the entire linked procedure, including the step to save the updated customizations.**
 
 ## References
 

--- a/operations/CSM_product_management/Redeploying_a_Chart.md
+++ b/operations/CSM_product_management/Redeploying_a_Chart.md
@@ -1,0 +1,214 @@
+# Redeploying a Chart
+
+Administrators are able to customize many aspects of the system in order to address problems or tailor it to better suit their requirements.
+Often this requires redeploying one or more Helm charts. This page outlines the procedure for doing this in CSM. Other parts of the CSM
+documentation will reference this page if you are instructed to redeploy a chart. In those cases, the source page that links to this one should
+specify which charts should be redeployed and what customizations (if any) should be made to them.
+
+* [Prerequisites](#prerequisites)
+* [Procedure](#procedure)
+  1. [Preparation](#1-preparation)
+  1. [Obtain and optionally update customizations](#2-obtain-and-optionally-update-customizations)
+  1. [Redeploy charts](#3-redeploy-charts)
+  1. [Save updated customizations](#4-save-updated-customizations)
+  1. [Cleanup](#5-cleanup)
+
+## Prerequisites
+
+* CSM is fully installed and operational.
+* The latest CSM documentation RPMs are installed on the node where this procedure is being performed. See
+  [Check for latest documentation](../../update_product_stream/README.md#check-for-latest-documentation).
+* If this procedure was linked from another page, the administrator must have the following information from that other page:
+  * The name of the charts to be redeployed (for example, `cray-hms-bss`, `cray-sysmgmt-health`, or `spire`).
+  * The base name of the manifest for each of these charts (for example, `sysmgmt`, `platform`, or `storage`).
+  * The customization changes to make, if any.
+  * The steps to validate that the chart deployment was successful.
+
+## Procedure
+
+### 1. Preparation
+
+1. (`ncn-mw#`) Create a temporary directory to use during this procedure.
+
+    ```bash
+    TEMPDIR=$(mktemp -d) ; echo "${TEMPDIR}"
+    ```
+
+1. (`ncn-mw#`) Change the current working directory to the new directory.
+
+    ```bash
+    cd "${TEMPDIR}"
+    ```
+
+### 2. Obtain and optionally update customizations
+
+1. (`ncn-mw#`) Save the current set of chart customizations to a file.
+
+    ```bash
+    CUSTOMIZATIONS="${TEMPDIR}/customizations.yaml"
+    kubectl get secrets -n loftsman site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d > "${CUSTOMIZATIONS}"
+    ```
+
+1. Edit the `${CUSTOMIZATIONS}` file, if appropriate.
+
+    The step involves updating the system customizations. In cases where a chart is being redeployed with no changes, or only changes to the chart version,
+    then this step should be skipped.
+
+    **If this procedure was linked from another page, that page should provide instructions on what edits to make, if any.**
+
+### 3. Redeploy charts
+
+If redeploying more than one chart at once, perform the steps in this section for each chart being redeployed.
+
+1. (`ncn-mw#`) Set helper variables.
+
+    1. Set variable with the name of the chart.
+
+        **If this procedure was linked from another page, that page should provide the chart name.**
+        Examples of chart names are `cray-hms-bss`, `cray-sysmgmt-health`, or `spire`.
+
+        ```bash
+        CHART_NAME=<put actual name here>
+        echo "${CHART_NAME}"
+        ```
+
+    1. Set variable with the base manifest name for this chart.
+
+        **If this procedure was linked from another page, that page should provide the base manifest name.**
+        Examples of base manifest names are `sysmgmt`, `platform`, or `storage`.
+
+        ```bash
+        BASE_MANIFEST_NAME=<put actual name here>
+        echo "${BASE_MANIFEST_NAME}"
+        ```
+
+    1. Set convenience variables for files that will be created during this procedure.
+
+        ```bash
+        BASE_MANIFEST_FILE="${TEMPDIR}/${BASE_MANIFEST_NAME}.yaml" ; echo "${BASE_MANIFEST_FILE}"
+        BASE_CHART_FILE="${TEMPDIR}/${CHART_NAME}.yaml" ; echo "${BASE_CHART_FILE}"
+        CUSTOMIZED_CHART_FILE="${TEMPDIR}/${CHART_NAME}-customized.yaml" ; echo "${CUSTOMIZED_CHART_FILE}"
+        ```
+
+1. (`ncn-mw#`) Save the base manifest to a file.
+
+    If redeploying multiple charts, this step does not need to be repeated for additional charts that use the same base manifest name.
+
+    ```bash
+    kubectl get cm -n loftsman "loftsman-${BASE_MANIFEST_NAME}" -o jsonpath='{.data.manifest\.yaml}'  > "${BASE_MANIFEST_FILE}"
+    ```
+
+1. (`ncn-mw#`) Make a copy of this file to use for redeploying the chart.
+
+    ```bash
+    cp -v "${BASE_MANIFEST_FILE}" "${BASE_CHART_FILE}"
+    ```
+
+1. (`ncn-mw#`) Edit the name of the manifest in the new file.
+
+    This is to prevent it from overwriting the original manifest when it is redeployed.
+
+    ```bash
+    NEW_MANIFEST_NAME="${CHART_NAME}-$(date +%Y%m%d%H%M%S)"
+    yq w -i "${BASE_CHART_FILE}" 'metadata.name' "${NEW_MANIFEST_NAME}"
+    ```
+
+1. Edit the `spec.charts` list in the `${BASE_CHART_FILE}` file so that it only contains the stanza for the chart to be redeployed.
+
+    For example, if the chart being redeployed was `cray-cfs-api`, then the `charts` list would resemble the following example after editing.
+    Note that the exact form and values may differ, because this is an example.
+
+    ```yaml
+          charts:
+            - name: cray-cfs-api
+              namespace: services
+              source: csm-algol60
+              version: 1.12.1
+    ```
+
+1. (`ncn-mw#`) Update the version numbers in `${BASE_CHART_FILE}` if necessary.
+
+    The information in the chart stanza is from the time the chart was deploying during the most recent install or upgrade of the CSM software. However,
+    it is possible that the chart has been redeployed more recently, using a newer chart version. This may happen when a hotfix is installed, or when
+    the procedure on this page was previously followed.
+
+    1. Show most recently deployed chart versions.
+
+        A record is saved in Kubernetes of every Loftsman chart deploy that has happened. This step uses a helper script to find and display the most recent
+        successful deployment of this chart, in order for the administrator to check the version numbers it used.
+
+        ```bash
+        /usr/share/doc/csm/scripts/operations/kubernetes/latest_chart_manifest.sh "${CHART_NAME}"
+        ```
+
+        Example output for the `cray-cfs-api` chart may resemble the following:
+
+        ```text
+        Displaying chart manifest for 'cray-cfs-api' from loftsman-sysmgmt
+
+        name: cray-cfs-api
+        namespace: services
+        source: csm-algol60
+        swagger:
+          - name: cfs
+            url: https://raw.githubusercontent.com/Cray-HPE/config-framework-service/v1.12.2/api/openapi.yaml
+            version: v1
+        version: 1.12.1
+        ```
+
+    1. Edit the version numbers in `${BASE_CHART_FILE}` if necessary.
+
+        In the example output from the previous step, the version numbers matches what we saw previously, so no updates are required.
+        If the output shows different version numbers, then edit the version numbers in the chart stanza of `${BASE_CHART_FILE}` to match them.
+
+1. (`ncn-mw#`) Apply customizations to the manifest.
+
+    **This must be done whether or not any changes were made to the customizations in the previous section.**
+
+    ```bash
+    manifestgen -c "${CUSTOMIZATIONS}" -i "${BASE_CHART_FILE}" -o "${CUSTOMIZED_CHART_FILE}"    
+    ```
+
+1. (`ncn-mw#`) Review the customized manifest file to verify that it contains the expected version numbers and customizations.
+
+    ```bash
+    cat "${CUSTOMIZED_CHART_FILE}"
+    ```
+
+1. (`ncn-mw#`) Redeploy the chart.
+
+    * In most cases, the Helm chart to be used is already in Nexus. Unless this procedure was linked from another page which specified an alternative location
+      for the Helm chart, then run the following command:
+
+        ```bash
+        loftsman ship --charts-repo https://packages.local/repository/charts --manifest-path "${CUSTOMIZED_CHART_FILE}"
+        ```
+
+    * If this procedure was linked from another page, and that page specified a directory location for the Helm chart, then run the following command,
+      substituting the directory name provided by the linking page.
+
+        ```bash
+        loftsman ship --charts-path <helm_chart_path> --manifest-path "${CUSTOMIZED_CHART_FILE}"
+        ```
+
+1. Validate that the redeploy was successful.
+
+    How to do this will vary based on what was redeployed. **If this procedure was linked from another page, that page should provide details on how to do this validation.**
+
+1. If additional charts are being redeployed, then repeat the previous steps in this section for each such chart.
+
+### 4. Save updated customizations
+
+If no changes were made to customizations, then skip this section. **If changes were made to customizations, then this step is critical.**
+
+(`ncn-mw#`) Update the copy of the customizations in Kubernetes. If this is not done, then the customization changes will not persist after the next CSM upgrade,
+the next hotfix that is applied, or the next time that this procedure is followed.
+
+```bash
+kubectl delete secret -n loftsman site-init
+kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
+```
+
+### 5. Cleanup
+
+The temporary directory created at the beginning of the procedure may be deleted if desired.

--- a/operations/configuration_management/Version_Control_Service_VCS.md
+++ b/operations/configuration_management/Version_Control_Service_VCS.md
@@ -114,147 +114,84 @@ To change the password in the `vcs-user-credentials` Kubernetes secret, use the 
 
 1. Enter the existing password (from previous step), new password, and confirmation, and then click `Update Password`.
 
-1. Now SSH into `ncn-w001` or `ncn-m001`.
+1. SSH into `ncn-w001` or `ncn-m001`.
 
-1. Run `git clone https://github.com/Cray-HPE/csm.git`.
+1. (`ncn-mw#`) Follow the [Redeploying a Chart](../CSM_product_management/Redeploying_a_Chart.md) procedure with the following specifications:
 
-1. Copy the directory `vendor/stash.us.cray.com/scm/shasta-cfg/stable/utils` to the desired working directory.
+   * Name of chart to be redeployed: `gitea`
+   * Base name of manifest: `sysmgmt`
+   * When reaching the step to update customizations, perform the following steps:
 
-1. Change directories to be in the working directory set in the previous step.
+      **Only follow these steps as part of the previously linked chart redeploy procedure.**
 
-1. (`ncn-mw#`) Save a local copy of the `customizations.yaml` file.
+      1. Run `git clone https://github.com/Cray-HPE/csm.git`.
 
-    ```bash
-    kubectl get secrets -n loftsman site-init -o jsonpath='{.data.customizations\.yaml}' |
-        base64 -d > customizations.yaml
-    ```
+      1. Copy the directory `vendor/stash.us.cray.com/scm/shasta-cfg/stable/utils` from the cloned repository into the desired working directory.
 
-1. Change the password in the `customizations.yaml` file.
+         ```bash
+         cp -vr ./csm/vendor/stash.us.cray.com/scm/shasta-cfg/stable/utils .
+         ```
 
-   The Gitea `crayvcs` password is stored in the `vcs-user-credentials` Kubernetes Secret in the `services` namespace. This must be updated so that clients which need to make requests can authenticate with the new password.
+      1. Change the password in the `customizations.yaml` file.
 
-   In the `customizations.yaml` file, set the values for the `gitea` keys in the `spec.kubernetes.sealed_secrets` field.
-   The value in the data element where the name is `password` needs to be changed to the new Gitea password. The section
-   below will replace the existing sealed secret data in the `customizations.yaml` file.
+         The Gitea `crayvcs` password is stored in the `vcs-user-credentials` Kubernetes Secret in the `services` namespace. This must be updated so that clients which need to make requests can authenticate with the new password.
 
-   For example:
+         In the `customizations.yaml` file, set the values for the `gitea` keys in the `spec.kubernetes.sealed_secrets` field.
+         The value in the data element where the name is `password` needs to be changed to the new Gitea password. The section
+         below will replace the existing sealed secret data in the `customizations.yaml` file.
 
-   ```yaml
-   gitea:
-      generate:
-         name: vcs-user-credentials
-         data:
-           - type: static
-             args:
-             name: vcs_password
-             value: my_secret_password
-           - type: static
-             args:
-             name: vcs_username
-             value: crayvcs
-   ```
+         For example:
 
-1. (`ncn-mw#`) Encrypt the values after changing the `customizations.yaml` file.
+         ```yaml
+         gitea:
+            generate:
+               name: vcs-user-credentials
+               data:
+                 - type: static
+                   args:
+                   name: vcs_password
+                   value: my_secret_password
+                 - type: static
+                   args:
+                   name: vcs_username
+                   value: crayvcs
+         ```
 
-    ```bash
-    ./utils/secrets-seed-customizations.sh customizations.yaml
-    ```
+      1. Encrypt the values after changing the `customizations.yaml` file.
 
-   (`ncn-mw#`) If the above command complains that it cannot find `certs/sealed_secrets.crt`, then run the following commands to create it:
+          > This command makes use of the `$CUSTOMIZATIONS` variable that is set earlier in the [Redeploying a Chart](../CSM_product_management/Redeploying_a_Chart.md) procedure.
 
-    ```bash
-    mkdir -p ./certs &&
-    ./utils/bin/linux/kubeseal --controller-name sealed-secrets --fetch-cert > ./certs/sealed_secrets.crt
-    ```
+          ```bash
+          ./utils/secrets-seed-customizations.sh "${CUSTOMIZATIONS}"
+          ```
 
-1. (`ncn-mw#`) Upload the modified `customizations.yaml` file to Kubernetes.
+         If the above command complains that it cannot find `certs/sealed_secrets.crt`, then run the following commands to create it:
 
-   ```bash
-   kubectl delete secret -n loftsman site-init
-   kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
-   ```
+          ```bash
+          mkdir -pv ./certs && ./utils/bin/linux/kubeseal --controller-name sealed-secrets --fetch-cert > ./certs/sealed_secrets.crt
+          ```
 
-1. (`ncn-mw#`) Get the current cached `sysmgmt` manifest and save it into a `gitea.yaml` file.
+   * When reaching the step to validate that the redeploy was successful, perform the following steps:
 
-    ```bash
-    kubectl get cm -n loftsman loftsman-sysmgmt -o jsonpath='{.data.manifest\.yaml}'  > gitea.yaml
-    ```
+      **Only follow these steps as part of the previously linked chart redeploy procedure.**
 
-1. (`ncn-mw#`) Remove non-Gitea charts from the `gitea.yaml` file.
+      1. Verify that the Secret has been updated.
 
-   The following command will also change the `metadata.name` so
-   that it does not overwrite the `sysmgmt.yaml` file that is stored in the `loftsman` namespace.
+         Give the SealedSecret controller a few seconds to update the Secret, then run the following command to see the current value of the Secret:
 
-   ```bash
-   for i in $(yq r gitea.yaml 'spec.charts[*].name' | grep -Ev '^gitea'); do yq d -i gitea.yaml  'spec.charts(name=='"$i"')'; done
-   yq w -i gitea.yaml metadata.name gitea
-   yq d -i gitea.yaml spec.sources
-   yq w -i gitea.yaml spec.sources.charts[0].location 'https://packages.local/repository/charts'
-   yq w -i gitea.yaml spec.sources.charts[0].name csm-algol60
-   yq w -i gitea.yaml spec.sources.charts[0].type repo
-   ```
+         ```bash
+         kubectl get secret -n services vcs-user-credentials --template={{.data.vcs_password}} | base64 --decode
+         ```
 
-   After the command is run, the beginning of the `gitea.yaml` file will resemble the following:
+      1. Run a VCS health check.
 
-   ```yaml
-   apiVersion: manifests/v1beta1
-     metadata:
-       name: sysmgmt
-     spec:
-       charts:
-         - name: gitea
-           namespace: services
-           source: csm-algol60
-           values:
-             cray-service:
-               sealedSecrets:
-               - apiVersion: bitnami.com/v1alpha1
-                 kind: SealedSecret
-                 metadata:
-                   annotations:
-                     sealedsecrets.bitnami.com/cluster-wide: 'true'
-                     ...
-       sources:
-         charts:
-           - location: https://packages.local/repository/charts
-             name: csm-algol60
-             type: repo
-   ```
+         ```bash
+         /usr/local/bin/cmsdev test -q vcs
+         ```
 
-1. (`ncn-mw#`) Generate the manifest that will be used to redeploy the chart with the modified resources.
+         For more details on this test, including known issues and other command line options, see [Software Management Services health checks](../../troubleshooting/known_issues/sms_health_check.md).
 
-    ```bash
-    manifestgen -c customizations.yaml -i gitea.yaml -o manifest.yaml
-    ```
-
-1. Validate that the `manifest.yaml` file only contains chart information for Gitea, and that the sources chart location
-   points to `https://packages.local/repository/charts`.
-
-1. (`ncn-mw#`) Re-apply the `gitea` Helm chart with the updated `customizations.yaml` file.
-
-   This will update the `vcs-user-credentials` SealedSecret which will cause the SealedSecret controller to update the Secret.
-
-    ```bash
-    loftsman ship --manifest-path ${PWD}/manifest.yaml
-    ```
-
-1. (`ncn-mw#`) Verify that the Secret has been updated.
-
-   Give the SealedSecret controller a few seconds to update the Secret, then run the following command to see the current value of the Secret:
-
-    ```bash
-    kubectl get secret -n services vcs-user-credentials \
-            --template={{.data.vcs_password}} | base64 --decode
-    ```
-
-1. (`ncn-mw#`) Save an updated copy of `customizations.yaml` to the `site-init` secret in the `loftsman` Kubernetes namespace.
-
-    ```bash
-    CUSTOMIZATIONS=$(base64 < customizations.yaml  | tr -d '\n')
-    kubectl get secrets -n loftsman site-init -o json |
-        jq ".data.\"customizations.yaml\" |= \"$CUSTOMIZATIONS\"" |
-        kubectl apply -f -
-    ```
+   * **Make sure to perform the entire linked procedure, including the step to save the updated customizations.**
 
 ## Access the `cray` Gitea organization
 

--- a/operations/node_management/Add_Remove_Replace_NCNs/Redeploy_Services.md
+++ b/operations/node_management/Add_Remove_Replace_NCNs/Redeploy_Services.md
@@ -16,7 +16,7 @@ The `docs-csm` RPM has been installed on the NCN. Verify that the following file
 ls /usr/share/docs/csm/scripts/operations/node_management/Add_Remove_Replace_NCNs/update_customizations.sh
 ```
 
-## Update the `nmn_ncn_storage` List
+## Update the `nmn_ncn_storage` list
 
 Update the `nmn_ncn_storage` list to include the IP addresses for any added or removed storage nodes.
 
@@ -51,7 +51,7 @@ Before redeploying the desired charts, update the `customizations.yaml` file in 
    git commit -m 'Add customizations.yaml from site-init secret'
    ```
 
-### Modify the Customizations
+### Modify the customizations
 
 Modify the customizations to include the added or removed storage node.
 
@@ -110,46 +110,16 @@ Modify the customizations to include the added or removed storage node.
 
 ### Redeploy S3
 
-Redeploy S3 to pick up any changes for storage node endpoints.
+Redeploy S3 to pick up any changes for storage node endpoints. Follow the [Redeploying a Chart](../../CSM_product_management/Redeploying_a_Chart.md) procedure with the following specifications:
 
-1. Determine the version of S3.
+- Name of chart to be redeployed: `cray-s3`
+- Base name of manifest: `platform`
+- No customization changes need to be made during the redeploy procedure -- they were already done earlier on this page.
+- (`ncn-mw#`) When reaching the step to validate that the redeploy was successful, perform the following step:
 
-    ```bash
-    S3_VERSION=$(kubectl -n loftsman get cm loftsman-platform -o jsonpath='{.data.manifest\.yaml}' |
-                        yq r - 'spec.charts.(name==cray-s3).version')
-    echo $S3_VERSION
-    ```
+    **Only follow this step as part of the previously linked chart redeploy procedure.**
 
-1. Create `s3-manifest.yaml`.
-
-    ```bash
-    cat > s3-manifest.yaml << EOF
-    apiVersion: manifests/v1beta1
-    metadata:
-        name: s3
-    spec:
-        charts:
-        - name: cray-s3
-          version: $S3_VERSION
-          namespace: ceph-rgw
-    EOF
-    ```
-
-1. Merge `customizations.yaml` with `s3-manifest.yaml`.
-
-    ```bash
-    manifestgen -c /tmp/customizations.yaml -i s3-manifest.yaml > s3-manifest.out.yaml
-    ```
-
-1. Redeploy the S3 helm chart.
-
-    ```bash
-    loftsman ship \
-        --charts-repo https://packages.local/repository/charts \
-        --manifest-path s3-manifest.out.yaml
-    ```
-
-1. Check that the new endpoint has been updated.
+    Check that the new endpoint has been updated.
 
     ```bash
     kubectl get endpoints -l app.kubernetes.io/instance=cray-s3 -n ceph-rgw -o jsonpath='{.items[*].subsets[].addresses}' | jq -r '.[] | .ip'
@@ -168,86 +138,16 @@ Redeploy S3 to pick up any changes for storage node endpoints.
 
 Redeploy `sysmgmt-health` to pick up any changes for storage node endpoints.
 
-1. Determine the version of `sysmgmt-health`.
+Follow the [Redeploying a Chart](../../CSM_product_management/Redeploying_a_Chart.md) procedure with the following specifications:
 
-    ```bash
-    SYSMGMT_VERSION=$(kubectl -n loftsman get cm loftsman-platform -o jsonpath='{.data.manifest\.yaml}' |
-                             yq r - 'spec.charts.(name==cray-sysmgmt-health).version')
-    echo $SYSMGMT_VERSION
-    ```
+- Name of chart to be redeployed: `cray-sysmgmt-health`
+- Base name of manifest: `platform`
+- No customization changes need to be made during the redeploy procedure -- they were already done earlier on this page.
+- (`ncn-mw#`) When reaching the step to validate that the redeploy was successful, perform the following step:
 
-1. Determine the current resources.
+    **Only follow this step as part of the previously linked chart redeploy procedure.**
 
-    ```bash
-    kubectl -n loftsman get cm loftsman-platform -o jsonpath='{.data.manifest\.yaml}' | 
-              yq r - 'spec.charts.(name==cray-sysmgmt-health).values.kube-prometheus-stack.prometheus.prometheusSpec.resources'
-    ```
-
-    Example output:
-
-    ```yaml
-    limits:
-      cpu: '6'
-      memory: 30Gi
-    requests:
-      cpu: '2'
-      memory: 15Gi
-    ```
-
-1. Determine the current retention settings.
-
-    ```bash
-    kubectl -n loftsman get cm loftsman-platform -o jsonpath='{.data.manifest\.yaml}' | yq r - 'spec.charts.(name==cray-sysmgmt-health).values.kube-prometheus-stack.prometheus.prometheusSpec.retention'
-    ```
-
-    Example output:
-
-    ```text
-    48h
-    ```
-
-1. Create `sysmgmt-health-manifest.yaml` and update the `resources` and `retention` sections as needed based upon the data from the previous steps.
-
-    ```bash
-    cat > sysmgmt-health-manifest.yaml << EOF
-    apiVersion: manifests/v1beta1
-    metadata:
-        name: sysmgmt-health
-    spec:
-        charts:
-        - name: cray-sysmgmt-health
-          version: $SYSMGMT_VERSION
-          namespace: sysmgmt-health
-          values:
-            kube-prometheus-stack:
-              prometheus:
-                prometheusSpec:
-                  resources:
-                    limits:
-                      cpu: '6'
-                      memory: 30Gi
-                    requests:
-                      cpu: '2'
-                      memory: 15Gi
-                  retention: 48h
-    EOF
-    ```
-
-1. Merge `customizations.yaml` with `sysmgmt-health-manifest.yaml`.
-
-    ```bash
-    manifestgen -c /tmp/customizations.yaml -i sysmgmt-health-manifest.yaml > sysmgmt-health-manifest.out.yaml
-    ```
-
-1. Redeploy the `sysmgmt-health` helm chart.
-
-    ```bash
-    loftsman ship \
-        --charts-repo https://packages.local/repository/charts \
-        --manifest-path sysmgmt-health-manifest.out.yaml
-    ```
-
-1. Check that the new endpoint has been updated.
+    Check that the new endpoint has been updated.
 
     ```bash
     kubectl get endpoints -l app=cray-sysmgmt-health-ceph-exporter -n sysmgmt-health -o jsonpath='{.items[*].subsets[].addresses}' | jq -r '.[] | .ip'
@@ -271,7 +171,7 @@ Remove temporary files.
 rm /tmp/customizations.yaml /tmp/customizations.original.yaml /tmp/customizations.original.yaml.pretty
 ```
 
-## Next Step
+## Next step
 
 Proceed to the next step:
 

--- a/operations/node_management/Add_TLS_Certificates_to_BMCs.md
+++ b/operations/node_management/Add_TLS_Certificates_to_BMCs.md
@@ -2,28 +2,33 @@
 
 Use the System Configuration Service \(SCSD\) tool to create TLS certificates and store them in Vault secure storage. Once certificates are created, they are placed on to the target BMCs.
 
-### Prerequisites
+- [Prerequisites](#prerequisites)
+- [Limitations](#limitations)
+- [Generate TLS certificates](#generate-tls-certificates)
+- [Regenerate TLS certificates](#regenerate-tls-certificates)
 
-- The Cray command line interface \(CLI\) tool is initialized and configured on the system.
+## Prerequisites
 
-### Limitations
+- The Cray command line interface \(CLI\) tool is initialized and configured on the system. See [Configure the Cray CLI](../configure_cray_cli.md).
+
+## Limitations
 
 TLS certificates can only be set for liquid-cooled BMCs. TLS certificate support for air-cooled BMCs is not supported in release 1.4.
 
-### Procedure
+## Generate TLS certificates
 
-1.  Use SCSD to generate TLS certificates.
+1. (`ncn-mw#`) Use SCSD to generate TLS certificates.
 
-    1.  Create a cert\_create.json JSON file containing all cabinet level certificate creation information.
+    1. Create a `cert_create.json` JSON file containing all cabinet level certificate creation information.
 
-        ```bash
+        ```json
         {
           "Domain": "Cabinet",
           "DomainIDs": [ "x0", "x1", "x2", "x3"]
         }
         ```
 
-    2.  Generate the TLS certificates.
+    1. Generate the TLS certificates.
 
         ```bash
         cray scsd bmc createcerts create --format json cert_create.json
@@ -31,7 +36,7 @@ TLS certificates can only be set for liquid-cooled BMCs. TLS certificate support
 
         Example output:
 
-        ```
+        ```json
         {
           "DomainIDs": [
             {
@@ -58,11 +63,11 @@ TLS certificates can only be set for liquid-cooled BMCs. TLS certificate support
         }
         ```
 
-2.  Apply the TLS certificates to the target BMCs.
+1. (`ncn-mw#`) Apply the TLS certificates to the target BMCs.
 
-    1.  Create a new cert\_set.json JSON file to specify the endpoints.
+    1. Create a new `cert_set.json` JSON file to specify the endpoints.
 
-        ```bash
+        ```json
         {
           "Force": false,
           "CertDomain": "Cabinet",
@@ -72,7 +77,7 @@ TLS certificates can only be set for liquid-cooled BMCs. TLS certificate support
         }
         ```
 
-    2.  Set the certificates on the target BMCs.
+    1. Set the certificates on the target BMCs.
 
         ```bash
         cray scsd bmc setcerts create --format json cert_set.json
@@ -80,7 +85,7 @@ TLS certificates can only be set for liquid-cooled BMCs. TLS certificate support
 
         Example output:
 
-        ```
+        ```json
         {
           "Targets": [
             {
@@ -107,171 +112,57 @@ TLS certificates can only be set for liquid-cooled BMCs. TLS certificate support
         }
         ```
 
-3.  Enable the CA\_URI variable in all Hardware Management Services \(HMS\) that use Redfish.
+1. (`ncn-mw#`) Follow the [Redeploying a Chart](../CSM_product_management/Redeploying_a_Chart.md) procedure with the following specifications:
 
-    Each system's customizations.yaml file needs an entry to specify the URI where the Certificate Authority \(CA\) bundle can be found.
+    - Name of chart to be redeployed: `cray-hms-smd`
+    - Base name of manifest: `sysmgmt`
+    - When reaching the step to update customizations, perform the following step:
 
-    ```bash
-    vi customizations.yaml
-    ```
+        **Only follow this step as part of the previously linked chart redeploy procedure.**
 
-    Example customizations.yaml:
+        Enable the `CA_URI` variable in all Hardware Management Services \(HMS\) that use Redfish.
 
-    ```
-    [...]
-
-    spec:
-      network:
-        ...
-      hms_ca_info:
-        hms_svc_ca_uri: "/usr/local/cray-pki/certificate_authority.crt"
-
-    [...]
-
-    services:
-
-    [...]
-
-      cray-hms-reds:
-    #   hms_ca_uri: "vault://pki_common/ca_chain"     # NOTE: this specifies the use of the Vault PKI directly
-        hms_ca_uri: "{{ hms_ca_info.hms_svc_ca_uri}}"
-      cray-hms-capmc:
-        hms_ca_uri: "{{ hms_ca_info.hms_svc_ca_uri}}"
-      cray-hms-meds:
-        hms_ca_uri: "{{ hms_ca_info.hms_svc_ca_uri}}"
-      cray-hms-hmcollector:
-        hms_ca_uri: "{{ hms_ca_info.hms_svc_ca_uri}}"
-      cray-hms-smd:
-        hms_ca_uri: "{{ hms_ca_info.hms_svc_ca_uri }}"
-      cray-hms-firmware-action:
-        hms_ca_uri: "{{ hms_ca_info.hms_svc_ca_uri}}"
-    ```
-
-4.  Deploy the services.
-
-    1.  Edit the manifest.yaml file.
-
-        The modifications to the system's customizations.yaml shown above will apply when CMS is installed or upgraded as a whole. When upgrading a single service, the manifest.yaml file must contain an override for ca\_host\_uri.
+        The `customizations.yaml` file needs an entry to specify the URI where the Certificate Authority \(CA\) bundle can be found.
 
         ```bash
-        vi manifest.yaml
+        vi customizations.yaml
         ```
 
-        Example manifest.yaml:
+        Example excerpts from `customizations.yaml`:
 
-        ```
-        ## Example manifest for a single service upgrade
-        ---
-        schema: v2
-        name: example-manifest
-        version: 1.0.0
-        failOnFirstError: True
-        repositories:
-          docker: dtr.dev.cray.com
-          helm: helmrepo.dev.cray.com:8080
-        charts: # Will install/upgrade charts in the order below
-          - name: "cray-hms-smd"
-            namespace: "services"
-            version: 1.4.4-20201104155929+70c870d
-            overrides:
-              - cray-service.imagesHost="{repos[docker]}"
-            values:
-              hms_ca_uri: "/usr/local/cray-pki/certificate_authority.crt"
+        ```yaml
+          hms_ca_info:
+            hms_svc_ca_uri: "/usr/local/cray-pki/certificate_authority.crt"
         ```
 
-    2.  Edit the sysman.yaml file to retrieve the entries in the values: section.
-
-        Locate the section for the target service in the sysman.yaml file and copy the information described in this step from the values: section. This content will be copied to the values: section in the manifest.yaml file in the next step.
-
-        ```bash
-        manifestgen -i /opt/cray/site-info/manifests/sysmgmt.yaml \
-        -c /opt/cray/site-info/customizations.yaml > sysman.yaml
-        vi sysman.yaml
+        ```yaml
+          cray-hms-reds:    
+            hms_ca_uri: "{{ hms_ca_info.hms_svc_ca_uri}}"
+          cray-hms-capmc:
+            hms_ca_uri: "{{ hms_ca_info.hms_svc_ca_uri}}"
+          cray-hms-meds:
+            hms_ca_uri: "{{ hms_ca_info.hms_svc_ca_uri}}"
+          cray-hms-hmcollector:
+            hms_ca_uri: "{{ hms_ca_info.hms_svc_ca_uri}}"
+          cray-hms-smd:
+            hms_ca_uri: "{{ hms_ca_info.hms_svc_ca_uri }}"
+          cray-hms-firmware-action:
+            hms_ca_uri: "{{ hms_ca_info.hms_svc_ca_uri}}"
         ```
 
-        Example sysman.yaml:
+        > Setting `hms_ca_uri` to `"vault://pki_common/ca_chain"` specifies the use of the Vault PKI directly.
 
-        ```
-        [...]
+    - When reaching the step to validate that the redeploy was successful, there are no additional steps to perform.
+    - **Make sure to perform the entire linked procedure, including the step to save the updated customizations.**
 
-        - name: cray-hms-scsd
-          namespace: services
-          overrides:
-          - cray-service.imagesHost="{repos[docker]}"
-          values:
-            hms_ca_uri: /usr/local/cray-pki/certificate_authority.crt  **\#\#\#\# only need to copy this line**
+## Regenerate TLS certificates
 
-        [...]
-        ```
+At any point the TLS certs can be regenerated and replaced on Redfish BMCs. The CA trust bundle can also be modified at any time. When this is to be done, the following steps are needed:
 
-        The Mountain Endpoint Discovery Service \(MEDS\) and River Endpoint Discovery Service \(REDS\) have sealed secret information in the values: section that need to be copied as well. For example:
+1. Modify the CA trust bundle.
 
-        ```bash
-        [...]
+   Once the CA trust bundle is modified, each service will automatically pick up the new CA bundle data. There is no manual step.
 
-        - name: cray-hms-reds
-          namespace: services
-          overrides:
-          - cray-service.imagesHost="{repos[docker]}"
-          - imagesHost="{repos[docker]}"
-          values:
-            cray-service: #### start copying from here
-              sealedSecrets:
-              - apiVersion: bitnami.com/v1alpha1
-                kind: SealedSecret
-                metadata:
-                  annotations:
-                    sealedsecrets.bitnami.com/cluster-wide: 'true'
-                  creationTimestamp: null
-                  name: cray-reds-credentials
-                  namespace: services
-                spec:
-                  encryptedData:
-                    vault_redfish_defaults: AgBdzvLKM468cpWcrXxf8TcveJa4d0OWw1fJCxl138zDDCL1haLl1DY9cETQm73nPwgpKL8v3Tz+2qkpXR+HNomrjf    XN+dauJA1lj1xTTKYwRRZdux0NlLuujxr9gjtChkT/CEvCA8gNDjA/O5/2RPaWizL5IGWXBLUhN/02KmNZozpfos3WhCewnhTJiEhGLoJ+ykl9oeMI3cf+W14dpZaU    0Tc5ZAIMfR+vrfTxIlxBClUhsa82Ot8RmtvQNacvGCWuuIRcUfZcCCMQzJCKWi75l0DtRu6VkhX1pnQq/mttGbWJkhveal/VJIEFm3eIOJzn6G1KyyTzU8tjRZHLey    UTY61CrdbczDjfQ8v47T8v43G3bGUUsMcB8evNqAOvlG+DTy+WvcPnmLnVItJkQ/30m+xMIzWG0tLf/YIu2fA7u0i56hERVcg2dwC7HZUM7+GZbIsONtKthmna+EiT    cewuuc/ftgRvxEGCS5lpTnOYhgYo/C0UNd7EmEOlzt+sWWQAocGKZemHiJVGU4HRSqyMJSk/mDTJlkN24EgfLj0k8VkrPPWFMT+hXi2YjLYrtkC9GtiDZ3tOkKPAxi    yh6pR5unjhBv7LtXBbW3uD5xMvv34D0CKOcKWLeMZ97JH84Oroc2iUOP62MYVYfaA/BrPhhOS/TwhJ7SDU6q/a+Pn4I6OslrzYy8haGpiFx6lGhvpSg8F5ez1hYXB9    OmNS1UNdcX4qZpp2npOCKHpN8PeRhnD9cCC1+ObHCflMhjRiHHlQ9PdZi21DoWqvwluDVw92afPpHdVuuSJu8akEDigHUJe3ITnb4jnlQnHDe6TEZ7gyGjZqBMXzxE    7269k8DSUIEy1ofcGIBJBE5K9j+aUdlmQtiNBIh/jbV9x4y2PoA2Zyo7w3Foztn2Kw/jbXfA5b4Z47qWR57tMitv8ZwTk2m5aH+d9BHvnSVsouM/eThT8ptDJLO5gN    HulXZoKYt5YMhdEY/I0lN/NIOmRX/HeYxPbjg1+dYhVSRzM=
-                    vault_switch_defaults: AgCV7pocyFV/BWZxqi9f3r4gUm7Csotf5e/X9iHo+U3Ctdkl4NW+iX1d8x+sG1UxjgSF7Vcis2y2JSbAgxz68LWBv/o    tQrDOu3v6hbxS6mu+M19D6iL5EiMbMkHpWKaG2QtHjPWrw2ZBLb+oVYivJF5N83wb1uHnwnss5SpBZTXVYg8sd5viBwKnpacQrB6dcMilceJ1Ag9gGPacyz0+gMEOP    tQZ2I4SFl82LkYdgWJyNqBvz3B8OA3SE7SBX3EKbUYUvdQ8QQptaz9l3gRVIRO8Z0I6HorYeOPzek0m6dDr6fHAAUJNrX2gcBQz/V/QvX1ngOpcpceGNumDwziwZb0    FmUQo8Tm1yrU6bcKWAch/FAv6M/HReE2eekOt41qd/dfWMs5EV5vUOauBfOdhirU1V8azlT+0HbuybWolcpTQV01t6kIUoQgyeLu5xGjV8lYfCov+FBSgYGBaQ2ZVb    L2ERWfzHLHIjvZVh0Hm6UaUc1tMqCW1gIW3FIYVMxijYet39qa54L/ARaJz/tl2u0pBwHDiJ2iTR6Lb8YGP4vFrGH7T2I9oLX6uc/K0IRTo3i7fpVBcckrXWbhLMyA    87bCoRxotERjZTIafduGgDMzJ0vlNrUK+7GAX2e8lI1hpmqc1f0CBSn6yVFELRvXX2Zgnm4yqRJb5TO0zGeoVSQCFEnHw6SdtcWmEzCiyTCDvm4r7kxmR35E6XGUqr    Qb6ypjQB70HkLFs1KucGHnOgzH3FkKka4ge1c20s8hEPdeSmLMEX8aNxNrAT6t9WznlndxZItZzlwuWrRnGSuC4oE57UBcpKZawHA6bc/nYzskW
-                  template:
-                    metadata:
-                      annotations:
-                        sealedsecrets.bitnami.com/cluster-wide: 'true'
-                      creationTimestamp: null
-                      name: cray-reds-credentials
-                      namespace: services
-                    type: Opaque
-            hms_ca_uri: /usr/local/cray-pki/certificate_authority.crt
-        ```
+1. Regenerate the TLS cabinet-level certificates as done is the preceding step.
 
-    3.  Copy the information recorded in the previous step to the values: section in the manifest.yaml file.
-
-        Ensure the proper indenting is preserved when copying information.
-
-        ```bash
-        vi manifest.yaml
-        ```
-
-    4.  Run loftsman to perform the upgrade.
-
-        If the image is not already in place, use docker to put it into place. The following example is for SMD:
-
-        ```bash
-        docker pull dtr.dev.cray.com/cray/cray-hms-smd:1.4.4-20201104155929_70c870d
-        docker tag dtr.dev.cray.com/cray/cray-hms-smd:1.4.4-20201104155929_70c870d registry.local/cray/cray-hms-smd:1.4.4-20201104155929_70c870d
-        docker push registry.local/cray/cray-hms-smd:1.4.4-20201104155929_70c870d
-        ```
-
-        Perform the upgrade:
-
-        ```bash
-        loftsman ship --shape --images-registry dtr.dev.cray.com \
-        --charts-repo http://helmrepo.dev.cray.com:8080 --loftsman-images-registry dtr.dev.cray.com \
-        --manifest-file-path ./manifest.yaml
-        ```
-
-At any point the TLS certs can be re-generated and replaced on Redfish BMCs. The CA trust bundle can also be modified at any time. When this is to be done, the following steps are needed:
-
-1.  Modify the CA trust bundle.
-
-    Once the CA trust bundle is modified, each service will automatically pick up the new CA bundle data. There is no manual step.
-
-2.  Regenerate the TLS cabinet-level certificates as done is the preceding step.
-3.  Place the TLS certificates onto the Redfish BMCs as in the preceding step.
-
+1. Place the TLS certificates onto the Redfish BMCs as in the preceding step.

--- a/operations/package_repository_management/Nexus_Service_Recovery.md
+++ b/operations/package_repository_management/Nexus_Service_Recovery.md
@@ -79,49 +79,23 @@ The following covers redeploying the Nexus service and restoring the data.
          persistentvolumeclaim "nexus-data" deleted
          ```
 
-1. (`ncn-mw#`) Redeploy the chart and wait for the resources to start.
+1. (`ncn-mw#`) Follow the [Redeploying a Chart](../CSM_product_management/Redeploying_a_Chart.md) procedure with the following specifications:
 
-   1. Create the manifest.
-
-      ```bash
-      kubectl get secrets -n loftsman site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d > customizations.yaml
-      kubectl get cm -n loftsman loftsman-nexus -o jsonpath='{.data.manifest\.yaml}' > cray-nexus.yaml
-      for i in $(yq r cray-nexus.yaml 'spec.charts[*].name' | grep -Ev '^cray-nexus$'); do yq d -i cray-nexus.yaml 'spec.charts(name=='"$i"')'; done
-      yq w -i cray-nexus.yaml metadata.name cray-nexus
-      yq d -i cray-nexus.yaml spec.sources
-      yq w -i cray-nexus.yaml spec.sources.charts[0].location 'https://csm-algol60.net/artifactory/csm-helm-charts/'
-      yq w -i cray-nexus.yaml spec.sources.charts[0].name csm-algol60
-      yq w -i cray-nexus.yaml spec.sources.charts[0].type repo
-      manifestgen -c customizations.yaml -i cray-nexus.yaml -o manifest.yaml
-      ```
-
-   1. Check that the chart version is correct based on the earlier `helm history`.
+   - Name of chart to be redeployed: `cray-nexus`
+   - Base name of manifest: `nexus`
+   - Chart files are located in Nexus.
+   - When reaching the step to update customizations, no edits need to be made to the customizations file.
+   - When running the `loftsman ship` command, use the following command:
 
       ```bash
-      grep "version:" manifest.yaml 
+      loftsman ship --charts-repo https://csm-algol60.net/artifactory/csm-helm-charts/ --manifest-path "${CUSTOMIZED_CHART_FILE}"
       ```
 
-      Example output:
+   - When reaching the step to validate that the redeploy was successful, perform the following step:
 
-      ```yaml
-            version: 0.6.0
-      ```
+      **Only follow this step as part of the previously linked chart redeploy procedure.**
 
-   1. Redeploy the chart.
-
-      ```bash
-      loftsman ship --manifest-path ${PWD}/manifest.yaml
-      ```
-
-      Example output contains:
-
-      ```text
-      NAME: nexus
-      ...
-      STATUS: deployed
-      ```
-
-   1. Wait for the resources to start.
+      Wait for the resources to start.
 
       ```bash
       watch "kubectl get pods -n nexus -l app=nexus"

--- a/operations/security_and_authentication/Add_LDAP_User_Federation.md
+++ b/operations/security_and_authentication/Add_LDAP_User_Federation.md
@@ -30,7 +30,7 @@ Be sure to modify the example URLs on this page by replacing `SYSTEM_DOMAIN_NAME
 
 ## Procedure
 
-1. Prepare to edit the `customizations.yaml` file.
+1. (`ncn-mw#`) Prepare to edit the `customizations.yaml` file.
 
    If the `customizations.yaml` file is managed in an external Git repository (as recommended), then clone a local working tree. Replace the `<URL>` value in the following command before running it.
 
@@ -67,7 +67,7 @@ Be sure to modify the example URLs on this page by replacing `SYSTEM_DOMAIN_NAME
 
    > **`NOTE`** All subsequent steps of this procedure should be performed within the `/root/site-init` directory created in this step.
 
-1. Repopulate the `keycloak_users_localize` and `cray-keycloak` sealed secrets in the `customizations.yaml` file with the desired configuration.
+1. (`ncn-mw#`) Repopulate the `keycloak_users_localize` and `cray-keycloak` sealed secrets in the `customizations.yaml` file with the desired configuration.
 
    Update the LDAP settings with the desired configuration. LDAP connection information
    is stored in the `keycloak-users-localize` secret in the `customizations.yaml` file.
@@ -279,7 +279,7 @@ Be sure to modify the example URLs on this page by replacing `SYSTEM_DOMAIN_NAME
          - type: string
    ```
 
-1. (Optional) Add the LDAP CA certificate in the `certs.jks` section of `customizations.yaml`.
+1. (Optional) (`ncn-mw#`) Add the LDAP CA certificate in the `certs.jks` section of `customizations.yaml`.
 
    If LDAP requires TLS (recommended), update the `cray-keycloak` sealed
    secret value by supplying a base-64-encoded Java KeyStore (JKS) that
@@ -474,7 +474,7 @@ Be sure to modify the example URLs on this page by replacing `SYSTEM_DOMAIN_NAME
       kubectl rollout restart -n services deployments cray-shared-kafka-entity-operator
       ```
 
-1. Prepare to generate sealed secrets.
+1. (`ncn-mw#`) Prepare to generate sealed secrets.
 
    Secrets are stored in `customizations.yaml` as `SealedSecret` resources
    (encrypted secrets), which are deployed by specific charts and decrypted by the
@@ -485,7 +485,7 @@ Be sure to modify the example URLs on this page by replacing `SYSTEM_DOMAIN_NAME
    ./utils/secrets-reencrypt.sh customizations.yaml ./certs/sealed_secrets.key ./certs/sealed_secrets.crt
    ```
 
-1. Encrypt the static values in the `customizations.yaml` file after making changes.
+1. (`ncn-mw#`) Encrypt the static values in the `customizations.yaml` file after making changes.
 
    The following command must be run within the `site-init` directory.
 
@@ -530,7 +530,7 @@ Be sure to modify the example URLs on this page by replacing `SYSTEM_DOMAIN_NAME
    Generating type static...
    ```
 
-1. Decrypt the sealed secret to verify it was generated correctly.
+1. (`ncn-mw#`) Decrypt the sealed secret to verify it was generated correctly.
 
    ```bash
    ./utils/secrets-decrypt.sh keycloak_users_localize | jq -r '.data.ldap_connection_url' | base64 --decode
@@ -542,146 +542,98 @@ Be sure to modify the example URLs on this page by replacing `SYSTEM_DOMAIN_NAME
    ldaps://my_ldap.my_org.test
    ```
 
-1. Upload the modified `customizations.yaml` file to Kubernetes.
+1. (`ncn-mw#`) Upload the modified `customizations.yaml` file to Kubernetes.
 
    ```bash
    kubectl delete secret -n loftsman site-init
    kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
    ```
 
-1. Re-apply the `cray-keycloak` Helm chart with the updated `customizations.yaml` file.
+1. (`ncn-mw#`) Re-apply the `cray-keycloak` Helm chart with the updated `customizations.yaml` file.
 
-   1. Retrieve the current `platform.yaml` manifest.
+   Follow the [Redeploying a Chart](../CSM_product_management/Redeploying_a_Chart.md) procedure with the following specifications:
 
-      ```bash
-      kubectl -n loftsman get cm loftsman-platform -o jsonpath='{.data.manifest\.yaml}' > platform.yaml
-      ```
+   - Name of chart to be redeployed: `cray-keycloak`
+   - Base name of manifest: `platform`
+   - Instead of downloading the customizations from Kubernetes, use the updated `customizations.yaml` file.
+   - When reaching the step to validate that the redeploy was successful, perform the following steps:
 
-   1. Remove all charts from the `platform.yaml` manifest except for `cray-keycloak`.
+      **Only follow these steps as part of the previously linked chart redeploy procedure.**
 
-      Edit the `platform.yaml` file and delete all sections starting with `-name: <chart_name>`, except for the `cray-keycloak` section.
+      1. Wait for the `keycloak-certs` secret to reflect the new `cert.jks`.
 
-   1. Change the name of the manifest being deployed from `platform` to `cray-keycloak`.
+         Run the following command until there is a non-empty value in the secret (this can take a minute or two):
 
-      ```bash
-      sed -i 's/name: platform/name: cray-keycloak/' platform.yaml
-      ```
+         ```bash
+         kubectl get secret -n services keycloak-certs -o yaml | grep certs.jks
+         ```
 
-   1. Populate the platform manifest with data from the `customizations.yaml` file.
+         Example output:
 
-      ```bash
-      manifestgen -i platform.yaml -c customizations.yaml -o new-platform.yaml
-      ```
+         ```text
+           certs.jks: <REDACTED>
+         ```
 
-   1. Re-apply the platform manifest with the updated `cray-keycloak` chart.
+      1. Restart the `cray-keycloak-` pods.
 
-      ```bash
-      loftsman ship --manifest-path ./new-platform.yaml --charts-repo https://packages.local/repository/charts
-      ```
+         ```bash
+         kubectl rollout restart statefulset -n services cray-keycloak
+         ```
 
-   1. Wait for the `keycloak-certs` secret to reflect the new `cert.jks`.
+      1. Wait for the Keycloak pods to restart.
 
-      Run the following command until there is a non-empty value in the secret (this can take a minute or two):
+         ```bash
+         kubectl rollout status statefulset -n services cray-keycloak
+         ```
 
-      ```bash
-      kubectl get secret -n services keycloak-certs -o yaml | grep certs.jks
-      ```
+   - **Make sure to perform the entire linked procedure, including the step to save the updated customizations.**
 
-      Example output:
+1. (`ncn-mw#`) Uninstall the current `cray-keycloak-users-localize` chart.
 
-      ```text
-        certs.jks: <REDACTED>
-      ```
+   ```bash
+   helm del cray-keycloak-users-localize -n services
+   ```
 
-   1. Restart the `cray-keycloak-` pods.
+1. (`ncn-mw#`) Re-apply the `cray-keycloak-users-localize` Helm chart with the updated `customizations.yaml` file.
 
-      ```bash
-      kubectl rollout restart statefulset -n services cray-keycloak
-      ```
+   Follow the [Redeploying a Chart](../CSM_product_management/Redeploying_a_Chart.md) procedure with the following specifications:
 
-   1. Wait for the Keycloak pods to restart.
+   - Name of chart to be redeployed: `cray-keycloak-users-localize`
+   - Base name of manifest: `platform`
+   - Instead of downloading the customizations from Kubernetes, use the updated `customizations.yaml` file.
+   - When reaching the step to validate that the redeploy was successful, perform the following steps:
 
-      ```bash
-      kubectl rollout status statefulset -n services cray-keycloak
-      ```
+      **Only follow these steps as part of the previously linked chart redeploy procedure.**
 
-1. Re-apply the `cray-keycloak-users-localize` Helm chart with the updated `customizations.yaml` file.
+      1. Watch the pod to check the status of the job.
 
-   1. Determine the `cray-keycloak-users-localize` chart version that is currently deployed.
+         The pod will go through the normal Kubernetes states. It will stay in a `Running` state for a while, and then it will go to `Completed`.
 
-      ```bash
-      helm ls -A -a | grep cray-keycloak-users-localize | awk '{print $(NF-1)}'
-      ```
+         ```bash
+         kubectl get pods -n services | grep keycloak-users-localize
+         ```
 
-      Example output:
+         Example output:
 
-      ```text
-      cray-keycloak-users-localize-<VERSION>
-      ```
+         ```text
+         keycloak-users-localize-1-sk2hn                                0/2     Completed   0          2m35s
+         ```
 
-   1. Create a manifest file that will be used to reapply the same chart version.
+      1. Check the pod's logs.
 
-      Create the file `./cray-keycloak-users-localize-manifest.yaml` with the following contents:
+         Replace the `KEYCLOAK_POD_NAME` value with the pod name from the previous step.
 
-      ```yaml
-      apiVersion: manifests/v1beta1
-      metadata:
-        name: reapply-cray-keycloak-users-localize
-      spec:
-        charts:
-          - name: cray-keycloak-users-localize
-            namespace: services
-            version: <VERSION FROM OUTPUT>
-      ```
+         ```bash
+         kubectl logs -n services KEYCLOAK_POD_NAME keycloak-localize
+         ```
 
-   1. Uninstall the current `cray-keycloak-users-localize` chart.
+         Example log entry showing that it has updated the "s3" objects and `ConfigMaps`:
 
-      ```bash
-      helm del cray-keycloak-users-localize -n services
-      ```
+         ```text
+         2020-07-20 18:26:15,774 - INFO    - keycloak_localize - keycloak-localize complete
+         ```
 
-   1. Populate the deployment manifest with data from the `customizations.yaml` file.
-
-      ```bash
-      manifestgen -i cray-keycloak-users-localize-manifest.yaml -c customizations.yaml -o deploy.yaml
-      ```
-
-   1. Reapply the `cray-keycloak-users-localize` chart.
-
-      ```bash
-      loftsman ship --manifest-path ./deploy.yaml \
-        --charts-repo https://packages.local/repository/charts
-      ```
-
-   1. Watch the pod to check the status of the job.
-
-      The pod will go through the normal Kubernetes states. It will stay in a `Running` state for a while, and then it will go to `Completed`.
-
-      ```bash
-      kubectl get pods -n services | grep keycloak-users-localize
-      ```
-
-      Example output:
-
-      ```text
-      keycloak-users-localize-1-sk2hn                                0/2     Completed   0          2m35s
-      ```
-
-   1. Check the pod's logs.
-
-      Replace the `KEYCLOAK_POD_NAME` value with the pod name from the previous step.
-
-      ```bash
-      kubectl logs -n services KEYCLOAK_POD_NAME keycloak-localize
-      ```
-
-      Example log entry showing that it has updated the "s3" objects and `ConfigMaps`:
-
-      ```text
-      2020-07-20 18:26:15,774 - INFO    - keycloak_localize - keycloak-localize complete
-      ```
-
-1. Sync the users and groups from Keycloak to the compute nodes.
+1. (`ncn-mw#`) Sync the users and groups from Keycloak to the compute nodes.
 
    1. Get the `crayvcs` password.
 
@@ -744,7 +696,7 @@ Be sure to modify the example URLs on this page by replacing `SYSTEM_DOMAIN_NAME
       cray bos v1 session create --template-uuid BOS_TEMPLATE --operation reboot
       ```
 
-1. Validate that LDAP integration was added successfully.
+1. (`ncn-mw#`) Validate that LDAP integration was added successfully.
 
    1. Retrieve the `admin` user's password for Keycloak.
 

--- a/operations/security_and_authentication/Change_the_Keycloak_Admin_Password.md
+++ b/operations/security_and_authentication/Change_the_Keycloak_Admin_Password.md
@@ -44,133 +44,80 @@ Be sure to modify the example URLs on this page by replacing `SYSTEM_DOMAIN_NAME
 
 1. Enter the new password and confirmation, and then click `Submit`.
 
-1. Log on to `ncn-w001`.
+1. (`ncn-w001#`) Follow the [Redeploying a Chart](../CSM_product_management/Redeploying_a_Chart.md) procedure with the following specifications:
 
-1. (`ncn-w001#`) Run `git clone https://github.com/Cray-HPE/csm.git`.
+   - Name of chart to be redeployed: `cray-keycloak`
+   - Base name of manifest: `platform`
+   - When reaching the step to update customizations, perform the following steps:
 
-1. (`ncn-w001#`) Copy the directory `vendor/stash.us.cray.com/scm/shasta-cfg/stable/utils` to your desired working directory, and
-   run the following commands from that work directory (not the `utils` directory).
+      **Only follow these steps as part of the previously linked chart redeploy procedure.**
 
-1. (`ncn-w001#`) Save a local copy of the `customizations.yaml` file.
+      1. Run `git clone https://github.com/Cray-HPE/csm.git`.
 
-    ```bash
-    kubectl get secrets -n loftsman site-init -o jsonpath='{.data.customizations\.yaml}' |
-         base64 -d > customizations.yaml
-    ```
+      1. Copy the directory `vendor/stash.us.cray.com/scm/shasta-cfg/stable/utils` from the cloned repository into the desired working directory.
 
-1. (`ncn-w001#`) Change the password in the `customizations.yaml` file.
+         ```bash
+         cp -vr ./csm/vendor/stash.us.cray.com/scm/shasta-cfg/stable/utils .
+         ```
 
-    The Keycloak master admin password is also stored in the `keycloak-master-admin-auth` Kubernetes Secret in the `services`
-    namespace. This must be updated so that clients which need to make requests as the master admin can authenticate with the new
-    password.
+      1. Change the password in the `customizations.yaml` file.
 
-    In the `customizations.yaml` file, set the values for the `keycloak_master_admin_auth` keys in the
-    `spec.kubernetes.sealed_secrets` field. The value in the data element where the name is `password` needs to be changed to the
-    new Keycloak master admin password. The section below will replace the existing sealed secret data in the `customizations.yaml`
-    file.
+         The Keycloak master admin password is also stored in the `keycloak-master-admin-auth` Kubernetes Secret in the `services`
+         namespace. This must be updated so that clients which need to make requests as the master admin can authenticate with the new
+         password.
 
-    For example:
+         In the `customizations.yaml` file, set the values for the `keycloak_master_admin_auth` keys in the
+         `spec.kubernetes.sealed_secrets` field. The value in the data element where the name is `password` needs to be changed to the
+         new Keycloak master admin password. The section below will replace the existing sealed secret data in the `customizations.yaml`
+         file.
 
-    ```yaml
-          keycloak_master_admin_auth:
-            generate:
-              name: keycloak-master-admin-auth
-              data:
-              - type: static
-                args:
-                  name: client-id
-                  value: admin-cli
-              - type: static
-                args:
-                  name: user
-                  value: admin
-              - type: static
-                args:
-                  name: password
-                  value: my_secret_password
-              - type: static
-                args:
-                  name: internal_token_url
-                  value: https://api-gw-service-nmn.local/keycloak/realms/master/protocol/openid-connect/token
-    ```
+         For example:
 
-1. (`ncn-w001#`) Encrypt the values after changing the `customizations.yaml` file.
+         ```yaml
+               keycloak_master_admin_auth:
+                 generate:
+                   name: keycloak-master-admin-auth
+                   data:
+                   - type: static
+                     args:
+                       name: client-id
+                       value: admin-cli
+                   - type: static
+                     args:
+                       name: user
+                       value: admin
+                   - type: static
+                     args:
+                       name: password
+                       value: my_secret_password
+                   - type: static
+                     args:
+                       name: internal_token_url
+                       value: https://api-gw-service-nmn.local/keycloak/realms/master/protocol/openid-connect/token
+         ```
 
-    ```bash
-    ./utils/secrets-seed-customizations.sh customizations.yaml
-    ```
+      1. Encrypt the values after changing the `customizations.yaml` file.
 
-    If the above command complains that it cannot find `certs/sealed_secrets.crt` then you can run the following commands to create it:
+         ```bash
+         ./utils/secrets-seed-customizations.sh customizations.yaml
+         ```
 
-    ```bash
-    mkdir -p certs &&
-         ./utils/bin/linux/kubeseal --controller-name sealed-secrets --fetch-cert > certs/sealed_secrets.crt
-    ```
+         If the above command complains that it cannot find `certs/sealed_secrets.crt` then you can run the following commands to create it:
 
-1. (`ncn-w001#`) Upload the modified `customizations.yaml` file to Kubernetes.
+         ```bash
+         mkdir -pV certs && ./utils/bin/linux/kubeseal --controller-name sealed-secrets --fetch-cert > certs/sealed_secrets.crt
+         ```
 
-   ```bash
-   kubectl delete secret -n loftsman site-init
-   kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
-   ```
+   - (`ncn-w001#`) When reaching the step to validate that the redeploy was successful, perform the following step:
 
-1. (`ncn-w001#`) Create a local copy of the `platform.yaml` file.
+      **Only follow this step as part of the previously linked chart redeploy procedure.**
 
-    ```bash
-    kubectl get cm -n loftsman loftsman-platform -o jsonpath='{.data.manifest\.yaml}'  > platform.yaml
-    ```
+      Verify that the Secret has been updated.
 
-1. (`ncn-w001#`) Edit the `platform.yaml` to only include the `cray-keycloak` chart and all its current data.
+      Give the SealedSecret controller a few seconds to update the Secret, then run the following command to see the current value of the Secret:
 
-    Example:
+      ```bash
+      kubectl get secret -n services keycloak-master-admin-auth --template={{.data.password}} | base64 --decode
+      ```
 
-    ```yaml
-    apiVersion: manifests/v1beta1
-      metadata:
-        name: platform
-      spec:
-        charts:
-        - name: cray-keycloak
-          namespace: services
-          source: csm-algol60
-          values:
-            internalTokenUrl: https://api-gw-service-nmn.local/keycloak/realms/master/protocol/openid-connect/token
-            sealedSecrets:
-            - apiVersion: bitnami.com/v1alpha1
-              kind: SealedSecret
-              metadata:
-                annotations:
-                  sealedsecrets.bitnami.com/cluster-wide: 'true'
-    ```
-
-1. (`ncn-w001#`) Generate the manifest that will be used to redeploy the chart with the modified resources.
-
-    ```bash
-    manifestgen -c customizations.yaml -i platform.yaml -o manifest.yaml
-    ```
-
-1. (`ncn-w001#`) Re-apply the `cray-keycloak` Helm chart with the updated `customizations.yaml` file.
-
-    This will update the `keycloak-master-admin-auth` SealedSecret which will cause the SealedSecret controller to update the Secret.
-
-    ```bash
-    loftsman ship --charts-path ${PATH_TO_RELEASE}/helm --manifest-path ./manifest.yaml
-    ```
-
-1. (`ncn-w001#`) Verify that the Secret has been updated.
-
-    Give the SealedSecret controller a few seconds to update the Secret, then run the following command to see the current value of the Secret:
-
-    ```bash
-    kubectl get secret -n services keycloak-master-admin-auth \
-                 --template={{.data.password}} | base64 --decode
-    ```
-
-1. (`ncn-w001#`) Save an updated copy of `customizations.yaml` to the `site-init` secret in the `loftsman` Kubernetes namespace.
-
-    ```bash
-    CUSTOMIZATIONS=$(base64 < customizations.yaml  | tr -d '\n')
-    kubectl get secrets -n loftsman site-init -o json |
-            jq ".data.\"customizations.yaml\" |= \"$CUSTOMIZATIONS\"" |
-            kubectl apply -f -
-    ```
+   - **Make sure to perform the entire linked procedure, including the step to save the updated customizations.**

--- a/operations/security_and_authentication/Keycloak_Service_Recovery.md
+++ b/operations/security_and_authentication/Keycloak_Service_Recovery.md
@@ -8,6 +8,7 @@ The following covers redeploying the Keycloak service and restoring the data.
 - All activities required for site maintenance are complete.
 - A backup or export of the data already exists.
 - The latest CSM documentation has been installed on the master nodes. See [Check for Latest Documentation](../../update_product_stream/index.md#check-for-latest-documentation).
+- The Cray CLI is configured on the node where the procedure is being performed. See [Configure the Cray CLI](../configure_cray_cli.md).
 
 ## Service recovery for Keycloak
 
@@ -40,19 +41,6 @@ The following covers redeploying the Keycloak service and restoring the data.
 
 1. (`ncn-mw#`) Uninstall the chart and wait for the resources to terminate.
 
-   1. Note the version of the chart that is currently deployed.
-
-      ```bash
-      helm history -n services cray-keycloak
-      ```
-
-      Example output:
-
-      ```text
-      REVISION    UPDATED                     STATUS      CHART               APP VERSION DESCRIPTION
-      1           Tue Aug  2 22:14:31 2022    deployed    cray-keycloak-3.3.1 3.1.1       Install complete
-      ```
-
    1. Uninstall the chart.
 
       ```bash
@@ -79,66 +67,35 @@ The following covers redeploying the Keycloak service and restoring the data.
 
 1. (`ncn-mw#`) Redeploy the chart and wait for the resources to start.
 
-   1. Create the manifest.
+    Follow the [Redeploying a Chart](../CSM_product_management/Redeploying_a_Chart.md) procedure **with the following specifications**:
 
-      ```bash
-      kubectl get secrets -n loftsman site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d > customizations.yaml
-      kubectl get cm -n loftsman loftsman-platform -o jsonpath='{.data.manifest\.yaml}' > cray-keycloak.yaml
-      for i in $(yq r cray-keycloak.yaml 'spec.charts[*].name' | grep -Ev '^cray-keycloak$'); do yq d -i cray-keycloak.yaml 'spec.charts(name=='"$i"')'; done
-      yq w -i cray-keycloak.yaml metadata.name cray-keycloak
-      yq d -i cray-keycloak.yaml spec.sources
-      yq w -i cray-keycloak.yaml spec.sources.charts[0].location 'https://packages.local/repository/charts'
-      yq w -i cray-keycloak.yaml spec.sources.charts[0].name csm-algol60
-      yq w -i cray-keycloak.yaml spec.sources.charts[0].type repo
-      manifestgen -c customizations.yaml -i cray-keycloak.yaml -o manifest.yaml
-      ```
+    - Chart name: `cray-keycloak`
+    - Base manifest name: `platform`
+    - When reaching the step to update customizations, no edits need to be made to the customizations file.
+    - When reaching the step to validate that the redeploy was successful, perform the following step:
 
-   1. Check that the chart version is correct based on the earlier `helm history`.
+        **Only follow this step as part of the previously linked chart redeploy procedure.**
 
-      ```bash
-      grep "version:" manifest.yaml 
-      ```
+        Wait for the resources to start.
 
-      Example output:
+        ```bash
+        watch "kubectl get pods -n services | grep keycloak"
+        ```
 
-      ```yaml
-            version: 3.3.1
-      ```
+        Example output:
 
-   1. Redeploy the chart.
-
-      ```bash
-      loftsman ship --manifest-path ${PWD}/manifest.yaml
-      ```
-
-      Example output contains:
-
-      ```text
-      NAME: cray-keycloak
-      ...
-      STATUS: deployed
-      ```
-
-   1. Wait for the resources to start.
-
-      ```bash
-      watch "kubectl get pods -n services | grep keycloak"
-      ```
-
-      Example output:
-
-      ```text
-      cray-keycloak-0                                                   2/2     Running     0          32m
-      cray-keycloak-1                                                   2/2     Running     0          32m
-      cray-keycloak-2                                                   2/2     Running     0          32m
-      keycloak-postgres-0                                               3/3     Running     0          32m
-      keycloak-postgres-1                                               3/3     Running     0          31m
-      keycloak-postgres-2                                               3/3     Running     0          30m
-      keycloak-setup-1-9kdl2                                            0/2     Completed   0          32m
-      keycloak-users-localize-1-jjb9b                                   2/2     Running     0          32m
-      keycloak-vcs-user-1-gqftw                                         0/2     Completed   0          31m
-      keycloak-wait-for-postgres-1-xt4nv                                0/2     Completed   0          32m
-      ```
+        ```text
+        cray-keycloak-0                                                   2/2     Running     0          32m
+        cray-keycloak-1                                                   2/2     Running     0          32m
+        cray-keycloak-2                                                   2/2     Running     0          32m
+        keycloak-postgres-0                                               3/3     Running     0          32m
+        keycloak-postgres-1                                               3/3     Running     0          31m
+        keycloak-postgres-2                                               3/3     Running     0          30m
+        keycloak-setup-1-9kdl2                                            0/2     Completed   0          32m
+        keycloak-users-localize-1-jjb9b                                   2/2     Running     0          32m
+        keycloak-vcs-user-1-gqftw                                         0/2     Completed   0          31m
+        keycloak-wait-for-postgres-1-xt4nv                                0/2     Completed   0          32m
+        ```
 
 1. (`ncn-mw#`) Restore the critical data.
 

--- a/operations/security_and_authentication/Update_Default_Air-Cooled_BMC_and_Leaf_BMC_Switch_SNMP_Credentials.md
+++ b/operations/security_and_authentication/Update_Default_Air-Cooled_BMC_and_Leaf_BMC_Switch_SNMP_Credentials.md
@@ -8,248 +8,199 @@ new air-cooled `NodeBMCs` and Slingshot switch BMCs (`RouterBMCs`), and SNMP cre
 > ***NOTE*** This procedure will not update the Redfish or SNMP credentials for existing air-cooled devices. To change the credentials on existing air-cooled hardware follow the
 > [Change Air-Cooled Node BMC Credentials](Change_Air-Cooled_Node_BMC_Credentials.md) and [Configuring SNMP in CSM]( ../../operations/network/management_network/configure_snmp.md) procedures.
 
+- [Limitation](#limitation)
+- [Procedure](#procedure)
+    1. [Update the default credentials used by REDS](#1-update-the default-credentials-used-by-reds)
+    1. [Restart the SNMP-backed RTS to pick up the SNMP credential changes](#2-restart-the-snmp-backed-rts-to-pick-up-the-snmp-credential-changes)
+
 ## Limitation
 
 The default global credentials used for liquid-cooled BMCs in the [Change Cray EX Liquid-Cooled Cabinet Global Default Password](Change_EX_Liquid-Cooled_Cabinet_Global_Default_Password.md)
 procedure needs to be the same as the one used in this procedure for air-cooled BMCs river hardware.
 
-## Prerequisites
-
-- The Cray command line interface \(CLI\) tool is initialized and configured on the system.
-
 ## Procedure
 
-### 1.1 Acquire `site-init`
+The River Endpoint Discovery Service (REDS) sealed secret contains the default global credential used by REDS.
 
-Before redeploying the River Endpoint Discovery Service (REDS), update the `customizations.yaml` file in the `site-init` secret in the `loftsman` namespace.
+### 1. Update the default credentials used by REDS
 
-1. If the `site-init` repository is available as a remote repository, then clone it to `ncn-m001`. Otherwise, ensure that the `site-init` repository is available on `ncn-m001`.
+Follow the [Redeploying a Chart](../CSM_product_management/Redeploying_a_Chart.md) procedure **with the following specifications**:
 
-    ```bash
-    git clone "$SITE_INIT_REPO_URL" site-init
-    ```
+- Chart name: `cray-hms-reds`
+- Base manifest name: `core-services`
+- (`ncn-mw#`) When reaching the step to update the customizations, perform the following steps:
 
-1. Acquire `customizations.yaml` from the currently running system:
+    **Only follow these steps as part of the previously linked chart redeploy procedure.**
 
-    ```bash
-    kubectl get secrets -n loftsman `site-init` -o jsonpath='{.data.customizations\.yaml}' | base64 -d > site-init/customizations.yaml
-    ```
+    1. Run `git clone https://github.com/Cray-HPE/csm.git`.
 
-1. Review, add, and commit `customizations.yaml` to the local `site-init` repository as appropriate.
+    1. Copy the directory `vendor/stash.us.cray.com/scm/shasta-cfg/stable/utils` from the cloned repository into the desired working directory.
 
-    > **`NOTE`** If `site-init` was cloned from a remote repository in step 1,
-    > there may not be any differences and hence nothing to commit. This is
-    > okay. If there are differences between what is in the repository and what
-    > was stored in the `site-init`, then it suggests settings were changed at some
-    > point.
+        ```bash
+        cp -vr ./csm/vendor/stash.us.cray.com/scm/shasta-cfg/stable/utils .
+        ```
 
-    ```bash
-    cd site-init
-    git diff
-    git add customizations.yaml
-    git commit -m 'Add customizations.yaml from site-init secret'
-    ```
+    1. Acquire sealed secret keys.
 
-1. Acquire sealed secret keys:
+        ```bash
+        mkdir -pv certs
+        kubectl -n kube-system get secret sealed-secrets-key -o jsonpath='{.data.tls\.crt}' | base64 -d > certs/sealed_secrets.crt
+        kubectl -n kube-system get secret sealed-secrets-key -o jsonpath='{.data.tls\.key}' | base64 -d > certs/sealed_secrets.key
+        ```
 
-    ```bash
-    mkdir -p certs
-    kubectl -n kube-system get secret sealed-secrets-key -o jsonpath='{.data.tls\.crt}' | base64 -d > certs/sealed_secrets.crt
-    kubectl -n kube-system get secret sealed-secrets-key -o jsonpath='{.data.tls\.key}' | base64 -d > certs/sealed_secrets.key
-    ```
+    1. Modify REDS sealed secret to use new global default credentials.
 
-### 1.2 Modify REDS sealed secret to use new global default credentials
+        1. Inspect the original default Redfish credentials used by REDS and HMS discovery.
 
-1. Inspect the original default Redfish credentials used by REDS and HMS Discovery:
+            ```bash
+            ./utils/secrets-decrypt.sh cray_reds_credentials ./certs/sealed_secrets.key ./customizations.yaml | jq .data.vault_redfish_defaults -r | base64 -d | jq
+            ```
 
-    ```bash
-    ./utils/secrets-decrypt.sh cray_reds_credentials ./certs/sealed_secrets.key ./customizations.yaml | jq .data.vault_redfish_defaults -r | base64 -d | jq
-    ```
+            Expected output looks similar to the following:
 
-    Expected output looks similar to the following:
+            ```json
+            {
+                "Cray": {
+                    "Username": "root",
+                    "Password": "foo"
+                }
+            }
+            ```
 
-    ```json
-    {
-        "Cray": {
-            "Username": "root",
-            "Password": "foo"
-        }
-    }
-    ```
+        1. Inspect the original default switch SNMP credentials used by REDS and HMS discovery.
 
-1. Inspect the original default switch SNMP credentials used by REDS and HMS Discovery:
+            ```bash
+            ./utils/secrets-decrypt.sh cray_reds_credentials ./certs/sealed_secrets.key ./customizations.yaml | jq .data.vault_switch_defaults -r | base64 -d | jq
+            ```
 
-    ```bash
-    ./utils/secrets-decrypt.sh cray_reds_credentials ./certs/sealed_secrets.key ./customizations.yaml | jq .data.vault_switch_defaults -r | base64 -d | jq
-    ```
+            Expected output looks similar to the following:
 
-    Expected output looks similar to the following:
+            ```json
+            {
+                "SNMPUsername": "testuser",
+                "SNMPAuthPassword": "foo",
+                "SNMPPrivPassword": "bar"
+            }
+            ```
 
-    ```json
-    {
-        "SNMPUsername": "testuser",
-        "SNMPAuthPassword": "foo",
-        "SNMPPrivPassword": "bar"
-    }
-    ```
+        1. Update the default credentials in `customizations.yaml` for REDS and HMS discovery to use.
 
-1. Update the default credentials in `customizations.yaml` for REDS and HMS Discovery to use:
+            1. Specify the desired default Redfish credentials.
 
-    Specify the desired default Redfish credentials:
+                ```bash
+                echo '{"Cray":{"Username":"root","Password":"foobar"}}' | base64 > reds.redfish.creds.json.b64
+                ```
 
-    ```bash
-    echo '{"Cray":{"Username":"root","Password":"foobar"}}' | base64 > reds.redfish.creds.json.b64
-    ```
+            1. Specify the desired default SNMP credentials.
 
-    Specify the desired default SNMP credentials:
+                ```bash
+                echo '{"SNMPUsername":"testuser","SNMPAuthPassword":"foo1","SNMPPrivPassword":"bar2"}' | base64 > reds.switch.creds.json.b64
+                ```
 
-    ```bash
-    echo '{"SNMPUsername":"testuser","SNMPAuthPassword":"foo1","SNMPPrivPassword":"bar2"}' | base64 > reds.switch.creds.json.b64
-    ```
+        1. Update and regenerate the `cray_reds_credentials` sealed secret.
 
-    Update and regenerate `cray_reds_credentials` sealed secret:
+            ```bash
+            cat << EOF | yq w - 'data.vault_redfish_defaults' "$(<reds.redfish.creds.json.b64)" | yq w - 'data.vault_switch_defaults' "$(<reds.switch.creds.json.b64)" | yq r -j - | ./utils/secrets-encrypt.sh | yq w -f - -i ./customizations.yaml 'spec.kubernetes.sealed_secrets.cray_reds_credentials'
+            {
+                "kind": "Secret",
+                "apiVersion": "v1",
+                "metadata": {
+                    "name": "cray-reds-credentials",
+                    "namespace": "services",
+                    "creationTimestamp": null
+                },
+                "data": {}
+            }
+            EOF
+            ```
 
-    ```bash
-    cat << EOF | yq w - 'data.vault_redfish_defaults' "$(<reds.redfish.creds.json.b64)" | yq w - 'data.vault_switch_defaults' "$(<reds.switch.creds.json.b64)" | yq r -j - | ./utils/secrets-encrypt.sh | yq w -f - -i ./customizations.yaml 'spec.kubernetes.sealed_secrets.cray_reds_credentials'
-    {
-        "kind": "Secret",
-        "apiVersion": "v1",
-        "metadata": {
-            "name": "cray-reds-credentials",
-            "namespace": "services",
-            "creationTimestamp": null
-        },
-        "data": {}
-    }
-    EOF
-    ```
+        1. Decrypt generated secret for review.
 
-1. Decrypt generated secret for review.
+            1. Review the default Redfish credentials.
 
-    Default Redfish credentials:
+                ```bash
+                ./utils/secrets-decrypt.sh cray_reds_credentials ./certs/sealed_secrets.key ./customizations.yaml | jq .data.vault_redfish_defaults -r | base64 -d | jq
+                ```
 
-    ```bash
-    ./utils/secrets-decrypt.sh cray_reds_credentials ./certs/sealed_secrets.key ./customizations.yaml | jq .data.vault_redfish_defaults -r | base64 -d | jq
-    ```
+                Expected output looks similar to the following:
 
-    Expected output looks similar to the following:
+                ```json
+                {
+                    "Username": "root",
+                    "Password": "foobar"
+                }
+                ```
 
-    ```json
-    {
-        "Username": "root",
-        "Password": "foobar"
-    }
-    ```
+            1. Review the default switch SNMP credentials.
 
-    Default Switch SNMP credentials:
+                ```bash
+                ./utils/secrets-decrypt.sh cray_reds_credentials ./certs/sealed_secrets.key ./customizations.yaml | jq .data.vault_switch_defaults -r | base64 -d | jq
+                ```
 
-    ```bash
-    ./utils/secrets-decrypt.sh cray_reds_credentials ./certs/sealed_secrets.key ./customizations.yaml | jq .data.vault_switch_defaults -r | base64 -d | jq
-    ```
+                Expected output looks similar to the following:
 
-    Expected output looks similar to the following:
+                ```json
+                {
+                    "SNMPUsername": "testuser",
+                    "SNMPAuthPassword": "foo1",
+                    "SNMPPrivPassword": "bar2"
+                }
+                ```
 
-    ```json
-    {
-        "SNMPUsername": "testuser",
-        "SNMPAuthPassword": "foo1",
-        "SNMPPrivPassword": "bar2"
-    }
-    ```
+- (`ncn-mw#`) When reaching the step to validate the redeployed chart, perform the following steps:
 
-1. Update the `site-init` secret for the system:
+    **Only follow these steps as part of the previously linked chart redeploy procedure.**
 
-    ```bash
-    kubectl delete secret -n loftsman site-init
-    kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
-    ```
+    1. Wait for the REDS Vault loader job to run to completion.
 
-### 1.3 Redeploy REDS to pick up the new sealed secret and push credentials into vault
+        ```bash
+        kubectl -n services wait job cray-reds-vault-loader --for=condition=complete --timeout=5m
+        ```
 
-1. Determine the version of REDS:
+    1. Verify that the default Redfish credentials have updated in Vault.
 
-    ```bash
-    REDS_VERSION=$(kubectl -n loftsman get cm loftsman-core-services -o jsonpath='{.data.manifest\.yaml}' | yq r - 'spec.charts.(name==cray-hms-reds).version')
-    echo $REDS_VERSION
-    ```
+        ```bash
+        VAULT_PASSWD=$(kubectl -n vault get secrets cray-vault-unseal-keys -o json | jq -r '.data["vault-root"]' |  base64 -d)
+        kubectl -n vault exec -it cray-vault-0 -c vault -- env VAULT_TOKEN=$VAULT_PASSWD VAULT_ADDR=http://127.0.0.1:8200 vault kv get secret/reds-creds/defaults
+        ```
 
-1. Create `reds-manifest.yaml`:
+        Expected output:
 
-    ```bash
-    cat > reds-manifest.yaml << EOF
-    apiVersion: manifests/v1beta1
-    metadata:
-        name: reds
-    spec:
-        charts:
-        - name: cray-hms-reds
-          version: $REDS_VERSION
-          namespace: services
-    EOF
-    ```
+        ```text
+        ==== Data ====
+        Key     Value
+        ---     -----
+        Cray    map[password:foobar username:root]
+        ```
 
-1. Merge `customizations.yaml` with `reds-manifest.yaml`:
+    1. Verify that the default SNMP credentials have updated in Vault.
 
-    ```bash
-    manifestgen -c customizations.yaml -i ./reds-manifest.yaml > ./reds-manifest.out.yaml
-    ```
+        ```bash
+        kubectl -n vault exec -it cray-vault-0 -c vault -- env VAULT_TOKEN=$VAULT_PASSWD VAULT_ADDR=http://127.0.0.1:8200 vault kv get secret/reds-creds/switch_defaults
+        ```
 
-1. Redeploy the REDS helm chart:
+        Expected output:
 
-    ```bash
-    loftsman ship \
-        --charts-repo https://packages.local/repository/charts \
-        --manifest-path reds-manifest.out.yaml
-    ```
+        ```text
+        ========== Data ==========
+        Key                 Value
+        ---                 -----
+        SNMPAuthPassword    foo1
+        SNMPPrivPassword    bar2
+        SNMPUsername        testuser
+        ```
 
-1. Wait for the REDS Vault loader job to run to completion:
+- **Make sure to perform the entire linked procedure, including the step to save the updated customizations.**
 
-    ```bash
-    kubectl -n services wait job cray-reds-vault-loader --for=condition=complete --timeout=5m
-    ```
+### 2. Restart the SNMP-backed RTS to pick up the SNMP credential changes
 
-1. Verify the default Redfish credentials have updated in Vault:
-
-    ```bash
-    VAULT_PASSWD=$(kubectl -n vault get secrets cray-vault-unseal-keys -o json | jq -r '.data["vault-root"]' |  base64 -d)
-    kubectl -n vault exec -it cray-vault-0 -c vault -- env VAULT_TOKEN=$VAULT_PASSWD VAULT_ADDR=http://127.0.0.1:8200 vault kv get secret/reds-creds/defaults
-    ```
-
-    Expected output:
-
-    ```text
-    ==== Data ====
-    Key     Value
-    ---     -----
-    Cray    map[password:foobar username:root]
-    ```
-
-1. Verify the default SNMP credentials have updated in Vault:
-
-    ```bash
-    kubectl -n vault exec -it cray-vault-0 -c vault -- env VAULT_TOKEN=$VAULT_PASSWD VAULT_ADDR=http://127.0.0.1:8200 vault kv get secret/reds-creds/switch_defaults
-    ```
-
-    Expected output:
-
-    ```text
-    ========== Data ==========
-    Key                 Value
-    ---                 -----
-    SNMPAuthPassword    foo1
-    SNMPPrivPassword    bar2
-    SNMPUsername        testuser
-    ```
-
-### 1.4 Restart the SNMP backed RTS to pick up the SNMP credential changes
-
-1. Scale the SNMP backed RTS down:
+1. Scale the SNMP-backed RTS down.
 
     ```bash
     kubectl scale deployment cray-hms-rts-snmp -n services --replicas=0
     ```
 
-1. Scale the SNMP backed RTS up:
+1. Scale the SNMP-backed RTS up.
 
     ```bash
     kubectl scale deployment cray-hms-rts-snmp -n services --replicas=1

--- a/operations/security_and_authentication/Update_Default_ServerTech_PDU_Credentials_used_by_the_Redfish_Translation_Service.md
+++ b/operations/security_and_authentication/Update_Default_ServerTech_PDU_Credentials_used_by_the_Redfish_Translation_Service.md
@@ -20,239 +20,188 @@ credential when getting added to the system.
 > [Change Credentials on ServerTech PDUs](Change_Credentials_on_ServerTech_PDUs.md) procedure. However, this procedure will update the global default credential that RTS
 > uses for its Redfish interface to other CSM services.
 
-## Prerequisites
+- [Procedure](#procedure)
 
-- The Cray command line interface \(CLI\) tool is initialized and configured on the system.
+    1. [Update credentials and redeploy RTS](#1-update-credentials-and-redeploy-rts)
+    1. [Restart the SNMP-backed RTS to pick up the global RTS credential changes](#2-restart-the-snmp-backed-rts-to-pick-up-the-global-rts-credential-changes)
 
 ## Procedure
 
-### 1.1 Acquire `site-init`
+### 1. Update credentials and redeploy RTS
 
-Before redeploying RTS, update the `customizations.yaml` file in the `site-init` secret in the `loftsman` namespace.
+Follow the [Redeploying a Chart](../CSM_product_management/Redeploying_a_Chart.md) procedure **with the following specifications**:
 
-1. If the `site-init` repository is available as a remote repository, then clone it to `ncn-m001`. Otherwise, ensure that the `site-init` repository is available on `ncn-m001`.
+- Chart name: `cray-hms-rts`
+- Base manifest name: `sysmgmt`
+- (`ncn-mw#`) When reaching the step to update the customizations, perform the following steps:
 
-    ```bash
-    git clone "$SITE_INIT_REPO_URL" site-init
-    ```
+    **Only follow these steps as part of the previously linked chart redeploy procedure.**
 
-1. Acquire `customizations.yaml` from the currently running system:
+    1. Run `git clone https://github.com/Cray-HPE/csm.git`.
 
-    ```bash
-    kubectl get secrets -n loftsman site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d > site-init/customizations.yaml
-    ```
+    1. Copy the directory `vendor/stash.us.cray.com/scm/shasta-cfg/stable/utils` from the cloned repository into the desired working directory.
 
-1. Review, add, and commit `customizations.yaml` to the local `site-init` repository as appropriate.
+        ```bash
+        cp -vr ./csm/vendor/stash.us.cray.com/scm/shasta-cfg/stable/utils .
+        ```
 
-    > **`NOTE:`** If `site-init` was cloned from a remote repository in step 1,
-    > there may not be any differences and hence nothing to commit. This is
-    > okay. If there are differences between what is in the repository and what
-    > was stored in the `site-init`, then it suggests settings were changed at some
-    > point.
+    1. Acquire sealed secret keys.
 
-    ```bash
-    cd site-init
-    git diff
-    git add customizations.yaml
-    git commit -m 'Add customizations.yaml from site-init secret'
-    ```
+        ```bash
+        mkdir -pv certs
+        kubectl -n kube-system get secret sealed-secrets-key -o jsonpath='{.data.tls\.crt}' | base64 -d > certs/sealed_secrets.crt
+        kubectl -n kube-system get secret sealed-secrets-key -o jsonpath='{.data.tls\.key}' | base64 -d > certs/sealed_secrets.key
+        ```
 
-1. Acquire sealed secret keys:
+    1. Modify RTS sealed secret to use new global default credentials.
 
-    ```bash
-    mkdir -p certs
-    kubectl -n kube-system get secret sealed-secrets-key -o jsonpath='{.data.tls\.crt}' | base64 -d > certs/sealed_secrets.crt
-    kubectl -n kube-system get secret sealed-secrets-key -o jsonpath='{.data.tls\.key}' | base64 -d > certs/sealed_secrets.key
-    ```
+        1. Inspect the original default ServerTech PDU credentials.
 
-### 1.2 Modify RTS sealed secret to use new global default credentials
+            ```bash
+            ./utils/secrets-decrypt.sh cray_hms_rts_credentials ./certs/sealed_secrets.key ./customizations.yaml | jq .data.vault_pdu_defaults -r | base64 -d | jq
+            ```
 
-1. Inspect the original default ServerTech PDU credentials:
+            Expected output looks similar to the following:
 
-    ```bash
-    ./utils/secrets-decrypt.sh cray_hms_rts_credentials ./certs/sealed_secrets.key ./customizations.yaml | jq .data.vault_pdu_defaults -r | base64 -d | jq
-    ```
+            ```json
+            {
+              "Username": "admn",
+              "Password": "foo"
+            }
+            ```
 
-    Expected output looks similar to the following:
+        1. Inspect the original default RTS Redfish interface credentials.
 
-    ```json
-    {
-      "Username": "admn",
-      "Password": "foo"
-    }
-    ```
+            ```bash
+            ./utils/secrets-decrypt.sh cray_hms_rts_credentials ./certs/sealed_secrets.key ./customizations.yaml | jq .data.vault_rts_defaults -r | base64 -d | jq
+            ```
 
-1. Inspect the original default RTS Redfish Interface credentials:
+            Expected output looks similar to the following:
 
-    ```bash
-    ./utils/secrets-decrypt.sh cray_hms_rts_credentials ./certs/sealed_secrets.key ./customizations.yaml | jq .data.vault_rts_defaults -r | base64 -d | jq
-    ```
+            ```json
+            {
+              "Username": "root",
+              "Password": "secret"
+            }
+            ```
 
-    Expected output looks similar to the following:
+        1. Update the default credentials in `customizations.yaml` for RTS.
 
-    ```json
-    {
-      "Username": "root",
-      "Password": "secret"
-    }
-    ```
+            1. Specify the desired default ServerTech PDU credentials.
 
-1. Update the default credentials in `customizations.yaml` for RTS:
+                ```bash
+                echo '{"Username":"admn", "Password":"foobar"}' | base64 > rts.pdu.creds.json.b64
+                ```
 
-    Specify the desired default ServerTech PDU credentials:
+            1. Specify the desired default RTS Redfish interface credentials.
 
-    ```bash
-    echo '{"Username":"admn", "Password":"foobar"}' | base64 > rts.pdu.creds.json.b64
-    ```
+                ```bash
+                echo '{"Username":"root", "Password":"supersecret"}' | base64 > rts.redfish.creds.json.b64
+                ```
 
-    Specify the desired default RTS Redfish interface credentials:
+        1. Update and regenerate the `cray_hms_rts_credentials` sealed secret.
 
-    ```bash
-    echo '{"Username":"root", "Password":"supersecret"}' | base64 > rts.redfish.creds.json.b64
-    ```
+            ```bash
+            cat << EOF | yq w - 'data.vault_pdu_defaults' "$(<rts.pdu.creds.json.b64)" | yq w - 'data.vault_rts_defaults' "$(<rts.redfish.creds.json.b64)" | yq r -j - | ./utils/secrets-encrypt.sh | yq w -f - -i ./customizations.yaml 'spec.kubernetes.sealed_secrets.cray_hms_rts_credentials'
+            {
+                "kind": "Secret",
+                "apiVersion": "v1",
+                "metadata": {
+                    "name": "cray-hms-rts-credentials",
+                    "namespace": "services",
+                    "creationTimestamp": null
+                },
+                "data": {}
+            }
+            EOF
+            ```
 
-    Update and regenerate `cray_hms_rts_credentials` sealed secret:
+        1. Decrypt generated secret for review.
 
-    ```bash
-    cat << EOF | yq w - 'data.vault_pdu_defaults' "$(<rts.pdu.creds.json.b64)" | yq w - 'data.vault_rts_defaults' "$(<rts.redfish.creds.json.b64)" | yq r -j - | ./utils/secrets-encrypt.sh | yq w -f - -i ./customizations.yaml 'spec.kubernetes.sealed_secrets.cray_hms_rts_credentials'
-    {
-        "kind": "Secret",
-        "apiVersion": "v1",
-        "metadata": {
-            "name": "cray-hms-rts-credentials",
-            "namespace": "services",
-            "creationTimestamp": null
-        },
-        "data": {}
-    }
-    EOF
-    ```
+            1. Review the default ServerTech PDU credentials.
 
-1. Decrypt generated secret for review.
+                ```bash
+                ./utils/secrets-decrypt.sh cray_hms_rts_credentials ./certs/sealed_secrets.key ./customizations.yaml | jq .data.vault_pdu_defaults -r | base64 -d | jq
+                ```
 
-    Default ServerTech PDU credentials:
+                Expected output looks similar to the following:
 
-    ```bash
-    ./utils/secrets-decrypt.sh cray_hms_rts_credentials ./certs/sealed_secrets.key ./customizations.yaml | jq .data.vault_pdu_defaults -r | base64 -d | jq
-    ```
+                ```json
+                {
+                  "Username": "admn",
+                  "Password": "foobar"
+                }
+                ```
 
-    Expected output looks similar to the following:
+            1. Review the Default RTS Redfish interface credentials.
 
-    ```json
-    {
-      "Username": "admn",
-      "Password": "foobar"
-    }
-    ```
+                ```bash
+                ./utils/secrets-decrypt.sh cray_hms_rts_credentials ./certs/sealed_secrets.key ./customizations.yaml | jq .data.vault_rts_defaults -r | base64 -d | jq
+                ```
 
-    Default RTS Redfish interface credentials:
+                Expected output looks similar to the following:
 
-    ```bash
-    ./utils/secrets-decrypt.sh cray_hms_rts_credentials ./certs/sealed_secrets.key ./customizations.yaml | jq .data.vault_rts_defaults -r | base64 -d | jq
-    ```
+                ```json
+                {
+                  "Username": "root",
+                  "Password": "supersecret"
+                }
+                ```
 
-    Expected output looks similar to the following:
+- (`ncn-mw#`) When reaching the step to validate the redeployed chart, perform the following steps:
 
-    ```json
-    {
-      "Username": "root",
-      "Password": "supersecret"
-    }
-    ```
+    **Only follow these steps as part of the previously linked chart redeploy procedure.**
 
-1. Update the `site-init` secret for the system:
+    1. Wait for the RTS job to run to completion:
 
-    ```bash
-    kubectl delete secret -n loftsman site-init
-    kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
-    ```
+        ```bash
+        kubectl -n services wait job cray-hms-rts-init --for=condition=complete --timeout=5m
+        ```
 
-### 1.3 Redeploy RTS to pick up the new sealed secret and push credentials into vault
+    1. Verify that the default ServerTech PDU credentials have updated in Vault.
 
-1. Determine the version of RTS:
+        ```bash
+        VAULT_PASSWD=$(kubectl -n vault get secrets cray-vault-unseal-keys -o json | jq -r '.data["vault-root"]' |  base64 -d)
+        kubectl -n vault exec -it cray-vault-0 -c vault -- env VAULT_TOKEN=$VAULT_PASSWD VAULT_ADDR=http://127.0.0.1:8200 vault kv get secret/pdu-creds/global/pdu
+        ```
 
-    ```bash
-    RTS_VERSION=$(kubectl -n loftsman get cm loftsman-sysmgmt -o jsonpath='{.data.manifest\.yaml}' | yq r - 'spec.charts.(name==cray-hms-rts).version')
-    echo $RTS_VERSION
-    ```
+        Expected output:
 
-1. Create `rts-manifest.yaml`:
+        ```text
+        ====== Data ======
+        Key         Value
+        ---         -----
+        Password    foobar
+        Username    admn
+        ```
 
-    ```bash
-    cat > rts-manifest.yaml << EOF
-    apiVersion: manifests/v1beta1
-    metadata:
-        name: rts
-    spec:
-        charts:
-        - name: cray-hms-rts
-          version: $RTS_VERSION
-          namespace: services
-    EOF
-    ```
+    1. Verify that the default RTS Redfish interface credential has updated in Vault.
 
-1. Merge `customizations.yaml` with `rts-manifest.yaml`:
+        ```bash
+        kubectl -n vault exec -it cray-vault-0 -c vault -- env VAULT_TOKEN=$VAULT_PASSWD VAULT_ADDR=http://127.0.0.1:8200 vault kv get secret/pdu-creds/global/rts
+        ```
 
-    ```bash
-    manifestgen -c customizations.yaml -i ./rts-manifest.yaml > ./rts-manifest.out.yaml
-    ```
+        Expected output:
 
-1. Redeploy the RTS helm chart:
+        ```text
+        ====== Data ======
+        Key         Value
+        ---         -----
+        Password    supersecret
+        Username    root
+        ```
 
-    ```bash
-    loftsman ship \
-        --charts-repo https://packages.local/repository/charts \
-        --manifest-path rts-manifest.out.yaml
-    ```
+- **Make sure to perform the entire linked procedure, including the step to save the updated customizations.**
 
-1. Wait for the RTS job to run to completion:
+### 2. Restart the SNMP-backed RTS to pick up the global RTS credential changes
 
-    ```bash
-    kubectl -n services wait job cray-hms-rts-init --for=condition=complete --timeout=5m
-    ```
-
-1. Verify the default ServerTech PDU credentials have updated in Vault:
-
-    ```bash
-    VAULT_PASSWD=$(kubectl -n vault get secrets cray-vault-unseal-keys -o json | jq -r '.data["vault-root"]' |  base64 -d)
-    kubectl -n vault exec -it cray-vault-0 -c vault -- env VAULT_TOKEN=$VAULT_PASSWD VAULT_ADDR=http://127.0.0.1:8200 vault kv get secret/pdu-creds/global/pdu
-    ```
-
-    Expected output:
-
-    ```text
-    ====== Data ======
-    Key         Value
-    ---         -----
-    Password    foobar
-    Username    admn
-    ```
-
-1. Verify that default RTS Redfish interface credential has updated in Vault:
-
-    ```bash
-    kubectl -n vault exec -it cray-vault-0 -c vault -- env VAULT_TOKEN=$VAULT_PASSWD VAULT_ADDR=http://127.0.0.1:8200 vault kv get secret/pdu-creds/global/rts
-    ```
-
-    Expected output:
-
-    ```text
-    ====== Data ======
-    Key         Value
-    ---         -----
-    Password    supersecret
-    Username    root
-    ```
-
-### 1.4 Restart the SNMP backed RTS to pick up the global RTS credential changes
-
-1. Scale the SNMP backed RTS down:
+1. (`ncn-mw#`) Scale the SNMP-backed RTS down.
 
     ```bash
     kubectl scale deployment cray-hms-rts-snmp -n services --replicas=0
     ```
 
-1. Scale the SNMP backed RTS up:
+1. (`ncn-mw#`) Scale the SNMP-backed RTS up.
 
     ```bash
     kubectl scale deployment cray-hms-rts-snmp -n services --replicas=1

--- a/operations/security_and_authentication/Updating_the_Liquid-Cooled_EX_Cabinet_Default_Credentials_after_a_CEC_Password_Change.md
+++ b/operations/security_and_authentication/Updating_the_Liquid-Cooled_EX_Cabinet_Default_Credentials_after_a_CEC_Password_Change.md
@@ -8,202 +8,140 @@ product documentation. To update Slingshot switch BMCs, refer to "Change Rosetta
 
 This procedure provisions only the default Redfish `root` account passwords. It does not modify Redfish accounts that have been added after an initial system installation.
 
+- [Prerequisites](#prerequisites)
+- [Procedure](#procedure)
+
+    1. [Update the default credentials used by MEDS for new hardware](#1-update the-default-credentials-used-by-meds-for-new-hardware)
+    1. [Update credentials for existing EX hardware in the system](#2-update-credentials-for-existing-ex-hardware-in-the-system)
+    1. [Reapply BMC settings if a `StatefulReset` was performed on any BMC](#3-reapply-bmc-settings-if-a-statefulreset-was-performed-on-any-bmc)
+
 ## Prerequisites
 
+- The Cray command line interface \(CLI\) tool is initialized and configured on the system. See [Configure the Cray CLI](../configure_cray_cli.md).
 - The `hms-discovery` Kubernetes CronJob has been disabled.
 - All blades in the cabinets have been powered off.
-- Procedures in [Provisioning a Liquid-Cooled EX Cabinet CEC with Default Credentials](Provisioning_a_Liquid-Cooled_EX_Cabinet_CEC_with_Default_Credentials.md) have
+- The procedures in [Provisioning a Liquid-Cooled EX Cabinet CEC with Default Credentials](Provisioning_a_Liquid-Cooled_EX_Cabinet_CEC_with_Default_Credentials.md) have
   been performed on all CECs in the system.
 - All of the CECs must be configured with the **same** global credential.
 - The previous default global credential for liquid-cooled BMCs must be known.
 
 ## Procedure
 
+The Mountain Endpoint Discovery Service (MEDS) sealed secret contains the default global credential used by MEDS when it discovers new liquid-cooled EX cabinet hardware.
+
 ### 1. Update the default credentials used by MEDS for new hardware
 
-The MEDS sealed secret contains the default global credential used by MEDS when it discovers new liquid-cooled EX cabinet hardware.
+Follow the [Redeploying a Chart](../CSM_product_management/Redeploying_a_Chart.md) procedure **with the following specifications**:
 
-#### 1.1 Acquire `site-init`
+- Chart name: `cray-hms-bss`
+- Base manifest name: `core-services`
+- (`ncn-mw#`) When reaching the step to update the customizations, perform the following steps:
 
-Before redeploying MEDS, update the `customizations.yaml` file in the `site-init` secret in the `loftsman` namespace.
+    **Only follow these steps as part of the previously linked chart redeploy procedure.**
 
-1. Ensure that the `site-init` repository is available on `ncn-m001`.
+    1. Run `git clone https://github.com/Cray-HPE/csm.git`.
 
-    If the `site-init` repository is available as a remote repository, then clone it to `ncn-m001`.
+    1. Copy the directory `vendor/stash.us.cray.com/scm/shasta-cfg/stable/utils` from the cloned repository into the desired working directory.
 
-    ```bash
-    git clone "$SITE_INIT_REPO_URL" site-init
-    ```
+        ```bash
+        cp -vr ./csm/vendor/stash.us.cray.com/scm/shasta-cfg/stable/utils .
+        ```
 
-1. Acquire `customizations.yaml` from the currently running system.
+    1. Acquire sealed secret keys.
 
-    ```bash
-    kubectl get secrets -n loftsman site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d > site-init/customizations.yaml
-    ```
+        ```bash
+        mkdir -pv certs
+        kubectl -n kube-system get secret sealed-secrets-key -o jsonpath='{.data.tls\.crt}' | base64 -d > certs/sealed_secrets.crt
+        kubectl -n kube-system get secret sealed-secrets-key -o jsonpath='{.data.tls\.key}' | base64 -d > certs/sealed_secrets.key
+        ```
 
-1. Review, add, and commit `customizations.yaml` to the local `site-init` repository as appropriate.
+    1. Modify MEDS sealed secret to use new global default credential.
 
-    > **`NOTE`** If `site-init` was cloned from a remote repository, then
-    > there may not be any differences and hence nothing to commit. This is
-    > okay. If there are differences between what is in the repository and what
-    > was stored in the `site-init`, then this suggests that settings were changed at some
-    > point.
+        1. Inspect the original default credential for MEDS.
 
-    ```bash
-    cd site-init
-    git diff
-    git add customizations.yaml
-    git commit -m 'Add customizations.yaml from site-init secret'
-    ```
+            ```bash
+            ./utils/secrets-decrypt.sh cray_meds_credentials ./certs/sealed_secrets.key ./customizations.yaml | jq .data.vault_redfish_defaults -r | base64 -d | jq
+            ```
 
-1. Acquire sealed secret keys:
+            Example output:
 
-    ```bash
-    mkdir -p certs
-    kubectl -n kube-system get secret sealed-secrets-key -o jsonpath='{.data.tls\.crt}' | base64 -d > certs/sealed_secrets.crt
-    kubectl -n kube-system get secret sealed-secrets-key -o jsonpath='{.data.tls\.key}' | base64 -d > certs/sealed_secrets.key
-    ```
+            ```json
+            {
+                "Username": "root",
+                "Password": "bar"
+            }
+            ```
 
-#### 1.2 Modify MEDS sealed secret to use new global default credential
+        1. Specify the desired default credentials for MEDS to use with new hardware.
 
-1. Inspect the original default credentials for MEDS.
+            > Replace `foobar` with the `root` user password configured on the CECs.
 
-    ```bash
-    ./utils/secrets-decrypt.sh cray_meds_credentials ./certs/sealed_secrets.key ./customizations.yaml | jq .data.vault_redfish_defaults -r | base64 -d | jq
-    ```
+            ```bash
+            echo '{ "Username": "root", "Password": "foobar" }' | base64 > creds.json.b64
+            ```
 
-    Example output:
+        1. Update and regenerate the `cray_meds_credentials` sealed secret.
 
-    ```json
-    {
-        "Username": "root",
-        "Password": "bar"
-    }
-    ```
+            ```bash
+            cat << EOF | yq w - 'data.vault_redfish_defaults' "$(<creds.json.b64)" | yq r -j - | ./utils/secrets-encrypt.sh | yq w -f - -i ./customizations.yaml 'spec.kubernetes.sealed_secrets.cray_meds_credentials'
+            {
+                "kind": "Secret",
+                "apiVersion": "v1",
+                "metadata": {
+                    "name": "cray-meds-credentials",
+                    "namespace": "services",
+                    "creationTimestamp": null
+                },
+                "data": {}
+            }
+            EOF
+            ```
 
-1. Specify the desired default credentials for MEDS to use with new hardware.
+        1. Decrypt updated sealed secret for review.
 
-    > Replace `foobar` with the `root` user password configured on the CECs.
+            The sealed secret should match the credentials set on the CEC.
 
-    ```bash
-    echo '{ "Username": "root", "Password": "foobar" }' | base64 > creds.json.b64
-    ```
+            ```bash
+            ./utils/secrets-decrypt.sh cray_meds_credentials ./certs/sealed_secrets.key ./customizations.yaml | jq .data.vault_redfish_defaults -r | base64 -d | jq
+            ```
 
-1. Update and regenerate the `cray_meds_credentials` sealed secret.
+            Example output:
 
-    ```bash
-    cat << EOF | yq w - 'data.vault_redfish_defaults' "$(<creds.json.b64)" | yq r -j - | ./utils/secrets-encrypt.sh | yq w -f - -i ./customizations.yaml 'spec.kubernetes.sealed_secrets.cray_meds_credentials'
-    {
-        "kind": "Secret",
-        "apiVersion": "v1",
-        "metadata": {
-            "name": "cray-meds-credentials",
-            "namespace": "services",
-            "creationTimestamp": null
-        },
-        "data": {}
-    }
-    EOF
-    ```
+            ```json
+            {
+                "Username": "root",
+                "Password": "foobar"
+            }
+            ```
 
-1. Decrypt updated sealed secret for review.
+- (`ncn-mw#`) When reaching the step to validate the redeployed chart, perform the following steps:
 
-    The sealed secret should match the credentials set on the CEC.
+    **Only follow these steps as part of the previously linked chart redeploy procedure.**
 
-    ```bash
-    ./utils/secrets-decrypt.sh cray_meds_credentials ./certs/sealed_secrets.key ./customizations.yaml | jq .data.vault_redfish_defaults -r | base64 -d | jq
-    ```
+    1. Wait for the MEDS Vault loader job to run to completion.
 
-    Example output:
+        ```bash
+        kubectl wait -n services job cray-meds-vault-loader --for=condition=complete --timeout=5m
+        ```
 
-    ```json
-    {
-        "Username": "root",
-        "Password": "foobar"
-    }
-    ```
+    1. Verify that the default credentials have changed in Vault.
 
-1. Update the `site-init` secret containing `customizations.yaml` for the system.
+        ```bash
+        VAULT_PASSWD=$(kubectl -n vault get secrets cray-vault-unseal-keys -o json | jq -r '.data["vault-root"]' |  base64 -d)
+        kubectl -n vault exec -it cray-vault-0 -c vault -- env VAULT_TOKEN=$VAULT_PASSWD VAULT_ADDR=http://127.0.0.1:8200 vault kv get secret/meds-cred/global/ipmi
+        ```
 
-    ```bash
-    kubectl delete secret -n loftsman site-init
-    kubectl create secret -n loftsman generic site-init --from-file=customizations.yaml
-    ```
+        Example output:
 
-1. Check in changes made to `customizations.yaml`.
+        ```text
+        ====== Data ======
+        Key         Value
+        ---         -----
+        Password    foobar
+        Username    root
+        ```
 
-    ```bash
-    git diff
-    git add customizations.yaml
-    git commit -m 'Update customizations.yaml with global default credential for MEDS'
-    ```
-
-1. Push to the remote repository as appropriate.
-
-    ```bash
-    git push
-    ```
-
-#### 1.3 Redeploy MEDS to pick up the new sealed secret and push credentials into Vault
-
-1. Determine the version of MEDS.
-
-    ```bash
-    MEDS_VERSION=$(kubectl -n loftsman get cm loftsman-core-services -o jsonpath='{.data.manifest\.yaml}' | yq r - 'spec.charts.(name==cray-hms-meds).version')
-    echo $MEDS_VERSION
-    ```
-
-1. Create `meds-manifest.yaml`.
-
-    ```bash
-    cat > meds-manifest.yaml << EOF
-    apiVersion: manifests/v1beta1
-    metadata:
-        name: meds
-    spec:
-        charts:
-        - name: cray-hms-meds
-          version: $MEDS_VERSION
-          namespace: services
-    EOF
-    ```
-
-1. Merge `customizations.yaml` with `meds-manifest.yaml`.
-
-    ```bash
-    manifestgen -c customizations.yaml -i ./meds-manifest.yaml > ./meds-manifest.out.yaml
-    ```
-
-1. Redeploy the MEDS Helm chart.
-
-    ```bash
-    loftsman ship \
-        --charts-repo https://packages.local/repository/charts \
-        --manifest-path meds-manifest.out.yaml
-    ```
-
-1. Wait for the MEDS Vault loader job to run to completion.
-
-    ```bash
-    kubectl wait -n services job cray-meds-vault-loader --for=condition=complete --timeout=5m
-    ```
-
-1. Verify the default credentials have changed in Vault.
-
-    ```bash
-    VAULT_PASSWD=$(kubectl -n vault get secrets cray-vault-unseal-keys -o json | jq -r '.data["vault-root"]' |  base64 -d)
-    kubectl -n vault exec -it cray-vault-0 -c vault -- env VAULT_TOKEN=$VAULT_PASSWD VAULT_ADDR=http://127.0.0.1:8200 vault kv get secret/meds-cred/global/ipmi
-    ```
-
-    Example output:
-
-    ```text
-    ====== Data ======
-    Key         Value
-    ---         -----
-    Password    foobar
-    Username    root
-    ```
+- **Make sure to perform the entire linked procedure, including the step to save the updated customizations.**
 
 ### 2. Update credentials for existing EX hardware in the system
 

--- a/operations/security_and_authentication/Vault_Service_Recovery.md
+++ b/operations/security_and_authentication/Vault_Service_Recovery.md
@@ -96,47 +96,17 @@ The following covers redeploying the Vault service and restoring the data.
 
 1. (`ncn-mw#`) Redeploy the chart and wait for the resources to start.
 
-   1. Create the manifest.
+   Follow the [Redeploying a Chart](../CSM_product_management/Redeploying_a_Chart.md) procedure with the following specifications:
 
-      ```bash
-      kubectl get secrets -n loftsman site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d > customizations.yaml
-      kubectl get cm -n loftsman loftsman-platform -o jsonpath='{.data.manifest\.yaml}' > cray-vault.yaml
-      for i in $(yq r cray-vault.yaml 'spec.charts[*].name' | grep -Ev '^cray-vault$'); do yq d -i cray-vault.yaml 'spec.charts(name=='"$i"')'; done
-      yq w -i cray-vault.yaml metadata.name cray-vault
-      yq d -i cray-vault.yaml spec.sources
-      yq w -i cray-vault.yaml spec.sources.charts[0].location 'https://packages.local/repository/charts'
-      yq w -i cray-vault.yaml spec.sources.charts[0].name csm-algol60
-      yq w -i cray-vault.yaml spec.sources.charts[0].type repo
-      manifestgen -c customizations.yaml -i cray-vault.yaml -o manifest.yaml
-      ```
+   - Name of chart to be redeployed: `cray-vault`
+   - Base name of manifest: `platform`
+   - Chart files are located in Nexus.
+   - When reaching the step to update customizations, no edits need to be made to the customizations file.
+   - When reaching the step to validate that the redeploy was successful, perform the following step:
 
-   1. Check that the chart version is correct based on the earlier `helm history`.
+      **Only follow this step as part of the previously linked chart redeploy procedure.**
 
-      ```bash
-      grep "version:" manifest.yaml 
-      ```
-
-      Example output:
-
-      ```yaml
-            version: 1.3.1
-      ```
-
-   1. Redeploy the chart.
-
-      ```bash
-      loftsman ship --manifest-path ${PWD}/manifest.yaml
-      ```
-
-      Example output contains:
-
-      ```text
-      NAME: cray-vault
-      ...
-      STATUS: deployed
-      ```
-
-   1. Wait for the resources to start.
+      Wait for the resources to start.
 
       ```bash
       watch "kubectl get pods -n vault -l vault_cr=cray-vault"

--- a/operations/spire/Spire_Service_Recovery.md
+++ b/operations/spire/Spire_Service_Recovery.md
@@ -94,82 +94,51 @@ The following covers redeploying the Spire service and restoring the data.
 
 1. (`ncn-mw#`) Redeploy the chart and wait for the resources to start.
 
-   1. Create the manifest.
+   Follow the [Redeploying a Chart](../CSM_product_management/Redeploying_a_Chart.md) procedure with the following specifications:
 
-      ```bash
-      kubectl get secrets -n loftsman site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d > customizations.yaml
-      kubectl get cm -n loftsman loftsman-sysmgmt -o jsonpath='{.data.manifest\.yaml}' > spire.yaml
-      for i in $(yq r spire.yaml 'spec.charts[*].name' | grep -Ev '^spire$'); do yq d -i spire.yaml 'spec.charts(name=='"$i"')'; done
-      yq w -i spire.yaml metadata.name spire
-      yq d -i spire.yaml spec.sources
-      yq w -i spire.yaml spec.sources.charts[0].location 'https://packages.local/repository/charts'
-      yq w -i spire.yaml spec.sources.charts[0].name csm-algol60
-      yq w -i spire.yaml spec.sources.charts[0].type repo
-      manifestgen -c customizations.yaml -i spire.yaml -o manifest.yaml
-      ```
+   - Name of chart to be redeployed: `spire`
+   - Base name of manifest: `sysmgmt`
+   - When reaching the step to update customizations, no edits need to be made to the customizations file.
+   - When reaching the step to validate that the redeploy was successful, perform the following step:
 
-   1. Check that the chart version is correct based on the earlier `helm history`.
+      **Only follow this step as part of the previously linked chart redeploy procedure.**
 
-      ```bash
-      grep "version:" manifest.yaml 
-      ```
+      1. Wait for the resources to start.
 
-      Example output:
+         ```bash
+         watch "kubectl get pods -n spire"
+         ```
 
-      ```yaml
-            version: 2.6.0
-      ```
+         Example output:
 
-   1. Redeploy the chart.
+         ```text
+         NAME                                     READY   STATUS      RESTARTS   AGE
+         request-ncn-join-token-89hp7             2/2     Running     0          31m
+         request-ncn-join-token-fvqdj             2/2     Running     0          31m
+         request-ncn-join-token-h7qc2             2/2     Running     0          31m
+         request-ncn-join-token-wv56n             2/2     Running     0          31m
+         request-ncn-join-token-dnfhk             2/2     Running     0          31m
+         request-ncn-join-token-hbvwc             2/2     Running     0          31m
+         spire-agent-cmn9q                        1/1     Running     0          31m
+         spire-agent-gzn2d                        1/1     Running     0          31m
+         spire-agent-pl595                        1/1     Running     0          31m
+         spire-create-pooler-schema-1-g6gr6       0/3     Completed   0          31m
+         spire-jwks-6c97b5694f-d94rg              3/3     Running     0          31m
+         spire-jwks-6c97b5694f-h89lb              3/3     Running     0          31m
+         spire-jwks-6c97b5694f-kz9k4              3/3     Running     0          31m
+         spire-postgres-0                         3/3     Running     0          31m
+         spire-postgres-1                         3/3     Running     0          31m
+         spire-postgres-2                         3/3     Running     0          30m
+         spire-postgres-pooler-695d4cd48f-57p5s   2/2     Running     0          30m
+         spire-postgres-pooler-695d4cd48f-bzm6n   2/2     Running     0          30m
+         spire-postgres-pooler-695d4cd48f-mv57z   2/2     Running     0          30m
+         spire-server-0                           2/2     Running     4          31m
+         spire-server-1                           2/2     Running     0          28m
+         spire-server-2                           2/2     Running     0          28m
+         spire-update-bss-1-cfbxc                 0/2     Completed   0          31m
+         ```
 
-      ```bash
-      loftsman ship --manifest-path ${PWD}/manifest.yaml
-      ```
-
-      Example output contains:
-
-      ```text
-      NAME: spire
-      ...
-      STATUS: deployed
-      ```
-
-   1. Wait for the resources to start.
-
-      ```bash
-      watch "kubectl get pods -n spire"
-      ```
-
-      Example output:
-
-      ```text
-      NAME                                     READY   STATUS      RESTARTS   AGE
-      request-ncn-join-token-89hp7             2/2     Running     0          31m
-      request-ncn-join-token-fvqdj             2/2     Running     0          31m
-      request-ncn-join-token-h7qc2             2/2     Running     0          31m
-      request-ncn-join-token-wv56n             2/2     Running     0          31m
-      request-ncn-join-token-dnfhk             2/2     Running     0          31m
-      request-ncn-join-token-hbvwc             2/2     Running     0          31m
-      spire-agent-cmn9q                        1/1     Running     0          31m
-      spire-agent-gzn2d                        1/1     Running     0          31m
-      spire-agent-pl595                        1/1     Running     0          31m
-      spire-create-pooler-schema-1-g6gr6       0/3     Completed   0          31m
-      spire-jwks-6c97b5694f-d94rg              3/3     Running     0          31m
-      spire-jwks-6c97b5694f-h89lb              3/3     Running     0          31m
-      spire-jwks-6c97b5694f-kz9k4              3/3     Running     0          31m
-      spire-postgres-0                         3/3     Running     0          31m
-      spire-postgres-1                         3/3     Running     0          31m
-      spire-postgres-2                         3/3     Running     0          30m
-      spire-postgres-pooler-695d4cd48f-57p5s   2/2     Running     0          30m
-      spire-postgres-pooler-695d4cd48f-bzm6n   2/2     Running     0          30m
-      spire-postgres-pooler-695d4cd48f-mv57z   2/2     Running     0          30m
-      spire-server-0                           2/2     Running     4          31m
-      spire-server-1                           2/2     Running     0          28m
-      spire-server-2                           2/2     Running     0          28m
-      spire-update-bss-1-cfbxc                 0/2     Completed   0          31m
-      ```
-
-   1. Rejoin the storage nodes to spire and restart the spire-agent on all NCNs
+   1. Rejoin the storage nodes to Spire and restart the `spire-agent` on all NCNs.
 
       ```bash
       /opt/cray/platform-utils/spire/fix-spire-on-storage.sh

--- a/scripts/operations/kubernetes/latest_chart_manifest.sh
+++ b/scripts/operations/kubernetes/latest_chart_manifest.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# Usage: latest_chart_manifest.sh <chart_name>
+#
+# Given the name of a CSM service chart, looks up the most recent successful Loftsman deployment
+# of that chart, and prints the contents of the corresponding chart stanza from that manifest's/-ship-log$//
+# 'spec.charts' list
+
+set -e
+set -o pipefail
+
+workdir=$(mktemp -d)
+
+function cleanup {
+  if [[ -d ${workdir} ]]; then
+    rm "${workdir}"/* > /dev/null 2>&1
+    rmdir "${workdir}" > /dev/null 2>&1
+  fi
+}
+
+function err_exit {
+  echo "ERROR: $*" >&2
+  cleanup
+  exit 1
+}
+
+function get_deployed_manifest_config_maps {
+  # Looks up all loftsman manifest CMs that have associated -ship-log configmaps showing that they deployed successfully.
+  # Creates an array of their names, sorted from most recently deployed to least recently deployed.
+  # Stores result in array named manifest_cms_sorted
+
+  # Find all loftsman CMs with label app.kubernetes.io/managed-by=loftsman, excluding those with name suffix -ship-log.
+  # Convert the list to a regular expression of the form 'name1|name2|name3|..."namen'
+  local manifest_cms_regex manifest_cms_chrono cm
+  manifest_cms_regex=$(
+    kubectl get cm -n loftsman -l app.kubernetes.io/managed-by=loftsman -o custom-columns=':.metadata.name' --no-headers \
+      | grep -v "[-]ship-log$" | tr '\n' '|' | sed 's/|$//'
+  )
+
+  # Create array of corresponding manifest -ship-log CM names in chronological order, from most recent to least recent, then strip off the -ship-log suffixes.
+  readarray -t manifest_cms_chrono < <(
+    kubectl get cm -n loftsman -l app.kubernetes.io/managed-by=loftsman --sort-by='.metadata.creationTimestamp' \
+      -o custom-columns=':.metadata.name' --no-headers \
+      | grep -E "^(${manifest_cms_regex})-ship-log$" | tac | sed 's/-ship-log$//'
+  )
+
+  manifest_cms_sorted=()
+  for cm in "${manifest_cms_chrono[@]}"; do
+    # Did it deploy successfully?
+    kubectl get cm -n loftsman "${cm}-ship-log" -o jsonpath='{.data.loftsman\.log}' \
+      | jq -r 'select(.message?) | select(.message | startswith("Ship status: success")) | .message' \
+      | grep -q "^Ship status: success" || continue
+    manifest_cms_sorted+=("${cm}")
+  done
+}
+
+[[ $# -eq 1 ]] || err_exit "Chart name must be specified"
+
+chart="$1"
+
+# Validate chart name
+[[ -n ${chart} ]] || err_exit "Chart name may not be blank"
+[[ ! ${chart} =~ ^[^a-z0-9] ]] || err_exit "Invalid starting character in chart name: '${chart}'"
+[[ ! ${chart} =~ [^a-z0-9]$ ]] || err_exit "Invalid final character in chart name: '${chart}'"
+[[ ! ${chart} =~ [^-a-z0-9] ]] || err_exit "Invalid characters in chart name: '${chart}'"
+
+get_deployed_manifest_config_maps
+
+# If no deployed manifests were found, then there is nothing to do
+[[ ${#manifest_cms_sorted[@]} -ne 0 ]] || err_exit "No successfully deployed manifests found for chart '${chart}'"
+
+for cm in "${manifest_cms_sorted[@]}"; do
+  chart_file="${workdir}/${chart}.yaml"
+  if ! kubectl get cm -n loftsman ${cm} -o jsonpath='{.data.manifest\.yaml}' | yq r -j - | jq -r ".spec?.charts?[] | select(.name? == \"${chart}\")" 2> /dev/null | yq r -P - > "${chart_file}" 2> /dev/null; then
+    # This chart was not found
+    [[ -e ${chart_file} ]] && rm "${chart_file}"
+    continue
+  elif [[ ! -s ${chart_file} ]]; then
+    # This also means the chart was not found
+    [[ -e ${chart_file} ]] && rm "${chart_file}"
+    continue
+  fi
+  echo "Displaying chart manifest for '${chart}' from ${cm}"
+  cat "${chart_file}"
+  cleanup
+  exit 0
+done
+
+err_exit "No successfully deployed manifests found for chart '${chart}'"


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
In a number of places in the docs we have administrators redeploy charts, for a variety of reasons. These are not done in a uniform way. Many of them assume that the loftsman manifest from the CSM install/upgrade will exist unchanged in the loftsman Kubernetes configmap, while others overwrite it, in some cases overwriting it with most of the charts removed.

I raised this issue in a Slack DM and there has been much discussion about what we should be doing. I am not an expert on this, but I do know we need to make some change to the docs to at least make sure we aren't overwriting things, or having customers regress product versions inadvertently.

This PR updates chart redeploy procedure to prevent overwriting existing manifests while still using correct versions and customizations. It is not meant to be the ideal eventual solution to the problem, It is just meant to get rid of the worst problems we currently face:
1. Procedures that overwrite previously-deployed manifests, including those from the CSM install/upgrade
2. Procedures which assume that the "correct" version for a chart is the one from that manifest, even though hotfixes may have been subsequently deployed
3. Generally inconsistent procedures

It does this by making one page which outlines how to redeploy a chart. The high level procedure it uses is:
1. Download the customizations from Kubernetes and (optionally) make changes.
2. Download the base CSM install/upgrade manifest for the chart in question
3. Make a copy of that manifest file that strips out all of the charts except for the one being redeployed, and which gives the manifest a unique name (so it won't overwrite the original when deployed)
4. Look to see if the most recent loftsman deployment of the chart (which may be more recent than the CSM upgrade/install) is using a different version. If so, update your copied file with that version number.*
  * I used a small shell script for this, because it's tedious work. I originally wrote the shell script when toying with ways to handle this for CSM hotfix deploys. We ended up not using it there, but I had tested it pretty well for that purpose. It seems better and less error-prone than having the admin have to do that stuff manually.
5. Apply the customizations to your file.
6. Redeploy the chart
7. If you made customizations changes, then upload them back into K8s

The plan is for other pages to reference this procedure when needing to redeploy a chart.

**PLEASE BEAR IN MIND that this is NOT meant to be the eventual solution. This is just meant to be something that isn't going to break customer systems the way our current procedures risk doing.**

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

Backports:
- [1.4](https://github.com/Cray-HPE/docs-csm/pull/3897)
- [1.3](https://github.com/Cray-HPE/docs-csm/pull/3898)
- [1.2](https://github.com/Cray-HPE/docs-csm/pull/3899)
- [1.0](https://github.com/Cray-HPE/docs-csm/pull/3900)


# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
