### PR TITLE
CASMTRIAGE-6575-1.5: One additional pod getting listed for keycloak - unexpectedly

### DIFF
--- a/operations/security_and_authentication/Keycloak_Service_Recovery.md
+++ b/operations/security_and_authentication/Keycloak_Service_Recovery.md
@@ -56,7 +56,7 @@ The following covers redeploying the Keycloak service and restoring the data.
    1. Wait for the resources to terminate.
 
       ```bash
-      watch "kubectl get pods -n services | grep keycloak | grep -v 'keycloak-users-localize\|keycloak-vcs-user'"
+      watch "kubectl get pods -n services | grep keycloak | grep -v 'keycloak-users-localize\|keycloak-vcs-user\|logical-backup'"
       ```
 
      Example output:


### PR DESCRIPTION

# Description
Fixes CASMTRIAGE-6375 for CSM 1.5
Tested on starlord

# Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
