### PR TITLE
CASMCMS-8720: Update argo workflows for CFS v3 and paging

### DIFF
--- a/workflows/ncn/hooks/after-each/wait-for-cfs-after-rebuild.yaml
+++ b/workflows/ncn/hooks/after-each/wait-for-cfs-after-rebuild.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -83,7 +83,7 @@ spec:
     echo "Desired configuration for CFS component '${TARGET_XNAME}' is '${DESIRED_CONFIG}'"
 
     while true; do
-      RESULT=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/cfs/v3/components?ids=${TARGET_XNAME}&status=pending" | jq length)
+      RESULT=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/cfs/v3/components?ids=${TARGET_XNAME}&status=pending" | jq '.components | length')
       if [[ "$RESULT" -eq 0 ]]; then
         break
       fi
@@ -91,11 +91,11 @@ spec:
       sleep 30
     done
 
-    CONFIGURED=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/cfs/v3/components?ids=${TARGET_XNAME}&status=configured" | jq length)
-    FAILED=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/cfs/v3/components?ids=${TARGET_XNAME}&status=failed" | jq length)
+    CONFIGURED=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/cfs/v3/components?ids=${TARGET_XNAME}&status=configured" | jq '.components | length')
+    FAILED=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/cfs/v3/components?ids=${TARGET_XNAME}&status=failed" | jq '.components | length')
     echo "Configuration complete. $CONFIGURED component(s) completed successfully.  $FAILED component(s) failed."
     if [ "$FAILED" -ne "0" ]; then
-      echo "The following components failed: $(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/cfs/v3/components?ids=${TARGET_XNAME}&status=failed"  | jq -r '. | map(.id) | join(",")')"
+      echo "The following components failed: $(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/cfs/v3/components?ids=${TARGET_XNAME}&status=failed"  | jq -r '.components | map(.id) | join(",")')"
       exit 1
     fi
   templateRefName: kubectl-and-curl-template

--- a/workflows/templates/storage.wait-for-cfs.yaml
+++ b/workflows/templates/storage.wait-for-cfs.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -113,7 +113,7 @@ spec:
                     echo "Desired configuration for CFS component '${TARGET_XNAME}' is '${DESIRED_CONFIG}'"
 
                     while true; do
-                      RESULT=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/cfs/v3/components?ids=${TARGET_XNAME}&status=pending" | jq length)
+                      RESULT=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/cfs/v3/components?ids=${TARGET_XNAME}&status=pending" | jq '.components | length')
                       if [[ "$RESULT" -eq 0 ]]; then
                         break
                       fi
@@ -121,10 +121,10 @@ spec:
                       sleep 30
                     done
 
-                    CONFIGURED=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/cfs/v3/components?ids=${TARGET_XNAME}&status=configured" | jq length)
-                    FAILED=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/cfs/v3/components?ids=${TARGET_XNAME}&status=failed" | jq length)
+                    CONFIGURED=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/cfs/v3/components?ids=${TARGET_XNAME}&status=configured" | jq '.components | length')
+                    FAILED=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/cfs/v3/components?ids=${TARGET_XNAME}&status=failed" | jq '.components | length')
                     echo "Configuration complete. $CONFIGURED component(s) completed successfully.  $FAILED component(s) failed."
                     if [ "$FAILED" -ne "0" ]; then
-                      echo "The following components failed: $(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/cfs/v3/components?ids=${TARGET_XNAME}&status=failed"  | jq -r '. | map(.id) | join(",")')"
+                      echo "The following components failed: $(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/cfs/v3/components?ids=${TARGET_XNAME}&status=failed"  | jq -r '.components | map(.id) | join(",")')"
                       exit 1
                     fi


### PR DESCRIPTION
# Description

Follow up after #4283 - accommodate change in `/apis/cfs/v3/components` response format in argo workflows.

# Checklist
- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
