### PR TITLE
CASMTRIAGE-6251: Fix cray-sat image location

### DIFF
--- a/workflows/templates/base/sat-general-iuf.template.argo.yaml
+++ b/workflows/templates/base/sat-general-iuf.template.argo.yaml
@@ -62,7 +62,8 @@ spec:
             valueFrom:
               path: "{{inputs.parameters.script_stdout_file}}"
       script:
-        image: artifactory.algol60.net/sat-docker/stable/cray-sat:3.25.6
+        # Note that the tag is replaced at install time by update_tags.sh
+        image: artifactory.algol60.net/csm-docker/stable/cray-sat:3.26.0
         command: [sh]
         source: |
           #!/bin/sh


### PR DESCRIPTION
# Description

The cray-sat image has moved from sat-docker to csm-docker for CSM 1.6.0. Update the cray-sat image location in the Argo workflow template to match. Without this fix, the `update_tags.sh` script fails when trying to update image tags in the Argo workflow templates, which actually causes the docs-csm RPM installation to fail because the script is executed as an RPM post-install scriptlet.

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
