### PR TITLE
CASMINST-6676: Ensure hpe-csm-goss-package RPM is installed/updated when csm-testing is installed/updated

### DIFF
--- a/install/pre-installation.md
+++ b/install/pre-installation.md
@@ -448,6 +448,15 @@ in `/etc/environment` from the [Download CSM tarball](#21-download-csm-tarball) 
               --no-gpg-checks install -y iuf-cli
        ```
 
+   1. Install `hpe-csm-goss-package` RPM.
+
+       > ***NOTE*** This package provides the necessary test driver for validating the pre-installation, installation, and more.
+
+       ```bash
+       zypper --plus-repo "${CSM_PATH}/rpm/cray/csm/sle-$(awk -F= '/VERSION=/{gsub(/["-]/, "") ; print tolower($NF)}' /etc/os-release)/" \
+              --no-gpg-checks install -y hpe-csm-goss-package
+       ```
+
    1. Install `csm-testing` RPM.
 
        > ***NOTE*** This package provides the necessary tests and their dependencies for validating the pre-installation, installation, and more.

--- a/upgrade/1.4.1/README.md
+++ b/upgrade/1.4.1/README.md
@@ -149,10 +149,12 @@ with IUF. If this step is skipped, IUF will fail when updating or upgrading prod
 
 ### Update test suite packages
 
-(`ncn-m001#`) Update the `csm-testing` and `goss-servers` RPMs on the NCNs.
+(`ncn-m001#`) Update select RPMs on the NCNs.
 
 ```bash
-pdsh -b -w $(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u |  tr -t '\n' ',') 'zypper install -y csm-testing goss-servers craycli'
+pdsh -b -S -w $(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u |  tr -t '\n' ',') \
+    'zypper install -y hpe-csm-goss-package csm-testing goss-servers craycli && systemctl enable goss-servers && systemctl start goss-servers' \
+    && echo PASSED || echo FAILED
 ```
 
 ### Verification

--- a/upgrade/1.4.2/README.md
+++ b/upgrade/1.4.2/README.md
@@ -215,10 +215,12 @@ This step will create an imperative CFS session that can be used to configure bo
 
 ### Update test suite packages
 
-(`ncn-m001#`) Update the `csm-testing` and `goss-servers` RPMs on the NCNs.
+(`ncn-m001#`) Update select RPMs on the NCNs.
 
 ```bash
-pdsh -b -w $(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u |  tr -t '\n' ',') 'zypper install -y csm-testing goss-servers craycli'
+pdsh -b -S -w $(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u |  tr -t '\n' ',') \
+    'zypper install -y hpe-csm-goss-package csm-testing goss-servers craycli && systemctl enable goss-servers && systemctl start goss-servers' \
+    && echo PASSED || echo FAILED
 ```
 
 ### Verification

--- a/upgrade/1.4.3/README.md
+++ b/upgrade/1.4.3/README.md
@@ -209,7 +209,7 @@ version of CSM being installed. It then waits for the components to reach a conf
 
 ### Update test suite packages
 
-(`ncn-m001#`) Update the `csm-testing` and `goss-servers` RPMs on the NCNs.
+(`ncn-m001#`) Update select RPMs on the NCNs.
 
 ```bash
 /usr/share/doc/csm/upgrade/scripts/upgrade/util/upgrade-test-rpms.sh

--- a/upgrade/scripts/upgrade/util/upgrade-test-rpms.sh
+++ b/upgrade/scripts/upgrade/util/upgrade-test-rpms.sh
@@ -25,8 +25,8 @@
 set -euo pipefail
 ncns=$(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u |  tr -t '\n' ',')
 
-echo "Installing updated versions of csm-testing goss-servers craycli rpms"
-pdsh -S -b -w ${ncns} 'zypper install -y csm-testing goss-servers craycli'
+echo "Installing updated versions of hpe-csm-goss-package csm-testing goss-servers craycli rpms"
+pdsh -S -b -w ${ncns} 'zypper install -y hpe-csm-goss-package csm-testing goss-servers craycli'
 
 echo "Enabling and starting goss-servers"
 pdsh -S -b -w ${ncns} 'systemctl enable goss-servers && systemctl start goss-servers'


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/docs-csm/pull/4314