### PR TITLE
CASMNET-2175 - cray-dns-unbound - Make interface used for NID alias configurable.

### DIFF
--- a/operations/network/dns/Manage_the_DNS_Unbound_Resolver.md
+++ b/operations/network/dns/Manage_the_DNS_Unbound_Resolver.md
@@ -278,7 +278,7 @@ This behaviour is configurable, use the following procedure to change the HSN NI
    Valid values are "all" or the numeric index of a HSN interface. This variable should be set to the number of an interface that is common to all nodes with HSN interfaces.
    For example if `HSN_NIC_ALIAS` is set to `4` and there are nodes in the system that only have two HSN interfaces then aliases will not be created for those nodes.
 
-   ```text
+   ```yaml
    - name: HSN_NIC_ALIAS
      value: "all"
    ```

--- a/operations/network/dns/Manage_the_DNS_Unbound_Resolver.md
+++ b/operations/network/dns/Manage_the_DNS_Unbound_Resolver.md
@@ -10,6 +10,7 @@ This instance is accessible only within the HPE Cray EX system.
 - [Clear bad data in the Unbound ConfigMap](#clear-bad-data-in-the-unbound-configmap)
 - [Change the site DNS server](#change-the-site-dns-server)
 - [Increase the number of Unbound pods](#increase-the-number-of-unbound-pods)
+- [Change which HSN NIC is used for the nid alias](#change-which-hsn-nic-is-used-for-the-nid-alias)
 
 ## Check the status of the `cray-dns-unbound` pods
 

--- a/operations/network/dns/Manage_the_DNS_Unbound_Resolver.md
+++ b/operations/network/dns/Manage_the_DNS_Unbound_Resolver.md
@@ -248,10 +248,9 @@ See [Scale `cray-dns-unbound` service](../../CSM_product_management/Post_Install
 
 Previous CSM versions associate all HSN IPs with the node nid alias.
 
-Example output:
+Example output from the `host nid000001` command:
 
 ```bash
-ncn-m001:~ # host nid000001
 nid000001 has address 10.253.0.1
 nid000001 has address 10.253.0.1
 nid000001 has address 10.253.0.1
@@ -260,10 +259,9 @@ nid000001 has address 10.253.0.1
 
 Some workload managers do not handle this well so CSM 1.6 and above will only use the IP address of the first HSN NIC for this alias.
 
-Example output:
+Example output from the `host nid000001` command:
 
 ```bash
-ncn-m001:~ # host nid000001
 nid000001 has address 10.253.0.1
 ```
 

--- a/operations/network/dns/Manage_the_DNS_Unbound_Resolver.md
+++ b/operations/network/dns/Manage_the_DNS_Unbound_Resolver.md
@@ -250,7 +250,7 @@ Previous CSM versions associate all HSN IPs with the node `nid` alias.
 
 Example output from the `host nid000001` command:
 
-```bash
+```text
 nid000001 has address 10.253.0.1
 nid000001 has address 10.253.0.1
 nid000001 has address 10.253.0.1
@@ -261,7 +261,7 @@ Some workload managers do not handle this well so CSM 1.6 and above will only us
 
 Example output from the `host nid000001` command:
 
-```bash
+```text
 nid000001 has address 10.253.0.1
 ```
 

--- a/operations/network/dns/Manage_the_DNS_Unbound_Resolver.md
+++ b/operations/network/dns/Manage_the_DNS_Unbound_Resolver.md
@@ -10,7 +10,7 @@ This instance is accessible only within the HPE Cray EX system.
 - [Clear bad data in the Unbound ConfigMap](#clear-bad-data-in-the-unbound-configmap)
 - [Change the site DNS server](#change-the-site-dns-server)
 - [Increase the number of Unbound pods](#increase-the-number-of-unbound-pods)
-- [Change which HSN NIC is used for the nid alias](#change-which-hsn-nic-is-used-for-the-nid-alias)
+- [Change which HSN NIC is used for the node alias](#change-which-hsn-nic-is-used-for-the-node-alias)
 
 ## Check the status of the `cray-dns-unbound` pods
 
@@ -244,9 +244,9 @@ Use the following procedure to change the site DNS server that Unbound forwards 
 On large systems it may be necessary to increase the number of Unbound Pods because of the increased DNS query load.
 See [Scale `cray-dns-unbound` service](../../CSM_product_management/Post_Install_Customizations.md#scale-cray-dns-unbound-service) for more information.
 
-## Change which HSN NIC is used for the nid alias
+## Change which HSN NIC is used for the node alias
 
-Previous CSM versions associate all HSN IPs with the node nid alias.
+Previous CSM versions associate all HSN IPs with the node `nid` alias.
 
 Example output from the `host nid000001` command:
 
@@ -265,7 +265,7 @@ Example output from the `host nid000001` command:
 nid000001 has address 10.253.0.1
 ```
 
-This behaviour is configurable, use the following procedure to change the HSN NIC used for the nid alias.
+This behaviour is configurable, use the following procedure to change the HSN NIC used for the `nid` alias.
 
 1. (`ncn-mw#`) Edit the `cray-dns-unbound-manager` CronJob.
 


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

cray-dns-unbound manager associates all HSN NICs with the nid alias.

```
ncn-m001:~ # host nid001046
nid001046 has address 10.150.0.45
nid001046 has address 10.150.0.126
nid001046 has address 10.150.0.142
nid001046 has address 10.150.0.141
```

Some WLMs handle this poorly and some customers desire WLM communication with a node to happen over a single HSN interface so this behaviour is now configurable.

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
