### PR TITLE
CASMPET-6634: Save cert-manager data in a secret in prereq upgrade

### DIFF
--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -809,18 +809,57 @@ else
   echo "====> ${state_name} has been completed" | tee -a "${LOG_FILE}"
 fi
 
+# Helper functions for below
+has_cm_init() {
+  ns="${1?no namespace provided}"
+  helm list -n "${ns}" --filter cray-certmanager-init | grep cray-certmanager-init > /dev/null 2>&1
+}
+
+has_craycm() {
+  ns="${1?no namespace provided}"
+  helm list -n "${ns}" --filter 'cray-certmanager$' | grep cray-certmanager > /dev/null 2>&1
+}
+
 state_name="UPGRADE_CERTMANAGER_CHART"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
 if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
   echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
   {
     cmns="cert-manager"
+    cminitns="cert-manager-init"
+
+    backup_secret="cm-restore-data"
+
+    # We need to backup before any helm uninstalls.
+    needs_backup=0
+
+    if has_craycm ${cmns}; then
+      ((needs_backup+=1))
+    fi
+
+    if has_cm_init ${cminitns}; then
+      ((needs_backup+=1))
+    fi
+
+    # Ok so the gist of this "backup" is we back up all the cert-manager data as
+    # guided by them. The secret we use for this is only kept around until this
+    # prereq state completes.
+    if [ "${needs_backup}" -gt 0 ]; then
+      # Note, check that the secret is present in case only one helm chart is
+      # removed and we error later, we don't want to backup stuff again at that
+      # point.
+      if ! kubectl get secret "${backup_secret?}" > /dev/null 2>&1; then
+        data=$(kubectl get --all-namespaces -o yaml clusterissuer,cert,issuer)
+        kubectl create secret generic "${backup_secret?}" --from-literal=data="${data?}"
+      fi
+    fi
+
     # Only remove these charts if installed
-    if helm list -n "${cmns}" --filter 'cray-certmanager$' | grep cray-certmanager > /dev/null 2>&1; then
+    if has_craycm ${cmns}; then
       helm uninstall -n "${cmns}" cray-certmanager
     fi
-    cminitns="cert-manager-init"
-    if helm list -n "${cminitns}" --filter cray-certmanager-init | grep cray-certmanager-init > /dev/null 2>&1; then
+
+    if has_cm_init ${cminitns}; then
       helm uninstall -n "${cminitns}" cray-certmanager-init
     fi
 
@@ -836,10 +875,16 @@ if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
     if ! helm list -n "${cminitns}" --filter cray-certmanager-init | grep cray-certmanager-init > /dev/null; then
       cminit=0
     fi
+
     if [ "${cm}" = "1" ] || [ "${cminit}" = "1" ]; then
       printf "fatal: helm uninstall did not remove expected charts, cert-manager %s cert-manager-init %s\n" "${cm}" "${cminit}" >&2
       exit 1
     fi
+
+    # Ensure the cert-manager namespace is deleted in a case of both helm charts
+    # removed but there might be detritous leftover in the namespace.
+    kubectl delete namespce "${cmns}" || :
+
     tmp_manifest=/tmp/certmanager-tmp-manifest.yaml
 
     cat > "${tmp_manifest}" << EOF
@@ -881,7 +926,17 @@ EOF
     # cray-certmanager-issuers is also in this category in that it should be
     # unnecessary as the upgrade will reinstall it anyway but this is just
     # to be complete.
+    #
+    # This only needs to happen for this 0.14.1->1.55 upgrade. We should remove
+    # this on the next release doing this work each time is unnecessary.
     loftsman ship --charts-path "${CSM_ARTI_DIR}/helm" --manifest-path "${tmp_manifest}"
+
+    # If the restore secret exists, apply that data here and when done then
+    # remove the secret as its purpose is no longer necessary.
+    if kubectl get secret "${backup_secret?}" > /dev/null 2>&1; then
+      kubectl get secret "${backup_secret?}" -o jsonpath='{.data.data}' | base64 -d | kubectl apply -f -
+      kubectl delete secret "${backup_secret}"
+    fi
   } >> "${LOG_FILE}" 2>&1
   record_state "${state_name}" "$(hostname)" | tee -a "${LOG_FILE}"
 else


### PR DESCRIPTION
Update certmanager upgrade logic to backup specific certmanager objects into a temporary k8s secret.

This is then restored *after* the new certmanager is installed. Once restored the secret is removed.

# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
