### PR TITLE
CASMCMS-8623: Updating latest ims-load-artifacts for arch

### DIFF
--- a/workflows/iuf/operations/ims-upload.yaml
+++ b/workflows/iuf/operations/ims-upload.yaml
@@ -232,7 +232,7 @@ spec:
           default: "{}"
 
     container:
-      image: artifactory.algol60.net/csm-docker/stable/cray-ims-load-artifacts:2.5.2
+      image: artifactory.algol60.net/csm-docker/stable/cray-ims-load-artifacts:2.6.0
       command:
         - "/bin/sh"
       args: ["-c", "/ims_load_artifacts/argo_entrypoint.sh"]


### PR DESCRIPTION
Latest version `2.6.0` of ims-load-artifacts is required for arch IUF manifest changes to process correctly.

Must merge with:
https://github.com/Cray-HPE/cray-nls/pull/181 - [CASMCMS-8623](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8623)


# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
