### PR TITLE
CASMCMS-8672: ARM image sat bootprep documentation

### DIFF
--- a/operations/iuf/IUF.md
+++ b/operations/iuf/IUF.md
@@ -45,7 +45,7 @@ The following IUF topics are discussed in the sections below.
   - [Log files](#log-files)
 - [Site and recipe variables](#site-and-recipe-variables)
 - [`sat bootprep` configuration files](#sat-bootprep-configuration-files)
-  - [ARM Images](#arm-images)
+  - [ARM images](#arm-images)
 - [Recovering from failures](#recovering-from-failures)
   - [Addressing the issue without changing products](#addressing-the-issue-without-changing-products)
   - [Addressing the issue by removing a product](#addressing-the-issue-by-removing-a-product)
@@ -714,9 +714,9 @@ HPE provides management NCN and managed node `sat bootprep` configuration files 
 CFS configuration, image, and BOS session template definitions. The administrator may customize the files as needed. The files include
 variables, and the values used are provided by the recipe variables and/or site variables files specified when running `iuf run`.
 
-### ARM Images
+### ARM images
 
-`sat bootprep` files support building ARM images on an opt-in basis. There is provided commented out configuration in the `compute-and-uan-bootprep.yaml`.
+`sat bootprep` files support building ARM images on an opt-in basis. A commented configuration is provided in the `compute-and-uan-bootprep.yaml` file.
 
 ```yaml
 # The following images are required only on systems with aarch64 (ARM) nodes.

--- a/operations/iuf/IUF.md
+++ b/operations/iuf/IUF.md
@@ -45,6 +45,7 @@ The following IUF topics are discussed in the sections below.
   - [Log files](#log-files)
 - [Site and recipe variables](#site-and-recipe-variables)
 - [`sat bootprep` configuration files](#sat-bootprep-configuration-files)
+  - [ARM Images](#arm-images)
 - [Recovering from failures](#recovering-from-failures)
   - [Addressing the issue without changing products](#addressing-the-issue-without-changing-products)
   - [Addressing the issue by removing a product](#addressing-the-issue-by-removing-a-product)
@@ -712,6 +713,41 @@ input files to define the CFS configurations used to customize management NCN an
 HPE provides management NCN and managed node `sat bootprep` configuration files in the HPC CSM Software Recipe. The files provide default
 CFS configuration, image, and BOS session template definitions. The administrator may customize the files as needed. The files include
 variables, and the values used are provided by the recipe variables and/or site variables files specified when running `iuf run`.
+
+### ARM Images
+
+`sat bootprep` files support building ARM images on an opt-in basis. There is provided commented out configuration in the `compute-and-uan-bootprep.yaml`.
+
+```yaml
+# The following images are required only on systems with aarch64 (ARM) nodes.
+# Uncomment the lines below if ARM images are needed.
+#- name: "{{default.note}}{{base.name}}{{default.suffix}}"
+#  ref_name: base_cos_image.aarch64
+#  base:
+#    product:
+#      name: cos
+#      type: recipe
+#      version: "{{cos.version}}"
+#      filter:
+#        arch: aarch64
+#
+#- name: "compute-{{base.name}}"
+#  ref_name: compute_image.aarch64
+#  base:
+#    image_ref: base_cos_image.aarch64
+#  configuration: "{{default.note}}compute-{{recipe.version}}{{default.suffix}}"
+#  configuration_group_names:
+#  - Compute
+#
+#- name: "uan-{{base.name}}"
+#  ref_name: uan_image.aarch64
+#  base:
+#    image_ref: base_cos_image.aarch64
+#  configuration: "{{default.note}}uan-{{recipe.version}}{{default.suffix}}"
+#  configuration_group_names:
+#  - Application
+#  - Application_UAN
+```
 
 ## Recovering from failures
 

--- a/operations/iuf/stages/prepare_images.md
+++ b/operations/iuf/stages/prepare_images.md
@@ -10,6 +10,7 @@ files can be substituted with values found in the recipe variables (`-rv`) and/o
 
 - [Impact](#impact)
 - [Input](#input)
+  - [ARM Images](#arm-images)
 - [Artifacts created](#input)
 - [Execution details](#execution-details)
 - [Example](#example)
@@ -31,6 +32,10 @@ The following arguments are most often used with the `prepare-images` stage. See
 | Recipe variables                              | `-rv RECIPE_VARS`                | Path to YAML file containing recipe variables provided by HPE                                         |
 | Site variables                                | `-sv SITE_VARS`                  | Path to YAML file containing site defaults and any overrides                                          |
 | Recipe variables product mask                 | `-mrp MASK_RECIPE_PRODS`         | Mask the recipe variables file entries for the products specified, use product catalog values instead |
+
+### ARM Images
+
+If the customer requires to build `aarch64` images see the [IUF `sat bootprep` ARM](../IUF.md#arm-images)
 
 ## Artifacts created
 

--- a/operations/iuf/stages/prepare_images.md
+++ b/operations/iuf/stages/prepare_images.md
@@ -1,9 +1,12 @@
 # `prepare-images`
 
-The `prepare-images` stage configures NCN management node images and builds and configures compute node, application node, and GPU images. It also creates new BOS session templates corresponding to the new node and image content.
-The `prepare-images` stage does not reboot nodes to the new images; however, that is done by the `management-nodes-rollout` and `managed-nodes-rollout` stages.
+The `prepare-images` stage configures NCN management node images and builds and configures compute node, application
+node, and GPU images. It also creates new BOS session templates corresponding to the new node and image content.
+The `prepare-images` stage does not reboot nodes to the new images; however, that is done by
+the `management-nodes-rollout` and `managed-nodes-rollout` stages.
 
-The product content used to create the images is defined in `sat bootprep` input files. The `sat bootprep` input files used can be specified by `-bc`, `-bm`, and/or `-bpcd` as described below. Variables within the `sat bootprep`
+The product content used to create the images is defined in `sat bootprep` input files. The `sat bootprep` input files
+used can be specified by `-bc`, `-bm`, and/or `-bpcd` as described below. Variables within the `sat bootprep`
 files can be substituted with values found in the recipe variables (`-rv`) and/or site variables (`-sv`) files.
 
 `prepare-images` details are explained in the following sections:
@@ -17,14 +20,16 @@ files can be substituted with values found in the recipe variables (`-rv`) and/o
 
 ## Impact
 
-The `prepare-images` stage does not change the running state of the system as it does not deploy the newly created images; that is done by the `management-nodes-rollout` and `managed-nodes-rollout` stages.
+The `prepare-images` stage does not change the running state of the system as it does not deploy the newly created
+images; that is done by the `management-nodes-rollout` and `managed-nodes-rollout` stages.
 
 ## Input
 
-The following arguments are most often used with the `prepare-images` stage. See `iuf -h` and `iuf run -h` for additional arguments.
+The following arguments are most often used with the `prepare-images` stage. See `iuf -h` and `iuf run -h` for
+additional arguments.
 
 | Input                                         | `iuf` Argument                   | Description                                                                                           |
-| --------------------------------------------- | -------------------------------- | ----------------------------------------------------------------------------------------------------- |
+|-----------------------------------------------|----------------------------------|-------------------------------------------------------------------------------------------------------|
 | Activity                                      | `-a ACTIVITY`                    | Activity created for the install or upgrade operations                                                |
 | Managed `sat bootprep` configuration files    | `-bc BOOTPREP_CONFIG_MANAGED`    | The `sat bootprep` configuration file used for managed nodes                                          |
 | Management `sat bootprep` configuration files | `-bm BOOTPREP_CONFIG_MANAGEMENT` | The `sat bootprep` configuration file used for management nodes                                       |
@@ -39,10 +44,12 @@ If it is necessary to build `aarch64` images, then see [ARM images](../IUF.md#ar
 
 ## Artifacts created
 
-The artifacts created by the `prepare-images` stage can found by examining the output from `iuf run` or by examining a Kubernetes ConfigMap associated with the IUF activity specified when executing the `prepare-images` stage.
-The following examples show how to find the management node and managed node artifacts from the ConfigMap.
+The artifacts created by the `prepare-images` stage can found by examining the output from `iuf run` or by examining a
+Kubernetes ConfigMap associated with the IUF activity specified when executing the `prepare-images` stage. The following
+examples show how to find the management node and managed node artifacts from the ConfigMap.
 
-(`ncn-m001#`) Examine the activity ConfigMap to identify the management node images and CFS configurations created by `prepare-images`.
+(`ncn-m001#`) Examine the activity ConfigMap to identify the management node images and CFS configurations created
+by `prepare-images`.
 
 ```bash
 kubectl get configmaps -n argo "${ACTIVITY_NAME}" -o jsonpath='{.data.iuf_activity}' | jq '.operation_outputs.stage_params["prepare-images"]["prepare-management-images"]["sat-bootprep-run"].script_stdout' | xargs -0 echo -e
@@ -79,7 +86,8 @@ kubectl get configmaps -n argo "${ACTIVITY_NAME}" -o jsonpath='{.data.iuf_activi
 }"
 ```
 
-(`ncn-m001#`) Examine the activity ConfigMap to identify the managed node images, CFS configurations, and BOS session templates created by `prepare-images`.
+(`ncn-m001#`) Examine the activity ConfigMap to identify the managed node images, CFS configurations, and BOS session
+templates created by `prepare-images`.
 
 ```bash
 kubectl get configmaps -n argo "${ACTIVITY_NAME}" -o jsonpath='{.data.iuf_activity}' | jq '.operation_outputs.stage_params["prepare-images"]["prepare-managed-images"]["sat-bootprep-run"].script_stdout' | xargs -0 echo -e
@@ -150,15 +158,19 @@ kubectl get configmaps -n argo "${ACTIVITY_NAME}" -o jsonpath='{.data.iuf_activi
 
 ## Execution details
 
-The code executed by this stage utilizes `sat bootprep` to build and customize images. See the `prepare-images` entry in `/usr/share/doc/csm/workflows/iuf/stages.yaml` and the corresponding files in `/usr/share/doc/csm/workflows/iuf/operations/`
+The code executed by this stage utilizes `sat bootprep` to build and customize images. See the `prepare-images` entry
+in `/usr/share/doc/csm/workflows/iuf/stages.yaml` and the corresponding files
+in `/usr/share/doc/csm/workflows/iuf/operations/`
 for details on the commands executed.
 
-See the [HPE Cray EX System Admin Toolkit (SAT) Guide](https://cray-hpe.github.io/docs-sat/) documentation for details on `sat bootprep`.
+See the [HPE Cray EX System Admin Toolkit (SAT) Guide](https://cray-hpe.github.io/docs-sat/) documentation for details
+on `sat bootprep`.
 
 ## Example
 
-(`ncn-m001#`) Execute the `prepare-images` stage for activity `admin-230127` using the `/etc/cray/upgrade/csm/admin/site_vars.yaml` file and the managed and management `sat bootprep` configuration files and the `product_vars.yaml` configuration file
-found in the `/etc/cray/upgrade/csm/admin` directory.
+(`ncn-m001#`) Execute the `prepare-images` stage for activity `admin-230127` using
+the `/etc/cray/upgrade/csm/admin/site_vars.yaml` file and the managed and management `sat bootprep` configuration files
+and the `product_vars.yaml` configuration file found in the `/etc/cray/upgrade/csm/admin` directory.
 
 ```bash
 iuf -a admin-230127 run -sv /etc/cray/upgrade/csm/admin/site_vars.yaml -bpcd /etc/cray/upgrade/csm/admin -r prepare-images

--- a/operations/iuf/stages/prepare_images.md
+++ b/operations/iuf/stages/prepare_images.md
@@ -10,7 +10,7 @@ files can be substituted with values found in the recipe variables (`-rv`) and/o
 
 - [Impact](#impact)
 - [Input](#input)
-  - [ARM Images](#arm-images)
+  - [ARM images](#arm-images)
 - [Artifacts created](#input)
 - [Execution details](#execution-details)
 - [Example](#example)
@@ -33,9 +33,9 @@ The following arguments are most often used with the `prepare-images` stage. See
 | Site variables                                | `-sv SITE_VARS`                  | Path to YAML file containing site defaults and any overrides                                          |
 | Recipe variables product mask                 | `-mrp MASK_RECIPE_PRODS`         | Mask the recipe variables file entries for the products specified, use product catalog values instead |
 
-### ARM Images
+### ARM images
 
-If the customer requires to build `aarch64` images see the [IUF `sat bootprep` ARM](../IUF.md#arm-images)
+If it is necessary to build `aarch64` images, then see [ARM images](../IUF.md#arm-images).
 
 ## Artifacts created
 

--- a/operations/iuf/workflows/image_preparation.md
+++ b/operations/iuf/workflows/image_preparation.md
@@ -8,6 +8,7 @@ and images are created with the correct content and configuration values.
 - [1. Execute the IUF `update-cfs-config` and `prepare-images` stages](#1-execute-the-iuf-update-cfs-config-and-prepare-images-stages)
 - [2. Manually prepare additional images](#2-manually-prepare-additional-images)
   - [2.1 UAI images](#21-uai-images)
+  - [2.2 ARM image](#22-arm-images)
 - [3. Next steps](#3-next-steps)
 
 ## 1. Execute the IUF `update-cfs-config` and `prepare-images` stages
@@ -53,6 +54,10 @@ If User Access Instances are utilized on the system, refer to one of the followi
 Once this step has completed:
 
 - New UAI images have been created
+
+### 2.2 ARM Images
+
+If the customer requires to build `aarch64` images see the [IUF `sat bootprep` ARM](../IUF.md#arm-images)
 
 ## 3. Next steps
 

--- a/operations/iuf/workflows/image_preparation.md
+++ b/operations/iuf/workflows/image_preparation.md
@@ -8,7 +8,7 @@ and images are created with the correct content and configuration values.
 - [1. Execute the IUF `update-cfs-config` and `prepare-images` stages](#1-execute-the-iuf-update-cfs-config-and-prepare-images-stages)
 - [2. Manually prepare additional images](#2-manually-prepare-additional-images)
   - [2.1 UAI images](#21-uai-images)
-  - [2.2 ARM image](#22-arm-images)
+  - [2.2 ARM images](#22-arm-images)
 - [3. Next steps](#3-next-steps)
 
 ## 1. Execute the IUF `update-cfs-config` and `prepare-images` stages
@@ -55,9 +55,9 @@ Once this step has completed:
 
 - New UAI images have been created
 
-### 2.2 ARM Images
+### 2.2 ARM images
 
-If the customer requires to build `aarch64` images see the [IUF `sat bootprep` ARM](../IUF.md#arm-images)
+If it is necessary to build `aarch64` images, then see [ARM images](../IUF.md#arm-images).
 
 ## 3. Next steps
 


### PR DESCRIPTION
Update installation procedures that use IUF. Mention that if you have ARM nodes on your system that you should uncomment the ARM section of the sat bootprep input file, so that the ARM images are built. This section is commented out by default, so that systems must opt-in. You do not want to accidentally build ARM images if your system does not contain ARM nodes.

[CASMCMS-8672](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8672)