### PR TITLE
CASMTRIAGE-5799-release/1.4 correct /etc/containers/registries.conf file written by disable_local_registry.sh

### DIFF
--- a/scripts/operations/ceph/disable_local_registry.sh
+++ b/scripts/operations/ceph/disable_local_registry.sh
@@ -56,59 +56,81 @@ function disable_local_registries() {
 
 function fix_registries_conf() {
   HEREFILE=$(mktemp)
-  cat > "${HEREFILE}" <<'EOF'
+  cat > "${HEREFILE}" << 'EOF'
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 # For more information on this configuration file, see containers-registries.conf(5).
 #
-# Registries to search for images that are not fully-qualified.
-# i.e. foobar.com/my_image:latest vs my_image:latest
-[registries.search]
-registries = []
-unqualified-search-registries = ["registry.local", "localhost"]
-
-# Registries that do not use TLS when pulling images or uses self-signed
-# certificates.
-[registries.insecure]
-registries = []
-unqualified-search-registries = ["localhost", "registry.local"]
-
-# Blocked Registries, blocks the  from pulling from the blocked registry.  If you specify
-# "*", then the docker daemon will only be allowed to pull from registries listed above in the search
-# registries.  Blocked Registries is deprecated because other container runtimes and tools will not use it.
-# It is recommended that you use the trust policy file /etc/containers/policy.json to control which
-# registries you want to allow users to pull and push from.  policy.json gives greater flexibility, and
-# supports all container runtimes and tools including the docker daemon, cri-o, buildah ...
-[registries.block]
-registries = []
-
-## ADD BELOW
+# NOTE: RISK OF USING UNQUALIFIED IMAGE NAMES
+# We recommend always using fully qualified image names including the registry
+# server (full dns name), namespace, image name, and tag
+# (e.g., registry.redhat.io/ubi8/ubi:latest). Pulling by digest (i.e.,
+# quay.io/repository/name@digest) further eliminates the ambiguity of tags.
+# When using short names, there is always an inherent risk that the image being
+# pulled could be spoofed. For example, a user wants to pull an image named
+# `foobar` from a registry and expects it to come from myregistry.com. If
+# myregistry.com is not first in the search list, an attacker could place a
+# different `foobar` image at a registry earlier in the search list. The user
+# would accidentally pull and run the attacker's image and code rather than the
+# intended content. We recommend only adding registries which are completely
+# trusted (i.e., registries which don't allow unknown or anonymous users to
+# create accounts with arbitrary names). This will prevent an image from being
+# spoofed, squatted or otherwise made insecure.  If it is necessary to use one
+# of these registries, it should be added at the end of the list.
+#
+# An array of host[:port] registries to try when pulling an unqualified image, in order.
+unqualified-search-registries = ["localhost",
+    "pit.nmn:5000",
+    "registry.local",
+    "stable"]
 
 [[registry]]
-prefix = "registry.local"
 location = "registry.local"
 insecure = true
 
 [[registry.mirror]]
 prefix = "registry.local"
-location = "localhost:5000"
+location = "pit.nmn:5000"
 insecure = true
 
 [[registry]]
-location = "localhost:5000"
+location = "pit.nmn:5000"
 insecure = true
 
+# The ones below are important for the artifactory build
 [[registry]]
-prefix = "localhost"
-location = "localhost:5000"
-insecure = true
-
-[[registry]]
-prefix = "artifactory.algol60.net/csm-docker/stable/quay.io"
-location = "artifactory.algol60.net/csm-docker/stable/quay.io"
+location = "artifactory.algol60.net"
 insecure = true
 
 [[registry.mirror]]
-prefix = "artifactory.algol60.net/csm-docker/stable/quay.io"
-location = "registry.local/artifactory.algol60.net/csm-docker/stable/quay.io"
+prefix = "artifactory.algol60.net"
+location = "registry.local/artifactory.algol60.net"
+insecure = true
+
+[[registry.mirror]]
+prefix = "artifactory.algol60.net"
+location = "pit.nmn:5000/artifactory.algol60.net"
 insecure = true
 
 EOF


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
Registries.conf file is overwritten by disable_local_registry.sh. However the file that is put there is an invalid format and prevents images from being pulled. This issue only arises when disable_local_registry.sh is run after at least 1 storage node has already been upgraded because it overwrites the correct registries.conf file that is in the 1.5 image.

This was discovered in CSM 1.5 however it affects CSM 1.4 because in 1.4 the process is writing an invalid registries.conf file. This means that if the storage nodes do need to pull a new image from Nexus, it will not be able to pull the image.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams