### PR TITLE
CASMCMS-8769 - fix formatting for helm chart example.

### DIFF
--- a/operations/conman/Complete_Reset_of_the_Console_Services.md
+++ b/operations/conman/Complete_Reset_of_the_Console_Services.md
@@ -92,10 +92,10 @@ The existing console log files will be retained, but there will be a gap in the 
         cat > cray-console-data.yaml << EOF
         apiVersion: manifests/v1beta1
         metadata:
-        name: cray-console-data-20230712194246
+          name: cray-console-data-20230712194246
         spec:
-        charts:
-            - name: cray-console-data
+          charts:
+          - name: cray-console-data
             namespace: services
             version: 2.0.0
         EOF


### PR DESCRIPTION
# Description
https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8769

This just fixes the indentation on example code creating a helm chart.

# Checklist
- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
