### PR TITLE
CASMINST-6632: Remove uas-mgr from gateway tests

### DIFF
--- a/scripts/operations/gateway-test/gateway-test-defn.yaml
+++ b/scripts/operations/gateway-test/gateway-test-defn.yaml
@@ -170,13 +170,6 @@ ingress_api_services:
   namespace: services
   gateways: ["services-gateway","customer-admin-gateway"]
   project: CSM
-- name: cray-uas-mgr
-  path: apis/uas-mgr/v1/images
-  port: 443
-  expected-result: 200
-  namespace: services
-  gateways: ["services-gateway","customer-admin-gateway"]
-  project: CSM
 - name: nmdv2-service
   path: apis/v2/nmd/dumps
   port: 443


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

CASMINST-6632 describes an intermittent issue with the `cray uas images list --format toml` command.   It was decided not to address the intermittent issue because UAS is being phased out in favor of the K3s on UAN for management of UAIs in UAN 2.7/2.8.    To avoid continuing to hit this issue occasionally in the gateway tests, we are removing the uas-mgr service from the gateway tests.

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
