### PR TITLE
CASM-4505 sort by semantic versioning

### DIFF
--- a/workflows/update_tags.sh
+++ b/workflows/update_tags.sh
@@ -28,7 +28,7 @@ set -e
 THIS_REGISTRY_NAME="registry.local"
 THIS_REGISTRY_PROTOCOL="https"
 THIS_PODMAN_TLS=""
-SCRIPT_DIR=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 cd $SCRIPT_DIR
 
 

--- a/workflows/update_tags.sh
+++ b/workflows/update_tags.sh
@@ -63,7 +63,15 @@ function get_list_of_images_to_update() {
 function get_latest_tag_for_image() {
   THIS_IMAGE=$1
   THIS_PREFIX=$([[ $(echo $THIS_IMAGE | grep -e "^${THIS_REGISTRY_NAME}/") ]] && echo "" || echo "${THIS_REGISTRY_NAME}/")
-  podman search $THIS_PODMAN_TLS $THIS_PREFIX$THIS_IMAGE --list-tags --format=json | jq -r '.[0].Tags | sort_by(.) | last'
+  podman search $THIS_PODMAN_TLS $THIS_PREFIX$THIS_IMAGE --list-tags --format=json | jq -r '
+    def opt(f):
+      . as $in | try f catch $in;
+    def semver_cmp:
+          sub("\\+.*$"; "")
+            | capture("^(?<v>[^-]+)(?:-(?<p>.*))?$") | [.v, .p // empty]
+            | map(split(".") | map(opt(tonumber)))
+            | .[1] |= (. // {});
+    .[0].Tags | sort_by(.|semver_cmp) | last'
 }
 
 function get_filenames_referring_to_image() {

--- a/workflows/update_tags.sh
+++ b/workflows/update_tags.sh
@@ -31,7 +31,6 @@ THIS_PODMAN_TLS=""
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 cd $SCRIPT_DIR
 
-
 # Ensure the script is running from within the workflows directory so it finds argo yaml files."
 if [[ "$(basename ${SCRIPT_DIR})" != "workflows" ]]; then
   echo "ERROR: This script must be located in the workflows directory to run."

--- a/workflows/update_tags.sh
+++ b/workflows/update_tags.sh
@@ -28,7 +28,7 @@ set -e
 THIS_REGISTRY_NAME="registry.local"
 THIS_REGISTRY_PROTOCOL="https"
 THIS_PODMAN_TLS=""
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+SCRIPT_DIR=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
 cd $SCRIPT_DIR
 
 


### PR DESCRIPTION
# Description

The update_tags.sh script was introduced in [CASMINST-6528](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6528) to mitigate the possibility of not having the images declared in latest doc on the system, and to fall back to whatever is available.

The problem is that the images that are chosen on the system are not based on semantic versioning, rather on a textual sort. This is incorrect as it ends up selecting previous versions. E.g. between 0.1.10 and 0.1.3, it will select 0.1.3 which is incorrect.

The solution is to add semantic version comparisons and sort before selecting the latest image.

Tested with different types of version tags, including ones with textual prefixes and suffixes in the version tag.

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
