### PR TITLE
CASMINST-6429 update management-node-rollout docs for CSM 1.5

### DIFF
--- a/install/pre-installation.md
+++ b/install/pre-installation.md
@@ -425,35 +425,18 @@ in `/etc/environment` from the [Download CSM tarball](#21-download-csm-tarball) 
    tar -zxvf  "${PITDATA}/csm-${CSM_RELEASE}.tar.gz" -C ${PITDATA}
    ```
 
-1. (`pit#`) Upload the RPMs and container images to Nexus.
-
-   ```bash
-   /srv/cray/metal-provision/scripts/nexus/setup-nexus.sh -s
-   ```
-
 1. (`pit#`) Install/update the RPMs necessary for the CSM installation.
 
    > ***NOTE*** `--no-gpg-checks` is used because the repository contained within the tarball does not provide a GPG key.
 
-   1. Add nexus repositories
-
-      > ***NOTE*** The `${releasever_major}` and `${releasever_minor}` must be surrounded in
-      > single-quotes, these are special Zypper variables that are interpolated when Zypper
-      > adds the repository. The values of these will always be replaced with respect to the
-      > running SLES release.
-
-      ```bash
-      zypper addrepo --no-gpgcheck --refresh http://packages/repository/csm-noos csm-noos
-      zypper addrepo --no-gpgcheck --refresh 'http://packages/repository/csm-sle-${releasever_major}sp${releasever_minor}' 'csm-sle-${releasever_major}sp${releasever_minor}'
-      ```
-
-   1. Update `cray-site-init`, `craycli`, and `canu`.
+   1. Update `cray-site-init`.
 
        > ***NOTE*** This provides `csi`, a tool for creating and managing configurations, as well as
        > orchestrating the [handoff and deploy of the final non-compute node](deploy_final_non-compute_node.md).
 
        ```bash
-       zypper update -y cray-site-init craycli canu
+       zypper --plus-repo "${CSM_PATH}/rpm/cray/csm/sle-$(awk -F= '/VERSION=/{gsub(/["-]/, "") ; print tolower($NF)}' /etc/os-release)/" \
+              --no-gpg-checks update -y cray-site-init
        ```
 
    1. Install `iuf-cli`.
@@ -461,7 +444,8 @@ in `/etc/environment` from the [Download CSM tarball](#21-download-csm-tarball) 
        > ***NOTE*** This provides `iuf`, a command line interface to the [Install and Upgrade Framework](../operations/iuf/IUF.md).
 
        ```bash
-       zypper install -y iuf-cli
+       zypper --plus-repo "${CSM_PATH}/rpm/cray/csm/sle-$(awk -F= '/VERSION=/{gsub(/["-]/, "") ; print tolower($NF)}' /etc/os-release)/" \
+              --no-gpg-checks install -y iuf-cli
        ```
 
    1. Install `csm-testing` RPM.
@@ -469,7 +453,8 @@ in `/etc/environment` from the [Download CSM tarball](#21-download-csm-tarball) 
        > ***NOTE*** This package provides the necessary tests and their dependencies for validating the pre-installation, installation, and more.
 
        ```bash
-       zypper install -y csm-testing
+       zypper --plus-repo "${CSM_PATH}/rpm/cray/csm/sle-$(awk -F= '/VERSION=/{gsub(/["-]/, "") ; print tolower($NF)}' /etc/os-release)/" \
+              --no-gpg-checks install -y csm-testing
        ```
 
 1. (`pit#`) Get the artifact versions.

--- a/operations/iuf/IUF.md
+++ b/operations/iuf/IUF.md
@@ -61,7 +61,7 @@ The following IUF topics are discussed in the sections below.
   those configurations to their specific needs. Note that `sat` capabilities used by IUF rely on BOS V2.
 - IUF will fail and provide feedback to the administrator in the event of an error, but it cannot automatically resolve issues.
 - IUF does not handle many aspects of installs and upgrades of CSM itself and cannot be used until a base level of CSM functionality is present.
-- The `management-nodes-rollout` stage currently does not automatically upgrade management storage nodes or `ncn-m001`. These nodes must be upgraded using non-IUF methods described in the IUF documentation.
+- The `management-nodes-rollout` stage does not automatically upgrade `ncn-m001`. This node must be upgraded using non-IUF methods described in the IUF documentation.
 - If the `iuf run` subcommand ends unexpectedly before the Argo workflow it created completes, there is no CLI option to reconnect to the Argo workflow and continue displaying status. It is recommended the administrator
   monitors progress via the Argo workflow UI and/or IUF log files in this scenario.
 - It is currently not possible to add or remove product distribution files to an in progress IUF session without first re-executing the `process-media` stage and then re-executing any other stages required for that product. See
@@ -381,8 +381,10 @@ options:
                         Override list used to target specific nodes only when rolling out managed nodes.  Arguments
                         should be xnames or HSM node groups. Defaults to the Compute role.
   --limit-management-rollout LIMIT_MANAGEMENT_ROLLOUT [LIMIT_MANAGEMENT_ROLLOUT ...]
-                        Override list used to target specific role_subrole(s) only when rolling out management nodes.
-                        Defaults to the Management_Worker role.
+                        List used to target specific hostnames or HSM management role_subrole only when rolling 
+                        out management nodes. Hostname arguments can only belong to a single node type. For example, 
+                        both master and worker hostnames can not be provided at the same time. Defaults to an empty list
+                        which means no nodes will be rolled out.
   -mrp MASK_RECIPE_PRODS [MASK_RECIPE_PRODS ...], --mask-recipe-prods MASK_RECIPE_PRODS [MASK_RECIPE_PRODS ...]
                         If `--recipe-vars` is specified, mask the versions found within the recipe variables YAML
                         file for the specified products, such that the largest version of the package already installed on

--- a/operations/iuf/stages/management_nodes_rollout.md
+++ b/operations/iuf/stages/management_nodes_rollout.md
@@ -22,7 +22,7 @@ See the [3. Execute the IUF `management-nodes-rollout` stage](../workflows/manag
 - [Manually upgrade or rebuild NCN worker node with specific image and CFS configuration outside of IUF](#manually-upgrade-or-rebuild-ncn-worker-node-with-specific-image-and-cfs-configuration-outside-of-iuf)
 - [Action needed if a worker rebuild fails](#action-needed-if-a-worker-rebuild-fails)
 - [Examples](#examples)
-- [Set NCN boot image for ncn-m001](#set-ncn-boot-image-for-ncn-m001)
+- [Set NCN boot image for `ncn-m001`](#set-ncn-boot-image-for-ncn-m001)
 
 ## Impact
 
@@ -166,9 +166,9 @@ or [Upgrade CSM and additional products with IUF](../workflows/upgrade_csm_and_a
 
 1. (`ncn-mw#`) Get the xname for `ncn-m001`:
 
-        ```bash
-        ssh ncn-m001 cat /etc/cray/xname
-        ```
+    ```bash
+    ssh ncn-m001 cat /etc/cray/xname
+    ```
 
 1. (`ncn-mw#`) Update boot parameters for an NCN. Perform the following procedure for `ncn-m001`.
 

--- a/operations/iuf/stages/management_nodes_rollout.md
+++ b/operations/iuf/stages/management_nodes_rollout.md
@@ -1,18 +1,25 @@
 # `management-nodes-rollout`
 
-The `management-nodes-rollout` stage performs a controlled update of management NCNs by configuring them with a new CFS configuration and/or rebuilding or upgrading them to a new image.
-A "rebuild" is a reboot operation that clears the persistent OverlayFS file system on that node, i.e. all data on node-local storage will be discarded.
-An "upgrade" is similar to a rebuild, but it intentionally does not clear all information off of NCN storage and master nodes.
-IUF will account for the necessary minimum number of critical software instances running on the nodes to ensure the `management-nodes-rollout` stage operates without impacting software availability.
+The `management-nodes-rollout` stage performs a controlled update of management NCNs by configuring them with a new CFS
+configuration and/or rebuilding or upgrading them to a new image. A "rebuild" is a reboot operation that clears the
+persistent OverlayFS file system on that node, i.e. all data on node-local storage will be discarded. An "upgrade" is
+similar to a rebuild, but it intentionally does not clear all information off of NCN storage and master nodes. IUF will
+account for the necessary minimum number of critical software instances running on the nodes to ensure
+the `management-nodes-rollout` stage operates without impacting software availability.
 
-**`NOTE`** `management-nodes-rollout` has a different procedure depending on whether or not CSM itself is being upgraded. The two procedures differ in the handling of NCN storage nodes and NCN master nodes, but both procedures use
+**`NOTE`** `management-nodes-rollout` has a different procedure depending on whether or not CSM itself is being
+upgraded. The two procedures differ in the handling of NCN storage nodes and NCN master nodes, but both procedures use
 the same steps for rebuilding/upgrading NCN worker nodes.
 
-1. If CSM **is not** being upgraded, then NCN storage and master nodes will not be upgraded with a new image but will be updated with a CFS configuration created in [update-cfs-config](../stages/update_cfs_config.md).
+1. If CSM **is not** being upgraded, then NCN storage and master nodes will not be upgraded with a new image but will be
+   updated with a CFS configuration created in [update-cfs-config](../stages/update_cfs_config.md).
 
-1. If CSM **is** being upgraded, then NCN storage and master nodes will be upgraded with a new image and CFS configuration.
+1. If CSM **is** being upgraded, then NCN storage and master nodes will be upgraded with a new image and CFS
+   configuration.
 
-See the [3. Execute the IUF `management-nodes-rollout` stage](../workflows/management_rollout.md#3-execute-the-iuf-management-nodes-rollout-stage) documentation for more information.
+See
+the [3. Execute the IUF `management-nodes-rollout` stage](../workflows/management_rollout.md#3-execute-the-iuf-management-nodes-rollout-stage)
+documentation for more information.
 
 `management-nodes-rollout` details are explained in the following sections:
 
@@ -30,47 +37,66 @@ The `management-nodes-rollout` stage changes the running state of the system.
 
 ## Input
 
-The following arguments are most often used with the `management-nodes-rollout` stage. See `iuf -h` and `iuf run -h` for additional arguments.
+The following arguments are most often used with the `management-nodes-rollout` stage. See `iuf -h` and `iuf run -h` for
+additional arguments.
 
-| Input                                    | `iuf` Argument                                        | Description                                                                            |
-| ---------------------------------------- | ----------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| Activity                                 | `-a ACTIVITY`                                         | Activity created for the install or upgrade operations                                 |
-| Concurrent management rollout percentage | `-cmrp CONCURRENT_MANAGEMENT_ROLLOUT_PERCENTAGE`      | Percentage value that limits the number of NCN worker nodes rolled out in parallel |
-| Limit management rollout list            | `--limit-management-rollout LIMIT_MANAGEMENT_ROLLOUT` | List of NCN management nodes to be rolled out, specified by HSM role and subrole (`Management_Master`, `Management_Worker`, `Management_Storage`) or by NCN hostname (e.g. `ncn-w003`, `ncn-s001`, etc.)      |
+| Input                                    | `iuf` Argument                                        | Description                                                                                                                                                                                              |
+|------------------------------------------|-------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Activity                                 | `-a ACTIVITY`                                         | Activity created for the install or upgrade operations                                                                                                                                                   |
+| Concurrent management rollout percentage | `-cmrp CONCURRENT_MANAGEMENT_ROLLOUT_PERCENTAGE`      | Percentage value that limits the number of NCN worker nodes rolled out in parallel                                                                                                                       |
+| Limit management rollout list            | `--limit-management-rollout LIMIT_MANAGEMENT_ROLLOUT` | List of NCN management nodes to be rolled out, specified by HSM role and subrole (`Management_Master`, `Management_Worker`, `Management_Storage`) or by NCN hostname (e.g. `ncn-w003`, `ncn-s001`, etc.) |
 
 ## Execution details
 
-The code executed by this stage exists within IUF. See the `management-nodes-rollout` entry in `/usr/share/doc/csm/workflows/iuf/stages.yaml` and the corresponding files in `/usr/share/doc/csm/workflows/iuf/operations/`
+The code executed by this stage exists within IUF. See the `management-nodes-rollout` entry
+in `/usr/share/doc/csm/workflows/iuf/stages.yaml` and the corresponding files
+in `/usr/share/doc/csm/workflows/iuf/operations/`
 for details on the commands executed.
 
-There are two methods administrators can use to avoid rollouts on specific NCN management nodes: by specifying the `--limit-management-rollout` argument for specifying which group(s) of nodes should be rebuilt or by using `kubectl` to label nodes with `iuf-prevent-rollout=true`.
+There are two methods administrators can use to avoid rollouts on specific NCN management nodes: by specifying
+the `--limit-management-rollout` argument for specifying which group(s) of nodes should be rebuilt or by using `kubectl`
+to label nodes with `iuf-prevent-rollout=true`.
 
-When NCN worker nodes are being rebuilt/upgraded and when NCN storage nodes are being upgraded, an additional Argo workflow will execute in addition to the standard IUF Argo workflows. It will include the string `ncn-lifecycle-rebuild` in its name.
+When NCN worker nodes are being rebuilt/upgraded and when NCN storage nodes are being upgraded, an additional Argo
+workflow will execute in addition to the standard IUF Argo workflows. It will include the string `ncn-lifecycle-rebuild`
+in its name.
 
-The `-cmrp` argument limits the percentage of worker nodes rolled out in parallel. The worker node rebuild can coordinate rebuilding multiple worker nodes at once.
-It starts by rebuilding one worker node. Once that node has been removed from the system, the workflow checks if it is safe to rebuild the next worker node based on what services are running in the system.
-If it is safe, it will proceed to rebuild the next node, partially in parallel with the first worker node rebuild. If it is unsafe to rebuild in parallel because the system could get into a bad state, then it waits to rebuild the second node until it is safe.
-The `-cmrp` parameter selects the percentage of worker nodes that the worker node rebuild should coordinate rebuilding at one time.
-For example, if there are 15 worker nodes and `-cmrp 33` is specified, then 5 worker nodes will be rebuilt at once and with as much parallelization as possible given the state of the system.
+The `-cmrp` argument limits the percentage of worker nodes rolled out in parallel. The worker node rebuild can
+coordinate rebuilding multiple worker nodes at once. It starts by rebuilding one worker node. Once that node has been
+removed from the system, the workflow checks if it is safe to rebuild the next worker node based on what services are
+running in the system. If it is safe, it will proceed to rebuild the next node, partially in parallel with the first
+worker node rebuild. If it is unsafe to rebuild in parallel because the system could get into a bad state, then it waits
+to rebuild the second node until it is safe. The `-cmrp` parameter selects the percentage of worker nodes that the
+worker node rebuild should coordinate rebuilding at one time. For example, if there are 15 worker nodes and `-cmrp 33`
+is specified, then 5 worker nodes will be rebuilt at once and with as much parallelization as possible given the state
+of the system.
 
-`-limit-management-rollout Management_Master` only needs to be specified when performing a CSM upgrade. This will upgrade `ncn-m002` and `ncn-m003` serially with a new image and configuration. This should be done before NCN worker
-nodes are upgraded. If not performing a CSM upgrade, then NCN master nodes should not be upgraded with a new image and should only be configured with the new CFS configuration created during the
+`-limit-management-rollout Management_Master` only needs to be specified when performing a CSM upgrade. This will
+upgrade `ncn-m002` and `ncn-m003` serially with a new image and configuration. This should be done before NCN worker
+nodes are upgraded. If not performing a CSM upgrade, then NCN master nodes should not be upgraded with a new image and
+should only be configured with the new CFS configuration created during the
 [update-cfs-config](../stages/update_cfs_config.md) stage.
 
 ## Manually upgrade or rebuild NCN worker node with specific image and CFS configuration outside of IUF
 
-**NOTE** This section describes how to manually rebuild/upgrade a worker node outside of IUF with an image and CFS configuration created through IUF. **This is not the normal procedure that IUF uses for rebuilding/upgrading NCN
-worker nodes.** This procedure should be followed if NCN worker nodes need to be rebuilt or upgraded outside of IUF.
+**NOTE** This section describes how to manually rebuild/upgrade a worker node outside of IUF with an image and CFS
+configuration created through IUF. **This is not the normal procedure that IUF uses for rebuilding/upgrading NCN worker
+nodes.** This procedure should be followed if NCN worker nodes need to be rebuilt or upgraded outside of IUF.
 
-The upgrade and rebuild procedures for NCN worker nodes are identical. These instructions apply to both NCN worker node upgrades and NCN worker node rebuilds.
-The words 'rebuild' and 'upgrade' are exchangeable in this section.
+The upgrade and rebuild procedures for NCN worker nodes are identical. These instructions apply to both NCN worker node
+upgrades and NCN worker node rebuilds. The words 'rebuild' and 'upgrade' are exchangeable in this section.
 
-1. Get the image ID and CFS configuration created for worker nodes during the `prepare-images` and `update-cfs-config` stages. Follow the instructions in the [`prepare-images` Artifacts created](prepare_images.md#artifacts-created)
-documentation to get the values for `final_image_id` and `configuration` for images with a `configuration_group_name` value matching `Management_Worker`. These values will be used in the next step.
+1. Get the image ID and CFS configuration created for worker nodes during the `prepare-images` and `update-cfs-config`
+   stages. Follow the instructions in the [`prepare-images` Artifacts created](prepare_images.md#artifacts-created)
+   documentation to get the values for `final_image_id` and `configuration` for images with a `configuration_group_name`
+   value matching `Management_Worker`. These values will be used in the next step.
 
-1. Upgrade/rebuild the worker node. The worker node is automatically rebuilt using Argo workflows. If rebuilding multiple worker nodes at once, see [this page](../../node_management/Rebuild_NCNs/Rebuild_NCNs.md#restrictions) for restrictions.
+1. Upgrade/rebuild the worker node. The worker node is automatically rebuilt using Argo workflows. If rebuilding
+   multiple worker nodes at once, see [this page](../../node_management/Rebuild_NCNs/Rebuild_NCNs.md#restrictions) for
+   restrictions.
 
-    (`ncn-m001#`) Rebuild a worker node. Use the values acquired in the previous step in place of `<final_image_id>` and `<configuration>`.
+   (`ncn-m001#`) Rebuild a worker node. Use the values acquired in the previous step in place of `<final_image_id>`
+   and `<configuration>`.
 
     ```bash
     /usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh ncn-w001 --image-id <final_image_id> --desired-cfs-conf <configuration>
@@ -78,22 +104,27 @@ documentation to get the values for `final_image_id` and `configuration` for ima
 
 ## Action needed if a worker rebuild fails
 
-In general, worker node rebuilds should complete successfully before starting another rebuild.
-A worker node can get into a bad state if it has been partially rebuilt and an attempt is made to restart the rebuild on that same node.
-As a result, it is not possible to start another worker node rebuild if there is an existing incomplete worker node rebuild workflow, where "incomplete" means it has stopped before successfully completing the full workflow.
-If an incomplete workflow exists and an attempt is made to start another worker rebuild workflow,
-the original incomplete worker rebuild workflow will continue and no new workflow will be created.
+In general, worker node rebuilds should complete successfully before starting another rebuild. A worker node can get
+into a bad state if it has been partially rebuilt and an attempt is made to restart the rebuild on that same node. As a
+result, it is not possible to start another worker node rebuild if there is an existing incomplete worker node rebuild
+workflow, where "incomplete" means it has stopped before successfully completing the full workflow. If an incomplete
+workflow exists and an attempt is made to start another worker rebuild workflow, the original incomplete worker rebuild
+workflow will continue and no new workflow will be created.
 
-If it is necessary to start an entirely new worker rebuild workflow after a previous worker rebuild workflow failed, the failed workflow must be deleted from Kubernetes first.
+If it is necessary to start an entirely new worker rebuild workflow after a previous worker rebuild workflow failed, the
+failed workflow must be deleted from Kubernetes first.
 
-**`WARNING`** Deleting a workflow will delete information about the state of that workflow and the steps that have been completed.
-Deleting a partially complete workflow should be done cautiously and only if needed.
+**`WARNING`** Deleting a workflow will delete information about the state of that workflow and the steps that have been
+completed. Deleting a partially complete workflow should be done cautiously and only if needed.
 
 To delete a failed Argo workflow, complete the following steps.
 
-1. Get the name of the failed workflow. All worker rebuild workflows start with `ncn-lifecycle-rebuild`. The name of the worker rebuild workflow can be found in the Argo UI or by searching workflows in Kubernetes with the following command.
+1. Get the name of the failed workflow. All worker rebuild workflows start with `ncn-lifecycle-rebuild`. The name of the
+   worker rebuild workflow can be found in the Argo UI or by searching workflows in Kubernetes with the following
+   command.
 
-    (`ncn-m#`) List failed worker rebuild workflows. Note that NCN storage upgrade workflows will also contain `ncn-lifecycle-rebuild` in their name and may be present in this list.
+   (`ncn-m#`) List failed worker rebuild workflows. Note that NCN storage upgrade workflows will also
+   contain `ncn-lifecycle-rebuild` in their name and may be present in this list.
 
     ```bash
     kubectl get workflows -n argo | grep 'ncn-lifecycle-rebuild' | grep 'Fail'
@@ -105,21 +136,24 @@ To delete a failed Argo workflow, complete the following steps.
     kubectl delete workflows -n argo <failed workflow>
     ```
 
-    After deleting the failed workflow, a new worker rebuild workflow can be started.
+   After deleting the failed workflow, a new worker rebuild workflow can be started.
 
 ## Examples
 
-(`ncn-m001#`) Execute the `management-nodes-rollout` stage for activity `admin-230127` using the default concurrent management rollout percentage and limiting the operation to `Management_Worker` nodes.
+(`ncn-m001#`) Execute the `management-nodes-rollout` stage for activity `admin-230127` using the default concurrent
+management rollout percentage and limiting the operation to `Management_Worker` nodes.
 
 ```bash
 iuf -a admin-230127 run --limit-management-rollout Management_Worker -r management-nodes-rollout
 ```
 
-Expected behavior: All NCN worker nodes will be rebuilt. Each set of worker nodes that is being rebuilt will contain 20% of the total number of worker nodes. For example, if there are 10 total worker nodes, then 2 will be rebuilt at a time.
+Expected behavior: All NCN worker nodes will be rebuilt. Each set of worker nodes that is being rebuilt will contain 20%
+of the total number of worker nodes. For example, if there are 10 total worker nodes, then 2 will be rebuilt at a time.
 
 ---
 
-(`ncn-m001#`) Execute the `management-nodes-rollout` stage for activity `admin-230127` using the default concurrent management rollout percentage and limiting the operation to `ncn-s001 ncn-s002` nodes.
+(`ncn-m001#`) Execute the `management-nodes-rollout` stage for activity `admin-230127` using the default concurrent
+management rollout percentage and limiting the operation to `ncn-s001 ncn-s002` nodes.
 
 ```bash
 iuf -a admin-230127 run --limit-management-rollout ncn-s001 ncn-s002  -r management-nodes-rollout
@@ -153,12 +187,14 @@ Expected behavior:
 
 ## Set NCN boot image for `ncn-m001`
 
-Follow these steps when upgrading `ncn-m001` during [3.1 `management-nodes-rollout` with CSM upgrade](../workflows/management_rollout.md#31-management-nodes-rollout-with-csm-upgrade)
+Follow these steps when upgrading `ncn-m001`
+during [3.1 `management-nodes-rollout` with CSM upgrade](../workflows/management_rollout.md#31-management-nodes-rollout-with-csm-upgrade)
 when following the procedures in
 [Install or upgrade additional products with IUF](../workflows/install_or_upgrade_additional_products_with_iuf.md)
 or [Upgrade CSM and additional products with IUF](../workflows/upgrade_csm_and_additional_products_with_iuf.md).
 
-1. (`ncn-mw#`) Set the `IMS_RESULTANT_IMAGE_ID` to be the `final_image_id` found in [3.1 `management-nodes-rollout` with CSM upgrade](../workflows/management_rollout.md#31-management-nodes-rollout-with-csm-upgrade).
+1. (`ncn-mw#`) Set the `IMS_RESULTANT_IMAGE_ID` to be the `final_image_id` found
+   in [3.1 `management-nodes-rollout` with CSM upgrade](../workflows/management_rollout.md#31-management-nodes-rollout-with-csm-upgrade).
 
     ```bash
     IMS_RESULTANT_IMAGE_ID=<value of final_image_id>
@@ -172,50 +208,51 @@ or [Upgrade CSM and additional products with IUF](../workflows/upgrade_csm_and_a
 
 1. (`ncn-mw#`) Update boot parameters for an NCN. Perform the following procedure for `ncn-m001`.
 
-    1. Get the existing `metal.server` setting for `ncn-m001`.
+  1. Get the existing `metal.server` setting for `ncn-m001`.
+
+      ```bash
+      XNAME=<node-xname>
+      METAL_SERVER=$(cray bss bootparameters list --hosts "${XNAME}" --format json | jq '.[] |."params"' \
+          | awk -F 'metal.server=' '{print $2}' \
+          | awk -F ' ' '{print $1}')
+      echo "${METAL_SERVER}"
+      ```
+
+  1. Create updated boot parameters that point to the new artifacts.
+
+    1. Set the path to the artifacts in S3.
+
+       **NOTE** This uses the `IMS_RESULTANT_IMAGE_ID` variable set in an earlier step.
 
         ```bash
-        XNAME=<node-xname>
-        METAL_SERVER=$(cray bss bootparameters list --hosts "${XNAME}" --format json | jq '.[] |."params"' \
-            | awk -F 'metal.server=' '{print $2}' \
-            | awk -F ' ' '{print $1}')
-        echo "${METAL_SERVER}"
+        S3_ARTIFACT_PATH="boot-images/${IMS_RESULTANT_IMAGE_ID}"
+        echo "${S3_ARTIFACT_PATH}"
         ```
 
-    1. Create updated boot parameters that point to the new artifacts.
-
-        1. Set the path to the artifacts in S3.
-
-            **NOTE** This uses the `IMS_RESULTANT_IMAGE_ID` variable set in an earlier step.
-
-            ```bash
-            S3_ARTIFACT_PATH="boot-images/${IMS_RESULTANT_IMAGE_ID}"
-            echo "${S3_ARTIFACT_PATH}"
-            ```
-
-        1. Set the new `metal.server` value.
-
-            ```bash
-            NEW_METAL_SERVER="s3://${S3_ARTIFACT_PATH}/rootfs"
-            echo "${NEW_METAL_SERVER}"
-            ```
-
-        1. Determine the modified boot parameters for the node.
-
-            ```bash
-            PARAMS=$(cray bss bootparameters list --hosts "${XNAME}" --format json | jq '.[] |."params"' | \
-                sed "/metal.server/ s|${METAL_SERVER}|${NEW_METAL_SERVER}|" | \
-                tr -d \")
-            echo "${PARAMS}"
-            ```
-
-            In the output of the `echo` command, verify that the value of `metal.server` is correctly set to the value of `${NEW_METAL_SERVER}`.
-
-    1. Update BSS with the new boot parameters.
+    1. Set the new `metal.server` value.
 
         ```bash
-        cray bss bootparameters update --hosts "${XNAME}" \
-            --kernel "s3://${S3_ARTIFACT_PATH}/kernel" \
-            --initrd "s3://${S3_ARTIFACT_PATH}/initrd" \
-            --params "${PARAMS}"
+        NEW_METAL_SERVER="s3://${S3_ARTIFACT_PATH}/rootfs"
+        echo "${NEW_METAL_SERVER}"
         ```
+
+    1. Determine the modified boot parameters for the node.
+
+        ```bash
+        PARAMS=$(cray bss bootparameters list --hosts "${XNAME}" --format json | jq '.[] |."params"' | \
+            sed "/metal.server/ s|${METAL_SERVER}|${NEW_METAL_SERVER}|" | \
+            tr -d \")
+        echo "${PARAMS}"
+        ```
+
+       In the output of the `echo` command, verify that the value of `metal.server` is correctly set to the value
+       of `${NEW_METAL_SERVER}`.
+
+  1. Update BSS with the new boot parameters.
+
+      ```bash
+      cray bss bootparameters update --hosts "${XNAME}" \
+          --kernel "s3://${S3_ARTIFACT_PATH}/kernel" \
+          --initrd "s3://${S3_ARTIFACT_PATH}/initrd" \
+          --params "${PARAMS}"
+      ```

--- a/operations/iuf/workflows/managed_rollout.md
+++ b/operations/iuf/workflows/managed_rollout.md
@@ -13,7 +13,8 @@ This section updates the software running on managed compute and application (UA
 
 ## 1. Update managed host firmware (FAS)
 
-Refer to [Update Firmware with FAS](../../firmware/Update_Firmware_with_FAS.md) for details on how to upgrade the firmware on managed nodes.
+Refer to [Update Firmware with FAS](../../firmware/Update_Firmware_with_FAS.md) for details on how to upgrade the
+firmware on managed nodes.
 
 Once this step has completed:
 
@@ -21,54 +22,70 @@ Once this step has completed:
 
 ## 2. Execute the IUF `managed-nodes-rollout` stage
 
-This section describes how to update software on managed nodes. It describes how to test a new image and CFS configuration on a single "canary node" first before rolling it out to the other managed nodes. Modify the procedure
-as necessary to accommodate site preferences for rebooting managed nodes. If the system has heterogeneous nodes, it may be desirable to repeat this process with multiple canary nodes, one for each distinct node configuration.
-The images, CFS configurations, and BOS session templates used are created by the `prepare-images` stage; see the [`prepare-images` Artifacts created](../stages/prepare_images.md#artifacts-created) documentation for details on how to query the
-images and CFS configurations.
+This section describes how to update software on managed nodes. It describes how to test a new image and CFS
+configuration on a single "canary node" first before rolling it out to the other managed nodes. Modify the procedure as
+necessary to accommodate site preferences for rebooting managed nodes. If the system has heterogeneous nodes, it may be
+desirable to repeat this process with multiple canary nodes, one for each distinct node configuration. The images, CFS
+configurations, and BOS session templates used are created by the `prepare-images` stage; see
+the [`prepare-images` Artifacts created](../stages/prepare_images.md#artifacts-created) documentation for details on how
+to query the images and CFS configurations.
 
-**`NOTE`** Additional arguments are available to control the behavior of the `managed-nodes-rollout` stage. See the [`managed-nodes-rollout` stage documentation](../stages/managed_nodes_rollout.md) for details and adjust the
+**`NOTE`** Additional arguments are available to control the behavior of the `managed-nodes-rollout` stage. See
+the [`managed-nodes-rollout` stage documentation](../stages/managed_nodes_rollout.md) for details and adjust the
 examples below if necessary.
 
 ### 2.1 LNet router nodes and gateway nodes
 
-LNet router nodes or gateway nodes should be upgraded before rebooting compute nodes to new images and CFS configurations. Since LNet routers and gateway nodes are examples of application nodes, the instructions in this section
+LNet router nodes or gateway nodes should be upgraded before rebooting compute nodes to new images and CFS
+configurations. Since LNet routers and gateway nodes are examples of application nodes, the instructions in this section
 are the same as in [2.3 Application nodes](#23-application-nodes).
 
-Since LNet router nodes and gateway nodes are not managed by workload managers, the IUF `managed-nodes-rollout` stage cannot reboot them in a controlled manner via the `-mrs stage` argument. The IUF `managed-nodes-rollout` stage
-can reboot LNet router and gateway nodes using the `-mrs reboot` argument, but an immediate reboot of the nodes is likely to be disruptive to users and overall system health and is not recommended. Administrators should determine
-the best approach for rebooting LNet router and gateway nodes outside of IUF that aligns with site preferences.
+Since LNet router nodes and gateway nodes are not managed by workload managers, the IUF `managed-nodes-rollout` stage
+cannot reboot them in a controlled manner via the `-mrs stage` argument. The IUF `managed-nodes-rollout` stage can
+reboot LNet router and gateway nodes using the `-mrs reboot` argument, but an immediate reboot of the nodes is likely to
+be disruptive to users and overall system health and is not recommended. Administrators should determine the best
+approach for rebooting LNet router and gateway nodes outside of IUF that aligns with site preferences.
 
 Once this step has completed:
 
-- Managed LNet router and gateway nodes (if any) have been rebooted to the images and CFS configurations created in previous steps of this workflow
-- Per-stage product hooks have executed for the `managed-nodes-rollout` stage if IUF `managed-nodes-rollout` procedures were used to perform the reboots
+- Managed LNet router and gateway nodes (if any) have been rebooted to the images and CFS configurations created in
+  previous steps of this workflow
+- Per-stage product hooks have executed for the `managed-nodes-rollout` stage if IUF `managed-nodes-rollout` procedures
+  were used to perform the reboots
 
 ### 2.2 Compute nodes
 
-1. The "Install and Upgrade Framework" section of each individual product's installation document may contain special actions that need to be performed outside of IUF for a stage. The "IUF Stage Documentation Per Product"
-section of the _HPE Cray EX System Software Stack Installation and Upgrade Guide for CSM (S-8052)_ provides a table that summarizes which product documents contain information or actions for the `managed-nodes-rollout` stage.
-Refer to that table and any corresponding product documents before continuing to the next step.
+1. The "Install and Upgrade Framework" section of each individual product's installation document may contain special
+   actions that need to be performed outside of IUF for a stage. The "IUF Stage Documentation Per Product"
+   section of the _HPE Cray EX System Software Stack Installation and Upgrade Guide for CSM (S-8052)_ provides a table
+   that summarizes which product documents contain information or actions for the `managed-nodes-rollout` stage. Refer
+   to that table and any corresponding product documents before continuing to the next step.
 
-1. Invoke `iuf run` with `-r` to execute the [`managed-nodes-rollout`](../stages/managed_nodes_rollout.md) stage on a single node to ensure the node reboots successfully with the desired image and CFS configuration. This node is
-referred to as the "canary node" in the remainder of this section. Use `--limit-managed-rollout` to target the canary node only and use `-mrs reboot` to reboot the canary node immediately.
+1. Invoke `iuf run` with `-r` to execute the [`managed-nodes-rollout`](../stages/managed_nodes_rollout.md) stage on a
+   single node to ensure the node reboots successfully with the desired image and CFS configuration. This node is
+   referred to as the "canary node" in the remainder of this section. Use `--limit-managed-rollout` to target the canary
+   node only and use `-mrs reboot` to reboot the canary node immediately.
 
-    (`ncn-m001#`) Execute the `managed-nodes-rollout` stage with a single xname, rebooting the canary node immediately. Replace the example value of `${XNAME}` with the xname of the canary node.
+   (`ncn-m001#`) Execute the `managed-nodes-rollout` stage with a single xname, rebooting the canary node immediately.
+   Replace the example value of `${XNAME}` with the xname of the canary node.
 
-    ```bash
-    XNAME=x3000c0s29b1n0
-    iuf -a "${ACTIVITY_NAME}" run -r managed-nodes-rollout --limit-managed-rollout "${XNAME}" -mrs reboot
-    ```
+   ```bash
+   XNAME=x3000c0s29b1n0
+   iuf -a "${ACTIVITY_NAME}" run -r managed-nodes-rollout --limit-managed-rollout "${XNAME}" -mrs reboot
+   ```
 
 1. Verify the canary node booted successfully with the desired image and CFS configuration.
 
-1. Invoke `iuf run` with `-r` to execute the [managed-nodes-rollout](../stages/managed_nodes_rollout.md) stage on all nodes. This will stage data to BOS and allow the workload manager to reboot the nodes when it is ready to do so. The workload manager
-must be configured to tell BOS to reboot nodes using this staged data. The following assumes Slurm is the workload manager.
-Follow the instructions in the section [Using staged sessions with Slurm](../../boot_orchestration/Rolling_Upgrades.md#using-staged-sessions-with-slurm)
-of the [Rolling Upgrades using BOS](../../boot_orchestration/Rolling_Upgrades.md) documentation.
-These instructions describe two parameters that must be set in the `slurm.conf` file. Return to these instructions after setting them.
-If an immediate reboot of compute nodes is desired instead, add `-mrs reboot` to the `iuf run` command.
+1. Invoke `iuf run` with `-r` to execute the [managed-nodes-rollout](../stages/managed_nodes_rollout.md) stage on all
+   nodes. This will stage data to BOS and allow the workload manager to reboot the nodes when it is ready to do so. The
+   workload manager must be configured to tell BOS to reboot nodes using this staged data. The following assumes Slurm
+   is the workload manager. Follow the instructions in the
+   section [Using staged sessions with Slurm](../../boot_orchestration/Rolling_Upgrades.md#using-staged-sessions-with-slurm)
+   of the [Rolling Upgrades using BOS](../../boot_orchestration/Rolling_Upgrades.md) documentation. These instructions
+   describe two parameters that must be set in the `slurm.conf` file. Return to these instructions after setting them.
+   If an immediate reboot of compute nodes is desired instead, add `-mrs reboot` to the `iuf run` command.
 
-    (`ncn-m001#`) Execute the `managed-nodes-rollout` stage.
+   (`ncn-m001#`) Execute the `managed-nodes-rollout` stage.
 
     ```bash
     iuf -a "${ACTIVITY_NAME}" run -r managed-nodes-rollout
@@ -76,9 +93,11 @@ If an immediate reboot of compute nodes is desired instead, add `-mrs reboot` to
 
    **NOTE:** If the `-mrs reboot` option is used, skip the following step.
 
-1. Tell the workload manager to reboot the compute nodes. This only works for compute nodes, and they must be specified explicitly. Using the keyword `ALL` to specify the nodes does not work presently.
+1. Tell the workload manager to reboot the compute nodes. This only works for compute nodes, and they must be specified
+   explicitly. Using the keyword `ALL` to specify the nodes does not work presently.
 
-    - Use this command to list all of the compute nodes in the system using their Node Identities (NIDs). First, enter the SAT bash shell using `sat bash`.
+  - Use this command to list all of the compute nodes in the system using their Node Identities (NIDs). First, enter the
+    SAT bash shell using `sat bash`.
 
     (`ncn-m001#`) sat bash
 
@@ -89,7 +108,8 @@ If an immediate reboot of compute nodes is desired instead, add `-mrs reboot` to
     logout
     ```
 
-    - Now, tell the workload manager to reboot the compute nodes. Paste the output from the previous step as the last argument.
+  - Now, tell the workload manager to reboot the compute nodes. Paste the output from the previous step as the last
+    argument.
 
     (`ncn-m001#`) A sample reboot command to reboot NIDs 1 through 4.
 
@@ -99,26 +119,34 @@ If an immediate reboot of compute nodes is desired instead, add `-mrs reboot` to
 
 Once this step has completed:
 
-- Managed compute nodes have been rebooted to the images and CFS configurations created in previous steps of this workflow
+- Managed compute nodes have been rebooted to the images and CFS configurations created in previous steps of this
+  workflow
 - Per-stage product hooks have executed for the `managed-nodes-rollout` stage
 
 ### 2.3 Application nodes
 
-**`NOTE`** If LNet router or gateway nodes were upgraded in the [2.1 LNet router nodes and gateway nodes](#21-lnet-router-nodes-and-gateway-nodes) section, there is no need to upgrade them again in this section. Follow the
-instructions in this section to upgrade any remaining applications (UANs, etc.) that have not been upgraded yet.
+**`NOTE`** If LNet router or gateway nodes were upgraded in
+the [2.1 LNet router nodes and gateway nodes](#21-lnet-router-nodes-and-gateway-nodes) section, there is no need to
+upgrade them again in this section. Follow the instructions in this section to upgrade any remaining applications (UANs,
+etc.) that have not been upgraded yet.
 
-Since application nodes are not managed by workload managers, the IUF `managed-nodes-rollout` stage cannot reboot them in a controlled manner via the `-mrs stage` argument. The IUF `managed-nodes-rollout` stage can reboot application
-nodes using the `-mrs reboot` argument, but an immediate reboot of application nodes is likely to be disruptive to users and overall system health and is not recommended. Administrators should determine the best approach for rebooting
+Since application nodes are not managed by workload managers, the IUF `managed-nodes-rollout` stage cannot reboot them
+in a controlled manner via the `-mrs stage` argument. The IUF `managed-nodes-rollout` stage can reboot application nodes
+using the `-mrs reboot` argument, but an immediate reboot of application nodes is likely to be disruptive to users and
+overall system health and is not recommended. Administrators should determine the best approach for rebooting
 application nodes outside of IUF that aligns with site preferences.
 
 Once this step has completed:
 
-- Managed application (UAN, etc.) nodes have been rebooted to the images and CFS configurations created in previous steps of this workflow
-- Per-stage product hooks have executed for the `managed-nodes-rollout` stage if IUF `managed-nodes-rollout` procedures were used to perform the reboots
+- Managed application (UAN, etc.) nodes have been rebooted to the images and CFS configurations created in previous
+  steps of this workflow
+- Per-stage product hooks have executed for the `managed-nodes-rollout` stage if IUF `managed-nodes-rollout` procedures
+  were used to perform the reboots
 
 ## 3. Update managed host Slingshot NIC firmware
 
-If new Slingshot NIC firmware was provided, refer to the "200Gbps NIC Firmware Management" section of the _Slingshot Operations Guide for Customers_ for details on how to update NIC firmware on managed nodes.
+If new Slingshot NIC firmware was provided, refer to the "200Gbps NIC Firmware Management" section of the _Slingshot
+Operations Guide for Customers_ for details on how to update NIC firmware on managed nodes.
 
 Once this step has completed:
 
@@ -126,13 +154,15 @@ Once this step has completed:
 
 ## 4. Execute the IUF `post-install-check` stage
 
-1. The "Install and Upgrade Framework" section of each individual product's installation document may contain special actions that need to be performed outside of IUF for a stage. The "IUF Stage Documentation Per Product"
-section of the _HPE Cray EX System Software Stack Installation and Upgrade Guide for CSM (S-8052)_ provides a table that summarizes which product documents contain information or actions for the `post-install-check` stage.
-Refer to that table and any corresponding product documents before continuing to the next step.
+1. The "Install and Upgrade Framework" section of each individual product's installation document may contain special
+   actions that need to be performed outside of IUF for a stage. The "IUF Stage Documentation Per Product"
+   section of the _HPE Cray EX System Software Stack Installation and Upgrade Guide for CSM (S-8052)_ provides a table
+   that summarizes which product documents contain information or actions for the `post-install-check` stage. Refer to
+   that table and any corresponding product documents before continuing to the next step.
 
 1. Invoke `iuf run` with `-r` to execute the [`post-install-check`](../stages/post_install_check.md) stage.
 
-    (`ncn-m001#`) Execute the `post-install-check` stage.
+   (`ncn-m001#`) Execute the `post-install-check` stage.
 
     ```bash
     iuf -a "${ACTIVITY_NAME}" run -r post-install-check
@@ -140,7 +170,8 @@ Refer to that table and any corresponding product documents before continuing to
 
 Once this step has completed:
 
-- Per-stage product hooks have executed for the `post-install-check` stage to verify product software is executing as expected
+- Per-stage product hooks have executed for the `post-install-check` stage to verify product software is executing as
+  expected
 
 ## 5. Next steps
 

--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -47,59 +47,28 @@ procedures based on whether or not CSM is being upgraded:
 
 ### 3.1 `management-nodes-rollout` with CSM upgrade
 
-All management nodes will be upgraded to a new image because CSM itself is being upgraded. NCN master nodes, excluding `ncn-m001`, and NCN worker nodes will be upgraded with IUF.
-NCN storage nodes and `ncn-m001` will be upgraded with manual commands.
-This section describes how to test a new image and CFS configuration on a single canary node for NCN master nodes and NCN worker nodes first before rolling it out to the other NCN master nodes and NCN worker nodes.
+All management nodes will be upgraded to a new image because CSM itself is being upgraded. All management nodes, excluding `ncn-m001`, will be upgraded with IUF.
+`ncn-m001` will be upgraded with manual commands.
+This section describes how to test a new image and CFS configuration on a single canary node first before rolling it out to the other management nodes of the same management type.
 Follow the steps below to upgrade all management nodes.
 
 1. The "Install and Upgrade Framework" section of each individual product's installation document may contain special actions that need to be performed outside of IUF for a stage. The "IUF Stage Documentation Per Product"
 section of the _HPE Cray EX System Software Stack Installation and Upgrade Guide for CSM (S-8052)_ provides a table that summarizes which product documents contain information or actions for the `management-nodes-rollout` stage.
 Refer to that table and any corresponding product documents before continuing to the next step.
 
-1. Get the image ID and CFS configuration created for management nodes during the `prepare-images` and `update-cfs-config` stages. Follow the instructions in the
-[`prepare-images` Artifacts created](../stages/prepare_images.md#artifacts-created) documentation to get the values for `final_image_id` and `configuration` for images with a `configuration_group_name` value matching `Management_Master`
-or `Management_Storage`. These values will be needed when upgrading NCN storage nodes and `ncn-m001` in the following steps.
+1. Perform the NCN storage node upgrades. This upgrades a single storage node first to test the storage node image and the upgrades the remaining storage nodes.
 
-1. Perform the NCN storage node upgrades.
+    **`NOTE`** The `management-nodes-rollout` stage creates additional separate Argo workflows when rebuilding NCN storage nodes. The Argo workflow names will include the string `ncn-lifecycle-rebuild`.
+    If monitoring progress with the Argo UI, remember to include these workflows.
 
-    1. Set the CFS configuration on all storage nodes.
-
-        1. (`ncn-m#`) Set `CFS_CONFIG_NAME` to be the value for `configuration` found for `Management_Storage` nodes in the previous step.
-
-            ```bash
-            CFS_CONFIG_NAME=<appropriate configuration value>
-            ```
-
-        1. (`ncn-m#`) Get all NCN storage node xnames.
-
-            ```bash
-            XNAMES=$(cray hsm state components list --role Management --subrole Storage --type Node --format json | jq -r '.Components | map(.ID) | join(",")')
-            echo "${XNAMES}"
-            ```
-
-        1. (`ncn-m#`) Set the configuration on all storage nodes.
-
-            ```bash
-            /usr/share/doc/csm/scripts/operations/configuration/apply_csm_configuration.sh \
-            --no-config-change --config-name "${CFS_CONFIG_NAME}" --xnames "${XNAMES}" --no-enable --no-clear-err
-            ```
-
-            The expected output is:
-
-              ```bash
-              All components updated successfully.
-              ```
-
-    1. Set the image in BSS for all storage nodes by following the [Set NCN boot image for `ncn-m001` and NCN storage nodes](../stages/management_nodes_rollout.md#set-ncn-boot-image-for-ncn-m001-and-ncn-storage-nodes)
-    section of the [Management nodes rollout stage documentation](../stages/management_nodes_rollout.md).
-    Set the `IMS_RESULTANT_IMAGE_ID` variable to the `final_image_id` value for `Management_Storage` found in step 2 above.
-
-    1. (`ncn-m#`) Upgrade one NCN storage node (`ncn-s001`).
-
-        **NOTE** This creates an additional, separate Argo workflow for rebuilding a NCN storage node. The Argo workflow name will include the string `ncn-lifecycle-rebuild`. If monitoring progress with the Argo UI, remember to include these workflows.
+    1. (`ncn-m001#`) Execute the `management-nodes-rollout` stage with a single NCN storage node.
 
         ```bash
-        /usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh ncn-s001 --upgrade
+        STORAGE_CANARY=ncn-s001
+        ```
+
+        ```bash
+        iuf -a "${ACTIVITY_NAME}" run -r management-nodes-rollout --limit-management-rolout ${STORAGE_CANARY}
         ```
 
     1. (`ncn-m#`) Verify that the storage node booted and is configured correctly. The CFS configuration can be
@@ -112,31 +81,18 @@ or `Management_Storage`. These values will be needed when upgrading NCN storage 
 
         The desired value for `configurationStatus` is `configured`. If it is `pending`, then wait for the status to change to `configured`.
 
-    1. (`ncn-m#`) Upgrade the remaining storage nodes serially.
-
-        **NOTE** This creates an additional, separate Argo workflow for upgrading NCN storage nodes. The Argo workflow name will include the string `ncn-lifecycle-rebuild`. If monitoring progress with the Argo UI, remember to include these workflows.
+    1. (`ncn-m001#`) Upgrade the remainging NCN storage nodes once the first has upgraded sucessfully. This upgrades NCN storage nodes serially.
+    Adjust the number of storage nodes based on the cluster.
 
         ```bash
-        /usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh ncn-s002,ncn-s003,ncn-s004 --upgrade
+        STORAGE_NODES="ncn-s002 ncn-s003 ncn-s004"
         ```
 
-    1. Follow the steps documented in [Ensure that `rbd` stats monitoring is enabled](../../../upgrade/Stage_1.md#ensure-that-rbd-stats-monitoring-is-enabled)
+        ```bash
+        iuf -a "${ACTIVITY_NAME}" run -r management-nodes-rollout --limit-management-rolout ${STORAGE_NODES}
+        ```
 
 1. Perform the NCN master node upgrade on `ncn-m002` and `ncn-m003`.
-
-    1. Use `kubectl` to label `ncn-m003` with `iuf-prevent-rollout=true` to ensure `management-nodes-rollout` only rebuilds the single NCN master node `ncn-m002`.
-
-        (`ncn-m001#`) Label `ncn-m003` to prevent it from rebuilding.
-
-        ```bash
-        kubectl label nodes "ncn-m003" --overwrite iuf-prevent-rollout=true
-        ```
-
-        (`ncn-m001#`) Verify the IUF node label is present on the desired node.
-
-        ```bash
-        kubectl get nodes --show-labels | grep iuf-prevent-rollout
-        ```
 
     1. Invoke `iuf run` with `-r` to execute the [`management-nodes-rollout`](../stages/management_nodes_rollout.md) stage on `ncn-m002`. This will rebuild `ncn-m002` with the new CFS configuration and image built in
     previous steps of the workflow.
@@ -144,25 +100,10 @@ or `Management_Storage`. These values will be needed when upgrading NCN storage 
         (`ncn-m001#`) Execute the `management-nodes-rollout` stage with `ncn-m002`.
 
         ```bash
-        iuf -a "${ACTIVITY_NAME}" run -r management-nodes-rollout --limit-management-rollout Management_Master
+        iuf -a "${ACTIVITY_NAME}" run -r management-nodes-rollout --limit-management-rollout ncn-m002
         ```
 
     1. Verify that `ncn-m002` booted successfully with the desired image and CFS configuration.
-
-    1. Use `kubectl` to remove the `iuf-prevent-rollout=true` label from `ncn-m003` and add it to `ncn-m002`.
-
-        (`ncn-m001#`) Remove label from `ncn-m003` and add it to `ncn-m002` to prevent it from rebuilding.
-
-        ```bash
-        kubectl label nodes "ncn-m002" --overwrite iuf-prevent-rollout=true
-        kubectl label nodes "ncn-m003" --overwrite iuf-prevent-rollout-
-        ```
-
-        (`ncn-m001#`) Verify the IUF node label is present on the desired node.
-
-        ```bash
-        kubectl get nodes --show-labels | grep iuf-prevent-rollout
-        ```
 
     1. Invoke `iuf run` with `-r` to execute the [`management-nodes-rollout`](../stages/management_nodes_rollout.md) stage on `ncn-m003`. This will rebuild `ncn-m003` with the new CFS configuration and image built in
     previous steps of the workflow.
@@ -170,29 +111,19 @@ or `Management_Storage`. These values will be needed when upgrading NCN storage 
         (`ncn-m001#`) Execute the `management-nodes-rollout` stage with `ncn-m003`.
 
         ```bash
-        iuf -a "${ACTIVITY_NAME}" run -r management-nodes-rollout --limit-management-rollout Management_Master
-        ```
-
-    1. Use `kubectl` to remove the `iuf-prevent-rollout=true` label from `ncn-m002`.
-
-        (`ncn-m001#`) Remove label from `ncn-m002`.
-
-        ```bash
-        kubectl label nodes "ncn-m002" --overwrite iuf-prevent-rollout-
-        ```
-
-        (`ncn-m001#`) Verify the IUF node label is no longer set on `ncn-m002`.
-
-        ```bash
-        kubectl get nodes --show-labels | grep iuf-prevent-rollout
+        iuf -a "${ACTIVITY_NAME}" run -r management-nodes-rollout --limit-management-rollout ncn-m003
         ```
 
 1. Perform the NCN worker node upgrade. To upgrade worker nodes, follow the procedure in section [3.3 NCN worker nodes](#33-ncn-worker-nodes) and then return to this procedure to complete the next step.
 
 1. Upgrade `ncn-m001`.
 
-    1. Follow the steps documented in [Stage 2.3 - `ncn-m001` upgrade](../../../upgrade/Stage_2.md#stage-23---ncn-m001-upgrade).
-    **Stop** before performing the specific [upgrade `ncn-m001`](../../../upgrade/Stage_2.md#upgrade-ncn-m001) step and return to this document.
+    1. Follow the steps documented in [Stage 3.3 - `ncn-m001` upgrade](../../../upgrade/Stage_3.md#stage-33---ncn-m001-upgrade).
+    **Stop** before performing the specific [upgrade `ncn-m001`](../../../upgrade/Stage_3.md#upgrade-ncn-m001) step and return to this document.
+
+    1. Get the image ID and CFS configuration created for NCN master nodes during the `prepare-images` and `update-cfs-config` stages. Follow the instructions in the
+    [`prepare-images` Artifacts created](../stages/prepare_images.md#artifacts-created) documentation to get the values for `final_image_id` and `configuration` for images with a `configuration_group_name` value matching `Management_Master`.
+    These values will be needed for upgrading `ncn-m001` in the following steps.
 
     1. Set the CFS configuration on `ncn-m001`.
 
@@ -222,7 +153,7 @@ or `Management_Storage`. These values will be needed when upgrading NCN storage 
               All components updated successfully.
               ```
 
-    1. Set the image in BSS for `ncn-m001` by following the [Set NCN boot image for `ncn-m001` and NCN storage nodes](../stages/management_nodes_rollout.md#set-ncn-boot-image-for-ncn-m001-and-ncn-storage-nodes)
+    1. Set the image in BSS for `ncn-m001` by following the [Set NCN boot image for `ncn-m001`](../stages/management_nodes_rollout.md#set-ncn-boot-image-for-ncn-m001)
     section of the [Management nodes rollout stage documentation](../stages/management_nodes_rollout.md).
     Set the `IMS_RESULTANT_IMAGE_ID` variable to the `final_image_id` for `Management_Master` found in the second step.
 
@@ -232,11 +163,11 @@ or `Management_Storage`. These values will be needed when upgrading NCN storage 
         /usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-master-nodes.sh ncn-m001
         ```
 
-1. Follow the steps documented in [Stage 2.4 - Upgrade `weave` and `multus`](../../../upgrade/Stage_2.md#stage-24---upgrade-weave-and-multus)
+1. Follow the steps documented in [Stage 3.4 - Upgrade `weave` and `multus`](../../../upgrade/Stage_3.md#stage-34---upgrade-weave-and-multus)
 
-1. Follow the steps documented in [Stage 2.5 - `coredns` anti-affinity](../../../upgrade/Stage_2.md#stage-25---coredns-anti-affinity)
+1. Follow the steps documented in [Stage 3.5 - `coredns` anti-affinity](../../../upgrade/Stage_3.md#stage-35---coredns-anti-affinity)
 
-1. Follow the steps documented in [Stage 2.6 - Complete Kubernetes upgrade](../../../upgrade/Stage_2.md#stage-26---complete-kubernetes-upgrade).
+1. Follow the steps documented in [Stage 3.6 - Complete Kubernetes upgrade](../../../upgrade/Stage_3.md#stage-36---complete-kubernetes-upgrade).
 
 Once this step has completed:
 
@@ -307,8 +238,7 @@ Continue to the next section [4. Update management host Slingshot NIC firmware](
 ### 3.3 NCN worker nodes
 
 NCN worker node images contain kernel module content from non-CSM products and need to be rebuilt as part of the workflow. This section describes how to test a new image and CFS configuration on a single canary node (`ncn-w001`) first before
-rolling it out to the other NCN worker nodes. Modify the procedure as necessary to accommodate site preferences for rebuilding NCN worker nodes. Since the default node target for the `management-nodes-rollout` is `Management_Worker`
-nodes, the `--limit-management-rollout` argument is not used in the instructions below.
+rolling it out to the other NCN worker nodes. Modify the procedure as necessary to accommodate site preferences for rebuilding NCN worker nodes.
 
 The images and CFS configurations used are created by the `prepare-images` and `update-cfs-config` stages respectively; see the [`prepare-images` Artifacts created](../stages/prepare_images.md#artifacts-created) documentation
 for details on how to query the images and CFS configurations and see the [update-cfs-config](../stages/update_cfs_config.md) documentation for details about how the CFS configuration is updated.
@@ -320,63 +250,47 @@ remember to include these workflows.
 section of the _HPE Cray EX System Software Stack Installation and Upgrade Guide for CSM (S-8052)_ provides a table that summarizes which product documents contain information or actions for the `management-nodes-rollout` stage.
 Refer to that table and any corresponding product documents before continuing to the next step.
 
-1. Use `kubectl` to label all NCN worker nodes but one with `iuf-prevent-rollout=true` to ensure `management-nodes-rollout` only rebuilds a single NCN worker node. This node is referred to as the canary node in the remainder of
-this section and the steps are documented with `ncn-w001` as the canary node.
+1. Invoke `iuf run` with `-r` to execute the [`management-nodes-rollout`](../stages/management_nodes_rollout.md) stage on the canary node. This will rebuild the canary node with the new CFS configuration and image built in
+previous steps of the workflow.
 
-    (`ncn-m001#`) Label a NCN to prevent it from rebuilding. Replace the example value of `${HOSTNAME}` with the appropriate value. **Repeat this step for all NCN worker nodes except for the canary node.**
+    (`ncn-m001#`) Execute the `management-nodes-rollout` stage with a single NCN worker node. The worker canary node can be any worker node and does not have to be `ncn-w001`.
 
     ```bash
-    HOSTNAME=ncn-w002
-    kubectl label nodes "${HOSTNAME}" --overwrite iuf-prevent-rollout=true
+    WORKER_CANARY=ncn-w001
     ```
 
-    (`ncn-m001#`) Verify the IUF node labels are present on the desired node.
+    ```bash
+    iuf -a "${ACTIVITY_NAME}" run -r management-nodes-rollout --limit-management-rollout ${WORKER_CANARY}
+    ```
+
+1. Verify the canary node booted successfully with the desired image and CFS configuration.
+
+1. (`ncn-m001#`) Use `kubectl` to apply the `iuf-prevent-rollout=true` label to the canary node to prevent it from unnecessarily rebuilding again.
+
+    ```bash
+    kubectl label nodes "${WORKER_CANARY}" --overwrite iuf-prevent-rollout=true
+    ```
+
+1. (`ncn-m001#`) Verify the IUF node labels are present on the desired node.
 
     ```bash
     kubectl get nodes --show-labels | grep iuf-prevent-rollout
     ```
 
-1. Invoke `iuf run` with `-r` to execute the [`management-nodes-rollout`](../stages/management_nodes_rollout.md) stage on the canary node. This will rebuild the canary node with the new CFS configuration and image built in
-previous steps of the workflow.
+1. (`ncn-m001#`) Execute the `management-nodes-rollout` stage on all remaining worker nodes.
 
-    (`ncn-m001#`) Execute the `management-nodes-rollout` stage with a single NCN worker node.
-
-    ```bash
-    iuf -a "${ACTIVITY_NAME}" run -r management-nodes-rollout
-    ```
-
-1. Verify the canary node booted successfully with the desired image and CFS configuration.
-
-1. Use `kubectl` to remove the `iuf-prevent-rollout=true` label from all NCN worker nodes and apply it to the canary node to prevent it from unnecessarily rebuilding again.
-
-    (`ncn-m001#`) Remove the label from a NCN to allow it to rebuild. Replace the example value of `${HOSTNAME}` with the appropriate value. **Repeat this step for all NCN worker nodes except for the canary node.**
+    **`NOTE`** Instead of supplying `Management_Worker` as the argument to `--limit-management-rollout`, worker node hostnames could be supplied.
+    For example, `--limit-management-rollout ncn-w002 ncn-w003` will rebuild `ncn-w002` and `ncn-w003`.
 
     ```bash
-    HOSTNAME=ncn-w002
-    kubectl label nodes "${HOSTNAME}" --overwrite iuf-prevent-rollout-
+    iuf -a "${ACTIVITY_NAME}" run -r management-nodes-rollout --limit-management-rollout Management_Worker
     ```
 
-    (`ncn-m001#`) Label the canary node to prevent it from rebuilding. Replace the example value of `${HOSTNAME}` with the hostname of the canary node.
+1. Use `kubectl` to remove the `iuf-prevent-rollout=true` label from the canary node.
 
     ```bash
     HOSTNAME=ncn-w001
-    kubectl label nodes "${HOSTNAME}" --overwrite iuf-prevent-rollout=true
-    ```
-
-1. Invoke `iuf run` with `-r` to execute the [`management-nodes-rollout`](../stages/management_nodes_rollout.md) stage on all remaining NCN worker nodes. This will rebuild the nodes with the new CFS configuration and
-image built in previous steps of the workflow.
-
-    (`ncn-m001#`) Execute the `management-nodes-rollout` stage on all remaining worker and master nodes.
-
-    ```bash
-    iuf -a "${ACTIVITY_NAME}" run -r management-nodes-rollout
-    ```
-
-1. Use `kubectl` to remove the `iuf-prevent-rollout=true` label from the canary node. Replace the example value of `${HOSTNAME}` with the hostname of the canary node.
-
-    ```bash
-    HOSTNAME=ncn-w001
-    kubectl label nodes "${HOSTNAME}" --overwrite iuf-prevent-rollout-
+    kubectl label nodes "${WORKER_CANARY}" --overwrite iuf-prevent-rollout-
     ```
 
 Once this step has completed:

--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -56,7 +56,7 @@ Follow the steps below to upgrade all management nodes.
 section of the _HPE Cray EX System Software Stack Installation and Upgrade Guide for CSM (S-8052)_ provides a table that summarizes which product documents contain information or actions for the `management-nodes-rollout` stage.
 Refer to that table and any corresponding product documents before continuing to the next step.
 
-1. Perform the NCN storage node upgrades. This upgrades a single storage node first to test the storage node image and the upgrades the remaining storage nodes.
+1. Perform the NCN storage node upgrades. This upgrades a single storage node first to test the storage node image and then upgrades the remaining storage nodes.
 
     **`NOTE`** The `management-nodes-rollout` stage creates additional separate Argo workflows when rebuilding NCN storage nodes. The Argo workflow names will include the string `ncn-lifecycle-rebuild`.
     If monitoring progress with the Argo UI, remember to include these workflows.
@@ -250,10 +250,9 @@ remember to include these workflows.
 section of the _HPE Cray EX System Software Stack Installation and Upgrade Guide for CSM (S-8052)_ provides a table that summarizes which product documents contain information or actions for the `management-nodes-rollout` stage.
 Refer to that table and any corresponding product documents before continuing to the next step.
 
-1. Invoke `iuf run` with `-r` to execute the [`management-nodes-rollout`](../stages/management_nodes_rollout.md) stage on the canary node. This will rebuild the canary node with the new CFS configuration and image built in
-previous steps of the workflow.
-
-    (`ncn-m001#`) Execute the `management-nodes-rollout` stage with a single NCN worker node. The worker canary node can be any worker node and does not have to be `ncn-w001`.
+1. (`ncn-m001#`) Execute the `management-nodes-rollout` stage with a single    NCN worker node.
+This will rebuild the canary node with the new CFS configuration and image built in previous steps of the workflow.
+The worker canary node can be any worker node and does not have to be `ncn-w001`.
 
     ```bash
     WORKER_CANARY=ncn-w001
@@ -289,7 +288,6 @@ previous steps of the workflow.
 1. Use `kubectl` to remove the `iuf-prevent-rollout=true` label from the canary node.
 
     ```bash
-    HOSTNAME=ncn-w001
     kubectl label nodes "${WORKER_CANARY}" --overwrite iuf-prevent-rollout-
     ```
 

--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -250,7 +250,7 @@ remember to include these workflows.
 section of the _HPE Cray EX System Software Stack Installation and Upgrade Guide for CSM (S-8052)_ provides a table that summarizes which product documents contain information or actions for the `management-nodes-rollout` stage.
 Refer to that table and any corresponding product documents before continuing to the next step.
 
-1. (`ncn-m001#`) Execute the `management-nodes-rollout` stage with a single    NCN worker node.
+1. (`ncn-m001#`) Execute the `management-nodes-rollout` stage with a single NCN worker node.
 This will rebuild the canary node with the new CFS configuration and image built in previous steps of the workflow.
 The worker canary node can be any worker node and does not have to be `ncn-w001`.
 


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

CASMINST-6208 and CASMPET-6610 adjusted the functionality of IUF stage management-nodes-rollout. These changes include automating the storage node rollouts with IUF and being able to specify an NCN hostname to rebuild through IUF. These changes are documented by this PR. 
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
