### PR TITLE
CASMPET-5392: remove jaeger references

### DIFF
--- a/operations/network/external_dns/External_DNS.md
+++ b/operations/network/external_dns/External_DNS.md
@@ -16,7 +16,6 @@ The following services are currently available:
 - System Management Health Grafana \(redirects to OAuth2 Proxy for SSO\)
 - System Management Health Alertmanager \(redirects to OAuth2 Proxy for SSO\)
 - Kiali, for Istio service mesh visibility \(redirects to OAuth2 Proxy for SSO\)
-- Jaeger, for Istio tracing \(redirects to OAuth2 Proxy for SSO\)
 
 In general, external hostnames should resolve to a external IP address for one of the following services:
 

--- a/operations/network/external_dns/External_DNS_Failing_to_Discover_Services_Workaround.md
+++ b/operations/network/external_dns/External_DNS_Failing_to_Discover_Services_Workaround.md
@@ -24,7 +24,6 @@ Use this procedure to resolve any external DNS routing issues with backend servi
     ```text
     NAMESPACE        NAME                              GATEWAYS                       HOSTS                                                          AGE
     istio-system     kiali                             [services/services-gateway]    [kiali-istio.cmn.SYSTEM_DOMAIN_NAME]                           2d16h
-    istio-system     tracing                           [services/services-gateway]    [jaeger-istio.cmn.SYSTEM_DOMAIN_NAME]                          2d16h
     nexus            nexus                             [services/services-gateway]    [packages.local registry.local nexus.cmn.SYSTEM_DOMAIN_NAME]   2d16h
     services         gitea-vcs-external                [services/services-gateway]    [vcs.cmn.SYSTEM_DOMAIN_NAME]                                   2d16h
     services         sma-grafana                       [services-gateway]             [sma-grafana.cmn.SYSTEM_DOMAIN_NAME]                           2d16h

--- a/operations/network/external_dns/Ingress_Routing.md
+++ b/operations/network/external_dns/Ingress_Routing.md
@@ -61,7 +61,7 @@ namespace. Also, notice that the `VirtualService` for `prometheus.cmn.SYSTEM_DOM
 
 ## Secure Ingress via OAuth2 Proxy
 
-Web apps intended to be accessed via the browser, such as Prometheus, Alertmanager, Grafana, Kiali, Jaeger, Kibana, Elasticsearch, should go through the OAuth2 Proxy reverse proxy. Browser sessions are
+Web apps intended to be accessed via the browser, such as Prometheus, Alertmanager, Grafana, Kiali, Kibana, Elasticsearch, should go through the OAuth2 Proxy reverse proxy. Browser sessions are
 automatically configured to use a JSON Web Token \(JWT\) for authorization to Istio's ingress gateway, enabling a central enforcement point of Open Policy Agent \(OPA\) policies for system management traffic.
 
 The OAuth2 Proxy will inject HTTP headers so that an upstream endpoint can identify the user and customize access as needed. To enable ingress via OAuth2 Proxy external hostnames, web apps need to be added to

--- a/operations/network/external_dns/Troubleshoot_DNS_Configuration_Issues.md
+++ b/operations/network/external_dns/Troubleshoot_DNS_Configuration_Issues.md
@@ -77,7 +77,7 @@ The Domain Name Service \(DNS\) is not configured properly.
     Example output:
 
     ```text
-    10.101.5.128    opa-gpm.cmn.SYSTEM_DOMAIN_NAME jaeger-istio.cmn.SYSTEM_DOMAIN_NAME kiali-istio.cmn.SYSTEM_DOMAIN_NAME prometheus.cmn.SYSTEM_DOMAIN_NAME alertmanager.cmn.SYSTEM_DOMAIN_NAME grafana.cmn.SYSTEM_DOMAIN_NAME vcs.cmn.SYSTEM_DOMAIN_NAME sma-grafana.cmn.SYSTEM_DOMAIN_NAME sma-kibana.cmn.SYSTEM_DOMAIN_NAME csms.cmn.SYSTEM_DOMAIN_NAME
+    10.101.5.128    opa-gpm.cmn.SYSTEM_DOMAIN_NAME kiali-istio.cmn.SYSTEM_DOMAIN_NAME prometheus.cmn.SYSTEM_DOMAIN_NAME alertmanager.cmn.SYSTEM_DOMAIN_NAME grafana.cmn.SYSTEM_DOMAIN_NAME vcs.cmn.SYSTEM_DOMAIN_NAME sma-grafana.cmn.SYSTEM_DOMAIN_NAME sma-kibana.cmn.SYSTEM_DOMAIN_NAME csms.cmn.SYSTEM_DOMAIN_NAME
     10.101.5.129    api.cmn.SYSTEM_DOMAIN_NAME auth.cmn.SYSTEM_DOMAIN_NAME nexus.cmn.SYSTEM_DOMAIN_NAME
     10.101.5.130    s3.cmn.SYSTEM_DOMAIN_NAME
     10.92.100.71    api.nmn.SYSTEM_DOMAIN_NAME auth.nmn.SYSTEM_DOMAIN_NAME

--- a/operations/network/external_dns/Troubleshoot_Systems_Not_Provisioned_with_External_IP_Addresses.md
+++ b/operations/network/external_dns/Troubleshoot_Systems_Not_Provisioned_with_External_IP_Addresses.md
@@ -27,7 +27,6 @@ The Customer Management Network \(CMN\) is not supported on the system.
     ```console
     NAMESPACE        NAME                              GATEWAYS                       HOSTS                                                          AGE
     istio-system     kiali                             [services/services-gateway]    [kiali-istio.cmn.SYSTEM_DOMAIN_NAME]                           2d16h
-    istio-system     tracing                           [services/services-gateway]    [jaeger-istio.cmn.SYSTEM_DOMAIN_NAME]                          2d16h
     nexus            nexus                             [services/services-gateway]    [packages.local registry.local nexus.cmn.SYSTEM_DOMAIN_NAME]   2d16h
     services         gitea-vcs-external                [services/services-gateway]    [vcs.cmn.SYSTEM_DOMAIN_NAME]                                   2d16h
     services         sma-grafana                       [services-gateway]             [sma-grafana.cmn.SYSTEM_DOMAIN_NAME]                           2d16h

--- a/operations/system_management_health/System_Management_Health.md
+++ b/operations/system_management_health/System_Management_Health.md
@@ -6,7 +6,7 @@ The primary goal of the System Management Health service is to enable system adm
 -   The Prometheus operator provides custom resource definitions \(CRDs\) that make it easy to operate Prometheus and Alertmanager instances, scrape metrics from service endpoints, and trigger alerts
 -   Grafana supports pulling data from Prometheus, and dashboards for system components are readily available from the open source community
 -   The stable/prometheus-operator Helm chart integrates the Prometheus operator, Prometheus, Alertmanager, Grafana, node exporters \(daemon set\), and kube-state-metrics to provide a monitoring solution for Kubernetes clusters
--   Istio supports service mesh tracing and observability using Jaeger and Kiali, respectively
+-   Istio supports service mesh observability using Kiali
 
 The System Management Health service is intended to complement the System Monitoring Application \(SMA\) Framework, but the two are currently not integrated. The System Management Health metrics are not available using the Telemetry API. This service scrapes metrics from system components like Ceph, Kubernetes, and the hosts using node exporter, kube-state-metrics, and cadvisor. The design is flexible and supports:
 
@@ -14,6 +14,6 @@ The System Management Health service is intended to complement the System Monito
 -   Independent retention and persistence settings based on needs for specific services; the current default configuration retains metrics for ten days at the top level and four hours at intermediate levels
 -   Component-specific tooling for more detailed visibility:
     -   Grafana dashboards for Kubernetes
-    -   Grafana dashboards, Kiali, and Jaeger for Istio
+    -   Grafana dashboards and Kiali for Istio
     -   Grafana dashboards for Ceph
 


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
As we removed jaeger plugin since CSM 1.3, this PR removes jaeger references in CSM documentation.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
