### PR TITLE
CASMPET-6686 add overwrite flag when labeling worker cpm-pm-node

### DIFF
--- a/workflows/ncn/worker/worker.post-rebuild.yaml
+++ b/workflows/ncn/worker/worker.post-rebuild.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/workflows/ncn/worker/worker.post-rebuild.yaml
+++ b/workflows/ncn/worker/worker.post-rebuild.yaml
@@ -40,7 +40,7 @@ tasks:
             set +e
             CPS_PM_NODE=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" -X GET https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters?name=${TARGET_XNAME} | jq -r '.[].params' | grep -c "cps.pm-node=1")
             if [[ ${CPS_PM_NODE} -eq 1 ]]; then
-              kubectl label nodes ${TARGET_NCN} "cps-pm-node=True"
+              kubectl label nodes ${TARGET_NCN} --overwrite "cps-pm-node=True"
             fi
   - name: wait-for-cfs-after-rebuild
     templateRef:


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
CASMPET-6686 add overwrite flag when labeling worker cpm-pm-node. 

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
