### PR TITLE
CASMTRIAGE-6273 : Adding a note to inform about the time consumption for session check

### DIFF
--- a/operations/power_management/Prepare_the_System_for_Power_Off.md
+++ b/operations/power_management/Prepare_the_System_for_Power_Off.md
@@ -249,7 +249,7 @@ HPE Cray EX System Admin Toolkit (SAT) product stream documentation (`S-8031`) f
 
 1. (`ncn-mw#`) Check for running sessions.
 
-   > *Note:* This step may take a longer time if there are many BOS sessions. Recommend to keep the sessions count Minimal to save overall time taken.
+   > *Note:* This step may take a longer time if there are many BOS sessions running. It is recommended to keep the sessions count minimal to reduce the overall time taken.
 
     ```bash
     sat bootsys shutdown --stage session-checks 2>&1 | tee -a sat.session-checks

--- a/operations/power_management/Prepare_the_System_for_Power_Off.md
+++ b/operations/power_management/Prepare_the_System_for_Power_Off.md
@@ -249,6 +249,8 @@ HPE Cray EX System Admin Toolkit (SAT) product stream documentation (`S-8031`) f
 
 1. (`ncn-mw#`) Check for running sessions.
 
+   > *Note:* This step may take a longer time if there are many BOS sessions. Recommend to keep the sessions count Minimal to save overall time taken.
+
     ```bash
     sat bootsys shutdown --stage session-checks 2>&1 | tee -a sat.session-checks
     ```


### PR DESCRIPTION
IM:CASMTRIAGE-6273
Reviewer:Ryan

<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
It takes longer time to check the BOS sessions, when there are many of them. Hence a note is added to inform the user

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.
It takes longer time to check the BOS sessions, when there are many of them. Hence a note is added to inform the user

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
