### PR TITLE
CASMINST-6533 Don't move critical pod if node is not being rebuilt

### DIFF
--- a/workflows/ncn/hooks/before-all/move-critical-singleton-pods.yaml
+++ b/workflows/ncn/hooks/before-all/move-critical-singleton-pods.yaml
@@ -64,11 +64,13 @@ spec:
       podName=${pods[0]}
       currentNode=$(kubectl get po -A -o wide | grep $podName | awk '{print $8}')
       ns=$(kubectl get po -A | grep $podName | awk '{print $1}')
-      if [[ "$nodeMoveTo" != "$currentNode" ]]; then
+      if [[ $targetNcns != *$currentNode* ]]; then
+        echo "$podName is on $currentNode and that node is not being rebuilt by this workflow. Not moving $podName."
+      elif [[ "$nodeMoveTo" != "$currentNode" ]]; then
         echo "Move Pod: $podName to Node: $nodeMoveTo"
         /opt/cray/platform-utils/move_pod.sh $podName $nodeMoveTo > /dev/null
       fi
 
-      kubectl wait --for=condition=ready pod $podName -n $ns --timeout=5m
+      kubectl wait --for=condition=ready pod -l ${label} -n $ns --timeout=5m
     done
   templateRefName: ssh-template


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
Critical singleton pods are moved before a worker rebuild is done. This will move pods even if they are on a node that is not being rebuilt by the worker rebuild workflow. This means that the pod may have to move more times than necessary which is not ideal especially for pods like nexus. This change doesn't move a pod if it is not necessary.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
