### PR TITLE
Add script to enable goss-servers after update (CASMTRIAGE-6046)

### DIFF
--- a/upgrade/1.4.3/README.md
+++ b/upgrade/1.4.3/README.md
@@ -196,7 +196,7 @@ This step will create an imperative CFS session that can be used to configure bo
 (`ncn-m001#`) Update the `csm-testing` and `goss-servers` RPMs on the NCNs.
 
 ```bash
-pdsh -b -w $(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u |  tr -t '\n' ',') 'zypper install -y csm-testing goss-servers craycli'
+/usr/share/doc/csm/upgrade/scripts/upgrade/util/upgrade-test-rpms.sh
 ```
 
 ### Verification

--- a/upgrade/scripts/upgrade/util/upgrade-test-rpms.sh
+++ b/upgrade/scripts/upgrade/util/upgrade-test-rpms.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 ncns=$(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u |  tr -t '\n' ',')
 
 echo "Installing updated versions of csm-testing goss-servers craycli rpms"
-pdsh -b -w ${ncns} 'zypper install -y csm-testing goss-servers craycli'
+pdsh -S -b -w ${ncns} 'zypper install -y csm-testing goss-servers craycli'
 
 echo "Enabling and starting goss-servers"
-pdsh -b -w ${ncns} 'systemctl enable goss-servers && systemctl start goss-servers'
+pdsh -S -b -w ${ncns} 'systemctl enable goss-servers && systemctl start goss-servers'

--- a/upgrade/scripts/upgrade/util/upgrade-test-rpms.sh
+++ b/upgrade/scripts/upgrade/util/upgrade-test-rpms.sh
@@ -1,4 +1,27 @@
 #!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 set -euo pipefail
 ncns=$(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u |  tr -t '\n' ',')
 

--- a/upgrade/scripts/upgrade/util/upgrade-test-rpms.sh
+++ b/upgrade/scripts/upgrade/util/upgrade-test-rpms.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+set -euo pipefail
 ncns=$(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u |  tr -t '\n' ',')
 
 echo "Installing updated versions of csm-testing goss-servers craycli rpms"

--- a/upgrade/scripts/upgrade/util/upgrade-test-rpms.sh
+++ b/upgrade/scripts/upgrade/util/upgrade-test-rpms.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+ncns=$(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u |  tr -t '\n' ',')
+
+echo "Installing updated versions of csm-testing goss-servers craycli rpms"
+pdsh -b -w ${ncns} 'zypper install -y csm-testing goss-servers craycli'
+
+echo "Enabling and starting goss-servers"
+pdsh -b -w ${ncns} 'systemctl enable goss-servers && systemctl start goss-servers'


### PR DESCRIPTION
### Summary and Scope

Add step to enable/start goss-servers after update.

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6046

### Testing

fanta:

```
ncn-m001:~/brad # ./upgrade-test-rpms.sh
Installing updated versions of csm-testing goss-servers craycli rpms
ncn-s002: Loading repository data...
ncn-s003: Loading repository data...
ncn-s001: Loading repository data...
ncn-s002: Reading installed packages...
ncn-s003: Reading installed packages...
ncn-s001: Reading installed packages...
ncn-s004: Loading repository data...
ncn-s002: 'craycli' is already installed.
ncn-s002: No update candidate for 'craycli-0.74.0-1.x86_64'. The highest available version is already installed.
ncn-s002: 'goss-servers' is already installed.
ncn-s002: No update candidate for 'goss-servers-1.15.53-1.noarch'. The highest available version is already installed.
ncn-s002: 'csm-testing' is already installed.
ncn-s002: No update candidate for 'csm-testing-1.15.53-1.noarch'. The highest available version is already installed.
ncn-s002: Resolving package dependencies...
ncn-s003: 'craycli' is already installed.
ncn-s003: No update candidate for 'craycli-0.74.0-1.x86_64'. The highest available version is already installed.
ncn-s003: 'goss-servers' is already installed.
ncn-s003: No update candidate for 'goss-servers-1.15.53-1.noarch'. The highest available version is already installed.
ncn-s003: 'csm-testing' is already installed.
ncn-s003: No update candidate for 'csm-testing-1.15.53-1.noarch'. The highest available version is already installed.
ncn-s003: Resolving package dependencies...
ncn-s001: 'craycli' is already installed.
ncn-s001: No update candidate for 'craycli-0.74.0-1.x86_64'. The highest available version is already installed.
ncn-s001: 'goss-servers' is already installed.
ncn-s001: No update candidate for 'goss-servers-1.15.53-1.noarch'. The highest available version is already installed.
ncn-s001: 'csm-testing' is already installed.
ncn-s001: No update candidate for 'csm-testing-1.15.53-1.noarch'. The highest available version is already installed.
ncn-s001: Resolving package dependencies...
ncn-s004: Reading installed packages...
ncn-m001: Loading repository data...
ncn-s004: 'craycli' is already installed.
ncn-s004: No update candidate for 'craycli-0.74.0-1.x86_64'. The highest available version is already installed.
ncn-s004: 'goss-servers' is already installed.
ncn-s004: No update candidate for 'goss-servers-1.15.53-1.noarch'. The highest available version is already installed.
ncn-s004: 'csm-testing' is already installed.
ncn-s004: No update candidate for 'csm-testing-1.15.53-1.noarch'. The highest available version is already installed.
ncn-s004: Resolving package dependencies...
ncn-m001: Reading installed packages...
ncn-m001: 'craycli' is already installed.
ncn-m001: No update candidate for 'craycli-0.74.0-1.x86_64'. The highest available version is already installed.
ncn-m001: 'goss-servers' is already installed.
ncn-m001: No update candidate for 'goss-servers-1.15.53-1.noarch'. The highest available version is already installed.
ncn-m001: 'csm-testing' is already installed.
ncn-m001: No update candidate for 'csm-testing-1.15.53-1.noarch'. The highest available version is already installed.
ncn-m001: Resolving package dependencies...
ncn-w003: Loading repository data...
ncn-w003: Reading installed packages...
ncn-s002: Nothing to do.
ncn-s003: Nothing to do.
ncn-s001: Nothing to do.
ncn-w003: 'craycli' is already installed.
ncn-w003: No update candidate for 'craycli-0.74.0-1.x86_64'. The highest available version is already installed.
ncn-w003: 'goss-servers' is already installed.
ncn-w003: No update candidate for 'goss-servers-1.15.53-1.noarch'. The highest available version is already installed.
ncn-w003: 'csm-testing' is already installed.
ncn-w003: No update candidate for 'csm-testing-1.15.53-1.noarch'. The highest available version is already installed.
ncn-w003: Resolving package dependencies...
ncn-m002: Loading repository data...
ncn-m002: Reading installed packages...
ncn-w001: Loading repository data...
ncn-w001: Reading installed packages...
ncn-m002: 'craycli' is already installed.
ncn-m002: No update candidate for 'craycli-0.74.0-1.x86_64'. The highest available version is already installed.
ncn-m002: 'goss-servers' is already installed.
ncn-m002: No update candidate for 'goss-servers-1.15.53-1.noarch'. The highest available version is already installed.
ncn-m002: 'csm-testing' is already installed.
ncn-m002: No update candidate for 'csm-testing-1.15.53-1.noarch'. The highest available version is already installed.
ncn-m002: Resolving package dependencies...
ncn-m001: Nothing to do.
ncn-w001: 'craycli' is already installed.
ncn-w001: No update candidate for 'craycli-0.74.0-1.x86_64'. The highest available version is already installed.
ncn-w001: 'goss-servers' is already installed.
ncn-w001: No update candidate for 'goss-servers-1.15.53-1.noarch'. The highest available version is already installed.
ncn-w001: 'csm-testing' is already installed.
ncn-w001: No update candidate for 'csm-testing-1.15.53-1.noarch'. The highest available version is already installed.
ncn-w001: Resolving package dependencies...
ncn-s004: Nothing to do.
ncn-m002: Nothing to do.
ncn-m003: Loading repository data...
ncn-m003: Reading installed packages...
ncn-w001: Nothing to do.
ncn-m003: 'craycli' is already installed.
ncn-m003: No update candidate for 'craycli-0.74.0-1.x86_64'. The highest available version is already installed.
ncn-m003: 'goss-servers' is already installed.
ncn-m003: No update candidate for 'goss-servers-1.15.53-1.noarch'. The highest available version is already installed.
ncn-m003: 'csm-testing' is already installed.
ncn-m003: No update candidate for 'csm-testing-1.15.53-1.noarch'. The highest available version is already installed.
ncn-m003: Resolving package dependencies...
ncn-w003: Nothing to do.
ncn-m003: Nothing to do.
ncn-w002: Loading repository data...
ncn-w002: Reading installed packages...
ncn-w002: 'craycli' is already installed.
ncn-w002: No update candidate for 'craycli-0.74.0-1.x86_64'. The highest available version is already installed.
ncn-w002: 'goss-servers' is already installed.
ncn-w002: No update candidate for 'goss-servers-1.15.53-1.noarch'. The highest available version is already installed.
ncn-w002: 'csm-testing' is already installed.
ncn-w002: No update candidate for 'csm-testing-1.15.53-1.noarch'. The highest available version is already installed.
ncn-w002: Resolving package dependencies...
ncn-w004: Loading repository data...
ncn-w004: Reading installed packages...
ncn-w004: 'craycli' is already installed.
ncn-w004: No update candidate for 'craycli-0.74.0-1.x86_64'. The highest available version is already installed.
ncn-w004: 'goss-servers' is already installed.
ncn-w004: No update candidate for 'goss-servers-1.15.53-1.noarch'. The highest available version is already installed.
ncn-w004: 'csm-testing' is already installed.
ncn-w004: No update candidate for 'csm-testing-1.15.53-1.noarch'. The highest available version is already installed.
ncn-w004: Resolving package dependencies...
ncn-w002: Nothing to do.
ncn-w004: Nothing to do.
Enabling and starting goss-servers
ncn-s001: Created symlink /etc/systemd/system/multi-user.target.wants/goss-servers.service → /etc/systemd/system/goss-servers.service.
ncn-s003: Created symlink /etc/systemd/system/multi-user.target.wants/goss-servers.service → /etc/systemd/system/goss-servers.service.
ncn-s002: Created symlink /etc/systemd/system/multi-user.target.wants/goss-servers.service → /etc/systemd/system/goss-servers.service.
ncn-s004: Created symlink /etc/systemd/system/multi-user.target.wants/goss-servers.service → /etc/systemd/system/goss-servers.service.
ncn-w001: Created symlink /etc/systemd/system/multi-user.target.wants/goss-servers.service → /etc/systemd/system/goss-servers.service.
ncn-m002: Created symlink /etc/systemd/system/multi-user.target.wants/goss-servers.service → /etc/systemd/system/goss-servers.service.
ncn-m001: Created symlink /etc/systemd/system/multi-user.target.wants/goss-servers.service → /etc/systemd/system/goss-servers.service.
ncn-m003: Created symlink /etc/systemd/system/multi-user.target.wants/goss-servers.service → /etc/systemd/system/goss-servers.service.
ncn-w003: Created symlink /etc/systemd/system/multi-user.target.wants/goss-servers.service → /etc/systemd/system/goss-servers.service.
ncn-w002: Created symlink /etc/systemd/system/multi-user.target.wants/goss-servers.service → /etc/systemd/system/goss-servers.service.
ncn-w004: Created symlink /etc/systemd/system/multi-user.target.wants/goss-servers.service → /etc/systemd/system/goss-servers.service.
```

```
ncn-m001:~ # pdsh -w ncn-w00[1-4] -w ncn-m00[1-3] -w ncn-s00[1-4] systemctl is-enabled goss-servers.service
ncn-s002: enabled
ncn-s003: enabled
ncn-s001: enabled
ncn-s004: enabled
ncn-m001: enabled
ncn-w003: enabled
ncn-w004: enabled
ncn-w002: enabled
ncn-m002: enabled
ncn-w001: enabled
ncn-m003: enabled
```

N/A

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing

