### PR TITLE
CASMTRIAGE-6283 

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -453,6 +453,7 @@ buses
 c0
 catalog
 cataloged
+cdu
 cdu0sw01
 cdu0sw02
 cec0
@@ -542,6 +543,7 @@ laborer
 laborers
 laboring
 labors
+leaf-bmc
 license
 licenses
 lifecycle

--- a/operations/power_management/Save_Management_Network_Switch_Configurations.md
+++ b/operations/power_management/Save_Management_Network_Switch_Configurations.md
@@ -14,7 +14,7 @@ grep 'sw-' /etc/hosts
 
 Example output:
 
-```
+```bash
 10.254.0.2 sw-spine-001
 10.254.0.3 sw-spine-002
 10.254.0.4 sw-leaf-001

--- a/operations/power_management/Save_Management_Network_Switch_Configurations.md
+++ b/operations/power_management/Save_Management_Network_Switch_Configurations.md
@@ -15,9 +15,9 @@ grep 'sw-' /etc/hosts
 Example output:
 
 ```
-10.252.0.2 sw-spine-001
-10.252.0.3 sw-spine-002
-10.252.0.4 sw-leaf-001
+10.254.0.2 sw-spine-001
+10.254.0.3 sw-spine-002
+10.254.0.4 sw-leaf-001
 ncn-m001:~ #
 ```
 
@@ -35,7 +35,7 @@ For each switch:
 Example:
 
  ```bash
- ssh admin@sw-spine-001.nmn
+ ssh admin@sw-spine-001.hmn
  admin@sw-spine-001 password:
  write memory
  exit
@@ -53,7 +53,7 @@ On Dell and Mellanox based systems, all spine and any leaf switches will be Mell
 Mellanox Example:
 
  ```bash
- ssh admin@sw-spine-001.nmn
+ ssh admin@sw-spine-001.hmn
  admin@sw-spine-001 password:
  enable
  write memory


### PR DESCRIPTION
Fix example of how to save switch configs.

Relates to:
CASMTRIAGE-6283 