### PR TITLE
Ensure testing rpms are installed before running goss tests (CASMTRIAGE-5892)

### DIFF
--- a/scripts/ensure_testing_rpms.sh
+++ b/scripts/ensure_testing_rpms.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+target_ncn="${1:-$(hostname)}"
+
+while true; do
+  missing_rpms=""
+  for rpm in csm-testing goss-servers; do
+    if ! ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $target_ncn -t "rpm -qa | grep -q $rpm" 2> /dev/null; then
+      missing_rpms="$missing_rpms $rpm"
+    fi
+  done
+  if ! test -z "$missing_rpms"; then
+    echo "Waiting for the following rpm(s) to installed via cloud-init on $target_ncn: ${missing_rpms}..."
+    sleep 5
+  else
+    echo "csm-testing and goss-servers rpms verified on $target_ncn"
+    break
+  fi
+done

--- a/upgrade/scripts/upgrade/ncn-upgrade-master-nodes.sh
+++ b/upgrade/scripts/upgrade/ncn-upgrade-master-nodes.sh
@@ -196,6 +196,18 @@ else
   echo "====> ${state_name} has been completed"
 fi
 
+state_name="ENSURE_TESTING_RPMS"
+state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
+if [[ $state_recorded == "0" ]]; then
+  echo "====> ${state_name} ..."
+  {
+    /usr/share/doc/csm/scripts/ensure_testing_rpms.sh ${target_ncn}
+  } >> ${LOG_FILE} 2>&1
+  record_state "${state_name}" ${target_ncn}
+else
+  echo "====> ${state_name} has been completed"
+fi
+
 cat << EOF
 NOTE:
     If below test failed, try to fix it based on test output. Then run current script again

--- a/workflows/templates/post-rebuild-worker.yaml
+++ b/workflows/templates/post-rebuild-worker.yaml
@@ -37,7 +37,21 @@ spec:
           - name: switchPassword
       dag:
         tasks:
+        - name: worker-ensure-testing-rpms
+          templateRef:
+            name: ssh-template
+            template: shell-script
+          arguments:
+            parameters:
+              - name: dryRun
+                value: "{{inputs.parameters.dryRun}}"
+              - name: scriptContent
+                value: |
+                  TARGET_NCN="{{inputs.parameters.targetNcn}}"
+                  /usr/share/doc/csm/scripts/ensure_testing_rpms.sh ${TARGET_NCN}
         - name: goss
+          dependencies:
+            - worker-ensure-testing-rpms
           templateRef:
             name: ssh-template
             template: shell-script

--- a/workflows/templates/storage.goss-tests.yaml
+++ b/workflows/templates/storage.goss-tests.yaml
@@ -35,7 +35,21 @@ spec:
           - name: targetNcn
       dag:
         tasks:
+          - name: storage-ensure-testing-rpms
+            templateRef:
+              name: ssh-template
+              template: shell-script
+            arguments:
+              parameters:
+                - name: dryRun
+                  value: "{{inputs.parameters.dryRun}}"
+                - name: scriptContent
+                  value: |
+                    TARGET_NCN="{{inputs.parameters.targetNcn}}"
+                    /usr/share/doc/csm/scripts/ensure_testing_rpms.sh ${TARGET_NCN}
           - name: storage-goss-test-task
+            dependencies:
+              - storage-ensure-testing-rpms
             templateRef:
               name: ssh-template
               template: shell-script


### PR DESCRIPTION
### Summary and Scope

Add check for install of testing rpms before running goss suite.

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5892

### Testing (ashton)

```
ncn-m001:~ # kubectl logs -n argo ncn-lifecycle-rebuild-sjqbm-shell-script-566386351 -f
time="2023-09-01T19:30:29.832Z" level=info msg="capturing logs" argo=true
Warning: Permanently added 'ncn-m001' (ED25519) to the list of known hosts.
Warning: Permanently added 'ncn-m001' (ED25519) to the list of known hosts.
Waiting for the following rpm(s) to installed via cloud-init on ncn-s003:  csm-testing...
Waiting for the following rpm(s) to installed via cloud-init on ncn-s003:  csm-testing...
Waiting for the following rpm(s) to installed via cloud-init on ncn-s003:  csm-testing...
Waiting for the following rpm(s) to installed via cloud-init on ncn-s003:  csm-testing...
Waiting for the following rpm(s) to installed via cloud-init on ncn-s003:  csm-testing...
Waiting for the following rpm(s) to installed via cloud-init on ncn-s003:  csm-testing...
Waiting for the following rpm(s) to installed via cloud-init on ncn-s003:  csm-testing...
Waiting for the following rpm(s) to installed via cloud-init on ncn-s003:  csm-testing...
Waiting for the following rpm(s) to installed via cloud-init on ncn-s003:  csm-testing...
Waiting for the following rpm(s) to installed via cloud-init on ncn-s003:  csm-testing...
Waiting for the following rpm(s) to installed via cloud-init on ncn-s003:  csm-testing...
Waiting for the following rpm(s) to installed via cloud-init on ncn-s003:  csm-testing...
Waiting for the following rpm(s) to installed via cloud-init on ncn-s003:  csm-testing...
Waiting for the following rpm(s) to installed via cloud-init on ncn-s003:  csm-testing...
Waiting for the following rpm(s) to installed via cloud-init on ncn-s003:  csm-testing...
Waiting for the following rpm(s) to installed via cloud-init on ncn-s003:  csm-testing...
Waiting for the following rpm(s) to installed via cloud-init on ncn-s003:  csm-testing...
Waiting for the following rpm(s) to installed via cloud-init on ncn-s003:  csm-testing...
Waiting for the following rpm(s) to installed via cloud-init on ncn-s003:  csm-testing...
Waiting for the following rpm(s) to installed via cloud-init on ncn-s003:  csm-testing...
Waiting for the following rpm(s) to installed via cloud-init on ncn-s003:  csm-testing...
Waiting for the following rpm(s) to installed via cloud-init on ncn-s003:  csm-testing...
Waiting for the following rpm(s) to installed via cloud-init on ncn-s003:  csm-testing...
csm-testing and goss-servers rpms verified on ncn-s003
```

N/A

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing

