### PR TITLE
CASMTRIAGE-5639: Update the gateway-test.py for cmn nmn seperation.

### DIFF
--- a/scripts/operations/gateway-test/gateway-test.py
+++ b/scripts/operations/gateway-test/gateway-test.py
@@ -102,13 +102,13 @@ def get_access_token(adminSecret, tokenNet, nmn_override):
         tokendomain = "auth.{}.{}".format(tokenNet, SYSTEM_DOMAIN)
 
     url = "https://{}/keycloak/realms/shasta/protocol/openid-connect/token".format(tokendomain)
- 
+
     if not resolvable(tokendomain):
         return None
 
     if not reachable(tokendomain):
         return None
-   
+
     try:
       r = requests.post(url, data = payload, verify = False)
     except Exception as err:
@@ -163,7 +163,7 @@ def get_sls_networks(adminSecret, systemDomain, nets):
 
 def get_vs(service):
 
-    result = None	
+    result = None
     try:
         logging.debug("Getting gateways for service {}.".format(service['name']))
         command_line = ['kubectl', 'get', 'vs', service['name'], '-n', service['namespace'], '-o', 'yaml']
@@ -199,7 +199,7 @@ if __name__ == '__main__':
       logging.critical("{} does not exist.".format(test_defn_file))
       sys.exit(1)
 
-    SYSTEM_DOMAIN = (sys.argv[1]).lower() 
+    SYSTEM_DOMAIN = (sys.argv[1]).lower()
     NODE_TYPE = (sys.argv[2]).lower()
     ADMIN_SECRET = os.environ.get("ADMIN_CLIENT_SECRET", "")
 
@@ -336,27 +336,21 @@ if __name__ == '__main__':
 
           if net['gateway'] not in svcgws:
             svcexp = 404
-          # if the token we have does not match the network we are testing, we expect a 403
-          # CMN tokens will work with NMN and vice versa, because they are using the same gateway in 1.2.
-          elif tokname == "cmn" and netname != tokname and netname != "nmnlb":
-            svcexp = 403
-          elif tokname == "nmnlb" and netname != tokname and netname != "cmn":
-            svcexp = 403
-          elif tokname not in ["cmn","nmnlb"] and tokname != netname:
+          elif tokname != netname:
             svcexp = 403
 
           headers = {
               'Authorization': "Bearer " + mytok
           }
 
-   
+
           try:
               response = requests.request("GET", url, headers=headers, verify = False)
           except Exception as err:
               print("{}".format(err))
               logging.error(f"An unanticipated exception occurred while retrieving {url} {err}")
               break
-    
+
           if response.status_code == svcexp:
               print("PASS - [" + svcname + "]: " + url + " - " + str(response.status_code))
           else:


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->
Change to the gateway-test.py  because the nmn and cmn have been separated in 1.5 meaning tokens from the nmn will not work on the cmn and vice versa. This is now expected behavior in 1.5 so the test should be updated from the expected behavior from 1.2-1.4.
# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams

Running the test post change on drax:

```/usr/share/doc/csm/scripts/operations/gateway-test/ncn-gateway-test.sh
System domain is drax.hpc.amslabs.hpecorp.net

Running tests on the NCN
auth.cmn.drax.hpc.amslabs.hpecorp.net is reachable
Token successfully retrieved at https://auth.cmn.drax.hpc.amslabs.hpecorp.net/keycloak/realms/shasta/protocol/openid-connect/token

Reachable networks: ['can', 'nmnlb', 'hmnlb', 'cmn']

Getting token for hmnlb
auth.hmnlb.drax.hpc.amslabs.hpecorp.net is reachable
Token successfully retrieved at https://auth.hmnlb.drax.hpc.amslabs.hpecorp.net/keycloak/realms/shasta/protocol/openid-connect/token


------------- api.hmnlb.drax.hpc.amslabs.hpecorp.net -------------------
api.hmnlb.drax.hpc.amslabs.hpecorp.net is reachable
PASS - [cray-argo]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/nls/v1/readiness - 404
PASS - [cray-bos]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/bos/v1/session - 404
PASS - [cray-bss]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/bss/boot/v1/bootparameters - 404
PASS - [cray-capmc]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/capmc/capmc/v1/health - 404
PASS - [cray-cfs-api]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/cfs/v2/sessions - 404
PASS - [cray-console-data]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/consoledata/liveness - 404
PASS - [cray-console-node]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/console-node/console-node/liveness - 404
PASS - [cray-console-operator]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/console-operator/console-operator/liveness - 404
SKIP - [cray-cps]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/v2/cps/contents - virtual service not found
PASS - [cray-fas]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/fas/v1/snapshots - 404
PASS - [cray-hbtd]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/hbtd/hmi/v1/health - 404
PASS - [cray-hmnfd]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/hmnfd/hmi/v2/health - 404
PASS - [cray-ims]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/ims/images - 404
PASS - [cray-powerdns-manager]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/powerdns-manager/v1/liveness - 404
PASS - [cray-reds]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/reds/v1/liveness - 404
PASS - [cray-scsd]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/scsd/v1/health - 404
PASS - [cray-sls]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/sls/v1/health - 404
PASS - [cray-smd]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/smd/hsm/v2/service/ready - 404
PASS - [cray-sts]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/sts/healthz - 404
PASS - [cray-uas-mgr]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/uas-mgr/v1/images - 404
SKIP - [nmdv2-service]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/v2/nmd/dumps - virtual service not found
SKIP - [slingshot-fabric-manager]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/fabric-manager/fabric/port-policies - virtual service not found
SKIP - [sma-telemetry]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/sma-telemetry-api/v1/ping - virtual service not found

------------- api.nmnlb.drax.hpc.amslabs.hpecorp.net -------------------
api.nmnlb.drax.hpc.amslabs.hpecorp.net is reachable
PASS - [cray-argo]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/nls/v1/readiness - 403
PASS - [cray-bos]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/bos/v1/session - 403
PASS - [cray-bss]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/bss/boot/v1/bootparameters - 403
PASS - [cray-capmc]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/capmc/capmc/v1/health - 403
PASS - [cray-cfs-api]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/cfs/v2/sessions - 403
PASS - [cray-console-data]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/consoledata/liveness - 403
PASS - [cray-console-node]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/console-node/console-node/liveness - 403
PASS - [cray-console-operator]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/console-operator/console-operator/liveness - 403
SKIP - [cray-cps]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/v2/cps/contents - virtual service not found
PASS - [cray-fas]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/fas/v1/snapshots - 403
PASS - [cray-hbtd]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/hbtd/hmi/v1/health - 403
PASS - [cray-hmnfd]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/hmnfd/hmi/v2/health - 403
PASS - [cray-ims]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/ims/images - 403
PASS - [cray-powerdns-manager]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/powerdns-manager/v1/liveness - 403
PASS - [cray-reds]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/reds/v1/liveness - 403
PASS - [cray-scsd]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/scsd/v1/health - 403
PASS - [cray-sls]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/sls/v1/health - 403
PASS - [cray-smd]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/smd/hsm/v2/service/ready - 403
PASS - [cray-sts]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/sts/healthz - 403
PASS - [cray-uas-mgr]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/uas-mgr/v1/images - 403
SKIP - [nmdv2-service]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/v2/nmd/dumps - virtual service not found
SKIP - [slingshot-fabric-manager]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/fabric-manager/fabric/port-policies - virtual service not found
SKIP - [sma-telemetry]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/sma-telemetry-api/v1/ping - virtual service not found

------------- api.cmn.drax.hpc.amslabs.hpecorp.net -------------------
api.cmn.drax.hpc.amslabs.hpecorp.net is reachable
PASS - [cray-argo]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/nls/v1/readiness - 403
PASS - [cray-bos]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/bos/v1/session - 403
PASS - [cray-bss]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/bss/boot/v1/bootparameters - 403
PASS - [cray-capmc]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/capmc/capmc/v1/health - 403
PASS - [cray-cfs-api]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/cfs/v2/sessions - 403
PASS - [cray-console-data]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/consoledata/liveness - 403
PASS - [cray-console-node]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/console-node/console-node/liveness - 403
PASS - [cray-console-operator]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/console-operator/console-operator/liveness - 403
SKIP - [cray-cps]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/v2/cps/contents - virtual service not found
PASS - [cray-fas]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/fas/v1/snapshots - 403
PASS - [cray-hbtd]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/hbtd/hmi/v1/health - 403
PASS - [cray-hmnfd]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/hmnfd/hmi/v2/health - 403
PASS - [cray-ims]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/ims/images - 403
PASS - [cray-powerdns-manager]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/powerdns-manager/v1/liveness - 403
PASS - [cray-reds]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/reds/v1/liveness - 403
PASS - [cray-scsd]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/scsd/v1/health - 403
PASS - [cray-sls]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/sls/v1/health - 403
PASS - [cray-smd]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/smd/hsm/v2/service/ready - 403
PASS - [cray-sts]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/sts/healthz - 403
PASS - [cray-uas-mgr]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/uas-mgr/v1/images - 403
SKIP - [nmdv2-service]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/v2/nmd/dumps - virtual service not found
SKIP - [slingshot-fabric-manager]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/fabric-manager/fabric/port-policies - virtual service not found
SKIP - [sma-telemetry]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/sma-telemetry-api/v1/ping - virtual service not found

------------- api.can.drax.hpc.amslabs.hpecorp.net -------------------
api.can.drax.hpc.amslabs.hpecorp.net is reachable
PASS - [cray-argo]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/nls/v1/readiness - 404
PASS - [cray-bos]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/bos/v1/session - 404
PASS - [cray-bss]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/bss/boot/v1/bootparameters - 404
PASS - [cray-capmc]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/capmc/capmc/v1/health - 404
PASS - [cray-cfs-api]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/cfs/v2/sessions - 404
PASS - [cray-console-data]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/consoledata/liveness - 404
PASS - [cray-console-node]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/console-node/console-node/liveness - 404
PASS - [cray-console-operator]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/console-operator/console-operator/liveness - 404
SKIP - [cray-cps]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/v2/cps/contents - virtual service not found
PASS - [cray-fas]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/fas/v1/snapshots - 404
PASS - [cray-hbtd]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/hbtd/hmi/v1/health - 404
PASS - [cray-hmnfd]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/hmnfd/hmi/v2/health - 404
PASS - [cray-ims]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/ims/images - 404
PASS - [cray-powerdns-manager]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/powerdns-manager/v1/liveness - 404
PASS - [cray-reds]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/reds/v1/liveness - 404
PASS - [cray-scsd]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/scsd/v1/health - 404
PASS - [cray-sls]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/sls/v1/health - 404
PASS - [cray-smd]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/smd/hsm/v2/service/ready - 404
PASS - [cray-sts]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/sts/healthz - 404
PASS - [cray-uas-mgr]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/uas-mgr/v1/images - 404
SKIP - [nmdv2-service]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/v2/nmd/dumps - virtual service not found
SKIP - [slingshot-fabric-manager]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/fabric-manager/fabric/port-policies - virtual service not found
SKIP - [sma-telemetry]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/sma-telemetry-api/v1/ping - virtual service not found

Getting token for nmnlb
auth.nmnlb.drax.hpc.amslabs.hpecorp.net is reachable
Token successfully retrieved at https://auth.nmnlb.drax.hpc.amslabs.hpecorp.net/keycloak/realms/shasta/protocol/openid-connect/token


------------- api.hmnlb.drax.hpc.amslabs.hpecorp.net -------------------
api.hmnlb.drax.hpc.amslabs.hpecorp.net is reachable
PASS - [cray-argo]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/nls/v1/readiness - 404
PASS - [cray-bos]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/bos/v1/session - 404
PASS - [cray-bss]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/bss/boot/v1/bootparameters - 404
PASS - [cray-capmc]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/capmc/capmc/v1/health - 404
PASS - [cray-cfs-api]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/cfs/v2/sessions - 404
PASS - [cray-console-data]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/consoledata/liveness - 404
PASS - [cray-console-node]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/console-node/console-node/liveness - 404
PASS - [cray-console-operator]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/console-operator/console-operator/liveness - 404
SKIP - [cray-cps]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/v2/cps/contents - virtual service not found
PASS - [cray-fas]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/fas/v1/snapshots - 404
PASS - [cray-hbtd]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/hbtd/hmi/v1/health - 404
PASS - [cray-hmnfd]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/hmnfd/hmi/v2/health - 404
PASS - [cray-ims]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/ims/images - 404
PASS - [cray-powerdns-manager]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/powerdns-manager/v1/liveness - 404
PASS - [cray-reds]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/reds/v1/liveness - 404
PASS - [cray-scsd]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/scsd/v1/health - 404
PASS - [cray-sls]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/sls/v1/health - 404
PASS - [cray-smd]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/smd/hsm/v2/service/ready - 404
PASS - [cray-sts]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/sts/healthz - 404
PASS - [cray-uas-mgr]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/uas-mgr/v1/images - 404
SKIP - [nmdv2-service]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/v2/nmd/dumps - virtual service not found
SKIP - [slingshot-fabric-manager]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/fabric-manager/fabric/port-policies - virtual service not found
SKIP - [sma-telemetry]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/sma-telemetry-api/v1/ping - virtual service not found

------------- api.nmnlb.drax.hpc.amslabs.hpecorp.net -------------------
api.nmnlb.drax.hpc.amslabs.hpecorp.net is reachable
PASS - [cray-argo]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/nls/v1/readiness - 204
PASS - [cray-bos]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/bos/v1/session - 200
PASS - [cray-bss]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/bss/boot/v1/bootparameters - 200
PASS - [cray-capmc]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/capmc/capmc/v1/health - 200
PASS - [cray-cfs-api]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/cfs/v2/sessions - 200
PASS - [cray-console-data]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/consoledata/liveness - 204
PASS - [cray-console-node]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/console-node/console-node/liveness - 204
PASS - [cray-console-operator]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/console-operator/console-operator/liveness - 204
SKIP - [cray-cps]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/v2/cps/contents - virtual service not found
PASS - [cray-fas]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/fas/v1/snapshots - 200
PASS - [cray-hbtd]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/hbtd/hmi/v1/health - 200
PASS - [cray-hmnfd]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/hmnfd/hmi/v2/health - 200
PASS - [cray-ims]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/ims/images - 200
PASS - [cray-powerdns-manager]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/powerdns-manager/v1/liveness - 204
PASS - [cray-reds]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/reds/v1/liveness - 204
PASS - [cray-scsd]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/scsd/v1/health - 200
PASS - [cray-sls]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/sls/v1/health - 200
PASS - [cray-smd]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/smd/hsm/v2/service/ready - 200
PASS - [cray-sts]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/sts/healthz - 200
PASS - [cray-uas-mgr]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/uas-mgr/v1/images - 200
SKIP - [nmdv2-service]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/v2/nmd/dumps - virtual service not found
SKIP - [slingshot-fabric-manager]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/fabric-manager/fabric/port-policies - virtual service not found
SKIP - [sma-telemetry]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/sma-telemetry-api/v1/ping - virtual service not found

------------- api.cmn.drax.hpc.amslabs.hpecorp.net -------------------
api.cmn.drax.hpc.amslabs.hpecorp.net is reachable
PASS - [cray-argo]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/nls/v1/readiness - 403
PASS - [cray-bos]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/bos/v1/session - 403
PASS - [cray-bss]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/bss/boot/v1/bootparameters - 403
PASS - [cray-capmc]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/capmc/capmc/v1/health - 403
PASS - [cray-cfs-api]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/cfs/v2/sessions - 403
PASS - [cray-console-data]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/consoledata/liveness - 403
PASS - [cray-console-node]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/console-node/console-node/liveness - 403
PASS - [cray-console-operator]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/console-operator/console-operator/liveness - 403
SKIP - [cray-cps]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/v2/cps/contents - virtual service not found
PASS - [cray-fas]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/fas/v1/snapshots - 403
PASS - [cray-hbtd]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/hbtd/hmi/v1/health - 403
PASS - [cray-hmnfd]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/hmnfd/hmi/v2/health - 403
PASS - [cray-ims]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/ims/images - 403
PASS - [cray-powerdns-manager]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/powerdns-manager/v1/liveness - 403
PASS - [cray-reds]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/reds/v1/liveness - 403
PASS - [cray-scsd]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/scsd/v1/health - 403
PASS - [cray-sls]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/sls/v1/health - 403
PASS - [cray-smd]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/smd/hsm/v2/service/ready - 403
PASS - [cray-sts]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/sts/healthz - 403
PASS - [cray-uas-mgr]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/uas-mgr/v1/images - 403
SKIP - [nmdv2-service]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/v2/nmd/dumps - virtual service not found
SKIP - [slingshot-fabric-manager]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/fabric-manager/fabric/port-policies - virtual service not found
SKIP - [sma-telemetry]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/sma-telemetry-api/v1/ping - virtual service not found

------------- api.can.drax.hpc.amslabs.hpecorp.net -------------------
api.can.drax.hpc.amslabs.hpecorp.net is reachable
PASS - [cray-argo]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/nls/v1/readiness - 404
PASS - [cray-bos]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/bos/v1/session - 404
PASS - [cray-bss]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/bss/boot/v1/bootparameters - 404
PASS - [cray-capmc]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/capmc/capmc/v1/health - 404
PASS - [cray-cfs-api]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/cfs/v2/sessions - 404
PASS - [cray-console-data]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/consoledata/liveness - 404
PASS - [cray-console-node]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/console-node/console-node/liveness - 404
PASS - [cray-console-operator]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/console-operator/console-operator/liveness - 404
SKIP - [cray-cps]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/v2/cps/contents - virtual service not found
PASS - [cray-fas]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/fas/v1/snapshots - 404
PASS - [cray-hbtd]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/hbtd/hmi/v1/health - 404
PASS - [cray-hmnfd]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/hmnfd/hmi/v2/health - 404
PASS - [cray-ims]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/ims/images - 404
PASS - [cray-powerdns-manager]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/powerdns-manager/v1/liveness - 404
PASS - [cray-reds]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/reds/v1/liveness - 404
PASS - [cray-scsd]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/scsd/v1/health - 404
PASS - [cray-sls]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/sls/v1/health - 404
PASS - [cray-smd]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/smd/hsm/v2/service/ready - 404
PASS - [cray-sts]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/sts/healthz - 404
PASS - [cray-uas-mgr]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/uas-mgr/v1/images - 404
SKIP - [nmdv2-service]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/v2/nmd/dumps - virtual service not found
SKIP - [slingshot-fabric-manager]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/fabric-manager/fabric/port-policies - virtual service not found
SKIP - [sma-telemetry]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/sma-telemetry-api/v1/ping - virtual service not found

Getting token for cmn
auth.cmn.drax.hpc.amslabs.hpecorp.net is reachable
Token successfully retrieved at https://auth.cmn.drax.hpc.amslabs.hpecorp.net/keycloak/realms/shasta/protocol/openid-connect/token


------------- api.hmnlb.drax.hpc.amslabs.hpecorp.net -------------------
api.hmnlb.drax.hpc.amslabs.hpecorp.net is reachable
PASS - [cray-argo]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/nls/v1/readiness - 404
PASS - [cray-bos]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/bos/v1/session - 404
PASS - [cray-bss]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/bss/boot/v1/bootparameters - 404
PASS - [cray-capmc]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/capmc/capmc/v1/health - 404
PASS - [cray-cfs-api]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/cfs/v2/sessions - 404
PASS - [cray-console-data]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/consoledata/liveness - 404
PASS - [cray-console-node]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/console-node/console-node/liveness - 404
PASS - [cray-console-operator]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/console-operator/console-operator/liveness - 404
SKIP - [cray-cps]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/v2/cps/contents - virtual service not found
PASS - [cray-fas]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/fas/v1/snapshots - 404
PASS - [cray-hbtd]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/hbtd/hmi/v1/health - 404
PASS - [cray-hmnfd]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/hmnfd/hmi/v2/health - 404
PASS - [cray-ims]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/ims/images - 404
PASS - [cray-powerdns-manager]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/powerdns-manager/v1/liveness - 404
PASS - [cray-reds]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/reds/v1/liveness - 404
PASS - [cray-scsd]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/scsd/v1/health - 404
PASS - [cray-sls]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/sls/v1/health - 404
PASS - [cray-smd]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/smd/hsm/v2/service/ready - 404
PASS - [cray-sts]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/sts/healthz - 404
PASS - [cray-uas-mgr]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/uas-mgr/v1/images - 404
SKIP - [nmdv2-service]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/v2/nmd/dumps - virtual service not found
SKIP - [slingshot-fabric-manager]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/fabric-manager/fabric/port-policies - virtual service not found
SKIP - [sma-telemetry]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/sma-telemetry-api/v1/ping - virtual service not found

------------- api.nmnlb.drax.hpc.amslabs.hpecorp.net -------------------
api.nmnlb.drax.hpc.amslabs.hpecorp.net is reachable
PASS - [cray-argo]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/nls/v1/readiness - 403
PASS - [cray-bos]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/bos/v1/session - 403
PASS - [cray-bss]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/bss/boot/v1/bootparameters - 403
PASS - [cray-capmc]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/capmc/capmc/v1/health - 403
PASS - [cray-cfs-api]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/cfs/v2/sessions - 403
PASS - [cray-console-data]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/consoledata/liveness - 403
PASS - [cray-console-node]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/console-node/console-node/liveness - 403
PASS - [cray-console-operator]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/console-operator/console-operator/liveness - 403
SKIP - [cray-cps]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/v2/cps/contents - virtual service not found
PASS - [cray-fas]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/fas/v1/snapshots - 403
PASS - [cray-hbtd]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/hbtd/hmi/v1/health - 403
PASS - [cray-hmnfd]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/hmnfd/hmi/v2/health - 403
PASS - [cray-ims]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/ims/images - 403
PASS - [cray-powerdns-manager]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/powerdns-manager/v1/liveness - 403
PASS - [cray-reds]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/reds/v1/liveness - 403
PASS - [cray-scsd]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/scsd/v1/health - 403
PASS - [cray-sls]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/sls/v1/health - 403
PASS - [cray-smd]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/smd/hsm/v2/service/ready - 403
PASS - [cray-sts]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/sts/healthz - 403
PASS - [cray-uas-mgr]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/uas-mgr/v1/images - 403
SKIP - [nmdv2-service]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/v2/nmd/dumps - virtual service not found
SKIP - [slingshot-fabric-manager]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/fabric-manager/fabric/port-policies - virtual service not found
SKIP - [sma-telemetry]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/sma-telemetry-api/v1/ping - virtual service not found

------------- api.cmn.drax.hpc.amslabs.hpecorp.net -------------------
api.cmn.drax.hpc.amslabs.hpecorp.net is reachable
PASS - [cray-argo]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/nls/v1/readiness - 204
PASS - [cray-bos]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/bos/v1/session - 200
PASS - [cray-bss]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/bss/boot/v1/bootparameters - 200
PASS - [cray-capmc]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/capmc/capmc/v1/health - 200
PASS - [cray-cfs-api]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/cfs/v2/sessions - 200
PASS - [cray-console-data]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/consoledata/liveness - 204
PASS - [cray-console-node]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/console-node/console-node/liveness - 204
PASS - [cray-console-operator]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/console-operator/console-operator/liveness - 204
SKIP - [cray-cps]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/v2/cps/contents - virtual service not found
PASS - [cray-fas]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/fas/v1/snapshots - 200
PASS - [cray-hbtd]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/hbtd/hmi/v1/health - 200
PASS - [cray-hmnfd]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/hmnfd/hmi/v2/health - 200
PASS - [cray-ims]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/ims/images - 200
PASS - [cray-powerdns-manager]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/powerdns-manager/v1/liveness - 204
PASS - [cray-reds]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/reds/v1/liveness - 204
PASS - [cray-scsd]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/scsd/v1/health - 200
PASS - [cray-sls]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/sls/v1/health - 200
PASS - [cray-smd]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/smd/hsm/v2/service/ready - 200
PASS - [cray-sts]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/sts/healthz - 200
PASS - [cray-uas-mgr]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/uas-mgr/v1/images - 200
SKIP - [nmdv2-service]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/v2/nmd/dumps - virtual service not found
SKIP - [slingshot-fabric-manager]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/fabric-manager/fabric/port-policies - virtual service not found
SKIP - [sma-telemetry]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/sma-telemetry-api/v1/ping - virtual service not found

------------- api.can.drax.hpc.amslabs.hpecorp.net -------------------
api.can.drax.hpc.amslabs.hpecorp.net is reachable
PASS - [cray-argo]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/nls/v1/readiness - 404
PASS - [cray-bos]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/bos/v1/session - 404
PASS - [cray-bss]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/bss/boot/v1/bootparameters - 404
PASS - [cray-capmc]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/capmc/capmc/v1/health - 404
PASS - [cray-cfs-api]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/cfs/v2/sessions - 404
PASS - [cray-console-data]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/consoledata/liveness - 404
PASS - [cray-console-node]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/console-node/console-node/liveness - 404
PASS - [cray-console-operator]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/console-operator/console-operator/liveness - 404
SKIP - [cray-cps]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/v2/cps/contents - virtual service not found
PASS - [cray-fas]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/fas/v1/snapshots - 404
PASS - [cray-hbtd]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/hbtd/hmi/v1/health - 404
PASS - [cray-hmnfd]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/hmnfd/hmi/v2/health - 404
PASS - [cray-ims]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/ims/images - 404
PASS - [cray-powerdns-manager]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/powerdns-manager/v1/liveness - 404
PASS - [cray-reds]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/reds/v1/liveness - 404
PASS - [cray-scsd]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/scsd/v1/health - 404
PASS - [cray-sls]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/sls/v1/health - 404
PASS - [cray-smd]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/smd/hsm/v2/service/ready - 404
PASS - [cray-sts]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/sts/healthz - 404
PASS - [cray-uas-mgr]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/uas-mgr/v1/images - 404
SKIP - [nmdv2-service]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/v2/nmd/dumps - virtual service not found
SKIP - [slingshot-fabric-manager]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/fabric-manager/fabric/port-policies - virtual service not found
SKIP - [sma-telemetry]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/sma-telemetry-api/v1/ping - virtual service not found

Getting token for can
auth.can.drax.hpc.amslabs.hpecorp.net is reachable
Token successfully retrieved at https://auth.can.drax.hpc.amslabs.hpecorp.net/keycloak/realms/shasta/protocol/openid-connect/token


------------- api.hmnlb.drax.hpc.amslabs.hpecorp.net -------------------
api.hmnlb.drax.hpc.amslabs.hpecorp.net is reachable
PASS - [cray-argo]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/nls/v1/readiness - 404
PASS - [cray-bos]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/bos/v1/session - 404
PASS - [cray-bss]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/bss/boot/v1/bootparameters - 404
PASS - [cray-capmc]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/capmc/capmc/v1/health - 404
PASS - [cray-cfs-api]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/cfs/v2/sessions - 404
PASS - [cray-console-data]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/consoledata/liveness - 404
PASS - [cray-console-node]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/console-node/console-node/liveness - 404
PASS - [cray-console-operator]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/console-operator/console-operator/liveness - 404
SKIP - [cray-cps]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/v2/cps/contents - virtual service not found
PASS - [cray-fas]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/fas/v1/snapshots - 404
PASS - [cray-hbtd]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/hbtd/hmi/v1/health - 404
PASS - [cray-hmnfd]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/hmnfd/hmi/v2/health - 404
PASS - [cray-ims]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/ims/images - 404
PASS - [cray-powerdns-manager]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/powerdns-manager/v1/liveness - 404
PASS - [cray-reds]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/reds/v1/liveness - 404
PASS - [cray-scsd]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/scsd/v1/health - 404
PASS - [cray-sls]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/sls/v1/health - 404
PASS - [cray-smd]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/smd/hsm/v2/service/ready - 404
PASS - [cray-sts]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/sts/healthz - 404
PASS - [cray-uas-mgr]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/uas-mgr/v1/images - 404
SKIP - [nmdv2-service]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/v2/nmd/dumps - virtual service not found
SKIP - [slingshot-fabric-manager]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/fabric-manager/fabric/port-policies - virtual service not found
SKIP - [sma-telemetry]: https://api.hmnlb.drax.hpc.amslabs.hpecorp.net/apis/sma-telemetry-api/v1/ping - virtual service not found

------------- api.nmnlb.drax.hpc.amslabs.hpecorp.net -------------------
api.nmnlb.drax.hpc.amslabs.hpecorp.net is reachable
PASS - [cray-argo]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/nls/v1/readiness - 403
PASS - [cray-bos]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/bos/v1/session - 403
PASS - [cray-bss]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/bss/boot/v1/bootparameters - 403
PASS - [cray-capmc]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/capmc/capmc/v1/health - 403
PASS - [cray-cfs-api]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/cfs/v2/sessions - 403
PASS - [cray-console-data]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/consoledata/liveness - 403
PASS - [cray-console-node]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/console-node/console-node/liveness - 403
PASS - [cray-console-operator]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/console-operator/console-operator/liveness - 403
SKIP - [cray-cps]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/v2/cps/contents - virtual service not found
PASS - [cray-fas]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/fas/v1/snapshots - 403
PASS - [cray-hbtd]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/hbtd/hmi/v1/health - 403
PASS - [cray-hmnfd]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/hmnfd/hmi/v2/health - 403
PASS - [cray-ims]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/ims/images - 403
PASS - [cray-powerdns-manager]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/powerdns-manager/v1/liveness - 403
PASS - [cray-reds]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/reds/v1/liveness - 403
PASS - [cray-scsd]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/scsd/v1/health - 403
PASS - [cray-sls]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/sls/v1/health - 403
PASS - [cray-smd]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/smd/hsm/v2/service/ready - 403
PASS - [cray-sts]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/sts/healthz - 403
PASS - [cray-uas-mgr]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/uas-mgr/v1/images - 403
SKIP - [nmdv2-service]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/v2/nmd/dumps - virtual service not found
SKIP - [slingshot-fabric-manager]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/fabric-manager/fabric/port-policies - virtual service not found
SKIP - [sma-telemetry]: https://api.nmnlb.drax.hpc.amslabs.hpecorp.net/apis/sma-telemetry-api/v1/ping - virtual service not found

------------- api.cmn.drax.hpc.amslabs.hpecorp.net -------------------
api.cmn.drax.hpc.amslabs.hpecorp.net is reachable
PASS - [cray-argo]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/nls/v1/readiness - 403
PASS - [cray-bos]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/bos/v1/session - 403
PASS - [cray-bss]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/bss/boot/v1/bootparameters - 403
PASS - [cray-capmc]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/capmc/capmc/v1/health - 403
PASS - [cray-cfs-api]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/cfs/v2/sessions - 403
PASS - [cray-console-data]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/consoledata/liveness - 403
PASS - [cray-console-node]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/console-node/console-node/liveness - 403
PASS - [cray-console-operator]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/console-operator/console-operator/liveness - 403
SKIP - [cray-cps]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/v2/cps/contents - virtual service not found
PASS - [cray-fas]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/fas/v1/snapshots - 403
PASS - [cray-hbtd]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/hbtd/hmi/v1/health - 403
PASS - [cray-hmnfd]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/hmnfd/hmi/v2/health - 403
PASS - [cray-ims]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/ims/images - 403
PASS - [cray-powerdns-manager]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/powerdns-manager/v1/liveness - 403
PASS - [cray-reds]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/reds/v1/liveness - 403
PASS - [cray-scsd]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/scsd/v1/health - 403
PASS - [cray-sls]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/sls/v1/health - 403
PASS - [cray-smd]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/smd/hsm/v2/service/ready - 403
PASS - [cray-sts]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/sts/healthz - 403
PASS - [cray-uas-mgr]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/uas-mgr/v1/images - 403
SKIP - [nmdv2-service]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/v2/nmd/dumps - virtual service not found
SKIP - [slingshot-fabric-manager]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/fabric-manager/fabric/port-policies - virtual service not found
SKIP - [sma-telemetry]: https://api.cmn.drax.hpc.amslabs.hpecorp.net/apis/sma-telemetry-api/v1/ping - virtual service not found

------------- api.can.drax.hpc.amslabs.hpecorp.net -------------------
api.can.drax.hpc.amslabs.hpecorp.net is reachable
PASS - [cray-argo]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/nls/v1/readiness - 404
PASS - [cray-bos]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/bos/v1/session - 404
PASS - [cray-bss]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/bss/boot/v1/bootparameters - 404
PASS - [cray-capmc]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/capmc/capmc/v1/health - 404
PASS - [cray-cfs-api]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/cfs/v2/sessions - 404
PASS - [cray-console-data]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/consoledata/liveness - 404
PASS - [cray-console-node]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/console-node/console-node/liveness - 404
PASS - [cray-console-operator]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/console-operator/console-operator/liveness - 404
SKIP - [cray-cps]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/v2/cps/contents - virtual service not found
PASS - [cray-fas]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/fas/v1/snapshots - 404
PASS - [cray-hbtd]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/hbtd/hmi/v1/health - 404
PASS - [cray-hmnfd]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/hmnfd/hmi/v2/health - 404
PASS - [cray-ims]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/ims/images - 404
PASS - [cray-powerdns-manager]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/powerdns-manager/v1/liveness - 404
PASS - [cray-reds]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/reds/v1/liveness - 404
PASS - [cray-scsd]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/scsd/v1/health - 404
PASS - [cray-sls]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/sls/v1/health - 404
PASS - [cray-smd]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/smd/hsm/v2/service/ready - 404
PASS - [cray-sts]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/sts/healthz - 404
PASS - [cray-uas-mgr]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/uas-mgr/v1/images - 404
SKIP - [nmdv2-service]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/v2/nmd/dumps - virtual service not found
SKIP - [slingshot-fabric-manager]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/fabric-manager/fabric/port-policies - virtual service not found
SKIP - [sma-telemetry]: https://api.can.drax.hpc.amslabs.hpecorp.net/apis/sma-telemetry-api/v1/ping - virtual service not found

Overall Gateway Test Status:  PASS```