### PR TITLE
CASMCMS-8765: Move NCN configuration steps into a script

### DIFF
--- a/upgrade/1.4.2/README.md
+++ b/upgrade/1.4.2/README.md
@@ -179,30 +179,14 @@ This step will install the `smart-mon` rpm on storage nodes, and reconfigure the
 
 This step will create an imperative CFS session that can be used to configure booted NCN with updated `sysctl` values.
 
-1. (`ncn-m001#`) Create a new CFS configuration entry for the release.
+1. (`ncn-m001#`) Run `configure_ncns.sh` to create a CFS configuration and session.
+
+    **IMPORTANT**: This script will overwrite any CFS configuration called ncn_nodes.  Change the `CONFIG_NAME` variable in the script to change this behavior.
+     
+     **IMPORTANT**: This script will not start a new CFS session if one of the same name already exists.  If an old session exists, delete it first or change the  `SESSION_NAME` variable in the script to use a different session name.
 
    ```bash
-   COMMIT=`kubectl -n services get cm cray-product-catalog -o jsonpath='{.data.csm}' 2>/dev/null | yq r -j - 2>/dev/null | jq --arg version "$CSM_RELEASE_VERSION" '. [$version].configuration.commit' | tr -d '"'`
-   echo '{
-     "layers": [
-       {
-         "cloneUrl": "https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git",
-         "commit": "COMMIT",
-         "name": "ncn_nodes",
-         "playbook": "ncn_nodes.yml"
-       }
-     ]
-   }' | sed -e "s/COMMIT/$COMMIT/g" > /tmp/ncn_nodes.yml.json
-   cray cfs configurations update ncn_nodes --file /tmp/ncn_nodes.yml.json
-   # Cleanup temporary file
-   rm /tmp/ncn_nodes.yml.json
-   ```
-
-1. (`ncn-m001#`) Imperatively launch CFS against management NCNs.
-
-   ```bash
-   cray cfs sessions create --name ncnnodes --configuration-name ncn_nodes
-   kubectl logs -f -n services jobs/`cray cfs sessions describe ncnnodes --format json | jq -r " .status.session.job"` -c ansible
+   /usr/share/doc/csm/upgrade/scripts/cfs/configure_ncns.sh
    ```
 
 1. (`ncn-m001#`) Wait for CFS to complete configuration.

--- a/upgrade/scripts/cfs/configure_ncns.sh
+++ b/upgrade/scripts/cfs/configure_ncns.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -euo pipefail
+
+
+if [ -z "$CSM_RELEASE_VERSION" ]; then
+  echo "Set CSM_RELEASE_VERSION before running this script"
+  exit 1
+fi
+
+COMMIT=$(kubectl -n services get cm cray-product-catalog -o jsonpath='{.data.csm}' 2>/dev/null | yq r -j - 2>/dev/null | jq --arg version "$CSM_RELEASE_VERSION" '. [$version].configuration.commit' | tr -d '"')
+echo "Found commit: $COMMIT"
+echo "{
+  \"layers\": [
+    {
+      \"cloneUrl\": \"https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git\",
+      \"commit\": \"$COMMIT\",
+      \"name\": \"ncn_nodes\",
+      \"playbook\": \"ncn_nodes.yml\"
+    }
+  ]
+}" | sed -e "s/COMMIT/$COMMIT/g" > /tmp/ncn_nodes.yml.json
+
+CONFIG_NAME="ncn_nodes"
+SESSION_NAME="ncnnodes"
+
+echo "Creating CFS configuration $CONFIG_NAME"
+cray cfs configurations update $CONFIG_NAME --file /tmp/ncn_nodes.yml.json
+echo "Configuration created"
+# Cleanup temporary file
+rm /tmp/ncn_nodes.yml.json
+# Launch CFS session
+echo "Launching configuration session $SESSION_NAME"
+cray cfs sessions create --name $SESSION_NAME --configuration-name $CONFIG_NAME
+echo "Session started"
+JOB_NAME=$(cray cfs sessions describe $SESSION_NAME --format json | jq -r " .status.session.job")
+echo "Run \"kubectl logs -f -n services jobs/$JOB_NAME -c ansible\" to follow the session logs"


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->
Moves the steps from "Configure NCNs without restart" into a script

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
