### PR TITLE
CASMINST-6519 use CSM_RELEASE_VERSION variable in 1.4.1 patch when uploading ncn-images

### DIFF
--- a/upgrade/1.4.1/README.md
+++ b/upgrade/1.4.1/README.md
@@ -70,7 +70,7 @@ If upgrading from CSM `v1.3.4` directly to `v1.4.1`, follow the procedures descr
    **IMPORTANT**: If necessary, change this command to match the actual location of the extracted files.
 
    ```bash
-   CSM_DISTDIR="$(pwd)/csm-1.4.1"
+   export CSM_DISTDIR="$(pwd)/csm-1.4.1"
    echo "${CSM_DISTDIR}"
    ```
 

--- a/upgrade/scripts/upgrade/upload-ncn-images.sh
+++ b/upgrade/scripts/upgrade/upload-ncn-images.sh
@@ -26,21 +26,23 @@
 set -u
 
 CSM_ARTI_DIR=${CSM_DISTDIR:-''}
-CSM_RELEASE=${CSM_RELEASE:-''}
+CSM_RELEASE=${CSM_RELEASE_VERSION:-''}
 
+# CSM_ARTI_DIR and CSM_RELEASE are required for ncn-ims-image-upload.sh script used below
 if [[ -z ${CSM_ARTI_DIR} ]]; then
     echo "CSM_DISTDIR environment variable needs to be set and exported. It should be set to the path \
 of the extracted CSM product release."
     exit 1
 fi
 
-# CSM_ARTI_DIR and CSM_RELEASE are required for ncn-ims-image-upload.sh script used below
-export CSM_ARTI_DIR
 if [[ -z ${CSM_RELEASE} ]]; then
-    echo "CSM_RELEASE environment variable needs to be set and exported. It should be set to the \
+    echo "CSM_RELEASE_VERSION environment variable needs to be set and exported. It should be set to the \
 version of CSM being patched. For example 'export CSM_RELEASE=\"1.4.1\"'"
     exit 1
 fi
+
+export CSM_ARTI_DIR
+export CSM_RELEASE
 
 artdir=${CSM_ARTI_DIR}/images
 SQUASHFS_ROOT_PW_HASH=$(awk -F':' /^root:/'{print $2}' < /etc/shadow)

--- a/upgrade/scripts/upgrade/upload-ncn-images.sh
+++ b/upgrade/scripts/upgrade/upload-ncn-images.sh
@@ -37,7 +37,7 @@ fi
 
 if [[ -z ${CSM_RELEASE} ]]; then
     echo "CSM_RELEASE_VERSION environment variable needs to be set and exported. It should be set to the \
-version of CSM being patched. For example 'export CSM_RELEASE=\"1.4.1\"'"
+version of CSM being patched. For example 'export CSM_RELEASE_VERSION=\"1.4.1\"'"
     exit 1
 fi
 


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
Fix variables needed in 1.4.1 patch when running upload ncn-images to edit the cray-product-catalog for the patch version.
Earlier steps in the patch use CSM_RELEASE_VERSION instead of CSM_RELEASE. A script called in ncn-image-modification.sh requires CSM_RELEASE. Instead of having the user export this variable, the script will export it.

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
