### PR TITLE
CASMNET-1791/CASMNET-1940 - ncn_add_pre-req.py fixes

### DIFF
--- a/scripts/operations/node_management/Add_Remove_Replace_NCNs/ncn_add_pre-req.py
+++ b/scripts/operations/node_management/Add_Remove_Replace_NCNs/ncn_add_pre-req.py
@@ -332,6 +332,20 @@ def delete_kea_lease(ip, token):
     kea_resp = ingress_api('POST', kea_url, headers=kea_request_header, json=kea_delete_data)
 
 
+def delete_smd_record(smd_id, token):
+    """
+    delete ethernetInterfaces record from SMD
+    :param smd_id:
+    :param token:
+    :return:
+    """
+
+    smd_url = '/apis/smd/hsm/v2/Inventory/EthernetInterfaces/' + smd_id
+    smd_request_header = {'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json'}
+
+    smd_resp = ingress_api('DELETE', smd_url, headers=smd_request_header)
+
+
 def add_ncn_network_update(add_ncn_count, network_list, api_header, sls_networks):
     """
     Updates SLS networks by expanding static IP range and moving DHCP IP pool.
@@ -469,6 +483,8 @@ def update_smd_and_kea(ips_update_in_smd, api_header, token):
                 post_result = post_api_request('/apis/smd/hsm/v2/Inventory/EthernetInterfaces/' + smd_id, api_header, post_data)
                 # placeholder print out
                 log.warning (f'Deleting {json.dumps(post_data)} from SMD EthernetInterfaces.')
+                # delete SMD ethernetInterfaces record
+                delete_smd_record(smd_id, token)
                 log.warning (f'Deleting {ip} from kea active leases.')
                 #kea lease delete
                 delete_kea_lease(ip, token)


### PR DESCRIPTION
# Description

* [CASMNET-1791](https://jira-pro.it.hpe.com:8443/browse/CASMNET-1791) - Update `ncn_add_pre-req.py` script to actually remove the HSM ethernetInterfaces record instead of just printing that it's going to do it.
* [CASMNET-1940](https://jira-pro.it.hpe.com:8443/browse/CASMNET-1940) - Add a check to `ncn_add_pre-req.py` so it aborts if the calculated `DHCPStart` value equals or exceeds `DHCPEnd` so an invalid configuration can't be uploaded to SLS which breaks Kea. 
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
