### PR TITLE
CASMCMS-8863: Add --clear-bos option to BOS import tool

### DIFF
--- a/scripts/operations/configuration/python_lib/bos.py
+++ b/scripts/operations/configuration/python_lib/bos.py
@@ -27,12 +27,15 @@
 import traceback
 import logging
 
-from typing import Dict, Union
+from typing import Dict, List, Union
 
 from . import api_requests
 from . import common
+from .bos_session_templates import BosSessionTemplate
+from .types import JsonObject
 
 BosOptions = Dict[str, Union[bool, int, str]]
+BosV2Session = Dict[str, JsonObject]
 
 BOS_BASE_URL = f"{api_requests.API_GW_BASE_URL}/apis/bos"
 
@@ -87,3 +90,63 @@ def update_options(new_options: BosOptions) -> BosOptions:
                       "expected_status_codes": {200},
                       "json": new_options}
     return api_requests.patch_retry_validate_return_json(**request_kwargs)
+
+# BOS v1 session functions
+
+def delete_v1_session(session_name: str) -> None:
+    """
+    Deletes the specified v1 session.
+    """
+    request_kwargs = {"url": f"{BOS_V1_SESSIONS_URL}/{session_name}",
+                      "add_api_token": True,
+                      "expected_status_codes": {204}}
+    api_requests.delete_retry_validate(**request_kwargs)
+
+def list_v1_session_names() -> List[str]:
+    """
+    Queries BOS for a list of all v1 session names, and returns that list.
+    """
+    request_kwargs = {"url": BOS_V1_SESSIONS_URL,
+                      "add_api_token": True,
+                      "expected_status_codes": {200}}
+    return api_requests.get_retry_validate_return_json(**request_kwargs)
+
+# BOS v2 session functions
+
+def delete_v2_session(session_name: str) -> None:
+    """
+    Deletes the specified v2 session.
+    """
+    request_kwargs = {"url": f"{BOS_V2_SESSIONS_URL}/{session_name}",
+                      "add_api_token": True,
+                      "expected_status_codes": {204}}
+    api_requests.delete_retry_validate(**request_kwargs)
+
+def list_v2_sessions() -> List[BosV2Session]:
+    """
+    Queries BOS for a list of all v1 session names, and returns that list.
+    """
+    request_kwargs = {"url": BOS_V2_SESSIONS_URL,
+                      "add_api_token": True,
+                      "expected_status_codes": {200}}
+    return api_requests.get_retry_validate_return_json(**request_kwargs)
+
+# BOS v2 session template functions
+
+def delete_v2_session_template(template_name: str) -> None:
+    """
+    Deletes the specified v2 session template.
+    """
+    request_kwargs = {"url": f"{BOS_V2_TEMPLATES_URL}/{template_name}",
+                      "add_api_token": True,
+                      "expected_status_codes": {204}}
+    api_requests.delete_retry_validate(**request_kwargs)
+
+def list_v2_session_templates() -> List[BosSessionTemplate]:
+    """
+    Queries BOS v2 for a list of all session templates, and returns that list.
+    """
+    request_kwargs = {"url": BOS_V2_TEMPLATES_URL,
+                      "add_api_token": True,
+                      "expected_status_codes": {200}}
+    return api_requests.get_retry_validate_return_json(**request_kwargs)


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
One of our disaster recovery scenarios involves a rapid rebuild wherein we do a pseudo-CSM-install and then import data from the old system. In this case, we want to completely remove any data created during the pseudo-install process. To enable this in the case of the BOS data import, this PR adds a "--clear-bos" option to the BOS import tool, which will delete existing BOS sessions and templates before the import is performed.

I tested this on wasp and verified that it works.

Backports:
1.5: https://github.com/Cray-HPE/docs-csm/pull/4464
1.4: https://github.com/Cray-HPE/docs-csm/pull/4465
1.3: https://github.com/Cray-HPE/docs-csm/pull/4466

No earlier backports needed as the tool did not exist.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
