### PR TITLE
CASMTRIAGE-6489 - correct cray command syntax in upgrade situation.

### DIFF
--- a/operations/iuf/workflows/management_rollout.md
+++ b/operations/iuf/workflows/management_rollout.md
@@ -76,7 +76,7 @@ Refer to that table and any corresponding product documents before continuing to
 
         ```bash
         XNAME=x3000c0s13b0n0
-        cray cfs v3 components describe "${XNAME}"
+        cray cfs components describe "${XNAME}"
         ```
 
         The desired value for `configuration_status` is `configured`. If it is `pending`, then wait for the status to change to `configured`.


### PR DESCRIPTION
# Description

CASMTRIAGE-6489 - the document was using a command directed to cfs v3, when in an upgrade only v2 may be available. For this particular command it should work using either api version, so we are changing the command to not use a specific API version.

# Checklist
- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

