### PR TITLE
CASMHMS-6115 rts init job war

### DIFF
--- a/operations/node_management/Reboot_NCNs.md
+++ b/operations/node_management/Reboot_NCNs.md
@@ -485,11 +485,13 @@ Before rebooting NCNs:
 
          If terminating pods are reported when checking the status of the Kubernetes pods, then wait for all pods to recover before proceeding.
 
-    1. Disconnect from the console.
+    1. If RTS was running on the worker node and it has not started Running, then see [RTS fails to start after worker node is restarted](../../troubleshooting/known_issues/rts_fails_to_start_after_worker_node_restart.md)
 
-    1. Repeat all of the sub-steps above for the remaining worker nodes, going from the highest to lowest number, until all worker nodes have successfully rebooted.
+    2. Disconnect from the console.
 
-1. Ensure that BGP sessions are reset so that all BGP peering sessions with the spine switches are in an `ESTABLISHED` state.
+    3. Repeat all of the sub-steps above for the remaining worker nodes, going from the highest to lowest number, until all worker nodes have successfully rebooted.
+
+2. Ensure that BGP sessions are reset so that all BGP peering sessions with the spine switches are in an `ESTABLISHED` state.
 
    See [Check BGP Status and Reset Sessions](../network/metallb_bgp/Check_BGP_Status_and_Reset_Sessions.md).
 

--- a/operations/node_management/Reboot_NCNs.md
+++ b/operations/node_management/Reboot_NCNs.md
@@ -487,9 +487,9 @@ Before rebooting NCNs:
 
     1. If RTS was running on the worker node and it has not started Running, then see [RTS fails to start after worker node is restarted](../../troubleshooting/known_issues/rts_fails_to_start_after_worker_node_restart.md)
 
-    2. Disconnect from the console.
+    1. Disconnect from the console.
 
-    3. Repeat all of the sub-steps above for the remaining worker nodes, going from the highest to lowest number, until all worker nodes have successfully rebooted.
+    1. Repeat all of the sub-steps above for the remaining worker nodes, going from the highest to lowest number, until all worker nodes have successfully rebooted.
 
 2. Ensure that BGP sessions are reset so that all BGP peering sessions with the spine switches are in an `ESTABLISHED` state.
 

--- a/operations/resiliency/Resilience_of_System_Management_Services.md
+++ b/operations/resiliency/Resilience_of_System_Management_Services.md
@@ -100,6 +100,9 @@ pods. Work is ongoing to correct these issues in a future release.
     `slingshot-fabric-manager` pod is brought back up and the sweeping process restarts.
   - The `slingshot-fabric-manager` relies on data in persistent storage. The data is persistent across upgrades but when the pods are deleted, the data is also deleted.
 
+- **RTS fails to start after worker node is restarted**
+  - If RTS was running on the worker node and it has not started Running, then see [RTS fails to start after worker node is restarted](../../troubleshooting/known_issues/rts_fails_to_start_after_worker_node_restart.md)
+
 ## Future Resiliency Improvements
 
 In a future release, strides will be made to further improve the resiliency of the system. These improvements may include one or more of the following:

--- a/operations/resiliency/Resiliency_Testing_Procedure.md
+++ b/operations/resiliency/Resiliency_Testing_Procedure.md
@@ -20,11 +20,11 @@ examples) to inform internal users and customers about our process.
 
 ## Prepare for resiliency testing
 
-* Confirm the component name (xname) mapping for each node on the system by running the `/opt/cray/platform-utils/ncnGetXnames.sh` script on each node.
+- Confirm the component name (xname) mapping for each node on the system by running the `/opt/cray/platform-utils/ncnGetXnames.sh` script on each node.
 
-* Verify that `metal.no-wipe=1` is set for each of the NCNs using output from running the `ncnGetXnames.sh` script.
+- Verify that `metal.no-wipe=1` is set for each of the NCNs using output from running the `ncnGetXnames.sh` script.
 
-* (`ncn-mw#`) Ensure the user account in use is an authorized user on the Cray CLI.
+- (`ncn-mw#`) Ensure the user account in use is an authorized user on the Cray CLI.
 
   Log in as a user account where the credentials are known:
 
@@ -34,20 +34,20 @@ examples) to inform internal users and customers about our process.
 
    Then, validate the authorization by executing the `cray uas list` command, for example. For more information, see the `Validate UAI Creation` section of [Validate CSM Health](../validate_csm_health.md).
 
-* (`ncn-mw#`) Verify that `kubectl get nodes` reports all master and worker nodes are `Ready`.
+- (`ncn-mw#`) Verify that `kubectl get nodes` reports all master and worker nodes are `Ready`.
 
    ```bash
    kubectl get nodes -o wide
    ```
 
-* (`ncn-mw#`) Get a current list of pods that have a status of anything other than `Running` or `Completed`. Investigate any of concern.
+- (`ncn-mw#`) Get a current list of pods that have a status of anything other than `Running` or `Completed`. Investigate any of concern.
   Save the list of pods for comparison once resiliency testing is completed and the system has been restored.
 
    ```bash
    kubectl get pods -o wide -A | grep -Ev 'Running|Completed'
    ```
 
-* (`ncn-mw#`) Note which pods are running on an NCN that will be taken down (as well as the total number of pods running). The following is an example that shows the listing of pods running on `ncn-w001`:
+- (`ncn-mw#`) Note which pods are running on an NCN that will be taken down (as well as the total number of pods running). The following is an example that shows the listing of pods running on `ncn-w001`:
 
    ```bash
    kubectl get pods -o wide -A | grep ncn-w001 | awk '{print $2}'
@@ -55,7 +55,7 @@ examples) to inform internal users and customers about our process.
 
    Note that the above would only apply to Kubernetes nodes, such as master and worker nodes.
 
-* (`linux#`) Verify `ipmitool` can report power status for the NCN to be shut down.
+- (`linux#`) Verify `ipmitool` can report power status for the NCN to be shut down.
 
    ```bash
    ipmitool -I lanplus -U root -P <password> -H <ncn-node-name> chassis power status
@@ -64,10 +64,10 @@ examples) to inform internal users and customers about our process.
    If `ncn-m001` is the node to be brought down, then note that it has the external network connection. Therefore it is important to establish that `ipmitool` commands are able to be run from a node external to the system, in
    order to get the power status of `ncn-m001`.
 
-* If `ncn-m001` is the node to be brought down, then establish Customer Access Network (CAN) links to bypass `ncn-m001` (because it will be down) in order to enable an external connection to one of the other master NCNs before,
+- If `ncn-m001` is the node to be brought down, then establish Customer Access Network (CAN) links to bypass `ncn-m001` (because it will be down) in order to enable an external connection to one of the other master NCNs before,
   during, and after `ncn-m001` is brought down.
 
-* Verify Boot Orchestration Service (BOS) templates and create a new one if needed (to be set-up for booting a specific compute nodes after the targeted NCN has been shutdown).
+- Verify Boot Orchestration Service (BOS) templates and create a new one if needed (to be set-up for booting a specific compute nodes after the targeted NCN has been shutdown).
 
    Before shutting down the NCN and beginning resiliency testing, verify that compute nodes identified for reboot validation can be successfully rebooted and configured.
 
@@ -79,7 +79,7 @@ examples) to inform internal users and customers about our process.
 
    For more information regarding management of BOS session templates, refer to [Manage a Session Template](../boot_orchestration/Manage_a_Session_Template.md).
 
-* If a UAN is present on the system, log onto it and verify that the workload manager (WLM) is configured by running a command.
+- If a UAN is present on the system, log onto it and verify that the workload manager (WLM) is configured by running a command.
 
    (`uan#`) The following is an example for Slurm:
 
@@ -349,9 +349,9 @@ a healthy state.
 
 1. If the target node for shutdown was a worker NCN, verify that the UAI launched on that node still exists. It should be running on another worker NCN.
 
-   * Any prior SSH session established with the UAI while it was running on the downed NCN worker node will be unresponsive. A new SSH session will need to be established once the UAI pods has been successfully relocated to
+   - Any prior SSH session established with the UAI while it was running on the downed NCN worker node will be unresponsive. A new SSH session will need to be established once the UAI pods has been successfully relocated to
      another worker NCN.
-   * Log back into the UAI and verify that the WLM batch job is still running and streaming output. The log file created with the kick-off of the batch job should still be accessible and the `squeue` command can be used to
+   - Log back into the UAI and verify that the WLM batch job is still running and streaming output. The log file created with the kick-off of the batch job should still be accessible and the `squeue` command can be used to
      verify that the job continues to run (for Slurm).
 
 1. If the WLM batch job was launched on a UAN, log back into it and verify that the batch job is still running and streaming output via the log file created with the batch job and/or the `squeue` command (if Slurm is used as
@@ -390,8 +390,8 @@ a healthy state.
 
    Check the following depending on the NCN type powered on:
 
-   * If the NCN being powered on is a master or worker, verify that `Terminating` pods on that NCN clear up. It may take several minutes. Watch the command prompt, previously set-up, that is displaying the `Terminating` pod list.
-   * If the NCN being powered on is a storage node, wait for Ceph to recover and again report a `HEALTH_OK` status. It may take several minutes for Ceph to resolve clock skew. This can be noted in the previously set-up window
+   - If the NCN being powered on is a master or worker, verify that `Terminating` pods on that NCN clear up. It may take several minutes. Watch the command prompt, previously set-up, that is displaying the `Terminating` pod list.
+   - If the NCN being powered on is a storage node, wait for Ceph to recover and again report a `HEALTH_OK` status. It may take several minutes for Ceph to resolve clock skew. This can be noted in the previously set-up window
      to watch Ceph status.
 
 1. Check that pod statuses have returned to the state that they were in at the beginning of this procedure, paying particular attention to any pods that were previously noted to be in a bad state while the NCN was down.
@@ -409,4 +409,4 @@ a healthy state.
 
    > **IMPORTANT:** Do not forget to remove the labels after the UAI has been created. Once the UAI has been created, log into it and ensure a new workload manager job can be launched.
 
-3. Ensure tickets have been opened for any unexpected behavior along with associated logs and notes on workarounds, if any were executed.
+1. Ensure tickets have been opened for any unexpected behavior along with associated logs and notes on workarounds, if any were executed.

--- a/operations/resiliency/Resiliency_Testing_Procedure.md
+++ b/operations/resiliency/Resiliency_Testing_Procedure.md
@@ -6,14 +6,17 @@ the loss of a single non-compute node (NCN).
 It is assumed that some procedures are already known by admins and thus does not go into great detail or attempt to encompass every command necessary for execution. It is intended to be higher level guidance (with some command
 examples) to inform internal users and customers about our process.
 
-* [Prepare for resiliency testing](#prepare-for-resiliency-testing)
-* [Establish system health before beginning](#establish-system-health-before-beginning)
-* [Monitor for changes](#monitor-for-changes)
-* [Launch a non-interactive batch job](#launch-a-non-interactive-batch-job)
-* [Shut down an NCN](#shut-down-an-ncn)
-* [Conduct testing](#conduct-testing)
-* [Power on the downed NCN](#power-on-the-downed-ncn)
-* [Execute post-boot health checks](#execute-post-boot-health-checks)
+- [Resiliency Testing Procedure](#resiliency-testing-procedure)
+  - [Prepare for resiliency testing](#prepare-for-resiliency-testing)
+  - [Establish system health before beginning](#establish-system-health-before-beginning)
+  - [Monitor for changes](#monitor-for-changes)
+  - [Launch a non-interactive batch job](#launch-a-non-interactive-batch-job)
+    - [Launch on a UAI](#launch-on-a-uai)
+    - [Launch on a UAN](#launch-on-a-uan)
+  - [Shut down an NCN](#shut-down-an-ncn)
+  - [Conduct testing](#conduct-testing)
+  - [Power on the downed NCN](#power-on-the-downed-ncn)
+  - [Execute post-boot health checks](#execute-post-boot-health-checks)
 
 ## Prepare for resiliency testing
 
@@ -399,9 +402,11 @@ a healthy state.
 
 1. Re-run the `Platform Health Checks` section of [Validate CSM Health](../validate_csm_health.md) noting any output that indicates output is not as expected.
 
+1. If RTS was running on the worker node and it has not started Running, then see [RTS fails to start after worker node is restarted](../../troubleshooting/known_issues/rts_fails_to_start_after_worker_node_restart.md)
+
 1. Ensure that after a downed NCN worker node (can ignore if not a worker node) has been powered up, a new UAI can be created on that NCN. It may be necessary to label the nodes again, to ensure the UAI gets created on the
    worker node that was just powered on. Refer to the section above for `Launch a Non-Interactive Batch Job` for the procedure.
 
    > **IMPORTANT:** Do not forget to remove the labels after the UAI has been created. Once the UAI has been created, log into it and ensure a new workload manager job can be launched.
 
-1. Ensure tickets have been opened for any unexpected behavior along with associated logs and notes on workarounds, if any were executed.
+3. Ensure tickets have been opened for any unexpected behavior along with associated logs and notes on workarounds, if any were executed.

--- a/operations/resiliency/Restore_System_Functionality_if_a_Kubernetes_Worker_Node_is_Down.md
+++ b/operations/resiliency/Restore_System_Functionality_if_a_Kubernetes_Worker_Node_is_Down.md
@@ -212,4 +212,6 @@ error state. Once any remaining testing or validation work is complete, these po
         kubectl describe pod POD_NAME
         ```
 
+    1. If RTS was running on the worker node and it has not started Running, then see [RTS fails to start after worker node is restarted](../../troubleshooting/known_issues/rts_fails_to_start_after_worker_node_restart.md)
+
 The node that encountered issues should now be returned to a healthy state.

--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -28,132 +28,132 @@ In the main repository landing page, change the branch to the CSM version being 
 Use the pre-populated GitHub "Search or jump to..." function in the upper left hand side of the page and append keywords related
 to the exiting problem seen into the existing search. (The example searches for "ping" and "PXE" related troubleshooting resources on the "main" branch.)
 
-* Follow any run-books, guides, or procedures which are directly related to the problem.
+- Follow any run-books, guides, or procedures which are directly related to the problem.
 
-* Change the branch to `main` and search a second time to retrieve very recent or beta run-books and guides.
+- Change the branch to `main` and search a second time to retrieve very recent or beta run-books and guides.
 
-* Users can also expand the search beyond the "troubleshooting" section (instead of doing "path troubleshooting") and/or use more advanced GitHub searches such as "path configure" to find the right context.
+- Users can also expand the search beyond the "troubleshooting" section (instead of doing "path troubleshooting") and/or use more advanced GitHub searches such as "path configure" to find the right context.
 
 ## Known issues
 
-* [SAT/HSM/CAPMC/PCS Component Power State Mismatch](known_issues/component_power_state_mismatch.md)
-* [HMS Discovery job not creating `RedfishEndpoint`s in Hardware State Manager](known_issues/discovery_job_not_creating_redfish_endpoints.md)
-* [`initrd.img.xz` not found](known_issues/initrd.img.zx_not_found.md)
-* [SSL Certificate Validation Issues](known_issues/ssl_certificate_validation_issues.md)
-* [SLS Not Working During Node Rebuild](known_issues/SLS_Not_Working_During_Node_Rebuild.md)
-* [Antero node NID allocation](known_issues/antero_node_NID_allocation.md)
-* [HPE nodes not properly transitioning power state](known_issues/hpe_systems_not_transitioning_power_state.md)
-* [Software Management Services health check](known_issues/sms_health_check.md)
-* [QLogic driver crash on storage nodes](known_issues/qlogic_driver_crash.md)
-* [Nexus Fails Authentication with Keycloak Users](known_issues/Nexus_Fail_Authentication_with_Keycloak_Users.md)
-* [RTS fails to start after worker node is restarted](known_issues/rts_fails_to_start_after_worker_node_restart.md)
+- [SAT/HSM/CAPMC/PCS Component Power State Mismatch](known_issues/component_power_state_mismatch.md)
+- [HMS Discovery job not creating `RedfishEndpoint`s in Hardware State Manager](known_issues/discovery_job_not_creating_redfish_endpoints.md)
+- [`initrd.img.xz` not found](known_issues/initrd.img.zx_not_found.md)
+- [SSL Certificate Validation Issues](known_issues/ssl_certificate_validation_issues.md)
+- [SLS Not Working During Node Rebuild](known_issues/SLS_Not_Working_During_Node_Rebuild.md)
+- [Antero node NID allocation](known_issues/antero_node_NID_allocation.md)
+- [HPE nodes not properly transitioning power state](known_issues/hpe_systems_not_transitioning_power_state.md)
+- [Software Management Services health check](known_issues/sms_health_check.md)
+- [QLogic driver crash on storage nodes](known_issues/qlogic_driver_crash.md)
+- [Nexus Fails Authentication with Keycloak Users](known_issues/Nexus_Fail_Authentication_with_Keycloak_Users.md)
+- [RTS fails to start after worker node is restarted](known_issues/rts_fails_to_start_after_worker_node_restart.md)
 
 ## Booting
 
 ### UAN boot issues
 
-* [UAN Boot Issues](../operations/boot_orchestration/Troubleshoot_UAN_Boot_Issues.md)
+- [UAN Boot Issues](../operations/boot_orchestration/Troubleshoot_UAN_Boot_Issues.md)
 
 ### Compute node boot issues
 
-* [Issues Related to Unified Extensible Firmware Interface (UEFI)](../operations/boot_orchestration/Troubleshoot_Compute_Node_Boot_Issues_Related_to_Unified_Extensible_Firmware_Interface_UEFI.md)
-* [Issues Related to Dynamic Host Configuration Protocol (DHCP)](../operations/boot_orchestration/Troubleshoot_Compute_Node_Boot_Issues_Related_to_Dynamic_Host_Configuration_Protocol_DHCP.md)
-* [Issues Related to the Boot Script Service](../operations/boot_orchestration/Troubleshoot_Compute_Node_Boot_Issues_Related_to_the_Boot_Script_Service_BSS.md)
-* [Issues Related to Trivial File Transfer Protocol (TFTP)](../operations/boot_orchestration/Troubleshoot_Compute_Node_Boot_Issues_Related_to_Trivial_File_Transfer_Protocol_TFTP.md)
-* [Troubleshooting Using Kubernetes](../operations/boot_orchestration/Troubleshoot_Compute_Node_Boot_Issues_Using_Kubernetes.md)
-* [Log File Locations and Ports Used](../operations/boot_orchestration/Log_File_Locations_and_Ports_Used_in_Compute_Node_Boot_Troubleshooting.md)
-* [Issues Related to Slow Boot Times](../operations/boot_orchestration/Troubleshoot_Compute_Node_Boot_Issues_Related_to_Slow_Boot_Times.md)
+- [Issues Related to Unified Extensible Firmware Interface (UEFI)](../operations/boot_orchestration/Troubleshoot_Compute_Node_Boot_Issues_Related_to_Unified_Extensible_Firmware_Interface_UEFI.md)
+- [Issues Related to Dynamic Host Configuration Protocol (DHCP)](../operations/boot_orchestration/Troubleshoot_Compute_Node_Boot_Issues_Related_to_Dynamic_Host_Configuration_Protocol_DHCP.md)
+- [Issues Related to the Boot Script Service](../operations/boot_orchestration/Troubleshoot_Compute_Node_Boot_Issues_Related_to_the_Boot_Script_Service_BSS.md)
+- [Issues Related to Trivial File Transfer Protocol (TFTP)](../operations/boot_orchestration/Troubleshoot_Compute_Node_Boot_Issues_Related_to_Trivial_File_Transfer_Protocol_TFTP.md)
+- [Troubleshooting Using Kubernetes](../operations/boot_orchestration/Troubleshoot_Compute_Node_Boot_Issues_Using_Kubernetes.md)
+- [Log File Locations and Ports Used](../operations/boot_orchestration/Log_File_Locations_and_Ports_Used_in_Compute_Node_Boot_Troubleshooting.md)
+- [Issues Related to Slow Boot Times](../operations/boot_orchestration/Troubleshoot_Compute_Node_Boot_Issues_Related_to_Slow_Boot_Times.md)
 
 ## Configuration management
 
-* [Troubleshoot CFS Issues](../operations/configuration_management/Troubleshoot_CFS_Issues.md)
-* [Incrementally Configuring Images](incrementally_configuring_images.md)
+- [Troubleshoot CFS Issues](../operations/configuration_management/Troubleshoot_CFS_Issues.md)
+- [Incrementally Configuring Images](incrementally_configuring_images.md)
 
 ## ConMan
 
-* [Console Services Troubleshooting Guide](../operations/conman/Console_Services_Troubleshooting_Guide.md)
-* [ConMan Blocking Access to a Node BMC](../operations/conman/Troubleshoot_ConMan_Blocking_Access_to_a_Node_BMC.md)
-* [ConMan Failing to Connect to a Console](../operations/conman/Troubleshoot_ConMan_Failing_to_Connect_to_a_Console.md)
-* [ConMan Asking for Password on SSH Connection](../operations/conman/Troubleshoot_ConMan_Asking_for_Password_on_SSH_Connection.md)
-* [Console Node Pod Stuck in Terminating State](../operations/conman/Troubleshoot_ConMan_Node_Pod_Stuck_Terminating.md)
+- [Console Services Troubleshooting Guide](../operations/conman/Console_Services_Troubleshooting_Guide.md)
+- [ConMan Blocking Access to a Node BMC](../operations/conman/Troubleshoot_ConMan_Blocking_Access_to_a_Node_BMC.md)
+- [ConMan Failing to Connect to a Console](../operations/conman/Troubleshoot_ConMan_Failing_to_Connect_to_a_Console.md)
+- [ConMan Asking for Password on SSH Connection](../operations/conman/Troubleshoot_ConMan_Asking_for_Password_on_SSH_Connection.md)
+- [Console Node Pod Stuck in Terminating State](../operations/conman/Troubleshoot_ConMan_Node_Pod_Stuck_Terminating.md)
 
 ## Customer Management Network (CMN)
 
-* [DHCP run book](dhcp_runbook.md)
-* [DNS run book](dns_runbook.md)
-* [General configuration and troubleshooting](../operations/network/management_network/README.md)
-* [Troubleshoot CMN Issues](../operations/network/customer_accessible_networks/Troubleshoot_CMN_Issues.md)
-* [Troubleshoot DHCP Issues](../operations/network/dhcp/Troubleshoot_DHCP_Issues.md)
-* [Troubleshoot Common DNS Issues](../operations/network/dns/Troubleshoot_Common_DNS_Issues.md)
-* [Troubleshoot PowerDNS Issues](../operations/network/dns/Troubleshoot_PowerDNS.md)
-* [Troubleshoot Common DNS configuration Issues](../operations/network/external_dns/Troubleshoot_DNS_Configuration_Issues.md)
-* [Troubleshoot External DNS Issues](../operations/network/external_dns/Troubleshoot_Systems_Not_Provisioned_with_External_IP_Addresses.md)
-* [Troubleshoot BGP not accepting routes from MetalLB](../operations/network/metallb_bgp/Troubleshoot_BGP_not_Accepting_Routes_from_MetalLB.md)
-* [Troubleshoot BGP services without an allocated IP address](../operations/network/metallb_bgp/Troubleshoot_Services_without_an_Allocated_IP_Address.md)
-* [Troubleshoot PXE boot](../install/troubleshooting_pxe_boot.md)
+- [DHCP run book](dhcp_runbook.md)
+- [DNS run book](dns_runbook.md)
+- [General configuration and troubleshooting](../operations/network/management_network/README.md)
+- [Troubleshoot CMN Issues](../operations/network/customer_accessible_networks/Troubleshoot_CMN_Issues.md)
+- [Troubleshoot DHCP Issues](../operations/network/dhcp/Troubleshoot_DHCP_Issues.md)
+- [Troubleshoot Common DNS Issues](../operations/network/dns/Troubleshoot_Common_DNS_Issues.md)
+- [Troubleshoot PowerDNS Issues](../operations/network/dns/Troubleshoot_PowerDNS.md)
+- [Troubleshoot Common DNS configuration Issues](../operations/network/external_dns/Troubleshoot_DNS_Configuration_Issues.md)
+- [Troubleshoot External DNS Issues](../operations/network/external_dns/Troubleshoot_Systems_Not_Provisioned_with_External_IP_Addresses.md)
+- [Troubleshoot BGP not accepting routes from MetalLB](../operations/network/metallb_bgp/Troubleshoot_BGP_not_Accepting_Routes_from_MetalLB.md)
+- [Troubleshoot BGP services without an allocated IP address](../operations/network/metallb_bgp/Troubleshoot_Services_without_an_Allocated_IP_Address.md)
+- [Troubleshoot PXE boot](../install/troubleshooting_pxe_boot.md)
 
 ## Grafana dashboards
 
-* [Grafana Dashboards](../operations/system_management_health/Troubleshoot_Grafana_Dashboard.md)
+- [Grafana Dashboards](../operations/system_management_health/Troubleshoot_Grafana_Dashboard.md)
 
 ## Domain Name Service (DNS)
 
-* [Connectivity to Services with External IP addresses](../operations/network/external_dns/Troubleshoot_Systems_Not_Provisioned_with_External_IP_Addresses.md)
-* [DNS Configuration Issues](../operations/network/external_dns/Troubleshoot_DNS_Configuration_Issues.md)
+- [Connectivity to Services with External IP addresses](../operations/network/external_dns/Troubleshoot_Systems_Not_Provisioned_with_External_IP_Addresses.md)
+- [DNS Configuration Issues](../operations/network/external_dns/Troubleshoot_DNS_Configuration_Issues.md)
 
 ## Kubernetes
 
-* [General Kubernetes Commands for Troubleshooting](kubernetes/Kubernetes_Troubleshooting_Information.md)
-* [Kubernetes Log File Locations](kubernetes/Kubernetes_Log_File_Locations.md)
-* [Liveliness or Readiness Probe Failures](kubernetes/Troubleshoot_Liveliness_Readiness_Probe_Failures.md)
-* [Unresponsive `kubectl` Commands](kubernetes/Troubleshoot_Unresponsive_kubectl_Commands.md)
-* [Kubernetes Node `NotReady`](kubernetes/Troubleshoot_Kubernetes_Node_NotReady.md)
-* [Kubernetes Pods not Starting](kubernetes/Troubleshoot_Kubernetes_Pods_Not_Starting.md)
-* [Postgres Database](../operations/kubernetes/Troubleshoot_Postgres_Database.md)
-* [Recover from Postgres WAL Event](../operations/kubernetes/Troubleshoot_Postgres_Database.md)
-* [Restore Postgres](../operations/kubernetes/Restore_Postgres.md)
-* [Disaster Recovery for Postgres](../operations/kubernetes/Disaster_Recovery_Postgres.md)
+- [General Kubernetes Commands for Troubleshooting](kubernetes/Kubernetes_Troubleshooting_Information.md)
+- [Kubernetes Log File Locations](kubernetes/Kubernetes_Log_File_Locations.md)
+- [Liveliness or Readiness Probe Failures](kubernetes/Troubleshoot_Liveliness_Readiness_Probe_Failures.md)
+- [Unresponsive `kubectl` Commands](kubernetes/Troubleshoot_Unresponsive_kubectl_Commands.md)
+- [Kubernetes Node `NotReady`](kubernetes/Troubleshoot_Kubernetes_Node_NotReady.md)
+- [Kubernetes Pods not Starting](kubernetes/Troubleshoot_Kubernetes_Pods_Not_Starting.md)
+- [Postgres Database](../operations/kubernetes/Troubleshoot_Postgres_Database.md)
+- [Recover from Postgres WAL Event](../operations/kubernetes/Troubleshoot_Postgres_Database.md)
+- [Restore Postgres](../operations/kubernetes/Restore_Postgres.md)
+- [Disaster Recovery for Postgres](../operations/kubernetes/Disaster_Recovery_Postgres.md)
 
 ## MetalLB
 
-* [Services Without an Allocated IP Address](../operations/network/metallb_bgp/Troubleshoot_Services_without_an_Allocated_IP_Address.md)
-* [BGP not Accepting Routes from MetalLB](../operations/network/metallb_bgp/Troubleshoot_BGP_not_Accepting_Routes_from_MetalLB.md)
+- [Services Without an Allocated IP Address](../operations/network/metallb_bgp/Troubleshoot_Services_without_an_Allocated_IP_Address.md)
+- [BGP not Accepting Routes from MetalLB](../operations/network/metallb_bgp/Troubleshoot_BGP_not_Accepting_Routes_from_MetalLB.md)
 
 ## Node management
 
-* [Issues with Redfish Endpoint `DiscoveryCheck` for Redfish Events from Nodes](../operations/node_management/Troubleshoot_Issues_with_Redfish_Endpoint_Discovery.md)
-* [Interfaces with IP Address Issues](../operations/node_management/Troubleshoot_Interfaces_with_IP_Address_Issues.md)
-* [Loss of Console Connections and Logs on Gigabyte Nodes](../operations/node_management/Troubleshoot_Loss_of_Console_Connections_and_Logs_on_Gigabyte_Nodes.md)
+- [Issues with Redfish Endpoint `DiscoveryCheck` for Redfish Events from Nodes](../operations/node_management/Troubleshoot_Issues_with_Redfish_Endpoint_Discovery.md)
+- [Interfaces with IP Address Issues](../operations/node_management/Troubleshoot_Interfaces_with_IP_Address_Issues.md)
+- [Loss of Console Connections and Logs on Gigabyte Nodes](../operations/node_management/Troubleshoot_Loss_of_Console_Connections_and_Logs_on_Gigabyte_Nodes.md)
 
 ## Security and authentication
 
-* [Common Vault Cluster Issues](../operations/security_and_authentication/Troubleshoot_Common_Vault_Cluster_Issues.md)
-* [Keycloak User Localization](../operations/security_and_authentication/Keycloak_User_Localization.md)
-* [Troubleshoot Kyverno configuration manually](../operations/security_and_authentication/Troubleshoot_Kyverno_Configuration_manually.md)
+- [Common Vault Cluster Issues](../operations/security_and_authentication/Troubleshoot_Common_Vault_Cluster_Issues.md)
+- [Keycloak User Localization](../operations/security_and_authentication/Keycloak_User_Localization.md)
+- [Troubleshoot Kyverno configuration manually](../operations/security_and_authentication/Troubleshoot_Kyverno_Configuration_manually.md)
 
 ## Spire
 
-* [Restore Spire Postgres without a Backup](../operations/spire/Restore_Spire_Postgres_without_a_Backup.md)
-* [Spire Database Cluster DNS Lookup Failure](known_issues/spire_database_lookup_error.md)
-* [Spire Failing to Start on NCNs](../operations/spire/Troubleshoot_Spire_Failing_to_Start_on_NCNs.md)
+- [Restore Spire Postgres without a Backup](../operations/spire/Restore_Spire_Postgres_without_a_Backup.md)
+- [Spire Database Cluster DNS Lookup Failure](known_issues/spire_database_lookup_error.md)
+- [Spire Failing to Start on NCNs](../operations/spire/Troubleshoot_Spire_Failing_to_Start_on_NCNs.md)
 
 ## User Access service UAS
 
-* [Viewing UAI Log Output](../operations/UAS_user_and_admin_topics/Troubleshoot_UAIs_by_Viewing_Log_Output.md)
-* [Stale Brokered UAIs](../operations/UAS_user_and_admin_topics/Troubleshoot_Stale_Brokered_UAIs.md)
-* [UAI Stuck in `ContainerCreating`](../operations/UAS_user_and_admin_topics/Troubleshoot_UAI_Stuck_in_ContainerCreating.md)
-* [Duplicate Mount Paths in a UAI](../operations/UAS_user_and_admin_topics/Troubleshoot_Duplicate_Mount_Paths_in_a_UAI.md)
-* [Missing or Incorrect UAI Images](../operations/UAS_user_and_admin_topics/Troubleshoot_Missing_or_Incorrect_UAI_Images.md)
-* [Common Mistakes When Creating a Custom End-User UAI Image](../operations/UAS_user_and_admin_topics/Troubleshoot_Common_Mistakes_when_Creating_a_Custom_End-User_UAI_Image.md)
+- [Viewing UAI Log Output](../operations/UAS_user_and_admin_topics/Troubleshoot_UAIs_by_Viewing_Log_Output.md)
+- [Stale Brokered UAIs](../operations/UAS_user_and_admin_topics/Troubleshoot_Stale_Brokered_UAIs.md)
+- [UAI Stuck in `ContainerCreating`](../operations/UAS_user_and_admin_topics/Troubleshoot_UAI_Stuck_in_ContainerCreating.md)
+- [Duplicate Mount Paths in a UAI](../operations/UAS_user_and_admin_topics/Troubleshoot_Duplicate_Mount_Paths_in_a_UAI.md)
+- [Missing or Incorrect UAI Images](../operations/UAS_user_and_admin_topics/Troubleshoot_Missing_or_Incorrect_UAI_Images.md)
+- [Common Mistakes When Creating a Custom End-User UAI Image](../operations/UAS_user_and_admin_topics/Troubleshoot_Common_Mistakes_when_Creating_a_Custom_End-User_UAI_Image.md)
 
 ## Utility storage
 
-* [Failure to Get Ceph Health](../operations/utility_storage/Troubleshoot_Failure_to_Get_Ceph_Health.md)
-* [Down OSDs](../operations/utility_storage/Troubleshoot_a_Down_OSD.md)
-* [Ceph OSDs Reporting Full](../operations/utility_storage/Troubleshoot_Ceph_OSDs_Reporting_Full.md)
-* [System Clock Skew](../operations/utility_storage/Troubleshoot_System_Clock_Skew.md)
-* [Unresponsive S3 Endpoint](../operations/utility_storage/Troubleshoot_an_Unresponsive_S3_Endpoint.md)
-* [Ceph-Mon Processes Stopping and Exceeding Max Restarts](../operations/utility_storage/Troubleshoot_Ceph-Mon_Processes_Stopping_and_Exceeding_Max_Restarts.md)
-* [Large Object Map Objects in Ceph Health](../operations/utility_storage/Troubleshoot_Large_Object_Map_Objects_in_Ceph_Health.md)
-* [Failure of RGW Health Check](../operations/utility_storage/Troubleshoot_RGW_Health_Check_Fail.md)
-* [Troubleshoot S3FS Mounts](../operations/utility_storage/Troubleshoot_S3FS_Mounts.md)
+- [Failure to Get Ceph Health](../operations/utility_storage/Troubleshoot_Failure_to_Get_Ceph_Health.md)
+- [Down OSDs](../operations/utility_storage/Troubleshoot_a_Down_OSD.md)
+- [Ceph OSDs Reporting Full](../operations/utility_storage/Troubleshoot_Ceph_OSDs_Reporting_Full.md)
+- [System Clock Skew](../operations/utility_storage/Troubleshoot_System_Clock_Skew.md)
+- [Unresponsive S3 Endpoint](../operations/utility_storage/Troubleshoot_an_Unresponsive_S3_Endpoint.md)
+- [Ceph-Mon Processes Stopping and Exceeding Max Restarts](../operations/utility_storage/Troubleshoot_Ceph-Mon_Processes_Stopping_and_Exceeding_Max_Restarts.md)
+- [Large Object Map Objects in Ceph Health](../operations/utility_storage/Troubleshoot_Large_Object_Map_Objects_in_Ceph_Health.md)
+- [Failure of RGW Health Check](../operations/utility_storage/Troubleshoot_RGW_Health_Check_Fail.md)
+- [Troubleshoot S3FS Mounts](../operations/utility_storage/Troubleshoot_S3FS_Mounts.md)

--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -2,23 +2,24 @@
 
 This document provides links to troubleshooting information for services and functionality provided by CSM.
 
-* [Helpful tips for navigating the CSM repository](#helpful-tips-for-navigating-the-csm-repository)
-* [Known issues](#known-issues)
-* [Booting](#booting)
-  * [UAN boot issues](#uan-boot-issues)
-  * [Compute node boot issues](#compute-node-boot-issues)
-* [Configuration management](#configuration-management)
-* [ConMan](#conman)
-* [Customer Management Network (CMN)](#customer-management-network-cmn)
-* [Domain Name Service (DNS)](#domain-name-service-dns)
-* [Grafana dashboards](#grafana-dashboards)
-* [Kubernetes](#kubernetes)
-* [MetalLB](#metallb)
-* [Node management](#node-management)
-* [Security and authentication](#security-and-authentication)
-* [Spire](#spire)
-* [User Access Service (UAS)](#user-access-service-uas)
-* [Utility storage](#utility-storage)
+- [CSM Troubleshooting Information](#csm-troubleshooting-information)
+  - [Helpful tips for navigating the CSM repository](#helpful-tips-for-navigating-the-csm-repository)
+  - [Known issues](#known-issues)
+  - [Booting](#booting)
+    - [UAN boot issues](#uan-boot-issues)
+    - [Compute node boot issues](#compute-node-boot-issues)
+  - [Configuration management](#configuration-management)
+  - [ConMan](#conman)
+  - [Customer Management Network (CMN)](#customer-management-network-cmn)
+  - [Grafana dashboards](#grafana-dashboards)
+  - [Domain Name Service (DNS)](#domain-name-service-dns)
+  - [Kubernetes](#kubernetes)
+  - [MetalLB](#metallb)
+  - [Node management](#node-management)
+  - [Security and authentication](#security-and-authentication)
+  - [Spire](#spire)
+  - [User Access service UAS](#user-access-service-uas)
+  - [Utility storage](#utility-storage)
 
 ## Helpful tips for navigating the CSM repository
 
@@ -45,6 +46,7 @@ to the exiting problem seen into the existing search. (The example searches for 
 * [Software Management Services health check](known_issues/sms_health_check.md)
 * [QLogic driver crash on storage nodes](known_issues/qlogic_driver_crash.md)
 * [Nexus Fails Authentication with Keycloak Users](known_issues/Nexus_Fail_Authentication_with_Keycloak_Users.md)
+* [RTS fails to start after worker node is restarted](known_issues/rts_fails_to_start_after_worker_node_restart.md)
 
 ## Booting
 

--- a/troubleshooting/known_issues/rts_fails_to_start_after_worker_node_restart.md
+++ b/troubleshooting/known_issues/rts_fails_to_start_after_worker_node_restart.md
@@ -8,6 +8,7 @@ failure, any RTS pod that is running on that worker node may not properly start 
 ```bash
 kubectl get pods -n services | egrep rts | egrep -v Running
 ```
+
 ```text
 services         cray-hms-rts-744577c9b5-fs287                 0/3     Init:0/2           0                 45m
 services         cray-hms-rts-snmp-776695546-thxlb             0/3     Init:0/2           0                 45m

--- a/troubleshooting/known_issues/rts_fails_to_start_after_worker_node_restart.md
+++ b/troubleshooting/known_issues/rts_fails_to_start_after_worker_node_restart.md
@@ -1,0 +1,61 @@
+# Known Issue: RTS fails to restart after a worker node has been rebooted
+
+After a system has been running a while and a worker node is rebooted either due to maintenance or
+failure, any RTS pod that is running on that worker node may not properly start up.
+
+1. (`ncn-mw#`) Check current status of RTS.
+```bash
+kubectl get pods -n services | egrep rts | egrep -v Running
+```
+```text
+services         cray-hms-rts-744577c9b5-fs287                 0/3     Init:0/2           0                 45m
+services         cray-hms-rts-snmp-776695546-thxlb             0/3     Init:0/2           0                 45m
+```
+
+The RTS pods are looking for the `cray-hms-rts-init` job that indicates the prerequisites are ready
+but that job no longer exists because it has been cleaned up.
+
+## Fix
+1. (`ncn-mw#`) Generate a RTS init yaml from the manifest.
+```bash
+helm get manifest -n services cray-hms-rts | yq4 ea 'select(.kind == "Job")' > cray-hms-rts-init.yaml
+```
+
+2. (`ncn-mw#`) Apply the RTS init yaml to get it created.
+```bash
+kubectl apply -n services -f cray-hms-rts-init.yaml
+```
+
+3. (`ncn-mw#`) Wait for the RTS init job to complete.
+```bash
+while [ -z "$DONT_WAIT" -a "`kubectl get jobs -n services cray-hms-rts-init \
+-o jsonpath='{.status.conditions[0].type}'`" != "Complete" ]; do \
+echo "Waiting for cray-hms-rts-init to complete"; sleep 3;  done; echo "Completed";
+```
+```text
+Waiting for cray-hms-rts-init to complete
+Waiting for cray-hms-rts-init to complete
+Waiting for cray-hms-rts-init to complete
+Waiting for cray-hms-rts-init to complete
+Waiting for cray-hms-rts-init to complete
+Waiting for cray-hms-rts-init to complete
+Waiting for cray-hms-rts-init to complete
+Waiting for cray-hms-rts-init to complete
+Waiting for cray-hms-rts-init to complete
+Waiting for cray-hms-rts-init to complete
+Waiting for cray-hms-rts-init to complete
+Waiting for cray-hms-rts-init to complete
+Waiting for cray-hms-rts-init to complete
+Waiting for cray-hms-rts-init to complete
+Completed
+```
+
+4. (`ncn-mw#`) Check to make sure RTS has properly been started.
+```bash
+kubectl get pods -n services | egrep rts
+```
+```text
+cray-hms-rts-dbbc87df4-rzrgl                                      3/3     Running            0                 4m20s
+cray-hms-rts-init-vctgv                                           0/2     Completed          0                 104s
+cray-hms-rts-snmp-776695546-zh4k4                                 3/3     Running            0                 24h
+```

--- a/troubleshooting/known_issues/rts_fails_to_start_after_worker_node_restart.md
+++ b/troubleshooting/known_issues/rts_fails_to_start_after_worker_node_restart.md
@@ -18,13 +18,13 @@ but that job no longer exists because it has been cleaned up.
 
 ## Fix
 
-1. (`ncn-mw#`) Generate a RTS init yaml from the manifest.
+1. (`ncn-mw#`) Generate a RTS init `yaml` from the manifest.
 
 ```bash
 helm get manifest -n services cray-hms-rts | yq4 ea 'select(.kind == "Job")' > cray-hms-rts-init.yaml
 ```
 
-1. (`ncn-mw#`) Apply the RTS init yaml to get it created.
+1. (`ncn-mw#`) Apply the RTS init `yaml` to get it created.
 
 ```bash
 kubectl apply -n services -f cray-hms-rts-init.yaml

--- a/troubleshooting/known_issues/rts_fails_to_start_after_worker_node_restart.md
+++ b/troubleshooting/known_issues/rts_fails_to_start_after_worker_node_restart.md
@@ -4,6 +4,7 @@ After a system has been running a while and a worker node is rebooted either due
 failure, any RTS pod that is running on that worker node may not properly start up.
 
 1. (`ncn-mw#`) Check current status of RTS.
+
 ```bash
 kubectl get pods -n services | egrep rts | egrep -v Running
 ```
@@ -16,22 +17,27 @@ The RTS pods are looking for the `cray-hms-rts-init` job that indicates the prer
 but that job no longer exists because it has been cleaned up.
 
 ## Fix
+
 1. (`ncn-mw#`) Generate a RTS init yaml from the manifest.
+
 ```bash
 helm get manifest -n services cray-hms-rts | yq4 ea 'select(.kind == "Job")' > cray-hms-rts-init.yaml
 ```
 
-2. (`ncn-mw#`) Apply the RTS init yaml to get it created.
+1. (`ncn-mw#`) Apply the RTS init yaml to get it created.
+
 ```bash
 kubectl apply -n services -f cray-hms-rts-init.yaml
 ```
 
-3. (`ncn-mw#`) Wait for the RTS init job to complete.
+1. (`ncn-mw#`) Wait for the RTS init job to complete.
+
 ```bash
 while [ -z "$DONT_WAIT" -a "`kubectl get jobs -n services cray-hms-rts-init \
 -o jsonpath='{.status.conditions[0].type}'`" != "Complete" ]; do \
 echo "Waiting for cray-hms-rts-init to complete"; sleep 3;  done; echo "Completed";
 ```
+
 ```text
 Waiting for cray-hms-rts-init to complete
 Waiting for cray-hms-rts-init to complete
@@ -50,10 +56,12 @@ Waiting for cray-hms-rts-init to complete
 Completed
 ```
 
-4. (`ncn-mw#`) Check to make sure RTS has properly been started.
+1. (`ncn-mw#`) Check to make sure RTS has properly been started.
+
 ```bash
 kubectl get pods -n services | egrep rts
 ```
+
 ```text
 cray-hms-rts-dbbc87df4-rzrgl                                      3/3     Running            0                 4m20s
 cray-hms-rts-init-vctgv                                           0/2     Completed          0                 104s


### PR DESCRIPTION
# Description
The RTS pods require a job to have run and completed for them to know they can start. This job gets cleaned up after a while so if the RTS pods need to restart they will wait forever for the job to complete. This WAR provides instructions on how to recreate the job so the RTS pods can properly start.

Relates to: [CASMHMS-6115](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6115)

# Checklist

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
