### PR TITLE
CASMCMS-8877: Fix minor CFS documentation bugs

### DIFF
--- a/operations/configuration_management/CFS_Configurations.md
+++ b/operations/configuration_management/CFS_Configurations.md
@@ -121,7 +121,7 @@ Example output:
 }
 ```
 
-(`ncn-mw#`) If the branch information does not need to be stored, use `--update-branches`.
+(`ncn-mw#`) If the branch information does not need to be stored, use `--drop-branches`.
 This is useful in cases where the branch is being provided to allow CFS to find the correct commit, but the branch should not be stored to avoid accidentally updating the commit ID in the future.
 
 ```bash

--- a/operations/configuration_management/CFS_Sources.md
+++ b/operations/configuration_management/CFS_Sources.md
@@ -56,7 +56,7 @@ Example output
 }
 ```
 
-## Update a CFS configuration
+## Update a CFS source
 
 (`ncn-mw#`) Use the `cray cfs v3 sources update` command.
 


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

* Replace a reference to incorrect `--update-branches` option with the correct `--drop-branches` option.
* Change "CFS configuration" to "CFS source" in CFS Sources documentation.

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
