### PR TITLE
Add editor config to match shfmt

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+trim_trailing_spaces = true
+trim_trailing_whitespace = true
+
+# 4 space indentation
+[*.{py,go}]
+indent_size = 4
+
+# 2 space indentation
+[*.{json,yml,yaml}]
+indent_size = 2
+
+[*.sh]
+indent_size = 2
+
+[*.{adoc,md}]
+trim_trailing_whitespace = false
+indent_size = 2


### PR DESCRIPTION
Restores `.editorconfig` to align bash editing with #3846 .