### PR TITLE
CASMPET-6747 upgrade ceph after storage nodes have SP5

### DIFF
--- a/workflows/templates/storage.ceph-upgrade.yaml
+++ b/workflows/templates/storage.ceph-upgrade.yaml
@@ -46,8 +46,8 @@ spec:
                   value: |
                     ssh_options="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
                     for storage_node in $(ceph orch host ls -f json |jq -r '.[].hostname'); do
-                      if [[ -z $(ssh ${storage_node} ${ssh_options} 'cat /etc/os-release' | grep 'VERSION="15-SP4"') ]]; then
-                        echo "Not all storage nodes have been upgraded and are running SP4."
+                      if [[ -z $(ssh ${storage_node} ${ssh_options} 'cat /etc/os-release' | grep 'VERSION="15-SP5"') ]]; then
+                        echo "Not all storage nodes have been upgraded and are running SP5."
                         echo "Waiting to upgrade Ceph until all storage nodes have been upgraded."
                         exit 0
                       fi


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
After the storage node images are upgraded, Ceph is upgraded by the Argo workflow. The logic in the workflow check to see that all storage nodes are running the new os-version. This was previously checking for SP4, however, now we are upgrading to SP5 on the storage nodes so the check needs to look for SP5 on storage nodes.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
