### PR TITLE
CASMINST-6538: Update CSM health validation procedure to reflect that the CMS, HMS tests are part of the main Goss suite

### DIFF
--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -92,7 +92,14 @@ If `ncn-m001` is the PIT node, then run these checks on `ncn-m001`; otherwise ru
         export SW_ADMIN_PASSWORD
         ```
 
-    1. Run the NCN and Kubernetes health checks.
+    1. Run the combined health check script.
+
+        This script runs a variety of health checks including:
+
+        - Kubernetes health checks
+        - NCN health checks
+        - [Hardware Management Service CT tests](#21-hms-ct-test-execution)
+        - [Software Management Services health checks](#3-software-management-services-sms-health-checks).
 
         ```bash
         /opt/cray/tests/install/ncn/automated/ncn-k8s-combined-healthcheck
@@ -151,31 +158,11 @@ Note: Do not run multiple instances of the HMS tests concurrently as they may in
 
 ### 2.1 HMS CT test execution
 
-These tests may be executed on any one worker or master NCN (but **not** `ncn-m001` if it is still the PIT node).
+The HMS CT tests are run automatically by the test script run in [1.1 NCN health checks](#11-ncn-health-checks).
+If any failures occur, investigate the cause of each and take remediation steps if needed.
 
-(`ncn-mw#`) Run the HMS CT tests.
-
-```bash
-/opt/cray/csm/scripts/hms_verification/run_hms_ct_tests.sh
-```
-
-The return code of the script is zero if all HMS CT tests run and pass, non-zero if not.
-On CT test errors or failures, the script will print the path to the CT test log file for the administrator to inspect.
-If one or more failures occur, investigate the cause of each and take remediation steps if needed.
-See the [Interpreting HMS Health Check Results](../troubleshooting/interpreting_hms_health_check_results.md) documentation for more information.
-
-After remediating a test failure for a particular service, just the tests for that individual service
-can be re-run by supplying the name of the service to the `run_hms_ct_tests.sh` script with the `-t` option:
-
-```bash
-/opt/cray/csm/scripts/hms_verification/run_hms_ct_tests.sh -t <service>
-```
-
-To list the HMS services that can be tested, use the `-l` option:
-
-```bash
-/opt/cray/csm/scripts/hms_verification/run_hms_ct_tests.sh -l
-```
+See [Interpreting HMS Health Check Results](../troubleshooting/interpreting_hms_health_check_results.md) for more information
+on the tests and how to interpret their results.
 
 ### 2.2 Hardware State Manager discovery validation
 
@@ -386,22 +373,11 @@ See the [Flags Set For Nodes In HSM](../troubleshooting/known_issues/flags_set_f
 
 ## 3 Software Management Services (SMS) health checks
 
-This test requires that the Cray CLI is configured on nodes where the test is executed.
-See [Cray command line interface](#0-cray-command-line-interface).
+The SMS health checks are run automatically by the test script run in [1.1 NCN health checks](#11-ncn-health-checks).
+If any failures occur, investigate the cause of each and take remediation steps if needed.
 
-(`ncn-mw#`) To validate all SMS services, run the following:
-
-```bash
-/usr/local/bin/cmsdev test -q all
-```
-
-Successful output ends with a line similar to the following:
-
-```text
-SUCCESS: All 6 service tests passed: bos, cfs, conman, ims, tftp, vcs
-```
-
-For more details, including known issues and other command line options, see [Software Management Services health checks](../troubleshooting/known_issues/sms_health_check.md).
+See [Software Management Services health checks](../troubleshooting/known_issues/sms_health_check.md) for more information
+on the tests and how to interpret their results.
 
 ## 4. Gateway health and SSH access checks
 

--- a/troubleshooting/interpreting_hms_health_check_results.md
+++ b/troubleshooting/interpreting_hms_health_check_results.md
@@ -5,6 +5,9 @@
   - [Prerequisites](#prerequisites)
   - [Overview](#overview)
   - [Execution](#execution)
+    - [Test all HMS services](#test-all-hms-services)
+    - [Test specific HMS service](#test-specific-hms-service)
+    - [Example output](#example-output)
   - [Failure analysis](#failure-analysis)
     - [Smoke test failure](#smoke-test-failure)
     - [Functional test failure](#functional-test-failure)
@@ -52,6 +55,33 @@ the proper management or expected use of hardware in the system.
 
 The `run_hms_ct_tests.sh` script executes the HMS CT tests in parallel. It waits for each Helm test job to complete, logs the results in a file for the test run, and
 prints a summary of the results. The script returns a status code of zero if all tests pass and non-zero if there are one or more failures.
+
+These tests may be executed on any one worker or master NCN (but **not** `ncn-m001` if it is still the PIT node).
+
+### Test all HMS services
+
+(`ncn-mw#`) Run the HMS CT tests by executing the following command:
+
+```bash
+/opt/cray/csm/scripts/hms_verification/run_hms_ct_tests.sh
+```
+
+### Test specific HMS service
+
+(`ncn-mw#`) After remediating a test failure for a particular service, just the tests for that individual service
+can be re-run by supplying the name of the service to the `run_hms_ct_tests.sh` script with the `-t` option:
+
+```bash
+/opt/cray/csm/scripts/hms_verification/run_hms_ct_tests.sh -t <service>
+```
+
+(`ncn-mw#`) To list the HMS services that can be tested, use the `-l` option:
+
+```bash
+/opt/cray/csm/scripts/hms_verification/run_hms_ct_tests.sh -l
+```
+
+### Example output
 
 Example output:
 


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
The following `csm-testing` PR modified the Goss suites so that the CMS and HMS CT tests are now executed as part of the main Goss suite:
https://github.com/Cray-HPE/csm-testing/pull/509

This `docs-csm` PR modifies the CSM health validation procedure to remove the now superfluous manual execution of those steps. Some of the information from the HMS CT test section was added to the "Interpreting HMS test results" page instead, since that is where people are directed if there are failures.

This change is only for CSM 1.5 -- no backports are needed.

[ ] This PR should ideally not merge until the csm-testing PR has been in a few builds, so that people don't stop manually running the CMS/HMS tests prematurely.

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
