### PR TITLE
CASMINST-6617: Update kubectl example output

### DIFF
--- a/install/deploy_final_non-compute_node.md
+++ b/install/deploy_final_non-compute_node.md
@@ -315,13 +315,13 @@ It is important to backup some files from `ncn-m001` before it is rebooted.
     Expected output looks similar to the following:
 
     ```text
-    NAME       STATUS   ROLES                  AGE   VERSION
-    ncn-m001   Ready    control-plane,master   27s   v1.20.13
-    ncn-m002   Ready    control-plane,master   4h    v1.20.13
-    ncn-m003   Ready    control-plane,master   4h    v1.20.13
-    ncn-w001   Ready    <none>                 4h    v1.20.13
-    ncn-w002   Ready    <none>                 4h    v1.20.13
-    ncn-w003   Ready    <none>                 4h    v1.20.13
+    NAME       STATUS   ROLES                  AGE     VERSION
+    ncn-m001   Ready    control-plane,master   3m31s   v1.22.13
+    ncn-m002   Ready    control-plane,master   115m    v1.22.13
+    ncn-m003   Ready    control-plane,master   114m    v1.22.13
+    ncn-w001   Ready    <none>                 114m    v1.22.13
+    ncn-w002   Ready    <none>                 114m    v1.22.13
+    ncn-w003   Ready    <none>                 112m    v1.22.13
     ```
 
 1. (`ncn-m001#`) Restore and verify the site link.

--- a/install/deploy_non-compute_nodes.md
+++ b/install/deploy_non-compute_nodes.md
@@ -230,11 +230,11 @@ for all nodes, the Ceph storage will have been initialized and the Kubernetes cl
 
         ```text
         NAME       STATUS   ROLES                  AGE     VERSION    INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                                                  KERNEL-VERSION                 CONTAINER-RUNTIME
-        ncn-m002   Ready    control-plane,master   7m39s   v1.22.13   10.252.1.5    <none>        SUSE Linux Enterprise High Performance Computing 15 SP4   5.14.21-150400.24.66-default   containerd://1.5.16
-        ncn-m003   Ready    control-plane,master   7m16s   v1.22.13   10.252.1.6    <none>        SUSE Linux Enterprise High Performance Computing 15 SP4   5.14.21-150400.24.66-default   containerd://1.5.16
-        ncn-w001   Ready    <none>                 7m16s   v1.22.13   10.252.1.7    <none>        SUSE Linux Enterprise High Performance Computing 15 SP4   5.14.21-150400.24.66-default   containerd://1.5.16
-        ncn-w002   Ready    <none>                 7m18s   v1.22.13   10.252.1.8    <none>        SUSE Linux Enterprise High Performance Computing 15 SP4   5.14.21-150400.24.66-default   containerd://1.5.16
-        ncn-w003   Ready    <none>                 7m16s   v1.22.13   10.252.1.9    <none>        SUSE Linux Enterprise High Performance Computing 15 SP4   5.14.21-150400.24.66-default   containerd://1.5.16
+        ncn-m002   Ready    control-plane,master   7m39s   v1.22.13   10.252.1.5    <none>        SUSE Linux Enterprise High Performance Computing 15 SP5   5.14.21-150500.55.12-default   containerd://1.5.16
+        ncn-m003   Ready    control-plane,master   7m16s   v1.22.13   10.252.1.6    <none>        SUSE Linux Enterprise High Performance Computing 15 SP5   5.14.21-150500.55.12-default   containerd://1.5.16
+        ncn-w001   Ready    <none>                 7m16s   v1.22.13   10.252.1.7    <none>        SUSE Linux Enterprise High Performance Computing 15 SP5   5.14.21-150500.55.12-default   containerd://1.5.16
+        ncn-w002   Ready    <none>                 7m18s   v1.22.13   10.252.1.8    <none>        SUSE Linux Enterprise High Performance Computing 15 SP5   5.14.21-150500.55.12-default   containerd://1.5.16
+        ncn-w003   Ready    <none>                 7m16s   v1.22.13   10.252.1.9    <none>        SUSE Linux Enterprise High Performance Computing 15 SP5   5.14.21-150500.55.12-default   containerd://1.5.16
         ```
 
 1. (`pit#`) Stop watching the consoles.

--- a/install/deploy_non-compute_nodes.md
+++ b/install/deploy_non-compute_nodes.md
@@ -229,12 +229,12 @@ for all nodes, the Ceph storage will have been initialized and the Kubernetes cl
         Expected output looks similar to the following:
 
         ```text
-        NAME       STATUS   ROLES                  AGE   VERSION    INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                                                  KERNEL-VERSION         CONTAINER-RUNTIME
-        ncn-m002   Ready    control-plane,master   2h    v1.20.13   10.252.1.5    <none>        SUSE Linux Enterprise High Performance Computing 15 SP3   5.3.18-59.19-default   containerd://1.5.7
-        ncn-m003   Ready    control-plane,master   2h    v1.20.13   10.252.1.6    <none>        SUSE Linux Enterprise High Performance Computing 15 SP3   5.3.18-59.19-default   containerd://1.5.7
-        ncn-w001   Ready    <none>                 2h    v1.20.13   10.252.1.7    <none>        SUSE Linux Enterprise High Performance Computing 15 SP3   5.3.18-59.19-default   containerd://1.5.7
-        ncn-w002   Ready    <none>                 2h    v1.20.13   10.252.1.8    <none>        SUSE Linux Enterprise High Performance Computing 15 SP3   5.3.18-59.19-default   containerd://1.5.7
-        ncn-w003   Ready    <none>                 2h    v1.20.13   10.252.1.9    <none>        SUSE Linux Enterprise High Performance Computing 15 SP3   5.3.18-59.19-default   containerd://1.5.7
+        NAME       STATUS   ROLES                  AGE     VERSION    INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                                                  KERNEL-VERSION                 CONTAINER-RUNTIME
+        ncn-m002   Ready    control-plane,master   7m39s   v1.22.13   10.252.1.5    <none>        SUSE Linux Enterprise High Performance Computing 15 SP4   5.14.21-150400.24.66-default   containerd://1.5.16
+        ncn-m003   Ready    control-plane,master   7m16s   v1.22.13   10.252.1.6    <none>        SUSE Linux Enterprise High Performance Computing 15 SP4   5.14.21-150400.24.66-default   containerd://1.5.16
+        ncn-w001   Ready    <none>                 7m16s   v1.22.13   10.252.1.7    <none>        SUSE Linux Enterprise High Performance Computing 15 SP4   5.14.21-150400.24.66-default   containerd://1.5.16
+        ncn-w002   Ready    <none>                 7m18s   v1.22.13   10.252.1.8    <none>        SUSE Linux Enterprise High Performance Computing 15 SP4   5.14.21-150400.24.66-default   containerd://1.5.16
+        ncn-w003   Ready    <none>                 7m16s   v1.22.13   10.252.1.9    <none>        SUSE Linux Enterprise High Performance Computing 15 SP4   5.14.21-150400.24.66-default   containerd://1.5.16
         ```
 
 1. (`pit#`) Stop watching the consoles.


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/docs-csm/pull/4161, but with the CSM 1.5 versions