### PR TITLE
CASMTRIAGE-6380: fix broken file reference

### DIFF
--- a/operations/spire/Restore_Spire_Postgres_without_a_Backup.md
+++ b/operations/spire/Restore_Spire_Postgres_without_a_Backup.md
@@ -21,7 +21,7 @@ Reinstall the Spire Helm chart in the event that `spire-postgres` databases cann
    master nodes) and delete the join data.
 
    ```bash
-   for ncn in $(kubectl get nodes -o name | cut -d'/' -f2); do ssh "${ncn}" systemctl stop spire-agent; ssh "${ncn}" rm /var/lib/spire/data/svid.key /var/lib/spire/agent_svid.der /var/lib/spire/bundle.der; done
+   for ncn in $(kubectl get nodes -o name | cut -d'/' -f2); do ssh "${ncn}" systemctl stop spire-agent; ssh "${ncn}" rm /var/lib/spire/data/keys.json /var/lib/spire/agent_svid.der /var/lib/spire/bundle.der; done
    ```
 
 ## Re-install the Spire Helm Chart

--- a/operations/spire/Spire_Service_Recovery.md
+++ b/operations/spire/Spire_Service_Recovery.md
@@ -88,7 +88,7 @@ The following covers redeploying the Spire service and restoring the data.
          for ncn in $(kubectl get nodes -o name | cut -d'/' -f2); do
              echo "Cleaning up NCN ${ncn}"
              ssh "${ncn}" systemctl stop spire-agent
-             ssh "${ncn}" rm -v /var/lib/spire/data/svid.key /var/lib/spire/agent_svid.der /var/lib/spire/bundle.der
+             ssh "${ncn}" rm -v /var/lib/spire/data/keys.json /var/lib/spire/agent_svid.der /var/lib/spire/bundle.der
          done
          ```
 

--- a/operations/spire/Troubleshoot_Spire_Failing_to_Start_on_NCNs.md
+++ b/operations/spire/Troubleshoot_Spire_Failing_to_Start_on_NCNs.md
@@ -39,11 +39,11 @@ renewncnjoin NODE_HOSTNAME
 
 The spire-agent service may also fail if an NCN was powered off for too long
 and its tokens expired. If this happens, delete `/var/lib/spire/agent_svid.der`,
-`/var/lib/spire/bundle.der`, and `/var/lib/spire/data/svid.key` off the NCN before
+`/var/lib/spire/bundle.der`, and `/var/lib/spire/data/keys.json` off the NCN before
 deleting the `request-ncn-join-token` `daemonset` pod.
 
 ```bash
 rm /var/lib/spire/agent_svid.der
 rm /var/lib/spire/bundle.der
-rm /var/lib/spire/data/svid.key
+rm /var/lib/spire/data/keys.json
 ```

--- a/scripts/operations/xnamevalidation.sh
+++ b/scripts/operations/xnamevalidation.sh
@@ -226,7 +226,7 @@ disable_spire_on_NCNs() {
 
   for node in $storageNodes $ncnNodes; do
     sshnh "$node" systemctl stop spire-agent
-    sshnh "$node" rm -f /var/lib/spire/data/svid.key /var/lib/spire/bundle.der /var/lib/spire/agent_svid.der
+    sshnh "$node" rm -f /var/lib/spire/data/keys.json /var/lib/spire/bundle.der /var/lib/spire/agent_svid.der
   done
 }
 

--- a/troubleshooting/known_issues/issues_with_ncn_health_checks.md
+++ b/troubleshooting/known_issues/issues_with_ncn_health_checks.md
@@ -64,7 +64,7 @@
         ```
 
   - The `spire-agent` service may also fail if an NCN was powered off for too long and its tokens are expired. If this happens, delete
-    `/var/lib/spire/agent_svid.der`, `/var/lib/spire/bundle.der`, and `/var/lib/spire/data/svid.key` off the NCN before deleting the
+    `/var/lib/spire/agent_svid.der`, `/var/lib/spire/bundle.der`, and `/var/lib/spire/data/keys.json` off the NCN before deleting the
     `request-ncn-join-token` daemon set pod.
 
 - `cfs-state-reporter service ran successfully`


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
After the spire upgrade, the svid.key file name has been replaced with keys.json. This PR fixes the broken file name references.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
