### PR TITLE
CASMTRIAGE-6233 edit upgrade-state.sh file to only remove the .ssh/config if being called by prerequisites.sh

### DIFF
--- a/upgrade/scripts/common/upgrade-state.sh
+++ b/upgrade/scripts/common/upgrade-state.sh
@@ -95,8 +95,11 @@ function err_report() {
   echo "${cmd}"
 
   # restore previous ssh config if there was one, remove ours
-  rm -f /root/.ssh/config
-  test -f /root/.ssh/config.bak && mv /root/.ssh/config.bak /root/.ssh/config
+  # only do this if called by prerequisites.
+  if [[ -n $(echo "${caller}" | grep 'prerequisites.sh') ]]; then
+    rm -f /root/.ssh/config
+    test -f /root/.ssh/config.bak && mv /root/.ssh/config.bak /root/.ssh/config
+  fi
 
   # ignore some internal expected errors
   local ignoreCmd="cray artifacts list config-data"

--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -319,18 +319,19 @@ else
   echo "====> ${state_name} has been completed" | tee -a "${LOG_FILE}"
 fi
 
+# Set new ssh config, this should be done everytime the script is run
+# This is reversed at the end of the script and also reversed in err_report function
+test -f /root/.ssh/config && mv /root/.ssh/config /root/.ssh/config.bak
+cat << EOF > /root/.ssh/config
+Host *
+    StrictHostKeyChecking no
+EOF
+
 state_name="UPDATE_SSH_KEYS"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
 if [[ ${state_recorded} == "0" ]]; then
   echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
   {
-
-    test -f /root/.ssh/config && mv /root/.ssh/config /root/.ssh/config.bak
-    cat << EOF > /root/.ssh/config
-Host *
-    StrictHostKeyChecking no
-EOF
-
     grep -oP "(ncn-\w+)" /etc/hosts | sort -u | xargs -t -i ssh {} 'truncate --size=0 ~/.ssh/known_hosts'
 
     grep -oP "(ncn-\w+)" /etc/hosts | sort -u | xargs -t -i ssh {} 'grep -oP "(ncn-s\w+|ncn-m\w+|ncn-w\w+)" /etc/hosts | sort -u | xargs -t -i ssh-keyscan -H \{\} >> /root/.ssh/known_hosts'


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

**Problem**
The `prerequisites.sh` script run sets a new `.ssh/config` file that contains no host key checking. The end of `prerequisites.sh` script and also the `err_report` function in `upgrade_state.sh` reset this file to the original. This means the `err_report` works when called by the `prerequisites.sh` script. However, when `err_report` is called by other scripts, it removes the `config` file and there is no backup. The other problem is the the `prerequisites.sh` file only sets a new config file once because it is inside a step that tracks state and will only run once. This means that if the there is an error, `err_report` is called which removes the config, and then when `prerequisites.sh` is called again, it will not reset the config file.

**Resolution**
Only remove the `config` file in `err_report` function when caller is prerequisites.sh. Also, have `prerequisistes.sh` set new config file every time it is run, don't track whether this step has run by tracking state.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
