### PR TITLE
CASMTRIAGE-5888: Add in documentation for other issues with keycloak-users-localize

### DIFF
--- a/troubleshooting/known_issues/craycli_403_forbidden_errors.md
+++ b/troubleshooting/known_issues/craycli_403_forbidden_errors.md
@@ -44,7 +44,8 @@ To recover from this situation, the following can be done.
 1. If you see an error showing that there is a duplicate group, complete the next step.
 1. Go to the Groups page in the Keycloak admin console and delete the groups.
 1. If you see an error saying there was a `KeyError: 'gidNumber'` or `KeyError: 'cn'`, complete the next steps.
-    1. Get the groups missing some atributes (ncn-m#):
+    1. Get the groups missing some attributes (ncn-m#):
+
        ```bash
        IP=$(kubectl get service/keycloak -n services -o json | jq -r '.spec.clusterIP')
        ADMIN_SECRET=$(kubectl get secret -n services keycloak-master-admin-auth --template={{.data.password}} | base64 -d)
@@ -57,12 +58,13 @@ To recover from this situation, the following can be done.
        curl -s -H "Authorization: Bearer $TOKEN" http://$IP:8080/keycloak/admin/realms/shasta/groups?briefRepresentation=false \
        | jq '.[] | select(.attributes.cn[0] == null or .attributes.gidNumber[0] == null)'
        ```
+
     1. Go to the Groups page in the Keycloak admin console
     1. Search and select the group that is missing some attribute
     1. Click on the attribute tab
     1. Add a new attribute named 'cn' with a value of the group name
     1. Add a second new attribute named 'gidNumber' with a random number over 1000000001 and under 4000000000
-    1. Repeat for all groups missing atributes
+    1. Repeat for all groups missing attributes
 1. Wait three minutes for the configuration to re-sync.
 1. Re-run the Keycloak localize job.
 

--- a/troubleshooting/known_issues/craycli_403_forbidden_errors.md
+++ b/troubleshooting/known_issues/craycli_403_forbidden_errors.md
@@ -43,6 +43,26 @@ To recover from this situation, the following can be done.
 
 1. If you see an error showing that there is a duplicate group, complete the next step.
 1. Go to the Groups page in the Keycloak admin console and delete the groups.
+1. If you see an error saying there was a `KeyError: 'gidNumber'` or `KeyError: 'cn'`, complete the next steps.
+    1. Get the groups missing some atributes (ncn-m#):
+       ```bash
+       IP=$(kubectl get service/keycloak -n services -o json | jq -r '.spec.clusterIP')
+       ADMIN_SECRET=$(kubectl get secret -n services keycloak-master-admin-auth --template={{.data.password}} | base64 -d)
+       TOKEN=$(curl -s http://$IP:8080/keycloak/realms/master/protocol/openid-connect/token \
+               -d grant_type=password \
+               -d client_id=admin-cli \
+               -d username=admin \
+               --data-urlencode password=$ADMIN_SECRET \
+               | jq -r '.access_token')
+       curl -s -H "Authorization: Bearer $TOKEN" http://$IP:8080/keycloak/admin/realms/shasta/groups?briefRepresentation=false \
+       | jq '.[] | select(.attributes.cn[0] == null or .attributes.gidNumber[0] == null)'
+       ```
+    1. Go to the Groups page in the Keycloak admin console
+    1. Search and select the group that is missing some attribute
+    1. Click on the attribute tab
+    1. Add a new attribute named 'cn' with a value of the group name
+    1. Add a second new attribute named 'gidNumber' with a random number over 1000000001 and under 4000000000
+    1. Repeat for all groups missing atributes
 1. Wait three minutes for the configuration to re-sync.
 1. Re-run the Keycloak localize job.
 

--- a/troubleshooting/known_issues/craycli_403_forbidden_errors.md
+++ b/troubleshooting/known_issues/craycli_403_forbidden_errors.md
@@ -44,7 +44,7 @@ To recover from this situation, the following can be done.
 1. If you see an error showing that there is a duplicate group, complete the next step.
 1. Go to the Groups page in the Keycloak admin console and delete the groups.
 1. If you see an error saying there was a `KeyError: 'gidNumber'` or `KeyError: 'cn'`, complete the next steps.
-    1. Get the groups missing some attributes (ncn-m#):
+    1. Get the groups missing some attributes (`ncn-m#`):
 
        ```bash
        IP=$(kubectl get service/keycloak -n services -o json | jq -r '.spec.clusterIP')


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->
This adds in the steps for fixing keycloak-users-localize if it errors out with a different error due to Keycloak internal groups. The steps are added to the standard 403 errors because that document is linked with the goss test that checks for the job status.
# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
