### PR TITLE
Remove step that uninstalls etcd-operator (CASMTRIAGE-5821)

### DIFF
--- a/upgrade/Stage_3.md
+++ b/upgrade/Stage_3.md
@@ -233,7 +233,7 @@ Run the following script to apply anti-affinity to `coredns` pods:
 
 ## Stage 3.6 - Complete Kubernetes upgrade
 
-Complete the Kubernetes upgrade. This script will restart several pods on each master node to their new Docker containers.
+- Complete the Kubernetes upgrade. This script will restart several pods on each master node to their new Docker containers.
 
 ```bash
 /usr/share/doc/csm/upgrade/scripts/k8s/upgrade_control_plane.sh
@@ -241,9 +241,15 @@ Complete the Kubernetes upgrade. This script will restart several pods on each m
 
 > **`NOTE`**: `kubelet` has been upgraded already, ignore the warning to upgrade it.
 
-If the previous three steps were executed as part of the IUF [Deploy Product](../operations/iuf/workflows/deploy_product.md)
-procedure, return to the IUF [Deploy Product](../operations/iuf/workflows/deploy_product.md) procedure and
-complete the remaining steps. Otherwise, proceed to the following topic.
+- Uninstall the deprecated `etcd-operator`.
+
+```bash
+helm uninstall -n operators cray-etcd-operator
+```
+
+> If this step was executed as part of the IUF [Deploy Product](../operations/iuf/workflows/deploy_product.md)
+> procedure, return to the IUF [Deploy Product](../operations/iuf/workflows/deploy_product.md) procedure and
+> complete the remaining steps. Otherwise, proceed to the following topic.
 
 ### Stop typescript on `ncn-m002`
 

--- a/upgrade/scripts/upgrade/ncn-upgrade-master-nodes.sh
+++ b/upgrade/scripts/upgrade/ncn-upgrade-master-nodes.sh
@@ -79,19 +79,6 @@ if [[ ${target_ncn} == "ncn-m001" ]]; then
   fi
 fi
 
-if helm ls -n operators | grep -q etcd-operator; then
-  old_clusters=$(kubectl get etcdclusters.etcd.database.coreos.com -A --output=custom-columns=name:.metadata.name --no-headers 2>&1)
-  if [ "$old_clusters" != "No resources found" ]; then
-    echo "Upgrade Failed!  The following etcd cluster(s) will not function with"
-    echo "Kubernetes 1.22 and must be converted to the bitnami etcd helm chart:"
-    echo ""
-    echo $old_clusters
-    exit 1
-  fi
-  echo "Uninstalling deprecated etcd-operator"
-  helm uninstall -n operators cray-etcd-operator
-fi
-
 {
   first_master_hostname=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters?name=Global \
     | jq -r '.[] | ."cloud-init"."meta-data"."first-master-hostname"')


### PR DESCRIPTION
### Summary and Scope

Keep the etcd-operator around until after deploy-products has run,
allowing non-CSM etcd clusters to remain healthy through NCN
rebuilds.

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5821

### Testing

tyr:

```
ncn-m002:~ # kubectl get po -n services | grep 'fox\|cvt'
cray-cvt-556898ccbb-dwkp4                                         2/2     Running            0          16h
cray-cvt-etcd-h5tr5fzfz8                                          1/1     Running            0          15h
cray-cvt-etcd-nf95mvm9z7                                          1/1     Running            0          11h
cray-cvt-etcd-nzqg6zjhch                                          1/1     Running            0          16h
cray-fox-6cbc67fdb9-b8pxb                                         2/2     Running            0          11h
cray-fox-etcd-59rzm8t9sz                                          1/1     Running            0          15h
cray-fox-etcd-gsrc8ntc6v                                          1/1     Running            0          11h
cray-fox-etcd-hh68l6lt4b                                          1/1     Running            0          16h
```

N/A

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing

