### PR TITLE
CASMTRIAGE-6343 - fix IMS recipe create argument spelling.

### DIFF
--- a/operations/image_management/Upload_and_Register_an_Image_Recipe.md
+++ b/operations/image_management/Upload_and_Register_an_Image_Recipe.md
@@ -102,7 +102,7 @@ Download and expand recipe archives from S3 and IMS. Modify and upload a recipe 
     ```bash
     cray ims recipes create --name "My Recipe" \
             --recipe-type kiwi-ng --linux-distribution sles15 \
-            --arch x86_64 --reqire-dkms False
+            --arch x86_64 --require-dkms False
     ```
 
     Example output:

--- a/operations/image_management/Working_With_aarch64_Images.md
+++ b/operations/image_management/Working_With_aarch64_Images.md
@@ -63,7 +63,7 @@ these workflows.
     ```bash
         cray ims recipes create --name "My Recipe" \
             --recipe-type kiwi-ng --linux-distribution sles15 \
-            --arch = "aarch64" --reqire-dkms False
+            --arch = "aarch64" --require-dkms False
     ```
 
     Expected output will look something like:


### PR DESCRIPTION
# Description
https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6343

Simple spelling fix for an argument to 'cray ims recipes create' examples.

# Checklist
- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
