### PR TITLE
CASMTRIAGE-6127: prerequisites.sh: Update csm-config earlier and wait for import to complete

### DIFF
--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -534,6 +534,56 @@ else
   echo "====> ${state_name} has been completed" | tee -a "${LOG_FILE}"
 fi
 
+do_upgrade_csm_chart csm-config sysmgmt.yaml
+
+# Wait for the csm-config-import Kubernetes job to complete before proceeding
+state_name="WAIT_FOR_CSM_CONFIG_IMPORT"
+state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
+  echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
+  {
+    job_name="csm-config-import-${CSM_RELEASE}"
+    i=1
+    max_checks=40
+    wait_time=15
+    # First, wait for the job to be created
+    created=no
+    while [[ ${i} -le ${max_checks} ]]; do
+      echo "Waiting for Kubernetes job ${job_name} to exist (${i}/${max_checks})"
+      sleep ${wait_time}
+      i=$((i + 1))
+      if kubectl get job -n services "${job_name}" 2> /dev/null; then
+        echo "Kubernetes job ${job_name} exists"
+        created=yes
+        break
+      fi
+    done
+    if [[ ${created} == no ]]; then
+      echo "ERROR: Kubernetes job ${job_name} does not exist after $((max_checks * wait_time)) seconds" >&2
+      exit 1
+    fi
+    # Now wait for the job to succeed
+    passed=no
+    while [[ ${i} -le ${max_checks} ]]; do
+      echo "Waiting for Kubernetes job ${job_name} to succeed (${i}/${max_checks})"
+      sleep ${wait_time}
+      i=$((i + 1))
+      if [[ $(kubectl get job -n services "${job_name}" -o jsonpath='{.status.succeeded}') == 1 ]]; then
+        echo "Kubernetes job ${job_name} succeeded"
+        passed=yes
+        break
+      fi
+    done
+    if [[ ${passed} == no ]]; then
+      echo "ERROR: Kubernetes job ${job_name} did not succeed after $((max_checks * wait_time)) seconds" >&2
+      exit 1
+    fi
+  } >> "${LOG_FILE}" 2>&1
+  record_state "${state_name}" "$(hostname)" | tee -a "${LOG_FILE}"
+else
+  echo "====> ${state_name} has been completed" | tee -a "${LOG_FILE}"
+fi
+
 # Note for csm 1.5/k8s 1.22 only if ANY chart depends on /v1 cert-manager api
 # usage it *MUST* come after this or prerequisites will fail on an upgrade.
 # Helper functions for cert-manager upgrade
@@ -747,7 +797,6 @@ else
   echo "====> ${state_name} has been completed" | tee -a "${LOG_FILE}"
 fi
 
-do_upgrade_csm_chart csm-config sysmgmt.yaml
 do_upgrade_csm_chart cray-drydock platform.yaml
 do_upgrade_csm_chart cray-kyverno platform.yaml
 do_upgrade_csm_chart kyverno-policy platform.yaml


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
On fanta the csm-config import job failed and worked when I manually retried it. I believe the failure was caused by the gitea postgres pods not being ready at the time when it tried to do the import. This PR moves the csm-config update earlier in the prerequisites script (before any postgres stuff happens), and then wait for the csm-config import job to succeed before proceeding. This job usually finishes quickly (within a few minutes), so this should not introduce a significant delay.

I tested the updated prerequisites.sh script on fanta and validated that it worked as expected.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
