### PR TITLE
CASMCMS-8826 - fix console command to log into a node.

### DIFF
--- a/operations/conman/Establish_a_Serial_Connection_to_NCNs.md
+++ b/operations/conman/Establish_a_Serial_Connection_to_NCNs.md
@@ -84,7 +84,7 @@ The user performing these procedures needs to have access permission to the `cra
 1. (`ncn-mw#`) Establish a serial console session with the desired NCN.
 
     ```bash
-    kubectl -n services exec -it $NODE_POD -- conman -j $XNAME
+    kubectl -n services exec -it $NODE_POD -c cray-console-node -- conman -j $XNAME
     ```
 
     The console session log files for each NCN are located in a shared volume in the `cray-console-node` pods.


### PR DESCRIPTION
# Description
https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8826

Need to specify which container in the pod to exec into. Slight modification of the docs.

# Checklist
- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
