### PR TITLE
CASM-4352 Backport to release/1.4

### DIFF
--- a/workflows/iuf/operations/extract-release-distributions.yaml
+++ b/workflows/iuf/operations/extract-release-distributions.yaml
@@ -69,7 +69,7 @@ spec:
               - start-operation
             inline:
               script:
-                image: artifactory.algol60.net/csm-docker/stable/iuf:v0.1.3
+                image: artifactory.algol60.net/csm-docker/stable/iuf:csm-latest
                 command: [sh]
                 source: |
                   #!/bin/sh


### PR DESCRIPTION
# PLEASE MERGE CORRESPONDING CSM PR **BEFORE** MERGING THIS PR
Corresponding csm PR: https://github.com/Cray-HPE/csm/pull/2382

## Summary and Scope

Remove installation of dependencies using zypper entirely to rely upon the host for dependencies.

We are removing these because the dependencies in the host are more up-to-date, as opposed to the embedding them within this container which doesn't get updated often.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

Yes

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASM-4352](https://jira-pro.it.hpe.com:8443/browse/CASM-4352)
* Merged code PR: https://github.com/Cray-HPE/iuf-containers/pull/18

## Testing

### Tested on:

Drax

### Test description:

Removed internally embedded dependencies from the image, volume mounted the host /usr/bin directory, appended the $PATH inside the container, and checked if the dependencies are accessible.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

No


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

