### PR TITLE
CASMINST-6671 Release notes for CSM 1.5

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -244,8 +244,6 @@ Kibana
 Kubernetes
 Kyverno
 LAN
-LAN
-LANs
 LANs
 LNet
 LVM
@@ -275,6 +273,7 @@ MetalLB's
 Mi100
 Motivair
 Multus
+Multitenancy
 MyMellanox
 NCN
 NCN-UAN

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,7 +11,7 @@
 * Updates to all services using `etcd` cluster to migrate to use of `bitnami-etcd`
 * Support for old and new `spire` versions running simultaneously toward zero downtime upgrades
 * Technical Preview Support for `spire` `TPM-based` remote node attestation
-* V1 of Power Control Service (PCS) is released
+* Power Control Service (PCS) is released
 * The V3 CFS API is now available, including support for paging, external repository "sources", and new options for debugging.
 * Update of all services using `postgres` to support new versions of `postgres` and `postgres-operator`
 * `BOS V2` is the default

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,10 +11,10 @@
 * Updates to all services using `etcd` cluster to migrate to use of `bitnami-etcd`
 * Support for old and new `spire` versions running simultaneously toward zero downtime upgrades
 * Technical Preview Support for `spire` `TPM-based` remote node attestation
-* v1 of Power Control Service (PCS) is active.
-* The v3 CFS API is now available, including support for paging, external repository "sources", and new options for debugging.
+* V1 of Power Control Service (PCS) is released
+* The V3 CFS API is now available, including support for paging, external repository "sources", and new options for debugging.
 * Update of all services using `postgres` to support new versions of `postgres` and `postgres-operator`
-* Required changes in multiple places to make `bosV2` the default
+* `BOS V2` is the default
 * Update `spire` version
 * Update version of `cert-manager`
 * Upgrade to `Kubernetes` version 1.22
@@ -35,7 +35,7 @@
 * Added support for specifying IMS Image and Recipe architecture in IUF
 * Upgraded node-images to SLES15SP5
 * Updated Spire Server to work with TPM
-* Added Improved error logging for`bos` command
+* Added improved error logging for`bos` command
 * Added a method to stop `CFS/Batcher` and cancel configuration for in-flight customizations
 * Added support for git `submodules` in CFS runs
 * Added support for `ARM 64` based builds through emulation
@@ -54,7 +54,7 @@
 * Add switches in HSM to PCS and allow for power reset actions
 * Updated HMS discovery process to populate a node's architecture when making the information available via Redfish
 * Update to `ilorest-4.1.0.0` for `Gen11` Support
-* Support for ARM64 added in `metal-ipxe`
+* Support for ARM64 added
 * Hardware validation of the EX2500 Cabinet
 * Support JL627A switches as an edge router for BI-CAN
 
@@ -130,10 +130,10 @@
 * Addition of a CSM cabling page for the management and edge network
 * Added system recovery procedure for `keycloak`
 * Updates in several places as a result of migration to `bitnami-etcd`
-* Updates to BOS documentation to replace CAPMC references
+* Update to BOS documentation to replace CAPMC references
 * Update to IUF upgrade with CSM workflow diagram and documentation
-* Updates to `postgres` backup procedures
-* Updates to NCN Customization and Personalization documentation to use `sat-bootprep`
+* Update to `postgres` backup procedures
+* Update to NCN Customization and Personalization documentation to use `sat-bootprep`
 * Remove known issue about restored etcd clusters missing PVC
 * Added SNMP setup for all switches to Install/Update instructions
 * Updated Keycloak documentation to use CMN LB for administrative tasks
@@ -192,5 +192,3 @@ For a list of all deprecated CSM features, see [Deprecations](introduction/depre
 For a list of all features with an announced removal target, see [Removals](introduction/deprecated_features/README.md#removals)
 
 ## Known issues
-
-### Security vulnerability exceptions in CSM 1.5

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -145,8 +145,8 @@
 
 * Fix for when QLogic adapter firmware stops responding then fails recovery causing the node to crash.
 ** Fixes
-*** QLogic/Marvel Driver Update - RPM: qlgc-fastlinq-kmp-default-8.74.1.0_k5.14.21_150500.53-1.sles15sp5.x86_64.rpm
-*** SUSE Kernel Update: Version: 5.14.21-150400.24.92.1.27088.1.PTF.1215587
+*** QLogic/Marvel Driver Update - RPM: `qlgc-fastlinq-kmp-default-8.74.1.0_k5.14.21_150500.53-1.sles15sp5.x86_64.rpm`
+*** SUSE Kernel Update: Version: `5.14.21-150400.24.92.1.27088.1.PTF.1215587`
 * Fix for invalid `preinstall` `VCS` check in IUF in the event of a fresh install
 * Fix deployment failure due to DNS timeouts when `max_fails=0` is set in `coredns`
 * Fixed an issue on upgrade of master NCNs due to not generating the `admin-tools` keyring

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -24,7 +24,7 @@
 * For Bifurcated CAN update `cray-sysmgmt-health` to use the new API Gateways
 * For Bifurcated CAN update `gitea-vcs-web` to use CMN Only Istio Gateway
 * For Bifurcated CAN update `gitea-vcs-external` to use CMN Only Istio Gateway
-* Improved logging in `cray-nls` based on StageOutput
+* Improved logging in `cray-nls` based on `StageOutput`
 * IMS - created an `arm64` version of the barebones recipe
 * Support for large system `ARP` configuration for first boot and DHCP
 * Hardware Discovery Process populates a nodes's architecture
@@ -34,14 +34,14 @@
 * Added support for specifying `IMS` Image and Recipe architecture in IUF
 * Upgraded node-images to SLES15SP5
 * Updated Spire Server to work with TPM
-* Added Improved error logging for cray `bos` command
+* Added Improved error logging for`bos` command
 * Added a method to stop `CFS/Batcher` and cancel configuration for in-flight customizations
-* Added support for git submodules in `cfs` runs
+* Added support for git `submodules` in `cfs` runs
 * Added support for `ARM 64` based builds through emulation
 * Enhanced Multi-Tenancy Phase II support
 * Improved `IUF` Logging
 * Created Networking Red Light / Green Light Dashboard
-* Implemented highly available Prometheus setup with long term storage capabilities with Thanos
+* Implemented highly available Prometheus setup with long term storage capabilities with `Thanos`
 
 ### Monitoring
 
@@ -57,8 +57,8 @@
 
 * Add switches in HSM to PCS and allow for power reset actions
 * Updated HMS discovery process to populate a node's architecture when making the information available via Redfish
-* Update to `ilorest 4.1.0.0` for Gen11 Support
-* Support for `arm64` added in metal-ipxe
+* Update to `ilorest 4.1.0.0` for `Gen11` Support
+* Support for `arm64` added in `metal-ipxe`
 * Hardware validation of the EX2500 Cabinet
 * Support `JL627A` switches as an edge router for BI-CAN
 
@@ -105,8 +105,8 @@
 * Updates to `libfreebl3-hmac`, `libfreebl3`, `tar`, and `wireshark` in `NCN` image for `CVEs`
 * `Metal-basecamp` and `cray-site-init` dependency updates
 * Additional of `kyverno` and network policies to ensure some secure controls over `mqtt` namespace
-* cf-gitea-import: Use CSM-provided alpine base image to resolve vulnerabilities
-* Updated metacontroller:v4.4.0 to address CVE's
+* `cf-gitea-import`: Use CSM-provided alpine base image to resolve vulnerabilities
+* Updated `metacontroller:v4.4.0` to address CVE's
 * Fixed `CVE-2023-0386` in CSM 1.5 NCN Images
 * Fixed `CVE-2023-32233` in CSM 1.5 NCN Images
 * Developed OPA Policy to force Keycloak admin operations through CMN
@@ -115,7 +115,7 @@
 * Moved `istio-ingressgateway-cmn` service to use the customer-admin-gateway
 * Kyverno Upgrade Needed for `N-2` Support Policy
 * Fixed Improper Certificate Validation CVE in `cfs-operator`
-* Fixed Regular Expression DoS CVE in cfs-ara
+* Fixed Regular Expression DoS CVE in `cfs-ara`
 * Addressed `Zenbleed` CVE on NCNs
 * Addressed `CVE-2023-38545` (curl & `libcurl`) on NCNs
 * Added Default RBAC Role for Telemetry API
@@ -160,9 +160,9 @@
 * Fix issue with `etcd_cluster_balance.sh` reporting failure when 3 pods are healthy and 4th is terminating
 * Fixed issue where upgrading the `cray-dns-unbound` Helm chart should not wipe the DNS records
 * Fixed an incorrectly written Network Policy in `cray-drydock` for `mqtt/spire` communication
-* Fixed an issue where restarting `kea` on large systems wipes DNS records from configmap
+* Fixed an issue where restarting `kea` on large systems wipes DNS records from `configmap`
 * Updated Unbound to not forward `.hsn` queries to the site DNS
-* Fixed when `cray-externaldns-manager` crashes when used with external-dns 0.13
+* Fixed when `cray-externaldns-manager` crashes when used with `external-dns 0.13`
 * Fixed an issue where Weave pods were not starting after upgrading to CSM V1.4 content
 * Fixed `PowerDNS` server `TLD` is missing `NS` delegation records for subdomains
 * Fixed an issue where FRU Tracking doesn't create a detected event after a removed event
@@ -171,13 +171,13 @@
 
 * The `ipv4-resolvers` option has been removed for `CSI` as it is not used
 * Removed `ARS from Cray CLI and BSS API spec
-* Removed deprecated `BOS v1 cfs` fields from session templates
+* Removed deprecated `BOS v1` `cfs` fields from session templates
 
 For a list of all deprecated CSM features, see [Deprecations](introduction/deprecated_features/README.md#deprecations).
 
 ## Removals
 
-* Remove `TRS operator` for fresh installs and on upgrades
+* Remove `TRS-operator` for fresh installs and on upgrades
 * Remove `metal-net` scripts as they are no longer used
 * Remove `etcd-operator` as a result of migration to use `bitnami-etcd`
 * [CRUS](glossary.md#compute-rolling-upgrade-service-crus)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -39,11 +39,15 @@
 * Added a method to stop `CFS/Batcher` and cancel configuration for in-flight customizations
 * Added support for git `submodules` in CFS runs
 * Added support for `ARM 64` based builds through emulation
-* Enhanced Multi-Tenancy Phase II support
 * Improved IUF Logging
 * Created Networking Red Light / Green Light Dashboard
 * Removed clear text switch passwords from the `cray-sysmgmt-health-canu-test` pod log
 * Ceph nodes run user facing docker registry that is writable anonymously
+* Added support for NID allocation defragmentation
+* Multi-tenancy: Vault Transit (KMS) Support for Encrypted Secrets in VCS
+* Multi-tenancy: Enable Tenant ID + Tenant Admin AuthZ Awareness for API Ingress (OPA policy)
+* Multitenancy: Enable Tenant ID + Tenant Admin AuthZ Awareness for API Ingress
+* Multitenancy: BOS Support for boot, reboot, node power on and off in tenant
 
 ### New Hardware Support
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -144,9 +144,9 @@
 ## Bug fixes
 
 * Fix for when QLogic adapter firmware stops responding then fails recovery causing the node to crash.
-** Fixes
-*** QLogic/Marvel Driver Update - RPM: `qlgc-fastlinq-kmp-default-8.74.1.0_k5.14.21_150500.53-1.sles15sp5.x86_64.rpm`
-*** SUSE Kernel Update: Version: `5.14.21-150400.24.92.1.27088.1.PTF.1215587`
+    * Fixes
+        * QLogic/Marvel Driver Update - RPM: `qlgc-fastlinq-kmp-default-8.74.1.0_k5.14.21_150500.53-1.sles15sp5.x86_64.rpm`
+        * SUSE Kernel Update: Version: `5.14.21-150400.24.92.1.27088.1.PTF.1215587`
 * Fix for invalid `preinstall` `VCS` check in IUF in the event of a fresh install
 * Fix deployment failure due to DNS timeouts when `max_fails=0` is set in `coredns`
 * Fixed an issue on upgrade of master NCNs due to not generating the `admin-tools` keyring

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -34,6 +34,14 @@
 * Added support for specifying IMS Image and Recipe architecture in IUF
 * Upgraded node-images to SLES15SP5
 * Updated Spire Server to work with TPM
+* Added Improved error logging for cray bos command
+* Added a method to stop CFS/Batcher and cancel configuration for in-flight customizations
+* Added support for git submodules in cfs runs
+* Added support for ARM 64 based builds through emulation
+* Enhanced Multi-Tenancy Phase II support
+* Improved IUF Logging
+* Created Networking Red Light / Green Light Dashboard
+* Implemented highly available Prometheus setup with long term storage capabilities with Thanos
 
 ### Monitoring
 
@@ -46,10 +54,14 @@
 * Ceph nodes run user facing docker registry that is writable anonymously
 
 ### New hardware support
+
 * Add switches in HSM to PCS and allow for power reset actions
 * Updated HMS discovery process to populate a node's architecture when making the information available via Redfish
 * Update to ilorest 4.1.0.0 for Gen11 Support
-* Support for arm64 added in metal-ipxe 
+* Support for arm64 added in metal-ipxe
+* Hardware vailidation of the EX2500 Cabinet
+* Support JL627A switches as an edge router for BI-CAN
+* 
 
 ### Automation improvements
 
@@ -107,6 +119,7 @@
 * Fixed Regular Expression DoS CVE in cfs-ara
 * Addressed Zenbleed CVE on NCNs
 * Addressed CVE-2023-38545 (curl & libcurl) on NCNs
+* Added Default RBAC Role for Telemetry API
   
 ### Customer-requested enhancements
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -40,7 +40,6 @@
 * Enhanced Multi-Tenancy Phase II support
 * Improved IUF Logging
 * Created Networking Red Light / Green Light Dashboard
-* Used Thanos to Implement a highly available Prometheus setup with long term storage capabilities
 
 * ### Monitoring
 
@@ -169,7 +168,7 @@
 
 * The `ipv4-resolvers` option has been removed for CSI as it is not used
 * CAPMC](glossary.md#cray-advanced-platform-monitoring-and-control-capmc)
-* Removed ARS from Cray CLI and BSS API spec
+* Removed ARS from Cray CLI and BSS API specification
 * Removed deprecated BOS V1 CFS fields from session templates
 
 For a list of all deprecated CSM features, see [Deprecations](introduction/deprecated_features/README.md#deprecations).

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -20,32 +20,32 @@
 * Upgrade `argo` version to pick up bug-fixes
 * BOS implement OPA policies for Multi-Tenancy
 * Create DNAME records in PowerDNS
-* For Bifurcated CAN update kiali to use the new API Gateways
-* For Bifurcated CAN update cray-sysmgmt-health to use the new API Gateways
-* For Bifurcated CAN update gitea-vcs-web to use CMN Only Istio Gateway
-* For Bifurcated CAN update gitea-vcs-external to use CMN Only Istio Gateway
-* Improved logging in cray-nls based on StageOutput
-* IMS - created an arm64 version of the barebones recipe
-* Support for large system ARP configuration for first boot and DHCP
+* For Bifurcated CAN update `kiali` to use the new API Gateways
+* For Bifurcated CAN update `cray-sysmgmt-health` to use the new API Gateways
+* For Bifurcated CAN update `gitea-vcs-web` to use CMN Only Istio Gateway
+* For Bifurcated CAN update `gitea-vcs-external` to use CMN Only Istio Gateway
+* Improved logging in `cray-nls` based on StageOutput
+* IMS - created an `arm64` version of the barebones recipe
+* Support for large system `ARP` configuration for first boot and DHCP
 * Hardware Discovery Process populates a nodes's architecture
-* Argo-driven Upgrade Automation for K8s Storage Nodes
-* An arm64 version of the barebones recipe has been created
+* Argo-driven Upgrade Automation for `K8s` Storage Nodes
+* An `arm64` version of the barebones recipe has been created
 * SLS: Added caching to improve performance and robustness
-* Added support for specifying IMS Image and Recipe architecture in IUF
+* Added support for specifying `IMS` Image and Recipe architecture in IUF
 * Upgraded node-images to SLES15SP5
 * Updated Spire Server to work with TPM
-* Added Improved error logging for cray bos command
-* Added a method to stop CFS/Batcher and cancel configuration for in-flight customizations
-* Added support for git submodules in cfs runs
-* Added support for ARM 64 based builds through emulation
+* Added Improved error logging for cray `bos` command
+* Added a method to stop `CFS/Batcher` and cancel configuration for in-flight customizations
+* Added support for git submodules in `cfs` runs
+* Added support for `ARM 64` based builds through emulation
 * Enhanced Multi-Tenancy Phase II support
-* Improved IUF Logging
+* Improved `IUF` Logging
 * Created Networking Red Light / Green Light Dashboard
 * Implemented highly available Prometheus setup with long term storage capabilities with Thanos
 
 ### Monitoring
 
-* Removed clear text switch passwords from the cray-sysmgmt-health-canu-test pod log
+* Removed clear text switch passwords from the `cray-sysmgmt-health-canu-test` pod log
 
 ### Networking
 
@@ -57,19 +57,19 @@
 
 * Add switches in HSM to PCS and allow for power reset actions
 * Updated HMS discovery process to populate a node's architecture when making the information available via Redfish
-* Update to ilorest 4.1.0.0 for Gen11 Support
-* Support for arm64 added in metal-ipxe
+* Update to `ilorest 4.1.0.0` for Gen11 Support
+* Support for `arm64` added in metal-ipxe
 * Hardware validation of the EX2500 Cabinet
-* Support JL627A switches as an edge router for BI-CAN
+* Support `JL627A` switches as an edge router for BI-CAN
 
 ### Automation improvements
 
-* Updates to etcd health checks due to replacement of `etcd` vendor to `bitnami-etcd`
+* Updates to `etcd` health checks due to replacement of `etcd` vendor to `bitnami-etcd`
 * `IUF` stage for `management-nodes-rollout` consumes logs from `ncn-rebuild`
 * Add a test to check taints on master nodes
 * Augment `postgres` backup `goss` test to also check for `cronjob`
-* Argo-driven Upgrade Automation for K8s Storage Nodes
-* ceph upgrade added to automated storage upgrade  
+* Argo-driven Upgrade Automation for `K8s` Storage Nodes
+* `ceph` upgrade added to automated storage upgrade  
 
 ### Base platform component upgrades
 
@@ -107,23 +107,23 @@
 * Additional of `kyverno` and network policies to ensure some secure controls over `mqtt` namespace
 * cf-gitea-import: Use CSM-provided alpine base image to resolve vulnerabilities
 * Updated metacontroller:v4.4.0 to address CVE's
-* Fixed CVE-2023-0386 in CSM 1.5 NCN Images
-* Fixed CVE-2023-32233 in CSM 1.5 NCN Images
+* Fixed `CVE-2023-0386` in CSM 1.5 NCN Images
+* Fixed `CVE-2023-32233` in CSM 1.5 NCN Images
 * Developed OPA Policy to force Keycloak admin operations through CMN
-* Updated cfs-ara:1.0.2 to address CVE's
-* Updated hms-shcd-parser:1.8.0 to address CVE's
-* Moved istio-ingressgateway-cmn service to use the customer-admin-gateway
-* Kyverno Upgrade Needed for N-2 Support Policy
-* Fixed Improper Certificate Validation CVE in cfs-operator
+* Updated `cfs-ara:1.0.2` to address CVE's
+* Updated `hms-shcd-parser:1.8.0` to address CVE's
+* Moved `istio-ingressgateway-cmn` service to use the customer-admin-gateway
+* Kyverno Upgrade Needed for `N-2` Support Policy
+* Fixed Improper Certificate Validation CVE in `cfs-operator`
 * Fixed Regular Expression DoS CVE in cfs-ara
-* Addressed Zenbleed CVE on NCNs
-* Addressed CVE-2023-38545 (curl & libcurl) on NCNs
+* Addressed `Zenbleed` CVE on NCNs
+* Addressed `CVE-2023-38545` (curl & `libcurl`) on NCNs
 * Added Default RBAC Role for Telemetry API
   
 ### Customer-requested enhancements
 
 * Keycloak upgrade for CVE fixes
-* Enable bonded NMN connections for the UANs
+* Enable bonded `NMN` connections for the UANs
 
 ### Documentation enhancements
 
@@ -156,24 +156,22 @@
 * Update `tds_lower_cpu_requests.sh` script for `opensearch-masters` due to CPU it eats
 * Fixed bug where `PCS` can become out of sync with `etcd`
 * Removed `subPath` `volumeMount` in the `multus` `daemonset` to avoid being stuck in termination
-* Improve existing image check logic for ims-python-helper
-* Fix issue with etcd_cluster_balance.sh reporting failure when 3 pods are healthy and 4th is terminating
-* Fixed issue where upgrading the cray-dns-unbound Helm chart should not wipe the DNS records
-* Fixed an incorrectly written Network Policy in cray-drydock for mqtt/spire communication
-* Fixed an issue where restarting kea on large systems wipes DNS records from configmap
-* Updated Unbound to not forward .hsn queries to the site DNS
-* Fixed when cray-externaldns-manager crashes when used with external-dns 0.13
-* Fixed Unbound to not forward .hsn queries to the site DNS
+* Improve existing image check logic for `ims-python-helper`
+* Fix issue with `etcd_cluster_balance.sh` reporting failure when 3 pods are healthy and 4th is terminating
+* Fixed issue where upgrading the `cray-dns-unbound` Helm chart should not wipe the DNS records
+* Fixed an incorrectly written Network Policy in `cray-drydock` for `mqtt/spire` communication
+* Fixed an issue where restarting `kea` on large systems wipes DNS records from configmap
+* Updated Unbound to not forward `.hsn` queries to the site DNS
+* Fixed when `cray-externaldns-manager` crashes when used with external-dns 0.13
 * Fixed an issue where Weave pods were not starting after upgrading to CSM V1.4 content
-* Fixed PowerDNS server TLD is missing NS delegation records for subdomains
-* fixed an issue where FRU Tracking doesn't create a detected event after a removed event
+* Fixed `PowerDNS` server `TLD` is missing `NS` delegation records for subdomains
+* Fixed an issue where FRU Tracking doesn't create a detected event after a removed event
   
 ## Deprecations
 
 * The `ipv4-resolvers` option has been removed for `CSI` as it is not used
-* [CAPMC](glossary.md#cray-advanced-platform-monitoring-and-control-capmc)
-* Removed ARS from Cray CLI and BSS API spec
-* Removed deprecated BOS v1 cfs fields from session templates
+* Removed `ARS from Cray CLI and BSS API spec
+* Removed deprecated `BOS v1 cfs` fields from session templates
 
 For a list of all deprecated CSM features, see [Deprecations](introduction/deprecated_features/README.md#deprecations).
 
@@ -183,11 +181,9 @@ For a list of all deprecated CSM features, see [Deprecations](introduction/depre
 * Remove `metal-net` scripts as they are no longer used
 * Remove `etcd-operator` as a result of migration to use `bitnami-etcd`
 * [CRUS](glossary.md#compute-rolling-upgrade-service-crus)
-* Deprecated [Boot Orchestration Service (BOS)](glossary.md#boot-orchestration-service-bos)
-  v1 session template and boot set fields are no longer stored in BOS. For more information, see
-  [Deprecated fields](operations/boot_orchestration/Session_Templates.md#deprecated-fields)
-*  Removed -P option from cray-dhcp-kea startup options
-*  Stopped using skopeo images < 1.13.2
+* Deprecated [Boot Orchestration Service (BOS)](glossary.md#boot-orchestration-service-bos)v1 session template and boot set fields are no longer stored in BOS. For more information, see [Deprecated fields](operations/boot_orchestration/Session_Templates.md#deprecated-fields)
+*  Removed -P option from `cray-dhcp-kea` startup options
+*  Stopped using `skopeo` images < 1.13.2
 
 For a list of all features with an announced removal target, see [Removals](introduction/deprecated_features/README.md#removals)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,14 +18,28 @@
 * Upgrade to `Kubernetes` version 1.22
 * Bump `iuf-cli` version to 1.4.5
 * Upgrade `argo` version to pick up bug-fixes
+* BOS implement OPA policies for Multi-Tenancy
+* Create DNAME records in PowerDNS
+* For Birfurcated CAN update kiali to use the new API Gateways
+* For Birfurcated CAN update cray-sysmgmt-health to use the new API Gateways
+* For Birfurcated CAN update gitea-vcs-web to use CMN Only Istio Gateway
+* For Birfurcated CAN update gitea-vcs-external to use CMN Only Istio Gateway
+* Improved logging in cray-nls based on StageOutput
+* IMS - created an arm64 version of the barebones recipe
+* Support for large system ARP configuration for first boot and DHCP    
 
 ### Monitoring
+* Removed cleartext switch passwords from the cray-sysmgmt-health-canu-test pod log
 
 ### Networking
 
 ### Miscellaneous functionality
+* Ceph nodes run user facing docker registry that is writable anonymously
 
 ### New hardware support
+* Add switches in HSM to PCS and allow for power reset actions
+* Updated HMS discovery process to populate a node's architecture when making the information available via Redfish
+* Update to ilorest 4.1.0.0 for Gen11 Support
 
 ### Automation improvements
 
@@ -33,6 +47,8 @@
 * `IUF` stage for `management-nodes-rollout` consumes logs from `ncn-rebuild`
 * Add a test to check taints on master nodes
 * Augment `postgres` backup `goss` test to also check for `cronjob`
+* Argo-driven Upgrade Automation for K8s Storage Nodes
+* ceph upgrade added to automated storage upgrade    
 
 ### Base platform component upgrades
 
@@ -67,6 +83,14 @@
 * Updates to `libfreebl3-hmac`, `libfreebl3`, `tar`, and `wireshark` in `NCN` image for `CVEs`
 * `Metal-basecamp` and `cray-site-init` dependency updates
 * Additional of `kyverno` and network policies to ensure some secure controls over `mqtt` namespace
+* cf-gitea-import: Use CSM-provided alpine base image to resolve vulnerabilities
+* Updated metacontroller:v4.4.0 to address CVE's
+* Fixed CVE-2023-0386 in CSM 1.5 NCN Images
+* Fixed CVE-2023-32233 in CSM 1.5 NCN Images 
+* Developed OPA Policy to force Keycloak admin operations through CMN
+* Updated cfs-ara:1.0.2 to address CVE's
+* Updated hms-shcd-parser:1.8.0 to address CVE's
+* Moved istio-ingressgateway-cmn service to use the customer-admin-gateway
   
 ### Customer-requested enhancements
 
@@ -83,6 +107,11 @@
 * Update to `IUF` upgrade with `CSM` workflow diagram and documentation
 * Updates to `postgres` backup procedures
 * Updates to `NCN` Customization and Personalization documentation to use `sat bootprep`
+* Remove known issue about restored etcd clusters missing PVC
+* Added SNMP setup for all switches to Install/Update instructions
+* Updated Keycloak documentation to use CMN LB for administrative tasks
+* Updated screenshots and documentation steps for LDAP in upgraded Keycloak
+* Updated IUF management-nodes-rollout documentation   
 
 ## Bug fixes
 
@@ -97,6 +126,13 @@
 * Update `tds_lower_cpu_requests.sh` script for `opensearch-masters` due to CPU it eats
 * Fixed bug where `PCS` can become out of sync with `etcd`
 * Removed `subPath` `volumeMount` in the `multus` `daemonset` to avoid being stuck in termination
+* Improve existing image check logic for ims-python-helper
+* Fix issue with etcd_cluster_balance.sh reporting failure when 3 pods are healthy and 4th is terminating
+* Fixed issue where upgrading the cray-dns-unbound Helm chart should not wipe the DNS records
+* Fixed an incorrectly written Network Policy in cray-drydock for mqtt/spire communication
+* Fixed an issue where restarting kea on large systems wipes DNS records from configmap
+* Updated Unbound to not forward .hsn queries to the site DNS
+* Fxed for cray-externaldns-manager crashes when used with external-dns 0.13  
   
 ## Deprecations
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -33,7 +33,7 @@
 * `IUF` stage for `management-nodes-rollout` consumes logs from `ncn-rebuild`
 * Add a test to check taints on master nodes
 * Augment `postgres` backup `goss` test to also check for `cronjob`
- 
+
 ### Base platform component upgrades
 
 | Platform Component           | Version        |

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -191,4 +191,4 @@ For a list of all deprecated CSM features, see [Deprecations](introduction/depre
 
 For a list of all features with an announced removal target, see [Removals](introduction/deprecated_features/README.md#removals)
 
-## Known issues
+## Known Issues

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,9 +3,20 @@
 [CSM](glossary.md#cray-system-management-csm) 1.5 contains many changes spanning bug fixes, new feature development, and documentation improvements. This page lists some of the highlights.
 
 ## New
-
+* Highly available prometheus through integration of thanos
+* Support and migration to `bitnami-etcd`
+* Updates to all services using `etcd` cluster to migrate to use of `bitnami-etcd`
+* Support for old and new `spire` versions running simultaneously toward zero downtime upgrades
+* Technical Preview Support for `spire` `TPM-based` remote node attestation
 * v1 of Power Control Service (PCS) is active.
 * The v3 CFS API is now available, including support for paging, external repository "sources", and new options for debugging.
+* Update of all services using `postgres` to support new versions of `postgres` and `postgres-operator`
+* Required changes in multiple places to make `bosV2` the default
+* Update `spire` version
+* Update version of `cert-manager`
+* Upgrade to `Kubernetes` version 1.22
+* Bump `iuf-cli` version to 1.4.5
+* Upgrade `argo` verson to pick up bug-fixes
 
 ### Monitoring
 
@@ -16,28 +27,81 @@
 ### New hardware support
 
 ### Automation improvements
-
+* Updates to etcd health checks due to replacement of `etcd` vendor to `bitnami-etcd`
+* `IUF` stage for `management-nodes-rollout` consumes logs from `ncn-rebuild`
+* Add a test to check taints on master nodes
+* Augment `postgres` backup `goss` test to also check for `cronjob`
+ 
 ### Base platform component upgrades
 
 | Platform Component           | Version        |
 |------------------------------|----------------|
+| `Kubernetes`                 | 1.22.13        |
+| `containerd`                 | 1.5.16         |
+| `istio`                      | 1.11.8         |
+| `thanos`                     | 0.31.0         |
+| `prometheus-operator`        | 0.63.0         |
+| `grafterm`                   | 1.0.3          |
+| `keycloak`                   | 21.1.1         |
+| `bitnami-etcd` on `ncn-mxxx` | 3.5.0          |
+| `bitnami-etcd` for clusters  | 3.5.9          |
+| `coredns`                    | 1.8.4          |
+| `helm`                       | 3.11.2         |
+| `postgresql`                 | 14.8           |
+| `postgres-operator`          | 1.8.2          |
+| `spire`                      | 0.12.2         |
+| `spire-intermediate`         | 1.0.0          |
+| `cray-spire`                 | 1.5.5          |
+| `metrics-server`             | 0.6.3          |
+| `cray-certmanager`           | 1.5.5          |
+| `argo-workflows`             | 3.3.6          |
+| `argo workflow-controller`   | 3.4.5          |
 
 ### Security improvements
-
+* `CVE - KERNEL 5.14.21-150400.24.46.1 - mozilla-nss`
+* Removed `postgresql` from `NCNs` to fix `CVEs`
+* Updates to `bind-utils`, `curl`, `git-core`, `java-1_8_0-ibm`, and `less` in `NCN` image for `CVEs`
+* Updates to `libfreebl3-hmac`, `libfreebl3`, `tar`, and `wireshark` in `NCN` image for `CVEs`
+* `Metal-basecamp` and `cray-site-init` dependency updates
+* Additional of `kyverno` and network policies to ensure some secure controls over `mqtt` namespace
+  
 ### Customer-requested enhancements
+* Keycloak upgrade for CVE fixes
+* Enablement of bonded NMN connections for the UANs
 
 ### Documentation enhancements
+* `IUF` documentation updates for `upgrade_all_products` issues
+* Addition of a `CSM` cabling page for the management and edge network
+* Added system recovery procedure for `keycloak`
+* Updates in several places as a result of migration to `bitnami-etcd`
+* Updates to `BOS` documentation to replace `CAPMC` references
+* Update to `IUF` upgrade with `CSM` workflow diagram and documentation
+* Updates to `postgres` backup procedures
+* Updates to `NCN` Customization and Personalization documentation to use `sat bootprep`
 
 ## Bug fixes
-
+* Fix for invalid `preinstall` `VCS` check in `IUF` in the event of a fresh install
+* Fix deployment failure due to `DNS` timeouts when `max_fails=0` is set in `coredns`
+* Fixed an issue on upgrade of master `NCNs` due to not generating the `admin-tools` keyring
+* Fix for case where `bootprep` files are missing when `prepare-images` stage is run in `IUF` with one argument
+* Fix `IUF` issue with `SHS` error in `update-vcs-config` stage
+* Ensure `IUF` stage for `management-node-rollout` is aborted, also abort `ncn-rebuild`
+* Fixed issue with `Nexus` failing to move to another `NCN` on upgrade
+* Fixed procedure to change root password and `SSH` keys so it would also work on image customization
+* Update `tds_lower_cpu_requests.sh` script for `opensearch-masters` due to CPU it eats
+* Fixed bug where `PCS` can become out of sync with `etcd`
+* Removed `subPath` `volumeMount` in the `multus` `daemonset` to avoid being stuck in termination
+  
 ## Deprecations
-
+* The `ipv4-resolvers` option has been removed for `CSI` as it is not used
 * [CAPMC](glossary.md#cray-advanced-platform-monitoring-and-control-capmc)
 
 For a list of all deprecated CSM features, see [Deprecations](introduction/deprecated_features/README.md#deprecations).
 
 ## Removals
-
+* Remove `TRS operator` for fresh installs and on upgrades
+* Remove `metal-net` scripts as they are no longer used
+* Remove `etcd-operator` as a result of migration to use `bitnami-etcd`
 * [CRUS](glossary.md#compute-rolling-upgrade-service-crus)
 * Deprecated [Boot Orchestration Service (BOS)](glossary.md#boot-orchestration-service-bos)
   v1 session template and boot set fields are no longer stored in BOS. For more information, see

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -28,7 +28,7 @@
 * IMS - created an ARM64 version of the barebones recipe
 * Support for large system ARP configuration for first boot and DHCP
 * Hardware Discovery Process populates a nodes's architecture
-* Argo-driven Upgrade Automation for K8s Storage Nodes
+* Argo-driven Upgrade Automation for Kubernetes Storage Nodes
 * SLS: Added caching to improve performance and robustness
 * Added support for specifying IMS Image and Recipe architecture in IUF
 * Upgraded node-images to SLES15SP5
@@ -40,7 +40,7 @@
 * Enhanced Multi-Tenancy Phase II support
 * Improved `IUF Logging
 * Created Networking Red Light / Green Light Dashboard
-* Implemented highly available Prometheus setup with long term storage capabilities with `Thanos`
+* Implemented highly available Prometheus setup with long term storage capabilities using Thanos
 
 ### Monitoring
 
@@ -56,7 +56,7 @@
 
 * Add switches in HSM to PCS and allow for power reset actions
 * Updated HMS discovery process to populate a node's architecture when making the information available via Redfish
-* Update to `ilorest 4.1.0.0` for `Gen11` Support
+* Update to `ilorest-4.1.0.0` for `Gen11` Support
 * Support for ARM64 added in `metal-ipxe`
 * Hardware validation of the EX2500 Cabinet
 * Support JL627A switches as an edge router for BI-CAN
@@ -93,13 +93,13 @@
 | `metrics-server`             | 0.6.3          |
 | `cray-certmanager`           | 1.5.5          |
 | `argo-workflows`             | 3.3.6          |
-| `argo workflow-controller`   | 3.4.5          |
+| `argo-workflow-controller`   | 3.4.5          |
 | `ceph`                       | 16.2.13        |
 
 ### Security improvements
 
-* `CVE - KERNEL 5.14.21-150400.24.46.1 - mozilla-nss`
-* Removed `postgresql` from `NCNs` to fix `CVEs`
+* CVE 'kernel-5.14.21-150400.24.46.1` for `mozilla-nss`
+* Removed `postgresql` from NCNs to fix CVEs
 * Updates to `bind-utils`, `curl`, `git-core`, `java-1_8_0-ibm`, and `less` in `NCN` image for `CVEs`
 * Updates to `libfreebl3-hmac`, `libfreebl3`, `tar`, and `wireshark` in `NCN` image for `CVEs`
 * `Metal-basecamp` and `cray-site-init` dependency updates
@@ -133,7 +133,7 @@
 * Updates to BOS documentation to replace CAPMC references
 * Update to IUF upgrade with CSM workflow diagram and documentation
 * Updates to `postgres` backup procedures
-* Updates to NCN Customization and Personalization documentation to use `sat bootprep`
+* Updates to NCN Customization and Personalization documentation to use `sat-bootprep`
 * Remove known issue about restored etcd clusters missing PVC
 * Added SNMP setup for all switches to Install/Update instructions
 * Updated Keycloak documentation to use CMN LB for administrative tasks
@@ -147,13 +147,12 @@
 * Fix for invalid `preinstall` `VCS` check in IUF in the event of a fresh install
 * Fix deployment failure due to DNS timeouts when `max_fails=0` is set in `coredns`
 * Fixed an issue on upgrade of master NCNs due to not generating the `admin-tools` keyring
-* Fix for case where `bootprep` files are missing when `prepare-images` stage is run in IUF with one argument
+* Fix for a case where `bootprep` files are missing when `prepare-images` stage is run in IUF with one argument
 * Fix IUF issue with SHS error in `update-vcs-config` stage
 * Ensure IU` stage for `management-node-rollout` is aborted, also abort `ncn-rebuild`
 * Fixed issue with Nexus failing to move to another NCN on upgrade
 * Fixed procedure to change root password and SSH keys so it would also work on image customization
 * Update `tds_lower_cpu_requests.sh` script for `opensearch-masters` due to CPU it eats
-* Fixed bug where PC` can become out of sync with `etcd`
 * Removed `subPath volumeMount` in the `multus daemonset` to avoid being stuck in termination
 * Improve existing image check logic for `ims-python-helper`
 * Fix issue with `etcd_cluster_balance.sh` reporting failure when 3 pods are healthy and 4th is terminating
@@ -171,7 +170,7 @@
 * The `ipv4-resolvers` option has been removed for CSI as it is not used
 * CAPMC](glossary.md#cray-advanced-platform-monitoring-and-control-capmc)
 * Removed ARS from Cray CLI and BSS API spec
-* Removed deprecated `BOS v1 cfs` fields from session templates
+* Removed deprecated BOS V1 CFS fields from session templates
 
 For a list of all deprecated CSM features, see [Deprecations](introduction/deprecated_features/README.md#deprecations).
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,7 +3,8 @@
 [CSM](glossary.md#cray-system-management-csm) 1.5 contains many changes spanning bug fixes, new feature development, and documentation improvements. This page lists some of the highlights.
 
 ## New
-* Highly available prometheus through integration of thanos
+
+* Highly available `prometheus` through integration of `thanos`
 * Support and migration to `bitnami-etcd`
 * Updates to all services using `etcd` cluster to migrate to use of `bitnami-etcd`
 * Support for old and new `spire` versions running simultaneously toward zero downtime upgrades
@@ -16,7 +17,7 @@
 * Update version of `cert-manager`
 * Upgrade to `Kubernetes` version 1.22
 * Bump `iuf-cli` version to 1.4.5
-* Upgrade `argo` verson to pick up bug-fixes
+* Upgrade `argo` version to pick up bug-fixes
 
 ### Monitoring
 
@@ -27,6 +28,7 @@
 ### New hardware support
 
 ### Automation improvements
+
 * Updates to etcd health checks due to replacement of `etcd` vendor to `bitnami-etcd`
 * `IUF` stage for `management-nodes-rollout` consumes logs from `ncn-rebuild`
 * Add a test to check taints on master nodes
@@ -58,6 +60,7 @@
 | `argo workflow-controller`   | 3.4.5          |
 
 ### Security improvements
+
 * `CVE - KERNEL 5.14.21-150400.24.46.1 - mozilla-nss`
 * Removed `postgresql` from `NCNs` to fix `CVEs`
 * Updates to `bind-utils`, `curl`, `git-core`, `java-1_8_0-ibm`, and `less` in `NCN` image for `CVEs`
@@ -66,10 +69,12 @@
 * Additional of `kyverno` and network policies to ensure some secure controls over `mqtt` namespace
   
 ### Customer-requested enhancements
+
 * Keycloak upgrade for CVE fixes
-* Enablement of bonded NMN connections for the UANs
+* Enable bonded NMN connections for the UANs
 
 ### Documentation enhancements
+
 * `IUF` documentation updates for `upgrade_all_products` issues
 * Addition of a `CSM` cabling page for the management and edge network
 * Added system recovery procedure for `keycloak`
@@ -80,6 +85,7 @@
 * Updates to `NCN` Customization and Personalization documentation to use `sat bootprep`
 
 ## Bug fixes
+
 * Fix for invalid `preinstall` `VCS` check in `IUF` in the event of a fresh install
 * Fix deployment failure due to `DNS` timeouts when `max_fails=0` is set in `coredns`
 * Fixed an issue on upgrade of master `NCNs` due to not generating the `admin-tools` keyring
@@ -93,12 +99,14 @@
 * Removed `subPath` `volumeMount` in the `multus` `daemonset` to avoid being stuck in termination
   
 ## Deprecations
+
 * The `ipv4-resolvers` option has been removed for `CSI` as it is not used
 * [CAPMC](glossary.md#cray-advanced-platform-monitoring-and-control-capmc)
 
 For a list of all deprecated CSM features, see [Deprecations](introduction/deprecated_features/README.md#deprecations).
 
 ## Removals
+
 * Remove `TRS operator` for fresh installs and on upgrades
 * Remove `metal-net` scripts as they are no longer used
 * Remove `etcd-operator` as a result of migration to use `bitnami-etcd`

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -143,6 +143,10 @@
 
 ## Bug fixes
 
+* Fix for when QLogic adapter firmware stops responding then fails recovery causing the node to crash.
+** Fixes
+*** QLogic/Marvel Driver Update - RPM: qlgc-fastlinq-kmp-default-8.74.1.0_k5.14.21_150500.53-1.sles15sp5.x86_64.rpm
+*** SUSE Kernel Update: Version: 5.14.21-150400.24.92.1.27088.1.PTF.1215587
 * Fix for invalid `preinstall` `VCS` check in IUF in the event of a fresh install
 * Fix deployment failure due to DNS timeouts when `max_fails=0` is set in `coredns`
 * Fixed an issue on upgrade of master NCNs due to not generating the `admin-tools` keyring

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -117,6 +117,7 @@
 * Addressed `Zenbleed` CVE on NCNs
 * Addressed `CVE-2023-38545` (curl & `libcurl`) on NCNs
 * Added Default RBAC Role for Telemetry API
+* In SAT upgradeded paramiko to resolve CVE-2023-48795 
   
 ### Customer-Requested Enhancements
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,8 @@
 
 ## New
 
+### New Software Support
+
 * Highly available `prometheus` through integration of `thanos`
 * Support and migration to `bitnami-etcd`
 * Updates to all services using `etcd` cluster to migrate to use of `bitnami-etcd`
@@ -40,18 +42,10 @@
 * Enhanced Multi-Tenancy Phase II support
 * Improved IUF Logging
 * Created Networking Red Light / Green Light Dashboard
-
-* ### Monitoring
-
 * Removed clear text switch passwords from the `cray-sysmgmt-health-canu-test` pod log
-
-### Networking
-
-### Miscellaneous functionality
-
 * Ceph nodes run user facing docker registry that is writable anonymously
 
-### New hardware support
+### New Hardware Support
 
 * Add switches in HSM to PCS and allow for power reset actions
 * Updated HMS discovery process to populate a node's architecture when making the information available via Redfish
@@ -60,7 +54,9 @@
 * Hardware validation of the EX2500 Cabinet
 * Support JL627A switches as an edge router for BI-CAN
 
-### Automation improvements
+## Improvements
+
+### Automation Improvements
 
 * Updates to `etcd` health checks due to replacement of `etcd` vendor to `bitnami-etcd`
 * IUF stage for `management-nodes-rollout` consumes logs from `ncn-rebuild`
@@ -69,7 +65,7 @@
 * Argo-driven Upgrade Automation for Kubernetes Storage Nodes
 * Ceph upgrade added to automated storage upgrade  
 
-### Base platform component upgrades
+### Base Platform Component Upgrades
 
 | Platform Component           | Version        |
 |------------------------------|----------------|
@@ -95,7 +91,7 @@
 | `argo-workflow-controller`   | 3.4.5          |
 | `ceph`                       | 16.2.13        |
 
-### Security improvements
+### Security Improvements
 
 * CVE Kernel 5.14.21-150400.24.46.1 for `mozilla-nss`
 * Removed `postgresql` from NCNs to fix CVEs
@@ -118,7 +114,7 @@
 * Addressed `CVE-2023-38545` (curl & `libcurl`) on NCNs
 * Added Default RBAC Role for Telemetry API
   
-### Customer-requested enhancements
+### Customer-Requested Enhancements
 
 * Keycloak upgrade for CVE fixes
 * Enable bonded `NMN` connections for the UANs
@@ -141,13 +137,13 @@
 * Updated screenshots and doc steps for LDAP in upgraded Keycloak
 * Updated IUF management-nodes-rollout docs
 
-## Bug fixes
+## Bug Fixes
 
 * Fix for when QLogic adapter firmware stops responding then fails recovery causing the node to crash.
     * Fixes
         * QLogic/Marvel Driver Update - RPM: `qlgc-fastlinq-kmp-default-8.74.1.0_k5.14.21_150500.53-1.sles15sp5.x86_64.rpm`
         * SUSE Kernel Update: Version: `5.14.21-150400.24.92.1.27088.1.PTF.1215587`
-* Fix for invalid `preinstall` `VCS` check in IUF in the event of a fresh install
+* Fix for invalid `preinstall` VCS check in IUF in the event of a fresh install
 * Fix deployment failure due to DNS timeouts when `max_fails=0` is set in `coredns`
 * Fixed an issue on upgrade of master NCNs due to not generating the `admin-tools` keyring
 * Fix for a case where `bootprep` files are missing when `prepare-images` stage is run in IUF with one argument
@@ -171,7 +167,7 @@
 ## Deprecations
 
 * The `ipv4-resolvers` option has been removed for CSI as it is not used
-* CAPMC](glossary.md#cray-advanced-platform-monitoring-and-control-capmc)
+* [CAPMC](glossary.md#cray-advanced-platform-monitoring-and-control-capmc)
 * Removed ARS from Cray CLI and BSS API specification
 * Removed deprecated BOS V1 CFS fields from session templates
 
@@ -183,7 +179,8 @@ For a list of all deprecated CSM features, see [Deprecations](introduction/depre
 * Remove `metal-net` scripts as they are no longer used
 * Remove `etcd-operator` as a result of migration to use `bitnami-etcd`
 * [CRUS](glossary.md#compute-rolling-upgrade-service-crus)
-* Deprecated [Boot Orchestration Service (BOS)](glossary.md#boot-orchestration-service-bos)v1 session template and boot set fields are no longer stored in BOS. For more information, see [Deprecated fields](operations/boot_orchestration/Session_Templates.md#deprecated-fields)
+* Deprecated [Boot Orchestration Service (BOS)](glossary.md#boot-orchestration-service-bos) v1 session template and boot set fields are no longer stored in BOS.
+    * For more information, see [Deprecated fields](operations/boot_orchestration/Session_Templates.md#deprecated-fields)
 * Removed -P option from `cray-dhcp-kea` startup options
 * Stopped using `skopeo` images < 1.13.2
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -20,10 +20,10 @@
 * Upgrade `argo` version to pick up bug-fixes
 * BOS implement OPA policies for Multi-Tenancy
 * Create DNAME records in PowerDNS
-* For Birfurcated CAN update kiali to use the new API Gateways
-* For Birfurcated CAN update cray-sysmgmt-health to use the new API Gateways
-* For Birfurcated CAN update gitea-vcs-web to use CMN Only Istio Gateway
-* For Birfurcated CAN update gitea-vcs-external to use CMN Only Istio Gateway
+* For Bifurcated CAN update kiali to use the new API Gateways
+* For Bifurcated CAN update cray-sysmgmt-health to use the new API Gateways
+* For Bifurcated CAN update gitea-vcs-web to use CMN Only Istio Gateway
+* For Bifurcated CAN update gitea-vcs-external to use CMN Only Istio Gateway
 * Improved logging in cray-nls based on StageOutput
 * IMS - created an arm64 version of the barebones recipe
 * Support for large system ARP configuration for first boot and DHCP
@@ -45,7 +45,7 @@
 
 ### Monitoring
 
-* Removed cleartext switch passwords from the cray-sysmgmt-health-canu-test pod log
+* Removed clear text switch passwords from the cray-sysmgmt-health-canu-test pod log
 
 ### Networking
 
@@ -59,9 +59,8 @@
 * Updated HMS discovery process to populate a node's architecture when making the information available via Redfish
 * Update to ilorest 4.1.0.0 for Gen11 Support
 * Support for arm64 added in metal-ipxe
-* Hardware vailidation of the EX2500 Cabinet
+* Hardware validation of the EX2500 Cabinet
 * Support JL627A switches as an edge router for BI-CAN
-* 
 
 ### Automation improvements
 
@@ -163,7 +162,7 @@
 * Fixed an incorrectly written Network Policy in cray-drydock for mqtt/spire communication
 * Fixed an issue where restarting kea on large systems wipes DNS records from configmap
 * Updated Unbound to not forward .hsn queries to the site DNS
-* Fxed for cray-externaldns-manager crashes when used with external-dns 0.13
+* Fixed when cray-externaldns-manager crashes when used with external-dns 0.13
 * Fixed Unbound to not forward .hsn queries to the site DNS
 * Fixed an issue where Weave pods were not starting after upgrading to CSM V1.4 content
 * Fixed PowerDNS server TLD is missing NS delegation records for subdomains
@@ -190,7 +189,7 @@ For a list of all deprecated CSM features, see [Deprecations](introduction/depre
 *  Removed -P option from cray-dhcp-kea startup options
 *  Stopped using skopeo images < 1.13.2
 
-For a list of all features with an announced removal target, see [Removals](introduction/deprecated_features/README.md#removals).
+For a list of all features with an announced removal target, see [Removals](introduction/deprecated_features/README.md#removals)
 
 ## Known issues
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -38,7 +38,7 @@
 * Added support for git `submodules` in CFS runs
 * Added support for `ARM 64` based builds through emulation
 * Enhanced Multi-Tenancy Phase II support
-* Improved `IUF Logging
+* Improved IUF Logging
 * Created Networking Red Light / Green Light Dashboard
 * Implemented highly available Prometheus setup with long term storage capabilities using Thanos
 
@@ -149,11 +149,11 @@
 * Fixed an issue on upgrade of master NCNs due to not generating the `admin-tools` keyring
 * Fix for a case where `bootprep` files are missing when `prepare-images` stage is run in IUF with one argument
 * Fix IUF issue with SHS error in `update-vcs-config` stage
-* Ensure IU` stage for `management-node-rollout` is aborted, also abort `ncn-rebuild`
+* Ensure IUF stage for `management-node-rollout` is aborted, also abort `ncn-rebuild`
 * Fixed issue with Nexus failing to move to another NCN on upgrade
 * Fixed procedure to change root password and SSH keys so it would also work on image customization
 * Update `tds_lower_cpu_requests.sh` script for `opensearch-masters` due to CPU it eats
-* Removed `subPath volumeMount` in the `multus daemonset` to avoid being stuck in termination
+* Removed `subPath-volumeMount` in the `multus-daemonset` to avoid being stuck in termination
 * Improve existing image check logic for `ims-python-helper`
 * Fix issue with `etcd_cluster_balance.sh` reporting failure when 3 pods are healthy and 4th is terminating
 * Fixed issue where upgrading the `cray-dns-unbound` Helm chart should not wipe the DNS records

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 # Cray System Management (CSM) - Release Notes
 
-[CSM](glossary.md#cray-system-management-csm) 1.5 contains many changes spanning bug fixes, new feature development, and documentation improvements. This page lists some of the highlights.
+[CSM](glossary.md#cray-system-management-csm) 1.5 contains many changes spanning bug fixes, new feature development, and
+documentation improvements. This page lists some of the highlights.
 
 ## New
 
@@ -12,7 +13,8 @@
 * Support for old and new `spire` versions running simultaneously toward zero downtime upgrades
 * Technical Preview Support for `spire` `TPM-based` remote node attestation
 * Power Control Service (PCS) is released
-* The V3 CFS API is now available, including support for paging, external repository "sources", and new options for debugging.
+* The V3 CFS API is now available, including support for paging, external repository "sources", and new options for
+  debugging.
 * Update of all services using `postgres` to support new versions of `postgres` and `postgres-operator`
 * `BOS V2` is the default
 * Update `spire` version
@@ -68,33 +70,33 @@
 * Add a test to check master node taints
 * Augment `postgres` backup `goss` test to also check for `cronjob`
 * Argo-driven Upgrade Automation for Kubernetes Storage Nodes
-* Ceph upgrade added to automated storage upgrade  
+* Ceph upgrade added to automated storage upgrade
 
 ### Base Platform Component Upgrades
 
-| Platform Component           | Version        |
-|------------------------------|----------------|
-| `Kubernetes`                 | 1.22.13        |
-| `containerd`                 | 1.5.16         |
-| `istio`                      | 1.11.8         |
-| `thanos`                     | 0.31.0         |
-| `prometheus-operator`        | 0.63.0         |
-| `grafterm`                   | 1.0.3          |
-| `keycloak`                   | 21.1.1         |
-| `bitnami-etcd` on `ncn-mxxx` | 3.5.0          |
-| `bitnami-etcd` for clusters  | 3.5.9          |
-| `coredns`                    | 1.8.4          |
-| `helm`                       | 3.11.2         |
-| `postgresql`                 | 14.8           |
-| `postgres-operator`          | 1.8.2          |
-| `spire`                      | 0.12.2         |
-| `spire-intermediate`         | 1.0.0          |
-| `cray-spire`                 | 1.5.5          |
-| `metrics-server`             | 0.6.3          |
-| `cray-certmanager`           | 1.5.5          |
-| `argo-workflows`             | 3.3.6          |
-| `argo-workflow-controller`   | 3.4.5          |
-| `ceph`                       | 16.2.13        |
+| Platform Component           | Version |
+|------------------------------|---------|
+| `Kubernetes`                 | 1.22.13 |
+| `containerd`                 | 1.5.16  |
+| `istio`                      | 1.11.8  |
+| `thanos`                     | 0.31.0  |
+| `prometheus-operator`        | 0.63.0  |
+| `grafterm`                   | 1.0.3   |
+| `keycloak`                   | 21.1.1  |
+| `bitnami-etcd` on `ncn-mxxx` | 3.5.0   |
+| `bitnami-etcd` for clusters  | 3.5.9   |
+| `coredns`                    | 1.8.4   |
+| `helm`                       | 3.11.2  |
+| `postgresql`                 | 14.8    |
+| `postgres-operator`          | 1.8.2   |
+| `spire`                      | 0.12.2  |
+| `spire-intermediate`         | 1.0.0   |
+| `cray-spire`                 | 1.5.5   |
+| `metrics-server`             | 0.6.3   |
+| `cray-certmanager`           | 1.5.5   |
+| `argo-workflows`             | 3.3.6   |
+| `argo-workflow-controller`   | 3.4.5   |
+| `ceph`                       | 16.2.13 |
 
 ### Security Improvements
 
@@ -118,8 +120,8 @@
 * Addressed `Zenbleed` CVE on NCNs
 * Addressed `CVE-2023-38545` (curl & `libcurl`) on NCNs
 * Added Default RBAC Role for Telemetry API
-* In SAT upgraded `paramiko` to resolve `CVE-2023-48795` 
-  
+* In SAT upgraded `paramiko` to resolve `CVE-2023-48795`
+
 ### Customer-Requested Enhancements
 
 * Keycloak upgrade for CVE fixes
@@ -147,7 +149,8 @@
 
 * Fix for when QLogic adapter firmware stops responding then fails recovery causing the node to crash.
     * Fixes
-        * QLogic/Marvel Driver Update - RPM: `qlgc-fastlinq-kmp-default-8.74.1.0_k5.14.21_150500.53-1.sles15sp5.x86_64.rpm`
+        * QLogic/Marvel Driver Update -
+          RPM: `qlgc-fastlinq-kmp-default-8.74.1.0_k5.14.21_150500.53-1.sles15sp5.x86_64.rpm`
         * SUSE Kernel Update: Version: `5.14.21-150500.55.39.1.27360.1.PTF.1215587`
 * Fix for invalid `preinstall` VCS check in IUF in the event of a fresh install
 * Fix deployment failure due to DNS timeouts when `max_fails=0` is set in `coredns`
@@ -169,7 +172,7 @@
 * Fixed an issue where Weave pods were not starting after upgrading to CSM V1.4 content
 * Fixed PowerDNS server TLD is missing NS delegation records for subdomains
 * Fixed an issue where FRU Tracking doesn't create a detected event after a removed event
-  
+
 ## Deprecations
 
 * The `ipv4-resolvers` option has been removed for CSI as it is not used
@@ -185,11 +188,14 @@ For a list of all deprecated CSM features, see [Deprecations](introduction/depre
 * Remove `metal-net` scripts as they are no longer used
 * Remove `etcd-operator` as a result of migration to use `bitnami-etcd`
 * [CRUS](glossary.md#compute-rolling-upgrade-service-crus)
-* Deprecated [Boot Orchestration Service (BOS)](glossary.md#boot-orchestration-service-bos) v1 session template and boot set fields are no longer stored in BOS.
-    * For more information, see [Deprecated fields](operations/boot_orchestration/Session_Templates.md#deprecated-fields)
+* Deprecated [Boot Orchestration Service (BOS)](glossary.md#boot-orchestration-service-bos) v1 session template and boot
+  set fields are no longer stored in BOS.
+    * For more information,
+      see [Deprecated fields](operations/boot_orchestration/Session_Templates.md#deprecated-fields)
 * Removed -P option from `cray-dhcp-kea` startup options
 * Stopped using `skopeo` images < 1.13.2
 
-For a list of all features with an announced removal target, see [Removals](introduction/deprecated_features/README.md#removals)
+For a list of all features with an announced removal target,
+see [Removals](introduction/deprecated_features/README.md#removals)
 
 ## Known Issues

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -65,7 +65,7 @@
 
 * Updates to `etcd` health checks due to replacement of `etcd` vendor to `bitnami-etcd`
 * IUF stage for `management-nodes-rollout` consumes logs from `ncn-rebuild`
-* Add a test to check taints on master nodes
+* Add a test to check master node taints
 * Augment `postgres` backup `goss` test to also check for `cronjob`
 * Argo-driven Upgrade Automation for Kubernetes Storage Nodes
 * Ceph upgrade added to automated storage upgrade  

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -57,6 +57,7 @@
 * Support for ARM64 added
 * Hardware validation of the EX2500 Cabinet
 * Support JL627A switches as an edge router for BI-CAN
+* Support for Broadcom PXE boots, and interface naming
 
 ## Improvements
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -17,7 +17,7 @@
 * Update version of `cert-manager`
 * Upgrade to `Kubernetes` version 1.22
 * Bump `iuf-cli` version to 1.4.5
-* Upgrade `argo` version to pick up bug-fixes
+* Upgrade Argo version to pick up bug-fixes
 * BOS implement OPA policies for Multi-Tenancy
 * Create DNAME records in PowerDNS
 * For Bifurcated CAN update `kiali` to use the new API Gateways
@@ -25,21 +25,20 @@
 * For Bifurcated CAN update `gitea-vcs-web` to use CMN Only Istio Gateway
 * For Bifurcated CAN update `gitea-vcs-external` to use CMN Only Istio Gateway
 * Improved logging in `cray-nls` based on `StageOutput`
-* IMS - created an `arm64` version of the barebones recipe
-* Support for large system `ARP` configuration for first boot and DHCP
+* IMS - created an ARM64 version of the barebones recipe
+* Support for large system ARP configuration for first boot and DHCP
 * Hardware Discovery Process populates a nodes's architecture
-* Argo-driven Upgrade Automation for `K8s` Storage Nodes
-* An `arm64` version of the barebones recipe has been created
+* Argo-driven Upgrade Automation for K8s Storage Nodes
 * SLS: Added caching to improve performance and robustness
-* Added support for specifying `IMS` Image and Recipe architecture in IUF
+* Added support for specifying IMS Image and Recipe architecture in IUF
 * Upgraded node-images to SLES15SP5
 * Updated Spire Server to work with TPM
 * Added Improved error logging for`bos` command
 * Added a method to stop `CFS/Batcher` and cancel configuration for in-flight customizations
-* Added support for git `submodules` in `cfs` runs
+* Added support for git `submodules` in CFS runs
 * Added support for `ARM 64` based builds through emulation
 * Enhanced Multi-Tenancy Phase II support
-* Improved `IUF` Logging
+* Improved `IUF Logging
 * Created Networking Red Light / Green Light Dashboard
 * Implemented highly available Prometheus setup with long term storage capabilities with `Thanos`
 
@@ -58,18 +57,18 @@
 * Add switches in HSM to PCS and allow for power reset actions
 * Updated HMS discovery process to populate a node's architecture when making the information available via Redfish
 * Update to `ilorest 4.1.0.0` for `Gen11` Support
-* Support for `arm64` added in `metal-ipxe`
+* Support for ARM64 added in `metal-ipxe`
 * Hardware validation of the EX2500 Cabinet
-* Support `JL627A` switches as an edge router for BI-CAN
+* Support JL627A switches as an edge router for BI-CAN
 
 ### Automation improvements
 
 * Updates to `etcd` health checks due to replacement of `etcd` vendor to `bitnami-etcd`
-* `IUF` stage for `management-nodes-rollout` consumes logs from `ncn-rebuild`
+* IUF stage for `management-nodes-rollout` consumes logs from `ncn-rebuild`
 * Add a test to check taints on master nodes
 * Augment `postgres` backup `goss` test to also check for `cronjob`
-* Argo-driven Upgrade Automation for `K8s` Storage Nodes
-* `ceph` upgrade added to automated storage upgrade  
+* Argo-driven Upgrade Automation for K8s Storage Nodes
+* Ceph upgrade added to automated storage upgrade  
 
 ### Base platform component upgrades
 
@@ -127,14 +126,14 @@
 
 ### Documentation enhancements
 
-* `IUF` documentation updates for `upgrade_all_products` issues
-* Addition of a `CSM` cabling page for the management and edge network
+* IUF documentation updates for `upgrade_all_products` issues
+* Addition of a CSM cabling page for the management and edge network
 * Added system recovery procedure for `keycloak`
 * Updates in several places as a result of migration to `bitnami-etcd`
-* Updates to `BOS` documentation to replace `CAPMC` references
-* Update to `IUF` upgrade with `CSM` workflow diagram and documentation
+* Updates to BOS documentation to replace CAPMC references
+* Update to IUF upgrade with CSM workflow diagram and documentation
 * Updates to `postgres` backup procedures
-* Updates to `NCN` Customization and Personalization documentation to use `sat bootprep`
+* Updates to NCN Customization and Personalization documentation to use `sat bootprep`
 * Remove known issue about restored etcd clusters missing PVC
 * Added SNMP setup for all switches to Install/Update instructions
 * Updated Keycloak documentation to use CMN LB for administrative tasks
@@ -145,17 +144,17 @@
 
 ## Bug fixes
 
-* Fix for invalid `preinstall` `VCS` check in `IUF` in the event of a fresh install
-* Fix deployment failure due to `DNS` timeouts when `max_fails=0` is set in `coredns`
-* Fixed an issue on upgrade of master `NCNs` due to not generating the `admin-tools` keyring
-* Fix for case where `bootprep` files are missing when `prepare-images` stage is run in `IUF` with one argument
-* Fix `IUF` issue with `SHS` error in `update-vcs-config` stage
-* Ensure `IUF` stage for `management-node-rollout` is aborted, also abort `ncn-rebuild`
-* Fixed issue with `Nexus` failing to move to another `NCN` on upgrade
-* Fixed procedure to change root password and `SSH` keys so it would also work on image customization
+* Fix for invalid `preinstall` `VCS` check in IUF in the event of a fresh install
+* Fix deployment failure due to DNS timeouts when `max_fails=0` is set in `coredns`
+* Fixed an issue on upgrade of master NCNs due to not generating the `admin-tools` keyring
+* Fix for case where `bootprep` files are missing when `prepare-images` stage is run in IUF with one argument
+* Fix IUF issue with SHS error in `update-vcs-config` stage
+* Ensure IU` stage for `management-node-rollout` is aborted, also abort `ncn-rebuild`
+* Fixed issue with Nexus failing to move to another NCN on upgrade
+* Fixed procedure to change root password and SSH keys so it would also work on image customization
 * Update `tds_lower_cpu_requests.sh` script for `opensearch-masters` due to CPU it eats
-* Fixed bug where `PCS` can become out of sync with `etcd`
-* Removed `subPath` `volumeMount` in the `multus` `daemonset` to avoid being stuck in termination
+* Fixed bug where PC` can become out of sync with `etcd`
+* Removed `subPath volumeMount` in the `multus daemonset` to avoid being stuck in termination
 * Improve existing image check logic for `ims-python-helper`
 * Fix issue with `etcd_cluster_balance.sh` reporting failure when 3 pods are healthy and 4th is terminating
 * Fixed issue where upgrading the `cray-dns-unbound` Helm chart should not wipe the DNS records
@@ -164,14 +163,15 @@
 * Updated Unbound to not forward `.hsn` queries to the site DNS
 * Fixed when `cray-externaldns-manager` crashes when used with `external-dns 0.13`
 * Fixed an issue where Weave pods were not starting after upgrading to CSM V1.4 content
-* Fixed `PowerDNS` server `TLD` is missing `NS` delegation records for subdomains
+* Fixed PowerDNS server TLD is missing NS delegation records for subdomains
 * Fixed an issue where FRU Tracking doesn't create a detected event after a removed event
   
 ## Deprecations
 
-* The `ipv4-resolvers` option has been removed for `CSI` as it is not used
-* Removed `ARS from Cray CLI and BSS API spec
-* Removed deprecated `BOS v1` `cfs` fields from session templates
+* The `ipv4-resolvers` option has been removed for CSI as it is not used
+* CAPMC](glossary.md#cray-advanced-platform-monitoring-and-control-capmc)
+* Removed ARS from Cray CLI and BSS API spec
+* Removed deprecated `BOS v1 cfs` fields from session templates
 
 For a list of all deprecated CSM features, see [Deprecations](introduction/deprecated_features/README.md#deprecations).
 
@@ -182,8 +182,8 @@ For a list of all deprecated CSM features, see [Deprecations](introduction/depre
 * Remove `etcd-operator` as a result of migration to use `bitnami-etcd`
 * [CRUS](glossary.md#compute-rolling-upgrade-service-crus)
 * Deprecated [Boot Orchestration Service (BOS)](glossary.md#boot-orchestration-service-bos)v1 session template and boot set fields are no longer stored in BOS. For more information, see [Deprecated fields](operations/boot_orchestration/Session_Templates.md#deprecated-fields)
-*  Removed -P option from `cray-dhcp-kea` startup options
-*  Stopped using `skopeo` images < 1.13.2
+* Removed -P option from `cray-dhcp-kea` startup options
+* Stopped using `skopeo` images < 1.13.2
 
 For a list of all features with an announced removal target, see [Removals](introduction/deprecated_features/README.md#removals)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -26,20 +26,30 @@
 * For Birfurcated CAN update gitea-vcs-external to use CMN Only Istio Gateway
 * Improved logging in cray-nls based on StageOutput
 * IMS - created an arm64 version of the barebones recipe
-* Support for large system ARP configuration for first boot and DHCP    
+* Support for large system ARP configuration for first boot and DHCP
+* Hardware Discovery Process populates a nodes's architecture
+* Argo-driven Upgrade Automation for K8s Storage Nodes
+* An arm64 version of the barebones recipe has been created
+* SLS: Added caching to improve performance and robustness
+* Added support for specifying IMS Image and Recipe architecture in IUF
+* Upgraded node-images to SLES15SP5
+* Updated Spire Server to work with TPM
 
 ### Monitoring
+
 * Removed cleartext switch passwords from the cray-sysmgmt-health-canu-test pod log
 
 ### Networking
 
 ### Miscellaneous functionality
+
 * Ceph nodes run user facing docker registry that is writable anonymously
 
 ### New hardware support
 * Add switches in HSM to PCS and allow for power reset actions
 * Updated HMS discovery process to populate a node's architecture when making the information available via Redfish
 * Update to ilorest 4.1.0.0 for Gen11 Support
+* Support for arm64 added in metal-ipxe 
 
 ### Automation improvements
 
@@ -48,7 +58,7 @@
 * Add a test to check taints on master nodes
 * Augment `postgres` backup `goss` test to also check for `cronjob`
 * Argo-driven Upgrade Automation for K8s Storage Nodes
-* ceph upgrade added to automated storage upgrade    
+* ceph upgrade added to automated storage upgrade  
 
 ### Base platform component upgrades
 
@@ -74,6 +84,7 @@
 | `cray-certmanager`           | 1.5.5          |
 | `argo-workflows`             | 3.3.6          |
 | `argo workflow-controller`   | 3.4.5          |
+| `ceph`                       | 16.2.13        |
 
 ### Security improvements
 
@@ -86,11 +97,16 @@
 * cf-gitea-import: Use CSM-provided alpine base image to resolve vulnerabilities
 * Updated metacontroller:v4.4.0 to address CVE's
 * Fixed CVE-2023-0386 in CSM 1.5 NCN Images
-* Fixed CVE-2023-32233 in CSM 1.5 NCN Images 
+* Fixed CVE-2023-32233 in CSM 1.5 NCN Images
 * Developed OPA Policy to force Keycloak admin operations through CMN
 * Updated cfs-ara:1.0.2 to address CVE's
 * Updated hms-shcd-parser:1.8.0 to address CVE's
 * Moved istio-ingressgateway-cmn service to use the customer-admin-gateway
+* Kyverno Upgrade Needed for N-2 Support Policy
+* Fixed Improper Certificate Validation CVE in cfs-operator
+* Fixed Regular Expression DoS CVE in cfs-ara
+* Addressed Zenbleed CVE on NCNs
+* Addressed CVE-2023-38545 (curl & libcurl) on NCNs
   
 ### Customer-requested enhancements
 
@@ -111,7 +127,9 @@
 * Added SNMP setup for all switches to Install/Update instructions
 * Updated Keycloak documentation to use CMN LB for administrative tasks
 * Updated screenshots and documentation steps for LDAP in upgraded Keycloak
-* Updated IUF management-nodes-rollout documentation   
+* Updated IUF management-nodes-rollout documentation
+* Updated screenshots and doc steps for LDAP in upgraded Keycloak
+* Updated IUF management-nodes-rollout docs
 
 ## Bug fixes
 
@@ -132,12 +150,18 @@
 * Fixed an incorrectly written Network Policy in cray-drydock for mqtt/spire communication
 * Fixed an issue where restarting kea on large systems wipes DNS records from configmap
 * Updated Unbound to not forward .hsn queries to the site DNS
-* Fxed for cray-externaldns-manager crashes when used with external-dns 0.13  
+* Fxed for cray-externaldns-manager crashes when used with external-dns 0.13
+* Fixed Unbound to not forward .hsn queries to the site DNS
+* Fixed an issue where Weave pods were not starting after upgrading to CSM V1.4 content
+* Fixed PowerDNS server TLD is missing NS delegation records for subdomains
+* fixed an issue where FRU Tracking doesn't create a detected event after a removed event
   
 ## Deprecations
 
 * The `ipv4-resolvers` option has been removed for `CSI` as it is not used
 * [CAPMC](glossary.md#cray-advanced-platform-monitoring-and-control-capmc)
+* Removed ARS from Cray CLI and BSS API spec
+* Removed deprecated BOS v1 cfs fields from session templates
 
 For a list of all deprecated CSM features, see [Deprecations](introduction/deprecated_features/README.md#deprecations).
 
@@ -149,7 +173,9 @@ For a list of all deprecated CSM features, see [Deprecations](introduction/depre
 * [CRUS](glossary.md#compute-rolling-upgrade-service-crus)
 * Deprecated [Boot Orchestration Service (BOS)](glossary.md#boot-orchestration-service-bos)
   v1 session template and boot set fields are no longer stored in BOS. For more information, see
-  [Deprecated fields](operations/boot_orchestration/Session_Templates.md#deprecated-fields).
+  [Deprecated fields](operations/boot_orchestration/Session_Templates.md#deprecated-fields)
+*  Removed -P option from cray-dhcp-kea startup options
+*  Stopped using skopeo images < 1.13.2
 
 For a list of all features with an announced removal target, see [Removals](introduction/deprecated_features/README.md#removals).
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -148,7 +148,7 @@
 * Fix for when QLogic adapter firmware stops responding then fails recovery causing the node to crash.
     * Fixes
         * QLogic/Marvel Driver Update - RPM: `qlgc-fastlinq-kmp-default-8.74.1.0_k5.14.21_150500.53-1.sles15sp5.x86_64.rpm`
-        * SUSE Kernel Update: Version: `5.14.21-150400.24.92.1.27088.1.PTF.1215587`
+        * SUSE Kernel Update: Version: `5.14.21-150500.55.39.1.27360.1.PTF.1215587`
 * Fix for invalid `preinstall` VCS check in IUF in the event of a fresh install
 * Fix deployment failure due to DNS timeouts when `max_fails=0` is set in `coredns`
 * Fixed an issue on upgrade of master NCNs due to not generating the `admin-tools` keyring

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -40,9 +40,9 @@
 * Enhanced Multi-Tenancy Phase II support
 * Improved IUF Logging
 * Created Networking Red Light / Green Light Dashboard
-* Implemented highly available Prometheus setup with long term storage capabilities using Thanos
+* Used Thanos to Implement a highly available Prometheus setup with long term storage capabilities
 
-### Monitoring
+* ### Monitoring
 
 * Removed clear text switch passwords from the `cray-sysmgmt-health-canu-test` pod log
 
@@ -67,7 +67,7 @@
 * IUF stage for `management-nodes-rollout` consumes logs from `ncn-rebuild`
 * Add a test to check taints on master nodes
 * Augment `postgres` backup `goss` test to also check for `cronjob`
-* Argo-driven Upgrade Automation for K8s Storage Nodes
+* Argo-driven Upgrade Automation for Kubernetes Storage Nodes
 * Ceph upgrade added to automated storage upgrade  
 
 ### Base platform component upgrades
@@ -98,7 +98,7 @@
 
 ### Security improvements
 
-* CVE 'kernel-5.14.21-150400.24.46.1` for `mozilla-nss`
+* CVE Kernel 5.14.21-150400.24.46.1 for `mozilla-nss`
 * Removed `postgresql` from NCNs to fix CVEs
 * Updates to `bind-utils`, `curl`, `git-core`, `java-1_8_0-ibm`, and `less` in `NCN` image for `CVEs`
 * Updates to `libfreebl3-hmac`, `libfreebl3`, `tar`, and `wireshark` in `NCN` image for `CVEs`
@@ -160,7 +160,7 @@
 * Fixed an incorrectly written Network Policy in `cray-drydock` for `mqtt/spire` communication
 * Fixed an issue where restarting `kea` on large systems wipes DNS records from `configmap`
 * Updated Unbound to not forward `.hsn` queries to the site DNS
-* Fixed when `cray-externaldns-manager` crashes when used with `external-dns 0.13`
+* Fixed when `cray-externaldns-manager` crashes when used with `external-dns-0.13`
 * Fixed an issue where Weave pods were not starting after upgrading to CSM V1.4 content
 * Fixed PowerDNS server TLD is missing NS delegation records for subdomains
 * Fixed an issue where FRU Tracking doesn't create a detected event after a removed event

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -44,9 +44,9 @@
 * Removed clear text switch passwords from the `cray-sysmgmt-health-canu-test` pod log
 * Ceph nodes run user facing docker registry that is writable anonymously
 * Added support for NID allocation defragmentation
-* Multi-tenancy: Vault Transit (KMS) Support for Encrypted Secrets in VCS
-* Multi-tenancy: Enable Tenant ID + Tenant Admin AuthZ Awareness for API Ingress (OPA policy)
-* Multitenancy: Enable Tenant ID + Tenant Admin AuthZ Awareness for API Ingress
+* Multitenancy: Vault Transit (KMS) Support for Encrypted Secrets in VCS
+* Multitenancy: Enable Tenant ID + Tenant Admin `AuthZ` Awareness for API Ingress (OPA policy)
+* Multitenancy: Enable Tenant ID + Tenant Admin `AuthZ` Awareness for API Ingress
 * Multitenancy: BOS Support for boot, reboot, node power on and off in tenant
 
 ### New Hardware Support
@@ -117,7 +117,7 @@
 * Addressed `Zenbleed` CVE on NCNs
 * Addressed `CVE-2023-38545` (curl & `libcurl`) on NCNs
 * Added Default RBAC Role for Telemetry API
-* In SAT upgradeded paramiko to resolve CVE-2023-48795 
+* In SAT upgraded `paramiko` to resolve `CVE-2023-48795` 
   
 ### Customer-Requested Enhancements
 

--- a/background/ncn_kernel.md
+++ b/background/ncn_kernel.md
@@ -724,7 +724,7 @@ This value sets the `xname` for the node, detailing the geolocation of the node.
 | CSM 1.3.0                 | 5.3.18-150300.59.**87.1**                      | [`CVE-2022-33981`][23]                              |
 | CSM 1.3.1                 | 5.3.18-150300.59.87.1                          |                                                     |
 | CSM 1.4.0                 | 5.**14.21-150400.24.38.1.25440.1.PTF.1204911** | SLES-15-SP4 upgrade and SUSE patch (case #00502283) |
-| CSM 1.5.0                 | 5.14.21-150**500.55.28.1.26977.2.PTF.1214754** | SLES-15-SP5 bond bug (SUSE case #00703657)          |
+| CSM 1.5.0                 | 5.14.21-**150500.55.39.1.27360.1.PTF.1215587** | SUSE case #00703657 and #00707151                   |
 
 [1]:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/networking_guide/sec-consistent_network_device_naming_using_biosdevname
 


### PR DESCRIPTION
This is a work-in-progress PR for the CSM 1.5 Release notes.  It only includes content fron CASMREL tickets through CSM1.5.0-alpha.25.  The alpha CASMRELs go through 75 and then there are another 80+ beta releases, I believe.  So it could take several more dedicated hours to get through pouring through all remaining tickets if we want a super complete list.  At a high level, though, the new features at least need to be in the list.  I am creating the PR in the event that someone else has time to pick up the branch and continue from the alpha-26 CASMREL.  