### PR TITLE
CASMINST-6679: Use explicit cray-sat container image version

### DIFF
--- a/workflows/templates/base/sat-general-iuf.template.argo.yaml
+++ b/workflows/templates/base/sat-general-iuf.template.argo.yaml
@@ -62,7 +62,7 @@ spec:
             valueFrom:
               path: "{{inputs.parameters.script_stdout_file}}"
       script:
-        image: artifactory.algol60.net/sat-docker/stable/cray-sat:csm-latest
+        image: artifactory.algol60.net/sat-docker/stable/cray-sat:3.25.2
         command: [sh]
         source: |
           #!/bin/sh


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

Use an explicit version tag for the cray-sat container image. The 3.25.2 version is the version included in the latest release/1.5 branch of the csm repository. We can run into problems with caching of the image on the Kubernetes nodes if we use the `csm-latest` tag.

An alternative to this might be to use an imagePullPolicy of Always, but I'm not sure what other impacts that might have. Additionally, using an explicit version is what was done for the iuf container in the iufBase template, so do the same here for consistency.

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
