### PR TITLE
CASMINST-6283 make template to set NCN image and CFS config. Run template in storage node upgrade

### DIFF
--- a/workflows/ncn/storage/storage.upgrade.yaml
+++ b/workflows/ncn/storage/storage.upgrade.yaml
@@ -115,9 +115,13 @@ spec:
             arguments:
               parameters:
                 - name: dryRun
-                  value: "{{$.DryRun}}"  
+                  value: "{{$.DryRun}}"
                 - name: targetNcn
                   value: {{$value}}
+                - name: imageId
+                  value: "{{$.ImageId}}"
+                - name: desiredCfsConfig
+                  value: "{{$.DesiredCfsConfig}}"
           - name: set-bss-no-wipe-to-1-{{$value}}
             templateRef:
               name: set-no-wipe

--- a/workflows/templates/drain-worker.yaml
+++ b/workflows/templates/drain-worker.yaml
@@ -98,74 +98,22 @@ spec:
                   if [ "$CPS_PM_NODE" = "True" ]; then
                     /host_usr_bin/csi handoff bss-update-param --set cps.pm-node=1 --limit $TARGET_XNAME
                   fi
-      
-                  # set image to boot into in BSS
-                  IMAGE_ID={{inputs.parameters.imageId}}
-
-                  if [[ -n $IMAGE_ID ]]; then
-                    # get needed paths
-                    image_manifest_str=$(cray ims images describe $IMAGE_ID --format json | jq '.link.path')
-                    image_manifest_str=${image_manifest_str#*s3://}
-                    bucket="$( cut -d '/' -f 1 <<< "$image_manifest_str" )"
-                    bucket_rm="${bucket}/"
-                    path=${image_manifest_str#*${bucket_rm}}
-                    path=${path%?}
-
-                    temp_file="/tmp/$(echo $RANDOM | md5sum | head -c 21; echo).json"
-                    cray artifacts get $bucket $path $temp_file
-
-                    metal_image=$(jq '.artifacts | map({"path": .link.path, "type": .type}) | .[] | select( .type == "application/vnd.cray.image.rootfs.squashfs") | .path ' < $temp_file)
-                    echo "Setting metal.server image to: $metal_image"
-                    kernel_image=$(jq '.artifacts | map({"path": .link.path, "type": .type}) | .[] | select( .type == "application/vnd.cray.image.kernel") | .path ' < $temp_file)
-                    kernel_image=$(echo "$kernel_image" | tr -d '"')
-                    echo "Setting kernel image to: $kernel_image"
-                    initrd_image=$(jq '.artifacts | map({"path": .link.path, "type": .type}) | .[] | select( .type == "application/vnd.cray.image.initrd") | .path ' < $temp_file)
-                    initrd_image=$(echo "$initrd_image" | tr -d '"')
-                    echo "Setting initrd image to: $initrd_image"
-
-                    echo "INFO  Changing boot image in bss to $IMAGE_ID"
-                    METAL_SERVER=$(cray bss bootparameters list --hosts "${TARGET_XNAME}" --format json | jq '.[] |."params"' \
-                    | awk -F 'metal.server=' '{print $2}' \
-                    | awk -F ' ' '{print $1}')
-                    NEW_METAL_SERVER=$metal_image
-                    PARAMS=$(cray bss bootparameters list --hosts "${TARGET_XNAME}" --format json | jq '.[] |."params"' | \
-                        sed "/metal.server/ s|${METAL_SERVER}|${NEW_METAL_SERVER}|" | \
-                        sed "s/metal.no-wipe=1/metal.no-wipe=0/" | \
-                        tr -d \")
-                    cray bss bootparameters update --hosts "${TARGET_XNAME}" \
-                      --kernel $kernel_image \
-                      --initrd $initrd_image \
-                      --params "${PARAMS}"
-                  else
-                    echo "INFO  No Image ID was specified for the boot image. The image that will be booted is the current image in BSS."
-                    echo "INFO setting metal.no-wipe=0 in BSS"
-                    /host_usr_bin/csi handoff bss-update-param --delete metal.no-wipe --limit $TARGET_XNAME
-                    /host_usr_bin/csi handoff bss-update-param --set metal.no-wipe=0 --limit $TARGET_XNAME
-                  fi
-        - name: update-cfs
+                  echo "INFO setting metal.no-wipe=0 in BSS"
+                  /host_usr_bin/csi handoff bss-update-param --delete metal.no-wipe --limit $TARGET_XNAME
+                  /host_usr_bin/csi handoff bss-update-param --set metal.no-wipe=0 --limit $TARGET_XNAME
+        - name: set-bss-image-and-cfs-config
+          dependencies:
+          - update-bss
           templateRef:
-            name: kubectl-and-curl-template
-            template: shell-script
+            name: set-bss-image-cfs-config
+            template: main
           arguments:
             parameters:
               - name: dryRun
                 value: "{{inputs.parameters.dryRun}}"
-              - name: scriptContent
-                value: |
-                  TOKEN=$(curl -k -s -S -d grant_type=client_credentials \
-                    -d client_id=admin-client \
-                    -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
-                    https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
-                  TARGET_NCN={{inputs.parameters.targetNcn}}
-                  TARGET_XNAME=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management" | \
-                      jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"$TARGET_NCN\")) | .Xname")
-                  
-                  DESIRED_CFS_CONFIG={{inputs.parameters.desiredCfsConfig}}
-                  if [[ -n $DESIRED_CFS_CONFIG ]]; then
-                    echo "INFO  Changing CFS configuration to $DESIRED_CFS_CONFIG"
-                    cray cfs components update ${TARGET_XNAME} --enabled false --desired-config "${DESIRED_CFS_CONFIG}"
-                  else
-                    echo "INFO  No desired CFS configuration was specified so the CFS configuration after reboot will be the current CFS configuration."
-                  fi
-            
-      
+              - name: targetNcn
+                value: "{{inputs.parameters.targetNcn}}"
+              - name: imageId
+                value: "{{inputs.parameters.imageId}}"
+              - name: desiredCfsConfig
+                value: "{{inputs.parameters.desiredCfsConfig}}"

--- a/workflows/templates/set-bss-images-cfs-config.yaml
+++ b/workflows/templates/set-bss-images-cfs-config.yaml
@@ -40,7 +40,7 @@ spec:
         tasks:
         - name: update-image-in-bss
           templateRef:
-            name: kubectl-and-curl-template #iuf-base-template
+            name: ssh-template
             template: shell-script
           arguments:
             parameters:
@@ -100,7 +100,7 @@ spec:
                   fi
         - name: update-cfs-config
           templateRef:
-            name: kubectl-and-curl-template #iuf-base-template
+            name: ssh-template
             template: shell-script
           arguments:
             parameters:

--- a/workflows/templates/set-bss-images-cfs-config.yaml
+++ b/workflows/templates/set-bss-images-cfs-config.yaml
@@ -1,0 +1,125 @@
+#
+# MIT License
+#
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: set-bss-image-cfs-config
+  namespace: argo
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      inputs:
+        parameters:
+          - name: targetNcn
+          - name: dryRun
+          - name: desiredCfsConfig
+          - name: imageId
+      dag:
+        tasks:
+        - name: update-image-in-bss
+          templateRef:
+            name: kubectl-and-curl-template #iuf-base-template
+            template: shell-script
+          arguments:
+            parameters:
+              - name: dryRun
+                value: "{{inputs.parameters.dryRun}}"
+              - name: scriptContent
+                value: |
+                  TOKEN=$(curl -k -s -S -d grant_type=client_credentials \
+                    -d client_id=admin-client \
+                    -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
+                    https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
+                  TARGET_NCN={{inputs.parameters.targetNcn}}
+                  TARGET_XNAME=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management" | \
+                      jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"$TARGET_NCN\")) | .Xname")
+
+                  # set image to boot into in BSS
+                  IMAGE_ID={{inputs.parameters.imageId}}
+
+                  if [[ -n $IMAGE_ID ]]; then
+                    # USE BELOW COMMAND ONCE LIBCSM IS UPDATED IN CSM
+                    # bss-set-image --xnames $TARGET_XNAME --image_id $IMAGE_ID
+                    
+                    # BELOW IS TEMPORARY UNTIL LIBCSM IS UPDATED
+                    image_manifest_str=$(cray ims images describe $IMAGE_ID --format json | jq '.link.path')
+                    image_manifest_str=${image_manifest_str#*s3://}
+                    bucket="$( cut -d '/' -f 1 <<< "$image_manifest_str" )"
+                    bucket_rm="${bucket}/"
+                    path=${image_manifest_str#*${bucket_rm}}
+                    path=${path%?}
+
+                    temp_file="/tmp/$(echo $RANDOM | md5sum | head -c 21; echo).json"
+                    cray artifacts get $bucket $path $temp_file
+
+                    metal_image=$(jq '.artifacts | map({"path": .link.path, "type": .type}) | .[] | select( .type == "application/vnd.cray.image.rootfs.squashfs") | .path ' < $temp_file)
+                    echo "Setting metal.server image to: $metal_image"
+                    kernel_image=$(jq '.artifacts | map({"path": .link.path, "type": .type}) | .[] | select( .type == "application/vnd.cray.image.kernel") | .path ' < $temp_file)
+                    kernel_image=$(echo "$kernel_image" | tr -d '"')
+                    echo "Setting kernel image to: $kernel_image"
+                    initrd_image=$(jq '.artifacts | map({"path": .link.path, "type": .type}) | .[] | select( .type == "application/vnd.cray.image.initrd") | .path ' < $temp_file)
+                    initrd_image=$(echo "$initrd_image" | tr -d '"')
+                    echo "Setting initrd image to: $initrd_image"
+
+                    echo "INFO  Changing boot image in bss to $IMAGE_ID"
+                    METAL_SERVER=$(cray bss bootparameters list --hosts "${TARGET_XNAME}" --format json | jq '.[] |."params"' \
+                    | awk -F 'metal.server=' '{print $2}' \
+                    | awk -F ' ' '{print $1}')
+                    NEW_METAL_SERVER=$metal_image
+                    PARAMS=$(cray bss bootparameters list --hosts "${TARGET_XNAME}" --format json | jq '.[] |."params"' | \
+                        sed "/metal.server/ s|${METAL_SERVER}|${NEW_METAL_SERVER}|" | \
+                        tr -d \")
+                    cray bss bootparameters update --hosts "${TARGET_XNAME}" \
+                      --kernel $kernel_image \
+                      --initrd $initrd_image \
+                      --params "${PARAMS}"
+                  else
+                    echo "INFO  No Image ID was specified for the boot image. The image that will be booted is the current image in BSS."
+                  fi
+        - name: update-cfs-config
+          templateRef:
+            name: kubectl-and-curl-template #iuf-base-template
+            template: shell-script
+          arguments:
+            parameters:
+              - name: dryRun
+                value: "{{inputs.parameters.dryRun}}"
+              - name: scriptContent
+                value: |
+                  TOKEN=$(curl -k -s -S -d grant_type=client_credentials \
+                    -d client_id=admin-client \
+                    -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
+                    https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
+                  TARGET_NCN={{inputs.parameters.targetNcn}}
+                  TARGET_XNAME=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management" | \
+                      jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"$TARGET_NCN\")) | .Xname")
+                  
+                  DESIRED_CFS_CONFIG={{inputs.parameters.desiredCfsConfig}}
+                  if [[ -n $DESIRED_CFS_CONFIG ]]; then
+                    echo "INFO  Changing CFS configuration to $DESIRED_CFS_CONFIG"
+                    cray cfs components update ${TARGET_XNAME} --enabled false --desired-config "${DESIRED_CFS_CONFIG}"
+                  else
+                    echo "INFO  No desired CFS configuration was specified so the CFS configuration after reboot will be the current CFS configuration."
+                  fi

--- a/workflows/templates/storage.before-each.yaml
+++ b/workflows/templates/storage.before-each.yaml
@@ -33,6 +33,8 @@ spec:
         parameters:
           - name: dryRun
           - name: targetNcn
+          - name: imageId
+          - name: desiredCfsConfig
       dag:
         tasks:
           - name: verify-bss-runcmd
@@ -83,3 +85,19 @@ spec:
                     scp /opt/cray/tests/install/ncn/scripts/check_bootloader.sh $TARGET_NCN:/opt/cray/csm/scripts/check_bootloader.sh
                     ssh $TARGET_NCN '/opt/cray/csm/scripts/check_bootloader.sh; rm -rf /metal/recovery/*'
                     echo "Successfully checked bootloader on $TARGET_NCN and removed /metal/recovery."
+          - name: set-bss-image-and-cfs-config
+            dependencies:
+            - verify-bss-runcmd
+            templateRef:
+              name: set-bss-image-cfs-config
+              template: main
+            arguments:
+              parameters:
+                - name: dryRun
+                  value: "{{inputs.parameters.dryRun}}"
+                - name: targetNcn
+                  value: "{{inputs.parameters.targetNcn}}"
+                - name: imageId
+                  value: "{{inputs.parameters.imageId}}"
+                - name: desiredCfsConfig
+                  value: "{{inputs.parameters.desiredCfsConfig}}"


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
A workflow template was created to set CFS configuration and BSS image. Worker workflows already had this capability but this change makes it reusable so that it can be used by the storage upgrade workflow. This is necessary now that IUF will run storage node upgrades, IUF will provide the image and CFS config to storage node upgrade the nodes will be rebuilt into that image.

This was tested on Surtur in the storage node upgrade on 6/13/23. A dry-run of a worker rebuild was performed to make sure the worker node workflow changes work as well.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
