### PR TITLE
CASMCMS-8861: Add --no-tar option to IMS export tool

### DIFF
--- a/scripts/operations/configuration/export_ims_data.py
+++ b/scripts/operations/configuration/export_ims_data.py
@@ -65,12 +65,19 @@ def parse_args() -> argparse.Namespace:
 
     parser.add_argument(
         '--exclude-linked-artifacts', action='store_true',
-        help="Exclude linked recipe and image S3 artifacts (included by default)"
+        help="Exclude linked recipe and image S3 artifacts (included by default). This implies --no-tar"
+    )
+
+    parser.add_argument(
+        '--no-tar', action='store_true',
+        help=("Do not create a tar archive of the exported data. This is the default behavior if "
+              "--exclude-linked-artifacts is specified. Otherwise, by default the individual export files are deleted "
+              "after being added to a tar archive")
     )
 
     parser.add_argument(
         'target_directory', nargs='?', default=os.getcwd(), type=args.readable_directory,
-        help='Directory in which to create IMS export archive'
+        help='Directory in which to create IMS export'
     )
 
     return parser.parse_args()
@@ -83,8 +90,10 @@ def main():
                         format='%(asctime)s %(levelname)-8s %(message)s',
                         datefmt='%Y-%m-%d %H:%M:%S')
     try:
-        ims_export.do_export(parsed_args.ignore_running_jobs, parsed_args.include_deleted,
-                             parsed_args.exclude_linked_artifacts, parsed_args.target_directory)
+        ims_export.do_export(ignore_running_jobs=parsed_args.ignore_running_jobs,
+                             include_deleted=parsed_args.include_deleted,
+                             exclude_linked_artifacts=parsed_args.exclude_linked_artifacts, no_tar=parsed_args.no_tar,
+                             target_directory=parsed_args.target_directory)
     except ims_import_export.ImsJobsRunning:
         LOGGER.info("Wait until jobs are completed or see script usage for override option")
         common.print_err_exit("Aborted export due to incomplete jobs")

--- a/scripts/operations/configuration/import_ims_data.py
+++ b/scripts/operations/configuration/import_ims_data.py
@@ -116,7 +116,8 @@ def do_import(script_args: argparse.Namespace) -> None:
     # Backup current IMS data
     LOGGER.info("Performing pre-import backup of IMS data to directory '%s'", script_args.backup_dir)
     current_data, _ = ims_export.do_export(ignore_running_jobs=script_args.ignore_running_jobs, include_deleted=True,
-                                           exclude_linked_artifacts=True, target_directory=script_args.backup_dir)
+                                           exclude_linked_artifacts=True, no_tar=True,
+                                           target_directory=script_args.backup_dir)
 
     # We pass ignore_running_jobs = True here because we have already checked this above, if applicable
     import_options = ims_import.ImportOptions(tarfile_dir=tarfile_dir,


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
Adds a new option to the IMS export tool giving the option for it not to create a tar archive of the exported data. This is being added to improve performance in a specific DR scenario.

Given the nature of the change in this PR, I don't think a particular CMS or IMS SME is required for review. Anyone with Python knowledge is fine.

Backports:
1.5: https://github.com/Cray-HPE/docs-csm/pull/4443
1.4: https://github.com/Cray-HPE/docs-csm/pull/4444
1.3: https://github.com/Cray-HPE/docs-csm/pull/4445

No earlier backports needed -- the tool did not exist prior to 1.3.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
