### PR TITLE
CASMTRIAGE-6538 remove setting metal.no-wipe in upgrade prerequisites because this is done automatically

### DIFF
--- a/operations/configuration_management/Management_Node_Image_Customization.md
+++ b/operations/configuration_management/Management_Node_Image_Customization.md
@@ -458,7 +458,6 @@ new customized image.
             ```bash
             PARAMS=$(cray bss bootparameters list --hosts "${XNAME}" --format json | jq '.[] |."params"' | \
                 sed "/metal.server/ s|${METAL_SERVER}|${NEW_METAL_SERVER}|" | \
-                sed "s/metal.no-wipe=1/metal.no-wipe=0/" | \
                 tr -d \")
             echo "${PARAMS}"
             ```


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

We do not need to set the value of metal.no-wipe when updating management node boot parameters. Metal.no-wipe is set by the scripts and workflows that execute NCN rebuilds and NCN upgrades. I am assuming that the only time [Update Management node boot-parameters](https://github.com/Cray-HPE/docs-csm/blob/release/1.5/operations/configuration_management/Management_Node_Image_Customization.md#4-update-management-node-boot-parameters) operation being run is before a node rebuild or a node upgrade. I do not believe there would be a reason to run this procedure at any other time.

For NCN upgrades, the value of metal.no-wipe is being set in the following places for [master nodes](https://github.com/Cray-HPE/docs-csm/blob/release/1.5/upgrade/scripts/upgrade/ncn-upgrade-master-nodes.sh#L138), [worker nodes](https://github.com/Cray-HPE/docs-csm/blob/release/1.5/workflows/templates/wipe-and-reboot-worker.yaml#L88), and [storage nodes](https://github.com/Cray-HPE/docs-csm/blob/release/1.5/workflows/ncn/storage/storage.upgrade.yaml#L125).
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
