### PR TITLE
CASMTRIAGE-6288: increase suggested time-out

### DIFF
--- a/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
@@ -174,11 +174,11 @@ Verify that the Lustre file system is available from the management cluster.
 1. (`ncn-m001#`) Start the Kubernetes cluster.
 
     Note that the default timeout for Ceph to become healthy is 600 seconds, which is excessive. To work
-    around this issue, set the timeout to a more reasonable value (like 60 seconds) using the `--ceph-timeout`
+    around this issue, set the timeout to a more reasonable value (like 120 seconds) using the `--ceph-timeout`
     option, as shown below.
 
     ```bash
-    sat bootsys boot --stage platform-services --ceph-timeout 60
+    sat bootsys boot --stage platform-services --ceph-timeout 120
     ```
 
     Example output:
@@ -205,8 +205,8 @@ Verify that the Lustre file system is available from the management cluster.
 
     ```text
     Executing step: Start inactive Ceph services, unfreeze Ceph cluster and wait for Ceph health.
-    Waiting up to 60 seconds for Ceph to become healthy after unfreeze
-    Waiting for condition "Ceph cluster in healthy state" timed out after 60 seconds
+    Waiting up to 120 seconds for Ceph to become healthy after unfreeze
+    Waiting for condition "Ceph cluster in healthy state" timed out after 120 seconds
     ERROR: Fatal error in step "Start inactive Ceph services, unfreeze Ceph cluster and wait for Ceph health." of platform services start: Ceph is not healthy. Please correct Ceph health and try again.
     ```
 


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
During the system power-on testing, it was found that the suggested 60 second time-out setting for ceph was not sufficient. This PR doubles the suggested time-out setting to 120 seconds.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
