### PR TITLE
CASMINST-6596 Adhoc NCN configuration for 1.4.2 release (including sysctl values)

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -873,7 +873,6 @@ SFP-10G-T
 SFP-10G-ZR
 SR SFP-10G
 Sr4
-sysctl
 twinax
 USR SFP-10G
 vcs-user-credentials

--- a/.spelling
+++ b/.spelling
@@ -873,6 +873,7 @@ SFP-10G-T
 SFP-10G-ZR
 SR SFP-10G
 Sr4
+sysctl
 twinax
 USR SFP-10G
 vcs-user-credentials

--- a/upgrade/1.4.2/README.md
+++ b/upgrade/1.4.2/README.md
@@ -205,7 +205,7 @@ This step will create an imperative CFS session that can be used to configure bo
    kubectl logs -f -n services jobs/`cray cfs sessions describe ncnnodes --format json | jq -r " .status.session.job"` -c ansible
    ```
 
-3. (`ncn-m001#`) Wait for CFS to complete configuration
+1. (`ncn-m001#`) Wait for CFS to complete configuration.
 
    ```bash
    cray cfs sessions describe ncnnodes

--- a/upgrade/1.4.2/README.md
+++ b/upgrade/1.4.2/README.md
@@ -34,7 +34,7 @@ If upgrading from CSM `v1.3.x` directly to `v1.4.2`, follow the procedures descr
 1. [Upload NCN images](#upload-ncn-images)
 1. [Upgrade Ceph and stop local Docker registries](#upgrade-ceph-and-stop-local-docker-registries)
 1. [Enable `Smartmon` Metrics on Storage NCNs](#enable-smartmon-metrics-on-storage-ncns)
-1. [Configure NCN nodes without restart](#configure-ncn-nodes-without-restart)
+1. [Configure NCNs without restart](#configure-ncn-nodes-without-restart)
 1. [Update test suite packages](#update-test-suite-packages)
 1. [Verification](#verification)
 1. [Take Etcd Manual Backup](#take-etcd-manual-backup)
@@ -175,9 +175,9 @@ This step will install the `smart-mon` rpm on storage nodes, and reconfigure the
    /usr/share/doc/csm/scripts/operations/ceph/enable-smart-mon-storage-nodes.sh
    ```
 
-## Configure NCN nodes without restart
+## Configure NCNs without restart
 
-This step will create an imperative CFS session that can be used to configure booted NCN nodes with updated `sysctl` values.
+This step will create an imperative CFS session that can be used to configure booted NCN with updated `sysctl` values.
 
 1. (`ncn-m001#`) Create a new CFS configuration entry for the release.
 

--- a/upgrade/1.4.2/README.md
+++ b/upgrade/1.4.2/README.md
@@ -34,6 +34,7 @@ If upgrading from CSM `v1.3.x` directly to `v1.4.2`, follow the procedures descr
 1. [Upload NCN images](#upload-ncn-images)
 1. [Upgrade Ceph and stop local Docker registries](#upgrade-ceph-and-stop-local-docker-registries)
 1. [Enable `Smartmon` Metrics on Storage NCNs](#enable-smartmon-metrics-on-storage-ncns)
+1. [Configure NCN nodes without restart](#configure-ncn-nodes-without-restart)
 1. [Update test suite packages](#update-test-suite-packages)
 1. [Verification](#verification)
 1. [Take Etcd Manual Backup](#take-etcd-manual-backup)
@@ -201,14 +202,14 @@ This step will create an imperative CFS session that can be used to configure bo
 
    ```bash
    cray cfs sessions create --name ncnnodes --configuration-name ncn_nodes
-   kubectl logs -f -n services jobs/`cray cfs sessions describe ncnnodes --format json | jq " .status.session.job" | tr -d '"'` -c ansible
+   kubectl logs -f -n services jobs/`cray cfs sessions describe ncnnodes --format json | jq -r " .status.session.job"` -c ansible
    ```
 
 3. (`ncn-m001#`) Wait for CFS to complete configuration
 
    ```bash
    cray cfs sessions describe ncnnodes
-   kubectl logs -f -n services jobs/`cray cfs sessions describe ncnnodes --format json | jq " .status.session.job" | tr -d '"'` -c ansible
+   kubectl logs -f -n services jobs/`cray cfs sessions describe ncnnodes --format json | jq -r " .status.session.job"` -c ansible
    ```
 
 ## Update test suite packages

--- a/upgrade/1.4.2/README.md
+++ b/upgrade/1.4.2/README.md
@@ -178,7 +178,7 @@ This step will install the `smart-mon` rpm on storage nodes, and reconfigure the
 
 This step will create an imperative CFS session that can be used to configure booted NCN nodes with updated `sysctl` values.
 
-1. (`ncn-m001#`) Create a new CFS Configuration Entry for the release
+1. (`ncn-m001#`) Create a new CFS configuration entry for the release.
 
    ```bash
    COMMIT=`kubectl -n services get cm cray-product-catalog -o jsonpath='{.data.csm}' 2>/dev/null | yq r -j - 2>/dev/null | jq --arg version "$CSM_RELEASE_VERSION" '. [$version].configuration.commit' | tr -d '"'`

--- a/upgrade/1.4.2/README.md
+++ b/upgrade/1.4.2/README.md
@@ -187,26 +187,28 @@ echo '{
     {
       "cloneUrl": "https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git",
       "commit": "COMMIT",
-      "name": "ncn_sysctl",
-      "playbook": "ncn_sysctl.yml"
+      "name": "ncn_nodes",
+      "playbook": "ncn_nodes.yml"
     }
   ]
-}' | sed -e "s/COMMIT/$COMMIT/g" > /tmp/ncn_sysctl.yml.json
-cray cfs configurations update ncn_sysctl --file /tmp/ncn_sysctl.yml.json
+}' | sed -e "s/COMMIT/$COMMIT/g" > /tmp/ncn_nodes.yml.json
+cray cfs configurations update ncn_nodes --file /tmp/ncn_nodes.yml.json
 # Cleanup temporary file
-rm /tmp/ncn_sysctl.yml.json
+rm /tmp/ncn_nodes.yml.json
 ```   
 
-2. (`ncn-m001#`) Launch CFS to configure NCN sysctl values
+2. (`ncn-m001#`) Imperatively launch CFS against NCN nodes
 
 ```bash
-cray cfs sessions create --name ncn_sysctl --configuration-name ncnsysctl
+cray cfs sessions create --name ncnnodes --configuration-name ncn_nodes
+kubectl logs -f -n services jobs/`cray cfs sessions describe ncnnodes --format json | jq " .status.session.job" | tr -d '"'` -c ansible
 ```
 
 3. (`ncn-m001#`) Wait for CFS to complete configuration
 
 ```bash
-watch `cray cfs sessions describe ncnsysctl`
+cray cfs sessions describe ncnnodes
+kubectl logs -f -n services jobs/`cray cfs sessions describe ncnnodes --format json | jq " .status.session.job" | tr -d '"'` -c ansible
 ```
 
 

--- a/upgrade/1.4.2/README.md
+++ b/upgrade/1.4.2/README.md
@@ -214,7 +214,7 @@ This step will create an imperative CFS session that can be used to configure bo
 
 The playbook in question will run to completion with a message indicating success.
 
-   ```
+   ```text
    All playbooks completed successfully
    ```
 

--- a/upgrade/1.4.2/README.md
+++ b/upgrade/1.4.2/README.md
@@ -211,7 +211,6 @@ This step will create an imperative CFS session that can be used to configure bo
    kubectl logs -f -n services jobs/`cray cfs sessions describe ncnnodes --format json | jq " .status.session.job" | tr -d '"'` -c ansible
    ```
 
-
 ## Update test suite packages
 
 Update the `csm-testing` and `goss-servers` RPMs on the NCNs.

--- a/upgrade/1.4.2/README.md
+++ b/upgrade/1.4.2/README.md
@@ -212,7 +212,7 @@ This step will create an imperative CFS session that can be used to configure bo
    kubectl logs -f -n services jobs/`cray cfs sessions describe ncnnodes --format json | jq -r " .status.session.job"` -c ansible
    ```
 
-The playbook in question will run to completion with a message indicating success.
+   The playbook in question will run to completion with a message indicating success.
 
    ```text
    All playbooks completed successfully

--- a/upgrade/1.4.2/README.md
+++ b/upgrade/1.4.2/README.md
@@ -197,6 +197,7 @@ This step will create an imperative CFS session that can be used to configure bo
    rm /tmp/ncn_nodes.yml.json
    ```   
 
+
 2. (`ncn-m001#`) Imperatively launch CFS against NCN nodes
 
    ```bash

--- a/upgrade/1.4.2/README.md
+++ b/upgrade/1.4.2/README.md
@@ -180,36 +180,36 @@ This step will create an imperative CFS session that can be used to configure bo
 
 1. (`ncn-m001#`) Create a new CFS Configuration Entry for the release
 
-```bash
-COMMIT=`kubectl -n services get cm cray-product-catalog -o jsonpath='{.data.csm}' 2>/dev/null | yq r -j - 2>/dev/null | jq --arg version "$CSM_RELEASE_VERSION" '. [$version].configuration.commit' | tr -d '"'`
-echo '{
-  "layers": [
-    {
-      "cloneUrl": "https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git",
-      "commit": "COMMIT",
-      "name": "ncn_nodes",
-      "playbook": "ncn_nodes.yml"
-    }
-  ]
-}' | sed -e "s/COMMIT/$COMMIT/g" > /tmp/ncn_nodes.yml.json
-cray cfs configurations update ncn_nodes --file /tmp/ncn_nodes.yml.json
-# Cleanup temporary file
-rm /tmp/ncn_nodes.yml.json
-```   
+   ```bash
+   COMMIT=`kubectl -n services get cm cray-product-catalog -o jsonpath='{.data.csm}' 2>/dev/null | yq r -j - 2>/dev/null | jq --arg version "$CSM_RELEASE_VERSION" '. [$version].configuration.commit' | tr -d '"'`
+   echo '{
+     "layers": [
+       {
+         "cloneUrl": "https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git",
+         "commit": "COMMIT",
+         "name": "ncn_nodes",
+         "playbook": "ncn_nodes.yml"
+       }
+     ]
+   }' | sed -e "s/COMMIT/$COMMIT/g" > /tmp/ncn_nodes.yml.json
+   cray cfs configurations update ncn_nodes --file /tmp/ncn_nodes.yml.json
+   # Cleanup temporary file
+   rm /tmp/ncn_nodes.yml.json
+   ```   
 
 2. (`ncn-m001#`) Imperatively launch CFS against NCN nodes
 
-```bash
-cray cfs sessions create --name ncnnodes --configuration-name ncn_nodes
-kubectl logs -f -n services jobs/`cray cfs sessions describe ncnnodes --format json | jq " .status.session.job" | tr -d '"'` -c ansible
-```
+   ```bash
+   cray cfs sessions create --name ncnnodes --configuration-name ncn_nodes
+   kubectl logs -f -n services jobs/`cray cfs sessions describe ncnnodes --format json | jq " .status.session.job" | tr -d '"'` -c ansible
+   ```
 
 3. (`ncn-m001#`) Wait for CFS to complete configuration
 
-```bash
-cray cfs sessions describe ncnnodes
-kubectl logs -f -n services jobs/`cray cfs sessions describe ncnnodes --format json | jq " .status.session.job" | tr -d '"'` -c ansible
-```
+   ```bash
+   cray cfs sessions describe ncnnodes
+   kubectl logs -f -n services jobs/`cray cfs sessions describe ncnnodes --format json | jq " .status.session.job" | tr -d '"'` -c ansible
+   ```
 
 
 ## Update test suite packages

--- a/upgrade/1.4.2/README.md
+++ b/upgrade/1.4.2/README.md
@@ -198,7 +198,7 @@ This step will create an imperative CFS session that can be used to configure bo
    rm /tmp/ncn_nodes.yml.json
    ```
 
-1. (`ncn-m001#`) Imperatively launch CFS against NCNs.
+1. (`ncn-m001#`) Imperatively launch CFS against management NCNs.
 
    ```bash
    cray cfs sessions create --name ncnnodes --configuration-name ncn_nodes

--- a/upgrade/1.4.2/README.md
+++ b/upgrade/1.4.2/README.md
@@ -195,8 +195,7 @@ This step will create an imperative CFS session that can be used to configure bo
    cray cfs configurations update ncn_nodes --file /tmp/ncn_nodes.yml.json
    # Cleanup temporary file
    rm /tmp/ncn_nodes.yml.json
-   ```   
-
+   ```
 
 2. (`ncn-m001#`) Imperatively launch CFS against NCN nodes
 

--- a/upgrade/1.4.2/README.md
+++ b/upgrade/1.4.2/README.md
@@ -176,7 +176,7 @@ This step will install the `smart-mon` rpm on storage nodes, and reconfigure the
 
 ## Configure NCN nodes without restart
 
-This step will create an imperative CFS session that can be used to configure booted NCN nodes with updated sysctl values.
+This step will create an imperative CFS session that can be used to configure booted NCN nodes with updated `sysctl` values.
 
 1. (`ncn-m001#`) Create a new CFS Configuration Entry for the release
 

--- a/upgrade/1.4.2/README.md
+++ b/upgrade/1.4.2/README.md
@@ -198,7 +198,7 @@ This step will create an imperative CFS session that can be used to configure bo
    rm /tmp/ncn_nodes.yml.json
    ```
 
-2. (`ncn-m001#`) Imperatively launch CFS against NCN nodes
+1. (`ncn-m001#`) Imperatively launch CFS against NCNs.
 
    ```bash
    cray cfs sessions create --name ncnnodes --configuration-name ncn_nodes

--- a/upgrade/1.4.2/README.md
+++ b/upgrade/1.4.2/README.md
@@ -212,6 +212,12 @@ This step will create an imperative CFS session that can be used to configure bo
    kubectl logs -f -n services jobs/`cray cfs sessions describe ncnnodes --format json | jq -r " .status.session.job"` -c ansible
    ```
 
+The playbook in question will run to completion with a message indicating success.
+
+   ```
+   All playbooks completed successfully
+   ```
+
 ## Update test suite packages
 
 Update the `csm-testing` and `goss-servers` RPMs on the NCNs.


### PR DESCRIPTION
# Description
During minor version upgrades of CSM, a way to apply CSM configuration against NCN nodes that does not require a reboot is needed. In the 1.4.2 upgrade timeframe, the best way to do that is through imperatively setting a new value. For this release, the primary motivator is to get new sysctl values set on NCN nodes.

Relates to:
- [CASMINST-6596](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6596)

# Checklist
- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.