### PR TITLE
CASMTRIAGE-6537 make bss calls in storage node upgrade serial

### DIFF
--- a/workflows/ncn/storage/storage.upgrade.yaml
+++ b/workflows/ncn/storage/storage.upgrade.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/workflows/ncn/storage/storage.upgrade.yaml
+++ b/workflows/ncn/storage/storage.upgrade.yaml
@@ -126,13 +126,9 @@ spec:
             templateRef:
               name: set-no-wipe
               template: set-bss-no-wipe-1-no-wipe-osds
-            dependencies: 
-              {{ if eq $index 0 }}
-              - before-all
-              {{ end }}
-              {{ if ne $index 0 }}
-              - run-storage-goss-tests-{{ index $.TargetNcns (add $index -1) }}
-              {{ end }}
+            dependencies:
+              # this is after before-each because of possible race condition if bss command in before-each runs at the same time as this step
+              - before-each-{{$value}}
             arguments:
               parameters:
                 - name: dryRun
@@ -144,12 +140,7 @@ spec:
               name: rd-live-dir-rd-live-overlay-reset
               template: set-rd-live-overlay-reset
             dependencies: 
-              {{ if eq $index 0 }}
-              - before-all
-              {{ end }}
-              {{ if ne $index 0 }}
-              - run-storage-goss-tests-{{ index $.TargetNcns (add $index -1) }}
-              {{ end }}
+              - set-bss-no-wipe-to-1-{{$value}}
             arguments:
               parameters:
                 - name: dryRun
@@ -179,9 +170,7 @@ spec:
               template: main
             dependencies: 
               - backup-ceph-data-{{$value}}
-              - set-bss-no-wipe-to-1-{{$value}}
               - set-overlay-reset-{{$value}}
-              - before-each-{{$value}}
             arguments:
               parameters:
                 - name: dryRun


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
A race condition was hit during the strorage node upgrade. Two calls to BSS were made at the same time and resulted in one of the parameters not being set correctly. To avoid this, calls to BSS are now being done serially.

I have tested this during a storage node upgrade on drax. A screenshot of the changed portion of the workflow shows these BSS steps running serially.
<img width="327" alt="image" src="https://github.com/Cray-HPE/docs-csm/assets/87664908/b6456e59-f694-430b-8733-51c8a03fda2b">

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
