### PR TITLE
CASMINST-6534: Remove chart source fields from manifest, to force it to use the source specified on the loftsman command line

### DIFF
--- a/operations/CSM_product_management/Redeploying_a_Chart.md
+++ b/operations/CSM_product_management/Redeploying_a_Chart.md
@@ -126,6 +126,16 @@ If redeploying more than one chart at once, perform the steps in this section fo
               version: 1.12.1
     ```
 
+1. Remove chart source fields from the `${BASE_CHART_FILE}` file.
+
+    Remove the `spec.sources` stanza and remove the `source` field from each chart listing.
+
+    > These commands will work even if the stanzas and fields are not present in the file.
+
+    ```bash
+    ncn-mw# yq d -i "${BASE_CHART_FILE}" spec.sources && yq d -i "${BASE_CHART_FILE}" spec.charts[\*].source
+    ```
+
 1. Update the version numbers in `${BASE_CHART_FILE}` if necessary.
 
     The information in the chart stanza is from the time the chart was deploying during the most recent install or upgrade of the CSM software. However,


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/docs-csm/pull/3964