### PR TITLE
CASMPET-6873 add loop to retry ceph health check after storage node upgrade

### DIFF
--- a/workflows/templates/storage.ceph-health-check.yaml
+++ b/workflows/templates/storage.ceph-health-check.yaml
@@ -45,4 +45,17 @@ spec:
                   value: "{{inputs.parameters.dryRun}}"  
                 - name: scriptContent
                   value: |
-                    /opt/cray/tests/install/ncn/scripts/ceph-service-status.sh -v true
+                    sleep_time=15
+                    max_retries=45
+                    attempt=1
+                    while [[ $attempt -le $max_retries ]]; do
+                      echo -e "\nChecking Ceph health status. Attempt ${attempt}/${max_retries}..."
+                      if ! /opt/cray/tests/install/ncn/scripts/ceph-service-status.sh -v true; then
+                        attempt=$(( attempt + 1 ))
+                        sleep $sleep_time
+                      else
+                        exit 0
+                      fi
+                    done
+                    echo "ERROR Ceph is unhealthy. Please run 'Ceph health detail' and investigate what is causing Ceph to be unhealthy".
+                    exit 1


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
During the storage node upgrade, there is an argo task which checks ceph health. This task only runs the health check once. If it fails, then argo starts up a new pod and retries the check. This means that argo is continuously creating new pods to check Ceph health. Usually, when this check is run, Ceph will not be healthy and will need some time to recover from the node upgrade. I have added a loop to this check so that one argo pod will check ceph health multiple times and sleep in between checks. This is beneficial because argo is not continuously creating pods. The user also has a better experience because the user will no longer see an argo pod keep failing and they will not think that something is wrong.

Tested on Beau
- I tested the script independently of argo
- I tested this change within an argo workflow that is created the same way as the storage node upgrade workflow. I saw that the script performed correctly when ceph was healthy and when ceph was not healthy.

- Resolves [CASMPET-6873](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6873)

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
