### PR TITLE
CASMTRIAGE-6271 1.6 : DOCS: CSM upgrade to 1.4 prep step has flawed Nexus size estimation script

### DIFF
--- a/operations/package_repository_management/Nexus_Export_and_Restore.md
+++ b/operations/package_repository_management/Nexus_Export_and_Restore.md
@@ -17,8 +17,8 @@ that the cluster has left.
 
 ```bash
 kubectl exec -n nexus deploy/nexus -c nexus -- df -P /nexus-data | grep '/nexus-data' |
-    awk '{print "Amount of space the Nexus export will take up on cluster: "(($3 * 3)/1048576)" GiB";}' &&
-ceph df | grep 'TOTAL' | awk '{ print "Currently used: " $7 $8 ", Max Available " $10 $11;}'
+     awk '{print "Amount of space the Nexus export will take up on cluster: "(($3 * 3)/1048576)" GiB";}' &&
+ceph df | grep 'TOTAL' | awk '{ print "Currently used: " $6" "$7 ", Max Available " $4" "$5;}'
 ```
 
 The above commands will return the following information:


### PR DESCRIPTION
# Description

Fixes Nexus size estimation script

Verified on 
* rocket (CSM 1.3.5)
```
ncn-m001:~ # kubectl exec -n nexus deploy/nexus -c nexus -- df -P /nexus-data | grep '/nexus-data' |
>       awk '{print "Amount of space the Nexus export will take up on cluster: "(($3 * 3)/1048576)" GiB";}' &&
>  ceph df | grep 'TOTAL' | awk '{ print "Currently used: " $6" "$7 ", Max Available " $4" "$5;}'
Amount of space the Nexus export will take up on cluster: 3424.23 GiB
Currently used: 36 TiB, Max Available 48 TiB
```

* loki (CSM 1.4.3)
```
ncn-m001:~ # kubectl exec -n nexus deploy/nexus -c nexus -- df -P /nexus-data | grep '/nexus-data' |
>        awk '{print "Amount of space the Nexus export will take up on cluster: "(($3 * 3)/1048576)" GiB";}' &&
>   ceph df | grep 'TOTAL' | awk '{ print "Currently used: " $6" "$7 ", Max Available " $4" "$5;}'
Amount of space the Nexus export will take up on cluster: 2023.05 GiB
Currently used: 10 TiB, Max Available 32 TiB
```

* drax (CSM 1.5)
```
ncn-m001:~ # kubectl exec -n nexus deploy/nexus -c nexus -- df -P /nexus-data | grep '/nexus-data' |
>      awk '{print "Amount of space the Nexus export will take up on cluster: "(($3 * 3)/1048576)" GiB";}' &&
> ceph df | grep 'TOTAL' | awk '{ print "Currently used: " $6" "$7 ", Max Available " $4" "$5;}'
Amount of space the Nexus export will take up on cluster: 1226.55 GiB
Currently used: 9.5 TiB, Max Available 53 TiB
```

# Checklist
Resolves [CASMTRIAGE-6271](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6271)
Backporting to release/1.5, 1.4, 1.3

- [ ] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [ ] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
