### PR TITLE
CASMTRIAGE-5738 to release/1.5

### DIFF
--- a/workflows/iuf/operations/extract-release-distributions.yaml
+++ b/workflows/iuf/operations/extract-release-distributions.yaml
@@ -69,7 +69,7 @@ spec:
               - start-operation
             inline:
               script:
-                image: artifactory.algol60.net/csm-docker/stable/iuf:csm-latest
+                image: artifactory.algol60.net/csm-docker/stable/iuf:v0.1.12
                 command: [sh]
                 source: |
                   #!/bin/sh

--- a/workflows/templates/base/echo.template.argo.yaml
+++ b/workflows/templates/base/echo.template.argo.yaml
@@ -26,7 +26,7 @@ kind: WorkflowTemplate
 metadata:
   name: echo-template
   labels:
-    version: "4.0.1"
+    version: "4.0.2"
 spec:
   entrypoint: echo-message
   templates:

--- a/workflows/templates/base/echo.template.argo.yaml
+++ b/workflows/templates/base/echo.template.argo.yaml
@@ -44,7 +44,7 @@ spec:
         annotations:
           sidecar.istio.io/inject: "false"
       script:
-        image: artifactory.algol60.net/csm-docker/stable/iuf:csm-latest
+        image: artifactory.algol60.net/csm-docker/stable/iuf:v0.1.12
         command: [sh]
         source: |
           #!/usr/bin/bash

--- a/workflows/templates/base/iufBase.template.argo.yaml
+++ b/workflows/templates/base/iufBase.template.argo.yaml
@@ -26,7 +26,7 @@ kind: WorkflowTemplate
 metadata:
   name: iuf-base-template
   labels:
-    version: "4.0.2"
+    version: "4.0.3"
 spec:
   entrypoint: shell-script
   templates:


### PR DESCRIPTION
## Summary and Scope

We reverted our use of `csm-latest` tag for iuf-containers image because csm-latest tag was having cache issues local a machine.

After we switched back to using hard-coded version tags, it turns out we were still configuring the infrastructure to use csm-latest. This caused some problems. This PR completely removes csm-latest tag for iuf from CSM.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

Yes

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-5738](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5738)
* 
## Testing

### Tested on:

Not tested yet. Will be tested as part of CSM install

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_

No

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

