### PR TITLE
CASMINST-6773 Worker rebuild workflow: wait after drain

### DIFF
--- a/workflows/templates/drain-worker.yaml
+++ b/workflows/templates/drain-worker.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -53,7 +53,7 @@ spec:
                   if [[ $res -eq 0 ]]; then
                     csi automate ncn kubernetes --action delete-ncn --ncn {{inputs.parameters.targetNcn}} --kubeconfig mykubeconfig/admin.conf
                   fi
-        - name: wait-for-postgres-operator
+        - name: wait-for-pods
           dependencies:
             - drain
           templateRef:
@@ -65,18 +65,23 @@ spec:
                 value: "{{inputs.parameters.dryRun}}"
               - name: scriptContent
                 value: |
-                  while true; do
-                    numOfRunningPgOperatorPod=$(kubectl get pods -n services -l app.kubernetes.io/name=postgres-operator | grep "Running" | wc -l)
-                    if [[ $numOfRunningPgOperatorPod -ne 1 ]];then
-                      echo "ERROR - Postgres Operator is not running yet"
-                      sleep 5
-                      continue
-                    else
-                      echo "Postgres Operator is running"
-                      break
-                    fi
-                  done
+                  echo "Waiting for nexus ..."
+                  kubectl wait --for=condition=ready pod -l app=nexus -n nexus --timeout=30m
+                  echo "Waiting for keycloak ..."
+                  kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=keycloak -n services --timeout=30m
+                  echo "Waiting for postgresql-operator ..."
+                  kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=postgres-operator -n services --timeout=30m
+                  echo "Waiting for cray-sls ..."
+                  kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=cray-sls -n services --timeout=30m
+                  echo "Waiting for cray-tftp ..."
+                  kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=cray-tftp -n services --timeout=30m
+                  echo "Waiting for cray-scsd ..."
+                  kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=cray-scsd -n services --timeout=30m
+                  echo "Waiting for cray-smd ..."
+                  kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=cray-smd -n services --timeout=30m
         - name: update-bss
+          dependencies:
+          - wait-for-pods
           templateRef:
             name: kubectl-and-curl-template
             template: shell-script

--- a/workflows/templates/wipe-and-reboot-worker.yaml
+++ b/workflows/templates/wipe-and-reboot-worker.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -39,41 +39,7 @@ spec:
           - name: bootTimeoutInSeconds
       dag:
         tasks:
-        - name: wait-for-keycloak
-          templateRef:
-            name: kubectl-and-curl-template
-            template: shell-script
-          arguments:
-            parameters:
-              - name: dryRun
-                value: "{{inputs.parameters.dryRun}}"
-              - name: scriptContent
-                value: |
-                  client_secret=$(kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d)
-                  echo "Sleeping for 60 seconds to let keycloak settle after node drain"
-                  sleep 60
-                  count=0
-                  total=120
-                  sleep=5
-                  while true; do
-                    http_code=$(curl -k -s -S -o /dev/null -w '%{http_code}' -d grant_type=client_credentials -d client_id=admin-client \
-                        -d client_secret="$client_secret" https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token || true)
-                    if [ "${http_code}" == "200" ]; then
-                      echo "keycloak is up"
-                      break
-                    else
-                      if [ "${count}" == "${total}" ]; then
-                          echo "keycloak is down after ${total} checks, giving up ..."
-                          exit 1
-                      fi
-                      count=$(($count + 1))
-                      echo "keycloak is down, sleeping for $sleep seconds and retry, attempt $count/$total ..."
-                      sleep $sleep
-                    fi
-                  done
         - name: "validate-bss-ntp"
-          dependencies:
-          - wait-for-keycloak
           templateRef:
             name: ssh-template
             template: shell-script


### PR DESCRIPTION
# Description

Currently, we only wait for PostgreSQL operator and keycloak pods to stabilize after worker drain. However, many other services are needed to proceed, such as TFTP, SMD, SCSD etc. We have sporadic failures when workflow tries to access one of these services, and service is not yet ready (due to a pod being evicted from drained worker).

These failures are mitigated by simply re-triggering argo workflow from the point where it failed. However, for automated testing we need to ensure that it passes without retriggering, so appropriate wait condition is needed.

# Testing
https://jenkins.algol60.net/blue/organizations/jenkins/Cray-HPE%2Fcsm-vshasta-deploy/detail/feature%2Fupgrade-1.5/9/pipeline

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
