### PR TITLE
CASMTRIAGE-6548 add the execution of upload-rebuild-templates.sh before running IUF

### DIFF
--- a/operations/iuf/workflows/product_delivery.md
+++ b/operations/iuf/workflows/product_delivery.md
@@ -14,7 +14,7 @@ This section ensures the product content is loaded onto the system and available
 section of the _HPE Cray EX System Software Stack Installation and Upgrade Guide for CSM (S-8052)_ provides a table that summarizes which product documents contain information or actions for the `process-media` or `pre-install-check` stages.
 Refer to that table and any corresponding product documents before continuing to the next step.
 
-1. Run `upload-rebuild-tempaltes.sh` to update all `WorkflowTemplates` that will be used by Argo and to ensure the correct CSM product versions will be used by Argo.
+1. Run `upload-rebuild-tempaltes.sh` to update all the workflows that will be used by IUF and to ensure the correct CSM product versions will be used by IUF.
 
     (`ncn-m001#`) Execute the `upload-rebuild-tempaltes.sh` script.
 

--- a/operations/iuf/workflows/product_delivery.md
+++ b/operations/iuf/workflows/product_delivery.md
@@ -14,6 +14,14 @@ This section ensures the product content is loaded onto the system and available
 section of the _HPE Cray EX System Software Stack Installation and Upgrade Guide for CSM (S-8052)_ provides a table that summarizes which product documents contain information or actions for the `process-media` or `pre-install-check` stages.
 Refer to that table and any corresponding product documents before continuing to the next step.
 
+1. Run `upload-rebuild-tempaltes.sh` to update all `WorkflowTemplates` that will be used by Argo and to ensure the correct CSM product versions will be used by Argo.
+
+    (`ncn-m001#`) Execute the `upload-rebuild-tempaltes.sh` script.
+
+    ```bash
+    /usr/share/doc/csm/workflows/scripts/upload-rebuild-templates.sh
+    ```
+
 1. Invoke `iuf run` with activity identifier `${ACTIVITY_NAME}` and use `-e` to execute the [`process-media`](../stages/process_media.md) and [`pre-install-check`](../stages/pre_install_check.md) stages. Perform the upgrade
    using product content found in `${MEDIA_DIR}`.
 

--- a/operations/iuf/workflows/product_delivery.md
+++ b/operations/iuf/workflows/product_delivery.md
@@ -14,9 +14,9 @@ This section ensures the product content is loaded onto the system and available
 section of the _HPE Cray EX System Software Stack Installation and Upgrade Guide for CSM (S-8052)_ provides a table that summarizes which product documents contain information or actions for the `process-media` or `pre-install-check` stages.
 Refer to that table and any corresponding product documents before continuing to the next step.
 
-1. Run `upload-rebuild-tempaltes.sh` to update all the workflows that will be used by IUF and to ensure the correct CSM product versions will be used by IUF.
+1. Run `upload-rebuild-templates.sh` to update all the workflows that will be used by IUF and to ensure the correct CSM product versions will be used by IUF.
 
-    (`ncn-m001#`) Execute the `upload-rebuild-tempaltes.sh` script.
+    (`ncn-m001#`) Execute the `upload-rebuild-templates.sh` script.
 
     ```bash
     /usr/share/doc/csm/workflows/scripts/upload-rebuild-templates.sh


### PR DESCRIPTION

<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description

This changes adds the execution of upload-rebuild-templates.sh before running IUF steps. This updates CSM product versions and makes sure the IUF workflowTemplates used by Argo are updated.

This is necessary because we ran into a specific case where IUF was trying to install the incorrect product version. We believe this happened because of an ordering issue, where a newer version of docs-csm rpm is installed after a CSM upgrade. If a newer version of docs-csm is installed but this script is not run, then IUF might be referencing old versions. This script is run in prerequisistes.sh which is likely why we don't run into this problem more often.
<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
