### PR TITLE
CASMINST-6722: Add procedure for handling VCS merge conflicts

### DIFF
--- a/operations/configuration_management/VCS_Branching_Strategy.md
+++ b/operations/configuration_management/VCS_Branching_Strategy.md
@@ -30,3 +30,51 @@ The "Branch Workflow" diagram is an example workflow that can be used to manage 
 require any specific branching strategy. Users are free to manage the branches as they see fit with the exception of the pristine branches imported by individual HPE Cray
 products. CFS configuration layers \(see [CFS Configurations](CFS_Configurations.md)\) only require a Git commit ID, a Git repository clone URL, and the path to an
 Ansible playbook to run the configuration content in the repository.
+
+## Resolving VCS merge conflicts
+
+If the `update-vcs-config` stage of IUF fails due to git merge conflicts, they must be resolved manually. To do so, follow these steps:
+
+1. (`ncn-mw#`) Get the VCS username and password for git operations.
+
+    ```bash
+    echo $(kubectl get secret -n services vcs-user-credentials \
+        --template={{.data.vcs_username}} | base64 -d)
+    echo $(kubectl get secret -n services vcs-user-credentials \
+        --template={{.data.vcs_password}} | base64 -d)
+    ```
+
+1. (`ncn-mw#`) Clone the VCS repository. This example uses the COS repo, but this procedure can be applied for any VCS repo.
+
+    ```bash
+    git clone https://api-gw-service-nmn.local/vcs/cray/cos-config-management.git
+    cd cos-config-management
+    ```
+
+1. (`ncn-mw#`) Get the name of the previous integration branch, new integration branch, and pristine branch (e.g. `integration-2.4.109`, `integration-2.4.118`, `origin/cray/cos/2.5.132`).
+    Use `git branch -r` to list the available branches.
+
+    ```bash
+    git branch -r
+    ```
+
+1. (`ncn-mw#`) Create the new integration branch from the previous integration branch and merge the pristine branch.
+
+    ```bash
+    git checkout <previous integration branch>
+    git branch <new integration branch>
+    git checkout <new integration branch>
+    git merge <pristine branch>
+    ```
+
+1. (`ncn-mw#`) Resolve the merge conflicts.
+
+1. (`ncn-mw#`) Commit the merge and push the results:
+
+    ```bash
+    git add .
+    git commit
+    git push origin <new integration branch>
+    ```
+
+1. (`ncn-mw#`) If the merge conflict occurred during an IUF run, re-run the IUF update-vcs-config stage.


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
Adds a procedure for handling VCS merge conflicts

Relates to:
- CASMINST-6722
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
