### PR TITLE
CASMTRIAGE-5856 Fix `yq4` call

### DIFF
--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -775,7 +775,7 @@ if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
       else
 
         # csi handoff bss-update-cloud-init --user-data` only takes JSON, convert the human-friendlier YAML to JSON and nest it under the expected key.
-        yq4 '{"user-data": .}' "${sourcefile}.yaml" --output-format json > "${sourcefile}.json"
+        yq4 eval '{"user-data": .}' "${sourcefile}.yaml" -j > "${sourcefile}.json"
 
         # Set `do_patch` to 1 so that the operations in this stage run.
         do_patch=1


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->
The `yq4` call is invalid and causing the step to fail.

In `yq` 4.33.0 the command works, but in 4.6.0 it does not. In 4.6.0 (what's installed on 1.4) an `eval` is needed as well as a `-j`.

`-j` also works in 4.33.0 (what's installed in 1.5 and 1.6), but a deprecation notice will print.
    
```
Flag --tojson has been deprecated, please use -o=json instead
```

Tested
```bash
ncn-m001:~ # yq4 eval '{"user-data": .}' "${sourcefile}.yaml" -j > "${sourcefile}.json"
ncn-m001:~ # cat !$
cat "${sourcefile}.json"
{
  "user-data": {
    "repos": [
      {
        "id": "csm-noos",
        "name": "csm-noos",
        "baseurl": "https://packages/repository/csm-noos?ssl_verify=no",
        "enabled": 1,
        "autorefresh": 1,
        "gpgcheck": 0
      },
      {
        "id": "csm-sle",
        "name": "csm-sle-${releasever_major}sp${releasever_minor}",
        "baseurl": "https://packages/repository/csm-sle-${releasever_major}sp${releasever_minor}?ssl_verify=no",
        "enabled": 1,
        "autorefresh": 1,
        "gpgcheck": 0
      }
    ],
    "packages": [
      "cani",
      "canu",
      "cray-cmstools-crayctldeploy",
      "csm-testing",
      "goss-servers",
      "iuf-cli",
      "libcsm",
      "platform-utils"
    ]
  }
}
```

Then running the for-loop produced the desired results:
```
ncn-m001:~ # for ncn_xname in "${NCN_XNAMES[@]}"; do csi handoff bss-update-cloud-init --limit "$ncn_xname" --delete 'user-data.repos'; cray bss bootparameters list --format json --hosts x3000c0s3b0n0 | jq '.[]."cloud-init"."user-data".repos'; csi handoff bss-update-cloud-init --limit "$ncn_xname" --delete 'user-data.packages'; cray bss bootparameters list --format json --hosts x3000c0s3b0n0 | jq '.[]."cloud-init"."user-data".packages'; csi handoff bss-update-cloud-init --limit "$ncn_xname" --user-data "${sourcefile}.json"; done
2023/08/10 20:32:16 Getting management NCNs from SLS...
2023/08/10 20:32:16 Done getting management NCNs from SLS.
2023/08/10 20:32:16 Updating NCN cloud-init parameters...
2023/08/10 20:32:16 Successfully PUT BSS entry for x3000c0s1b0n0
2023/08/10 20:32:16 Done updating NCN cloud-init parameters.
null
2023/08/10 20:32:17 Getting management NCNs from SLS...
2023/08/10 20:32:17 Done getting management NCNs from SLS.
2023/08/10 20:32:17 Updating NCN cloud-init parameters...
2023/08/10 20:32:17 Successfully PUT BSS entry for x3000c0s1b0n0
2023/08/10 20:32:17 Done updating NCN cloud-init parameters.
null
2023/08/10 20:32:18 Getting management NCNs from SLS...
2023/08/10 20:32:18 Done getting management NCNs from SLS.
2023/08/10 20:32:18 Updating NCN cloud-init parameters...
2023/08/10 20:32:18 Updating repos on x3000c0s1b0n0
2023/08/10 20:32:18 Updating packages on x3000c0s1b0n0
2023/08/10 20:32:18 Writing back to BSS: x3000c0s1b0n0
2023/08/10 20:32:18 Successfully PUT BSS entry for x3000c0s1b0n0
2023/08/10 20:32:18 Done updating NCN cloud-init parameters.
2023/08/10 20:32:18 Getting management NCNs from SLS...
2023/08/10 20:32:18 Done getting management NCNs from SLS.
2023/08/10 20:32:18 Updating NCN cloud-init parameters...
2023/08/10 20:32:18 Successfully PUT BSS entry for x3000c0s3b0n0
2023/08/10 20:32:18 Done updating NCN cloud-init parameters.
null
2023/08/10 20:32:19 Getting management NCNs from SLS...
2023/08/10 20:32:19 Done getting management NCNs from SLS.
2023/08/10 20:32:19 Updating NCN cloud-init parameters...
2023/08/10 20:32:19 Successfully PUT BSS entry for x3000c0s3b0n0
2023/08/10 20:32:19 Done updating NCN cloud-init parameters.
null
2023/08/10 20:32:20 Getting management NCNs from SLS...
2023/08/10 20:32:20 Done getting management NCNs from SLS.
2023/08/10 20:32:20 Updating NCN cloud-init parameters...
2023/08/10 20:32:20 Updating repos on x3000c0s3b0n0
2023/08/10 20:32:20 Updating packages on x3000c0s3b0n0
2023/08/10 20:32:20 Writing back to BSS: x3000c0s3b0n0
2023/08/10 20:32:20 Successfully PUT BSS entry for x3000c0s3b0n0
2023/08/10 20:32:20 Done updating NCN cloud-init parameters.
2023/08/10 20:32:20 Getting management NCNs from SLS...
2023/08/10 20:32:20 Done getting management NCNs from SLS.
2023/08/10 20:32:20 Updating NCN cloud-init parameters...
2023/08/10 20:32:20 Successfully PUT BSS entry for x3000c0s29b0n0
2023/08/10 20:32:20 Done updating NCN cloud-init parameters.
[
  {
    "autorefresh": 1,
    "baseurl": "https://packages/repository/csm-noos?ssl_verify=no",
    "enabled": 1,
    "gpgcheck": 0,
    "id": "csm-noos",
    "name": "csm-noos"
  },
  {
    "autorefresh": 1,
    "baseurl": "https://packages/repository/csm-sle-${releasever_major}sp${releasever_minor}?ssl_verify=no",
    "enabled": 1,
    "gpgcheck": 0,
    "id": "csm-sle",
    "name": "csm-sle-${releasever_major}sp${releasever_minor}"
  }
]
2023/08/10 20:32:21 Getting management NCNs from SLS...
2023/08/10 20:32:21 Done getting management NCNs from SLS.
2023/08/10 20:32:21 Updating NCN cloud-init parameters...
2023/08/10 20:32:21 Successfully PUT BSS entry for x3000c0s29b0n0
2023/08/10 20:32:21 Done updating NCN cloud-init parameters.
[
  "cani",
  "canu",
  "cray-cmstools-crayctldeploy",
  "csm-testing",
  "goss-servers",
  "iuf-cli",
  "libcsm",
  "platform-utils"
]
2023/08/10 20:32:22 Getting management NCNs from SLS...
2023/08/10 20:32:22 Done getting management NCNs from SLS.
2023/08/10 20:32:22 Updating NCN cloud-init parameters...
2023/08/10 20:32:22 Updating repos on x3000c0s29b0n0
2023/08/10 20:32:22 Updating packages on x3000c0s29b0n0
2023/08/10 20:32:22 Writing back to BSS: x3000c0s29b0n0
2023/08/10 20:32:22 Successfully PUT BSS entry for x3000c0s29b0n0
2023/08/10 20:32:22 Done updating NCN cloud-init parameters.
2023/08/10 20:32:22 Getting management NCNs from SLS...
2023/08/10 20:32:22 Done getting management NCNs from SLS.
2023/08/10 20:32:22 Updating NCN cloud-init parameters...
2023/08/10 20:32:22 Successfully PUT BSS entry for x3000c0s7b0n0
2023/08/10 20:32:22 Done updating NCN cloud-init parameters.
[
  {
    "autorefresh": 1,
    "baseurl": "https://packages/repository/csm-noos?ssl_verify=no",
    "enabled": 1,
    "gpgcheck": 0,
    "id": "csm-noos",
    "name": "csm-noos"
  },
  {
    "autorefresh": 1,
    "baseurl": "https://packages/repository/csm-sle-${releasever_major}sp${releasever_minor}?ssl_verify=no",
    "enabled": 1,
    "gpgcheck": 0,
    "id": "csm-sle",
    "name": "csm-sle-${releasever_major}sp${releasever_minor}"
  }
]
2023/08/10 20:32:23 Getting management NCNs from SLS...
2023/08/10 20:32:23 Done getting management NCNs from SLS.
2023/08/10 20:32:23 Updating NCN cloud-init parameters...
2023/08/10 20:32:23 Successfully PUT BSS entry for x3000c0s7b0n0
2023/08/10 20:32:23 Done updating NCN cloud-init parameters.
[
  "cani",
  "canu",
  "cray-cmstools-crayctldeploy",
  "csm-testing",
  "goss-servers",
  "iuf-cli",
  "libcsm",
  "platform-utils"
]
2023/08/10 20:32:24 Getting management NCNs from SLS...
2023/08/10 20:32:24 Done getting management NCNs from SLS.
2023/08/10 20:32:24 Updating NCN cloud-init parameters...
2023/08/10 20:32:24 Updating packages on x3000c0s7b0n0
2023/08/10 20:32:24 Updating repos on x3000c0s7b0n0
2023/08/10 20:32:24 Writing back to BSS: x3000c0s7b0n0
2023/08/10 20:32:24 Successfully PUT BSS entry for x3000c0s7b0n0
2023/08/10 20:32:24 Done updating NCN cloud-init parameters.
2023/08/10 20:32:24 Getting management NCNs from SLS...
2023/08/10 20:32:24 Done getting management NCNs from SLS.
2023/08/10 20:32:24 Updating NCN cloud-init parameters...
2023/08/10 20:32:24 Successfully PUT BSS entry for x3000c0s11b0n0
2023/08/10 20:32:24 Done updating NCN cloud-init parameters.
[
  {
    "autorefresh": 1,
    "baseurl": "https://packages/repository/csm-noos?ssl_verify=no",
    "enabled": 1,
    "gpgcheck": 0,
    "id": "csm-noos",
    "name": "csm-noos"
  },
  {
    "autorefresh": 1,
    "baseurl": "https://packages/repository/csm-sle-${releasever_major}sp${releasever_minor}?ssl_verify=no",
    "enabled": 1,
    "gpgcheck": 0,
    "id": "csm-sle",
    "name": "csm-sle-${releasever_major}sp${releasever_minor}"
  }
]
2023/08/10 20:32:25 Getting management NCNs from SLS...
2023/08/10 20:32:25 Done getting management NCNs from SLS.
2023/08/10 20:32:25 Updating NCN cloud-init parameters...
2023/08/10 20:32:25 Successfully PUT BSS entry for x3000c0s11b0n0
2023/08/10 20:32:25 Done updating NCN cloud-init parameters.
[
  "cani",
  "canu",
  "cray-cmstools-crayctldeploy",
  "csm-testing",
  "goss-servers",
  "iuf-cli",
  "libcsm",
  "platform-utils"
]
2023/08/10 20:32:26 Getting management NCNs from SLS...
2023/08/10 20:32:26 Done getting management NCNs from SLS.
2023/08/10 20:32:26 Updating NCN cloud-init parameters...
2023/08/10 20:32:26 Updating repos on x3000c0s11b0n0
2023/08/10 20:32:26 Updating packages on x3000c0s11b0n0
2023/08/10 20:32:26 Writing back to BSS: x3000c0s11b0n0
2023/08/10 20:32:26 Successfully PUT BSS entry for x3000c0s11b0n0
2023/08/10 20:32:26 Done updating NCN cloud-init parameters.
2023/08/10 20:32:26 Getting management NCNs from SLS...
2023/08/10 20:32:26 Done getting management NCNs from SLS.
2023/08/10 20:32:26 Updating NCN cloud-init parameters...
2023/08/10 20:32:26 Successfully PUT BSS entry for x3000c0s5b0n0
2023/08/10 20:32:26 Done updating NCN cloud-init parameters.
[
  {
    "autorefresh": 1,
    "baseurl": "https://packages/repository/csm-noos?ssl_verify=no",
    "enabled": 1,
    "gpgcheck": 0,
    "id": "csm-noos",
    "name": "csm-noos"
  },
  {
    "autorefresh": 1,
    "baseurl": "https://packages/repository/csm-sle-${releasever_major}sp${releasever_minor}?ssl_verify=no",
    "enabled": 1,
    "gpgcheck": 0,
    "id": "csm-sle",
    "name": "csm-sle-${releasever_major}sp${releasever_minor}"
  }
]
2023/08/10 20:32:27 Getting management NCNs from SLS...
2023/08/10 20:32:27 Done getting management NCNs from SLS.
2023/08/10 20:32:27 Updating NCN cloud-init parameters...
2023/08/10 20:32:27 Successfully PUT BSS entry for x3000c0s5b0n0
2023/08/10 20:32:27 Done updating NCN cloud-init parameters.
[
  "cani",
  "canu",
  "cray-cmstools-crayctldeploy",
  "csm-testing",
  "goss-servers",
  "iuf-cli",
  "libcsm",
  "platform-utils"
]
2023/08/10 20:32:27 Getting management NCNs from SLS...
2023/08/10 20:32:28 Done getting management NCNs from SLS.
2023/08/10 20:32:28 Updating NCN cloud-init parameters...
2023/08/10 20:32:28 Updating repos on x3000c0s5b0n0
2023/08/10 20:32:28 Updating packages on x3000c0s5b0n0
2023/08/10 20:32:28 Writing back to BSS: x3000c0s5b0n0
2023/08/10 20:32:28 Successfully PUT BSS entry for x3000c0s5b0n0
2023/08/10 20:32:28 Done updating NCN cloud-init parameters.
2023/08/10 20:32:28 Getting management NCNs from SLS...
2023/08/10 20:32:28 Done getting management NCNs from SLS.
2023/08/10 20:32:28 Updating NCN cloud-init parameters...
2023/08/10 20:32:28 Successfully PUT BSS entry for x3000c0s13b0n0
2023/08/10 20:32:28 Done updating NCN cloud-init parameters.
[
  {
    "autorefresh": 1,
    "baseurl": "https://packages/repository/csm-noos?ssl_verify=no",
    "enabled": 1,
    "gpgcheck": 0,
    "id": "csm-noos",
    "name": "csm-noos"
  },
  {
    "autorefresh": 1,
    "baseurl": "https://packages/repository/csm-sle-${releasever_major}sp${releasever_minor}?ssl_verify=no",
    "enabled": 1,
    "gpgcheck": 0,
    "id": "csm-sle",
    "name": "csm-sle-${releasever_major}sp${releasever_minor}"
  }
]
2023/08/10 20:32:28 Getting management NCNs from SLS...
2023/08/10 20:32:28 Done getting management NCNs from SLS.
2023/08/10 20:32:28 Updating NCN cloud-init parameters...
2023/08/10 20:32:29 Successfully PUT BSS entry for x3000c0s13b0n0
2023/08/10 20:32:29 Done updating NCN cloud-init parameters.
[
  "cani",
  "canu",
  "cray-cmstools-crayctldeploy",
  "csm-testing",
  "goss-servers",
  "iuf-cli",
  "libcsm",
  "platform-utils"
]
2023/08/10 20:32:29 Getting management NCNs from SLS...
2023/08/10 20:32:29 Done getting management NCNs from SLS.
2023/08/10 20:32:29 Updating NCN cloud-init parameters...
2023/08/10 20:32:29 Updating repos on x3000c0s13b0n0
2023/08/10 20:32:29 Updating packages on x3000c0s13b0n0
2023/08/10 20:32:29 Writing back to BSS: x3000c0s13b0n0
2023/08/10 20:32:29 Successfully PUT BSS entry for x3000c0s13b0n0
2023/08/10 20:32:29 Done updating NCN cloud-init parameters.
2023/08/10 20:32:29 Getting management NCNs from SLS...
2023/08/10 20:32:30 Done getting management NCNs from SLS.
2023/08/10 20:32:30 Updating NCN cloud-init parameters...
2023/08/10 20:32:30 Successfully PUT BSS entry for x3000c0s9b0n0
2023/08/10 20:32:30 Done updating NCN cloud-init parameters.
[
  {
    "autorefresh": 1,
    "baseurl": "https://packages/repository/csm-noos?ssl_verify=no",
    "enabled": 1,
    "gpgcheck": 0,
    "id": "csm-noos",
    "name": "csm-noos"
  },
  {
    "autorefresh": 1,
    "baseurl": "https://packages/repository/csm-sle-${releasever_major}sp${releasever_minor}?ssl_verify=no",
    "enabled": 1,
    "gpgcheck": 0,
    "id": "csm-sle",
    "name": "csm-sle-${releasever_major}sp${releasever_minor}"
  }
]
2023/08/10 20:32:30 Getting management NCNs from SLS...
2023/08/10 20:32:30 Done getting management NCNs from SLS.
2023/08/10 20:32:30 Updating NCN cloud-init parameters...
2023/08/10 20:32:30 Successfully PUT BSS entry for x3000c0s9b0n0
2023/08/10 20:32:30 Done updating NCN cloud-init parameters.
[
  "cani",
  "canu",
  "cray-cmstools-crayctldeploy",
  "csm-testing",
  "goss-servers",
  "iuf-cli",
  "libcsm",
  "platform-utils"
]
2023/08/10 20:32:31 Getting management NCNs from SLS...
2023/08/10 20:32:31 Done getting management NCNs from SLS.
2023/08/10 20:32:31 Updating NCN cloud-init parameters...
2023/08/10 20:32:31 Updating repos on x3000c0s9b0n0
2023/08/10 20:32:31 Updating packages on x3000c0s9b0n0
2023/08/10 20:32:31 Writing back to BSS: x3000c0s9b0n0
2023/08/10 20:32:31 Successfully PUT BSS entry for x3000c0s9b0n0
2023/08/10 20:32:31 Done updating NCN cloud-init parameters.
2023/08/10 20:32:31 Getting management NCNs from SLS...
2023/08/10 20:32:31 Done getting management NCNs from SLS.
2023/08/10 20:32:31 Updating NCN cloud-init parameters...
2023/08/10 20:32:31 Successfully PUT BSS entry for x3000c0s15b0n0
2023/08/10 20:32:31 Done updating NCN cloud-init parameters.
[
  {
    "autorefresh": 1,
    "baseurl": "https://packages/repository/csm-noos?ssl_verify=no",
    "enabled": 1,
    "gpgcheck": 0,
    "id": "csm-noos",
    "name": "csm-noos"
  },
  {
    "autorefresh": 1,
    "baseurl": "https://packages/repository/csm-sle-${releasever_major}sp${releasever_minor}?ssl_verify=no",
    "enabled": 1,
    "gpgcheck": 0,
    "id": "csm-sle",
    "name": "csm-sle-${releasever_major}sp${releasever_minor}"
  }
]
2023/08/10 20:32:32 Getting management NCNs from SLS...
2023/08/10 20:32:32 Done getting management NCNs from SLS.
2023/08/10 20:32:32 Updating NCN cloud-init parameters...
2023/08/10 20:32:32 Successfully PUT BSS entry for x3000c0s15b0n0
2023/08/10 20:32:32 Done updating NCN cloud-init parameters.
[
  "cani",
  "canu",
  "cray-cmstools-crayctldeploy",
  "csm-testing",
  "goss-servers",
  "iuf-cli",
  "libcsm",
  "platform-utils"
]
2023/08/10 20:32:33 Getting management NCNs from SLS...
2023/08/10 20:32:33 Done getting management NCNs from SLS.
2023/08/10 20:32:33 Updating NCN cloud-init parameters...
2023/08/10 20:32:33 Updating repos on x3000c0s15b0n0
2023/08/10 20:32:33 Updating packages on x3000c0s15b0n0
2023/08/10 20:32:33 Writing back to BSS: x3000c0s15b0n0
2023/08/10 20:32:33 Successfully PUT BSS entry for x3000c0s15b0n0
2023/08/10 20:32:33 Done updating NCN cloud-init parameters.
2023/08/10 20:32:33 Getting management NCNs from SLS...
2023/08/10 20:32:33 Done getting management NCNs from SLS.
2023/08/10 20:32:33 Updating NCN cloud-init parameters...
2023/08/10 20:32:33 Limit to xname not found in management NCNs: x3000c0s17b0n0
[
  {
    "autorefresh": 1,
    "baseurl": "https://packages/repository/csm-noos?ssl_verify=no",
    "enabled": 1,
    "gpgcheck": 0,
    "id": "csm-noos",
    "name": "csm-noos"
  },
  {
    "autorefresh": 1,
    "baseurl": "https://packages/repository/csm-sle-${releasever_major}sp${releasever_minor}?ssl_verify=no",
    "enabled": 1,
    "gpgcheck": 0,
    "id": "csm-sle",
    "name": "csm-sle-${releasever_major}sp${releasever_minor}"
  }
]
2023/08/10 20:32:34 Getting management NCNs from SLS...
2023/08/10 20:32:34 Done getting management NCNs from SLS.
2023/08/10 20:32:34 Updating NCN cloud-init parameters...
2023/08/10 20:32:34 Limit to xname not found in management NCNs: x3000c0s17b0n0
[
  "cani",
  "canu",
  "cray-cmstools-crayctldeploy",
  "csm-testing",
  "goss-servers",
  "iuf-cli",
  "libcsm",
  "platform-utils"
]
2023/08/10 20:32:35 Getting management NCNs from SLS...
2023/08/10 20:32:35 Done getting management NCNs from SLS.
2023/08/10 20:32:35 Updating NCN cloud-init parameters...
2023/08/10 20:32:35 Limit to xname not found in management NCNs: x3000c0s17b0n0
```

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
