### PR TITLE
Fix post-rebuild-worker yaml parsing (CASMPET-6764)

### DIFF
--- a/workflows/templates/post-rebuild-worker.yaml
+++ b/workflows/templates/post-rebuild-worker.yaml
@@ -47,7 +47,7 @@ spec:
                 value: "{{inputs.parameters.dryRun}}"
               - name: scriptContent
                 value: |
-                  TARGET_NCN="{{inputs.parameters.targetNcn}}"
+                  TARGET_NCN="{{inputs.parameters.targetNcn}}" \
                   /usr/share/doc/csm/scripts/ensure_testing_rpms.sh ${TARGET_NCN}
         - name: goss
           dependencies:


### PR DESCRIPTION
### Summary and Scope

Fix yaml parsing error for workflow that ensures testing rpms are installed.

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMPET-6764

### Testing

Yaml validator

N/A

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing

