### PR TITLE
Cleanup 1.4 cephfs share mount script, address issue seen on creek (CASMTRIAGE-6275)

### DIFF
--- a/scripts/mount-cephfs-share.sh
+++ b/scripts/mount-cephfs-share.sh
@@ -117,11 +117,14 @@ function create-admin-tools-cephfs-share {
     echo "fstab entry for cephfs already present..."
   fi
 
+  echo "Calling systemctl daemon-reload to ensure changes to ${fstab} are loaded..."
+  systemctl daemon-reload
+
   umount -f ${upgrade_dir} > /dev/null 2>&1
   mkdir -p ${upgrade_dir} > /dev/null 2>&1
   mount ${upgrade_dir}
 
-  if ! mountpoint ${upgrade_dir} > /dev/null 2>&1; then
+  if [[ "$?" -ne 0 ]]; then
     echo "ERROR: CSM share failed to mount!"
     exit 1
   fi


### PR DESCRIPTION
### Summary and Scope

Cleanup 1.4 cephfs share mount script, address issue seen on creek

### Issues and Related PRs

  * CASMTRIAGE-6275: mount-cephfs-share.sh fails to mount newly created /etc/cray/upgrade/csm filesystem

### Testing

beau 
```
ncn-m001:~ # ./mount-cephfs-share.sh
admin-tools ceph fs share already created...
Adding fstab entry for cephfs share...
Calling systemctl daemon-reload to ensure changes to /etc/fstab are loaded...
Done! /etc/cray/upgrade/csm is mounted as a cephfs share!
ncn-m001:~ # ls /etc/cray/upgrade/csm
media
ncn-m001:~ # df -h /etc/cray/upgrade/csm
Filesystem                                         Size  Used Avail Use% Mounted on
10.252.1.4:6789,10.252.1.5:6789,10.252.1.6:6789:/  2.7T  109G  2.6T   5% /etc/cray/upgrade/csm
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing

