### PR TITLE
DVS-3179 update location of prechecks_for_worker_reboots

### DIFF
--- a/workflows/ncn/hooks/before-each/cos-prechecks-for-worker-reboots.yaml
+++ b/workflows/ncn/hooks/before-each/cos-prechecks-for-worker-reboots.yaml
@@ -32,20 +32,9 @@ spec:
     #!/bin/sh
     SSH_OPT="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
     SSH_OPT="${SSH_OPT} -o ConnectTimeout=10"
-    # Note: this file path cannot change without coordinated changes to the COS
-    # product stream
-    file_path=/opt/cray/shasta/cos/bin/prechecks_for_worker_reboots
-    # Check for remote installation, gracefully handling non-existence as COS
-    # may not be installed yet (or this functionality may be deprecated).
-    has_file=$(ssh ${SSH_OPT} ${TARGET_NCN} find ${file_path} || true)
-    if [[ -z ${has_file} ]]; then
-        # double check that we can generally ssh to TARGET_NCN
-        ssh ${SSH_OPT} ${TARGET_NCN} hostname
-        # 'hostname' failure triggers 'set -e' (established in calling context)
-        echo "cannot find ${file_path} on ${TARGET_NCN}"
-        exit 0
-    fi
-    # remotely execute the file using its exit code as our own
-    ssh ${SSH_OPT} ${TARGET_NCN} ${file_path}
+    # Note: this file path cannot change without coordinated changes to the COS product stream
+    # Run the precheck_for_worker_reboots script from the new location or the old location
+    # If not found, return a message and continue
+    ssh ${SSH_OPT} ${TARGET_NCN} "if [[ -f /opt/cray/shasta/cne/bin/prechecks_for_worker_reboots ]]; then /opt/cray/shasta/cne/bin/prechecks_for_worker_reboots; elif [[ -f /opt/cray/shasta/cos/bin/prechecks_for_worker_reboots ]]; then /opt/cray/shasta/cos/bin/prechecks_for_worker_reboots; else echo WARN prechecks_for_worker_reboots not present on ${TARGET_NCN}; fi"
     exit $?
   templateRefName: ssh-template


### PR DESCRIPTION
Align the docs-csm cos precheck hook to point to the new location post cos-replan.

Fall back to old location if the new one is not found in order to preserve interoperability with old images.

Tested in immediate mode on slice, verifying the new logic picks the correct directory for both new style and old style directories.

testing:
```
ncn-m001:~ # cat > /tmp/foo
    #!/bin/sh
    SSH_OPT="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
    SSH_OPT="${SSH_OPT} -o ConnectTimeout=10"
    # Note: this file path cannot change without coordinated changes to the COS product stream
    # Run the precheck_for_worker_reboots script from the new location or the old location
    # If not found, return a message and continue
    ssh ${SSH_OPT} ${TARGET_NCN} "if [[ -f /opt/cray/shasta/cne/bin/prechecks_for_worker_reboots ]]; then /opt/cray/shasta/cne/bin/prechecks_for_worker_reboots; elif [[ -f /opt/cray/shasta/cos/bin/prechecks_for_worker_reboots ]]; then /opt/cray/shasta/cos/bin/prechecks_for_worker_reboots; else echo WARN prechecks_for_worker_reboots not present on ${TARGET_NCN}; fi"
    exit $?
ncn-m001:~ # export TARGET_NCN=ncn-w001
ncn-m001:~ # sh /tmp/foo
Warning: Permanently added 'ncn-w001,10.252.1.10' (ECDSA) to the list of known hosts.
test prechecks_for_worker_reboots script in the cne location
ncn-m001:~ # sh /tmp/foo
Warning: Permanently added 'ncn-w001,10.252.1.10' (ECDSA) to the list of known hosts.
test prechecks_for_worker_reboots script in the cos location
ncn-m001:~ # sh /tmp/foo
Warning: Permanently added 'ncn-w001,10.252.1.10' (ECDSA) to the list of known hosts.
WARN prechecks_for_worker_reboots not present on ncn-w001
ncn-m001:~ #
```

<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
