### PR TITLE
CAST-33719 remove docs stating to deploy rgw on all nodes with '*'

### DIFF
--- a/operations/utility_storage/Add_Ceph_Node.md
+++ b/operations/utility_storage/Add_Ceph_Node.md
@@ -87,24 +87,16 @@
    **IMPORTANT:** `radosgw` by default is deployed to the first three storage nodes. This includes `haproxy` and `keepalived`.
    This is automated as part of the install, but the configuration may need to be regenerated if not running on the first three storage nodes or all nodes.
 
-1. Deploy Rados Gateway containers to the new nodes.
-
-   - If running Rados Gateway on all nodes is the desired configuration, then run:
-
-      ```bash
-      ncn-s00(1/2/3)# ceph orch apply rgw site1 zone1 --placement="*" --port=8080
-      ```
-
-   - If deploying to select nodes, then instead run:
+1. `ncn-s00[1/2/3]#` Deploy Rados Gateway containers to the new nodes. The placement should be all nodes that Rados Gateway should be running on, not only the new node.
 
      ```bash
-     ncn-s00(1/2/3)# ceph orch apply rgw site1 zone1 --placement="<num-daemons> <node1 node2 node3 node4 ... >" --port=8080
+     ceph orch apply rgw site1 zone1 --placement="<num-daemons> <node1 node2 node3 node4 ... >" --port=8080
      ```
 
-1. Verify that Rados Gateway is running on the desired nodes.
+1. `ncn-s00[1/2/3]#` Verify that Rados Gateway is running on the desired nodes.
 
     ```bash
-    ncn-s00(1/2/3)# ceph orch ps --daemon_type rgw
+    ceph orch ps --daemon_type rgw
     ```
 
     Example output:


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
Remove docs stating to deploy rgw on all nodes with '\*'. This causes an issue where the add_node_to_haproxy.sh script was unable to get hostnames running rgw. The json information returned had a '\*' instead of listing the hostnames. Explicitly stating the hostnames, allows the script to retrieve the correct information from the json.

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
