### PR TITLE
CASMCMS-8800: Document automatic removal of deprecated BOS v1 session template fields

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -38,6 +38,9 @@ For a list of all deprecated CSM features, see [Deprecations](introduction/depre
 ## Removals
 
 * [CRUS](glossary.md#compute-rolling-upgrade-service-crus)
+* Deprecated [Boot Orchestration Service (BOS)](glossary.md#boot-orchestration-service-bos)
+  v1 session template and boot set fields are no longer stored in BOS. For more information, see
+  [Deprecated fields](operations/boot_orchestration/Session_Templates.md#deprecated-fields).
 
 For a list of all features with an announced removal target, see [Removals](introduction/deprecated_features/README.md#removals).
 

--- a/introduction/deprecated_features/README.md
+++ b/introduction/deprecated_features/README.md
@@ -28,6 +28,13 @@ in chronological order.
 ### Removals in CSM 1.5
 
 * [Compute Rolling Upgrade Service (CRUS)](../../glossary.md#compute-rolling-upgrade-service-crus)
+* Deprecated [Boot Orchestration Service (BOS)](../../glossary.md#boot-orchestration-service-bos)
+  v1 session template and boot set fields are no longer stored in BOS.
+  * When upgrading to CSM 1.5, these fields will automatically be removed from all BOS session
+    templates that contain them.
+  * When creating BOS v1 session templates, these fields are automatically removed.
+  * For more information, see
+    [Deprecated fields](../../operations/boot_orchestration/Session_Templates.md#deprecated-fields).
 
 ### Removals in CSM 1.6
 

--- a/operations/UAS_user_and_admin_topics/Customize_End-User_UAI_Images.md
+++ b/operations/UAS_user_and_admin_topics/Customize_End-User_UAI_Images.md
@@ -35,7 +35,7 @@ See [Configure the Cray CLI](../configure_cray_cli.md).
     Identify the session template name to use. A full list may be found with the following command:
 
     ```bash
-    cray bos v1 sessiontemplate list --format yaml
+    cray bos v2 sessiontemplates list --format yaml
     ```
 
     Example output:
@@ -43,10 +43,8 @@ See [Configure the Cray CLI](../configure_cray_cli.md).
     ```yaml
     - boot_sets:
         compute:
-          boot_ordinal: 2
           etag: d54782b3853a2d8713a597d80286b93e
           kernel_parameters: ip=dhcp quiet spire_join_token=${SPIRE_JOIN_TOKEN}
-          network: nmn
           node_roles_groups:
           - Compute
           path: s3://boot-images/0c0d4081-2e8b-433f-b6f7-e1ef0b907be3/manifest.json
@@ -74,7 +72,7 @@ See [Configure the Cray CLI](../configure_cray_cli.md).
     Use the session template name to download a compute node SquashFS from a BOS session template name:
 
     ```bash
-    ST_ID=$(cray bos v1 sessiontemplate describe $ST_NAME --format json | jq -r '.boot_sets.compute.path' | awk -F/ '{print $4}')
+    ST_ID=$(cray bos v2 sessiontemplates describe $ST_NAME --format json | jq -r '.boot_sets.compute.path' | awk -F/ '{print $4}')
 
     cray artifacts get boot-images $ST_ID/rootfs rootfs.squashfs
     ```

--- a/operations/UAS_user_and_admin_topics/Troubleshoot_Common_Mistakes_when_Creating_a_Custom_End-User_UAI_Image.md
+++ b/operations/UAS_user_and_admin_topics/Troubleshoot_Common_Mistakes_when_Creating_a_Custom_End-User_UAI_Image.md
@@ -3,7 +3,7 @@
 There are several problems that may occur while making or working with custom end-user UAI images.
 The following are some basic troubleshooting questions to ask:
 
-* Does `SESSION_NAME` match an actual entry in `cray bos v1 sessiontemplate list`?
+* Does `SESSION_NAME` match an actual entry in `cray bos v2 sessiontemplates list`?
 * Is the `SESSION_ID` set to an appropriate UUID format? Did the `awk` command not parse the UUID correctly?
 * Did the file `/etc/security/limits.d/99-slingshot-network.conf` get removed from the tarball correctly?
 * Does the `ENTRYPOINT` `/usr/bin/uai-ssh.sh` exist?

--- a/operations/boot_orchestration/Exporting_and_Importing_BOS_Data.md
+++ b/operations/boot_orchestration/Exporting_and_Importing_BOS_Data.md
@@ -167,40 +167,15 @@ BOS session templates or BOS v2 options can also be manually exported and import
       BOS_TEMPLATE_FILE="${BOS_EXPORT_DIR}/${BOS_TEMPLATE_NAME}.json"
       ```
 
-   1. Determine the BOS version of the session template.
-
-      ```bash
-      /usr/share/doc/csm/scripts/operations/configuration/bos_session_template_version.py "${BOS_TEMPLATE_FILE}"
-      ```
-
-      Example output:
-
-      ```text
-      Template 'uan-sessiontemplate-2.0.27' is BOS version 2
-      ```
-
    1. Import the session template into BOS.
 
-      The command to do this varies depending on the BOS version found in the previous step.
+      ```bash
+      cray bos v2 sessiontemplates create \
+             --file <(jq 'del(.name)' "${BOS_TEMPLATE_FILE}") \
+             "${BOS_TEMPLATE_NAME}" --format json
+      ```
 
-      - BOS version 1
-
-         ```bash
-         cray bos v1 sessiontemplate create --file "${BOS_TEMPLATE_FILE}" \
-                                            --name "${BOS_TEMPLATE_NAME}"
-         ```
-
-         If successful, the command will output the name of the created session template.
-
-      - BOS version 2
-
-         ```bash
-         cray bos v2 sessiontemplates create \
-                --file <(jq 'del(.name)' "${BOS_TEMPLATE_FILE}") \
-                "${BOS_TEMPLATE_NAME}" --format json
-         ```
-
-         If successful, the command will output the entire session template in JSON.
+      If successful, the command will output the entire session template in JSON.
 
 1. (`ncn-mw#`) The CLI can also be used to change BOS v2 options to match the values that were exported.
 

--- a/operations/boot_orchestration/Manage_a_Session_Template.md
+++ b/operations/boot_orchestration/Manage_a_Session_Template.md
@@ -39,6 +39,9 @@ cray bos v2 sessiontemplates create --file <INPUT_FILE> --name <NEW_TEMPLATE_NAM
 
 (`ncn-mw#`) v1 command:
 
+> In CSM 1.5, even when using BOS v1 to create a session template, some deprecated fields are automatically removed.
+> See [Deprecated fields](Session_Templates.md#deprecated-fields) for more information.
+
 ```bash
 cray bos v1 sessiontemplate create --file <INPUT_FILE> --name <NEW_TEMPLATE_NAME>
 ```

--- a/operations/boot_orchestration/Session_Templates.md
+++ b/operations/boot_orchestration/Session_Templates.md
@@ -14,6 +14,7 @@ Session templates can be created via the API by providing JSON data or via the C
   * [`rootfs` providers](#rootfs-providers)
     * [`root` kernel parameter example](#root-kernel-parameter-example)
   * [Overriding configuration (BOS v2 only)](#overriding-configuration-bos-v2-only)
+* [Deprecated fields](#deprecated-fields)
 
 ## Session template structure
 
@@ -195,3 +196,26 @@ The DVS configuration files determine which interface to use (NMN or HSN). Howev
 
 It is also possible to specify CFS configuration in the boot set. If specified, this will override whatever value is set in the base session template.
 This feature is not supported for BOS v1.
+
+## Deprecated fields
+
+The following fields do not exist in BOS v2 and are deprecated in BOS v1:
+
+* Session template fields
+  * `cfs_branch`
+  * `cfs_url`
+  * `partition`
+* Boot set fields
+  * `boot_ordinal`
+  * `network`
+  * `shutdown_ordinal`
+
+When upgrading to CSM 1.5, these fields are automatically removed from all BOS session
+templates that contain them.
+
+In CSM 1.5, when a BOS v1 session template is created that includes any of these fields,
+the fields are automatically removed during the creation.
+
+In both cases, the result of stripping the fields is a session template which has a valid
+format for both BOS v1 and BOS v2. This does not change the behavior of the session template,
+because these fields had no effect in BOS v1.

--- a/operations/image_management/Create_UAN_Boot_Images.md
+++ b/operations/image_management/Create_UAN_Boot_Images.md
@@ -730,9 +730,7 @@ x3000c0s22b0n0
         {
           "boot_sets": {
             "uan": {
-              "boot_ordinal": 2,
               "kernel_parameters": "console=ttyS0,115200 bad_page=panic crashkernel=360M hugepagelist=2m-2g intel_iommu=off intel_pstate=disable iommu=pt ip=nmn0:dhcp numa_interleave_omit=headless numa_zonelist_order=node oops=panic pageblock_order=14 pcie_ports=native printk.synchronous=y quiet rd.neednet=1 rd.retry=10 rd.shell turbo_boost_limit=999 ifmap=net2:nmn0,lan0:hsn0,lan1:hsn1 spire_join_token=${SPIRE_JOIN_TOKEN}",
-              "network": "nmn",
               "node_list": [
                 "#... List of Application Nodes from cray hsm state command ..."
               ],
@@ -756,15 +754,9 @@ x3000c0s22b0n0
     The following command uses the JSON session template file to save a session template in BOS. This step allows administrators to boot UANs by referring to the session template name.
 
     ```bash
-    cray bos v1 sessiontemplate create \
-            --name uan-sessiontemplate-PRODUCT_VERSION \
-            --file uan-sessiontemplate-PRODUCT_VERSION.json
-    ```
-
-    Example output:
-
-    ```text
-    /sessionTemplate/uan-sessiontemplate-PRODUCT_VERSION
+    cray bos v2 sessiontemplates create \
+            --file uan-sessiontemplate-PRODUCT_VERSION.json \
+            uan-sessiontemplate-PRODUCT_VERSION
     ```
 
 Perform [Boot UANs](../boot_orchestration/Boot_UANs.md) to boot the UANs with the new image and BOS session template.

--- a/operations/network/dns/Enable_ncsd_on_UANs.md
+++ b/operations/network/dns/Enable_ncsd_on_UANs.md
@@ -31,9 +31,7 @@ enabling `nscd` in the image only has to be done once. Then all UANs that use th
     {
        "boot_sets": {
          "uan": {
-           "boot_ordinal": 2,
-           "kernel_parameters": "console=ttyS0,115200 bad_page=panic crashkernel=340M hugepagelist=2m-2g intel_iommu=off intel_pstate=disable iommu=pt ip=nmn0:dhcp numa_interleave_omit=headless numa_zonelist_order=node oops=panic pageblock_order=14 pcie_ports=native printk.synchronous=y quiet rd.neednet=1 rd.retry=10 rd.shell turbo_boost_limit=999 ifmap=net2:nmn0,lan0:hsn0,lan1:hsn1 spire_join_token=${SPIRE_JOIN_TOKEN}",
-         "network": "nmn",
+         "kernel_parameters": "console=ttyS0,115200 bad_page=panic crashkernel=340M hugepagelist=2m-2g intel_iommu=off intel_pstate=disable iommu=pt ip=nmn0:dhcp numa_interleave_omit=headless numa_zonelist_order=node oops=panic pageblock_order=14 pcie_ports=native printk.synchronous=y quiet rd.neednet=1 rd.retry=10 rd.shell turbo_boost_limit=999 ifmap=net2:nmn0,lan0:hsn0,lan1:hsn1 spire_join_token=${SPIRE_JOIN_TOKEN}",
          "node_list": [
             "LIST_OF_APPLICATION_NODES"
          ],

--- a/operations/node_management/Add_a_Standard_Rack_Node.md
+++ b/operations/node_management/Add_a_Standard_Rack_Node.md
@@ -511,12 +511,12 @@ Follow the [Added Hardware](../network/management_network/added_hardware.md) pro
       configuration to include any new compute nodes added to the system.
    * **If PBS Pro is the installed workload manager**: *Coming soon*
 
-1. (`ncn#`) Use the Boot Orchestration Service \(BOS\) to power on and boot the nodes.
+1. (`ncn-mw#`) Use the Boot Orchestration Service \(BOS\) to power on and boot the nodes.
 
     Use the appropriate BOS template for the node type.
 
     ```bash
-    cray bos v1 session create --template-name cle-VERSION \
+    cray bos v2 sessions create --template-name cle-VERSION \
         --operation reboot --limit x3000c0s27b0n0,x3000c0s27b0n1,x3000c0s27b0n2,x3000c0s27b00n3
     ```
 

--- a/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System.md
+++ b/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System.md
@@ -454,7 +454,7 @@ Use boot orchestration to power on and boot the nodes. Specify the appropriate [
 
     ```bash
     BOS_TEMPLATE=cos-2.0.30-slurm-healthy-compute
-    cray bos v1 sessiontemplate describe $BOS_TEMPLATE --format json|jq '.boot_sets[] | select(.node_list)'
+    cray bos v2 sessiontemplates describe $BOS_TEMPLATE --format json|jq '.boot_sets[] | select(.node_list)'
     ```
 
     * If this query returns empty, then skip to booting the nodes.
@@ -465,8 +465,11 @@ Use boot orchestration to power on and boot the nodes. Specify the appropriate [
 
        1. Dump the current session template.
 
+          > The `name` field cannot be present in the file, or else the subsequent command to create the
+          > Session template will fail. The `jq` command in the following example strips out this field.
+
           ```bash
-          cray bos v1 sessiontemplate describe $BOS_TEMPLATE --format json > tmp.txt
+          cray bos v2 sessiontemplates describe $BOS_TEMPLATE --format json | jq 'del(.name)' > tmp.txt
           ```
 
        1. Edit the `tmp.txt` file, adding the new nodes to the `node_list`.
@@ -488,19 +491,19 @@ Use boot orchestration to power on and boot the nodes. Specify the appropriate [
        1. Create the session template.
 
           ```bash
-          cray bos v1 sessiontemplate create --file tmp.txt --name $BOS_TEMPLATE
+          cray bos v2 sessiontemplates create --file tmp.txt $BOS_TEMPLATE
           ```
 
        1. Verify that the session template contains the additional nodes and the proper name.
 
            ```bash
-           cray bos v1 sessiontemplate describe $BOS_TEMPLATE --format json
+           cray bos v2 sessiontemplates describe $BOS_TEMPLATE --format json
            ```
 
     1. (`ncn-mw#`) Boot the nodes.
 
        ```bash
-       cray bos v1 session create --template-name $BOS_TEMPLATE \
+       cray bos v2 sessions create --template-name $BOS_TEMPLATE \
             --operation reboot --limit x1005c3s0b0n0,x1005c3s0b0n1,x1005c3s0b1n0,x1005c3s0b1n1
        ```
 

--- a/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System_Using_SAT.md
+++ b/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System_Using_SAT.md
@@ -89,7 +89,7 @@ This procedure will add a liquid-cooled blade to an HPE Cray EX system.
       If it is unclear which session template is in use, proceed to the next substep.
 
       ```bash
-      cray bos v1 sessiontemplate list
+      cray bos v2 sessiontemplates list
       ```
 
    1. Find the node xnames with `sat status`. In this example, the target blade is in slot `x9000c3s0`.
@@ -126,7 +126,7 @@ This procedure will add a liquid-cooled blade to an HPE Cray EX system.
    1. Find the required `templateName` value with BOS.
 
       ```bash
-      cray bos v1 session describe BOS_SESSION --format toml | grep templateName
+      cray bos v2 sessions describe BOS_SESSION --format toml | grep templateName
       ```
 
       Example output:
@@ -138,7 +138,7 @@ This procedure will add a liquid-cooled blade to an HPE Cray EX system.
    1. Determine the list of xnames associated with the desired session template.
 
       ```bash
-      cray bos v1 sessiontemplate describe SESSION_TEMPLATE_NAME --format toml | grep node_list
+      cray bos v2 sessiontemplates describe SESSION_TEMPLATE_NAME --format toml | grep node_list
       ```
 
       Example output:

--- a/operations/node_management/Move_a_Standard_Rack_Node_SameRack_SameHSNPorts.md
+++ b/operations/node_management/Move_a_Standard_Rack_Node_SameRack_SameHSNPorts.md
@@ -401,6 +401,6 @@ This procedure works with both application and compute nodes. This example moves
     Specify the appropriate BOS template for the node type.
 
     ```bash
-    cray bos v1 session create --template-name cle-VERSION \
+    cray bos v2 sessions create --template-name cle-VERSION \
         --operation reboot --limit x3000c0s27b1n0,x3000c0s27b2n0,x3000c0s27b3n0,x3000c0s27b4n0
     ```

--- a/operations/node_management/Removing_a_Liquid-cooled_blade_from_a_System.md
+++ b/operations/node_management/Removing_a_Liquid-cooled_blade_from_a_System.md
@@ -33,7 +33,7 @@ This procedure will remove a liquid-cooled blades from an HPE Cray EX system.
 
     ```bash
     BOS_TEMPLATE=cos-2.0.30-slurm-healthy-compute
-    cray bos v1 session create --template-name $BOS_TEMPLATE --operation shutdown --limit x9000c3s0b0n0,x9000c3s0b0n1,x9000c3s0b1n0,x9000c3s0b1n1
+    cray bos v2 sessions create --template-name $BOS_TEMPLATE --operation shutdown --limit x9000c3s0b0n0,x9000c3s0b0n1,x9000c3s0b1n0,x9000c3s0b1n1
     ```
 
 ### 2. Disable the Redfish endpoints for the nodes

--- a/operations/node_management/Removing_a_Liquid-cooled_blade_from_a_System_Using_SAT.md
+++ b/operations/node_management/Removing_a_Liquid-cooled_blade_from_a_System_Using_SAT.md
@@ -35,7 +35,7 @@ This procedure will remove a liquid-cooled blade from an HPE Cray EX system.
       If it is unclear which session template is in use, proceed to the next substep.
 
       ```bash
-      cray bos v1 sessiontemplate list
+      cray bos v2 sessiontemplates list
       ```
 
    1. Find the node xnames with `sat status`. In this example, the target blade is in slot `x9000c3s0`.
@@ -72,7 +72,7 @@ This procedure will remove a liquid-cooled blade from an HPE Cray EX system.
    1. Find the required `templateName` value with BOS.
 
       ```bash
-      cray bos v1 session describe BOS_SESSION --format toml | grep templateName
+      cray bos v2 sessions describe BOS_SESSION --format toml | grep templateName
       ```
 
       Example output:
@@ -84,7 +84,7 @@ This procedure will remove a liquid-cooled blade from an HPE Cray EX system.
    1. Determine the list of xnames associated with the desired boot session template.
 
       ```bash
-      cray bos v1 sessiontemplate describe SESSION_TEMPLATE_NAME --format toml | grep node_list
+      cray bos v2 sessiontemplates describe SESSION_TEMPLATE_NAME --format toml | grep node_list
       ```
 
       Example output:

--- a/operations/node_management/Removing_a_Standard_Node_from_a_System.md
+++ b/operations/node_management/Removing_a_Standard_Node_from_a_System.md
@@ -42,7 +42,7 @@ This procedure is applicable for the following types of standard rack nodes:
 
     ```bash
     BOS_TEMPLATE=cos-2.0.30-slurm-healthy-compute
-    cray bos v1 session create --template-name $BOS_TEMPLATE --operation shutdown --limit x9000c3s0b0n0,x9000c3s0b0n1,x9000c3s0b1n0,x9000c3s0b1n1
+    cray bos v2 sessions create --template-name $BOS_TEMPLATE --operation shutdown --limit x9000c3s0b0n0,x9000c3s0b0n1,x9000c3s0b1n0,x9000c3s0b1n1
     ```
 
 ### 3. Remove data from SLS and HSM

--- a/operations/node_management/Replace_a_Compute_Blade.md
+++ b/operations/node_management/Replace_a_Compute_Blade.md
@@ -33,7 +33,7 @@ Replace an HPE Cray EX liquid-cooled compute blade.
 1. (`ncn-mw#`) Use Boot Orchestration Services (BOS) to shut down the affected nodes. Specify the appropriate BOS template for the node type.
 
    ```bash
-   cray bos v1 session create --template-name BOS_TEMPLATE \
+   cray bos v2 sessions create --template-name BOS_TEMPLATE \
        --operation shutdown --limit x1000c3s0b0n0,x1000c3s0b0n1,x1000c3s0b1n0,x1000c3s0b1n1
    ```
 
@@ -283,6 +283,6 @@ Replace an HPE Cray EX liquid-cooled compute blade.
     Specify the appropriate BOS template for the node type.
 
     ```bash
-    cray bos v1 session create --template-name BOS_TEMPLATE --operation reboot \
+    cray bos v2 sessions create --template-name BOS_TEMPLATE --operation reboot \
         --limit x1000c3s0b0n0,x1000c3s0b0n1,x1000c3s0b1n0,x1000c3s0b1n1
     ```

--- a/operations/node_management/Replace_a_Compute_Blade_Using_SAT.md
+++ b/operations/node_management/Replace_a_Compute_Blade_Using_SAT.md
@@ -34,7 +34,7 @@ Replace an HPE Cray EX liquid-cooled compute blade.
       If it is unclear which session template is in use, proceed to the next substep.
 
       ```bash
-      cray bos v1 sessiontemplate list
+      cray bos v2 sessiontemplates list
       ```
 
    1. Find the node xnames with `sat status`. In this example, the target blade is in slot `x9000c3s0`.
@@ -71,7 +71,7 @@ Replace an HPE Cray EX liquid-cooled compute blade.
    1. Find the required `templateName` value with BOS.
 
       ```bash
-      cray bos v1 session describe BOS_SESSION --format toml | grep templateName
+      cray bos v2 sessions describe BOS_SESSION --format toml | grep templateName
       ```
 
       Example output:
@@ -83,7 +83,7 @@ Replace an HPE Cray EX liquid-cooled compute blade.
    1. Determine the list of xnames associated with the desired boot session template.
 
       ```bash
-      cray bos v1 sessiontemplate describe SESSION_TEMPLATE_NAME --format toml | grep node_list
+      cray bos v2 sessiontemplates describe SESSION_TEMPLATE_NAME --format toml | grep node_list
       ```
 
       Example output:

--- a/operations/node_management/Swap_a_Compute_Blade_with_a_Different_System.md
+++ b/operations/node_management/Swap_a_Compute_Blade_with_a_Different_System.md
@@ -94,7 +94,7 @@ Swap an HPE Cray EX liquid-cooled compute blade between two systems.
 
    ```bash
    BOS_TEMPLATE=cos-2.0.30-slurm-healthy-compute
-   cray bos v1 session create --template-name $BOS_TEMPLATE --operation shutdown --limit x9000c3s0b0n0,x9000c3s0b0n1,x9000c3s0b1n0,x9000c3s0b1n1
+   cray bos v2 sessions create --template-name $BOS_TEMPLATE --operation shutdown --limit x9000c3s0b0n0,x9000c3s0b0n1,x9000c3s0b1n0,x9000c3s0b1n1
    ```
 
 ### Source: Disable the Redfish endpoints for the nodes
@@ -269,7 +269,7 @@ The hardware management network MAC and IP addresses are assigned algorithmicall
 
     ```bash
     BOS_TEMPLATE=cos-2.0.30-slurm-healthy-compute
-    cray bos v1 session create --template-name $BOS_TEMPLATE --operation shutdown \
+    cray bos v2 sessions create --template-name $BOS_TEMPLATE --operation shutdown \
             --limit x1005c3s0b0n0,x1005c3s0b0n1,x1005c3s0b1n0,x1005c3s0b1n1
     ```
 
@@ -709,7 +709,7 @@ The hardware management network NIC MAC addresses for liquid-cooled blades are a
 
     ```bash
     BOS_TEMPLATE=cos-2.0.30-slurm-healthy-compute
-    cray bos v1 session create --template-name $BOS_TEMPLATE \
+    cray bos v2 sessions create --template-name $BOS_TEMPLATE \
             --operation reboot --limit x1005c3s0b0n0,x1005c3s0b0n1,x1005c3s0b1n0,x1005c3s0b1n1
     ```
 

--- a/operations/node_management/Swap_a_Compute_Blade_with_a_Different_System_Using_SAT.md
+++ b/operations/node_management/Swap_a_Compute_Blade_with_a_Different_System_Using_SAT.md
@@ -44,7 +44,7 @@ Swap an HPE Cray EX liquid-cooled compute blade between two systems.
       If it is unclear which session template is in use, proceed to the next substep.
 
       ```bash
-      cray bos v1 sessiontemplate list
+      cray bos v2 sessiontemplates list
       ```
 
    1. Find the node xnames with `sat status`.
@@ -83,7 +83,7 @@ Swap an HPE Cray EX liquid-cooled compute blade between two systems.
    1. Find the required `templateName` value with BOS.
 
       ```bash
-      cray bos v1 session describe BOS_SESSION --format toml | grep templateName
+      cray bos v2 sessions describe BOS_SESSION --format toml | grep templateName
       ```
 
       Example output:
@@ -95,7 +95,7 @@ Swap an HPE Cray EX liquid-cooled compute blade between two systems.
    1. Determine the list of xnames associated with the desired boot session template.
 
       ```bash
-      cray bos v1 sessiontemplate describe SESSION_TEMPLATE_NAME --format toml | grep node_list
+      cray bos v2 sessiontemplates describe SESSION_TEMPLATE_NAME --format toml | grep node_list
       ```
 
       Example output:

--- a/operations/node_management/Update_Compute_Node_Mellanox_HSN_NIC_Firmware.md
+++ b/operations/node_management/Update_Compute_Node_Mellanox_HSN_NIC_Firmware.md
@@ -124,5 +124,5 @@ See [Update Firmware with FAS](../firmware/Update_Firmware_with_FAS.md) for info
 1. (`ncn-m001#`) Use the Boot Orchestration Service \(BOS\) to reboot all the affected nodes.
 
     ```bash
-    cray bos v1 session create --template-name SESSION_TEMPLATE --operation reboot
+    cray bos v2 sessions create --template-name SESSION_TEMPLATE --operation reboot
     ```

--- a/operations/power_management/Power_On_and_Boot_Compute_Nodes_and_User_Access_Nodes.md
+++ b/operations/power_management/Power_On_and_Boot_Compute_Nodes_and_User_Access_Nodes.md
@@ -104,7 +104,7 @@ This procedure boots all compute nodes and user access nodes \(UANs\) in the con
     Identify the BOS session template names (such as `"cos-2.0.x"`, `slurm`, or `uan-slurm`), and choose the appropriate compute and UAN node templates for the power on and boot.
 
     ```bash
-    cray bos v1 sessiontemplate list --format toml
+    cray bos v2 sessiontemplates list --format toml
     ```
 
     Example output excerpts:
@@ -124,7 +124,7 @@ This procedure boots all compute nodes and user access nodes \(UANs\) in the con
 1. (`ncn-m001#`) To display more information about a session template, for example `cos-2.0.0`, use the `describe` option.
 
     ```bash
-    cray bos v1 sessiontemplate describe cos-2.0.x
+    cray bos v2 sessiontemplates describe cos-2.0.x
     ```
 
 1. (`ncn-m001#`) Use `sat bootsys boot` to power on and boot UANs and compute nodes.
@@ -144,20 +144,10 @@ This procedure boots all compute nodes and user access nodes \(UANs\) in the con
     Started boot operation on BOS session templates: cos-2.0.x, uan.
     Waiting up to 900 seconds for sessions to complete.
 
-    Waiting for BOA k8s job with id boa-a1a697fc-e040-4707-8a44-a6aef9e4d6ea to complete. Session template: uan.
-    To monitor the progress of this job, run the following command in a separate window:
-        'kubectl -n services logs -c boa -f --selector job-name=boa-a1a697fc-e040-4707-8a44-a6aef9e4d6ea'
-
-    Waiting for BOA k8s job with id boa-79584ffe-104c-4766-b584-06c5a3a60996 to complete. Session template: cos-2.0.0.
-    To monitor the progress of this job, run the following command in a separate window:
-        'kubectl -n services logs -c boa -f --selector job-name=boa-79584ffe-104c-4766-b584-06c5a3a60996'
-
     [...]
 
     All BOS sessions completed.
     ```
-
-    Note the returned job ID for each session, for example: `"boa-79584ffe-104c-4766-b584-06c5a3a60996"`.
 
     **Note:** In certain cases, the command may display an error similar to the following:
 
@@ -166,33 +156,6 @@ This procedure boots all compute nodes and user access nodes \(UANs\) in the con
     ```
 
     This is a non-fatal error and does not affect the `bos-operations` stage of `sat bootsys`.
-
-    **Note:** In certain cases, the command may fail before reaching the displayed timeout
-    and show warnings similar to the following:
-
-    ```text
-    WARNING: The 'kubectl wait' command failed instead of timing out. stderr: error: condition not met for jobs/boa-79584ffe-104c-4766-b584-06c5a3a60996
-    ```
-
-    The BOS operation can still proceed even with these warnings. However, the warnings
-    may result in the `bos-operations` stage of the `sat bootsys` command exiting before the BOS
-    operation is complete. Because of this, it is important to view the logs in order to monitor the
-    boot and to verify that the nodes reached the expected state. Both of these recommendations are shown
-    in the remaining steps.
-
-1. (`ncn-m001#`) Use the job ID strings to monitor the progress of the boot job.
-
-    **Tip:** The commands needed to monitor the progress of the job are provided in the output of the `sat bootsys boot` command.
-
-    ```bash
-    kubectl -n services logs -c boa -f --selector job-name=boa-79584ffe-104c-4766-b584-06c5a3a60996
-    ```
-
-1. (`ncn-m001#`) In another shell window, use a similar command to monitor the UAN session.
-
-    ```bash
-    kubectl -n services logs -c boa -f --selector job-name=boa-a1a697fc-e040-4707-8a44-a6aef9e4d6ea
-    ```
 
 1. Wait for compute nodes and UANs to boot and check the Configuration Framework Service \(CFS\) log for errors.
 

--- a/operations/power_management/Prepare_the_System_for_Power_Off.md
+++ b/operations/power_management/Prepare_the_System_for_Power_Off.md
@@ -34,7 +34,7 @@ HPE Cray EX System Admin Toolkit (SAT) product stream documentation (`S-8031`) f
        If it is unclear what session template is in use, proceed to the next substep.
 
        ```bash
-       cray bos v1 sessiontemplate list
+       cray bos v2 sessiontemplates list
        ```
 
     1. Find the xname with `sat status`.
@@ -68,7 +68,7 @@ HPE Cray EX System Admin Toolkit (SAT) product stream documentation (`S-8031`) f
     1. Find the required `templateName` value with BOS.
 
        ```bash
-       cray bos v1 session describe BOS_SESSION --format toml | grep templateName
+       cray bos v2 sessions describe BOS_SESSION --format toml | grep templateName
        ```
 
        Example output:
@@ -80,7 +80,7 @@ HPE Cray EX System Admin Toolkit (SAT) product stream documentation (`S-8031`) f
     1. Determine the list of xnames associated with the desired boot session template.
 
        ```bash
-       cray bos v1 sessiontemplate describe SESSION_TEMPLATE_NAME | egrep "node_list|node_roles_groups|node_groups"
+       cray bos v2 sessiontemplates describe SESSION_TEMPLATE_NAME | egrep "node_list|node_roles_groups|node_groups"
        ```
 
        Example outputs:
@@ -273,98 +273,22 @@ HPE Cray EX System Admin Toolkit (SAT) product stream documentation (`S-8031`) f
 
 1. (`ncn-mw#`) Cancel the running BOS sessions.
 
-    1. Identify the BOS Sessions and associated BOA Kubernetes jobs to delete.
-
-        Determine which BOS sessions to cancel. To cancel a BOS session, kill
-        its associated Boot Orchestration Agent (BOA) Kubernetes job.
-
-        To find a list of BOA jobs that are still running:
+    1. Identify the BOS Sessions to delete.
 
         ```bash
-        kubectl -n services get jobs|egrep -i "boa|Name"
+        cray bos v2 sessions list --format json
         ```
 
-        Output similar to the following will be returned:
-
-        ```text
-        NAME                                       COMPLETIONS   DURATION   AGE
-        boa-0216d2d9-b2bc-41b0-960d-165d2af7a742   0/1           36m        36m
-        boa-0dbd7adb-fe53-4cda-bf0b-c47b0c111c9f   1/1           36m        3d5h
-        boa-4274b117-826a-4d8b-ac20-800fcac9afcc   1/1           36m        3d7h
-        boa-504dd626-d566-4f58-9974-3c50573146d6   1/1           8m47s      3d5h
-        boa-bae3fc19-7d91-44fc-a1ad-999e03f1daef   1/1           36m        3d7h
-        boa-bd95dc0b-8cb2-4ad4-8673-bb4cc8cae9b0   1/1           36m        3d7h
-        boa-ccdd1c29-cbd2-45df-8e7f-540d0c9cf453   1/1           35m        3d5h
-        boa-e0543eb5-3445-4ee0-93ec-c53e3d1832ce   1/1           36m        3d5h
-        boa-e0fca5e3-b671-4184-aa21-84feba50e85f   1/1           36m        3d5h
-        ```
-
-        Any job with a `0/1` `COMPLETIONS` column is still running and is a candidate to be forcibly deleted.
-        The BOA Job ID appears in the NAME column.
-
-    1. Clean up prior to BOA job deletion.
-
-        The BOA pod mounts a ConfigMap under the name `boot-session` at the directory `/mnt/boot_session` inside the pod. This ConfigMap has a random UUID name like `e0543eb5-3445-4ee0-93ec-c53e3d1832ce`.
-        Prior to deleting a BOA job, delete its ConfigMap.
-        Find the BOA job's ConfigMap with the following command:
+    1. Delete each running BOS session.
 
         ```bash
-        kubectl -n services describe job <BOA Job ID> |grep ConfigMap -A 1 -B 1
+        cray bos v2 sessions delete <session ID>
         ```
 
         Example:
 
         ```bash
-        kubectl -n services describe job boa-0216d2d9-b2bc-41b0-960d-165d2af7a742 |grep ConfigMap -A 1 -B 1
-           boot-session:
-            Type:      ConfigMap (a volume populated by a ConfigMap)
-            Name:      e0543eb5-3445-4ee0-93ec-c53e3d1832ce    <<< ConfigMap name. Delete this one.
-        --
-           ca-pubkey:
-            Type:      ConfigMap (a volume populated by a ConfigMap)
-            Name:      cray-configmap-ca-public-key
-        ```
-
-        Delete the ConfigMap associated with the `boot-session`, not the `ca-pubkey`.
-
-        To delete the ConfigMap:
-
-        ```bash
-        kubectl -n services delete cm <ConfigMap name>
-        ```
-
-        Example:
-
-        ```bash
-        kubectl -n services delete cm e0543eb5-3445-4ee0-93ec-c53e3d1832ce
-        configmap "e0543eb5-3445-4ee0-93ec-c53e3d1832ce" deleted
-        ```
-
-    1. Delete the BOA jobs.
-
-        ```bash
-        kubectl -n services delete job <boa-job-id>
-        ```
-
-        This will kill the BOA job and the BOS session associated with it.
-
-        When a job is killed, BOA will no longer attempt to execute the operation it was attempting to perform. This does not mean that
-        nothing continues to happen. If BOA has instructed a node to power on, the node will continue to power even after the BOA job
-        has been killed.
-
-    1. Delete the BOS session.
-        BOS keeps track of sessions in its database. These entries need to be deleted.
-        The BOS Session ID is the same as the BOA Job ID minus the prepended `boa-`
-        string. Use the following command to delete the BOS database entry.
-
-        ```bash
-        cray bos v1 session delete <session ID>
-        ```
-
-        Example:
-
-        ```bash
-        cray bos v1 session delete 0216d2d9-b2bc-41b0-960d-165d2af7a742
+        cray bos v2 sessions delete 0216d2d9-b2bc-41b0-960d-165d2af7a742
         ```
 
 1. Coordinate with the site to prevent new sessions from starting in the services listed.

--- a/operations/power_management/Shut_Down_and_Power_Off_Compute_and_User_Access_Nodes.md
+++ b/operations/power_management/Shut_Down_and_Power_Off_Compute_and_User_Access_Nodes.md
@@ -15,7 +15,7 @@ System Admin Toolkit (SAT) (S-8031)* product stream documentation for instructio
    Identify the BOS session template names such as `cos-2.0.x`, `uan-slurm`, and choose the appropriate compute and UAN node templates for the shutdown.
 
    ```bash
-   cray bos v1 sessiontemplate list --format toml
+   cray bos v2 sessiontemplates list --format toml
    ```
 
    Example output excerpts:
@@ -39,7 +39,7 @@ System Admin Toolkit (SAT) (S-8031)* product stream documentation for instructio
 1. (`ncn-mw#`) To display more information about a session template, for example `cos-2.0.x`, use the `describe` option.
 
    ```bash
-   cray bos v1 sessiontemplate describe cos-2.0.x
+   cray bos v2 sessiontemplates describe cos-2.0.x
    ```
 
 1. (`ncn-mw#`) Use `sat bootsys shutdown` to shut down and power off UANs and compute nodes.
@@ -59,14 +59,6 @@ System Admin Toolkit (SAT) (S-8031)* product stream documentation for instructio
    Started boot operation on BOS session templates: cos-2.0.x, uan.
    Waiting up to 600 seconds for sessions to complete.
 
-   Waiting for BOA k8s job with id boa-a1a697fc-e040-4707-8a44-a6aef9e4d6ea to complete. Session template: uan.
-   To monitor the progress of this job, run the following command in a separate window:
-       'kubectl -n services logs -c boa -f --selector job-name=boa-a1a697fc-e040-4707-8a44-a6aef9e4d6ea'
-
-   Waiting for BOA k8s job with id boa-79584ffe-104c-4766-b584-06c5a3a60996 to complete. Session template: cos-2.0.0.
-   To monitor the progress of this job, run the following command in a separate window:
-       'kubectl -n services logs -c boa -f --selector job-name=boa-79584ffe-104c-4766-b584-06c5a3a60996'
-
    [...]
 
    All BOS sessions completed.
@@ -79,55 +71,6 @@ System Admin Toolkit (SAT) (S-8031)* product stream documentation for instructio
    ```
 
    This is a non-fatal error and does not affect the `bos-operations` stage of `sat bootsys`.
-
-   **Note:** In certain cases, the command may fail before reaching the displayed timeout
-   and show warnings similar to the following:
-
-   ```text
-   WARNING: The 'kubectl wait' command failed instead of timing out. stderr: error: condition not met for jobs/boa-79584ffe-104c-4766- b584-06c5a3a60996
-   ```
-
-    The BOS operation can still proceed even with these warnings. However, the warnings
-    may result in the `bos-operations` stage of the `sat bootsys` command exiting before the BOS
-    operation is complete. Because of this, it is important to view the logs in order to monitor the
-    boot and to verify that the nodes reached the expected state. Both of these recommendations are shown
-    in the remaining steps.
-
-1. Use the Job ID strings from the previous command to monitor the shutdown progress of the compute nodes.
-
-   For example, use the `cos-2.0.0` session `boa-79584ffe-104c-4766- b584-06c5a3a60996`.
-
-   The command to run is displayed in the output of the `sat bootsys shutdown` command.
-
-   ```bash
-   kubectl logs -n services -c boa -f \
-                --selector job-name=boa-79584ffe-104c-4766-b584-06c5a3a60996
-   ```
-
-   Example output:
-
-   ```text
-   2020-08-21 17:27:02,358 - DEBUG   - cray.boa - BOA starting
-   2020-08-21 17:27:02,358 - DEBUG   - cray.boa - Boot Agent Image:  created.
-   2020-08-21 17:27:02,358 - INFO    - cray.boa - Boot Session: boa-79584ffe-104c-4766-b584-06c5a3a60996
-   2020-08-21 17:27:02,371 - INFO    - cray.boa.connection - Reattempting GET request for 'http://cray-cfs-api/apis/cfs/sessions'
-   2020-08-21 17:27:02,373 - INFO    - cray.boa.connection - Reattempting GET request for 'http://cray-cfs-api/apis/cfs/sessions'
-   2020-08-21 17:27:02,395 - INFO    - cray.boa.connection - Reattempting GET request for 'http://cray-cfs-api/apis/cfs/sessions'
-   2020-08-21 17:27:02,437 - INFO    - cray.boa.connection - Reattempting GET request for 'http://cray-cfs-api/apis/cfs/sessions'
-   2020-08-21 17:27:02,519 - INFO    - cray.boa.connection - Reattempting GET request for 'http://cray-cfs-api/apis/cfs/sessions'
-   2020-08-21 17:27:02,681 - INFO    - cray.boa.connection - Reattempting GET request for 'http://cray-cfs-api/apis/cfs/sessions'
-   2020-08-21 17:27:03,003 - INFO    - cray.boa.connection - Reattempting GET request for 'http://cray-cfs-api/apis/cfs/sessions'
-   2020-08-21 17:27:03,645 - INFO    - cray.boa.connection - Reattempting GET request for 'http://cray-cfs-api/apis/cfs/sessions'
-
-   ```
-
-   The BOS shutdown session may or may not power off compute nodes depending on the session template being used.
-
-1. (`ncn-mw#`) In another shell window, use a similar command to monitor the UAN session.
-
-   ```bash
-   kubectl -n services logs -c boa -f --selector job-name=boa-a1a697fc-e040-4707-8a44-a6aef9e4d6ea
-   ```
 
 1. (`ncn-mw#`) Check the status of both UAN and compute nodes to verify that they are `Off`.
 

--- a/operations/resiliency/Resiliency_Testing_Procedure.md
+++ b/operations/resiliency/Resiliency_Testing_Procedure.md
@@ -71,7 +71,7 @@ examples) to inform internal users and customers about our process.
    (`ncn-mw#`) To see a list of BOS templates that exist on the system:
 
    ```bash
-   cray bos v1 sessiontemplate list
+   cray bos v2 sessiontemplates list
    ```
 
    For more information regarding management of BOS session templates, refer to [Manage a Session Template](../boot_orchestration/Manage_a_Session_Template.md).
@@ -122,7 +122,7 @@ In order to keep watch on various items during and after the fault has been intr
    ```
 
    ```bash
-   watch -n 5 "date; cray bos v1 session list"
+   watch -n 5 "date; cray bos v2 sessions list"
    ```
 
 1. Monitor Ceph health, in a window, during and after a single NCN is taken down.
@@ -334,30 +334,15 @@ pre-designated set of compute nodes. The timing of this test is recommended to b
 of a master or worker NCN) and for them to have been rescheduled and in a healthy state on another NCN. Going too much earlier than 10 minutes runs the risk that there are still some critical pods that are settling out to reach
 a healthy state.
 
-1. (`ncn-mw#`) Reboot a pre-designated set of compute nodes and watch the reboot.
+1. (`ncn-mw#`) Reboot a pre-designated set of compute nodes.
 
    1. Use BOS to reboot the designated compute nodes.
 
       ```bash
-      cray bos v1 session create --template-name boot-nids-1-4 --operation reboot
+      cray bos v2 sessions create --template-name boot-nids-1-4 --operation reboot
       ```
 
-      Issuing this reboot command will output a Boot Orchestration Agent (BOA) `jobId`, which can be used to find the new BOA pod that has been created for the boot. Then, the logs can be tailed to watch the compute boot proceed.
-
-   1. Find the BOA job name using the returned BOA `jobID`.
-
-      ```bash
-      kubectl get pods -o wide -A | grep <boa-job-id>
-      ```
-
-   1. Watch the progress of the reboot of the compute nodes.
-
-      ```bash
-      kubectl logs -n services <boa-job-pod-name> -c boa -f
-      ```
-
-      Failures or a timeout being reached in either the boot or CFS (post-boot configuration) phase will need investigation. For more information around accessing logs for the BOS operations, see
-      [Check the Progress of BOS Session Operations](../boot_orchestration/Check_the_Progress_of_BOS_Session_Operations.md).
+   1. Wait until the BOS reboot session has completed.
 
 1. If the target node for shutdown was a worker NCN, verify that the UAI launched on that node still exists. It should be running on another worker NCN.
 

--- a/operations/security_and_authentication/Add_LDAP_User_Federation.md
+++ b/operations/security_and_authentication/Add_LDAP_User_Federation.md
@@ -693,7 +693,7 @@ Be sure to modify the example URLs on this page by replacing `SYSTEM_DOMAIN_NAME
    1. Reboot with the Boot Orchestration Service (BOS).
 
       ```bash
-      cray bos v1 session create --template-name BOS_TEMPLATE --operation reboot
+      cray bos v2 sessions create --template-name BOS_TEMPLATE --operation reboot
       ```
 
 1. (`ncn-mw#`) Validate that LDAP integration was added successfully.

--- a/operations/security_and_authentication/Resync_Keycloak_Users_to_Compute_Nodes.md
+++ b/operations/security_and_authentication/Resync_Keycloak_Users_to_Compute_Nodes.md
@@ -70,5 +70,5 @@ The Slurm or PBS product must be installed.
     Or, reboot the compute nodes with the Boot Orchestration Service \(BOS\).
 
     ```bash
-    cray bos v1 session create --template-name BOS_TEMPLATE --operation reboot
+    cray bos v2 sessions create --template-name BOS_TEMPLATE --operation reboot
     ```


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
In CSM 1.5, all BOS session templates will be valid for use with BOS v2 (with the work done in [CASMCMS-8799](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8799)).

This PR updates the CSM docs in two ways:
1. Updates all operational BOS procedures to use BOS v2 instead of BOS v1 (this is mostly a selective backport from [this CSM 1.6 docs PR](https://github.com/Cray-HPE/docs-csm/pull/4059))
2. Documents the fact that BOS v1 session templates will automatically have deprecated fields removed from them in CSM 1.5, rendering them valid templates for both BOS v1 and BOS v2.

I'll be making a backport PR for that second part, to update the deprecation announcements in the other branches.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
