### PR TITLE
CASMINST-6731: Create tool to write switch admin password to Vault; SW_ADMIN_PASSWORD variable is not required to be set for tests anymore

### DIFF
--- a/install/install_csm_services.md
+++ b/install/install_csm_services.md
@@ -116,24 +116,21 @@ state of the switch. This step is not required to configure the management netwo
 unavailable, this step can be temporarily skipped. Any automated tests that depend on the switch
 credentials being in Vault will fail until they are added.
 
-First, write the switch admin password to the `SW_ADMIN_PASSWORD` variable if it is not already
-set.
+(`pit#`) The following script will prompt for the password, write it to Vault, and then read it back
+to verify that it was written correctly.
 
 ```bash
-read -s SW_ADMIN_PASSWORD
+/usr/share/doc/csm/scripts/operations/configuration/write_sw_admin_pw_to_vault.py
 ```
 
-Once the `SW_ADMIN_PASSWORD` variable is set, run the following commands to add the switch admin
-password to Vault.
+On success, the script will exit with return code 0 and have the following final lines
+of output:
 
-```bash
-VAULT_PASSWD=$(kubectl -n vault get secrets cray-vault-unseal-keys -o json | jq -r '.data["vault-root"]' |  base64 -d)
-alias vault='kubectl -n vault exec -i cray-vault-0 -c vault -- env VAULT_TOKEN="$VAULT_PASSWD" VAULT_ADDR=http://127.0.0.1:8200 VAULT_FORMAT=json vault'
-vault kv put secret/net-creds/switch_admin admin=$SW_ADMIN_PASSWORD
+```text
+Writing switch admin password to Vault
+Password read from Vault matches what was written
+SUCCESS
 ```
-
-Note: The use of `read -s` is a convention used throughout this documentation which allows for the
-user input of secrets without echoing them to the terminal or saving them in history.
 
 ## 4. Wait for everything to settle
 

--- a/operations/network/management_network/README.md
+++ b/operations/network/management_network/README.md
@@ -41,22 +41,21 @@ including `goss-switch-bgp-neighbor-aruba-or-mellanox` use these credentials to 
 is not required to configure the management network. If Vault is unavailable, this step can be temporarily skipped. Any
 automated tests that depend on the switch credentials being in Vault will fail until they are added.
 
-1. (`ncn-mw#`) Write the switch admin password to the `SW_ADMIN_PASSWORD` variable if it is not already set.
+(`ncn-mw#`) The following script will prompt for the password, write it to Vault, and then read it back
+to verify that it was written correctly.
 
-   > The use of `read -s` is a convention used throughout this documentation which allows for the
-   > user input of secrets without echoing them to the terminal or saving them in history.
+```bash
+/usr/share/doc/csm/scripts/operations/configuration/write_sw_admin_pw_to_vault.py
+```
 
-    ```bash
-    read -s SW_ADMIN_PASSWORD
-    ```
+On success, the script will exit with return code 0 and have the following final lines
+of output:
 
-1. (`ncn-mw#`) Run the following commands to add the password to Vault.
-
-    ```bash
-    VAULT_PASSWD=$(kubectl -n vault get secrets cray-vault-unseal-keys -o json | jq -r '.data["vault-root"]' |  base64 -d)
-    alias vault='kubectl -n vault exec -i cray-vault-0 -c vault -- env VAULT_TOKEN="$VAULT_PASSWD" VAULT_ADDR=http://127.0.0.1:8200 VAULT_FORMAT=json vault'
-    vault kv put secret/net-creds/switch_admin admin=$SW_ADMIN_PASSWORD
-    ```
+```text
+Writing switch admin password to Vault
+Password read from Vault matches what was written
+SUCCESS
+```
 
 ## Starting points
 

--- a/operations/node_management/Add_Remove_Replace_NCNs/Validate_Health.md
+++ b/operations/node_management/Add_Remove_Replace_NCNs/Validate_Health.md
@@ -30,14 +30,9 @@ The following procedures can be run from any master NCN.
    pdsh -w ncn-m00[1-3],ncn-w00[1-3],ncn-s00[1-3] systemctl restart goss-servers
    ```
 
-1. (`ncn-m#`) Specify the `admin` user password for the management switches in the system.
+1. If it has not been done previously, record in Vault the `admin` user password for the management switches in the system.
 
-   > `read -s` is used in order to prevent the password from being echoed to the screen or saved in the shell history.
-
-    ```bash
-    read -s SW_ADMIN_PASSWORD
-    export SW_ADMIN_PASSWORD
-    ```
+   See [Adding switch admin password to Vault](../../network/management_network/README.md#adding-switch-admin-password-to-vault).
 
 1. (`ncn-m#`) Validate the health of the various subsystems.
 

--- a/operations/node_management/Reboot_NCNs.md
+++ b/operations/node_management/Reboot_NCNs.md
@@ -133,18 +133,13 @@ Execute the rolling NCN reboot procedure steps for the particular node type bein
         This must be run after all worker node have been rebooted, in order
         to check the BGP peering sessions on the spine switches.
 
-        1. Set `SW_ADMIN_PASSWORD` to the `admin` user password for the management switches in the system.
+        1. If it has not been done previously, record in Vault the `admin` user password for the management switches in the system.
 
-            > `read -s` is used to prevent the password from being written to the screen or the shell history.
-
-            ```bash
-            read -r -s -p "Management switch admin user password: " SW_ADMIN_PASSWORD
-            ```
+            See [Adding switch admin password to Vault](../network/management_network/README.md#adding-switch-admin-password-to-vault).
 
         1. Run the validation.
 
             ```bash
-            export SW_ADMIN_PASSWORD
             GOSS_BASE=/opt/cray/tests/install/ncn goss \
                 -g /opt/cray/tests/install/ncn/tests/goss-switch-bgp-neighbor-aruba-or-mellanox.yaml \
                 --vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml validate

--- a/operations/validate_csm_health.md
+++ b/operations/validate_csm_health.md
@@ -78,19 +78,9 @@ If `ncn-m001` is the PIT node, then run these checks on `ncn-m001`; otherwise ru
 
 1. (`ncn-m#` or `pit#`) Run the automated tests.
 
-    1. Specify the `admin` user password for the management switches in the system.
+    1. If it has not been done previously, record in Vault the `admin` user password for the management switches in the system.
 
-        This is required for some of the tests to execute.
-
-        > `read -s` is used to prevent the password from being written to the screen or the shell history.
-
-        ```bash
-        read -r -s -p "Switch admin password: " SW_ADMIN_PASSWORD
-        ```
-
-        ```bash
-        export SW_ADMIN_PASSWORD
-        ```
+        See [Adding switch admin password to Vault](network/management_network/README.md#adding-switch-admin-password-to-vault).
 
     1. Run the combined health check script.
 

--- a/scripts/operations/configuration/python_lib/vault.py
+++ b/scripts/operations/configuration/python_lib/vault.py
@@ -39,6 +39,8 @@ K8S_SECRET_NAME = "cray-vault-unseal-keys"
 K8S_SERVICE_NAME = "cray-vault"
 
 CSM_ROOT_SECRET_KEY = "csm/users/root"
+SW_ADMIN_PW_KEY = "secret/net-creds/switch_admin"
+SW_ADMIN_PW_FIELD = "admin"
 
 API_STATUS_OK_WITH_DATA = 200
 API_STATUS_OK_EMPTY = 204
@@ -282,8 +284,21 @@ class Vault():
         """
         return self.get_secret(secret_key=CSM_ROOT_SECRET_KEY, **kwargs)
 
+    def get_sw_admin_password(self) -> str:
+        """
+        Wrapper function that supplies the switch admin password key to get_secret(),
+        and extracts the SW_ADMIN_PW_FIELD field from the result
+        """
+        return self.get_secret(secret_key=SW_ADMIN_PW_KEY, must_exist=True)[SW_ADMIN_PW_FIELD]
+
     def write_csm_root_secret(self, **kwargs) -> None:
         """
         Wrapper function that supplies the CSM root secret key to write_secret()
         """
         self.write_secret(secret_key=CSM_ROOT_SECRET_KEY, **kwargs)
+
+    def write_sw_admin_password(self, pw_string: str) -> None:
+        """
+        Wrapper function that supplies the switch admin password key to write_secret()
+        """
+        self.write_secret(secret_key=SW_ADMIN_PW_KEY, secret_data={ SW_ADMIN_PW_FIELD: pw_string })

--- a/scripts/operations/configuration/write_sw_admin_pw_to_vault.py
+++ b/scripts/operations/configuration/write_sw_admin_pw_to_vault.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+"""
+Prompts the user to enter (and confirm) the switch admin password.
+Writes this password to secret/net-creds/switch_admin in Vault, and reads it
+back to verify that it matches what was written.
+"""
+
+import getpass
+import logging
+import sys
+
+from python_lib import common
+from python_lib import logger
+from python_lib.vault import Vault
+
+
+def update_password_in_vault(pw_string: str) -> None:
+    """
+    Writes the switch admin password to Vault.
+    Then read it back to verify it matches what was written
+    """
+
+    vault = Vault()
+
+    logging.info("Writing switch admin password to Vault")
+    vault.write_sw_admin_password(pw_string)
+
+    # Read back PW from Vault.
+    pw_from_vault = vault.get_sw_admin_password()
+
+    # Compare what we wrote to what we read back
+    if pw_string != pw_from_vault:
+        msg = "Password read back from Vault does NOT match what was written to Vault"
+        logging.error(msg)
+        raise common.ScriptException(msg)
+
+    logging.info("Password read from Vault matches what was written")
+    return
+        
+
+def prompt_user_for_password() -> str:
+    """
+    Get the password from the user, verify it is not blank, and get them
+    to enter it a second time to make sure it matches. Return password
+    string.
+    """
+    while True:
+        pw1 = getpass.getpass("Enter switch admin password: ")
+        if not pw1:
+            sys.stderr.write("Password may not be blank\n\n")
+            continue
+        pw2 = getpass.getpass("Retype password: ")
+        if pw1 == pw2:
+            break
+        sys.stderr.write("Passwords do not match\n\n")
+    return pw1
+
+
+def main():
+    """
+    Prompt the user for the password, write it to Vault.
+    """
+    admin_pw = prompt_user_for_password()
+    update_password_in_vault(admin_pw)
+
+
+if __name__ == '__main__':
+    logger.configure_logging(filename='/var/log/write_sw_admin_pw_to_vault.log')
+    try:
+        main()
+    except common.ScriptException as script_exc:
+        common.print_err_exit(f"{script_exc}")
+    print("SUCCESS", flush=True)

--- a/upgrade/Stage_0_Prerequisites.md
+++ b/upgrade/Stage_0_Prerequisites.md
@@ -127,19 +127,9 @@ The http proxy variables must be `unset` after the desired artifacts are downloa
 
 ## Stage 0.2 - Prerequisites
 
-1. (`ncn-m001#`) Set the `SW_ADMIN_PASSWORD` environment variable.
+1. If it has not been done previously, record in Vault the `admin` user password for the management switches in the system.
 
-   Set it to the password for `admin` user on the switches. This is needed for preflight tests within the check script.
-
-   > **NOTE:** `read -s` is used to prevent the password from being written to the screen or the shell history.
-
-   ```bash
-   read -s SW_ADMIN_PASSWORD
-   ```
-
-   ```bash
-   export SW_ADMIN_PASSWORD
-   ```
+   See [Adding switch admin password to Vault](../operations/network/management_network/README.md#adding-switch-admin-password-to-vault).
 
 1. (`ncn-m001#`) Set the `NEXUS_PASSWORD` variable **only if needed**.
 

--- a/upgrade/Stage_1.md
+++ b/upgrade/Stage_1.md
@@ -29,19 +29,9 @@ after a break, always be sure that a typescript is running before proceeding.
 During this stage there will be a brief (approximately five minutes) window where pods with Persistent Volumes (`PV`s) will not be able to migrate between nodes.
 This is due to a redeployment of the Ceph `csi` provisioners into namespaces, in order to accommodate the newer charts and a better upgrade strategy.
 
-1. (`ncn-m001#`) Set the `SW_ADMIN_PASSWORD` environment variable.
+1. If it has not been done previously, record in Vault the `admin` user password for the management switches in the system.
 
-   Set it to the `admin` user password for the switches. This is required for post-upgrade tests.
-
-   > `read -s` is used to prevent the password from being written to the screen or the shell history.
-
-   ```bash
-   read -s SW_ADMIN_PASSWORD
-   ```
-
-   ```bash
-   export SW_ADMIN_PASSWORD
-   ```
+   See [Adding switch admin password to Vault](../operations/network/management_network/README.md#adding-switch-admin-password-to-vault).
 
 1. (`ncn-m001#`) Ensure that the `CSM_RELEASE` variable is set to the **target** CSM version of this upgrade.
 

--- a/upgrade/prepare_for_upgrade.md
+++ b/upgrade/prepare_for_upgrade.md
@@ -59,28 +59,9 @@ for details.
 
 ### 3. Adding switch admin password to Vault
 
-If CSM has been installed and Vault is running, add the switch credentials into Vault. Certain
-tests (for example, `goss-switch-bgp-neighbor-aruba-or-mellanox`) use these credentials to test the
-state of the switch. This step is not required to configure the management network. If Vault is
-unavailable, then this step can be temporarily skipped. Any automated tests that depend on the switch
-credentials being in Vault will fail until they are added.
+If it has not been done previously, record in Vault the `admin` user password for the management switches in the system.
 
-1. (`ncn-mw#`) Write the switch admin password to the `SW_ADMIN_PASSWORD` variable if it is not already set.
-
-   ```bash
-   read -s SW_ADMIN_PASSWORD
-   ```
-
-   > Note: The use of `read -s` is a convention used throughout this documentation which allows for the
-   > user input of secrets without echoing them to the terminal or saving them in history.
-
-1. (`ncn-mw#`) Run the following commands to add the switch admin password to Vault.
-
-   ```bash
-   VAULT_PASSWD=$(kubectl -n vault get secrets cray-vault-unseal-keys -o json | jq -r '.data["vault-root"]' |  base64 -d)
-   alias vault='kubectl -n vault exec -i cray-vault-0 -c vault -- env VAULT_TOKEN="$VAULT_PASSWD" VAULT_ADDR=http://127.0.0.1:8200 VAULT_FORMAT=json vault'
-   vault kv put secret/net-creds/switch_admin admin=$SW_ADMIN_PASSWORD
-   ```
+See [Adding switch admin password to Vault](../operations/network/management_network/README.md#adding-switch-admin-password-to-vault).
 
 ### 4. Ensure SNMP is configured on the management network switches
 <!-- snmp-authentication-tag -->

--- a/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh
+++ b/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh
@@ -210,16 +210,11 @@ function uploadWorkflowTemplates() {
 
 function createWorkflowPayload() {
   if [[ ${nodeType} == "worker" ]]; then
-    # ask for switch password if it's not set
-    if [[ -z ${SW_ADMIN_PASSWORD} ]]; then
-      read -r -s -p "Switch password:" SW_ADMIN_PASSWORD
-    fi
     echo
     cat << EOF
 {
 "dryRun": ${dryRun},
 "hosts": ${jsonArray},
-"switchPassword": "${SW_ADMIN_PASSWORD}",
 "imageId": "${imageId}",
 "bootTimeoutInSeconds": ${rebootTimeout},
 "desiredCfsConfig": "${desiredCfsConfig}"$(if [[ -n ${labels} ]]; then echo ", \"labels\": ${labels}"; fi)

--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -69,11 +69,6 @@ if [[ -z ${CSM_RELEASE} ]]; then
   exit 1
 fi
 
-if [[ -z ${SW_ADMIN_PASSWORD} ]]; then
-  echo "SW_ADMIN_PASSWORD environment variable has not been set"
-  exit 1
-fi
-
 if [[ -z ${CSM_ARTI_DIR} ]]; then
   echo "CSM_ARTI_DIR environment variable has not been set"
   echo "make sure you have run: prepare-assets.sh"

--- a/workflows/ncn/worker/worker.rebuild.yaml
+++ b/workflows/ncn/worker/worker.rebuild.yaml
@@ -208,8 +208,6 @@ spec:
                 value: {{$value}}
               - name: dryRun
                 value: "{{$.DryRun}}"
-              - name: switchPassword
-                value: "{{$.SwitchPassword}}"
           {{- end }}
           - name: after-all
             dependencies:

--- a/workflows/templates/post-rebuild-worker.yaml
+++ b/workflows/templates/post-rebuild-worker.yaml
@@ -34,7 +34,6 @@ spec:
         parameters:
           - name: targetNcn
           - name: dryRun
-          - name: switchPassword
       dag:
         tasks:
         - name: worker-ensure-testing-rpms
@@ -62,8 +61,7 @@ spec:
               - name: scriptContent
                 value: |
                   ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null {{inputs.parameters.targetNcn}} \
-                    -t "SW_ADMIN_PASSWORD='{{inputs.parameters.switchPassword}}' \
-                        GOSS_BASE=/opt/cray/tests/install/ncn \
+                    -t "GOSS_BASE=/opt/cray/tests/install/ncn \
                         TARGET_NCN={{inputs.parameters.targetNcn}} \
                         goss -g /opt/cray/tests/install/ncn/suites/ncn-upgrade-tests-worker.yaml \
                           --vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml validate \


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
Rather than using commands which expose credentials to any user looking at the running processes, this PR creates a small script to write the switch admin password to Vault.

It also updates the places in the docs where this procedure is done to instead use the script.

It also removes the various places where this value is stored and exported in an environment variable, as this is no longer required for the test (the test reads it directly from Vault).

In theory this could maybe also be backported to CSM 1.4, but for now I'm just doing it for CSM 1.5 and 1.6, because I am not sure if all versions of CSM 1.4 have the BGP test that does the automatic password detection from Vault.

1.5 backport PR: 

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
