### PR TITLE
CASMTRIAGE-5928 `UPDATE_NCN_CLOUD_INIT_PACKAGE_LISTS_AND_REPO_DEFINITIONS`

### DIFF
--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -786,7 +786,9 @@ if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
     if [ "$do_patch" -eq 1 ]; then
 
       # Get a list of NCNs.
-      IFS=$',' read -r -d '' -a NCN_XNAMES < <(cray hsm state components list --role Management --type Node --format json | jq -r '.Components | map(.ID) | join(",")')
+      if IFS=$',' read -rd '' -a NCN_XNAMES; then
+        :
+      fi <<< "$(cray hsm state components list --role Management --type Node --format json | jq -r '.Components | map(.ID) | join(",")')"
 
       # If no NCNs are found we should exit, otherwise if forces its way forward then NCNs will be missing critical packages.
       if [ "${#NCN_XNAMES[@]}" -eq '0' ]; then

--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -780,6 +780,8 @@ if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
         # Set `do_patch` to 1 so that the operations in this stage run.
         do_patch=1
       fi
+    else
+      do_patch=1
     fi
 
     # Patch cloud-init user-data for each NCN only if we have our ${sourcefile}.json.


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->
This fixes two problems:

1. The `read` command was returning a non-zero despite successfully populating the `NCN_XNAMES` array. A non-zero is returned by `read` if the delimiter is not found before the end of file. A trick to work around this is to use a loop/if statement.
2. Re-runs were successfully skipping this stage because `do_patch` is never set to 1 on a re-run. The conditional checking whether `cloud-init.json` was already created needs to also set `do_patch=1`

I tested this by re-running `prerequisites.sh` on fanta, after modifying the `state` file to allow this stage to run from scratch. The last few tests were ran piecemeal, this test is more accurate and this stage should stop giving us grief.

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
