### PR TITLE
CASMTRIAGE-5695/CASMTRIAGE-5719: Fix skipped tests in ssh access tests

### DIFF
--- a/scripts/operations/pyscripts/pyscripts/commands/test_bican_external/test_bican_external.py
+++ b/scripts/operations/pyscripts/pyscripts/commands/test_bican_external/test_bican_external.py
@@ -155,5 +155,5 @@ Over network {} ({})""".format(
 def get_ssh_host_for_node_type(node_type, excluded_hostnames):
     target_list = SSH_TARGETS.__dict__[node_type]
     for i in target_list:
-        if not i.hostname in excluded_hostnames and i.is_ready():
+        if not i.hostname in excluded_hostnames and i.is_ready(node_type):
             return i

--- a/scripts/operations/pyscripts/pyscripts/commands/test_bican_internal/test_bican_internal.py
+++ b/scripts/operations/pyscripts/pyscripts/commands/test_bican_internal/test_bican_internal.py
@@ -167,17 +167,6 @@ def test_from_node_type_to_node_type_over_network(from_node_type, from_node, fro
 
     to_node = to_node.with_domain_suffix(network_suffix)
 
-    if network == "nmn" and to_node.is_mellanox_switch():
-        print("""\nTesting SSH access:
-        From node type {}, using {}
-        Over network {} ({})
-        To node type {}
-        Expected to work: {}""".format(
-            from_node_type, from_node.get_full_domain_name(), network, network_suffix, to_node_type, expected))
-
-        print("\t\t^^^^ SKIPPED: Please see CASMNET-787 ^^^^")
-        return 0
-
     print("""\nTesting SSH access:
         From node type {}, using {}
         Over network {} ({})
@@ -218,5 +207,5 @@ def test_from_node_type_to_node_type_over_network(from_node_type, from_node, fro
 def get_ssh_host_for_node_type(node_type, excluded_hostnames):
     target_list = SSH_TARGETS.__dict__[node_type]
     for i in target_list:
-        if not i.hostname in excluded_hostnames and i.is_ready():
+        if not i.hostname in excluded_hostnames and i.is_ready(node_type):
             return i

--- a/scripts/operations/pyscripts/pyscripts/core/ssh/ssh_host.py
+++ b/scripts/operations/pyscripts/pyscripts/core/ssh/ssh_host.py
@@ -104,12 +104,16 @@ class SshHost:
         else:
             self.state = state
 
-    def is_ready(self):
+    def is_ready(self, node_type):
         """
         Whether this host is marked as ready for use
         """
         state = self.get_state()
-        return state == "Configured" or state == "Ready" or state == None # if None, state is unknown, so we'll assume it is ready
+
+        if node_type == "spine_switch":
+            return state == "On" or state == None # if None, state is unknown, so we'll assume it is ready
+        else:
+            return state == "Configured" or state == "Ready" or state == None # if None, state is unknown, so we'll assume it is ready
 
     def get_full_domain_name(self):
         """


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

There has been a change in behavior in HMS where spine switches now have a state of "On" rather than None in SMD.   The internal and external SSH access test have been modified to handle this change in behavior.    If the node type is "spine_switch" it will now look for "On" or None to determine if the node is ready.   The other node types will remain the same.

One of the tests was being skipped for mellanox switches to work around CASMNET-787.   That ticket has now been resolved for the test no longer needs to be skipped.

These changes were tested on both surtur and drax.

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
