### PR TITLE
CASMTRIAGE-6385 : Stuck while terminating nexus-data PVC (Nexus recovery)

### DIFF
--- a/operations/package_repository_management/Nexus_Export_and_Restore.md
+++ b/operations/package_repository_management/Nexus_Export_and_Restore.md
@@ -49,6 +49,8 @@ because of the size it will take follow the steps on [Nexus Space Cleanup](Nexus
 The restore will delete any changes made to Nexus after the backup was taken. The restore takes around half the time that the export took
 (for example, if the export took two hours then the restore would take around one hour). While the restore is underway, Nexus is unavailable.
 
+> If an export has been taken recently, then the export job may still exist and will need to be deleted prior to restoring. See [Cleanup export job](#cleanup-export-job).
+
 (`ncn-m#`) To restore Nexus to the state of the backup, run the restore script on any master node where the latest CSM documentation is installed. See
 [Check for latest documentation](../../update_product_stream/README.md#check-for-latest-documentation).
 


### PR DESCRIPTION

# Description
Resolves [CASMTRIAGE-6385](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6385) for CSM 1.6
Tested on starlord

# Checklist

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
