### PR TITLE
CASMINST-6676: Ensure hpe-csm-goss-package RPM is installed/updated when csm-testing is installed/updated

### DIFF
--- a/install/pre-installation.md
+++ b/install/pre-installation.md
@@ -550,7 +550,7 @@ successfully.
    > - This provides `iuf`, a command line interface to the [Install and Upgrade Framework](../operations/iuf/IUF.md).
 
    ```bash
-   zypper --no-gpg-checks install -y canu craycli csm-testing iuf-cli
+   zypper --no-gpg-checks install -y canu craycli csm-testing hpe-csm-goss-package iuf-cli
    ```
 
 ## 5 Validate the LiveCD


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
The pre-install step which installs/updates the `csm-testing` RPM should also include the `hpe-csm-goss-package` RPM, in case the updates `csm-testing` RPM requires a newer Goss version than what is currently installed.

Backports (which make parallel changes to the appropriate places in the previous release branches):
* [1.5 backport](https://github.com/Cray-HPE/docs-csm/pull/4315)
* [1.4 backport](https://github.com/Cray-HPE/docs-csm/pull/4316)
* [1.3 backport](https://github.com/Cray-HPE/docs-csm/pull/4317)
* [1.2 backport](https://github.com/Cray-HPE/docs-csm/pull/4318)
* [1.0 backport](https://github.com/Cray-HPE/docs-csm/pull/4319)

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
