### PR TITLE
Consolidate tds settings to a single yaml file in docs (CASMPET-6818)

### DIFF
--- a/install/install_csm_services.md
+++ b/install/install_csm_services.md
@@ -16,12 +16,12 @@ This procedure will install CSM applications and services into the CSM Kubernete
 
 ## 1. Install CSM services
 
-> **`NOTE`**: During this step, only on systems with only three worker nodes (typically Testing and
+> **`NOTE`**: During this step, only on systems with only four worker nodes (typically Testing and
 > Development Systems (TDS)), the `customizations.yaml` file will be automatically edited to lower
 > pod
 > CPU requests for some services, in order to better facilitate scheduling on smaller systems. See
 > the
-> file `${CSM_PATH}/tds_cpu_requests.yaml` for these settings. This file can be modified with
+> file `/usr/share/doc/csm/upgrade/scripts/upgrade/tds_cpu_requests.yaml` for these settings. This file can be modified with
 > different values (prior to executing the `yapl` command below), if other settings are desired in
 > the `customizations.yaml` file for this system. For more information about
 > modifying `customizations.yaml` and tuning for specific systems,

--- a/upgrade/scripts/k8s/tds_lower_cpu_requests.sh
+++ b/upgrade/scripts/k8s/tds_lower_cpu_requests.sh
@@ -24,52 +24,116 @@
 #
 
 #
-# Edit the following values as needed to suit specific system
-# requirements, ensuring pods run well and are not being throttled
-# at an unacceptable level.  Comment out any of the following lines
-# if changing the CPU request for that particular service is not
-# desired.
+# Values to be applied by this script  are taken from:
+#
+# /usr/share/doc/csm/upgrade/scripts/upgrade/tds_cpu_requests.yaml
 #
 
-spire_postgres_new_request=1
-cray_capmc_new_cpu_request=500m
-elasticsearch_master_new_cpu_request=1500m
-cluster_kafka_new_cpu_request=1
-sma_grafana_new_cpu_request=100m
-sma_kibana_new_cpu_request=100m
-cluster_zookeeper_new_cpu_request=100m
-cray_smd_new_cpu_request=1
-cray_smd_postgres_new_cpu_request=1
-sma_postgres_cluster_new_cpu_request=500m
-nexus_new_cpu_request=2
-cray_metallb_speaker_new_cpu_request=1
+base="spec.kubernetes.services"
+yaml="/usr/share/doc/csm/upgrade/scripts/upgrade/tds_cpu_requests.yaml"
 
+if [ ! -f $yaml ]; then
+  echo "ERROR: Unable to find file: $yaml"
+  echo "       Ensure the latest docs-csm rpm is installed on this system."
+  exit 1
+fi
+
+function roll_postgres() {
+  ns=$1
+  cluster=$2
+  setting=$3
+  current_req=$(kubectl get postgresql -n $ns $cluster -o json | jq -r '.spec.resources.requests.cpu')
+  echo "Patching $cluster cluster with new cpu request of $setting (from $current_req)"
+  kubectl patch postgresql -n $ns $cluster --type=json -p="[{'op' : 'replace', 'path':'/spec/resources/requests/cpu', 'value' : \"$setting\" }]"
+  until [[ $(kubectl get postgresql -n $ns $cluster -o json | jq -r '.status.PostgresClusterStatus') == "Running" ]]; do
+    echo "Waiting for $cluster cluster to reach running state..."
+    sleep 30
+  done
+  echo ""
+}
+
+function fail_if_empty() {
+  key=$1
+  value=$2
+  if [ -z $value ]; then
+    echo "ERROR: Unable to retrieve value for:"
+    echo "       $key"
+    echo "       Ensure the latest docs-csm rpm is installed on this system."
+    exit 1
+  fi
+}
+
+yaml_path="$base.spire.cray-postgresql.sqlCluster.resources.requests.cpu"
+spire_postgres_new_request=$(yq r $yaml -pv $yaml_path)
+fail_if_empty $yaml_path $spire_postgres_new_request
+
+yaml_path="$base.cray-spire.cray-postgresql.sqlCluster.resources.requests.cpu"
+cray_spire_postgres_new_request=$(yq r $yaml -pv $yaml_path)
+fail_if_empty $yaml_path $cray_spire_postgres_new_request
+
+yaml_path="$base.cray-dhcp-kea.cray-postgresql.sqlCluster.resources.requests.cpu"
+cray_dhcp_kea_postgres_new_request=$(yq r $yaml -pv $yaml_path)
+fail_if_empty $yaml_path $cray_dhcp_kea_postgres_new_request
+
+yaml_path="$base.cray-hms-capmc.cray-service.containers.cray-capmc.resources.requests.cpu"
+cray_capmc_new_cpu_request=$(yq r $yaml -pv $yaml_path)
+fail_if_empty $yaml_path $cray_capmc_new_cpu_request
+
+yaml_path="$base.sma-elasticsearch.resources.requests.cpu"
+elasticsearch_master_new_cpu_request=$(yq r $yaml -pv $yaml_path)
+fail_if_empty $yaml_path $elasticsearch_master_new_cpu_request
+
+yaml_path="$base.sma-zk-kafka.kafkaReqCPU"
+cluster_kafka_new_cpu_request=$(yq r $yaml -pv $yaml_path)
+fail_if_empty $yaml_path $cluster_kafka_new_cpu_request
+
+yaml_path="$base.sma-grafana.cray-service.containers.sma-grafana.resources.requests.cpu"
+sma_grafana_new_cpu_request=$(yq r $yaml -pv $yaml_path)
+fail_if_empty $yaml_path $sma_grafana_new_cpu_request
+
+yaml_path="$base.sma-kibana.cray-service.containers.sma-kibana.resources.requests.cpu"
+sma_kibana_new_cpu_request=$(yq r $yaml -pv $yaml_path)
+fail_if_empty $yaml_path $sma_kibana_new_cpu_request
+
+yaml_path="$base.sma-zk-kafka.zkReqCPU"
+cluster_zookeeper_new_cpu_request=$(yq r $yaml -pv $yaml_path)
+fail_if_empty $yaml_path $cluster_zookeeper_new_cpu_request
+
+yaml_path="$base.cray-hms-smd.cray-service.containers.cray-smd.resources.requests.cpu"
+cray_smd_new_cpu_request=$(yq r $yaml -pv $yaml_path)
+fail_if_empty $yaml_path $cray_smd_new_cpu_request
+
+yaml_path="$base.cray-hms-smd.cray-postgresql.sqlCluster.resources.requests.cpu"
+cray_smd_postgres_new_cpu_request=$(yq r $yaml -pv $yaml_path)
+fail_if_empty $yaml_path $cray_smd_postgres_new_cpu_request
+
+yaml_path="$base.sma-postgres-cluster.pgReqCPU"
+sma_postgres_cluster_new_cpu_request=$(yq r $yaml -pv $yaml_path)
+fail_if_empty $yaml_path $sma_postgres_cluster_new_cpu_request
+
+yaml_path="$base.cray-nexus.sonatype-nexus.nexus.resources.requests.cpu"
+nexus_new_cpu_request=$(yq r $yaml -pv $yaml_path)
+fail_if_empty $yaml_path $nexus_new_cpu_request
+
+yaml_path="$base.cray-metallb.metallb.speaker.resources.requests.cpu"
+cray_metallb_speaker_new_cpu_request=$(yq r $yaml -pv $yaml_path)
+fail_if_empty $yaml_path $cray_metallb_speaker_new_cpu_request
 
 if [ ! -z $spire_postgres_new_request ]; then
-  current_req=$(kubectl get postgresql -n spire spire-postgres -o json | jq -r '.spec.resources.requests.cpu')
-  echo "Patching spire-postgres cluster with new cpu request of $spire_postgres_new_request (from $current_req)"
-  kubectl patch postgresql spire-postgres -n spire --type=json -p="[{'op' : 'replace', 'path':'/spec/resources/requests/cpu', 'value' : \"$spire_postgres_new_request\" }]"
-  until [[ $(kubectl get postgresql -n spire spire-postgres -o json | jq -r '.status.PostgresClusterStatus') == "Running" ]]
-  do
-    echo "Waiting for spire-postgres cluster to reach running state..."
-    sleep 30
-  done
-  echo ""
+  roll_postgres "spire" "spire-postgres" $spire_postgres_new_request
 fi
 
+if [ ! -z $cray_spire_postgres_new_request ]; then
+  roll_postgres "spire" "cray-spire-postgres" $cray_spire_postgres_new_request
+fi
+
+if [ ! -z $cray_dhcp_kea_postgres_new_request ]; then
+  roll_postgres "services" "cray-dhcp-kea-postgres" $cray_dhcp_kea_postgres_new_request
+fi
 
 if [ ! -z $cray_smd_postgres_new_cpu_request ]; then
-  current_req=$(kubectl get postgresql cray-smd-postgres -n services -o json | jq -r '.spec.resources.requests.cpu')
-  echo "Patching cray-smd-postgres cluster with new cpu request of $cray_smd_postgres_new_cpu_request (from $current_req)"
-  kubectl patch postgresql cray-smd-postgres -n services --type=json -p="[{'op' : 'replace', 'path':'/spec/resources/requests/cpu', 'value' : \"$cray_smd_postgres_new_cpu_request\" }]"
-  until [[ $(kubectl get postgresqls.acid.zalan.do -n services cray-smd-postgres -o json | jq -r '.status.PostgresClusterStatus') == "Running" ]]
-  do
-    echo "Waiting for cray-smd-postgres cluster to reach running state..."
-    sleep 30
-  done
-  echo ""
+  roll_postgres "services" "cray-smd-postgres" $cray_smd_postgres_new_cpu_request
 fi
-
 
 if [ ! -z $cray_smd_new_cpu_request ]; then
   current_req=$(kubectl get deployment -n services cray-smd -o json | jq -r '.spec.template.spec.containers[] | select(.name== "cray-smd") | .resources.requests.cpu')
@@ -78,7 +142,6 @@ if [ ! -z $cray_smd_new_cpu_request ]; then
   kubectl rollout status deployment -n services cray-smd
   echo ""
 fi
-
 
 if [ ! -z $cray_capmc_new_cpu_request ]; then
   current_req=$(kubectl get deployment -n services cray-capmc -o json | jq -r '.spec.template.spec.containers[] | select(.name== "cray-capmc") | .resources.requests.cpu')
@@ -128,8 +191,7 @@ if [[ $kafkaDeployed -ne 0 ]]; then
     echo "Patching cluster-kafka with new cpu request of $cluster_kafka_new_cpu_request (from $current_req)"
     kubectl patch kafkas cluster -n sma --type=json -p="[{'op' : 'replace', 'path':'/spec/kafka/resources/requests/cpu', 'value' : \"$cluster_kafka_new_cpu_request\" }]"
     sleep 10
-    until [[ $(kubectl -n sma get statefulset cluster-kafka -o json | jq -r '.status.updatedReplicas') -eq 3 ]]
-    do
+    until [[ $(kubectl -n sma get statefulset cluster-kafka -o json | jq -r '.status.updatedReplicas') -eq 3 ]]; do
       echo "Waiting for cluster-kafka cluster to have three updated replicas..."
       sleep 30
     done
@@ -141,8 +203,7 @@ if [[ $kafkaDeployed -ne 0 ]]; then
     echo "Patching cluster-zookeeper statefulset with new cpu request of $cluster_zookeeper_new_cpu_request (from $current_req)"
     kubectl patch kafkas cluster -n sma --type=json -p="[{'op' : 'replace', 'path':'/spec/zookeeper/resources/requests/cpu', 'value' : \"$cluster_zookeeper_new_cpu_request\" }]"
     sleep 10
-    until [[ $(kubectl -n sma get statefulset cluster-zookeeper -o json | jq -r '.status.updatedReplicas') -eq 3 ]]
-    do
+    until [[ $(kubectl -n sma get statefulset cluster-zookeeper -o json | jq -r '.status.updatedReplicas') -eq 3 ]]; do
       echo "Waiting for cluster-zookeeper cluster to have three updated replicas..."
       sleep 30
     done
@@ -150,22 +211,12 @@ if [[ $kafkaDeployed -ne 0 ]]; then
   fi
 fi
 
-
 smaPgDeployed=$(kubectl get pods -n sma | grep sma-postgres-cluster | wc -l)
 if [[ $smaPgDeployed -ne 0 ]]; then
   if [ ! -z $sma_postgres_cluster_new_cpu_request ]; then
-    current_req=$(kubectl get postgresql -n sma sma-postgres-cluster -o json | jq -r '.spec.resources.requests.cpu')
-    echo "Patching sma-postgres-cluster statefulset with new cpu request of $sma_postgres_cluster_new_cpu_request (from $current_req)"
-    kubectl patch postgresql -n sma sma-postgres-cluster --type=json -p="[{'op' : 'replace', 'path':'/spec/resources/requests/cpu', 'value' : \"$sma_postgres_cluster_new_cpu_request\" }]"
-    until [[ $(kubectl get postgresql -n sma sma-postgres-cluster -o json | jq -r '.status.PostgresClusterStatus') == "Running" ]]
-    do
-      echo "Waiting for sma-postgres-cluster cluster to reach running state..."
-      sleep 30
-    done
-    echo ""
+    roll_postgres "sma" "sma-postgres-cluster" $sma_postgres_cluster_new_cpu_request
   fi
 fi
-
 
 if [ ! -z $nexus_new_cpu_request ]; then
   current_req=$(kubectl get deployment -n nexus nexus -o json | jq -r '.spec.template.spec.containers[] | select(.name== "nexus") | .resources.requests.cpu')
@@ -179,7 +230,7 @@ crayMetallbDeployed=$(kubectl get pods -n metallb-system | grep metallb-speaker 
 if [[ $crayMetallbDeployed -ne 0 ]]; then
   if [ ! -z $cray_metallb_speaker_new_cpu_request ]; then
     current_req=$(kubectl get daemonset metallb-speaker -n metallb-system -o json | jq -r '.spec.template.spec.containers[] | select(.name== "speaker") | .resources.requests.cpu')
-    echo "Patching nexus deployment with new cpu request of $cray_metallb_speaker_new_cpu_request (from $current_req)"
+    echo "Patching metallb deployment with new cpu request of $cray_metallb_speaker_new_cpu_request (from $current_req)"
     kubectl patch daemonset metallb-speaker -n metallb-system --type=json -p="[{'op' : 'replace', 'path':'/spec/template/spec/containers/0/resources/requests/cpu', 'value' : \"$cray_metallb_speaker_new_cpu_request\" }]"
     kubectl rollout status daemonset -n metallb-system metallb-speaker
     echo ""

--- a/upgrade/scripts/upgrade/tds_cpu_requests.yaml
+++ b/upgrade/scripts/upgrade/tds_cpu_requests.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,22 +21,40 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-
+# NOTE: If adding a section to this file, also make an edit to the script:
+#
+#       upgrade/scripts/k8s/tds_lower_cpu_requests.sh
+#
+#       ... in order for your changes to be applied on upgrade.
+#
 spec:
   kubernetes:
     services:
       cray-spire:
-        cray-service:
+        cray-postgresql:
+          sqlCluster:
+            resources:
+              requests:
+                cpu: "1"
+      spire:
+        cray-postgresql:
+          sqlCluster:
+            resources:
+              requests:
+                cpu: "1"
+      cray-dhcp-kea:
+        cray-postgresql:
           sqlCluster:
             resources:
               requests:
                 cpu: "1"
       cray-hms-smd:
-        cray-service:
+        cray-postgresql:
           sqlCluster:
             resources:
               requests:
                 cpu: "1"
+        cray-service:
           containers:
             cray-smd:
               resources:
@@ -79,6 +97,13 @@ spec:
         cray-service:
           containers:
             sma-kibana:
+              resources:
+                requests:
+                  cpu: "100m"
+      sma-dashboards:
+        cray-service:
+          containers:
+            sma-dashboards:
               resources:
                 requests:
                   cpu: "100m"

--- a/upgrade/scripts/upgrade/util/update-customizations.sh
+++ b/upgrade/scripts/upgrade/util/update-customizations.sh
@@ -201,6 +201,12 @@ fi
 # When upgrading to CSM 1.5 or later, ensure that we remove obsolete cray-service.sqlCluster entries (CASMPET-6584).
 yq4 -i eval 'del(.spec.kubernetes.services.*.cray-service.sqlCluster)' "$c"
 
+# lower cpu request for tds systems (4 workers)
+num_workers=$(kubectl get nodes | grep ncn-w | wc -l)
+if [ $num_workers -le 4 ]; then
+  yq m -i --overwrite "$c" /usr/share/doc/csm/upgrade/scripts/upgrade/tds_cpu_requests.yaml
+fi
+
 if [[ $inplace == "yes" ]]; then
   cp "$c" "$customizations"
 else


### PR DESCRIPTION
### Summary and Scope

Use a single yaml file for tds cpu request settings (in the docs-csm) repo.  Also modify the upgrade script to honor these values.

### Issues and Related PRs

* CASMPET-6818: Docs: review TDS CPU linits customization

### Testing

mug:

```
ncn-m001:/mnt/developer/bklein # ./tds_lower_cpu_requests.sh
Patching spire-postgres cluster with new cpu request of 1 (from 4)
postgresql.acid.zalan.do/spire-postgres patched

Patching cray-spire-postgres cluster with new cpu request of 1 (from 4)
postgresql.acid.zalan.do/cray-spire-postgres patched

Patching cray-dhcp-kea-postgres cluster with new cpu request of 1 (from 2)
postgresql.acid.zalan.do/cray-dhcp-kea-postgres patched

Patching cray-smd-postgres cluster with new cpu request of 1 (from 4)
postgresql.acid.zalan.do/cray-smd-postgres patched

Patching cray-smd deployment with new cpu request of 1 (from 4)
deployment.apps/cray-smd patched
Waiting for deployment "cray-smd" rollout to finish: 0 out of 3 new replicas have been updated...
Waiting for deployment "cray-smd" rollout to finish: 1 out of 3 new replicas have been updated...
Waiting for deployment "cray-smd" rollout to finish: 1 out of 3 new replicas have been updated...
Waiting for deployment "cray-smd" rollout to finish: 1 out of 3 new replicas have been updated...
Waiting for deployment "cray-smd" rollout to finish: 2 out of 3 new replicas have been updated...
Waiting for deployment "cray-smd" rollout to finish: 2 out of 3 new replicas have been updated...
Waiting for deployment "cray-smd" rollout to finish: 2 out of 3 new replicas have been updated...
Waiting for deployment "cray-smd" rollout to finish: 1 old replicas are pending termination...
Waiting for deployment "cray-smd" rollout to finish: 1 old replicas are pending termination...
deployment "cray-smd" successfully rolled out

Patching cray-capmc deployment with new cpu request of 500m (from 2)
deployment.apps/cray-capmc patched
Waiting for deployment "cray-capmc" rollout to finish: 0 out of 3 new replicas have been updated...
Waiting for deployment "cray-capmc" rollout to finish: 1 out of 3 new replicas have been updated...
Waiting for deployment "cray-capmc" rollout to finish: 2 out of 3 new replicas have been updated...
Waiting for deployment "cray-capmc" rollout to finish: 2 out of 3 new replicas have been updated...
Waiting for deployment "cray-capmc" rollout to finish: 2 out of 3 new replicas have been updated...
Waiting for deployment "cray-capmc" rollout to finish: 1 old replicas are pending termination...
Waiting for deployment "cray-capmc" rollout to finish: 1 old replicas are pending termination...
Waiting for deployment "cray-capmc" rollout to finish: 1 old replicas are pending termination...
Waiting for deployment "cray-capmc" rollout to finish: 2 of 3 updated replicas are available...
deployment "cray-capmc" successfully rolled out

Patching elasticsearch-master statefulset with new cpu request of 1500m (from 4)
statefulset.apps/elasticsearch-master patched
waiting for statefulset rolling update to complete 0 pods at revision elasticsearch-master-688bfb6f5...
Waiting for 1 pods to be ready...
Waiting for 1 pods to be ready...
waiting for statefulset rolling update to complete 1 pods at revision elasticsearch-master-688bfb6f5...
Waiting for 1 pods to be ready...
Waiting for 1 pods to be ready...
waiting for statefulset rolling update to complete 2 pods at revision elasticsearch-master-688bfb6f5...
Waiting for 1 pods to be ready...
Waiting for 1 pods to be ready...
statefulset rolling update complete 3 pods at revision elasticsearch-master-688bfb6f5...

Patching sma-grafana deployment with new cpu request of 100m (from 1)
deployment.apps/sma-grafana patched
Waiting for deployment "sma-grafana" rollout to finish: 0 out of 1 new replicas have been updated...
Waiting for deployment "sma-grafana" rollout to finish: 1 old replicas are pending termination...
Waiting for deployment "sma-grafana" rollout to finish: 1 old replicas are pending termination...
deployment "sma-grafana" successfully rolled out

Patching sma-kibana deployment with new cpu request of 100m (from 1)
deployment.apps/sma-kibana patched
Waiting for deployment "sma-kibana" rollout to finish: 0 out of 1 new replicas have been updated...
Waiting for deployment "sma-kibana" rollout to finish: 1 old replicas are pending termination...
Waiting for deployment "sma-kibana" rollout to finish: 1 old replicas are pending termination...
deployment "sma-kibana" successfully rolled out

Patching cluster-kafka with new cpu request of 1 (from 5)
kafka.kafka.strimzi.io/cluster patched
Waiting for cluster-kafka cluster to have three updated replicas...
Waiting for cluster-kafka cluster to have three updated replicas...
Waiting for cluster-kafka cluster to have three updated replicas...
Waiting for cluster-kafka cluster to have three updated replicas...
Waiting for cluster-kafka cluster to have three updated replicas...
Waiting for cluster-kafka cluster to have three updated replicas...
Waiting for cluster-kafka cluster to have three updated replicas...
Waiting for cluster-kafka cluster to have three updated replicas...
Waiting for cluster-kafka cluster to have three updated replicas...
Waiting for cluster-kafka cluster to have three updated replicas...
Waiting for cluster-kafka cluster to have three updated replicas...

Patching cluster-zookeeper statefulset with new cpu request of 100m (from 1)
kafka.kafka.strimzi.io/cluster patched

Patching sma-postgres-cluster cluster with new cpu request of 500m (from 2)
postgresql.acid.zalan.do/sma-postgres-cluster patched
Waiting for sma-postgres-cluster cluster to reach running state...
Waiting for sma-postgres-cluster cluster to reach running state...
Waiting for sma-postgres-cluster cluster to reach running state...
Waiting for sma-postgres-cluster cluster to reach running state...
Waiting for sma-postgres-cluster cluster to reach running state...
Waiting for sma-postgres-cluster cluster to reach running state...

Patching nexus deployment with new cpu request of 2 (from 500m)
deployment.apps/nexus patched
Waiting for deployment "nexus" rollout to finish: 0 out of 1 new replicas have been updated...
Waiting for deployment "nexus" rollout to finish: 0 out of 1 new replicas have been updated...
Waiting for deployment "nexus" rollout to finish: 0 out of 1 new replicas have been updated...
Waiting for deployment "nexus" rollout to finish: 0 of 1 updated replicas are available...
deployment "nexus" successfully rolled out

Patching metallb deployment with new cpu request of 1 (from 2)
daemonset.apps/metallb-speaker patched
Waiting for daemon set "metallb-speaker" rollout to finish: 0 out of 14 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 1 out of 14 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 1 out of 14 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 2 out of 14 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 2 out of 14 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 3 out of 14 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 3 out of 14 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 4 out of 14 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 4 out of 14 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 5 out of 14 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 5 out of 14 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 6 out of 14 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 6 out of 14 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 7 out of 14 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 7 out of 14 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 8 out of 14 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 8 out of 14 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 9 out of 14 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 9 out of 14 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 10 out of 14 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 10 out of 14 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 11 out of 14 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 11 out of 14 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 12 out of 14 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 12 out of 14 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 13 out of 14 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 13 out of 14 new pods have been updated...
Waiting for daemon set "metallb-speaker" rollout to finish: 13 of 14 updated pods are available...
daemon set "metallb-speaker" successfully rolled out
```

Second run:

```
ncn-m001:/mnt/developer/bklein # ./tds_lower_cpu_requests.sh
Patching spire-postgres cluster with new cpu request of 1 (from 1)
postgresql.acid.zalan.do/spire-postgres patched (no change)

Patching cray-spire-postgres cluster with new cpu request of 1 (from 1)
postgresql.acid.zalan.do/cray-spire-postgres patched (no change)

Patching cray-dhcp-kea-postgres cluster with new cpu request of 1 (from 1)
postgresql.acid.zalan.do/cray-dhcp-kea-postgres patched (no change)

Patching cray-smd-postgres cluster with new cpu request of 1 (from 1)
postgresql.acid.zalan.do/cray-smd-postgres patched (no change)

Patching cray-smd deployment with new cpu request of 1 (from 1)
deployment.apps/cray-smd patched (no change)
deployment "cray-smd" successfully rolled out

Patching cray-capmc deployment with new cpu request of 500m (from 500m)
deployment.apps/cray-capmc patched (no change)
deployment "cray-capmc" successfully rolled out

Patching elasticsearch-master statefulset with new cpu request of 1500m (from 1500m)
statefulset.apps/elasticsearch-master patched (no change)
statefulset rolling update complete 3 pods at revision elasticsearch-master-688bfb6f5...

Patching sma-grafana deployment with new cpu request of 100m (from 100m)
deployment.apps/sma-grafana patched (no change)
deployment "sma-grafana" successfully rolled out

Patching sma-kibana deployment with new cpu request of 100m (from 100m)
deployment.apps/sma-kibana patched (no change)
deployment "sma-kibana" successfully rolled out

Patching cluster-kafka with new cpu request of 1 (from 1)
kafka.kafka.strimzi.io/cluster patched (no change)

Patching cluster-zookeeper statefulset with new cpu request of 100m (from 100m)
kafka.kafka.strimzi.io/cluster patched (no change)

Patching sma-postgres-cluster cluster with new cpu request of 500m (from 500m)
postgresql.acid.zalan.do/sma-postgres-cluster patched (no change)

Patching nexus deployment with new cpu request of 2 (from 2)
deployment.apps/nexus patched (no change)
deployment "nexus" successfully rolled out

Patching metallb deployment with new cpu request of 1 (from 1)
daemonset.apps/metallb-speaker patched (no change)
daemon set "metallb-speaker" successfully rolled out
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing

