### PR TITLE
CASMTRIAGE-6331 edit IUF prepare images and update-cfs-config to print when -bm arg is not provided

### DIFF
--- a/workflows/iuf/operations/prepare-images/prepare-management-images-template.yaml
+++ b/workflows/iuf/operations/prepare-images/prepare-management-images-template.yaml
@@ -73,7 +73,7 @@ spec:
                     MEDIA_DIR="{{=jsonpath(inputs.parameters.global_params, '$.input_params.media_dir')}}"
                     BOOTPREP_FILE_PATH="{{=jsonpath(inputs.parameters.global_params, '$.input_params.bootprep_config_management')}}"
                     if [[ -z "$BOOTPREP_FILE_PATH" ]]; then
-                      echo "INFO Cannot access bootprep config file (Input parameter '-bc' not provided). Skipping the 'prepare-management-images' operation" 1>&2
+                      echo "INFO Cannot access bootprep config file (Input parameter '-bm' not provided). Skipping the 'prepare-management-images' operation" 1>&2
                       exit 0
                     else
                       echo "INFO Using bootprep file $BOOTPREP_FILE_PATH for preparing images on management nodes" 1>&2

--- a/workflows/iuf/operations/update-cfs-config/update-management-cfs-config.yaml
+++ b/workflows/iuf/operations/update-cfs-config/update-management-cfs-config.yaml
@@ -73,7 +73,7 @@ spec:
                     MEDIA_DIR="{{=jsonpath(inputs.parameters.global_params, '$.input_params.media_dir')}}"
                     BOOTPREP_FILE_PATH="{{=jsonpath(inputs.parameters.global_params, '$.input_params.bootprep_config_management')}}"
                     if [[ -z "$BOOTPREP_FILE_PATH" ]]; then
-                      echo "INFO Cannot access bootprep config file (Input parameter '-bc' not provided). Skipping the 'update-management-cfs-config' operation" 1>&2
+                      echo "INFO Cannot access bootprep config file (Input parameter '-bm' not provided). Skipping the 'update-management-cfs-config' operation" 1>&2
                       exit 0
                     else
                       echo "INFO Using bootprep config file $BOOTPREP_FILE_PATH for updating CFS config on management nodes" 1>&2


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

The management bootprep config argument is '-bm'. In IUF stages 'prepare-images' and 'update-cfs-config', both state this incorrectly as '-bc'. This PR corrects this argument name.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
