### PR TITLE
CASMINST-6676: Ensure hpe-csm-goss-package RPM is installed/updated when csm-testing is installed/updated

### DIFF
--- a/install/bootstrap_livecd_remote_iso.md
+++ b/install/bootstrap_livecd_remote_iso.md
@@ -629,10 +629,12 @@ Prepare the `site-init` directory by performing the [Prepare `Site Init`](prepar
    pit# export USERNAME IPMI_PASSWORD ; /root/bin/pit-init.sh
    ```
 
-1. Install `csm-testing`.
+1. Install `csm-testing` and `hpe-csm-goss-package`.
+
+   The following assumes the `CSM_PATH` environment variable is set to the absolute path of the unpacked CSM release.
 
    ```bash
-   pit# rpm -Uvh --force $(find ${CSM_PATH}/rpm/ -name "csm-testing*.rpm" | sort -V | tail -1)
+   pit# rpm -Uvh --force $(find ${CSM_PATH}/rpm/ -name "csm-testing*.rpm" | sort -V | tail -1) $(find ${CSM_PATH}/rpm/ -name "hpe-csm-goss-package*.rpm" | sort -V | tail -1)
    ```
 
 <a name="next-topic"></a>

--- a/install/bootstrap_livecd_usb.md
+++ b/install/bootstrap_livecd_usb.md
@@ -835,12 +835,12 @@ On first log in (over SSH or at local console), the LiveCD will prompt the admin
    pit# /root/bin/pit-init.sh
    ```
 
-1. Install `csm-testing`.
+1. Install `csm-testing` and `hpe-csm-goss-package`.
 
    The following assumes the `CSM_PATH` environment variable is set to the absolute path of the unpacked CSM release.
 
    ```bash
-   pit# rpm -Uvh --force $(find ${CSM_PATH}/rpm/ -name "csm-testing*.rpm" | sort -V | tail -1)
+   pit# rpm -Uvh --force $(find ${CSM_PATH}/rpm/ -name "csm-testing*.rpm" | sort -V | tail -1) $(find ${CSM_PATH}/rpm/ -name "hpe-csm-goss-package*.rpm" | sort -V | tail -1)
    ```
 
 <a name="next-topic"></a>

--- a/scripts/workarounds/boot-order/metal-lib.sh
+++ b/scripts/workarounds/boot-order/metal-lib.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -471,6 +471,7 @@ function paginate() {
 function install_csm_rpms() {
     local repos="csm-sle-15sp2 csm-sle-15sp3"
     local canu_url
+    local hpe_goss_url
     local goss_servers_url
     local csm_testing_url
     local platform_utils_url
@@ -490,6 +491,8 @@ function install_csm_rpms() {
         # Retreive the packages from nexus
         test -n "$canu_url" || canu_url=$(paginate "https://packages.local/service/rest/v1/components?repository=$repo" \
             | jq -r  '.items[] | .assets[] | .downloadUrl' | grep canu | sort -V | tail -1)
+        test -n "$hpe_goss_url" || hpe_goss_url=$(paginate "https://packages.local/service/rest/v1/components?repository=$repo" \
+            | jq -r  '.items[] | .assets[] | .downloadUrl' | grep hpe-csm-goss-package | sort -V | tail -1)
         test -n "$goss_servers_url" || goss_servers_url=$(paginate "https://packages.local/service/rest/v1/components?repository=$repo" \
             | jq -r  '.items[] | .assets[] | .downloadUrl' | grep goss-servers | sort -V | tail -1)
         test -n "$csm_testing_url" || csm_testing_url=$(paginate "https://packages.local/service/rest/v1/components?repository=$repo" \
@@ -500,9 +503,10 @@ function install_csm_rpms() {
     done
 
     test -z "$canu_url" && echo WARNING: unable to install canu
+    test -z "$hpe_goss_url" && echo WARNING: unable to install hpe-goss-csm-package
     test -z "$goss_servers_url" && echo WARNING: unable to install goss-servers
     test -z "$csm_testing_url" && echo WARNING: unable to install csm-testing
     test -z "$platform_utils_url" && echo WARNING: unable to install platform-utils
 
-    zypper install -y $canu_url $goss_servers_url $csm_testing_url $platform_utils_url && systemctl enable goss-servers && systemctl restart goss-servers
+    zypper install -y $canu_url $hpe_goss_url $csm_testing_url $goss_servers_url $platform_utils_url && systemctl enable goss-servers && systemctl restart goss-servers
 }


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/docs-csm/pull/4314