### PR TITLE
Add content for multi-tenancy related to cray cli (CASMPET-6649)

### DIFF
--- a/operations/configure_cray_cli.md
+++ b/operations/configure_cray_cli.md
@@ -15,6 +15,10 @@ There are two ways to initialize the `cray` CLI:
 
 - [Configure all NCNs with temporary Keycloak user](#configure-all-ncns-with-temporary-keycloak-user)
 
+**NOTE:**  The `cray` CLI supports an optional parameter (`--tenant <tenant-name>`) when using the CLI for tenant-scoped operations.
+This argument is not used by default, but the CLI should be configured with the appropriate tenant when operating on tenant specific resources (i.e. creating BOS session templates for Compute Nodes that are members of a tenant, etc..).
+See [Tenant Administrator Configuration](multi-tenancy/TenantAdminConfig.md) or execute `cray init --help` for more information.
+
 ## Single user already configured in Keycloak
 
 There are times in normal operation that a particular user must be authenticated on the `cray` CLI. In

--- a/operations/multi-tenancy/TenantAdminConfig.md
+++ b/operations/multi-tenancy/TenantAdminConfig.md
@@ -1,16 +1,23 @@
 # Tenant Administrator Configuration
 
-* [Overview](#overview)
-* [Kubernetes OIDC API integration](#kubernetes-oidc-api-integration)
-* [Tenant-specific Keycloak groups](#tenant-specific-keycloak-groups)
-* [`Roles` and `Rolebindings`](#roles-and-rolebindings)
-* [Retrieve an OIDC token](#retrieve-an-oidc-token)
-* [Using `kubelogin`](#using-kubelogin)
+- [Tenant Administrator Configuration](#tenant-administrator-configuration)
+  - [Overview](#overview)
+  - [Cray CLI Integration](#cray-cli-integration)
+  - [Kubernetes OIDC API integration](#kubernetes-oidc-api-integration)
+  - [Tenant-specific Keycloak groups](#tenant-specific-keycloak-groups)
+  - [`Roles` and `Rolebindings`](#roles-and-rolebindings)
+  - [Retrieve an OIDC token](#retrieve-an-oidc-token)
+  - [Using `kubelogin`](#using-kubelogin)
 
 ## Overview
 
 This page describes how to configure a user as a `Tenant Administrator`, allowing that person to perform administrative functions on one or more tenants,
 without giving them the same permissions an `Infrastructure Administrator` would have.
+
+## Cray CLI Integration
+
+When using the `cray` CLI for various operations specific to tenant-owned resources (Compute/Application Nodes), the CLI should be scoped to the appropriate tenant when `cray init` is executed.
+The CLI supports the optional `--tenant <tenant-name>` argument, which subsequently passes the `cray-tenant-name` value in the header for API requests to the respective service.
 
 ## Kubernetes OIDC API integration
 
@@ -106,7 +113,7 @@ Decoding this token will illustrate the `groups` and `name` claims added by Keyc
 
 This token can now be used by a the tenant administrator to interact with Kubernetes.
 
-* (`ncn-mw#`) The following is an example of listing pods in the `vcluster-blue` namespace (which was specified in the `ClusterRole` above as allowed):
+- (`ncn-mw#`) The following is an example of listing pods in the `vcluster-blue` namespace (which was specified in the `ClusterRole` above as allowed):
 
   ```bash
   curl -k -H "Authorization: Bearer $TOKEN"  https://kubernetes-api.vshasta.io:6443/api/v1/namespaces/vcluster-blue/pods
@@ -124,7 +131,7 @@ This token can now be used by a the tenant administrator to interact with Kubern
   "items": []
   ```
 
-* (`ncn-mw#`) Note that this token could not be used to list pods in a different namespace (`services` for example):
+- (`ncn-mw#`) Note that this token could not be used to list pods in a different namespace (`services` for example):
 
     ```bash
     curl -k -H "Authorization: Bearer $TOKEN"  https://kubernetes-api.vshasta.io:643/api/v1/namespaces/services/pods


### PR DESCRIPTION
### Summary and Scope

Add some content for the cray cli for scoping to a tenant.

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMPET-6649

### Testing

Tested on ashton:

```
ncn-m003:~/.config/cray/configurations # cray init --hostname https://api-gw-service-nmn.local
Overwrite configuration file at: /root/.config/cray/configurations/default ? [y/N]: y
Username: vshasta
Password:
Success!

Initialization complete.
ncn-m003:~/.config/cray/configurations # cat default
[core]
hostname = "https://api-gw-service-nmn.local"
tenant = ""

[auth.login]
username = "vshasta"
```

```
ncn-m003:~/.config/cray/configurations # cray init --hostname https://api-gw-service-nmn.local --tenant vcluster-blue
Overwrite configuration file at: /root/.config/cray/configurations/default ? [y/N]: y
Username: vshasta
Password:
Success!

Initialization complete.

ncn-m003:~/.config/cray/configurations # cat default
[core]
hostname = "https://api-gw-service-nmn.local"
tenant = "vcluster-blue"

[auth.login]
username = "vshasta"
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
