### PR TITLE
CASMPET-6795 fix storage node rebuild procedure by removing reference to Upload_ceph_images_to_nexus.sh

### DIFF
--- a/operations/node_management/Rebuild_NCNs/Prepare_Storage_Nodes.md
+++ b/operations/node_management/Rebuild_NCNs/Prepare_Storage_Nodes.md
@@ -67,13 +67,6 @@ Upload Ceph container images into Nexus.
     This procedure must be performed on a `ceph-mon`node. By default these will be
     any of the first three storage NCNs: `ncn-s001`, `ncn-s002`, or `ncn-s003`
 
-1. (`ncn-s#`) Copy `upload_ceph_images_to_nexus.sh` from `ncn-m001` and execute it.
-
-    ```bash
-    scp ncn-m001:/usr/share/doc/csm/scripts/upload_ceph_images_to_nexus.sh /srv/cray/scripts/common/upload_ceph_images_to_nexus.sh && \
-    /srv/cray/scripts/common/upload_ceph_images_to_nexus.sh
-    ```
-
 1. (`ncn-s#`) Check the status of Ceph.
 
     Check the OSD status, weight, and location:
@@ -113,7 +106,7 @@ Upload Ceph container images into Nexus.
 1. (`ncn-s#`) If the node is up, then stop and disable all the Ceph services on the node being rebuilt.
 
     ```bash
-    ceph orch maintenance enter <storage node hostname being rebuilt>
+    ceph orch host maintenance enter <storage node hostname being rebuilt>
     ```
 
     Example output:

--- a/scripts/join_ceph_cluster.sh
+++ b/scripts/join_ceph_cluster.sh
@@ -25,6 +25,8 @@
 
 #!/bin/bash
 
+ssh_options="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+
 host=$(hostname)
 host_ip=$(host ${host} | awk '{ print $NF }')
 
@@ -78,10 +80,60 @@ for node in ncn-s001 ncn-s002 ncn-s003; do
   fi
 done
 
-# run preload images on host
-echo "Running pre-load-images on $host"
-if [[ ! $(/srv/cray/scripts/common/pre-load-images.sh) ]]; then
-  echo "ERROR  Unable to run pre-load-images.sh on $host."
+# run preload images on host only if Ceph version is not v16.2.13
+# if ceph is v16.2.13, then pull images from Nexus becuase
+# if ceph is v16.2.13, then local docker registry has been stopped
+version=""
+for node in ncn-s001 ncn-s002 ncn-s003; do
+  if [[ "$host" =~ ^("ncn-s001"|"ncn-s002"|"ncn-s003")$ ]]; then
+    version=$(ceph version | grep '16.2.13')
+    if [[ $? -eq 0 ]]; then break; fi
+  else
+    version=$(ssh $node ${ssh_options} 'ceph version | grep "16.2.13"')
+    if [[ $? -eq 0 ]]; then break; fi
+  fi
+done
+if [[ -z $version ]]; then
+  # run pre-load-images if patch Ceph is not 16.2.13
+  echo "Running pre-load-images on $host"
+  if [[ ! $(/srv/cray/scripts/common/pre-load-images.sh) ]]; then
+    echo "ERROR  Unable to run pre-load-images.sh on $host."
+  fi
+else
+  # pull images from nexus if Ceph is 16.2.13
+  for container in "container_image_prometheus" "container_image_node_exporter" "container_image_alertmanager" "container_image_grafana"; do
+    image=$(ceph --name client.ro config get mgr mgr/cephadm/${container})
+    podman pull $image
+  done
+  active_mgr=$(ceph --name client.ro mgr dump | jq -r .active_name)
+  active_mgr_version=$(ceph --name client.ro orch ps -f json | jq --arg MGR $active_mgr '.[] | select(.daemon_name | contains($MGR)) | .version' | tr -d '"')
+  podman pull "registry.local/artifactory.algol60.net/csm-docker/stable/quay.io/ceph/ceph:v${active_mgr_version}"
+fi
+
+# exit maintenance mode if node is in maintenance mode
+maintenance=""
+maintenance=$(ceph --name client.ro orch host ls -f json | jq --arg host "$host" '.[] | select(.hostname==$host)' | grep -E 'maintenance|Maintenance')
+if [[ -n $maintenance ]]; then
+  success_exit_maint=0
+  if [[ "$host" =~ ^("ncn-s001"|"ncn-s002"|"ncn-s003")$ ]]; then
+    ceph orch host maintenance exit $host
+    if [[ $? -eq 0 ]]; then
+      success_exit_maint=1
+    fi
+  else
+    for node in ncn-s001 ncn-s002 ncn-s003; do
+      ssh $node ${ssh_options} "ceph orch host maintenance exit $host"
+      if [[ $? -eq 0 ]]; then
+        success_exit_maint=1
+        break
+      fi
+    done
+  fi
+  if [[ $success_exit_maint -eq 0 ]]; then
+      echo "ERROR failed to remove $host from maintenance mode."
+      echo "Try manually running 'ceph orch host maintenance exit $host' from ncn-s001, ncn-s002, or ncn-s003."
+      exit 1
+  fi
 fi
 
 sleep 30
@@ -110,6 +162,13 @@ do
     fi
   done
 done
+
+# reinstalling smartmon on storage nodes if Ceph version is 16.2.13
+if [[ -n $version ]]; then
+  echo "Reinstalling smartmon on storage nodes"
+  ssh ncn-m001 /usr/share/doc/csm/scripts/operations/ceph/enable-smart-mon-storage-nodes.sh
+  sleep 10
+fi
 
 # check if node-exporter needs to be restarted
 status=$(ceph --name client.ro orch ps $host --format json | jq '.[] | select(.daemon_type == "node-exporter") | .status_desc' | tr -d '"')

--- a/scripts/join_ceph_cluster.sh
+++ b/scripts/join_ceph_cluster.sh
@@ -101,7 +101,13 @@ if [[ -z $version ]]; then
   fi
 else
   # pull images from nexus if Ceph is 16.2.13
-  for container in "container_image_prometheus" "container_image_node_exporter" "container_image_alertmanager" "container_image_grafana"; do
+  containers=(
+'container_image_alertmanager'
+'container_image_grafana'
+'container_image_node_exporter'
+'container_image_prometheus'
+  )
+  for container in "${containers[@]}"; do
     image=$(ceph --name client.ro config get mgr mgr/cephadm/${container})
     podman pull $image
   done


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

This PR addresses the following 3 problems with the CSM 1.4 storage node rebuild.

1. We are running `ceph_upload_images_to_nexus.sh`. This script has known bugs and should have been removed from use. It is not necessary to run as part of the storage node rebuild so it should be removed from the procedure.

2. Before power cycling a storage node, the direction say to put the storage node into "maintenance mode". This is fine except that when the node comes back, it is still in maintenance mode. No daemons start back up on the node because it is in maintenance mode. The `ceph_join_cluster.sh` should have a check for exiting maintenance mode if the node is in it.

3. The `ceph_join_cluster.sh` runs the `pre-load-images.sh` on the storage node. This is a problem because this script starts the local docker registry on the node and loads images into it. We have tried to get away from using the local docker registry on storage nodes because of a security vulnerability. If the CSM 1.3.4+ or CSM 1.4.2+ patch has been applied, then the `ceph_join_cluster.sh` script should instead pull images from Nexus and not run the `pre-load-images.sh` script.

Multiple storage node rebuilds were tested on Surtur.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
