### PR TITLE
MTL-2000 Patch

### DIFF
--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -764,7 +764,7 @@ if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
   {
     do_patch=0
     error=0
-    sourcefile="${artdir}/rpm/cloud-init"
+    sourcefile="${CSM_ARTI_DIR}/rpm/cloud-init"
 
     # If this is a re-run and our source JSON was already created we don't need to recreate it.
     if [ ! -f "${sourcefile}.json" ]; then
@@ -776,9 +776,11 @@ if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
         # In this case, there is nothing to do because the CSM version we are upgrading to is too old.
         echo "No $(basename "$sourcefile").yaml file found at: ${sourcefile}.yaml. Skipping package & repo meta-data injection."
 
+        # Do not error out, if the file is missing then the feature is considered to be disabled/unused by the tarball's contents.
+        error=0
       else
 
-        # `csi handoff bss-update-cloud-init --user-data` only takes JSON, convert the human-friendlier YAML to JSON and nest it under the expected key.
+        # csi handoff bss-update-cloud-init --user-data` only takes JSON, convert the human-friendlier YAML to JSON and nest it under the expected key.
         yq4 '{"user-data": .}' "${sourcefile}.yaml" --output-format json > "${sourcefile}.json"
 
         # Set `do_patch` to 1 so that the operations in this stage run.


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->
The new MTL-2000 step was not running due to looking for the `cloud-init.yaml` file in the wrong location. Since `sourcefile` was using `$artdir` we were looking in `images/rpm/` instead of `rpm/`.

```
No cloud-init.yaml file found at: /etc/cray/upgrade/csm/csm-1.5.0-beta.30/tarball/csm-1.5.0-beta.30/images/rpm/cloud-init.yaml. Skipping package & repo meta-data injection.
```

The `sourcefile` variable should be set to `${CSM_ARTI_DIR}` and not `${artdir}`.

This also adds an explicit `error=0` to the case where the cloud-init file is not found, to help prevent confusion as to why the error is ignored. The error must be ignored to prevent breaking using his script with older CSM 1.5 tarballs.

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
