### PR TITLE
CASMTRIAGE-6188: add retries for tag retrieval

### DIFF
--- a/workflows/update_tags.sh
+++ b/workflows/update_tags.sh
@@ -88,6 +88,20 @@ function update_tags_in_file() {
 # Look up the latest tag for each image found and update the references in every file.
 for THIS_IMAGE in $(get_list_of_images_to_update); do
   LATEST_TAG=$(get_latest_tag_for_image $THIS_IMAGE)
+  # CASMTRIAGE-6188 retry for up to 60 seconds if LATEST_TAG is empty
+  i=1
+  while [[ -z ${LATEST_TAG} ]]; do
+    if [[ ${i} -le 6 ]]; then
+      echo "Retry getting the latest tag for image: $THIS_IMAGE"
+      sleep 10
+      LATEST_TAG=$(get_latest_tag_for_image $THIS_IMAGE)
+      i=$((i + 1))
+    else
+      echo "ERROR: unable to get the latest tag for image: $THIS_IMAGE"
+      exit 1
+    fi
+  done
+
   for FILE in $(get_filenames_referring_to_image); do
     update_tags_in_file $THIS_IMAGE $LATEST_TAG $FILE
   done


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
Occasionally the latest tag retrieval for images may return an empty string, this PR adds retries for up to 60 seconds.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
