### PR TITLE
Configure smartmon metrics on storage nodes in 1.3.5 (CASMINST-6562)

### DIFF
--- a/install/deploy_non-compute_nodes.md
+++ b/install/deploy_non-compute_nodes.md
@@ -29,6 +29,7 @@ the number of storage and worker nodes.
     1. [Configure `kubectl` on the PIT](#23-configure-kubectl-on-the-pit)
     1. [Run Ceph Latency Repair Script](#24-run-ceph-latency-repair-script)
     1. [Check LVM on Kubernetes NCNs](#25-check-lvm-on-kubernetes-ncns)
+    1. [Enable `Smartmon` Metrics on Storage NCNs](#26-enable-smartmon-metrics-on-storage-ncns)
 1. [Cleanup](#3-cleanup)
 1. [Validate deployment](#4-validate-deployment)
 1. [Next topic](#next-topic)
@@ -324,6 +325,16 @@ If the check fails, stop and:
     ```
 
 If the check fails after doing the rebuild, contact support.
+
+### 2.6 Enable `Smartmon` Metrics on Storage NCNs
+
+This step will install the `smart-mon` rpm on storage nodes, and reconfigure the `node-exporter` to provide `smartmon` metrics.
+
+1. (`ncn-m001#`) Execute the following script.
+
+   ```bash
+   /usr/share/doc/csm/scripts/operations/ceph/enable-smart-mon-storage-nodes.sh
+   ```
 
 ## 3. Cleanup
 

--- a/scripts/operations/ceph/enable-smart-mon-storage-nodes.sh
+++ b/scripts/operations/ceph/enable-smart-mon-storage-nodes.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+smartmon_url=''
+ssh_options="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+
+function get_smartmon_url() {
+    local repos
+
+    if ! curl -sSfk https://packages.local/service/rest/v1/repositories >& /dev/null; then
+        echo "***"
+        echo "WARNING: Unable to contact Nexus! This must be addressed before proceeding."
+        echo "***"
+        return
+    fi
+
+    # get a list of repos that start with "csm-noos"
+    repos=$(curl -sSfk https://packages.local/service/rest/v1/repositories | jq -r '.[] | .["name"]' | grep ^csm-noos | tr '\n' ' ')
+
+    echo "Will look for smart-mon rpm in the following repos: $repos"
+
+    # search through the csm-noos repos looking for our package
+    for repo in $repos; do
+        # Retrieve the packages from nexus
+        test -n "$smartmon_url" || smartmon_url=$(paginate "https://packages.local/service/rest/v1/components?repository=$repo" \
+            | jq -r  '.items[] | .assets[] | .downloadUrl' | grep smart-mon | sort -V | tail -1)
+    done
+
+    test -z "$smartmon_url" && echo WARNING: unable to install smart-mon rpm
+}
+
+function paginate() {
+    local url="$1"
+    local token
+
+    if test -z $url; then
+        echo "ERROR: paginate() called without an argument"
+        exit 1
+    fi
+
+    { token="$(curl -sSk "$url" | tee /dev/fd/3 | jq -r '.continuationToken // null')"; } 3>&1
+
+    if test -z $token; then
+        echo "ERROR on line $LINENO: unable to retreive continuation token, exiting"
+        exit 1
+    fi
+
+    until [[ "$token" == "null" ]]; do
+        {
+            token="$(curl -sSk "$url&continuationToken=${token}" | tee /dev/fd/3 | jq -r '.continuationToken // null')";
+        } 3>&1
+
+        if test -z $token; then
+            echo "ERROR on line $LINENO: unable to retreive continuation token, exiting"
+            exit 1
+        fi
+    done
+}
+
+get_smartmon_url
+
+echo "Using ${smartmon_url} to install rpm on storage nodes..." 
+
+for storage_node in $(ceph orch host ls -f json |jq -r '.[].hostname'); do
+  echo "Installing smart-mon rpm on ${storage_node}..." 
+  ssh ${storage_node} ${ssh_options} "zypper in ${smartmon_url} && systemctl enable smart && systemctl restart smart"
+done
+
+echo "Reconfiguring node-exporter to publish smartmon data"
+ssh ncn-s001 ${ssh_options} "ceph orch apply -i /etc/cray/ceph/node-exporter.yml"

--- a/upgrade/1.3.5/README.md
+++ b/upgrade/1.3.5/README.md
@@ -11,6 +11,7 @@ If upgrading from CSM `v1.2.2` directly to `v1.3.5`, follow the procedures descr
 * Fixed authentication failure with the `keycloak` integration into Nexus due to a change to the `keycloak` `opa` policy which was recently patched.
 * Fixed `dvs-mqtt` error in the Spire server configuration - note this is only an issue for a customer already running `mqtt` in their environment.
 * Upgrade Ceph to `v16.2.13` and stop running local Docker registries on storage nodes.
+* Enables `smartmon` metrics on storage NCNs.
 
 ## Steps
 
@@ -20,6 +21,7 @@ If upgrading from CSM `v1.2.2` directly to `v1.3.5`, follow the procedures descr
 1. [Upgrade CANU](#upgrade-canu)
 1. [Upgrade services](#upgrade-services)
 1. [Upgrade Ceph and stop local Docker registries](#upgrade-ceph-and-stop-local-docker-registries)
+1. [Enable `Smartmon` Metrics on Storage NCNs](#enable-smartmon-metrics-on-storage-ncns)
 1. [Update test suite packages](#update-test-suite-packages)
 1. [Verification](#verification)
 1. [Complete upgrade](#complete-upgrade)
@@ -168,6 +170,16 @@ The third step stops the local Docker registry on all storage nodes.
    ```bash
    scp /usr/share/doc/csm/scripts/operations/ceph/disable_local_registry.sh ncn-s001:/srv/cray/scripts/common/disable_local_registry.sh
    ssh ncn-s001 "/srv/cray/scripts/common/disable_local_registry.sh"
+   ```
+
+## Enable `Smartmon` Metrics on Storage NCNs
+
+This step will install the `smart-mon` rpm on storage nodes, and reconfigure the `node-exporter` to provide `smartmon` metrics.
+
+1. (`ncn-m001#`) Execute the following script.
+
+   ```bash
+   /usr/share/doc/csm/scripts/operations/ceph/enable-smart-mon-storage-nodes.sh
    ```
 
 ## Update test suite packages

--- a/upgrade/Stage_0_Prerequisites.md
+++ b/upgrade/Stage_0_Prerequisites.md
@@ -18,6 +18,7 @@ Stage 0 has several critical procedures which prepare the environment and verify
   - [CSM-only system upgrade](#csm-only-system-upgrade)
 - [Stage 0.4 - Backup workload manager data](#stage-04---backup-workload-manager-data)
 - [Stage 0.5 - Regenerate Postgres backups](#stage-05---regenerate-postgres-backups)
+- [Stage 0.6 - Enable `Smartmon` Metrics on Storage NCNs](#stage-06---enable-smartmon-metrics-on-storage-ncns)
 - [Stop typescript](#stop-typescript)
 - [Stage completed](#stage-completed)
 
@@ -395,6 +396,16 @@ The current Postgres opt-in backups need to be re-generated to fix a known issue
 
    ```text
    Postgres backup(s) have been successfully regenerated.
+   ```
+
+## Stage 0.6 - Enable `Smartmon` Metrics on Storage NCNs
+
+This step will install the `smart-mon` rpm on storage nodes, and reconfigure the `node-exporter` to provide `smartmon` metrics.
+
+1. (`ncn-m001#`) Execute the following script.
+
+   ```bash
+   /usr/share/doc/csm/scripts/operations/ceph/enable-smart-mon-storage-nodes.sh
    ```
 
 ## Stop typescript


### PR DESCRIPTION
### Summary and Scope

Include smart-mon rpm in 1.3.5 patch

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMINST-6562

### Testing

Build output:

```
[2023-07-26T19:52:08.957Z] 2023-07-26 19:52:08,832	INFO	Adding password to password_mgr for https://artifactory.algol60.net/artifactory/

[2023-07-26T19:52:08.957Z] 2023-07-26 19:52:08,833	INFO	adding basic_auth_handler to opener

[2023-07-26T19:52:08.957Z] 2023-07-26 19:52:08,835	INFO	Reading https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/

[2023-07-26T19:52:09.219Z] 2023-07-26 19:52:09,137	INFO	https://artifactory.algol60.net/artifactory/ is the parent url of https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/

[2023-07-26T19:52:09.482Z] 2023-07-26 19:52:09,417	INFO	[200 OK] https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/smart-mon/noarch/smart-mon-1.0.3-1.noarch.rpm
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
