### PR TITLE
Add etcd manual backup step after patch install (CASMPET-6727)

### DIFF
--- a/upgrade/1.4.2/README.md
+++ b/upgrade/1.4.2/README.md
@@ -56,6 +56,7 @@ If upgrading from CSM `v1.3.4` directly to `v1.4.2`, follow the procedures descr
 1. [Enable `Smartmon` Metrics on Storage NCNs](#enable-smartmon-metrics-on-storage-ncns)
 1. [Update test suite packages](#update-test-suite-packages)
 1. [Verification](#verification)
+1. [Take Etcd Manual Backup](#take-etcd-manual-backup)
 1. [Complete upgrade](#complete-upgrade)
 
 ## Preparation
@@ -237,6 +238,16 @@ pdsh -b -w $(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u |  tr -t '\n' ',') 'zyppe
 
    ```bash
    kubectl get cm cray-product-catalog -n services -o jsonpath='{.data.csm}' | yq r  - '"1.4.2".configuration.import_date'
+   ```
+
+## Take Etcd Manual Backup
+
+1. (`ncn-m001#`) Execute the following script to take a manual backup of the Etcd clusters.
+   These clusters are automatically backed up every 24 hours, but taking a manual backup
+   at this stage in the upgrade enables restoring from backup later in this process if needed.
+
+   ```bash
+   /usr/share/doc/csm/scripts/operations/etcd/take-etcd-manual-backups.sh post_patch
    ```
 
 ## Complete upgrade


### PR DESCRIPTION
### Summary and Scope

Add step to take a manual etcd backup after patch install, ensuring healthchecks see a backup within 24 hours.

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMPET-6727

### Testing

Tested on wasp -- healthcheck passed after running the script.


Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
