### PR TITLE
CASMINST-6475 - Power on procedure should rejoin storage nodes to spire

### DIFF
--- a/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
@@ -336,11 +336,17 @@ Verify that the Lustre file system is available from the management cluster.
     kubectl rollout restart -n spire deployment spire-jwks
     ```
 
-1. (`ncn-m001#`) Rejoin Kubernetes to the worker and master NCNs, to avoid issues with Spire tokens.
+1. (`ncn-m001#`) Rejoin Spire on the worker and master NCNs, to avoid issues with Spire tokens.
 
     ```bash
     kubectl rollout restart -n spire daemonset request-ncn-join-token
     kubectl rollout status -n spire daemonset request-ncn-join-token
+    ```
+
+1. (`ncn-m001#`) Rejoin Spire on the storage NCNs, to avoid issues with Spire tokens.
+
+    ```bash
+    /opt/cray/platform-utils/spire/fix-spire-on-storage.sh
     ```
 
 1. (`ncn-m001#`) Check if any pods are in `CrashLoopBackOff` state because of errors connecting to Vault.


### PR DESCRIPTION
# Description

Update management plane startup procedure to rejoin storage nodes to spire.

# Checklist

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.