### PR TITLE
CASMPET-6783 remove storage node rebuild step upload_ceph_images_to_nexus.sh

### DIFF
--- a/operations/node_management/Rebuild_NCNs/Prepare_Storage_Nodes.md
+++ b/operations/node_management/Rebuild_NCNs/Prepare_Storage_Nodes.md
@@ -67,14 +67,6 @@ Upload Ceph container images into Nexus.
     This procedure must be performed on a `ceph-mon`node. By default these will be
     any of the first three storage NCNs: `ncn-s001`, `ncn-s002`, or `ncn-s003`
 
-1. (`ncn-s#`) Copy the `upload_ceph_images_to_nexus.sh` script from `ncn-m001`, add the execute permission to the copied script, and then execute it.
-
-    ```bash
-    scp ncn-m001:/usr/share/doc/csm/scripts/upload_ceph_images_to_nexus.sh /srv/cray/scripts/common/upload_ceph_images_to_nexus.sh && \
-    chmod +x /srv/cray/scripts/common/upload_ceph_images_to_nexus.sh && \
-    /srv/cray/scripts/common/upload_ceph_images_to_nexus.sh
-    ```
-
 1. (`ncn-s#`) Check the status of Ceph.
 
     Check the OSD status, weight, and location:


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

The ```upload_ceph_images_to_nexus.sh``` script is meant to make storage node daemons use the image in Nexus. This script has been replaced in CSM 1.4 by a storage node upgrade and by a script that restarts storage node monitoring daemons onto images in Nexus. This script should not be run in CSM 1.5 at all because all storage node daemons will already be running the image in Nexus by this time.

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
