### PR TITLE
CASMTRIAGE-6225 copy Ceph files from another node when upgrading storage node if untar fails

### DIFF
--- a/workflows/templates/storage.add-node-to-ceph.yaml
+++ b/workflows/templates/storage.add-node-to-ceph.yaml
@@ -242,3 +242,43 @@ spec:
                   TARGET_NCN="{{inputs.parameters.targetNcn}}"
                   scp ./${TARGET_NCN}-ceph.tgz $TARGET_NCN:/
                   ssh ${TARGET_NCN} 'cd /; tar -xvf ./$(hostname)-ceph.tgz; rm /$(hostname)-ceph.tgz'
+                  # check that files are correctly on TARGET_NCN
+                  ceph_files=$(ssh ${TARGET_NCN} 'ls /etc/ceph')
+                  if [[ -z $(echo ${ceph_files} | grep 'rgw.pem') ]] || [[ -z $(echo ${ceph_files} | grep 'ceph.client.ro.keyring') ]]; then
+                    # ceph files are missing, try recopying the tar file over
+                    scp ./${TARGET_NCN}-ceph.tgz $TARGET_NCN:/
+                    ssh ${TARGET_NCN} 'cd /; tar -xvf ./$(hostname)-ceph.tgz; rm /$(hostname)-ceph.tgz'
+                  else
+                    # ceph files are there so exit
+                    exit 0
+                  fi
+                  # check that files are correctly on TARGET_NCN
+                  ceph_files=$(ssh ${TARGET_NCN} 'ls /etc/ceph')
+                  if [[ -z $(echo ${ceph_files} | grep 'rgw.pem') ]] || [[ -z $(echo ${ceph_files} | grep 'ceph.client.ro.keyring') ]]; then
+                    # ceph files are missing, copy files from another node
+                    echo "WARN unable to untar ${TARGET_NCN}-ceph.tgz on ${TARGET_NCN}. Copying neccessary Ceph files from another node instead of getting them from tar file."
+                    for node in ncn-s001 ncn-s002 ncn-s003; do
+                      if [[ "$TARGET_NCN" == "$node" ]]; then
+                        continue
+                      else
+                        if [[ "$TARGET_NCN" =~ ^("ncn-s001"|"ncn-s002"|"ncn-s003")$ ]]
+                        then
+                          scp $node:/etc/ceph/\{rgw.pem,ceph.conf,ceph_conf_min,ceph.client.ro.keyring,ceph.client.admin.keyring\} ${TARGET_NCN}:/etc/ceph
+                        else
+                          scp $node:/etc/ceph/\{rgw.pem,ceph.conf,ceph_conf_min,ceph.client.ro.keyring\}  ${TARGET_NCN}:/etc/ceph/
+                        fi
+                        break
+                      fi
+                    done
+                  else
+                    # ceph files are there so exit
+                    exit 0
+                  fi
+                  ceph_files=$(ssh ${TARGET_NCN} 'ls /etc/ceph')
+                  if [[ -z $(echo ${ceph_files} | grep 'rgw.pem') ]] || [[ -z $(echo ${ceph_files} | grep 'ceph.client.ro.keyring') ]]; then
+                    echo "ERROR neccessary Ceph files were not copied to ${TARGET_NCN}. Manually try to populate ${TARGET_NCN}:/etc/ceph with the same files seen in /etc/ceph other storage nodes."
+                    exit 1
+                  else
+                    echo "INFO /etc/ceph files were successfully copied to ${TARGET_NCN} from another storage node."
+                    exit 0
+                  fi


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
**Problem**
When upgrading storage nodes, the Ceph files in '/etc/ceph' are backed up to a tar file and then restored after the node is upgraded. However, we hit a situation where the tar file failed to untar so the Ceph files were missing. The tar file was corrupt and was not able to restore when done manually. This untar command fails silently (exits with 0) which caused the workflow to continue. This lead to haproxy not working on the storage node which caused the rgw-vip to be down which caused another storage node to fail to boot.

**Fix**
This PR will try to untar the backup tar file twice on the rebuilt node. If after both attempts the files in /etc/ceph are not present, then these files will be copied from another storage node.

Tested on Beau.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
