### PR TITLE
CASMPET-6706 remove upload_ceph_images_to_nexus and instead upgrade Ceph to 16.2.13 if not already upgraded 

### DIFF
--- a/scripts/operations/ceph/disable_local_registry.sh
+++ b/scripts/operations/ceph/disable_local_registry.sh
@@ -29,8 +29,8 @@
 # upgrade and by running redeploy_monitoring_stack_to_nexus.sh.
 
 function validate_all_daemons_are_running_nexus_image() {
-  for node in $(ceph orch host ls -f json |jq -r '.[].hostname'); do
-    for each in $(ssh ${node} ${ssh_options} "podman ps --format {{.Image}}" ); do
+  for node in $(ceph orch host ls -f json | jq -r '.[].hostname'); do
+    for each in $(ssh ${node} ${ssh_options} "podman ps --format {{.Image}}"); do
       if [[ -z $(echo $each | grep "registry.local/artifactory.algol60.net/csm-docker/stable/quay.io") && -z $(echo $each | grep "localhost/registry") ]]; then
         echo "$each is still being used. Not all Ceph daemons are using an image in Nexus."
         echo "The local registry should not be disabled until no Ceph daemons are using images from the local registry. Exiting."
@@ -44,7 +44,7 @@ function disable_local_registries() {
   echo "Disabling local docker registries"
   systemctl_force="--now"
 
-  for storage_node in $(ceph orch host ls -f json |jq -r '.[].hostname'); do
+  for storage_node in $(ceph orch host ls -f json | jq -r '.[].hostname'); do
     #shellcheck disable=SC2029
     if ssh ${storage_node} ${ssh_options} "systemctl disable registry.container.service ${systemctl_force}"; then
       if ! ssh ${storage_node} ${ssh_options} "systemctl is-enabled registry.container.service"; then

--- a/scripts/operations/ceph/disable_local_registry.sh
+++ b/scripts/operations/ceph/disable_local_registry.sh
@@ -29,15 +29,15 @@
 # upgrade and by running redeploy_monitoring_stack_to_nexus.sh.
 
 function validate_all_daemons_are_running_nexus_image() {
-    for node in $(ceph orch host ls -f json |jq -r '.[].hostname'); do
-        for each in $(ssh ${node} ${ssh_options} "podman ps --format {{.Image}}" ); do
-            if [[ -z $(echo $each | grep "registry.local/artifactory.algol60.net/csm-docker/stable/quay.io") && -z $(echo $each | grep "localhost/registry") ]]; then
-                echo "$each is still being used. Not all Ceph daemons are using an image in Nexus."
-                echo "The local registry should not be disabled until no Ceph daemons are using images from the local registry. Exiting."
-                exit 1
-            fi
-        done
+  for node in $(ceph orch host ls -f json |jq -r '.[].hostname'); do
+    for each in $(ssh ${node} ${ssh_options} "podman ps --format {{.Image}}" ); do
+      if [[ -z $(echo $each | grep "registry.local/artifactory.algol60.net/csm-docker/stable/quay.io") && -z $(echo $each | grep "localhost/registry") ]]; then
+        echo "$each is still being used. Not all Ceph daemons are using an image in Nexus."
+        echo "The local registry should not be disabled until no Ceph daemons are using images from the local registry. Exiting."
+        exit 1
+      fi
     done
+  done
 }
 
 function disable_local_registries() {
@@ -47,16 +47,16 @@ function disable_local_registries() {
   for storage_node in $(ceph orch host ls -f json |jq -r '.[].hostname'); do
     #shellcheck disable=SC2029
     if ssh ${storage_node} ${ssh_options} "systemctl disable registry.container.service ${systemctl_force}"; then
-       if ! ssh ${storage_node} ${ssh_options} "systemctl is-enabled registry.container.service"; then
-         echo "Docker registry service on ${storage_node} has been disabled"
-       fi
+      if ! ssh ${storage_node} ${ssh_options} "systemctl is-enabled registry.container.service"; then
+        echo "Docker registry service on ${storage_node} has been disabled"
+      fi
     fi
   done
 }
 
 function fix_registries_conf() {
   HEREFILE=$(mktemp)
-  cat > "${HEREFILE}" <<'EOF'
+  cat > "${HEREFILE}" << 'EOF'
 # For more information on this configuration file, see containers-registries.conf(5).
 #
 # Registries to search for images that are not fully-qualified.
@@ -113,7 +113,7 @@ insecure = true
 
 EOF
 
-  for storage_node in $(ceph orch host ls -f json |jq -r '.[].hostname'); do
+  for storage_node in $(ceph orch host ls -f json | jq -r '.[].hostname'); do
     scp ${ssh_options} "${HEREFILE}" "${storage_node}:/etc/containers/registries.conf"
   done
 } #end fix_registries_conf()

--- a/scripts/operations/ceph/disable_local_registry.sh
+++ b/scripts/operations/ceph/disable_local_registry.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# This will disable the local registry on all storage nodes.
+# This should be run once all Ceph daemons have transitioned to
+# using images in Nexus. This would have been done through a Ceph
+# upgrade and by running redeploy_monitoring_stack_to_nexus.sh.
+
+function validate_all_daemons_are_running_nexus_image() {
+    for node in $(ceph orch host ls -f json |jq -r '.[].hostname'); do
+        for each in $(ssh ${node} ${ssh_options} "podman ps --format {{.Image}}" ); do
+            if [[ -z $(echo $each | grep "registry.local/artifactory.algol60.net/csm-docker/stable/quay.io") && -z $(echo $each | grep "localhost/registry") ]]; then
+                echo "$each is still being used. Not all Ceph daemons are using an image in Nexus."
+                echo "The local registry should not be disabled until no Ceph daemons are using images from the local registry. Exiting."
+                exit 1
+            fi
+        done
+    done
+}
+
+function disable_local_registries() {
+  echo "Disabling local docker registries"
+  systemctl_force="--now"
+
+  for storage_node in $(ceph orch host ls -f json |jq -r '.[].hostname'); do
+    #shellcheck disable=SC2029
+    if ssh ${storage_node} ${ssh_options} "systemctl disable registry.container.service ${systemctl_force}"; then
+       if ! ssh ${storage_node} ${ssh_options} "systemctl is-enabled registry.container.service"; then
+         echo "Docker registry service on ${storage_node} has been disabled"
+       fi
+    fi
+  done
+}
+
+function fix_registries_conf() {
+  HEREFILE=$(mktemp)
+  cat > "${HEREFILE}" <<'EOF'
+# For more information on this configuration file, see containers-registries.conf(5).
+#
+# Registries to search for images that are not fully-qualified.
+# i.e. foobar.com/my_image:latest vs my_image:latest
+[registries.search]
+registries = []
+unqualified-search-registries = ["registry.local", "localhost"]
+
+# Registries that do not use TLS when pulling images or uses self-signed
+# certificates.
+[registries.insecure]
+registries = []
+unqualified-search-registries = ["localhost", "registry.local"]
+
+# Blocked Registries, blocks the  from pulling from the blocked registry.  If you specify
+# "*", then the docker daemon will only be allowed to pull from registries listed above in the search
+# registries.  Blocked Registries is deprecated because other container runtimes and tools will not use it.
+# It is recommended that you use the trust policy file /etc/containers/policy.json to control which
+# registries you want to allow users to pull and push from.  policy.json gives greater flexibility, and
+# supports all container runtimes and tools including the docker daemon, cri-o, buildah ...
+[registries.block]
+registries = []
+
+## ADD BELOW
+
+[[registry]]
+prefix = "registry.local"
+location = "registry.local"
+insecure = true
+
+[[registry.mirror]]
+prefix = "registry.local"
+location = "localhost:5000"
+insecure = true
+
+[[registry]]
+location = "localhost:5000"
+insecure = true
+
+[[registry]]
+prefix = "localhost"
+location = "localhost:5000"
+insecure = true
+
+[[registry]]
+prefix = "artifactory.algol60.net/csm-docker/stable/quay.io"
+location = "artifactory.algol60.net/csm-docker/stable/quay.io"
+insecure = true
+
+[[registry.mirror]]
+prefix = "artifactory.algol60.net/csm-docker/stable/quay.io"
+location = "registry.local/artifactory.algol60.net/csm-docker/stable/quay.io"
+insecure = true
+
+EOF
+
+  for storage_node in $(ceph orch host ls -f json |jq -r '.[].hostname'); do
+    scp ${ssh_options} "${HEREFILE}" "${storage_node}:/etc/containers/registries.conf"
+  done
+} #end fix_registries_conf()
+
+ssh_options="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+
+validate_all_daemons_are_running_nexus_image
+disable_local_registries
+fix_registries_conf

--- a/scripts/operations/ceph/redeploy_monitoring_stack_to_nexus.sh
+++ b/scripts/operations/ceph/redeploy_monitoring_stack_to_nexus.sh
@@ -50,9 +50,9 @@ function verify_monitoring_stack() {
     redeploy_failed_monitoring_daemons
     check_monitoring_daemons_using_nexus_image "false"
     if [[ $? -eq 0 ]]; then
-        monitoring_stack_redeployed="true"
+      monitoring_stack_redeployed="true"
     fi
-    mon_count=$(( mon_count + 1 ))
+    mon_count=$((mon_count + 1))
     if [[ $mon_count -eq 10 ]] && [[ $monitoring_stack_redeployed != "true" ]]; then
       echo "ERROR Redeploying monitoring stack onto images in Nexus. Manually investigate Ceph to see why monitoring stack cannot redeploy."
       echo "Run 'ceph health detail'."
@@ -69,7 +69,7 @@ function redeploy_failed_monitoring_daemons() {
   until [[ $should_recheck == 0 ]]; do
     should_recheck=0
     for daemon in "prometheus" "node-exporter" "alertmanager" "grafana"; do
-      # using grep to get the info below. jq cannot be used 
+      # using grep to get the info below. jq cannot be used
       # becasue some ceph 'event' values are incorrectly formatted and jq fails to filter json
       daemons_not_running=$(ceph orch ps --daemon_type $daemon | grep -v 'running' | tail -n+2 | awk '{print $1}')
       for each in $daemons_not_running; do
@@ -99,8 +99,8 @@ function check_monitoring_daemons_using_nexus_image() {
   echo "Checking that monitoring daemons are using the image in Nexus."
   all_using_nexus_image="true"
   for daemon in "prometheus" "node-exporter" "alertmanager" "grafana"; do
-    for node in $(ceph orch host ls -f json |jq -r '.[].hostname'); do
-      for each in $(ssh ${node} ${ssh_options} "podman ps --filter name=$daemon --format='{{.Image}},{{.ID}}'" ); do
+    for node in $(ceph orch host ls -f json | jq -r '.[].hostname'); do
+      for each in $(ssh ${node} ${ssh_options} "podman ps --filter name=$daemon --format='{{.Image}},{{.ID}}'"); do
         image=$(echo $each | awk -F, '{print $1}')
         container_id=$(echo $each | awk -F, '{print $2}')
         if [[ -z $(echo $image | grep "registry.local/artifactory.algol60.net/csm-docker/stable/quay.io") ]]; then

--- a/scripts/operations/ceph/redeploy_monitoring_stack_to_nexus.sh
+++ b/scripts/operations/ceph/redeploy_monitoring_stack_to_nexus.sh
@@ -69,14 +69,14 @@ function redeploy_failed_monitoring_daemons() {
   until [[ $should_recheck == 0 ]]; do
     should_recheck=0
     for daemon in "prometheus" "node-exporter" "alertmanager" "grafana"; do
-        # using grep to get the info below. jq cannot be used 
-        # becasue some ceph 'event' values are incorrectly formatted and jq fails to filter json
-        daemons_not_running=$(ceph orch ps --daemon_type $daemon | grep -v 'running' | tail -n+2 | awk '{print $1}')
-        for each in $daemons_not_running; do
-            should_recheck=1
-            echo "${each} is not 'running'. Redeploying ${each}."
-            ceph orch daemon redeploy $each
-        done
+      # using grep to get the info below. jq cannot be used 
+      # becasue some ceph 'event' values are incorrectly formatted and jq fails to filter json
+      daemons_not_running=$(ceph orch ps --daemon_type $daemon | grep -v 'running' | tail -n+2 | awk '{print $1}')
+      for each in $daemons_not_running; do
+        should_recheck=1
+        echo "${each} is not 'running'. Redeploying ${each}."
+        ceph orch daemon redeploy $each
+      done
     done
     if [[ $count -eq 10 ]]; then
       echo "ERROR Failed to redeploy Ceph monitoring stack. Please manually check \
@@ -84,11 +84,11 @@ that storage nodes are able to pull monitoring images from Nexus and that the 'C
 is set so that daemons are using container images in Nexus."
       exit 1
     else
-      count=$(( count + 1 ))
+      count=$((count + 1))
     fi
     if [[ $should_recheck -eq 1 ]]; then
-        echo "Sleeping 60 seconds to allow daemons to redeploy."
-        sleep 60
+      echo "Sleeping 60 seconds to allow daemons to redeploy."
+      sleep 60
     fi
   done
 } # end of redeploy_failed_monitoring_daemons()
@@ -137,26 +137,26 @@ function upload_ceph_container_images() {
 }
 
 function upload_image() {
-    # get local image and nexus image location
-    name=$1
-    prefix=$2
-    to_configure=$3
-    local_image=$(ceph --name client.ro orch ps --format json | jq --arg DAEMON "$name" '.[] | select(.daemon_type == $DAEMON) | .container_image_name' | tr -d '"' | sort -u | tail -1)
-    # if sha in image then remove and use version
-    if [[ $local_image == *"@sha"* ]]; then
-        without_sha=${local_image%"@sha"*}
-        version=$(ceph --name client.ro orch ps --format json | jq --arg DAEMON "$name" '.[] | select(.daemon_type == $DAEMON) | .version' | tr -d '"' | sort -u)
-        if [[ $version != "v"* ]]; then version="v""$version"; fi
-        local_image="$without_sha"":""$version"
-    fi
-    nexus_location="${prefix}""$(echo "$local_image" | rev | cut -d "/" -f1 | rev)"
+  # get local image and nexus image location
+  name=$1
+  prefix=$2
+  to_configure=$3
+  local_image=$(ceph --name client.ro orch ps --format json | jq --arg DAEMON "$name" '.[] | select(.daemon_type == $DAEMON) | .container_image_name' | tr -d '"' | sort -u | tail -1)
+  # if sha in image then remove and use version
+  if [[ $local_image == *"@sha"* ]]; then
+    without_sha=${local_image%"@sha"*}
+    version=$(ceph --name client.ro orch ps --format json | jq --arg DAEMON "$name" '.[] | select(.daemon_type == $DAEMON) | .version' | tr -d '"' | sort -u)
+    if [[ $version != "v"* ]]; then version="v""$version"; fi
+    local_image="$without_sha"":""$version"
+  fi
+  nexus_location="${prefix}""$(echo "$local_image" | rev | cut -d "/" -f1 | rev)"
 
-    # push images to nexus, point to nexus and run upgrade
-    echo -e "\nPushing image: $local_image to $nexus_location"
-    podman pull "$local_image"
-    podman tag "$local_image" "$nexus_location"
-    podman push --creds "$nexus_username":"$nexus_password" "$nexus_location"
-    ceph config set mgr $to_configure $nexus_location
+  # push images to nexus, point to nexus and run upgrade
+  echo -e "\nPushing image: $local_image to $nexus_location"
+  podman pull "$local_image"
+  podman tag "$local_image" "$nexus_location"
+  podman push --creds "$nexus_username":"$nexus_password" "$nexus_location"
+  ceph config set mgr $to_configure $nexus_location
 } # end of upload_image()
 
 ### END OF FUNCTIONS ###
@@ -178,8 +178,8 @@ fi
 
 check_monitoring_daemons_using_nexus_image "true"
 if [[ $? -eq 0 ]]; then
-    echo "Ceph monitoring daemons are already using images in Nexus."
-    exit 0
+  echo "Ceph monitoring daemons are already using images in Nexus."
+  exit 0
 fi
 
 upload_ceph_container_images

--- a/scripts/operations/ceph/redeploy_monitoring_stack_to_nexus.sh
+++ b/scripts/operations/ceph/redeploy_monitoring_stack_to_nexus.sh
@@ -1,0 +1,188 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# This script moves the Ceph monitoring daemons running a local image
+# to an image in Nexus. This pushes the local images to Nexus, sets the
+# Ceph configuration, and then redeploys the monitoring stack. Once this
+# script has completed, all Ceph monitoring daemons should be using an image
+# in Nexus.
+
+function redeploy_monitoring_stack() {
+  echo -e "\nREDEPLOYING CEPH MONITORING STACK."
+  echo "(This will redeploy all prometheus, node-exporter, alertmanager, and grafana daemons so that they will be using the container image in nexus.)"
+  for daemon in "prometheus" "node-exporter" "alertmanager" "grafana"; do
+    echo "Redploying $daemon daemons."
+    daemons_to_restart=$(ceph --name client.ro orch ps --daemon_type $daemon | awk '{print $1}' | tail -n+2)
+    for each in $daemons_to_restart; do
+      ceph orch daemon redeploy $each
+    done
+  done
+  sleep 90
+  verify_monitoring_stack
+}
+
+function verify_monitoring_stack() {
+  monitoring_stack_redeployed="false"
+  mon_count=0
+  until [[ $monitoring_stack_redeployed == "true" ]]; do
+    redeploy_failed_monitoring_daemons
+    check_monitoring_daemons_using_nexus_image "false"
+    if [[ $? -eq 0 ]]; then
+        monitoring_stack_redeployed="true"
+    fi
+    mon_count=$(( mon_count + 1 ))
+    if [[ $mon_count -eq 10 ]] && [[ $monitoring_stack_redeployed != "true" ]]; then
+      echo "ERROR Redeploying monitoring stack onto images in Nexus. Manually investigate Ceph to see why monitoring stack cannot redeploy."
+      echo "Run 'ceph health detail'."
+      exit 1
+    fi
+  done
+  echo "All Ceph monitoring daemons are using the image in Nexus."
+}
+
+function redeploy_failed_monitoring_daemons() {
+  echo -e "\nVerifying monitoring stack daemons are 'running'."
+  should_recheck=0
+  count=0
+  until [[ $should_recheck == 0 ]]; do
+    should_recheck=0
+    for daemon in "prometheus" "node-exporter" "alertmanager" "grafana"; do
+        # using grep to get the info below. jq cannot be used 
+        # becasue some ceph 'event' values are incorrectly formatted and jq fails to filter json
+        daemons_not_running=$(ceph orch ps --daemon_type $daemon | grep -v 'running' | tail -n+2 | awk '{print $1}')
+        for each in $daemons_not_running; do
+            should_recheck=1
+            echo "${each} is not 'running'. Redeploying ${each}."
+            ceph orch daemon redeploy $each
+        done
+    done
+    if [[ $count -eq 10 ]]; then
+      echo "ERROR Failed to redeploy Ceph monitoring stack. Please manually check \
+that storage nodes are able to pull monitoring images from Nexus and that the 'Ceph Config' \
+is set so that daemons are using container images in Nexus."
+      exit 1
+    else
+      count=$(( count + 1 ))
+    fi
+    if [[ $should_recheck -eq 1 ]]; then
+        echo "Sleeping 60 seconds to allow daemons to redeploy."
+        sleep 60
+    fi
+  done
+} # end of redeploy_failed_monitoring_daemons()
+
+function check_monitoring_daemons_using_nexus_image() {
+  # returns 1 if not all daemons are using Nexus image. Otherwise, returns 0
+  check_only=$1
+  echo "Checking that monitoring daemons are using the image in Nexus."
+  all_using_nexus_image="true"
+  for daemon in "prometheus" "node-exporter" "alertmanager" "grafana"; do
+    for node in $(ceph orch host ls -f json |jq -r '.[].hostname'); do
+      for each in $(ssh ${node} ${ssh_options} "podman ps --filter name=$daemon --format='{{.Image}},{{.ID}}'" ); do
+        image=$(echo $each | awk -F, '{print $1}')
+        container_id=$(echo $each | awk -F, '{print $2}')
+        if [[ -z $(echo $image | grep "registry.local/artifactory.algol60.net/csm-docker/stable/quay.io") ]]; then
+          daemon_name=$(ceph orch ps --daemon_type $daemon | grep $container_id | awk '{print $1}')
+          if [[ $check_only != "true" ]]; then
+            echo "$daemon_name is not using the image in Nexus. Redeploy $daemon_name."
+            ceph orch daemon redeploy $daemon_name
+            all_using_nexus_image="false"
+          else
+            return 1
+          fi
+        fi
+      done
+    done
+  done
+  if [[ $all_using_nexus_image == "false" ]] && [[ $check_only != "true" ]]; then
+    echo "Sleeping 60 seconds to allow daemons to redeploy."
+    sleep 60
+    return 1
+  fi
+  return 0
+}
+
+function upload_ceph_container_images() {
+  # Begin upload of local images into nexus
+  #prometheus, node-exporter, and alertmanager have this prefix
+  prometheus_prefix="registry.local/artifactory.algol60.net/csm-docker/stable/quay.io/prometheus/"
+  upload_image "prometheus" $prometheus_prefix "mgr/cephadm/container_image_prometheus"
+  upload_image "node-exporter" $prometheus_prefix "mgr/cephadm/container_image_node_exporter"
+  upload_image "alertmanager" $prometheus_prefix "mgr/cephadm/container_image_alertmanager"
+  ## grafana has this prfix
+  ceph_prefix="registry.local/artifactory.algol60.net/csm-docker/stable/quay.io/ceph/"
+  upload_image "grafana" $ceph_prefix "mgr/cephadm/container_image_grafana"
+}
+
+function upload_image() {
+    # get local image and nexus image location
+    name=$1
+    prefix=$2
+    to_configure=$3
+    local_image=$(ceph --name client.ro orch ps --format json | jq --arg DAEMON "$name" '.[] | select(.daemon_type == $DAEMON) | .container_image_name' | tr -d '"' | sort -u | tail -1)
+    # if sha in image then remove and use version
+    if [[ $local_image == *"@sha"* ]]; then
+        without_sha=${local_image%"@sha"*}
+        version=$(ceph --name client.ro orch ps --format json | jq --arg DAEMON "$name" '.[] | select(.daemon_type == $DAEMON) | .version' | tr -d '"' | sort -u)
+        if [[ $version != "v"* ]]; then version="v""$version"; fi
+        local_image="$without_sha"":""$version"
+    fi
+    nexus_location="${prefix}""$(echo "$local_image" | rev | cut -d "/" -f1 | rev)"
+
+    # push images to nexus, point to nexus and run upgrade
+    echo -e "\nPushing image: $local_image to $nexus_location"
+    podman pull "$local_image"
+    podman tag "$local_image" "$nexus_location"
+    podman push --creds "$nexus_username":"$nexus_password" "$nexus_location"
+    ceph config set mgr $to_configure $nexus_location
+} # end of upload_image()
+
+### END OF FUNCTIONS ###
+
+# pre-checks
+if [[ $(hostname) != @("ncn-s001"|"ncn-s002"|"ncn-s003") ]]; then
+  echo "This script can only be run from ncn-s001/2/3."
+  exit 1
+fi
+
+nexus_username="$(kubectl -n nexus get secret nexus-admin-credential --template '{{.data.username}}' | base64 --decode)"
+nexus_password="$(kubectl get secret -n nexus nexus-admin-credential --template '{{.data.password}}' | base64 --decode)"
+ssh_options="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+
+if [[ -z ${nexus_username} ]] || [[ -z ${nexus_password} ]]; then
+  echo "ERROR unable to get Nexus username or password. Make sure 'kubectl' commands can be run from the node this script is running on."
+  exit 1
+fi
+
+check_monitoring_daemons_using_nexus_image "true"
+if [[ $? -eq 0 ]]; then
+    echo "Ceph monitoring daemons are already using images in Nexus."
+    exit 0
+fi
+
+upload_ceph_container_images
+redeploy_monitoring_stack
+
+echo "Process is complete."

--- a/upgrade/scripts/ceph/ceph-upgrade-tool.py
+++ b/upgrade/scripts/ceph/ceph-upgrade-tool.py
@@ -167,8 +167,9 @@ def _verify_upgrade_version(starting_version: str, upgrade_version: str) -> bool
         print(f'Ceph version is already {starting_version}. Nothing to upgrade.')
         return False
     if not version.parse(starting_version) < version.parse(upgrade_version):
-        raise ValueError(f'Cannot upgrade Ceph. The upgrade version:{upgrade_version} \
-        is not greater than the current Ceph version running:{starting_version}.')
+        print(f'Cannot upgrade Ceph. The upgrade version:{upgrade_version} \
+is not greater than the current Ceph version running:{starting_version}.')
+        return False
     return True
 
 def _check_image_pull(image: str) -> None:

--- a/workflows/templates/storage.before-all.yaml
+++ b/workflows/templates/storage.before-all.yaml
@@ -55,7 +55,7 @@ spec:
                     csi_url=$(paginate "https://packages.local/service/rest/v1/components?repository=csm-sle-15sp4" \
                       | jq -r  '.items[] | .assets[] | .downloadUrl' | grep "cray-site-init" | sort -V | tail -1)
                     pdsh -S -w $(grep -oP 'ncn-\m\d+' /etc/hosts | sort -u | tr -t '\n' ',') "zypper install -y $csi_url"
-          - name: upload-ceph-stop-docker-registries
+          - name: upgrade-ceph-stop-docker-registries
             templateRef:
               name: ssh-template
               template: shell-script

--- a/workflows/templates/storage.before-all.yaml
+++ b/workflows/templates/storage.before-all.yaml
@@ -55,7 +55,7 @@ spec:
                     csi_url=$(paginate "https://packages.local/service/rest/v1/components?repository=csm-sle-15sp4" \
                       | jq -r  '.items[] | .assets[] | .downloadUrl' | grep "cray-site-init" | sort -V | tail -1)
                     pdsh -S -w $(grep -oP 'ncn-\m\d+' /etc/hosts | sort -u | tr -t '\n' ',') "zypper install -y $csi_url"
-          - name: upload-ceph-images-to-nexus
+          - name: upload-ceph-stop-docker-registries
             templateRef:
               name: ssh-template
               template: shell-script
@@ -65,17 +65,30 @@ spec:
                   value: "{{inputs.parameters.dryRun}}"
                 - name: scriptContent
                   value: |
-                    echo "This will upload Ceph images to nexus. It will restart ceph daemons so that they are using the image in nexus and not the local image."
-                    success=0
+                    echo "This will upgrade Ceph to v16.2.13 if Ceph is not already running that version. \
+                    It will then make sure Ceph monitoring daemons are running on the image in Nexus and will redeploy \
+                    them if they are running on a local image. Lastly, it will stop all local Docker registries running on storage nodes."
+
+                    export TERM=linux
+                    # setting PYTHONUNBUFFERED forces python to print output
+                    export PYTHONUNBUFFERED=1
+                    /usr/share/doc/csm/upgrade/scripts/ceph/ceph-upgrade-tool.py --version "v16.2.13"
+
                     for node in "ncn-s001" "ncn-s002" "ncn-s003"; do
-                      scp /usr/share/doc/csm/scripts/upload_ceph_images_to_nexus.sh ${node}:/srv/cray/scripts/common/upload_ceph_images_to_nexus.sh
-                      if [[ $(ssh ${node} "chmod +x /srv/cray/scripts/common/upload_ceph_images_to_nexus.sh; /srv/cray/scripts/common/upload_ceph_images_to_nexus.sh") ]]; then
-                        success=1
-                        break
+                      success=0
+                      scp /usr/share/doc/csm/scripts/operations/ceph/redeploy_monitoring_stack_to_nexus.sh ${node}:/srv/cray/scripts/common/redeploy_monitoring_stack_to_nexus.sh
+                      ssh ${node} "/srv/cray/scripts/common/redeploy_monitoring_stack_to_nexus.sh"
+                      if [[ $? -eq 0 ]]; then
+                        scp /usr/share/doc/csm/scripts/operations/ceph/disable_local_registry.sh ${node}:/srv/cray/scripts/common/disable_local_registry.sh
+                        ssh ${node} "/srv/cray/scripts/common/disable_local_registry.sh"
+                        if [[ $? -eq 0 ]]; then
+                          success=1
+                          break
+                        fi
                       fi
                     done
                     if [[ $success -eq 0 ]]; then
-                      echo "ERROR was not able to successfully run '/usr/share/doc/csm/scripts/upload_ceph_images_to_nexus.sh' on ncn-s00[1/2/3]."
+                      echo "ERROR was not able to upgrade Ceph, redeploy the monitoring stack and stop the local docker registries."
                       exit 1
                     fi
           - name: add-admin-label-to-ncn-s002


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
**Changes** - removed running upload_ceph_images_to_nexus.sh script and start running a Ceph upgrade instead. This Ceph upgrade should have been run as part of a 1.3.5 patch, or a 1.4 install, upgrade, or 1.4.2 patch. In an unexpected case where this has not already been run, this step will take care of it. If it has already been run, re-executing this step is not harmful and the step will run very fast.

**Reasoning** - In CSM 1.4 and later, we were running into issues with Ceph on upgrade because the container versions Ceph is running had changed Shas values which would stop daemons. In order to avoid this issue, we were running upload_ceph_images_to_nexus.sh before upgrading storage nodes. This script was not reliable and did not always work. We now are now performing a Ceph patch upgrade, specifically for running Smartmon on storage nodes, but this Ceph upgrade also helps resolve the sha issue. These new steps will upgrade Ceph to 16.2.13, redeploy the monitoring stack to images in Nexus, and will stop running local docker registries on Storage nodes. It is expected this step is run before the storage node upgrade, but if it is not, this step will resolve possible sha issues.

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
