### PR TITLE
CRAYSAT-1728: Update cronjob re-creation documentation

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -463,6 +463,7 @@ colors
 config
 configs
 cronjob
+cronjobs
 custom-config
 customizations.yaml
 customizations.yaml.

--- a/operations/power_management/Power_On_Compute_Cabinets.md
+++ b/operations/power_management/Power_On_Compute_Cabinets.md
@@ -52,21 +52,10 @@ power-on command from Cray System Management \(CSM\) software.
    Finally, the `sat bootsys` command waits for the components in the liquid-cooled cabinets to be
    powered on. The `sat bootsys` command controls power only to liquid-cooled cabinets.
 
-   The `sat bootsys` command may time out while waiting for the `hms-discovery` cronjob to be
-   scheduled and display the following message:
-
-   ```text
-   ERROR: The cronjob hms-discovery in namespace services was not scheduled within expected window after being resumed.
-   ```
-
-   If this occurs, first check if the cronjob needs to be re-created. To do this, follow the instructions
-   in the [Check `cronjobs`](Power_On_and_Start_the_Management_Kubernetes_Cluster.md#check-cronjobs)
-   section of the [Power On and Start the Management Kubernetes Cluster](Power_On_and_Start_the_Management_Kubernetes_Cluster.md)
-   procedure.
-
-   If the cronjob does not need to be re-created and has been scheduled within the time expected
-   (based on its cron schedule), execute the `sat bootsys boot --stage cabinet-power` command
-   again.
+   If the `hms-disocvery` cronjob fails to be scheduled after it is resumed, then SAT will delete
+   and re-create the cronjob, and will wait for it to run. After the cronjob has been scheduled
+   within the time expected based on its cron schedule, execute the `sat bootsys boot --stage
+   cabinet-power` command again.
 
    If `sat bootsys` fails to power on the cabinets through `hms-discovery`, then use CAPMC to manually power on the cabinet chassis,
    compute blade slots, and all populated switch blade slots \(1, 3, 5, and 7\). This example shows cabinets 1000-1003.

--- a/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
@@ -475,6 +475,11 @@ Verify that the Lustre file system is available from the management cluster.
 
 ### Check `cronjobs`
 
+The `sat bootsys boot --stage platform-services` command above checks that all cronjobs are being
+run on time according to their specified cron schedule. If a cronjob is not being scheduled on time,
+it will be deleted and re-created to force it to be scheduled again. It is recommended to check that
+all cronjobs are being scheduled on time after running `sat bootsys boot --stage platform-services`.
+
 1. (`ncn-m001#`) Display all the Kubernetes `cronjobs`.
 
     ```bash

--- a/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
@@ -475,7 +475,7 @@ Verify that the Lustre file system is available from the management cluster.
 
 ### Check `cronjobs`
 
-The `sat bootsys boot --stage platform-services` command above checks that all cronjobs are being
+The `sat bootsys boot --stage platform-services` command checks that all cronjobs
 run on time according to their specified cron schedule. If a cronjob is not being scheduled on time,
 it will be deleted and re-created to force it to be scheduled again. It is recommended to check that
 all cronjobs are being scheduled on time after running `sat bootsys boot --stage platform-services`.


### PR DESCRIPTION
SAT now re-creates cronjobs automatically, so this is now noted.

<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
