### PR TITLE
CASMINST-6700: retry cray-nls upgrade

### DIFF
--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -1359,12 +1359,26 @@ if [[ ${state_recorded} == "0" ]]; then
       exit 1
     fi
 
-    # retry cray-nls upgrade which is expected to succeed
-    "${locOfScript}/util/upgrade-cray-nls.sh"
+    # CASMINST-6700 retry cray-nls upgrade
+    set +e
+    i=0
+    max_checks=40
+    wait_time=30
+    until "${locOfScript}/util/upgrade-cray-nls.sh"; do
+      i=$((i + 1))
+      echo "Waiting for cray-nls upgrade to succeed (${i}/${max_checks})"
+      sleep ${wait_time}
+      # retry for up to 20 minutes
+      if [[ ${i} -gt ${max_checks} ]]; then
+        echo "ERROR: failed to finish cray-nls upgrade"
+        exit 1
+      fi
+    done
+
     # CASMINST-6040 - need to wait for hooks.cray-nls.hpe.com crd to be created
     # before uploading rebuild workflow templates which use hooks
     echo "Wait for hooks.cray-nls.hpe.com crd to be created"
-    set +e
+
     counter=0
     until kubectl get crd hooks.cray-nls.hpe.com; do
       counter=$((counter + 1))


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
cray-nls upgrade sometimes fails during pipeline run. This PR adds retries for up to 20 minutes to maximize its success rate.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
