### PR TITLE
CASMTRIAGE-6493

### DIFF
--- a/upgrade/scripts/rebuild/ncn-rebuild-master-nodes.sh
+++ b/upgrade/scripts/rebuild/ncn-rebuild-master-nodes.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -123,7 +123,7 @@ if [[ ${first_master_hostname} == ${target_ncn} ]]; then
     # it relies on SLS
     check_sls_health
 
-    scp /-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root/docs-csm-latest.noarch.rpm $promotingMaster:/root/docs-csm-latest.noarch.rpm
+    scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null /root/docs-csm-latest.noarch.rpm $promotingMaster:/root/docs-csm-latest.noarch.rpm
     ssh $promotingMaster "rpm --force -Uvh /root/docs-csm-latest.noarch.rpm"
     ssh $promotingMaster -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "/usr/share/doc/csm/upgrade/scripts/k8s/promote-initial-master.sh"
     VERBOSE=1 csi handoff bss-update-cloud-init --set meta-data.first-master-hostname=$promotingMaster --limit Global
@@ -178,7 +178,7 @@ state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
 if [[ $state_recorded == "0" ]]; then
   echo "====> ${state_name} ..."
   record_state "${state_name}" ${target_ncn}
-  scp /-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root/docs-csm-latest.noarch.rpm $target_ncn:/root/docs-csm-latest.noarch.rpm
+  scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null /root/docs-csm-latest.noarch.rpm $target_ncn:/root/docs-csm-latest.noarch.rpm
   ssh $target_ncn "rpm --force -Uvh /root/docs-csm-latest.noarch.rpm"
 else
   echo "====> ${state_name} has been completed"

--- a/upgrade/scripts/rebuild/ncn-rebuild-master-nodes.sh
+++ b/upgrade/scripts/rebuild/ncn-rebuild-master-nodes.sh
@@ -123,7 +123,7 @@ if [[ ${first_master_hostname} == ${target_ncn} ]]; then
     # it relies on SLS
     check_sls_health
 
-    scp /root/docs-csm-latest.noarch.rpm $promotingMaster:/root/docs-csm-latest.noarch.rpm
+    scp /-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root/docs-csm-latest.noarch.rpm $promotingMaster:/root/docs-csm-latest.noarch.rpm
     ssh $promotingMaster "rpm --force -Uvh /root/docs-csm-latest.noarch.rpm"
     ssh $promotingMaster -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "/usr/share/doc/csm/upgrade/scripts/k8s/promote-initial-master.sh"
     VERBOSE=1 csi handoff bss-update-cloud-init --set meta-data.first-master-hostname=$promotingMaster --limit Global
@@ -178,7 +178,7 @@ state_recorded=$(is_state_recorded "${state_name}" ${target_ncn})
 if [[ $state_recorded == "0" ]]; then
   echo "====> ${state_name} ..."
   record_state "${state_name}" ${target_ncn}
-  scp /root/docs-csm-latest.noarch.rpm $target_ncn:/root/docs-csm-latest.noarch.rpm
+  scp /-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root/docs-csm-latest.noarch.rpm $target_ncn:/root/docs-csm-latest.noarch.rpm
   ssh $target_ncn "rpm --force -Uvh /root/docs-csm-latest.noarch.rpm"
 else
   echo "====> ${state_name} has been completed"

--- a/upgrade/scripts/upgrade/ncn-upgrade-ceph-nodes.sh
+++ b/upgrade/scripts/upgrade/ncn-upgrade-ceph-nodes.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/upgrade/scripts/upgrade/ncn-upgrade-ceph-nodes.sh
+++ b/upgrade/scripts/upgrade/ncn-upgrade-ceph-nodes.sh
@@ -93,7 +93,7 @@ if [[ $state_recorded == "0" ]]; then
         ssh_keygen_keyscan "${target_ncn}"
         ssh_keys_done=1
     fi
-    scp /root/docs-csm-latest.noarch.rpm $target_ncn:/root/docs-csm-latest.noarch.rpm
+    scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null /root/docs-csm-latest.noarch.rpm $target_ncn:/root/docs-csm-latest.noarch.rpm
     ssh $target_ncn "rpm --force -Uvh /root/docs-csm-latest.noarch.rpm"
     } >> ${LOG_FILE} 2>&1
     record_state "${state_name}" ${target_ncn}

--- a/upgrade/scripts/upgrade/ncn-upgrade-master-nodes.sh
+++ b/upgrade/scripts/upgrade/ncn-upgrade-master-nodes.sh
@@ -114,7 +114,7 @@ fi
       # it relies on SLS
       check_sls_health
 
-      scp /root/docs-csm-latest.noarch.rpm $promotingMaster:/root/docs-csm-latest.noarch.rpm
+      scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null /root/docs-csm-latest.noarch.rpm $promotingMaster:/root/docs-csm-latest.noarch.rpm
       ssh $promotingMaster "rpm --force -Uvh /root/docs-csm-latest.noarch.rpm"
       ssh $promotingMaster -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "/usr/share/doc/csm/upgrade/scripts/k8s/promote-initial-master.sh"
       VERBOSE=1 csi handoff bss-update-cloud-init --set meta-data.first-master-hostname=$promotingMaster --limit Global
@@ -175,7 +175,7 @@ if [[ $state_recorded == "0" ]]; then
   echo "====> ${state_name} ..."
   {
     record_state "${state_name}" ${target_ncn}
-    scp /root/docs-csm-latest.noarch.rpm $target_ncn:/root/docs-csm-latest.noarch.rpm
+    scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null /root/docs-csm-latest.noarch.rpm $target_ncn:/root/docs-csm-latest.noarch.rpm
     ssh $target_ncn "rpm --force -Uvh /root/docs-csm-latest.noarch.rpm"
   } >> ${LOG_FILE} 2>&1
   record_state "${state_name}" ${target_ncn}


### PR DESCRIPTION
# Description
  Resolves CASMTRIAGE-6493
  
  During an IUF management-nodes-rollout with csm 1.5, the SSH from ncn-m002 to ncn-m001 had a host key verification failure which prevented the rollout to complete.

We have updated scp commands to ignore SSH Host key verification.

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions.
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

