### PR TITLE
CASMPET-5760: Fix missing quote

### DIFF
--- a/workflows/templates/cilium.migrate.yaml
+++ b/workflows/templates/cilium.migrate.yaml
@@ -100,7 +100,7 @@ spec:
                 value: |
                   echo "restarting daemonsets on {{inputs.parameters.targetNcn}}"
                   NODE={{inputs.parameters.targetNcn}}
-                  kubectl get node ${NODE} >/dev/null 2>&1 || { echo "Error: Invalid node name ${NODE}; exit 1; }
+                  kubectl get node ${NODE} >/dev/null 2>&1 || { echo "Error: Invalid node name ${NODE}"; exit 1; }
 
                   while read -r ns pod; do
                     echo "Restarting pod $pod"


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

Fixing missing quote from applying review comment suggestion on previous PR.   Didn't get a chance to retest the changes before it was merged.  (Should have moved the PR into draft while retesting.)

This has been retested on the cilium cluster migration.

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
