### PR TITLE
CASMTRIAGE-6263 shell check failure

### DIFF
--- a/upgrade/scripts/upgrade/ncn-upgrade-master-nodes.sh
+++ b/upgrade/scripts/upgrade/ncn-upgrade-master-nodes.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/upgrade/scripts/upgrade/ncn-upgrade-master-nodes.sh
+++ b/upgrade/scripts/upgrade/ncn-upgrade-master-nodes.sh
@@ -212,6 +212,7 @@ cat << EOF
 NOTE:
     If below test failed, try to fix it based on test output. Then run current script again
 EOF
+
 state_name="RUN_GOSS_TESTS"
 state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
 if [[ $state_recorded == "0" ]]; then
@@ -222,7 +223,7 @@ if [[ $state_recorded == "0" ]]; then
     while read line; do
       if [[ -n $(echo $line | grep 'Title\|desc') ]]; then
         echo "ERROR failed goss test: $line"
-	      return_code=1
+        return_code=1
       else
         echo -e "$line"
       fi


### PR DESCRIPTION
# Description
  Resolves CASMTRIAGE-6263 
  
  During an IUF management-nodes-rollout with csm 1.5, it was noted that tests that determine if the node can rebuilt are 
  not prefixed so they go to the user (INFO|WARN|ERROR). The CLI simply says the operation failed. IIRC there were no useful 
  msgs in the Argo UI either.

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions.
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

