### PR TITLE
CASMINST-6524: Update CFS import tool and documentation with clear option

### DIFF
--- a/operations/configuration_management/Exporting_and_Importing_CFS_Data.md
+++ b/operations/configuration_management/Exporting_and_Importing_CFS_Data.md
@@ -10,6 +10,7 @@
   - See [Configure the Cray CLI](../configure_cray_cli.md).
 - The latest CSM documentation RPM must be installed on the node where the procedure is being performed.
   - See [Check for latest documentation](../../update_product_stream/README.md#check-for-latest-documentation).
+- If importing both CFS and VCS data, the VCS import should be done before the CFS import.
 
 ## Export
 
@@ -52,6 +53,8 @@ This tool does the following things:
   - The CFS component on the live system does NOT have a desired configuration set.
   - The desired configuration for this component in the archive either already exists on the live system, or is going to be created
     as part of this import process.
+- If the `--clear-cfs` option is specified, then before deciding which changes need to be imported, the tool will delete all
+  configurations in CFS and will clear the state, desired configuration, and error counts of all components in CFS.
 
 The script takes a snapshot of the live system CFS data before it makes any changes, and after all changes have been made.
 The output of the script lists all of the updates it is making, as well as any updates that it is not performing because of the
@@ -63,8 +66,19 @@ criteria listed above.
 
 1. (`ncn-mw#`) Run the following script to import the data from the archive file.
 
-   > Modify the following example command to specify the path to the output file from the automated export script.
+   > Modify the following example commands to specify the path to the output file from the automated export script.
 
-   ```bash
-   /usr/share/doc/csm/scripts/operations/configuration/import_cfs_data.sh /tmp/cfs-export-20230410170613-Tg0nap.tgz
-   ```
+   - If this import is not happening after a reinstall of CSM, OR if VCS data was not imported from a previous CSM install,
+     then invoke the tool as follows:
+
+      ```bash
+      /usr/share/doc/csm/scripts/operations/configuration/import_cfs_data.sh /tmp/cfs-export-20230410170613-Tg0nap.tgz
+      ```
+
+   - If the CFS import is being done after a reinstall of CSM AND if VCS data from a prior CSM install has been imported, then
+     invoke the tool with the `--clear-cfs` option. This is because the CFS data created during the reinstall of
+     CSM will not match the re-imported VCS data.
+
+      ```bash
+      /usr/share/doc/csm/scripts/operations/configuration/import_cfs_data.sh --clear-cfs /tmp/cfs-export-20230410170613-Tg0nap.tgz
+      ```

--- a/scripts/operations/configuration/import_cfs_data.sh
+++ b/scripts/operations/configuration/import_cfs_data.sh
@@ -42,47 +42,46 @@ OUTPUT_DIR=""
 CLEAR_CFS=""
 ARCHIVE=""
 
-cleanup()
-{
-    [[ $CLEANUP == YES ]] || return
-    [[ -n ${OUTPUT_DIR} ]] || return
-    [[ -d ${OUTPUT_DIR} ]] || return
-    echo "Removing directory '${OUTPUT_DIR}'"
-    rm -rf "${OUTPUT_DIR}" || echo "WARNING: Error removing directory '${OUTPUT_DIR}'" >&2
-    OUTPUT_DIR=""
-    return 0
+cleanup() {
+  [[ $CLEANUP == YES ]] || return
+  [[ -n ${OUTPUT_DIR} ]] || return
+  [[ -d ${OUTPUT_DIR} ]] || return
+  echo "Removing directory '${OUTPUT_DIR}'"
+  rm -rf "${OUTPUT_DIR}" || echo "WARNING: Error removing directory '${OUTPUT_DIR}'" >&2
+  OUTPUT_DIR=""
+  return 0
 }
 
-err_exit()
-{
-    echo "ERROR: $*" >&2
-    cleanup
-    exit 1
+err_exit() {
+  echo "ERROR: $*" >&2
+  cleanup
+  exit 1
 }
 
-usage()
-{
-    echo "Usage: import_cfs_data.sh [--clear-cfs] [--no-cleanup] <CFS export file.tgz>"
-    echo
-    err_exit "$@"
+usage() {
+  echo "Usage: import_cfs_data.sh [--clear-cfs] [--no-cleanup] <CFS export file.tgz>"
+  echo
+  err_exit "$@"
 }
 
-run_cmd()
-{
-    "$@" || err_exit "Command failed with return code $?: $*"
+run_cmd() {
+  "$@" || err_exit "Command failed with return code $?: $*"
 }
 
 if [[ $# -eq 0 ]]; then
-    usage "Missing required argument"
+  usage "Missing required argument"
 fi
 
 while [[ $# -gt 0 ]]; do
-    case "$1" in
-        "--no-cleanup") CLEANUP="" ;;
-        "--clear-cfs")  CLEAR_CFS="$1" ;;
-        *)              [[ $# -eq 1 ]] || usage "Unrecognized argument: $1" ; ARCHIVE="$1" ;;
-    esac
-    shift
+  case "$1" in
+    "--no-cleanup") CLEANUP="" ;;
+    "--clear-cfs") CLEAR_CFS="$1" ;;
+    *)
+      [[ $# -eq 1 ]] || usage "Unrecognized argument: $1"
+      ARCHIVE="$1"
+      ;;
+  esac
+  shift
 done
 
 [[ ${ARCHIVE} =~ .*\.tgz$ ]] || usage "Invalid archive file name: '${ARCHIVE}'"
@@ -90,14 +89,14 @@ done
 [[ -f ${ARCHIVE} ]] || usage "Archive exists but is not a regular file: '${ARCHIVE}'"
 [[ -s ${ARCHIVE} ]] || usage "Archive file is zero size: '${ARCHIVE}'"
 
-basedir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+basedir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 import_python_script="${basedir}/import_cfs_data.py"
-[[ -e ${import_python_script} ]] ||
-    err_exit "File does not exist: '${import_python_script}'"
-[[ -f ${import_python_script} ]] ||
-    err_exit "Not a regular file: '${import_python_script}'"
-[[ -x ${import_python_script} ]] ||
-    err_exit "File is not executable: '${import_python_script}'"
+[[ -e ${import_python_script} ]] \
+  || err_exit "File does not exist: '${import_python_script}'"
+[[ -f ${import_python_script} ]] \
+  || err_exit "Not a regular file: '${import_python_script}'"
+[[ -x ${import_python_script} ]] \
+  || err_exit "File is not executable: '${import_python_script}'"
 
 OUTPUT_DIR_PREFIX="cfs-import-$(date +%Y%m%d%H%M%S)"
 OUTPUT_DIR=$(run_cmd mktemp --tmpdir -d "${OUTPUT_DIR_PREFIX}-XXX")
@@ -109,8 +108,8 @@ run_cmd tar -C "${OUTPUT_DIR}" -xzf "${ARCHIVE}"
 # There should be a subdirectory of $OUTPUT_DIR which contains components.json, configurations.json, and options.json
 JSON_DIR=$(find "${OUTPUT_DIR}" -type f -name components.json -printf "%h" -quit)
 [[ -n ${JSON_DIR} ]] || err_exit "No components.json found inside archive"
-for FNAME in configurations.json options.json ; do
-    [[ -f ${JSON_DIR}/${FNAME} ]] || err_exit "Archive directory containing components.json does not contain ${FNAME}"
+for FNAME in configurations.json options.json; do
+  [[ -f ${JSON_DIR}/${FNAME} ]] || err_exit "Archive directory containing components.json does not contain ${FNAME}"
 done
 
 # Call the Python importer script on this directory


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
One disaster recovery scenario that we are testing involves reinstalling CSM, then restoring the VCS data from the prior install. This means that things like git commit IDs will no longer match what is in CFS for the new install. So for this scenario specifically, we want an option in the CFS import tool which will clear the existing data before importing the backed up data. This is because by default the CFS import tool does not overwrite existing data. Making this change will ensure that CFS will only reference valid git data (or anyway, it will assuming that this was the case when the exports were made).

Specifically, the new clear option on the import tool:
* Deletes all configurations
* Clears all desired configurations, states, and error counts for components

This PR implements that new option in the import tool, and then updates the CFS import page to specify under what circumstances it should be used (and why).

Backports:
* 1.4: https://github.com/Cray-HPE/docs-csm/pull/3986
* 1.3: https://github.com/Cray-HPE/docs-csm/pull/3987

No earlier backports needed, as these scripts and procedures did not exist in those releases.

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
