### PR TITLE
Remove PREPARE_ETCD step during master rebuild/upgrade (CASMPET-6335)

### DIFF
--- a/upgrade/scripts/common/upgrade-state.sh
+++ b/upgrade/scripts/common/upgrade-state.sh
@@ -26,142 +26,136 @@
 CSM_REL_NAME=${CSM_REL_NAME-"csm-${CSM_RELEASE}"}
 mkdir -p "/etc/cray/upgrade/csm/${CSM_REL_NAME}"
 
-function record_state () {
-    state_name=$1
-    local target_ncn=$2
-    local state_dir="/etc/cray/upgrade/csm/${CSM_REL_NAME}/${target_ncn}"
+function record_state() {
+  state_name=$1
+  local target_ncn=$2
+  local state_dir="/etc/cray/upgrade/csm/${CSM_REL_NAME}/${target_ncn}"
 
-    mkdir -p "${state_dir}"
+  mkdir -p "${state_dir}"
 
-    if [[ -z ${state_name} ]]; then
-        echo "state name is not specified"
-        exit 1
-    fi
-    if [[ -z ${target_ncn} ]]; then
-        echo "upgrade ncn is not specified"
-        exit 1
-    fi
-    state_recorded=$(is_state_recorded $state_name $target_ncn)
-    if [[ $state_recorded == "0" ]]; then
-        printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "${state_name}" >> "${state_dir}/state"
-    fi
-    echo "====> ${state_name} has been completed"
+  if [[ -z ${state_name} ]]; then
+    echo "state name is not specified"
+    exit 1
+  fi
+  if [[ -z ${target_ncn} ]]; then
+    echo "upgrade ncn is not specified"
+    exit 1
+  fi
+  state_recorded=$(is_state_recorded $state_name $target_ncn)
+  if [[ $state_recorded == "0" ]]; then
+    printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "${state_name}" >> "${state_dir}/state"
+  fi
+  echo "====> ${state_name} has been completed"
 }
 
-function is_state_recorded () {
-    state_name=$1
-    local target_ncn=$2
-    local state_dir="/etc/cray/upgrade/csm/${CSM_REL_NAME}/${target_ncn}"
+function is_state_recorded() {
+  state_name=$1
+  local target_ncn=$2
+  local state_dir="/etc/cray/upgrade/csm/${CSM_REL_NAME}/${target_ncn}"
 
-    mkdir -p "${state_dir}"
+  mkdir -p "${state_dir}"
 
-    if [[ -z ${state_name} ]]; then
-        echo "state name is not specified"
-        exit 1
-    fi
-    if [[ -z ${target_ncn} ]]; then
-        echo "upgrade ncn is not specified"
-        exit 1
-    fi
-    state_recorded=$(grep "${state_name}" "${state_dir}/state" 2>/dev/null | wc -l)
-    if [[ ${state_recorded} != 0 ]]; then
-        echo "1"
-    else
-        echo "0"
-    fi
+  if [[ -z ${state_name} ]]; then
+    echo "state name is not specified"
+    exit 1
+  fi
+  if [[ -z ${target_ncn} ]]; then
+    echo "upgrade ncn is not specified"
+    exit 1
+  fi
+  state_recorded=$(grep "${state_name}" "${state_dir}/state" 2> /dev/null | wc -l)
+  if [[ ${state_recorded} != 0 ]]; then
+    echo "1"
+  else
+    echo "0"
+  fi
 }
 
-function move_state_file () {
-    # we only rename the state file
-    # this will not block another upgrade/rebuild/reboot
-    # it also leaves a trace of what happened before
-    local target_ncn=$1
-    local state_dir="/etc/cray/upgrade/csm/${CSM_REL_NAME}/${target_ncn}"
-    
-    mv "${state_dir}/state" "${state_dir}/state.bak"
+function move_state_file() {
+  # we only rename the state file
+  # this will not block another upgrade/rebuild/reboot
+  # it also leaves a trace of what happened before
+  local target_ncn=$1
+  local state_dir="/etc/cray/upgrade/csm/${CSM_REL_NAME}/${target_ncn}"
+
+  mv "${state_dir}/state" "${state_dir}/state.bak"
 }
 
 function err_report() {
-    #shellcheck disable=SC2155
-    local caller="$(caller)"
-    local cmd="$BASH_COMMAND"
-    if [[ -n $NO_ERROR_TRAP ]]; then
-        return 0
-    fi
-    # add more logging to capture next where exactly the error happened
-    echo "${caller}"
-    echo "${cmd}"
+  #shellcheck disable=SC2155
+  local caller="$(caller)"
+  local cmd="$BASH_COMMAND"
+  if [[ -n $NO_ERROR_TRAP ]]; then
+    return 0
+  fi
+  # add more logging to capture next where exactly the error happened
+  echo "${caller}"
+  echo "${cmd}"
 
-    # restore previous ssh config if there was one, remove ours
-    rm -f /root/.ssh/config
-    test -f /root/.ssh/config.bak && mv /root/.ssh/config.bak /root/.ssh/config
+  # restore previous ssh config if there was one, remove ours
+  rm -f /root/.ssh/config
+  test -f /root/.ssh/config.bak && mv /root/.ssh/config.bak /root/.ssh/config
 
-    # ignore some internal expected errors
-    local ignoreCmd="cray artifacts list config-data"
-    shouldIgnore=$(echo "$cmd" | grep "${ignoreCmd}" | wc -l)
-    if [[ ${shouldIgnore} -eq 1 ]]; then
-        return 0
-    fi
+  # ignore some internal expected errors
+  local ignoreCmd="cray artifacts list config-data"
+  shouldIgnore=$(echo "$cmd" | grep "${ignoreCmd}" | wc -l)
+  if [[ ${shouldIgnore} -eq 1 ]]; then
+    return 0
+  fi
 
-    ignoreCmd="https://api-gw-service-nmn.local/apis/bss/boot/v1/endpoint-history"
-    shouldIgnore=$(echo "$cmd" | grep "${ignoreCmd}" | wc -l)
-    if [[ ${shouldIgnore} -eq 1 ]]; then
-        return 0
-    fi
+  ignoreCmd="https://api-gw-service-nmn.local/apis/bss/boot/v1/endpoint-history"
+  shouldIgnore=$(echo "$cmd" | grep "${ignoreCmd}" | wc -l)
+  if [[ ${shouldIgnore} -eq 1 ]]; then
+    return 0
+  fi
 
-    ignoreCmd="csi automate ncn etcd --action add-member --ncn"
-    shouldIgnore=$(echo "$cmd" | grep "${ignoreCmd}" | wc -l)
-    if [[ ${shouldIgnore} -eq 1 ]]; then
-        return 0
-    fi
-    
-    # check if /dev/tty is available, it is not available when using argo workflows
-    if sh -c ": >/dev/tty" >/dev/null 2>/dev/null; then
-        # /dev/tty is available and usable
-        # force output to console regardless of redirection
-        echo >/dev/tty 
-        echo "[ERROR] - Unexpected errors, check logs: ${LOG_FILE}" >/dev/tty
-    else
-        # /dev/tty is not available
-        echo
-        echo "[ERROR] - Unexpected errors, check logs: ${LOG_FILE}"
-    fi
-    # avoid shell double trap
-    NO_ERROR_TRAP=1
+  # check if /dev/tty is available, it is not available when using argo workflows
+  if sh -c ": >/dev/tty" > /dev/null 2> /dev/null; then
+    # /dev/tty is available and usable
+    # force output to console regardless of redirection
+    echo > /dev/tty
+    echo "[ERROR] - Unexpected errors, check logs: ${LOG_FILE}" > /dev/tty
+  else
+    # /dev/tty is not available
+    echo
+    echo "[ERROR] - Unexpected errors, check logs: ${LOG_FILE}"
+  fi
+  # avoid shell double trap
+  NO_ERROR_TRAP=1
 }
 
 function ok_report() {
-    # check if /dev/tty is available, it is not available when using argo workflows
-    if sh -c ": >/dev/tty" >/dev/null 2>/dev/null; then
-        # /dev/tty is available and usable
-        # force output to console regardless of redirection
-        echo >/dev/tty 
-        echo "[OK] - Successfully completed" >/dev/tty
-    else
-        # /dev/tty is not available
-        echo
-        echo "[OK] - Successfully completed"
-    fi
-    # avoid shell double trap
-    NO_ERROR_TRAP=1
+  # check if /dev/tty is available, it is not available when using argo workflows
+  if sh -c ": >/dev/tty" > /dev/null 2> /dev/null; then
+    # /dev/tty is available and usable
+    # force output to console regardless of redirection
+    echo > /dev/tty
+    echo "[OK] - Successfully completed" > /dev/tty
+  else
+    # /dev/tty is not available
+    echo
+    echo "[OK] - Successfully completed"
+  fi
+  # avoid shell double trap
+  NO_ERROR_TRAP=1
 }
 
 function argo_err_report() {
-    #shellcheck disable=SC2155
-    local caller="$(caller)"
-    local cmd="$BASH_COMMAND"
-    if [[ -n $NO_ERROR_TRAP ]]; then
-        return 0
-    fi
-    # add more logging to capture next where exactly the error happened
-    echo "${caller}"
-    echo "${cmd}"
+  #shellcheck disable=SC2155
+  local caller="$(caller)"
+  local cmd="$BASH_COMMAND"
+  if [[ -n $NO_ERROR_TRAP ]]; then
+    return 0
+  fi
+  # add more logging to capture next where exactly the error happened
+  echo "${caller}"
+  echo "${cmd}"
 
-    # in case we have left over temp files
-    rm -f /tmp/argo-res.* > /dev/null 2>&1 || true
+  # in case we have left over temp files
+  rm -f /tmp/argo-res.* > /dev/null 2>&1 || true
 
-    echo
-    echo "[ERROR] - Unexpected errors"
-    # avoid shell double trap
-    NO_ERROR_TRAP=1
+  echo
+  echo "[ERROR] - Unexpected errors"
+  # avoid shell double trap
+  NO_ERROR_TRAP=1
 }

--- a/upgrade/scripts/rebuild/ncn-rebuild-master-nodes.sh
+++ b/upgrade/scripts/rebuild/ncn-rebuild-master-nodes.sh
@@ -24,7 +24,7 @@
 #
 
 set -e
-basedir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+basedir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 . ${basedir}/../common/upgrade-state.sh
 trap 'err_report' ERR
 
@@ -38,124 +38,100 @@ ssh_keygen_keyscan $1
 state_name="ENSURE_CSI_IS_INSTALLED"
 state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
 if [[ $state_recorded == "0" ]]; then
-    echo "====> ${state_name} ..."
-    if ! command -v csi > /dev/null; then
-        zypper --non-interactive install cray-site-init
-    fi
-    record_state "${state_name}" ${target_ncn}
+  echo "====> ${state_name} ..."
+  if ! command -v csi > /dev/null; then
+    zypper --non-interactive install cray-site-init
+  fi
+  record_state "${state_name}" ${target_ncn}
 else
-    echo "====> ${state_name} has been completed"
+  echo "====> ${state_name} has been completed"
 fi
 
 # Back up local files and directories used by System Admin Toolkit (SAT)
 state_name="BACKUP_SAT_LOCAL_FILES"
 state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
 if [[ $state_recorded == "0" ]]; then
-    echo "====> ${state_name} ..."
-    sat_paths_to_backup="/root/.config/sat/sat.toml
+  echo "====> ${state_name} ..."
+  sat_paths_to_backup="/root/.config/sat/sat.toml
         /root/.config/sat/tokens/
         /root/.config/sat/s3_access_key
         /root/.config/sat/s3_secret_key
         /var/log/cray/sat/sat.log"
-    # We would use mktemp here, but that will not work if this script runs multiple times.
-    sat_backup_directory="/tmp/sat-backup-${target_ncn}"
-    mkdir -p $sat_backup_directory
-    for path in $sat_paths_to_backup; do
-        # Check path exists on the remote host
-        if ssh "$target_ncn" "ls $path" 2>/dev/null; then
-            echo "Copying $path from $target_ncn to $sat_backup_directory"
-            mkdir -p "$(dirname "${sat_backup_directory}/${path}")"
-            rsync -azl "${target_ncn}:${path}" "${sat_backup_directory}/${path}"
-        else
-            echo "Path $path does not exist on host $target_ncn"
-        fi
-    done
-    echo "SAT local files backed up to $sat_backup_directory"
-    record_state "${state_name}" ${target_ncn}
+  # We would use mktemp here, but that will not work if this script runs multiple times.
+  sat_backup_directory="/tmp/sat-backup-${target_ncn}"
+  mkdir -p $sat_backup_directory
+  for path in $sat_paths_to_backup; do
+    # Check path exists on the remote host
+    if ssh "$target_ncn" "ls $path" 2> /dev/null; then
+      echo "Copying $path from $target_ncn to $sat_backup_directory"
+      mkdir -p "$(dirname "${sat_backup_directory}/${path}")"
+      rsync -azl "${target_ncn}:${path}" "${sat_backup_directory}/${path}"
+    else
+      echo "Path $path does not exist on host $target_ncn"
+    fi
+  done
+  echo "SAT local files backed up to $sat_backup_directory"
+  record_state "${state_name}" ${target_ncn}
 else
-    echo "====> ${state_name} has been completed"
+  echo "====> ${state_name} has been completed"
 fi
 
 if [[ ${target_ncn} == "ncn-m001" ]]; then
-   state_name="BACKUP_M001_NET_CONFIG"
-   state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
-   if [[ $state_recorded == "0" ]]; then
-      echo "====> ${state_name} ..."
+  state_name="BACKUP_M001_NET_CONFIG"
+  state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
+  if [[ $state_recorded == "0" ]]; then
+    echo "====> ${state_name} ..."
 
-      scp root@ncn-m001:/etc/sysconfig/network/ifcfg-lan0 .
-      record_state "${state_name}" ${target_ncn}
-   else
-      echo "====> ${state_name} has been completed"
-   fi
+    scp root@ncn-m001:/etc/sysconfig/network/ifcfg-lan0 .
+    record_state "${state_name}" ${target_ncn}
+  else
+    echo "====> ${state_name} has been completed"
+  fi
 fi
 
-first_master_hostname=`curl -s -k -H "Authorization: Bearer ${TOKEN}" https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters?name=Global | \
-     jq -r '.[] | ."cloud-init"."meta-data"."first-master-hostname"'`
+first_master_hostname=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters?name=Global \
+  | jq -r '.[] | ."cloud-init"."meta-data"."first-master-hostname"')
 #shellcheck disable=SC2053
 if [[ ${first_master_hostname} == ${target_ncn} ]]; then
-   state_name="RECONFIGURE_FIRST_MASTER"
-   state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
-   if [[ $state_recorded == "0" ]]; then
-      echo "====> ${state_name} ..."
-      promotingMaster="none"
-      masterNodes=$(kubectl get nodes| grep "ncn-m" | awk '{print $1}')
-      for node in $masterNodes; do
-        # skip target_ncn
-        if [[ ${node} == ${target_ncn} ]]; then
-            continue;
-        fi
-        # check if cloud-init data is healthy
-        ssh $node -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null 'cloud-init query -a > /dev/null 2>&1'
-        rc=$?
-        if [[ "$rc" -eq 0 ]]; then
-            promotingMaster=$node
-            echo "Promote: ${promotingMaster} to be FIRST_MASTER"
-            break;
-        fi
-      done
-
-      if [[ ${promotingMaster} == "none" ]];then
-        echo "No master nodes has healthy cloud-init metadata, fail upgrade. You may try to upgrade another master node first. If that still fails, we do not have any master nodes that can be promoted."
-        exit 1
-      fi
-
-      # Validate SLS health before calling csi handoff bss-update-*, since
-      # it relies on SLS
-      check_sls_health
-
-      scp /root/docs-csm-latest.noarch.rpm $promotingMaster:/root/docs-csm-latest.noarch.rpm
-      ssh $promotingMaster "rpm --force -Uvh /root/docs-csm-latest.noarch.rpm"
-      ssh $promotingMaster -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "/usr/share/doc/csm/upgrade/scripts/k8s/promote-initial-master.sh"
-      VERBOSE=1 csi handoff bss-update-cloud-init --set meta-data.first-master-hostname=$promotingMaster --limit Global
-
-      record_state "${state_name}" ${target_ncn}
-   else
-      echo "====> ${state_name} has been completed"
-   fi
-fi
-
-state_name="PREPARE_ETCD"
-state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
-if [[ $state_recorded == "0" ]]; then
+  state_name="RECONFIGURE_FIRST_MASTER"
+  state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
+  if [[ $state_recorded == "0" ]]; then
     echo "====> ${state_name} ..."
-    csi automate ncn etcd --action remove-member --ncn $target_ncn --kubeconfig /etc/kubernetes/admin.conf
-    ssh $target_ncn 'systemctl daemon-reload'
-    ssh $target_ncn 'systemctl stop etcd.service'
-    
-    set +e
-    while true ; do    
-        csi automate ncn etcd --action add-member --ncn $target_ncn --kubeconfig /etc/kubernetes/admin.conf
-        if [[ $? -eq 0 ]]; then
-            break
-        else
-            sleep 5
-        fi
+    promotingMaster="none"
+    masterNodes=$(kubectl get nodes | grep "ncn-m" | awk '{print $1}')
+    for node in $masterNodes; do
+      # skip target_ncn
+      if [[ ${node} == ${target_ncn} ]]; then
+        continue
+      fi
+      # check if cloud-init data is healthy
+      ssh $node -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null 'cloud-init query -a > /dev/null 2>&1'
+      rc=$?
+      if [[ $rc -eq 0 ]]; then
+        promotingMaster=$node
+        echo "Promote: ${promotingMaster} to be FIRST_MASTER"
+        break
+      fi
     done
-    set -e
+
+    if [[ ${promotingMaster} == "none" ]]; then
+      echo "No master nodes has healthy cloud-init metadata, fail upgrade. You may try to upgrade another master node first. If that still fails, we do not have any master nodes that can be promoted."
+      exit 1
+    fi
+
+    # Validate SLS health before calling csi handoff bss-update-*, since
+    # it relies on SLS
+    check_sls_health
+
+    scp /root/docs-csm-latest.noarch.rpm $promotingMaster:/root/docs-csm-latest.noarch.rpm
+    ssh $promotingMaster "rpm --force -Uvh /root/docs-csm-latest.noarch.rpm"
+    ssh $promotingMaster -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "/usr/share/doc/csm/upgrade/scripts/k8s/promote-initial-master.sh"
+    VERBOSE=1 csi handoff bss-update-cloud-init --set meta-data.first-master-hostname=$promotingMaster --limit Global
 
     record_state "${state_name}" ${target_ncn}
-else
+  else
     echo "====> ${state_name} has been completed"
+  fi
 fi
 
 drain_node $target_ncn
@@ -165,13 +141,13 @@ drain_node $target_ncn
 check_sls_health
 
 set +e
-while true ; do    
-    csi handoff bss-update-param --set metal.no-wipe=0 --limit $TARGET_XNAME
-    if [[ $? -eq 0 ]]; then
-        break
-    else
-        sleep 5
-    fi
+while true; do
+  csi handoff bss-update-param --set metal.no-wipe=0 --limit $TARGET_XNAME
+  if [[ $? -eq 0 ]]; then
+    break
+  else
+    sleep 5
+  fi
 done
 set -e
 
@@ -181,34 +157,34 @@ ${basedir}/../common/ncn-rebuild-common.sh $target_ncn --rebuild
 state_name="RESTORE_SAT_LOCAL_FILES"
 state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
 if [[ $state_recorded == "0" ]]; then
-    echo "====> ${state_name} ..."
-    sat_backup_directory="/tmp/sat-backup-${target_ncn}/"
-    # Check the existence of the SAT backup directory. The directory missing should
-    # not happen, but if it does the upgrade script probably should not fail.
-    if [ -d "$sat_backup_directory" ]; then
-        # Do not preserve ownership as this could lead to the owner of /root/ changing.
-        rsync -az --no-o "$sat_backup_directory" "${target_ncn}:/"
-    else
-        echo "$sat_backup_directory does not exist"
-    fi
-    record_state "${state_name}" ${target_ncn}
+  echo "====> ${state_name} ..."
+  sat_backup_directory="/tmp/sat-backup-${target_ncn}/"
+  # Check the existence of the SAT backup directory. The directory missing should
+  # not happen, but if it does the upgrade script probably should not fail.
+  if [ -d "$sat_backup_directory" ]; then
+    # Do not preserve ownership as this could lead to the owner of /root/ changing.
+    rsync -az --no-o "$sat_backup_directory" "${target_ncn}:/"
+  else
+    echo "$sat_backup_directory does not exist"
+  fi
+  record_state "${state_name}" ${target_ncn}
 else
-    echo "====> ${state_name} has been completed"
+  echo "====> ${state_name} has been completed"
 fi
 
 # Install the docs-csm on newly upgraded master
 state_name="INSTALL_DOCS_NEW_MASTER"
 state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
 if [[ $state_recorded == "0" ]]; then
-    echo "====> ${state_name} ..."
-    record_state "${state_name}" ${target_ncn}
-    scp /root/docs-csm-latest.noarch.rpm $target_ncn:/root/docs-csm-latest.noarch.rpm
-    ssh $target_ncn "rpm --force -Uvh /root/docs-csm-latest.noarch.rpm"
+  echo "====> ${state_name} ..."
+  record_state "${state_name}" ${target_ncn}
+  scp /root/docs-csm-latest.noarch.rpm $target_ncn:/root/docs-csm-latest.noarch.rpm
+  ssh $target_ncn "rpm --force -Uvh /root/docs-csm-latest.noarch.rpm"
 else
-    echo "====> ${state_name} has been completed"
+  echo "====> ${state_name} has been completed"
 fi
 
-cat <<EOF
+cat << EOF
 NOTE:
     If below test failed, try to fix it based on test output. Then run current script again
 EOF

--- a/upgrade/scripts/upgrade/ncn-upgrade-master-nodes.sh
+++ b/upgrade/scripts/upgrade/ncn-upgrade-master-nodes.sh
@@ -24,7 +24,7 @@
 #
 
 set -e
-basedir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+basedir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 . ${basedir}/../common/upgrade-state.sh
 trap 'err_report' ERR
 
@@ -38,8 +38,8 @@ ssh_keygen_keyscan $1
 state_name="BACKUP_SAT_LOCAL_FILES"
 state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
 if [[ $state_recorded == "0" ]]; then
-    echo "====> ${state_name} ..."
-    {
+  echo "====> ${state_name} ..."
+  {
     sat_paths_to_backup="/root/.config/sat/sat.toml
         /root/.config/sat/tokens/
         /root/.config/sat/s3_access_key
@@ -49,76 +49,76 @@ if [[ $state_recorded == "0" ]]; then
     sat_backup_directory="/tmp/sat-backup-${target_ncn}"
     mkdir -p $sat_backup_directory
     for path in $sat_paths_to_backup; do
-        # Check path exists on the remote host
-        if ssh "$target_ncn" "ls $path" 2>/dev/null; then
-            echo "Copying $path from $target_ncn to $sat_backup_directory"
-            mkdir -p "$(dirname "${sat_backup_directory}/${path}")"
-            rsync -azl "${target_ncn}:${path}" "${sat_backup_directory}/${path}"
-        else
-            echo "Path $path does not exist on host $target_ncn"
-        fi
+      # Check path exists on the remote host
+      if ssh "$target_ncn" "ls $path" 2> /dev/null; then
+        echo "Copying $path from $target_ncn to $sat_backup_directory"
+        mkdir -p "$(dirname "${sat_backup_directory}/${path}")"
+        rsync -azl "${target_ncn}:${path}" "${sat_backup_directory}/${path}"
+      else
+        echo "Path $path does not exist on host $target_ncn"
+      fi
     done
     echo "SAT local files backed up to $sat_backup_directory"
-    } >> ${LOG_FILE} 2>&1
-    record_state "${state_name}" ${target_ncn}
+  } >> ${LOG_FILE} 2>&1
+  record_state "${state_name}" ${target_ncn}
 else
-    echo "====> ${state_name} has been completed"
+  echo "====> ${state_name} has been completed"
 fi
 
 if [[ ${target_ncn} == "ncn-m001" ]]; then
-   state_name="BACKUP_M001_NET_CONFIG"
-   state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
-   if [[ $state_recorded == "0" ]]; then
-      echo "====> ${state_name} ..."
-      {
+  state_name="BACKUP_M001_NET_CONFIG"
+  state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
+  if [[ $state_recorded == "0" ]]; then
+    echo "====> ${state_name} ..."
+    {
       scp root@ncn-m001:/etc/sysconfig/network/ifcfg-lan0 .
-      } >> ${LOG_FILE} 2>&1
-      record_state "${state_name}" ${target_ncn}
-   else
-      echo "====> ${state_name} has been completed"
-   fi
+    } >> ${LOG_FILE} 2>&1
+    record_state "${state_name}" ${target_ncn}
+  else
+    echo "====> ${state_name} has been completed"
+  fi
 fi
 
 if helm ls -n operators | grep -q etcd-operator; then
-   old_clusters=$(kubectl get etcdclusters.etcd.database.coreos.com -A --output=custom-columns=name:.metadata.name --no-headers 2>&1)
-   if [ "$old_clusters" != "No resources found" ]; then
-      echo "Upgrade Failed!  The following etcd cluster(s) will not function with"
-      echo "Kubernetes 1.22 and must be converted to the bitnami etcd helm chart:"
-      echo ""
-      echo $old_clusters
-      exit 1
-   fi
-   echo "Uninstalling deprecated etcd-operator"
-   helm uninstall -n operators cray-etcd-operator
+  old_clusters=$(kubectl get etcdclusters.etcd.database.coreos.com -A --output=custom-columns=name:.metadata.name --no-headers 2>&1)
+  if [ "$old_clusters" != "No resources found" ]; then
+    echo "Upgrade Failed!  The following etcd cluster(s) will not function with"
+    echo "Kubernetes 1.22 and must be converted to the bitnami etcd helm chart:"
+    echo ""
+    echo $old_clusters
+    exit 1
+  fi
+  echo "Uninstalling deprecated etcd-operator"
+  helm uninstall -n operators cray-etcd-operator
 fi
 
 {
-first_master_hostname=`curl -s -k -H "Authorization: Bearer ${TOKEN}" https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters?name=Global | \
-     jq -r '.[] | ."cloud-init"."meta-data"."first-master-hostname"'`
-#shellcheck disable=SC2053
-if [[ ${first_master_hostname} == ${target_ncn} ]]; then
-   state_name="RECONFIGURE_FIRST_MASTER"
-   state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
-   if [[ $state_recorded == "0" ]]; then
+  first_master_hostname=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters?name=Global \
+    | jq -r '.[] | ."cloud-init"."meta-data"."first-master-hostname"')
+  #shellcheck disable=SC2053
+  if [[ ${first_master_hostname} == ${target_ncn} ]]; then
+    state_name="RECONFIGURE_FIRST_MASTER"
+    state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
+    if [[ $state_recorded == "0" ]]; then
       echo "====> ${state_name} ..."
       promotingMaster="none"
-      masterNodes=$(kubectl get nodes| grep "ncn-m" | awk '{print $1}')
+      masterNodes=$(kubectl get nodes | grep "ncn-m" | awk '{print $1}')
       for node in $masterNodes; do
         # skip target_ncn
         if [[ ${node} == ${target_ncn} ]]; then
-            continue;
+          continue
         fi
         # check if cloud-init data is healthy
         ssh $node -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null 'cloud-init query -a > /dev/null 2>&1'
         rc=$?
-        if [[ "$rc" -eq 0 ]]; then
-            promotingMaster=$node
-            echo "Promote: ${promotingMaster} to be FIRST_MASTER"
-            break;
+        if [[ $rc -eq 0 ]]; then
+          promotingMaster=$node
+          echo "Promote: ${promotingMaster} to be FIRST_MASTER"
+          break
         fi
       done
 
-      if [[ ${promotingMaster} == "none" ]];then
+      if [[ ${promotingMaster} == "none" ]]; then
         echo "No master nodes has healthy cloud-init metadata, fail upgrade. You may try to upgrade another master node first. If that still fails, we do not have any master nodes that can be promoted."
         exit 1
       fi
@@ -133,36 +133,11 @@ if [[ ${first_master_hostname} == ${target_ncn} ]]; then
       VERBOSE=1 csi handoff bss-update-cloud-init --set meta-data.first-master-hostname=$promotingMaster --limit Global
 
       record_state "${state_name}" ${target_ncn}
-   else
+    else
       echo "====> ${state_name} has been completed"
-   fi
-fi
+    fi
+  fi
 } >> ${LOG_FILE} 2>&1
-
-state_name="PREPARE_ETCD"
-state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
-if [[ $state_recorded == "0" ]]; then
-    echo "====> ${state_name} ..."
-    {
-    csi automate ncn etcd --action remove-member --ncn $target_ncn --kubeconfig /etc/kubernetes/admin.conf
-    ssh $target_ncn 'systemctl daemon-reload'
-    ssh $target_ncn 'systemctl stop etcd.service'
-
-    set +e
-    while true ; do    
-        csi automate ncn etcd --action add-member --ncn $target_ncn --kubeconfig /etc/kubernetes/admin.conf
-        if [[ $? -eq 0 ]]; then
-            break
-        else
-            sleep 5
-        fi
-    done
-    set -e
-    } >> ${LOG_FILE} 2>&1
-    record_state "${state_name}" ${target_ncn}
-else
-    echo "====> ${state_name} has been completed"
-fi
 
 drain_node $target_ncn
 
@@ -171,16 +146,16 @@ drain_node $target_ncn
 check_sls_health >> "${LOG_FILE}" 2>&1
 
 {
-set +e
-while true ; do    
+  set +e
+  while true; do
     csi handoff bss-update-param --set metal.no-wipe=0 --limit $TARGET_XNAME
     if [[ $? -eq 0 ]]; then
-        break
+      break
     else
-        sleep 5
+      sleep 5
     fi
-done
-set -e
+  done
+  set -e
 } >> ${LOG_FILE} 2>&1
 
 ${basedir}/../common/ncn-rebuild-common.sh $target_ncn
@@ -189,39 +164,39 @@ ${basedir}/../common/ncn-rebuild-common.sh $target_ncn
 state_name="RESTORE_SAT_LOCAL_FILES"
 state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
 if [[ $state_recorded == "0" ]]; then
-    echo "====> ${state_name} ..."
-    {
+  echo "====> ${state_name} ..."
+  {
     sat_backup_directory="/tmp/sat-backup-${target_ncn}/"
     # Check the existence of the SAT backup directory. The directory missing should
     # not happen, but if it does the upgrade script probably should not fail.
     if [ -d "$sat_backup_directory" ]; then
-        # Do not preserve ownership as this could lead to the owner of /root/ changing.
-        rsync -az --no-o "$sat_backup_directory" "${target_ncn}:/"
+      # Do not preserve ownership as this could lead to the owner of /root/ changing.
+      rsync -az --no-o "$sat_backup_directory" "${target_ncn}:/"
     else
-        echo "$sat_backup_directory does not exist"
+      echo "$sat_backup_directory does not exist"
     fi
-    } >> ${LOG_FILE} 2>&1
-    record_state "${state_name}" ${target_ncn}
+  } >> ${LOG_FILE} 2>&1
+  record_state "${state_name}" ${target_ncn}
 else
-    echo "====> ${state_name} has been completed"
+  echo "====> ${state_name} has been completed"
 fi
 
 # Install the docs-csm on newly upgraded master
 state_name="INSTALL_DOCS_NEW_MASTER"
 state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
 if [[ $state_recorded == "0" ]]; then
-    echo "====> ${state_name} ..."
-    {
+  echo "====> ${state_name} ..."
+  {
     record_state "${state_name}" ${target_ncn}
     scp /root/docs-csm-latest.noarch.rpm $target_ncn:/root/docs-csm-latest.noarch.rpm
     ssh $target_ncn "rpm --force -Uvh /root/docs-csm-latest.noarch.rpm"
-    } >> ${LOG_FILE} 2>&1
-    record_state "${state_name}" ${target_ncn}
+  } >> ${LOG_FILE} 2>&1
+  record_state "${state_name}" ${target_ncn}
 else
-    echo "====> ${state_name} has been completed"
+  echo "====> ${state_name} has been completed"
 fi
 
-cat <<EOF
+cat << EOF
 NOTE:
     If below test failed, try to fix it based on test output. Then run current script again
 EOF


### PR DESCRIPTION
### Summary and Scope

This change removes the need during upgrade or rebuild of a master NCN to remove the member prior to rebuild. Instead, the cloud-init code will perform the add/remove on boot of the new node, and trigger the cluster membership add/remove code based soley on whether the disk has been wiped or not.

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMPET-6335

### Testing

Wiped a craystack master and re-ran cloud-init without removing that node from the cluster:

```
Successfully reached https://10.103.17.194:2379 endpoint to get member list
This disk has been wiped, removing this node from the etcd cluster if present
Found member id 9005cacc3e00c2a9 for this host, removing from the cluster.
Member 9005cacc3e00c2a9 removed from cluster d6803fc7cb861a0a
Adding https://10.103.17.125:2380 for ncn-m003 to the cluster
Member 57698d46faf521f1 added to cluster d6803fc7cb861a0a
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
