### PR TITLE
CASMINST-6699: Ensure RPMs are updated on master NCNs

### DIFF
--- a/install/deploy_final_non-compute_node.md
+++ b/install/deploy_final_non-compute_node.md
@@ -16,8 +16,9 @@ procedure entails deactivating the LiveCD, meaning the LiveCD and all of its res
 1. [Reboot](#4-reboot)
 1. [Enable NCN disk wiping safeguard](#5-enable-ncn-disk-wiping-safeguard)
 1. [Remove the default NTP pool](#6-remove-the-default-ntp-pool)
-1. [Configure DNS and NTP on each BMC](#7-configure-dns-and-ntp-on-each-bmc)
-1. [Next topic](#8-next-topic)
+1. [Update select RPMs](#7-update-select-rpms)
+1. [Configure DNS and NTP on each BMC](#8-configure-dns-and-ntp-on-each-bmc)
+1. [Next topic](#9-next-topic)
 
 ## 1. Required services
 
@@ -435,7 +436,19 @@ it is used for Cray installation and bootstrap.
 sed -i "s/^! pool pool\.ntp\.org.*//" /etc/chrony.conf && systemctl restart chronyd
 ```
 
-## 7. Configure DNS and NTP on each BMC
+## 7. Update select RPMs
+
+(`ncn-m001`) Run the following command to ensure that select RPMs on `ncn-m001` are at the correct version.
+
+```bash
+zypper install -y hpe-csm-goss-package csm-testing goss-servers \
+    && systemctl enable goss-servers && systemctl restart goss-servers \
+    && echo PASSED || echo FAILED
+```
+
+If the output ends with `PASSED`, then it was successful, despite any warning messages that may have been displayed.
+
+## 8. Configure DNS and NTP on each BMC
 
  > **`NOTE`** Only follow this section if the NCNs are HPE hardware. If the system uses
  > Gigabyte or Intel hardware, then skip this section.
@@ -519,6 +532,6 @@ However, the commands in this section are all run **on** `ncn-m001`.
     done ; echo "Configuration completed on all NCN BMCs"
     ```
 
-## 8. Next topic
+## 9. Next topic
 
 After completing this procedure, the next step is to [Configure Administrative Access](README.md#5-configure-administrative-access).

--- a/upgrade/1.3.1/README.md
+++ b/upgrade/1.3.1/README.md
@@ -128,7 +128,7 @@ Reboot is probably not necessary.
 
 ```bash
 pdsh -b -S -w $(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u |  tr -t '\n' ',') \
-    'zypper install -y hpe-csm-goss-package csm-testing goss-servers && systemctl enable goss-servers && systemctl start goss-servers' \
+    'zypper install -y hpe-csm-goss-package csm-testing goss-servers && systemctl enable goss-servers && systemctl restart goss-servers' \
     && echo PASSED || echo FAILED
 ```
 

--- a/upgrade/1.3.2/README.md
+++ b/upgrade/1.3.2/README.md
@@ -176,7 +176,7 @@ Reboot is probably not necessary.
 
 ```bash
 pdsh -b -S -w $(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u |  tr -t '\n' ',') \
-    'zypper install -y hpe-csm-goss-package csm-testing goss-servers && systemctl enable goss-servers && systemctl start goss-servers' \
+    'zypper install -y hpe-csm-goss-package csm-testing goss-servers && systemctl enable goss-servers && systemctl restart goss-servers' \
     && echo PASSED || echo FAILED
 ```
 

--- a/upgrade/1.3.3/README.md
+++ b/upgrade/1.3.3/README.md
@@ -156,7 +156,7 @@ Reboot is probably not necessary.
 
 ```bash
 pdsh -b -S -w $(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u |  tr -t '\n' ',') \
-    'zypper install -y hpe-csm-goss-package csm-testing goss-servers && systemctl enable goss-servers && systemctl start goss-servers' \
+    'zypper install -y hpe-csm-goss-package csm-testing goss-servers && systemctl enable goss-servers && systemctl restart goss-servers' \
     && echo PASSED || echo FAILED
 ```
 

--- a/upgrade/1.3.4/README.md
+++ b/upgrade/1.3.4/README.md
@@ -156,7 +156,7 @@ Reboot is probably not necessary.
 
 ```bash
 pdsh -b -S -w $(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u |  tr -t '\n' ',') \
-    'zypper install -y hpe-csm-goss-package csm-testing goss-servers && systemctl enable goss-servers && systemctl start goss-servers' \
+    'zypper install -y hpe-csm-goss-package csm-testing goss-servers && systemctl enable goss-servers && systemctl restart goss-servers' \
     && echo PASSED || echo FAILED
 ```
 

--- a/upgrade/1.3.5/README.md
+++ b/upgrade/1.3.5/README.md
@@ -185,7 +185,7 @@ Reboot is probably not necessary.
 
 ```bash
 pdsh -b -S -w $(grep -oP 'ncn-\w\d+' /etc/hosts | sort -u |  tr -t '\n' ',') \
-    'zypper install -y hpe-csm-goss-package csm-testing goss-servers && systemctl enable goss-servers && systemctl start goss-servers' \
+    'zypper install -y hpe-csm-goss-package csm-testing goss-servers && systemctl enable goss-servers && systemctl restart goss-servers' \
     && echo PASSED || echo FAILED
 ```
 

--- a/upgrade/scripts/common/ncn-common.sh
+++ b/upgrade/scripts/common/ncn-common.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -216,4 +216,22 @@ function wait_for_kubernetes() {
   else
       echo "====> ${state_name} has been completed"
   fi
+}
+
+function update_test_rpms() {
+  local state_name state_recorded target_ncn
+  target_ncn=$1
+  state_name="UPDATE_TEST_RPMS"
+  state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
+  if [[ $state_recorded == "0" ]]; then
+      echo "====> ${state_name} ..."
+      {
+      ssh $target_ncn 'zypper install -y hpe-csm-goss-package csm-testing goss-servers && systemctl enable goss-servers && systemctl restart goss-servers'
+      } >> ${LOG_FILE} 2>&1
+
+      record_state "${state_name}" ${target_ncn}
+      echo
+   else
+      echo "====> ${state_name} has been completed"
+   fi
 }

--- a/upgrade/scripts/rebuild/ncn-rebuild-master-nodes.sh
+++ b/upgrade/scripts/rebuild/ncn-rebuild-master-nodes.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -194,6 +194,9 @@ if [[ $state_recorded == "0" ]]; then
 else
     echo "====> ${state_name} has been completed"
 fi
+
+# Update test RPMs on the newly upgraded master
+update_test_rpms $target_ncn
 
 cat <<EOF
 NOTE:

--- a/upgrade/scripts/upgrade/ncn-upgrade-master-nodes.sh
+++ b/upgrade/scripts/upgrade/ncn-upgrade-master-nodes.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -207,6 +207,9 @@ if [[ $state_recorded == "0" ]]; then
 else
     echo "====> ${state_name} has been completed"
 fi
+
+# Update test RPMs on the newly upgraded master
+update_test_rpms $target_ncn
 
 cat <<EOF
 NOTE:


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
In the case where the CSM release tarball contains newer versions of RPMs than the NCN images (which is frequently the case on CSM X.Y.Z releases where Z > 0), after redeploying ncn-m001 during a fresh install, it is using the older RPM versions. This PR adds a step to the redeploy procedure to ensure that these are updated.

The same situation occurs when rebuilding master nodes (during upgrades or regular rebuilds), so this PR also adds a similar step to those scripts.

Finally, this PR changes a "systemctl start" to "systemctl restart" because the command in question is running in cases where the service had already been started, and we actually want it to restart to pick up changes.

Backport PRs:
* 1.4: https://github.com/Cray-HPE/docs-csm/pull/4372
* 1.5: https://github.com/Cray-HPE/docs-csm/pull/4373
* 1.6: https://github.com/Cray-HPE/docs-csm/pull/4377
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
