### PR TITLE
CASMTRIAGE-6254 print all IUF deploy manifest information in the logs

### DIFF
--- a/workflows/iuf/operations/loftsman-manifest-deploy.yaml
+++ b/workflows/iuf/operations/loftsman-manifest-deploy.yaml
@@ -107,6 +107,7 @@ spec:
                     else
                       echo "INFO Deploying loftman manifest ${manifest}"
                       manifest_deploy_output=$(loftsman ship --manifest-path /tmp/"$(basename $manifest)" --charts-repo https://packages.local/repository/charts 2>&1)
+                      echo "DEBUG $manifest_deploy_output"
                       if [ $? -ne 0 ]; then
                         manifest_deploy_output=$(echo "$manifest_deploy_output" | sed -e 's/^/ERROR /')
                         echo "ERROR There was a problem deploying the loftsman manifest ${manifest}"
@@ -141,20 +142,16 @@ spec:
                         echo "INFO Deploying loftsman manifests under $MANIFEST_PATH/"
                         manifest_files=$(ls "${MANIFEST_PATH}"/*.yml "${MANIFEST_PATH}"/*.yaml 2>/dev/null) || true
                         for manifest in $manifest_files; do
-                          deploy_output=$(deploy_manifest ${manifest} $PRODUCT_NAME)
-                          deploy_result=$?
-                          echo "DEBUG $deploy_output"
-                          if [[ $deploy_result -ne 0 ]]; then
+                          deploy_manifest ${manifest} $PRODUCT_NAME
+                          if [[ $? -ne 0 ]]; then
                             echo "ERROR Unable to deploy manifest $manifest for product $PRODUCT_NAME"
                             echo "ERROR Loftsman manifest deployment failed"
                             err=1
                           fi
                         done
                       else
-                        deploy_output=$(deploy_manifest $MANIFEST_PATH $PRODUCT_NAME)
-                        deploy_result=$?
-                        echo "DEBUG $deploy_output"
-                        if [[ $deploy_result -ne 0 ]]; then
+                        deploy_manifest $MANIFEST_PATH $PRODUCT_NAME
+                        if [[ $? -ne 0 ]]; then
                           echo "ERROR Unable to deploy manifest $MANIFEST_PATH for product $PRODUCT_NAME"
                           echo "ERROR Loftsman manifest deployment failed"
                           err=1

--- a/workflows/iuf/operations/loftsman-manifest-deploy.yaml
+++ b/workflows/iuf/operations/loftsman-manifest-deploy.yaml
@@ -107,7 +107,7 @@ spec:
                     else
                       echo "INFO Deploying loftman manifest ${manifest}"
                       manifest_deploy_output=$(loftsman ship --manifest-path /tmp/"$(basename $manifest)" --charts-repo https://packages.local/repository/charts 2>&1)
-                      echo "DEBUG $manifest_deploy_output"
+                      echo >&2 "DEBUG $manifest_deploy_output"
                       if [ $? -ne 0 ]; then
                         manifest_deploy_output=$(echo "$manifest_deploy_output" | sed -e 's/^/ERROR /')
                         echo "ERROR There was a problem deploying the loftsman manifest ${manifest}"
@@ -144,16 +144,16 @@ spec:
                         for manifest in $manifest_files; do
                           deploy_manifest ${manifest} $PRODUCT_NAME
                           if [[ $? -ne 0 ]]; then
-                            echo "ERROR Unable to deploy manifest $manifest for product $PRODUCT_NAME"
-                            echo "ERROR Loftsman manifest deployment failed"
+                            echo >&2 "ERROR Unable to deploy manifest $manifest for product $PRODUCT_NAME"
+                            echo >&2 "ERROR Loftsman manifest deployment failed"
                             err=1
                           fi
                         done
                       else
                         deploy_manifest $MANIFEST_PATH $PRODUCT_NAME
                         if [[ $? -ne 0 ]]; then
-                          echo "ERROR Unable to deploy manifest $MANIFEST_PATH for product $PRODUCT_NAME"
-                          echo "ERROR Loftsman manifest deployment failed"
+                          echo >&2 "ERROR Unable to deploy manifest $MANIFEST_PATH for product $PRODUCT_NAME"
+                          echo >&2 "ERROR Loftsman manifest deployment failed"
                           err=1
                         fi
                       fi

--- a/workflows/iuf/operations/loftsman-manifest-deploy.yaml
+++ b/workflows/iuf/operations/loftsman-manifest-deploy.yaml
@@ -142,19 +142,21 @@ spec:
                         manifest_files=$(ls "${MANIFEST_PATH}"/*.yml "${MANIFEST_PATH}"/*.yaml 2>/dev/null) || true
                         for manifest in $manifest_files; do
                           deploy_output=$(deploy_manifest ${manifest} $PRODUCT_NAME)
-                          if [[ $? != 0 ]]; then
-                            deploy_output=$(echo "$deploy_output" | sed -e 's/^/DEBUG /')
+                          deploy_result=$?
+                          echo "DEBUG $deploy_output"
+                          if [[ $deploy_result -ne 0 ]]; then
                             echo "ERROR Unable to deploy manifest $manifest for product $PRODUCT_NAME"
-                            echo -e "DEBUG Loftsman manifest deployment failed with\n\n$deploy_output"
+                            echo "ERROR Loftsman manifest deployment failed"
                             err=1
                           fi
                         done
                       else
                         deploy_output=$(deploy_manifest $MANIFEST_PATH $PRODUCT_NAME)
-                        if [[ $? != 0 ]]; then
-                          deploy_output=$(echo "$deploy_output" | sed -e 's/^/DEBUG /')
+                        deploy_result=$?
+                        echo "DEBUG $deploy_output"
+                        if [[ $deploy_result -ne 0 ]]; then
                           echo "ERROR Unable to deploy manifest $MANIFEST_PATH for product $PRODUCT_NAME"
-                          echo -e "DEBUG Loftsman manifest deployment failed with\n\n$deploy_output"
+                          echo "ERROR Loftsman manifest deployment failed"
                           err=1
                         fi
                       fi


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
This resolves [CASMTRIAGE-6254](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6254).
Before this change, the IUF deploy-product stage would run loftsman ship for manifests and only print the output if there was an error. This means no logs, IUF logs or other logs, would keep track of what charts were deployed and the status of those charts. The logs would just be empty. We want to be able to trace what was deployed and we also don't want it to appear that the stage is doing nothing when in succeeds.

This change will print the loftsman output with the DEBUG prefix. I have tested this on wasp. 
Example output is below
```
INFO Deploying loftman manifest /etc/cray/upgrade/csm/media/restore/uan-2.6.2/manifests/uan.yaml
DEBUG 2023-11-29T17:47:59Z INF Initializing the connection to the Kubernetes cluster using KUBECONFIG (system default), and context (current-context) comm
and=ship
2023-11-29T17:47:59Z INF Initializing helm client object command=ship
         |\
         | \
         |  \
         |___\      Shipping your Helm workloads with Loftsman
       \--||___/
  ~~~~~~\_____/~~~~~~~

2023-11-29T17:47:59Z INF Ensuring that the loftsman namespace exists command=ship
2023-11-29T17:47:59Z INF Loftsman will use the charts repo at https://packages.local/repository/charts as the Helm install source command=ship
2023-11-29T17:47:59Z INF Running a release for the provided manifest at /tmp/uan.yaml command=ship

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Releasing cray-uan-install v1.12.8
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

2023-11-29T17:47:59Z INF Found value overrides for chart, applying:
cray-import-config:
  import_job:
    CF_IMPORT_PRODUCT_VERSION: 2.6.2
 chart=cray-uan-install command=ship namespace=services version=1.12.8
2023-11-29T17:47:59Z INF Running helm install/upgrade with arguments: upgrade --install cray-uan-install https://packages.local/repository/charts/cray-uan
-install-1.12.8.tgz --namespace services --create-namespace --set global.chart.name=cray-uan-install --set global.chart.version=1.12.8 -f /tmp/loftsman-17
01280079/cray-uan-install-values.yaml chart=cray-uan-install command=ship namespace=services version=1.12.8
2023-11-29T17:48:00Z INF Release "cray-uan-install" has been upgraded. Happy Helming!
NAME: cray-uan-install
LAST DEPLOYED: Wed Nov 29 17:47:59 2023
NAMESPACE: services
STATUS: deployed
REVISION: 2
TEST SUITE: None
 chart=cray-uan-install command=ship namespace=services version=1.12.8
2023-11-29T17:48:00Z INF Ship status: success. Recording status, manifest to configmap loftsman-uan in namespace loftsman command=ship
2023-11-29T17:48:00Z INF Recording log data to configmap loftsman-uan-ship-log in namespace loftsman command=ship
```
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
