### PR TITLE
CASMINST-6692 Perform post-install upgrade of CSM in vShasta

### DIFF
--- a/operations/utility_storage/Troubleshoot_HEALTH_ERR_Module_devicehealth.md
+++ b/operations/utility_storage/Troubleshoot_HEALTH_ERR_Module_devicehealth.md
@@ -38,7 +38,7 @@ Error Message:
    3. Delete pool
 
       ```bash
-      ncn-s001:~ # ceph osd pool rm .mgr .mgr --yes-i-really-really-meant-it
+      ncn-s001:~ # ceph osd pool rm .mgr .mgr --yes-i-really-really-mean-it
       ```
 
       The output should contain `pool '.mgr' removed`.

--- a/upgrade/scripts/common/ncn-rebuild-common.sh
+++ b/upgrade/scripts/common/ncn-rebuild-common.sh
@@ -136,7 +136,7 @@ wipefs --all --force /dev/mapper/metalvg*
 echo 'Disabling the bootloader by removing it'
 rm -rf /metal/recovery/*
 echo 'Deactivating disk boot entries to force netbooting for rebuilding ... '
-to_delete="$(efibootmgr | grep -P '(UEFI OS|cray)' | awk -F'[^0-9]*' '{print $0}' | sed 's/^Boot//g' | awk '{print $1}' | tr -d '*')"
+to_delete="$(efibootmgr | grep -P '(UEFI OS|cray)' | awk -F'[^0-9]*' '{print $0}' | sed 's/^Boot//g' | awk '{print $1}' | tr -d '*' || true)"
 if [ "${to_delete}" ]; then
     for item in ${to_delete}; do
         efibootmgr # print before
@@ -176,7 +176,7 @@ umount -v /var/lib/etcd /var/lib/sdu || true
 echo 'Disabling the bootloader by removing it'
 rm -rf /metal/recovery/*
 echo 'Deactivating disk boot entries to force netbooting for rebuilding ... '
-to_delete="$(efibootmgr | grep -P '(UEFI OS|cray)' | awk -F'[^0-9]*' '{print $0}' | sed 's/^Boot//g' | awk '{print $1}' | tr -d '*')"
+to_delete="$(efibootmgr | grep -P '(UEFI OS|cray)' | awk -F'[^0-9]*' '{print $0}' | sed 's/^Boot//g' | awk '{print $1}' | tr -d '*' || true)"
 if [ "${to_delete}" ]; then
     for item in ${to_delete}; do
         efibootmgr # print before
@@ -209,7 +209,7 @@ fi
 echo 'Disabling the bootloader by removing it'
 rm -rf /metal/recovery/*
 echo 'Deactivating disk boot entries to force netbooting for rebuilding ... '
-to_delete="$(efibootmgr | grep -P '(UEFI OS|cray)' | awk -F'[^0-9]*' '{print $0}' | sed 's/^Boot//g' | awk '{print $1}' | tr -d '*')"
+to_delete="$(efibootmgr | grep -P '(UEFI OS|cray)' | awk -F'[^0-9]*' '{print $0}' | sed 's/^Boot//g' | awk '{print $1}' | tr -d '*' || true)"
 if [ "${to_delete}" ]; then
     for item in ${to_delete}; do
         efibootmgr # print before

--- a/workflows/ncn/hooks/before-all/install-csi.yaml
+++ b/workflows/ncn/hooks/before-all/install-csi.yaml
@@ -31,6 +31,28 @@ spec:
   scriptContent: |
     #!/bin/sh
     source /srv/cray/scripts/metal/metal-lib.sh
+
+    echo "Sleeping for 60 seconds to let nexus to start after move of singleton pod"
+    sleep 60
+    count=0
+    total=120
+    sleep=5
+    while true; do
+      http_code=$(curl -k -s -S -o /dev/null -w '%{http_code}' https://packages.local/service/rest/v1/status || true)
+      if [ "${http_code}" == "200" ]; then
+        echo "nexus is up"
+        break
+      else
+        if [ "${count}" == "${total}" ]; then
+          echo "nexus is down after ${total} checks, giving up ..."
+          exit 1
+        fi
+        count=$(($count + 1))
+        echo "nexus is down, sleeping for $sleep seconds and retry, attempt $count/$total ..."
+        sleep $sleep
+      fi
+    done
+
     csi_url=$(paginate "https://packages.local/service/rest/v1/components?repository=csm-noos" \
       | jq -r  '.items[] | .assets[] | .downloadUrl' | grep "cray-site-init" | sort -V | tail -1)
     if [[ -z $csi_url ]]; then

--- a/workflows/templates/storage.add-node-to-ceph.yaml
+++ b/workflows/templates/storage.add-node-to-ceph.yaml
@@ -90,6 +90,8 @@ spec:
             templateRef:
               name: ssh-template
               template: shell-script
+            dependencies:
+              - update-ssh-keys
             arguments:
               parameters:
                 - name: dryRun

--- a/workflows/templates/storage.reboot.yaml
+++ b/workflows/templates/storage.reboot.yaml
@@ -148,6 +148,8 @@ spec:
                     TARGET_NCN={{inputs.parameters.targetNcn}}
                     TARGET_XNAME=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management" | \
                         jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"$TARGET_NCN\")) | .Xname")
+                    TARGET_MGMT_XNAME=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management" | \
+                      jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"$TARGET_NCN\")) | .Parent")
                     TARGET_NCN_mgmt_host="${TARGET_NCN}-mgmt"
                     export IPMI_USERNAME=$(curl -XGET -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds"| jq -r ".Targets[] | select(.Xname | contains(\"$TARGET_MGMT_XNAME\")) | .Username")
                     export IPMI_PASSWORD=$(curl -XGET -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds"| jq -r ".Targets[] | select(.Xname | contains(\"$TARGET_MGMT_XNAME\")) | .Password")

--- a/workflows/templates/storage.reboot.yaml
+++ b/workflows/templates/storage.reboot.yaml
@@ -46,10 +46,12 @@ spec:
                   value: "{{inputs.parameters.dryRun}}"
                 - name: scriptContent
                   value: |
-                    TOKEN=$(curl -k -s -S -d grant_type=client_credentials \
-                      -d client_id=admin-client \
-                      -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
-                      https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
+                    curl -k -s -d grant_type=client_credentials \
+                        -d client_id=admin-client \
+                        -d client_secret="$(kubectl get secrets admin-client-auth -ojsonpath='{.data.client-secret}' | base64 -d)" \
+                        https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token > /tmp/setup-token.json
+                    export CRAY_CREDENTIALS=/tmp/setup-token.json
+                    TOKEN=$(jq -r '.access_token' /tmp/setup-token.json)
                     TARGET_NCN="{{inputs.parameters.targetNcn}}"
                     TARGET_XNAME=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management" | \
                         jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"$TARGET_NCN\")) | .Xname")

--- a/workflows/templates/wipe-and-reboot-worker.yaml
+++ b/workflows/templates/wipe-and-reboot-worker.yaml
@@ -39,7 +39,41 @@ spec:
           - name: bootTimeoutInSeconds
       dag:
         tasks:
+        - name: wait-for-keycloak
+          templateRef:
+            name: kubectl-and-curl-template
+            template: shell-script
+          arguments:
+            parameters:
+              - name: dryRun
+                value: "{{inputs.parameters.dryRun}}"
+              - name: scriptContent
+                value: |
+                  client_secret=$(kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d)
+                  echo "Sleeping for 60 seconds to let keycloak settle after node drain"
+                  sleep 60
+                  count=0
+                  total=120
+                  sleep=5
+                  while true; do
+                    http_code=$(curl -k -s -S -o /dev/null -w '%{http_code}' -d grant_type=client_credentials -d client_id=admin-client \
+                        -d client_secret="$client_secret" https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token || true)
+                    if [ "${http_code}" == "200" ]; then
+                      echo "keycloak is up"
+                      break
+                    else
+                      if [ "${count}" == "${total}" ]; then
+                          echo "keycloak is down after ${total} checks, giving up ..."
+                          exit 1
+                      fi
+                      count=$(($count + 1))
+                      echo "keycloak is down, sleeping for $sleep seconds and retry, attempt $count/$total ..."
+                      sleep $sleep
+                    fi
+                  done
         - name: "validate-bss-ntp"
+          dependencies:
+          - wait-for-keycloak
           templateRef:
             name: ssh-template
             template: shell-script

--- a/workflows/templates/wipe-and-reboot-worker.yaml
+++ b/workflows/templates/wipe-and-reboot-worker.yaml
@@ -215,6 +215,8 @@ spec:
                   TARGET_NCN={{inputs.parameters.targetNcn}}
                   TARGET_XNAME=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management" | \
                       jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"$TARGET_NCN\")) | .Xname")
+                  TARGET_MGMT_XNAME=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management" | \
+                      jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"$TARGET_NCN\")) | .Parent")
                   TARGET_NCN_mgmt_host="${TARGET_NCN}-mgmt"
                   export IPMI_USERNAME=$(curl -XGET -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds"| jq -r ".Targets[] | select(.Xname | contains(\"$TARGET_MGMT_XNAME\")) | .Username")
                   export IPMI_PASSWORD=$(curl -XGET -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds"| jq -r ".Targets[] | select(.Xname | contains(\"$TARGET_MGMT_XNAME\")) | .Password")

--- a/workflows/templates/wipe-and-reboot-worker.yaml
+++ b/workflows/templates/wipe-and-reboot-worker.yaml
@@ -83,10 +83,12 @@ spec:
                 value: "{{inputs.parameters.dryRun}}"
               - name: scriptContent
                 value: |
-                  TOKEN=$(curl -k -s -S -d grant_type=client_credentials \
-                    -d client_id=admin-client \
-                    -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
-                    https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
+                  curl -k -s -d grant_type=client_credentials \
+                      -d client_id=admin-client \
+                      -d client_secret="$(kubectl get secrets admin-client-auth -ojsonpath='{.data.client-secret}' | base64 -d)" \
+                      https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token > /tmp/setup-token.json
+                  export CRAY_CREDENTIALS=/tmp/setup-token.json
+                  TOKEN=$(jq -r '.access_token' /tmp/setup-token.json)
                   TARGET_NCN={{inputs.parameters.targetNcn}}
                   TARGET_XNAME=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management" | \
                       jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"$TARGET_NCN\")) | .Xname")


### PR DESCRIPTION
# Description

Multiple fixes needed to support post-install upgrade of CSM from 1.4 to 1.5 on vShasta (CASMINST-6692). Most of issues fixed in this PR were previously masked by automated re-triggering of Argo workflows in case of error. We don't do automated re-triggering in automated pipeline (otherwise, errors are hard to detect and there's a chance of infinite looping).

Testing: dev version of `docs-csm` RPM, produced from this branch, is used for automated daily CSM 1.4 > 1.5 upgrades in vShasta.

# Checklist
- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
