### PR TITLE
CASMTRIAGE-6381 use a file to reduce amount of parames passing to arg…

### DIFF
--- a/workflows/iuf/operations/loftsman-manifest-upload/loftsman-manifest-upload-template.yaml
+++ b/workflows/iuf/operations/loftsman-manifest-upload/loftsman-manifest-upload-template.yaml
@@ -68,10 +68,11 @@ spec:
               value: false
             - name: scriptContent
               value: |
-                CONTENT=$(echo '{{inputs.parameters.global_params}}' | jq -r '.product_manifest.current_product.manifest')
-                PARENT_DIR=$(echo '{{inputs.parameters.global_params}}' | jq -r '.stage_params."process-media".current_product.parent_directory')
-                PRODUCT=$(echo '{{inputs.parameters.global_params}}' | jq -r '.product_manifest.current_product.manifest.name')
-                VERSION=$(echo '{{inputs.parameters.global_params}}' | jq -r '.product_manifest.current_product.manifest.version')
+                echo '{{inputs.parameters.global_params}}' > global.params.data
+                CONTENT=$(cat global.params.data | jq -r '.product_manifest.current_product.manifest')
+                PARENT_DIR=$(cat global.params.data | jq -r '.stage_params."process-media".current_product.parent_directory')
+                PRODUCT=$(cat global.params.data | jq -r '.product_manifest.current_product.manifest.name')
+                VERSION=$(cat global.params.data | jq -r '.product_manifest.current_product.manifest.version')
 
                 if [[ "${CONTENT,,}" == "null" ]] || [[ "$CONTENT" == "" ]]; then
                     echo "ERROR No products found. IUF requires at least one product. Please place at least one valid product tarball in {{inputs.parameters.global_params.media_dir}} and start again from the 'process-media' stage"


### PR DESCRIPTION
Details: https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6381

<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
