### PR TITLE
CASMTRIAGE-6377-2-1.5 : Added zcat -f to also support manual backups …

### DIFF
--- a/operations/kubernetes/Restore_Postgres.md
+++ b/operations/kubernetes/Restore_Postgres.md
@@ -133,7 +133,7 @@ In the event that the Spire Postgres cluster must be rebuilt and the data restor
 1. (`ncn-mw#`) Restore the data.
 
     ```bash
-    kubectl exec "${POSTGRESQL}-0" -c postgres -n "${NAMESPACE}" -it -- bash -c "zcat ${DUMPFILE} | psql -U postgres" 
+    kubectl exec "${POSTGRESQL}-0" -c postgres -n "${NAMESPACE}" -it -- bash -c "zcat -f ${DUMPFILE} | psql -U postgres" 
     ```
 
     Errors such as `... already exists` can be ignored; the restore can be considered successful when it completes.
@@ -446,7 +446,7 @@ In the event that the Keycloak Postgres cluster must be rebuilt and the data res
 1. (`ncn-mw#`) Restore the data.
 
     ```bash
-    kubectl exec "${POSTGRESQL}-0" -c postgres -n "${NAMESPACE}" -it -- bash -c "zcat ${DUMPFILE} | psql -U postgres" 
+    kubectl exec "${POSTGRESQL}-0" -c postgres -n "${NAMESPACE}" -it -- bash -c "zcat -f ${DUMPFILE} | psql -U postgres" 
     ```
 
     Errors such as `... already exists` can be ignored; the restore can be considered successful when it completes.
@@ -797,7 +797,7 @@ In the event that the VCS Postgres cluster must be rebuilt and the data restored
 1. (`ncn-mw#`) Restore the data.
 
     ```bash
-    kubectl exec "${POSTGRESQL}-0" -c postgres -n "${NAMESPACE}" -it -- bash -c "zcat ${DUMPFILE} | psql -U postgres" 
+    kubectl exec "${POSTGRESQL}-0" -c postgres -n "${NAMESPACE}" -it -- bash -c "zcat -f ${DUMPFILE} | psql -U postgres" 
     ```
 
     Errors such as `... already exists` can be ignored; the restore can be considered successful when it completes.


### PR DESCRIPTION
# Description
If a manual backup is being restored, it may not be in gzipped.  Change `zcat` to `zcat -f` to support either case.

# Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
