### PR TITLE
CASMTRIAGE-5542: Fix CFS troubleshooting docs link for failed sessions

### DIFF
--- a/operations/configuration_management/Track_the_Status_of_a_Session.md
+++ b/operations/configuration_management/Track_the_Status_of_a_Session.md
@@ -88,4 +88,4 @@ If a session is not starting, then see [Troubleshoot CFS Sessions Failing to Sta
 
 If a session is starting but not completing, then see [Troubleshoot CFS Session Failing to Complete](Troubleshoot_CFS_Session_Failing_to_Complete.md).
 
-If a session completed but did not succeed, then see [Troubleshoot Failed CFS Sessions](Troubleshoot_CFS_Session_Failed.md).
+If a session completed but did not succeed, then see [Troubleshoot Ansible Play Failures in CFS Sessions](Troubleshoot_Ansible_Play_Failures_in_CFS_Sessions.md).


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

Fixes an issue with a link in the CFS troubleshooting docs that was introduced by a a backport.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- CASMTRIAGE-5542
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
