### PR TITLE
CASMTRIAGE-6470: Ignore "csm-latest" tag when updating Argo templates

### DIFF
--- a/workflows/update_tags.sh
+++ b/workflows/update_tags.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -70,7 +70,7 @@ function get_latest_tag_for_image() {
             | capture("^(?<v>[^-]+)(?:-(?<p>.*))?$") | [.v, .p // empty]
             | map(split(".") | map(opt(tonumber)))
             | .[1] |= (. // {});
-    .[0].Tags | sort_by(.|semver_cmp) | last'
+    .[0].Tags | sort_by(.|semver_cmp) | map(select(. != "csm-latest")) | last'
 }
 
 function get_filenames_referring_to_image() {


### PR DESCRIPTION
# Description
The `cray-sat` container image gets uploaded with an explicit semantic version tag (e.g. `3.25.7`) and then also gets tagged as `csm-latest` to support SAT being installed both as part of CSM and as part of the separate SAT product.

Use of this tag in the Argo workflow templates causes issues because the image with this tag is cached in containerd on ncn-m001, and when the Argo workflow runs, it does not automatically pull the latest image because of the default Kubernetes image pull policy. Thus, `sat` commands fail if they try to use functionality introduced in the newer version of `sat`.

Instead, we want to prefer the latest explicit SemVer tag of the `cray-sat` image. This will ensure the newer image is pulled and used in the Argo workflow. To accomplish this, just ignore any `csm-latest` tags found by the `update_tags.sh` script. To our knowledge, the `cray-sat` image is the only one using a `csm-latest` tag.

# Test Description
Copied the contents of `/usr/share/doc/csm/workflows` to a different directory on fanta. Copied this modified version of the `update_tags.sh` script to that new directory. Ran the script and verified that the correct `cray-sat` image tag was identified and set in the Argo workflow template YAML file. Ensured that the tags identified for other images remained the same as before this change.

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.