### PR TITLE
CASMPET-6865 release 1.4 - source myenv before running master upgrade with IUF

### DIFF
--- a/workflows/iuf/operations/management-nodes-rollout/management-nodes-rollout.yaml
+++ b/workflows/iuf/operations/management-nodes-rollout/management-nodes-rollout.yaml
@@ -216,6 +216,9 @@ spec:
                       --initrd $initrd_image \
                       --params "${PARAMS}"
 
+                    if [[ -f /etc/cray/upgrade/csm/myenv ]]; then
+                      source /etc/cray/upgrade/csm/myenv
+                    fi
                     export TERM=linux
                     echo "NOTICE  upgrading ncn-m002"
                     /usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-master-nodes.sh ncn-m002
@@ -285,6 +288,9 @@ spec:
                       --initrd $initrd_image \
                       --params "${PARAMS}"
 
+                    if [[ -f /etc/cray/upgrade/csm/myenv ]]; then
+                      source /etc/cray/upgrade/csm/myenv
+                    fi
                     export TERM=linux
                     echo "NOTICE  upgrading ncn-m003"
                     /usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-master-nodes.sh ncn-m003


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

The master node upgrade is tracked by a state file in /etc/cray/upgrade/csm/csm-1.x.x. A directory is created when a node is upgraded that keeps track of which steps have completed for that node. Before running a master node upgrade without IUF, you need to export the CSM-RELEASE variable which is what determines where the state file will be put. When the node upgrade is run with IUF, the CSM_RELEASE variable is not set and the master node upgrade ends up saving the script in a directory named 'csm-'. This is inconsistent with state file tracked by a node rebuild and can eventually lead to bad behavior on a master node upgrade or rebuild.

This change exports the release variable as it is tracked in myenv file. This makes the master node upgrade use the correct dir when making a state file.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
