### PR TITLE
Improve instructions for latency repair script when on the pit (CASMINST-6681)

### DIFF
--- a/install/deploy_non-compute_nodes.md
+++ b/install/deploy_non-compute_nodes.md
@@ -269,6 +269,18 @@ for all nodes, the Ceph storage will have been initialized and the Kubernetes cl
 
 Ceph can begin to exhibit latency over time unless OSDs are restarted and some OSD memory settings are changed. It is recommended to run the `/usr/share/doc/csm/scripts/repair-ceph-latency.sh` script at [Known Issue: Ceph OSD latency](../troubleshooting/known_issues/ceph_osd_latency.md).
 
+1. (`pit#`) Copy the script to `ncn-m002`.
+
+    ```bash
+    scp /usr/share/doc/csm/scripts/repair-ceph-latency.sh ncn-m002:/tmp/repair-ceph-latency.sh
+    ```
+
+1. (`pit#`) Run the script on `ncn-m002`.
+
+    ```bash
+    ssh ncn-m002 /tmp/repair-ceph-latency.sh
+    ```
+
 ## 3. Validate deployment
 
 1. (`pit#`) Ensure that the working directory is the `prep` directory.


### PR DESCRIPTION
### Summary and Scope

Improve instructions for running the ceph repair latency script when on the pit.

### Issues and Related PRs

* CASMINST-6681: Docs: repair-ceph-latency.sh usage in fresh install could use clarification

### Testing

Slice

N/A

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing

