### PR TITLE
CASMHMS-6091: Update KEA docs for resilient KEA deployment in CSM 1.5

### DIFF
--- a/install/troubleshooting_pxe_boot.md
+++ b/install/troubleshooting_pxe_boot.md
@@ -297,22 +297,16 @@ HTTP 0x6d35da88 status 404 Not Found
 
 In some cases, rebooting the Kea pod has resolved PXE issues.
 
-1. (`ncn-mw#`) Get the Kea pod.
+1. (`ncn-mw#`) Restart Kea.
 
     ```bash
-    kubectl get pods -n services | grep kea
+    kubectl rollout restart deployment -n services cray-dhcp-kea
     ```
 
-    Example output:
-
-    ```text
-    cray-dhcp-kea-6bd8cfc9c5-m6bgw                                 3/3     Running     0          20h
-    ```
-
-1. (`ncn-mw#`) Delete the Kea pod.
+1. (`ncn-mw#`) Wait for deployment to restart.
 
     ```bash
-    kubectl delete pods -n services cray-dhcp-kea-6bd8cfc9c5-m6bgw
+    kubectl rollout status deployment -n services cray-dhcp-kea
     ```
 
 ### Missing BSS data

--- a/operations/boot_orchestration/Troubleshoot_Compute_Node_Boot_Issues_Related_to_Dynamic_Host_Configuration_Protocol_DHCP.md
+++ b/operations/boot_orchestration/Troubleshoot_Compute_Node_Boot_Issues_Related_to_Dynamic_Host_Configuration_Protocol_DHCP.md
@@ -24,11 +24,23 @@ Encryption of compute node logs is not enabled, so the passwords may be passed i
     Example output:
 
     ```
-    services cray-dhcp-kea-554698bb69-r9wwt          3/3 Running   0 13h
-    services cray-dhcp-kea-postgres-0                2/2 Running   0 10d
-    services cray-dhcp-kea-postgres-1                2/2 Running   0 3d18h
-    services cray-dhcp-kea-postgres-2                2/2 Running   0 10d
-    services cray-dhcp-kea-wait-for-postgres-3-7gqvg 0/3 Completed 0 10d
+    services cray-dhcp-kea-7d4c5c9fb5-hs5gg      3/3 Running   0 23h
+    services cray-dhcp-kea-7d4c5c9fb5-qtwtn      3/3 Running   0 23h
+    services cray-dhcp-kea-7d4c5c9fb5-t4mkw      3/3 Running   0 23h
+    services cray-dhcp-kea-helper-28256853-j8h6l 0/2 Completed 0 30m
+    services cray-dhcp-kea-helper-28256856-d5cl4 0/2 Completed 0 27m
+    services cray-dhcp-kea-helper-28256859-xj8tc 0/2 Completed 0 24m
+    services cray-dhcp-kea-helper-28256862-9pmx4 0/2 Completed 0 21m
+    services cray-dhcp-kea-helper-28256865-fljjs 0/2 Completed 0 18m
+    services cray-dhcp-kea-helper-28256868-9cl9q 0/2 Completed 0 15m
+    services cray-dhcp-kea-helper-28256871-sfhgs 0/2 Completed 0 12m
+    services cray-dhcp-kea-helper-28256874-7s8n2 0/2 Completed 0 9m30s
+    services cray-dhcp-kea-helper-28256877-jxhqt 0/2 Completed 0 6m30s
+    services cray-dhcp-kea-helper-28256880-pl48w 0/2 Completed 0 3m29s
+    services cray-dhcp-kea-init-24-nbhng         0/2 Completed 0 8d
+    services cray-dhcp-kea-postgres-0            3/3 Running   0 24h
+    services cray-dhcp-kea-postgres-1            3/3 Running   0 24h
+    services cray-dhcp-kea-postgres-2            3/3 Running   0 24h
     ```
 
 3.  Start a `tcpdump` session on the NCN.

--- a/operations/boot_orchestration/Troubleshoot_Compute_Node_Boot_Issues_Related_to_Dynamic_Host_Configuration_Protocol_DHCP.md
+++ b/operations/boot_orchestration/Troubleshoot_Compute_Node_Boot_Issues_Related_to_Dynamic_Host_Configuration_Protocol_DHCP.md
@@ -2,20 +2,20 @@
 
 DHCP issues can result in node boot failures. This procedure helps investigate and resolve such issues.
 
-### Prerequisites
+## Prerequisites
 
 - This procedure requires administrative privileges.
 - `kubectl` is installed.
 
-### Limitations
+## Limitations
 
 Encryption of compute node logs is not enabled, so the passwords may be passed in clear text.
 
-### Procedure
+## Procedure
 
-1.  Log in to a non-compute node \(NCN\) as root.
+1. Log in to a non-compute node \(NCN\) as root.
 
-2.  Check that the DHCP service is running.
+2. (`ncn-mw#`) Check that the DHCP service is running.
 
     ```bash
     kubectl get pods -A | grep kea
@@ -23,7 +23,7 @@ Encryption of compute node logs is not enabled, so the passwords may be passed i
 
     Example output:
 
-    ```
+    ```text
     services cray-dhcp-kea-7d4c5c9fb5-hs5gg      3/3 Running   0 23h
     services cray-dhcp-kea-7d4c5c9fb5-qtwtn      3/3 Running   0 23h
     services cray-dhcp-kea-7d4c5c9fb5-t4mkw      3/3 Running   0 23h
@@ -43,37 +43,38 @@ Encryption of compute node logs is not enabled, so the passwords may be passed i
     services cray-dhcp-kea-postgres-2            3/3 Running   0 24h
     ```
 
-3.  Start a `tcpdump` session on the NCN.
+3. (`ncn-mw#`) Start a `tcpdump` session on the NCN.
 
-    The following example sends tcpdump data to `stdout`.
+    The following example sends `tcpdump` data to `stdout`.
 
     ```bash
     tcpdump
     ```
 
-4.  Obtain the DHCP pod's ID.
+4. (`ncn-mw#`) Obtain the DHCP pod's ID.
 
     ```bash
     PODID=$(kubectl get pods --no-headers -o wide | grep cray-dhcp | awk '{print $1}')
     ```
 
-5.  Enter the DHCP pod using its ID.
+5. (`ncn-mw#`) Enter the DHCP pod using its ID.
 
     ```bash
     kubectl exec -it $PODID /bin/sh
     ```
 
-6.  Start a `tcpdump` session from within the DHCP pod.
+6. Start a `tcpdump` session from within the DHCP pod.
 
-7.  Open another terminal to perform the following tasks:
+7. Open another terminal to perform the following tasks:
 
-    1.  Issue a DHCP discover request from the NCN using nmap.
+    1. Issue a DHCP discover request from the NCN using `nmap`.
 
-    2.  Analyze the NCN tcpdump data in order to ensure that the DHCP discover request is visible.
+    2. Analyze the NCN `tcpdump` data in order to ensure that the DHCP discover request is visible.
 
-8.  Go back to the original terminal to analyze the DHCP pod's tcpdump data in order to ensure that the DHCP discover request is visible inside the pod.
+8. Go back to the original terminal to analyze the DHCP pod's `tcpdump` data in order to ensure that the DHCP discover request is visible inside the pod.
 
     **Troubleshooting Information:**
 
-    If the DHCP Discover request is not visible on the NCN, it may be due to a firewall issue. If the DHCP Discover request is not visible inside the pod, double check if the request was issued over the correct interface for the Node Management Network \(NMN\). If it was, it could indicate a firewall issue.
-
+    If the DHCP Discover request is not visible on the NCN, it may be due to a firewall issue. If the DHCP
+    Discover request is not visible inside the pod, double check if the request was issued over the correct
+    interface for the Node Management Network \(NMN\). If it was, it could indicate a firewall issue.

--- a/operations/network/dhcp/Troubleshoot_DHCP_Issues.md
+++ b/operations/network/dhcp/Troubleshoot_DHCP_Issues.md
@@ -38,6 +38,12 @@ Example output:
 
 ```text
 cray-dhcp-kea-api              ClusterIP     10.26.142.204  <none>         8000/TCP      5d23h
+cray-dhcp-kea-postgres         ClusterIP     10.19.97.142   <none>         5432/TCP      5d23h
+cray-dhcp-kea-postgres-0       ClusterIP     10.30.214.27   <none>         5432/TCP      5d23h
+cray-dhcp-kea-postgres-1       ClusterIP     10.27.232.156  <none>         5432/TCP      5d23h
+cray-dhcp-kea-postgres-2       ClusterIP     10.22.242.251  <none>         5432/TCP      5d23h
+cray-dhcp-kea-postgres-config  ClusterIP     None           <none>         <none>        5d23h
+cray-dhcp-kea-postgres-repl    ClusterIP     10.17.107.16   <none>         5432/TCP      5d23
 cray-dhcp-kea-tcp-hmn          LoadBalancer  10.24.79.120   10.94.100.222  67:32120/TCP  5d23h
 cray-dhcp-kea-tcp-nmn          LoadBalancer  10.19.139.179  10.92.100.222  67:31652/TCP  5d23h
 cray-dhcp-kea-udp-hmn          LoadBalancer  10.25.203.31   10.94.100.222  67:30840/UDP  5d23h
@@ -55,15 +61,31 @@ kubectl get pods -n services -o wide | grep kea
 Example output:
 
 ```text
-cray-dhcp-kea-788b4c899b-x6ltd 3/3 Running 0 36h 10.40.3.183 ncn-w002 <none> <none>
+cray-dhcp-kea-7d4c5c9fb5-hs5gg      3/3 Running   0 33m   10.33.0.22   ncn-w011 <none> <none>
+cray-dhcp-kea-7d4c5c9fb5-qtwtn      3/3 Running   0 33m   10.39.0.47   ncn-w006 <none> <none>
+cray-dhcp-kea-7d4c5c9fb5-t4mkw      3/3 Running   0 24h   10.40.0.13   ncn-w005 <none> <none>
+cray-dhcp-kea-helper-28256892-bl64f 0/2 Completed 0 29m   10.39.0.48   ncn-w006 <none> <none>
+cray-dhcp-kea-helper-28256895-6t674 0/2 Completed 0 26m   10.39.0.53   ncn-w006 <none> <none>
+cray-dhcp-kea-helper-28256898-8xzl2 0/2 Completed 0 23m   10.39.0.32   ncn-w006 <none> <none>
+cray-dhcp-kea-helper-28256901-4wzql 0/2 Completed 0 20m   10.39.0.41   ncn-w006 <none> <none>
+cray-dhcp-kea-helper-28256904-9h7hw 0/2 Completed 0 17m   10.39.0.48   ncn-w006 <none> <none>
+cray-dhcp-kea-helper-28256907-zstfk 0/2 Completed 0 14m   10.39.0.44   ncn-w006 <none> <none>
+cray-dhcp-kea-helper-28256910-566dd 0/2 Completed 0 11m   10.39.0.53   ncn-w006 <none> <none>
+cray-dhcp-kea-helper-28256913-n2q2x 0/2 Completed 0 8m19s 10.39.0.48   ncn-w006 <none> <none>
+cray-dhcp-kea-helper-28256916-j5w2n 0/2 Completed 0 5m19s 10.39.0.32   ncn-w006 <none> <none>
+cray-dhcp-kea-helper-28256919-xnhnw 0/2 Completed 0 2m19s 10.39.0.32   ncn-w006 <none> <none>
+cray-dhcp-kea-init-24-nbhng         0/2 Completed 0 8d    10.32.0.52   ncn-w001 <none> <none>
+cray-dhcp-kea-postgres-0            3/3 Running   0 24h   10.39.0.28   ncn-w006 <none> <none>
+cray-dhcp-kea-postgres-1            3/3 Running   0 24h   10.34.128.12 ncn-w004 <none> <none>
+cray-dhcp-kea-postgres-2            3/3 Running   0 24h   10.32.0.39   ncn-w001 <none> <none>
 ```
 
-The pods should be in a `Running` state. The output above will also indicate which worker node the `kea-dhcp` pod is currently running on.
+The pods should be in a `Running` state. The output above will also indicate which worker node the `kea-dhcp` pods are currently running on.
 
-(`ncn-mw#`) To restart the pods:
+(`ncn-mw#`) To restart the Kea pods.
 
 ```bash
-kubectl delete pods -n services -l app.kubernetes.io/name=cray-dhcp-kea
+kubectl rollout restart deployment -n services cray-dhcp-kea
 ```
 
 Use the command mentioned above to verify the pods are running again after restarting the pods.

--- a/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System.md
+++ b/operations/node_management/Adding_a_Liquid-cooled_blade_to_a_System.md
@@ -234,7 +234,7 @@ This procedure will add a liquid-cooled blades to an HPE Cray EX system.
         ```
 
     1. Repeat the preceding command for each node in the blade.
-    
+
     1. (`ncn-mw#`) Re-enable the `cray-dhcp-kea-helper` job.
 
         ```bash

--- a/operations/node_management/Removing_a_Liquid-cooled_blade_from_a_System.md
+++ b/operations/node_management/Removing_a_Liquid-cooled_blade_from_a_System.md
@@ -225,7 +225,7 @@ The `NodeBMC` MAC and IP addresses are assigned algorithmically and *must not be
 1. (`ncn-mw#`) Restart Kea.
 
     ```bash
-    ncn-mw# kubectl delete pods -n services -l app.kubernetes.io/name=cray-dhcp-kea
+    kubectl rollout restart deployment -n services cray-dhcp-kea
     ```
 
 ### 9. Remove the blade

--- a/troubleshooting/dhcp_runbook.md
+++ b/troubleshooting/dhcp_runbook.md
@@ -7,7 +7,7 @@
    1. [Verify that `cray-dhcp-kea` configuration is valid](#13-verify-that-cray-dhcp-kea-configuration-is-valid)
    1. [Review `cray-dhcp-kea` running configuration](#14-review-cray-dhcp-kea-running-configuration)
    1. [Verify that `cray-dhcp-kea` has active DHCP leases](#15-verify-that-cray-dhcp-kea-has-active-dhcp-leases)
-   1. [Check `dhcp-helper.py` output](#16-check-dhcp-helperpy-output)
+   1. [Check the `cray-dhcp-kea-helper` job](#16-check-the-cray-dhcp-kea-healper-job)
    1. [Check `cray-dhcp-kea` logs](#17-check-cray-dhcp-kea-logs)
 - [2 Troubleshooting DHCP for a specific node](#2-troubleshooting-dhcp-for-a-specific-node)
    1. [Check current DHCP leases](#21-check-current-dhcp-leases)
@@ -230,7 +230,7 @@ Verify that `cray-dhcp-kea` is managing DHCP leases.
    ```
 
    Example output:
-   
+
    ```text
    cray-dhcp-kea-helper-28256892-bl64f 0/2 Completed 0 29m
    cray-dhcp-kea-helper-28256895-6t674 0/2 Completed 0 26m

--- a/troubleshooting/dhcp_runbook.md
+++ b/troubleshooting/dhcp_runbook.md
@@ -7,7 +7,7 @@
    1. [Verify that `cray-dhcp-kea` configuration is valid](#13-verify-that-cray-dhcp-kea-configuration-is-valid)
    1. [Review `cray-dhcp-kea` running configuration](#14-review-cray-dhcp-kea-running-configuration)
    1. [Verify that `cray-dhcp-kea` has active DHCP leases](#15-verify-that-cray-dhcp-kea-has-active-dhcp-leases)
-   1. [Check the `cray-dhcp-kea-helper` job](#16-check-the-cray-dhcp-kea-healper-job)
+   1. [Check the `cray-dhcp-kea-helper` job](#16-check-the-cray-dhcp-kea-helper-job)
    1. [Check `cray-dhcp-kea` logs](#17-check-cray-dhcp-kea-logs)
 - [2 Troubleshooting DHCP for a specific node](#2-troubleshooting-dhcp-for-a-specific-node)
    1. [Check current DHCP leases](#21-check-current-dhcp-leases)

--- a/troubleshooting/dhcp_runbook.md
+++ b/troubleshooting/dhcp_runbook.md
@@ -2,7 +2,7 @@
 
 - [Get an API token](#get-an-api-token)
 - [1 Confirm the status of the `cray-dhcp-kea` services](#1-confirm-the-status-of-the-cray-dhcp-kea-services)
-   1. [Check `cray-dchp-kea` pods](#11-check-cray-dchp-kea-pods)
+   1. [Check `cray-dhcp-kea` pods](#11-check-cray-dhcp-kea-pods)
    1. [Check `cray-dhcp-kea` service endpoints](#12-check-cray-dhcp-kea-service-endpoints)
    1. [Verify that `cray-dhcp-kea` configuration is valid](#13-verify-that-cray-dhcp-kea-configuration-is-valid)
    1. [Review `cray-dhcp-kea` running configuration](#14-review-cray-dhcp-kea-running-configuration)
@@ -37,9 +37,9 @@ export TOKEN=$(curl -s -k -S -d grant_type=client_credentials -d client_id=admin
 
 Check if the Kea DHCP services are running properly.
 
-### 1.1 Check `cray-dchp-kea` pods
+### 1.1 Check `cray-dhcp-kea` pods
 
-1. (`ncn-mw#`) List the `cray-dchp-kea` pods.
+1. (`ncn-mw#`) List the `cray-dhcp-kea` pods.
 
    ```bash
    kubectl get pods -n services -o wide | grep kea
@@ -48,14 +48,30 @@ Check if the Kea DHCP services are running properly.
    Expected output looks similar to the following:
 
    ```text
-   cray-dhcp-kea-6f7ddf65dc-kckq6                                    3/3     Running            0          45h     10.37.0.47     ncn-w001   <none>           <none>
+   cray-dhcp-kea-7d4c5c9fb5-hs5gg      3/3 Running   0 33m   10.33.0.22   ncn-w011 <none> <none>
+   cray-dhcp-kea-7d4c5c9fb5-qtwtn      3/3 Running   0 33m   10.39.0.47   ncn-w006 <none> <none>
+   cray-dhcp-kea-7d4c5c9fb5-t4mkw      3/3 Running   0 24h   10.40.0.13   ncn-w005 <none> <none>
+   cray-dhcp-kea-helper-28256892-bl64f 0/2 Completed 0 29m   10.39.0.48   ncn-w006 <none> <none>
+   cray-dhcp-kea-helper-28256895-6t674 0/2 Completed 0 26m   10.39.0.53   ncn-w006 <none> <none>
+   cray-dhcp-kea-helper-28256898-8xzl2 0/2 Completed 0 23m   10.39.0.32   ncn-w006 <none> <none>
+   cray-dhcp-kea-helper-28256901-4wzql 0/2 Completed 0 20m   10.39.0.41   ncn-w006 <none> <none>
+   cray-dhcp-kea-helper-28256904-9h7hw 0/2 Completed 0 17m   10.39.0.48   ncn-w006 <none> <none>
+   cray-dhcp-kea-helper-28256907-zstfk 0/2 Completed 0 14m   10.39.0.44   ncn-w006 <none> <none>
+   cray-dhcp-kea-helper-28256910-566dd 0/2 Completed 0 11m   10.39.0.53   ncn-w006 <none> <none>
+   cray-dhcp-kea-helper-28256913-n2q2x 0/2 Completed 0 8m19s 10.39.0.48   ncn-w006 <none> <none>
+   cray-dhcp-kea-helper-28256916-j5w2n 0/2 Completed 0 5m19s 10.39.0.32   ncn-w006 <none> <none>
+   cray-dhcp-kea-helper-28256919-xnhnw 0/2 Completed 0 2m19s 10.39.0.32   ncn-w006 <none> <none>
+   cray-dhcp-kea-init-24-nbhng         0/2 Completed 0 8d    10.32.0.52   ncn-w001 <none> <none>
+   cray-dhcp-kea-postgres-0            3/3 Running   0 24h   10.39.0.28   ncn-w006 <none> <none>
+   cray-dhcp-kea-postgres-1            3/3 Running   0 24h   10.34.128.12 ncn-w004 <none> <none>
+   cray-dhcp-kea-postgres-2            3/3 Running   0 24h   10.32.0.39   ncn-w001 <none> <none>
    ```
 
 1. Verify that all pods listed are in `Running` state.
 
    If a `cray-dhcp-kea` pod is not in `Running` state, then perform Kubernetes troubleshooting.
 
-   This output will also show which worker node the `cray-kea-dhcp` pod is currently on. This information may be useful when debugging a Kubernetes problem.
+   This output will also show which worker nodes the `cray-kea-dhcp` pods are currently on. This information may be useful when debugging a Kubernetes problem.
 
 ### 1.2 Check `cray-dhcp-kea` service endpoints
 
@@ -68,11 +84,17 @@ Check if the Kea DHCP services are running properly.
    Expected output looks similar to the following:
 
    ```text
-   cray-dhcp-kea-api                             ClusterIP      10.31.247.201   <none>          8000/TCP                     3h36m
-   cray-dhcp-kea-tcp-hmn                         LoadBalancer   10.25.109.178   10.94.100.222   67:30833/TCP                 3h36m
-   cray-dhcp-kea-tcp-nmn                         LoadBalancer   10.21.240.208   10.92.100.222   67:31915/TCP                 3h36m
-   cray-dhcp-kea-udp-hmn                         LoadBalancer   10.20.37.60     10.94.100.222   67:30357/UDP                 3h36m
-   cray-dhcp-kea-udp-nmn                         LoadBalancer   10.24.246.19    10.92.100.222   67:32188/UDP                 3h36m
+   cray-dhcp-kea-api              ClusterIP     10.26.142.204  <none>         8000/TCP      5d23h
+   cray-dhcp-kea-postgres         ClusterIP     10.19.97.142   <none>         5432/TCP      5d23h
+   cray-dhcp-kea-postgres-0       ClusterIP     10.30.214.27   <none>         5432/TCP      5d23h
+   cray-dhcp-kea-postgres-1       ClusterIP     10.27.232.156  <none>         5432/TCP      5d23h
+   cray-dhcp-kea-postgres-2       ClusterIP     10.22.242.251  <none>         5432/TCP      5d23h
+   cray-dhcp-kea-postgres-config  ClusterIP     None           <none>         <none>        5d23h
+   cray-dhcp-kea-postgres-repl    ClusterIP     10.17.107.16   <none>         5432/TCP      5d23
+   cray-dhcp-kea-tcp-hmn          LoadBalancer  10.24.79.120   10.94.100.222  67:32120/TCP  5d23h
+   cray-dhcp-kea-tcp-nmn          LoadBalancer  10.19.139.179  10.92.100.222  67:31652/TCP  5d23h
+   cray-dhcp-kea-udp-hmn          LoadBalancer  10.25.203.31   10.94.100.222  67:30840/UDP  5d23h
+   cray-dhcp-kea-udp-nmn          LoadBalancer  10.19.187.168  10.92.100.222  67:31904/UDP  5d23h
    ```
 
 1. Verify that all `cray-dhcp-kea` services are listed as `Pending`.
@@ -199,17 +221,35 @@ Verify that `cray-dhcp-kea` is managing DHCP leases.
    If things are working normally, then the expectation is to have more than 0 leases found.
    If no leases are found, then that indicates the base configuration is being loaded or there is a network issue.
 
-### 1.6 Check `dhcp-helper.py` output
+### 1.6 Check the `cray-dhcp-kea-helper` job
 
-(`ncn-mw#`) Run `dhcp-helper.py`.
+- (`ncn-mw#`) Check the status of the most recent `cray-dhcp-kea-helper` job.
 
-```bash
-kubectl exec -n services $(kubectl get pods -A|grep kea| awk '{ print $2 }') -c cray-dhcp-kea -- /srv/kea/dhcp-helper.py
-```
+   ```bash
+   kubectl get pods -n services | grep cray-dhcp-kea-helper
+   ```
 
-If there are no errors, then `dhcp-helper.py` will not return any messages or logs.
+   Example output:
+   
+   ```text
+   cray-dhcp-kea-helper-28256892-bl64f 0/2 Completed 0 29m
+   cray-dhcp-kea-helper-28256895-6t674 0/2 Completed 0 26m
+   cray-dhcp-kea-helper-28256898-8xzl2 0/2 Completed 0 23m
+   cray-dhcp-kea-helper-28256901-4wzql 0/2 Completed 0 20m
+   cray-dhcp-kea-helper-28256904-9h7hw 0/2 Completed 0 17m
+   cray-dhcp-kea-helper-28256907-zstfk 0/2 Completed 0 14m
+   cray-dhcp-kea-helper-28256910-566dd 0/2 Completed 0 11m
+   cray-dhcp-kea-helper-28256913-n2q2x 0/2 Completed 0 8m19s
+   cray-dhcp-kea-helper-28256916-j5w2n 0/2 Completed 0 5m19s
+   cray-dhcp-kea-helper-28256919-xnhnw 0/2 Completed 0 2m19s
+   ```
 
-If there is output from running the above command, then the output will include a description of any problems found.
+- (`ncn-mw#`) If the status of the most recent `cray-dhcp-kea-helper` job is `Error`, check the logs for a
+              description of any problems found.
+
+   ```bash
+   kubectl logs -n services $(kubectl get pods -A|grep kea-helper| awk '{ print $2 }' | tail -n 1)
+   ```
 
 ### 1.7 Check `cray-dhcp-kea` logs
 


### PR DESCRIPTION
# Description

This updates KEA mentions in docs-csm for the clustered KEA deployment, CASM-2853.

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

