### PR TITLE
CASMINST-6680 remove dhcp-kea from singleton pods check in CSM worker upgrade workflow

### DIFF
--- a/workflows/ncn/hooks/before-all/move-critical-singleton-pods.yaml
+++ b/workflows/ncn/hooks/before-all/move-critical-singleton-pods.yaml
@@ -52,7 +52,7 @@ spec:
 
     echo
 
-    criticalPodLabels=( "app=nexus" "app.kubernetes.io/instance=cms-ipxe" "app.kubernetes.io/name=cray-dhcp-kea" "app.kubernetes.io/name=cray-cfs-api-db" )
+    criticalPodLabels=( "app=nexus" "app.kubernetes.io/instance=cms-ipxe" "app.kubernetes.io/name=cray-cfs-api-db" )
     for label in ${criticalPodLabels[@]};do
       pods=($(kubectl get pods -A -l ${label} -o custom-columns=:.metadata.name))
       if [[ ${#pods[@]} -eq 0 ]]; then


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

Before CSM 1.5, kea was running as a single pod. However, in CSM 1.5 this was changed and no kea runs is multiple pods on multiple nodes. The check to move the single kea pod before a worker rebuild fails because there a multiple pods. This check should be removed as it is no longer necessary.

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

Resolves [CASMINST-6680](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6680)

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
