### PR TITLE
CASMTRIAGE-6300 Adding work around mentioning during sat platform services 

### DIFF
--- a/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
+++ b/operations/power_management/Power_On_and_Start_the_Management_Kubernetes_Cluster.md
@@ -238,6 +238,8 @@ Verify that the Lustre file system is available from the management cluster.
 
     Once Ceph is healthy, repeat the `sat bootsys boot --stage platform-services` command to finish
     starting the Kubernetes cluster.
+    If any other errors are observed run the `sat bootsys boot --stage platform-services` command again
+    and verify if they are cleared.
 
 1. (`ncn-m001#`) Check the space available on the Ceph cluster.
 


### PR DESCRIPTION
IM:CASMTRIAGE-6300
Reviewer:Ryan Haskeen


while running sat bootsys boot --stage platform-services, a traceback error is observed due to instant calls in the code.

The addition of the step which checks for cronjobs that need to be recreated immediately after kubelet is started on all Kubernetes nodes. Hence adding a note in the doc as workaround to re run the cmd and validate, until a permanent fix is added.
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
