### PR TITLE
CASMPET-6690 release/1.5 edit output in ceph-upgrade-tool.py

### DIFF
--- a/upgrade/scripts/ceph/ceph-upgrade-tool.py
+++ b/upgrade/scripts/ceph/ceph-upgrade-tool.py
@@ -116,6 +116,7 @@ def upgrade_ceph(registry='registry.local', conf_file="") -> bool:
         raise Exception(f'{error}') from error
     # run upgrade
     upgrade_cmd = {"prefix":"orch upgrade start", "image":upgrade_image}
+    print(f'\nSTARTING CEPH UPGRADE. Using image {upgrade_image}.')
     ceph_api.run_ceph_cmd(upgrade_cmd)
     ceph_api.disconnect()
     return True
@@ -354,7 +355,7 @@ def main():
     if upgrading:
         success, error = monitor_upgrade()
         if success:
-            print('Ceph upgraded succeeded.')
+            print('Ceph upgrade succeeded.')
         else:
             print(f'Error: Ceph upgrade failed. {error}')
             sys.exit(1)


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
Edit output in ceph-upgrade-tool.py.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
