### PR TITLE
Add new combined health check for post-services upgrade (CASMPET-6670)

### DIFF
--- a/upgrade/Validate_CSM_Health_During_Upgrade.md
+++ b/upgrade/Validate_CSM_Health_During_Upgrade.md
@@ -26,7 +26,18 @@
 
 1. Validate CSM health.
 
-    See [Validate CSM Health](../operations/validate_csm_health.md).
+    Run the combined health check script, which runs a variety of health checks that should pass at this stage of the upgrade:
+
+    - Kubernetes health checks
+    - NCN health checks
+
+    ```bash
+    /opt/cray/tests/install/ncn/automated/ncn-k8s-combined-healthcheck-post-service-upgrade
+    ```
+
+    Review the output and follow the instructions provided to resolve any test failures. With the exception of
+    [Known issues with NCN health checks](../troubleshooting/known_issues/issues_with_ncn_health_checks.md),
+    all health checks are expected to pass.
 
 1. (`ncn-m002#`) Stop typescripts.
 


### PR DESCRIPTION
### Summary and Scope

Add combined health check for use after CSM services are upgraded, but NCNs have not yet rolled by IUF management node rollout.

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMPET-6670

### Testing

Drax (one expected failure):

```
ncn-m003:~ # /opt/cray/tests/install/ncn/automated/ncn-k8s-combined-healthcheck-post-service-upgrade

NCN and Kubernetes Checks (post CSM services upgrade)
------------------------------

Writing full output to /opt/cray/tests/install/logs/print_goss_json_results/20230718_212313.352790-566853-ygO1buGe/out

Running tests

Checking test results
Only errors will be printed to the screen

Result: FAIL
Source: http://ncn-m001.hmn:9008/ncn-healthcheck-master-single-post-service-upgrade
Test Name: Check hmnfd service
Description: Performs a basic health check on the hmnfd service. If this test fails, then manually run '/opt/cray/csm/scripts/hms_verification/run_hms_ct_tests.sh -t hmnfd' on the same node where the test failed. For more information, see 'troubleshooting/interpreting_hms_health_check_results.md' in the CSM documentation.
Test Summary: Command: hms-ct-test-hmnfd: exit-status:
Expected
    <int>: 1
to equal
    <int>: 0
Execution Time: 0.000020071 seconds
Node: ncn-m001



GRAND TOTAL: 679 passed, 1 failed
ERROR: There was at least one test failure

FAILED
```


Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
