### PR TITLE
CASMTRIAGE-5957 Remove hardcodes

### DIFF
--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -768,7 +768,7 @@ if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
         fi
 
         # Verify that user-data.zypper is now null.
-        if [ ! "$(cray bss bootparameters list --format json --hosts x3000c0s3b0n0 | jq '.[]."cloud-init"."user-data".zypper')" = 'null' ]; then
+        if [ ! "$(cray bss bootparameters list --format json --hosts "$ncn_xname" | jq '.[]."cloud-init"."user-data".zypper')" = 'null' ]; then
           echo >&2 "${ncn_xname}: user-data.zypper key is still defined!"
           error=1
         fi
@@ -779,7 +779,7 @@ if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
         fi
 
         # Verify that user-data.packages is now null.
-        if [ ! "$(cray bss bootparameters list --format json --hosts x3000c0s3b0n0 | jq '.[]."cloud-init"."user-data".packages')" = 'null' ]; then
+        if [ ! "$(cray bss bootparameters list --format json --hosts "$ncn_xname" | jq '.[]."cloud-init"."user-data".packages')" = 'null' ]; then
           echo >&2 "${ncn_xname}: user-data.packages key is still defined!"
           error=1
         fi

--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -744,9 +744,9 @@ if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
     if [ "$do_patch" -eq 1 ]; then
 
       # Get a list of NCNs.
-      if IFS=$',' read -rd '' -a NCN_XNAMES; then
+      if IFS=$'\n' read -rd '' -a NCN_XNAMES; then
         :
-      fi <<< "$(cray hsm state components list --role Management --type Node --format json | jq -r '.Components | map(.ID) | join(",")')"
+      fi <<< "$(cray hsm state components list --role Management --type Node --format json | jq -r '.Components | map(.ID) | join("\n")')"
 
       # If no NCNs are found we should exit, otherwise if forces its way forward then NCNs will be missing critical packages.
       if [ "${#NCN_XNAMES[@]}" -eq '0' ]; then


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->
Hardcodes for an xname made it into prereqs, preventing the cloud-init data from being updated properly.

The data was getting removed from each node, but then the same node was always being pinged for validation.

This also fixed an extra iteration of the loop, which was harmless but unnecessary and potentially risky.
# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
