### PR TITLE
CASMCMS-8796: Fix problems with calls to Bash shared library function

### DIFF
--- a/scripts/operations/configuration/apply_csm_configuration.sh
+++ b/scripts/operations/configuration/apply_csm_configuration.sh
@@ -23,7 +23,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-locOfScript=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+locOfScript=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 # Inform ShellCheck about the file we are sourcing
 # shellcheck source=./bash_lib/common.sh
 . "${locOfScript}/bash_lib/common.sh"
@@ -40,40 +40,39 @@ CLEAR_STATE=""
 NO_ENABLE=""
 NO_CLEAR_ERR=""
 
-usage()
-{
-   # Display help
-   echo "Updates CFS configurations"
-   echo "All parameters are optional and the values will be determined automatically if not set."
-   echo
-   echo "Usage 1: apply_csm_configuration.sh [ --config-change ] --config-name name"
-   echo "                                    [ --csm-release version ] [ --git-commit hash ]"
-   echo "                                    [ --git-clone-url url ] [ --ncn-config-file file ]"
-   echo "                                    [ --clear-state ] [ --no-enable ] [ --no-clear-err ]"
-   echo "                                    [ --xnames xname1,xname2... ]"
-   echo
-   echo "Usage 2: apply_csm_configuration.sh --no-config-change --config-name name"
-   echo "                                    [ --clear-state ] [ --no-enable ] [ --no-clear-err ]"
-   echo "                                    [ --xnames xname1,xname2... ]"
-   echo
-   echo "In usage 1, either a new CFS configuration is created or an existing CFS configuration is updated."
-   echo "In usage 2, an existing CFS configuration is used without modification."
-   echo
-   echo "Options:"
-   echo "config-name          Usage 1: name to use for the new/updated CFS configuration."
-   echo "                     Usage 2: name of existing CFS configuration to use"
-   echo "config-change        Specifies usage 1. (default)"
-   echo "no-config-change     Specifies usage 2."
-   echo "csm-release          The version of the CSM release to use. (e.g. 1.6.11). Only valid with usage 1."
-   echo "git-commit           The git commit hash for CFS to use. Only valid with usage 1."
-   echo "git-clone-url        The git clone url for CFS to use. Only valid with usage 1."
-   echo "ncn-config-file      A file containing the NCN CFS configuration. Only valid with usage 1."
-   echo "xnames               A comma-separated list of component names (xnames) to deploy to. All management nodes will be included if not set."
-   echo "clear-state          Clears existing state from components to ensure CFS runs."
-   echo "no-enable            By default, the script enables all of the NCNs and waits for them to complete configuration. If this flag is set,"
-   echo "                     however, it updates their desired configurations but leaves them disabled."
-   echo "no-clear-err         By default, the script clears the error count of all NCNs in CFS. If this flag is set, it does not."
-   echo
+usage() {
+  # Display help
+  echo "Updates CFS configurations"
+  echo "All parameters are optional and the values will be determined automatically if not set."
+  echo
+  echo "Usage 1: apply_csm_configuration.sh [ --config-change ] --config-name name"
+  echo "                                    [ --csm-release version ] [ --git-commit hash ]"
+  echo "                                    [ --git-clone-url url ] [ --ncn-config-file file ]"
+  echo "                                    [ --clear-state ] [ --no-enable ] [ --no-clear-err ]"
+  echo "                                    [ --xnames xname1,xname2... ]"
+  echo
+  echo "Usage 2: apply_csm_configuration.sh --no-config-change --config-name name"
+  echo "                                    [ --clear-state ] [ --no-enable ] [ --no-clear-err ]"
+  echo "                                    [ --xnames xname1,xname2... ]"
+  echo
+  echo "In usage 1, either a new CFS configuration is created or an existing CFS configuration is updated."
+  echo "In usage 2, an existing CFS configuration is used without modification."
+  echo
+  echo "Options:"
+  echo "config-name          Usage 1: name to use for the new/updated CFS configuration."
+  echo "                     Usage 2: name of existing CFS configuration to use"
+  echo "config-change        Specifies usage 1. (default)"
+  echo "no-config-change     Specifies usage 2."
+  echo "csm-release          The version of the CSM release to use. (e.g. 1.6.11). Only valid with usage 1."
+  echo "git-commit           The git commit hash for CFS to use. Only valid with usage 1."
+  echo "git-clone-url        The git clone url for CFS to use. Only valid with usage 1."
+  echo "ncn-config-file      A file containing the NCN CFS configuration. Only valid with usage 1."
+  echo "xnames               A comma-separated list of component names (xnames) to deploy to. All management nodes will be included if not set."
+  echo "clear-state          Clears existing state from components to ensure CFS runs."
+  echo "no-enable            By default, the script enables all of the NCNs and waits for them to complete configuration. If this flag is set,"
+  echo "                     however, it updates their desired configurations but leaves them disabled."
+  echo "no-clear-err         By default, the script clears the error count of all NCNs in CFS. If this flag is set, it does not."
+  echo
 }
 
 while [[ $# -gt 0 ]]; do
@@ -81,9 +80,9 @@ while [[ $# -gt 0 ]]; do
 
   # Make sure that flags which require arguments get them
   case "${key}" in
-    --csm-release|--csm-config-version|--git-commit|--git-clone-url|--ncn-config-file|--xnames|--config-name)
+    --csm-release | --csm-config-version | --git-commit | --git-clone-url | --ncn-config-file | --xnames | --config-name)
       [[ $# -lt 2 ]] && usage_err_exit "${key} requires an argument"
-      [[ -z "$2" ]] && usage_err_exit "Argument to ${key} may not be blank"
+      [[ -z $2 ]] && usage_err_exit "Argument to ${key} may not be blank"
       ;;
   esac
 
@@ -135,13 +134,12 @@ while [[ $# -gt 0 ]]; do
       ;;
     --ncn-config-file)
       [[ ${CONFIG_CHANGE} == false ]] && usage_err_exit "--ncn-config-file and --no-config-change are mutually exclusive"
-      # Make sure the file exists, is a regular file, is not empty, and 
-      # contains valid JSON data
-      [[ -e "$2" ]] || usage_err_exit "NCN config file ($2) does not exist"
-      [[ -f "$2" ]] || usage_err_exit "NCN config file ($2) exists but is not a regular file"
-      [[ -s "$2" ]] || usage_err_exit "NCN config file ($2) has zero size"
+      # Make sure the file exists, is a regular file, is not empty, and contains valid JSON data
+      [[ -e $2 ]] || usage_err_exit "NCN config file ($2) does not exist"
+      [[ -f $2 ]] || usage_err_exit "NCN config file ($2) exists but is not a regular file"
+      [[ -s $2 ]] || usage_err_exit "NCN config file ($2) has zero size"
       json=$(cat "$2" | jq) || usage_err_exit "NCN config file ($2) is not valid JSON format"
-      [[ -z "$json" ]] && usage_err_exit "NCN config file ($2) contains no JSON data"
+      [[ -z ${json} ]] && usage_err_exit "NCN config file ($2) contains no JSON data"
       OLD_NCN_CONFIG_FILE="$2"
       shift # past argument
       shift # past value
@@ -158,12 +156,12 @@ while [[ $# -gt 0 ]]; do
     --no-clear-err)
       NO_CLEAR_ERR="true"
       shift # past argument
-      ;;      
+      ;;
     --no-enable)
       NO_ENABLE="true"
       shift # past argument
       ;;
-    -h|--help) # help option
+    -h | --help) # help option
       usage
       exit 0
       ;;
@@ -182,105 +180,101 @@ done
 # CSM upgrades, this directory will be backed up, in case it is needed for
 # future reference.
 
-TMPDIR=$(run_mktemp -d "${HOME}/apply_csm_configuration.$(date +%Y%m%d_%H%M%S).XXXXXX")
-BACKUP_NCN_CONFIG_FILE=$(run_mktemp --tmpdir="${TMPDIR}" "backup-${CONFIG_NAME}-XXXXXX.json")
+TMPDIR=$(run_mktemp -d "${HOME}/apply_csm_configuration.$(date +%Y%m%d_%H%M%S).XXXXXX") || exit 1
+BACKUP_NCN_CONFIG_FILE=$(run_mktemp --tmpdir="${TMPDIR}" "backup-${CONFIG_NAME}-XXXXXX.json") || exit 1
 
 if [[ -z ${XNAMES} ]]; then
-    echo "Retrieving a list of all management node component names (xnames)"
-    XNAMES=$(cray hsm state components list --role Management --type Node --format json | jq -r '.Components | map(.ID) | join(",")')
-    [[ -n "${XNAMES}" ]] || err_exit "No management nodes found in HSM"
+  echo "Retrieving a list of all management node component names (xnames)"
+  XNAMES=$(cray hsm state components list --role Management --type Node --format json | jq -r '.Components | map(.ID) | join(",")')
+  [[ -n ${XNAMES} ]] || err_exit "No management nodes found in HSM"
 fi
 XNAME_LIST=${XNAMES//,/ }
 
 ## CONFIGURATION SETUP ##
 if [[ ${CONFIG_CHANGE} == true ]]; then
 
-    if [[ -z "${RELEASE}" && -z "${VERSION}" ]]; then
-        RELEASE=$(kubectl -n services get cm cray-product-catalog -o jsonpath='{.data.csm}' 2>/dev/null\
-            | yq r -j - 2>/dev/null | jq -r ' to_entries | max_by(.key) | .key' 2>/dev/null)
-        [[ -n "${RELEASE}" ]] || err_exit "Unable to determine CSM release version"
-        echo "Using latest release ${RELEASE}"
-    fi
+  if [[ -z ${RELEASE} && -z ${VERSION} ]]; then
+    RELEASE=$(kubectl -n services get cm cray-product-catalog -o jsonpath='{.data.csm}' 2> /dev/null | yq r -j - 2> /dev/null | jq -r ' to_entries | max_by(.key) | .key' 2> /dev/null)
+    [[ -n ${RELEASE} ]] || err_exit "Unable to determine CSM release version"
+    echo "Using latest release ${RELEASE}"
+  fi
 
-    if [[ -z "${VERSION}" ]]; then
-        VERSION=$(kubectl -n services get cm cray-product-catalog -o jsonpath='{.data.csm}' 2>/dev/null\
-            | yq r -j - 2>/dev/null | jq -r ".[\"$RELEASE\"].configuration.import_branch" 2>/dev/null\
-            | awk -F'/' '{ print $NF }')
-        [[ -n "${VERSION}" ]] || err_exit "Unable to determine CSM configuration version"
-        echo "Using CSM configuration version ${VERSION}"
-    fi
+  if [[ -z ${VERSION} ]]; then
+    VERSION=$(kubectl -n services get cm cray-product-catalog -o jsonpath='{.data.csm}' 2> /dev/null | yq r -j - 2> /dev/null | jq -r ".[\"$RELEASE\"].configuration.import_branch" 2> /dev/null | awk -F'/' '{ print $NF }')
+    [[ -n ${VERSION} ]] || err_exit "Unable to determine CSM configuration version"
+    echo "Using CSM configuration version ${VERSION}"
+  fi
 
-    # If a file is passed in as input, keep a copy in the temporary directory
-    if [[ -n ${OLD_NCN_CONFIG_FILE} && -f ${OLD_NCN_CONFIG_FILE} ]]; then
-        run_cmd cp "${OLD_NCN_CONFIG_FILE}" "${TMPDIR}"
-    fi
+  # If a file is passed in as input, keep a copy in the temporary directory
+  if [[ -n ${OLD_NCN_CONFIG_FILE} && -f ${OLD_NCN_CONFIG_FILE} ]]; then
+    run_cmd cp "${OLD_NCN_CONFIG_FILE}" "${TMPDIR}"
+  fi
 
-    CSM_CONFIG_FILE=$(run_mktemp --tmpdir="${TMPDIR}" "csm-config-${VERSION}-XXXXXX.json")
-    NCN_CONFIG_FILE=$(run_mktemp --tmpdir="${TMPDIR}" "new-${CONFIG_NAME}-XXXXXX.json")
+  CSM_CONFIG_FILE=$(run_mktemp --tmpdir="${TMPDIR}" "csm-config-${VERSION}-XXXXXX.json") || exit 1
+  NCN_CONFIG_FILE=$(run_mktemp --tmpdir="${TMPDIR}" "new-${CONFIG_NAME}-XXXXXX.json") || exit 1
 
-    if [[ -z "${CLONE_URL}" ]]; then
-        CLONE_URL="https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git"
-    fi
+  if [[ -z ${CLONE_URL} ]]; then
+    CLONE_URL="https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git"
+  fi
 
-    if [[ -z "${COMMIT}" ]]; then
-        VCS_USER=$(kubectl get secret -n services vcs-user-credentials --template='{{.data.vcs_username}}' | base64 --decode)
-        [[ -n "${VCS_USER}" ]] || err_exit "Unable to obtain VCS username"
-        VCS_PASSWORD=$(kubectl get secret -n services vcs-user-credentials --template='{{.data.vcs_password}}' | base64 --decode)
-        [[ -n "${VCS_PASSWORD}" ]] || err_exit "Unable to obtain VCS password"
-        TEMP_DIR=$(run_mktemp -d)
-        TEMP_HOME=${HOME}
-        HOME=${TEMP_DIR}
-        cd "${TEMP_DIR}" || err_exit "Unable to change directory to '${TEMP_DIR}'"
-        echo "${CLONE_URL/\/\//\/\/${VCS_USER}:${VCS_PASSWORD}@}" > .git-credentials
-        run_cmd git config --file .gitconfig credential.helper store
-        COMMIT=$(git ls-remote ${CLONE_URL} refs/heads/cray/csm/${VERSION} | awk '{print $1}')
-        if [[ -n ${COMMIT} ]]; then
-            echo "Found git commit ${COMMIT}"
-        else
-            echo "No git commit found"
-            exit 1
-        fi
-        cd - >/dev/null || err_exit "Unable to change directory back to previous directory"
-        HOME=${TEMP_HOME}
-        rm -r "${TEMP_DIR}" || echo "WARNING: Unable to delete temporary directory '${TEMP_DIR}'" 1>&2
-    fi
-
-    CONFIG="{ \"layers\": [ { \"name\": \"csm-${VERSION}\", \"cloneUrl\": \"${CLONE_URL}\", \"commit\": \"${COMMIT}\", \"playbook\": \"site.yml\" } ] }"
-
-    echo "Creating the configuration file ${CSM_CONFIG_FILE}"
-    echo "${CONFIG}" | jq > "${CSM_CONFIG_FILE}" || err_exit "Unexpected error parsing JSON or writing to '${CSM_CONFIG_FILE}'"
-
-    if [[ -n ${OLD_NCN_CONFIG_FILE} && -f ${OLD_NCN_CONFIG_FILE} ]]; then
-        echo "Combining new CSM configuration '${CSM_CONFIG_FILE}' with contents of '${OLD_NCN_CONFIG_FILE}' to generate '${NCN_CONFIG_FILE}'"
-        jq -n --slurpfile new "${CSM_CONFIG_FILE}" --slurpfile old "${OLD_NCN_CONFIG_FILE}" \
-            '{"layers": ($new[0].layers + ($old[0].layers | del(.[] | select(.cloneUrl == $new[0].layers[0].cloneUrl and .playbook == $new[0].layers[0].playbook))))}'\
-            > "${NCN_CONFIG_FILE}" || err_exit "Unexpected error combining JSON or writing to '${NCN_CONFIG_FILE}'"
+  if [[ -z ${COMMIT} ]]; then
+    VCS_USER=$(kubectl get secret -n services vcs-user-credentials --template='{{.data.vcs_username}}' | base64 --decode)
+    [[ -n ${VCS_USER} ]] || err_exit "Unable to obtain VCS username"
+    VCS_PASSWORD=$(kubectl get secret -n services vcs-user-credentials --template='{{.data.vcs_password}}' | base64 --decode)
+    [[ -n ${VCS_PASSWORD} ]] || err_exit "Unable to obtain VCS password"
+    TEMP_DIR=$(run_mktemp -d) || exit 1
+    TEMP_HOME=${HOME}
+    HOME=${TEMP_DIR}
+    cd "${TEMP_DIR}" || err_exit "Unable to change directory to '${TEMP_DIR}'"
+    echo "${CLONE_URL/\/\//\/\/${VCS_USER}:${VCS_PASSWORD}@}" > .git-credentials
+    run_cmd git config --file .gitconfig credential.helper store
+    COMMIT=$(git ls-remote ${CLONE_URL} refs/heads/cray/csm/${VERSION} | awk '{print $1}')
+    if [[ -n ${COMMIT} ]]; then
+      echo "Found git commit ${COMMIT}"
     else
-        echo "Creating new NCN configuration file ${NCN_CONFIG_FILE}"
-        run_cmd cp -p "${CSM_CONFIG_FILE}" "${NCN_CONFIG_FILE}"
+      err_exit "No git commit found"
     fi
+    cd - > /dev/null || err_exit "Unable to change directory back to previous directory"
+    HOME=${TEMP_HOME}
+    rm -r "${TEMP_DIR}" || err "WARNING: Unable to delete temporary directory '${TEMP_DIR}'"
+  fi
 
-    ## UPDATING CFS ##
+  CONFIG="{ \"layers\": [ { \"name\": \"csm-${VERSION}\", \"cloneUrl\": \"${CLONE_URL}\", \"commit\": \"${COMMIT}\", \"playbook\": \"site.yml\" } ] }"
 
-    echo "Disabling configuration for all listed components"
-    for xname in ${XNAME_LIST}; do
-        run_cmd cray cfs components update ${xname} --enabled false
-    done
+  echo "Creating the configuration file ${CSM_CONFIG_FILE}"
+  echo "${CONFIG}" | jq > "${CSM_CONFIG_FILE}" || err_exit "Unexpected error parsing JSON or writing to '${CSM_CONFIG_FILE}'"
 
-    # Before updating the configuration, make a backup of the existing configuration (if it exists)
-    echo "Backing up existing ${CONFIG_NAME} configuration (if any) to ${BACKUP_NCN_CONFIG_FILE}"
-    # Do not use run_cmd for this call because if it fails, that's okay -- it most likely means that the CFS configuration does not exist.
-    cray cfs configurations describe "${CONFIG_NAME}" --format json > "${BACKUP_NCN_CONFIG_FILE}" 2>&1
+  if [[ -n ${OLD_NCN_CONFIG_FILE} && -f ${OLD_NCN_CONFIG_FILE} ]]; then
+    echo "Combining new CSM configuration '${CSM_CONFIG_FILE}' with contents of '${OLD_NCN_CONFIG_FILE}' to generate '${NCN_CONFIG_FILE}'"
+    jq -n --slurpfile new "${CSM_CONFIG_FILE}" --slurpfile old "${OLD_NCN_CONFIG_FILE}" \
+      '{"layers": ($new[0].layers + ($old[0].layers | del(.[] | select(.cloneUrl == $new[0].layers[0].cloneUrl and .playbook == $new[0].layers[0].playbook))))}' \
+      > "${NCN_CONFIG_FILE}" || err_exit "Unexpected error combining JSON or writing to '${NCN_CONFIG_FILE}'"
+  else
+    echo "Creating new NCN configuration file ${NCN_CONFIG_FILE}"
+    run_cmd cp -p "${CSM_CONFIG_FILE}" "${NCN_CONFIG_FILE}"
+  fi
 
-    echo "Updating ${CONFIG_NAME} configuration"
-    run_cmd cray cfs configurations update "${CONFIG_NAME}" --file "${NCN_CONFIG_FILE}"
+  ## UPDATING CFS ##
+
+  echo "Disabling configuration for all listed components"
+  for xname in ${XNAME_LIST}; do
+    run_cmd cray cfs components update ${xname} --enabled false
+  done
+
+  # Before updating the configuration, make a backup of the existing configuration (if it exists)
+  echo "Backing up existing ${CONFIG_NAME} configuration (if any) to ${BACKUP_NCN_CONFIG_FILE}"
+  # Do not use run_cmd for this call because if it fails, that's okay -- it most likely means that the CFS configuration does not exist.
+  cray cfs configurations describe "${CONFIG_NAME}" --format json > "${BACKUP_NCN_CONFIG_FILE}" 2>&1
+
+  echo "Updating ${CONFIG_NAME} configuration"
+  run_cmd cray cfs configurations update "${CONFIG_NAME}" --file "${NCN_CONFIG_FILE}"
 
 else
 
-    # In this case, we are using an existing configuration. We will take a snapshot of it, and unlike above, we will
-    # fail if it does not exist
-    echo "Taking snapshot of existing ${CONFIG_NAME} configuration to ${BACKUP_NCN_CONFIG_FILE}"
-    run_cmd cray cfs configurations describe "${CONFIG_NAME}" --format json > "${BACKUP_NCN_CONFIG_FILE}"
+  # In this case, we are using an existing configuration. We will take a snapshot of it, and unlike above, we will
+  # fail if it does not exist
+  echo "Taking snapshot of existing ${CONFIG_NAME} configuration to ${BACKUP_NCN_CONFIG_FILE}"
+  run_cmd cray cfs configurations describe "${CONFIG_NAME}" --format json > "${BACKUP_NCN_CONFIG_FILE}"
 
 fi
 
@@ -288,41 +282,42 @@ CFS_COMP_UPDATE_MSG="Setting desired configuration"
 CFS_COMP_UPDATE_ARGS=""
 
 if [[ -n ${CLEAR_STATE} ]]; then
-    CFS_COMP_UPDATE_MSG+=", clearing state"
-    CFS_COMP_UPDATE_ARGS+=" --state []"
+  CFS_COMP_UPDATE_MSG+=", clearing state"
+  CFS_COMP_UPDATE_ARGS+=" --state []"
 fi
 
 if [[ -z ${NO_CLEAR_ERR} ]]; then
-    CFS_COMP_UPDATE_MSG+=", clearing error count"
-    CFS_COMP_UPDATE_ARGS+=" --error-count 0"
+  CFS_COMP_UPDATE_MSG+=", clearing error count"
+  CFS_COMP_UPDATE_ARGS+=" --error-count 0"
 fi
 
 if [[ -z ${NO_ENABLE} ]]; then
-    echo "${CFS_COMP_UPDATE_MSG}, enabling components in CFS"
-    for xname in ${XNAME_LIST}; do
-        run_cmd cray cfs components update ${xname} --enabled true ${CFS_COMP_UPDATE_ARGS} --desired-config "${CONFIG_NAME}"
-    done
+  echo "${CFS_COMP_UPDATE_MSG}, enabling components in CFS"
+  for xname in ${XNAME_LIST}; do
+    run_cmd cray cfs components update ${xname} --enabled true ${CFS_COMP_UPDATE_ARGS} --desired-config "${CONFIG_NAME}"
+  done
 else
-    echo "${CFS_COMP_UPDATE_MSG} components in CFS"
-    for xname in ${XNAME_LIST}; do
-        run_cmd cray cfs components update ${xname} --enabled false ${CFS_COMP_UPDATE_ARGS} --desired-config "${CONFIG_NAME}"
-    done
-    echo "All components updated successfully."
-    exit 0
+  echo "${CFS_COMP_UPDATE_MSG} components in CFS"
+  for xname in ${XNAME_LIST}; do
+    run_cmd cray cfs components update ${xname} --enabled false ${CFS_COMP_UPDATE_ARGS} --desired-config "${CONFIG_NAME}"
+  done
+  echo "All components updated successfully."
+  exit 0
 fi
 
 while true; do
   RESULT=$(cray cfs components list --status pending --ids ${XNAMES} --format json | jq length)
-  if [[ "${RESULT}" -eq 0 ]]; then
+  if [[ ${RESULT} -eq 0 ]]; then
     break
   fi
-  echo "Waiting for configuration to complete.  ${RESULT} components remaining."
+  echo "Waiting for configuration to complete. ${RESULT} components remaining."
   sleep 60
 done
 
 CONFIGURED=$(cray cfs components list --status configured --ids ${XNAMES} --format json | jq length)
 FAILED=$(cray cfs components list --status failed --ids ${XNAMES} --format json | jq length)
 echo "Configuration complete. ${CONFIGURED} component(s) completed successfully.  ${FAILED} component(s) failed."
-if [ "${FAILED}" -ne "0" ]; then
-   echo "The following components failed: $(cray cfs components list --status failed --ids ${XNAMES} --format json | jq -r '. | map(.id) | join(",")')"
+if [[ ${FAILED} -ne 0 ]]; then
+  echo "The following components failed: $(cray cfs components list --status failed --ids ${XNAMES} --format json | jq -r '. | map(.id) | join(",")')"
+  exit 1
 fi

--- a/scripts/operations/configuration/backup_cfs_config_comp.sh
+++ b/scripts/operations/configuration/backup_cfs_config_comp.sh
@@ -23,30 +23,29 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-locOfScript=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+locOfScript=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 # Inform ShellCheck about the file we are sourcing
 # shellcheck source=./bash_lib/common.sh
 . "${locOfScript}/bash_lib/common.sh"
 
 set -o pipefail
 
-usage()
-{
-   # Display help
-   echo "Backs up CFS components and configurations."
-   echo "All parameters are optional and the values will be determined automatically if not set."
-   echo
-   echo "Usage: backup_cfs_config_comp.sh [ -b base_directory | -d target_directory ]"
-   echo "                                 [--components-only | --configs-only]"
-   echo
-   echo "By default, a backup directory will be created as a subdirectory of /root."
-   echo
-   echo "Options:"
-   echo "-b base_directory    Create the backup directory under base_directory instead of /root"
-   echo "-d target_directory  Create the backup files in target_directory instead of creating a new directory."
-   echo "--components-only           Only back up components"
-   echo "--configs-only              Only back up configurations"
-   echo
+usage() {
+  # Display help
+  echo "Backs up CFS components and configurations."
+  echo "All parameters are optional and the values will be determined automatically if not set."
+  echo
+  echo "Usage: backup_cfs_config_comp.sh [ -b base_directory | -d target_directory ]"
+  echo "                                 [--components-only | --configs-only]"
+  echo
+  echo "By default, a backup directory will be created as a subdirectory of /root."
+  echo
+  echo "Options:"
+  echo "-b base_directory    Create the backup directory under base_directory instead of /root"
+  echo "-d target_directory  Create the backup files in target_directory instead of creating a new directory."
+  echo "--components-only           Only back up components"
+  echo "--configs-only              Only back up configurations"
+  echo
 }
 
 BASE_DIRECTORY=""
@@ -56,106 +55,104 @@ CFG_BACKUP=""
 CMP_BACKUP=""
 
 if [[ $# -eq 1 ]] && [[ $1 == "-h" || $1 == "--help" ]]; then
-    usage
-    exit 0
+  usage
+  exit 0
 fi
 
 while [[ $# -gt 0 ]]; do
-    key="$1"
+  key="$1"
 
-    if [[ ${key} == "--components-only" ]]; then
-        if [[ ${ONLY} == components ]]; then
-            usage_err_exit "Argument specified multiple times: ${key}"
-        elif [[ -n ${ONLY} ]]; then
-            usage_err_exit "--components-only and --configs-only are mutually exclusive"
-        fi
-        ONLY="components"
-        shift
-        continue
-    elif [[ ${key} == "--configs-only" ]]; then
-        if [[ ${ONLY} == configs ]]; then
-            usage_err_exit "Argument specified multiple times: ${key}"
-        elif [[ -n ${ONLY} ]]; then
-            usage_err_exit "--components-only and --configs-only are mutually exclusive"
-        fi
-        ONLY="configs"
-        shift
-        continue
-    elif [[ ${key} != "-b" && ${key} != "-d" ]]; then
-        usage_err_exit "Unknown argument: '${key}'"
+  if [[ ${key} == "--components-only" ]]; then
+    if [[ ${ONLY} == components ]]; then
+      usage_err_exit "Argument specified multiple times: ${key}"
+    elif [[ -n ${ONLY} ]]; then
+      usage_err_exit "--components-only and --configs-only are mutually exclusive"
     fi
-
-    # If we make it here, we are parsing -b or -d arguments
-
-    # Both -b and -d require a nonblank argument
-    [[ $# -lt 2 ]] && usage_err_exit "${key} requires an argument"
-    [[ -z $2 ]] && usage_err_exit "Argument to ${key} may not be blank"
-
-    # For both -b and -d, the argument must be an existing directory
-    [[ ! -e $2 ]] && usage_err_exit "Argument to ${key} must be an existing directory. Does not exist: '$2'"
-    [[ ! -d $2 ]] && usage_err_exit "Argument to ${key} must be a directory. Not a directory: '$2'"
-
-    if [[ ${key} == "-b" ]]; then
-        # -b
-        # No duplicate flags
-        [[ -n ${BASE_DIRECTORY} ]] && usage_err_exit "Argument specified multiple times: ${key}"
-
-        # -b and -d are mutually exclusive
-        [[ -n ${TARGET_DIRECTORY} ]] && usage_err_exit "-b and -d are mutually exclusive"
-
-        BASE_DIRECTORY="$2"
-    else
-        # -d
-        # No duplicate flags
-        [[ -n ${TARGET_DIRECTORY} ]] && usage_err_exit "Argument specified multiple times: ${key}"
-
-        # -b and -d are mutually exclusive
-        [[ -n ${BASE_DIRECTORY} ]] && usage_err_exit "-b and -d are mutually exclusive"
-
-        TARGET_DIRECTORY="$2"
+    ONLY="components"
+    shift
+    continue
+  elif [[ ${key} == "--configs-only" ]]; then
+    if [[ ${ONLY} == configs ]]; then
+      usage_err_exit "Argument specified multiple times: ${key}"
+    elif [[ -n ${ONLY} ]]; then
+      usage_err_exit "--components-only and --configs-only are mutually exclusive"
     fi
-    shift # past argument
-    shift # past value
+    ONLY="configs"
+    shift
+    continue
+  elif [[ ${key} != "-b" && ${key} != "-d" ]]; then
+    usage_err_exit "Unknown argument: '${key}'"
+  fi
+
+  # If we make it here, we are parsing -b or -d arguments
+
+  # Both -b and -d require a nonblank argument
+  [[ $# -ge 2 ]] || usage_err_exit "${key} requires an argument"
+  [[ -n $2 ]] || usage_err_exit "Argument to ${key} may not be blank"
+
+  # For both -b and -d, the argument must be an existing directory
+  [[ -e $2 ]] || usage_err_exit "Argument to ${key} must be an existing directory. Does not exist: '$2'"
+  [[ -d $2 ]] || usage_err_exit "Argument to ${key} must be a directory. Not a directory: '$2'"
+
+  if [[ ${key} == "-b" ]]; then
+    # -b
+    # No duplicate flags
+    [[ -z ${BASE_DIRECTORY} ]] || usage_err_exit "Argument specified multiple times: ${key}"
+
+    # -b and -d are mutually exclusive
+    [[ -z ${TARGET_DIRECTORY} ]] || usage_err_exit "-b and -d are mutually exclusive"
+
+    BASE_DIRECTORY="$2"
+  else
+    # -d
+    # No duplicate flags
+    [[ -z ${TARGET_DIRECTORY} ]] || usage_err_exit "Argument specified multiple times: ${key}"
+
+    # -b and -d are mutually exclusive
+    [[ -z ${BASE_DIRECTORY} ]] || usage_err_exit "-b and -d are mutually exclusive"
+
+    TARGET_DIRECTORY="$2"
+  fi
+  shift # past argument
+  shift # past value
 done
 
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
 if [[ -z ${TARGET_DIRECTORY} ]]; then
-    [[ -z ${BASE_DIRECTORY} ]] && BASE_DIRECTORY=/root
-    if [[ -z ${ONLY} ]]; then
-        TARGET_DIRECTORY=$(run_mktemp -d "${BASE_DIRECTORY}/cfs-configs-comps-backup-${TIMESTAMP}-XXX")
-    else
-        TARGET_DIRECTORY=$(run_mktemp -d "${BASE_DIRECTORY}/cfs-${ONLY}-backup-${TIMESTAMP}-XXX")
-    fi
+  [[ -n ${BASE_DIRECTORY} ]] || BASE_DIRECTORY=/root
+  if [[ -z ${ONLY} ]]; then
+    TARGET_DIRECTORY=$(run_mktemp -d "${BASE_DIRECTORY}/cfs-configs-comps-backup-${TIMESTAMP}-XXX") || exit 1
+  else
+    TARGET_DIRECTORY=$(run_mktemp -d "${BASE_DIRECTORY}/cfs-${ONLY}-backup-${TIMESTAMP}-XXX") || exit 1
+  fi
 
-    # Since we just created this directory, we know its name already includes a timestamp and the fact that
-    # these are CFS backups. We also then don't need to worry about existing files being in there whose names
-    # may collide with ours.
-    CFG_BACKUP="${TARGET_DIRECTORY}/configurations.json"
-    CMP_BACKUP="${TARGET_DIRECTORY}/components.json"
+  # Since we just created this directory, we know its name already includes a timestamp and the fact that
+  # these are CFS backups. We also then don't need to worry about existing files being in there whose names
+  # may collide with ours.
+  CFG_BACKUP="${TARGET_DIRECTORY}/configurations.json"
+  CMP_BACKUP="${TARGET_DIRECTORY}/components.json"
 else
-    # In this case, since the target directory is dictated to us, we include more information in the backup file
-    # names, as well as taking care to avoid existing files
-    if [[ -z ${ONLY} || ${ONLY} == configs ]]; then
-        CFG_BACKUP=$(run_mktemp "${TARGET_DIRECTORY}/cfs-configurations-backup-${TIMESTAMP}-XXX.json")
-    fi
+  # In this case, since the target directory is dictated to us, we include more information in the backup file
+  # names, as well as taking care to avoid existing files
+  if [[ -z ${ONLY} || ${ONLY} == configs ]]; then
+    CFG_BACKUP=$(run_mktemp "${TARGET_DIRECTORY}/cfs-configurations-backup-${TIMESTAMP}-XXX.json") || exit 1
+  fi
 
-    if [[ -z ${ONLY} || ${ONLY} == components ]]; then   
-        CMP_BACKUP=$(run_mktemp "${TARGET_DIRECTORY}/cfs-components-backup-${TIMESTAMP}-XXX.json")
-    fi
+  if [[ -z ${ONLY} || ${ONLY} == components ]]; then
+    CMP_BACKUP=$(run_mktemp "${TARGET_DIRECTORY}/cfs-components-backup-${TIMESTAMP}-XXX.json") || exit 1
+  fi
 fi
 
 echo "Backing up CFS to the following directory: ${TARGET_DIRECTORY}"
 
 if [[ -n ${CFG_BACKUP} ]]; then
-    echo "Backing up configurations to ${CFG_BACKUP}"
-    cray cfs configurations list --format json > "${CFG_BACKUP}" ||
-        err_exit "Error writing to ${CFG_BACKUP} or running command: cray cfs configurations list --format json"
+  echo "Backing up configurations to ${CFG_BACKUP}"
+  run_cmd cray cfs configurations list --format json > "${CFG_BACKUP}" || err_exit "Error writing to ${CFG_BACKUP}"
 fi
 
 if [[ -n ${CMP_BACKUP} ]]; then
-    echo "Backing up components to ${CMP_BACKUP}"
-    cray cfs components list --format json > "${CMP_BACKUP}" ||
-        err_exit "Error writing to ${CMP_BACKUP} or running command: cray cfs components list --format json"
+  echo "Backing up components to ${CMP_BACKUP}"
+  run_cmd cray cfs components list --format json > "${CMP_BACKUP}" || err_exit "Error writing to ${CMP_BACKUP}"
 fi
 
 echo "SUCCESS"

--- a/scripts/operations/configuration/bash_lib/common.sh
+++ b/scripts/operations/configuration/bash_lib/common.sh
@@ -26,53 +26,49 @@
 # Common functions
 
 # Returns 0 if argument is a defined Bash function, 1 otherwise
-is_function()
-{
-    [[ $(LC_ALL=C type -t "$1") == function ]] && return 0 || return 1
+is_function() {
+  [[ $(LC_ALL=C type -t "$1") == function ]] && return 0 || return 1
 }
 
 # Print an error message to stderr
-err()
-{
-    echo "ERROR: $*" >&2
+err() {
+  echo "ERROR: $*" >&2
 }
 
 # Print a provided error message to stderr and exit the script with return code 1
-err_exit()
-{
-    err "$@"
-    exit 1
+err_exit() {
+  [[ $# -eq 0 ]] || err "$@"
+  exit 1
 }
 
 # Call script usage function (if defined), then exit in error with the provided message
-usage_err_exit()
-{
-    # If a usage function is defined, call it to print the usage message first
-    if is_function usage; then
-        usage
-    fi
-    err_exit "usage: $*"
+usage_err_exit() {
+  # If a usage function is defined, call it to print the usage message first
+  if is_function usage; then
+    usage
+  fi
+  err_exit "usage: $*"
 }
 
 # Calls mktemp to create a file or directory. If unsuccessful, the script exits in error.
 # Otherwise, some checks are made on what was created. If they pass, the path to the file or directory
 # is printed to stdout
-run_mktemp()
-{
-    local tmpfile
-    tmpfile=$(mktemp "$@") || err_exit "Command failed with rc $?: mktemp $*"
-    [[ -n ${tmpfile} ]] || err_exit "mktemp command passed but gave no output"
-    [[ -e ${tmpfile} ]] || err_exit "mktemp command passed but '${tmpfile}' does not exist"
-    if [[ $# -gt 0 && "$1" == "-d" ]]; then
-        [[ -d ${tmpfile} ]] || err_exit "mktemp -d command passed and '${tmpfile}' exists, but is not a directory"
-    else
-        [[ -f ${tmpfile} ]] || err_exit "mktemp command passed and '${tmpfile}' exists, but is not a regular file"
-    fi
-    echo "${tmpfile}"
-    return 0
+#
+# If calling with -d flag, that should be the first argument
+run_mktemp() {
+  local tmpfile
+  tmpfile=$(mktemp "$@") || err_exit "Command failed with rc $?: mktemp $*"
+  [[ -n ${tmpfile} ]] || err_exit "mktemp command passed but gave no output"
+  [[ -e ${tmpfile} ]] || err_exit "mktemp command passed but '${tmpfile}' does not exist"
+  if [[ $# -gt 0 && $1 == "-d" ]]; then
+    [[ -d ${tmpfile} ]] || err_exit "mktemp -d command passed and '${tmpfile}' exists, but is not a directory"
+  else
+    [[ -f ${tmpfile} ]] || err_exit "mktemp command passed and '${tmpfile}' exists, but is not a regular file"
+  fi
+  echo "${tmpfile}"
+  return 0
 }
 
-run_cmd()
-{
-    "$@" || err_exit "Command failed with rc $?: $*"
+run_cmd() {
+  "$@" || err_exit "Command failed with rc $?: $*"
 }


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
While working on improvements to the IMS import/export tooling, I noticed a problem with how one of the Bash shared library functions is being used. The scripts using the `run_mktemp` command are relying on the fact that it exits the script in error if it fails. However, because they call the function in a subprocess, only that subprocess exits, not the containing script. This PR modifies the uses of that function so that if the subprocess exits in error, the entire script does so as well.

Also includes changes to appease the Bash script linter, and a change that allows the `err_exit` function to be called with no arguments (for when the relevant error message has already been displayed).

I've tested the changes on wasp as part of my IMS import/export development work.

Only need backports back to CSM 1.3 (that's as far back as the IMS import/export work is going to go, and the flaws being fixed by this PR don't exist prior to CSM 1.4).
1.5: https://github.com/Cray-HPE/docs-csm/pull/4253
1.4: https://github.com/Cray-HPE/docs-csm/pull/4254
1.3: https://github.com/Cray-HPE/docs-csm/pull/4255

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
