### PR TITLE
CASMTRIAGE-5800 to release 1.4

### DIFF
--- a/workflows/iuf/operations/extract-release-distributions.yaml
+++ b/workflows/iuf/operations/extract-release-distributions.yaml
@@ -69,7 +69,7 @@ spec:
               - start-operation
             inline:
               script:
-                image: artifactory.algol60.net/csm-docker/stable/iuf:csm-latest
+                image: artifactory.algol60.net/csm-docker/stable/iuf:v0.1.11
                 command: [sh]
                 source: |
                   #!/bin/sh


### PR DESCRIPTION
# Description
I removed the concept of `csm-latest` tag for iuf-containers image, but unfortunately I missed a spot in docs-csm for the release/1.4 branch.

For [CASMTRIAGE-5800](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5800)

# Checklist
- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
