### PR TITLE
CASMINST-6504 fix csi install where we grep a wrong string; add singl…

### DIFF
--- a/workflows/ncn/hooks/before-all/install-csi.yaml
+++ b/workflows/ncn/hooks/before-all/install-csi.yaml
@@ -39,7 +39,7 @@ spec:
         exit 1
     fi
     export PDSH_SSH_ARGS_APPEND="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
-    installed=$(pdsh -w $(grep -oP 'ncn-\m\d+' /etc/hosts | sort -u | tr -t '\n' ',') "zypper install -y $csi_url" | grep "cray-site-init.*done\|No update candidate for 'cray-site-init" | wc -l)
+    installed=$(pdsh -w $(grep -oP 'ncn-\m\d+' /etc/hosts | sort -u | tr -t '\n' ',') "zypper install -y $csi_url" | grep "cray-site-init.*done\|Nothing to do." | wc -l)
     if [[ $installed -lt $(grep -oP 'ncn-\m\d+' /etc/hosts | sort -u | wc -l) ]]; then
       echo "ERROR installing csi on master nodes. Make sure valid SSH keys exist from ncn-m001 to other master nodes. Manually run - zypper install -y $csi_url on master nodes."
       exit 1

--- a/workflows/ncn/hooks/before-all/move-critical-singleton-pods.yaml
+++ b/workflows/ncn/hooks/before-all/move-critical-singleton-pods.yaml
@@ -52,7 +52,7 @@ spec:
 
     echo
 
-    criticalPodLabels=( "app=nexus" "app.kubernetes.io/name=cray-ipxe-x86-64" "app.kubernetes.io/name=cray-ipxe-aarch64" "app.kubernetes.io/name=cray-dhcp-kea" "app.kubernetes.io/name=cray-cfs-api-db" )
+    criticalPodLabels=( "app=nexus" "app.kubernetes.io/name=cray-ipxe-x86-64" "app.kubernetes.io/name=cray-dhcp-kea" "app.kubernetes.io/name=cray-cfs-api-db" )
     for label in ${criticalPodLabels[@]};do
       pods=($(kubectl get pods -A -l ${label} -o custom-columns=:.metadata.name))
       # we may have multiple pods matched with the label

--- a/workflows/ncn/hooks/before-all/move-critical-singleton-pods.yaml
+++ b/workflows/ncn/hooks/before-all/move-critical-singleton-pods.yaml
@@ -52,7 +52,7 @@ spec:
 
     echo
 
-    criticalPodLabels=( "app=nexus" "app.kubernetes.io/name=cray-ipxe" "app.kubernetes.io/name=cray-dhcp-kea" "app.kubernetes.io/name=cray-cfs-api-db" )
+    criticalPodLabels=( "app=nexus" "app.kubernetes.io/name=cray-ipxe-x86-64" "app.kubernetes.io/name=cray-ipxe-aarch64" "app.kubernetes.io/name=cray-dhcp-kea" "app.kubernetes.io/name=cray-cfs-api-db" )
     for label in ${criticalPodLabels[@]};do
       pods=($(kubectl get pods -A -l ${label} -o custom-columns=:.metadata.name))
       # we may have multiple pods matched with the label


### PR DESCRIPTION
- fix csi install where we grep a wrong string
- add singleton pod handling for new ipxe arm

<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
