### PR TITLE
CASMPET-6873 add loop to retry ceph health check after storage node upgrade

### DIFF
--- a/workflows/templates/storage.ceph-health-check.yaml
+++ b/workflows/templates/storage.ceph-health-check.yaml
@@ -45,4 +45,17 @@ spec:
                   value: "{{inputs.parameters.dryRun}}"  
                 - name: scriptContent
                   value: |
-                    /opt/cray/tests/install/ncn/scripts/ceph-service-status.sh -v true
+                    sleep_time=15
+                    max_retries=45
+                    attempt=1
+                    while [[ $attempt -le $max_retries ]]; do
+                      echo -e "\nChecking Ceph health status. Attempt ${attempt}/${max_retries}..."
+                      if ! /opt/cray/tests/install/ncn/scripts/ceph-service-status.sh -v true; then
+                        attempt=$(( attempt + 1 ))
+                        sleep $sleep_time
+                      else
+                        exit 0
+                      fi
+                    done
+                    echo "ERROR Ceph is unhealthy. Please run 'Ceph health detail' and investigate what is causing Ceph to be unhealthy".
+                    exit 1


### PR DESCRIPTION
## Description 

During the storage node upgrade, there is an argo task which checks ceph health. This task only runs the health check once. If it fails, then argo starts up a new pod and retries the check. This means that argo is continuously creating new pods to check Ceph health. Usually, when this check is run, Ceph will not be healthy and will need some time to recover from the node upgrade. I have added a loop to this check so that one argo pod will check ceph health multiple times and sleep in between checks. This is beneficial because argo is not continuously creating pods. The user also has a better experience because the user will no longer see an argo pod keep failing and they will not think that something is wrong.

Tested on Beau

I tested the script independently of argo

I tested this change within an argo workflow that is created the same way as the storage node upgrade workflow. I saw that the script performed correctly when ceph was healthy and when ceph was not healthy.

Resolves [CASMPET-6873](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6873)