### PR TITLE
CASMINST-6628: Correct errors in VCS backup/restore procedure

### DIFF
--- a/operations/configuration_management/Version_Control_Service_VCS.md
+++ b/operations/configuration_management/Version_Control_Service_VCS.md
@@ -297,8 +297,8 @@ while the service is running using the following commands:
 
 ```bash
 POD=$(kubectl -n services get pod -l app.kubernetes.io/instance=gitea -o json | jq -r '.items[] | .metadata.name')
-kubectl -n services exec ${POD} -- tar -cvf vcs.tar /var/lib/gitea/
-kubectl -n services cp ${POD}:vcs.tar ./vcs.tar
+kubectl -n services exec ${POD} -- tar -cvf /tmp/vcs.tar /var/lib/gitea/
+kubectl -n services cp ${POD}:/tmp/vcs.tar ./vcs.tar
 ```
 
 Be sure to save the resulting `tar` file to a safe location.
@@ -314,8 +314,8 @@ process can be run at any time while the service is running using the following 
 
 ```bash
 POD=$(kubectl -n services get pod -l app.kubernetes.io/instance=gitea -o json | jq -r '.items[] | .metadata.name')
-kubectl -n services cp ./vcs.tar ${POD}:vcs.tar
-kubectl -n services exec ${POD} -- tar -xvf vcs.tar
+kubectl -n services cp ./vcs.tar ${POD}:/tmp/vcs.tar
+kubectl -n services exec ${POD} -- tar -C / -xvf /tmp/vcs.tar
 kubectl -n services rollout restart deployment gitea-vcs
 ```
 


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
The VCS backup/restore procedure currently has a few flaws:

1. When creating the tar file backup of the PVC data, the resulting tar file is being created in the directory that is being backed up. This means that if a subsequent backup is taken, it will include this file needlessly.
2. The same issue occurs on the restore side -- the tar file is copied into the pod in the same directory that will be included in future backups. Again, not desirable.
3. When restoring the PVC data, the tar file is expanded from the default working directory in the pod, which is not `/`. However, in order for the procedure to properly restore the data, it needs to be restored relative to the `/` path in the pod. 

Items 1 and 2 are minor, but item 3 breaks the restore procedure (as I discovered on wasp). This PR corrects all three. I have tested the updated procedures and they work fine.

Also, the revised restore procedure will work fine with backups taken using the original procedure, so no worries on that front.

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
