### PR TITLE
CASMINST-6692 Perform post-install upgrade of CSM in vShasta (#4577)

### DIFF
--- a/operations/utility_storage/Troubleshoot_HEALTH_ERR_Module_devicehealth.md
+++ b/operations/utility_storage/Troubleshoot_HEALTH_ERR_Module_devicehealth.md
@@ -38,7 +38,7 @@ Error Message:
    3. Delete pool
 
       ```bash
-      ncn-s001:~ # ceph osd pool rm .mgr .mgr --yes-i-really-really-meant-it
+      ncn-s001:~ # ceph osd pool rm .mgr .mgr --yes-i-really-really-mean-it
       ```
 
       The output should contain `pool '.mgr' removed`.

--- a/upgrade/scripts/common/ncn-rebuild-common.sh
+++ b/upgrade/scripts/common/ncn-rebuild-common.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -136,7 +136,7 @@ wipefs --all --force /dev/mapper/metalvg*
 echo 'Disabling the bootloader by removing it'
 rm -rf /metal/recovery/*
 echo 'Deactivating disk boot entries to force netbooting for rebuilding ... '
-to_delete="$(efibootmgr | grep -P '(UEFI OS|cray)' | awk -F'[^0-9]*' '{print $0}' | sed 's/^Boot//g' | awk '{print $1}' | tr -d '*')"
+to_delete="$(efibootmgr | grep -P '(UEFI OS|cray)' | awk -F'[^0-9]*' '{print $0}' | sed 's/^Boot//g' | awk '{print $1}' | tr -d '*' || true)"
 if [ "${to_delete}" ]; then
     for item in ${to_delete}; do
         efibootmgr # print before
@@ -180,7 +180,7 @@ umount -v /var/lib/etcd /var/lib/sdu || true
 echo 'Disabling the bootloader by removing it'
 rm -rf /metal/recovery/*
 echo 'Deactivating disk boot entries to force netbooting for rebuilding ... '
-to_delete="$(efibootmgr | grep -P '(UEFI OS|cray)' | awk -F'[^0-9]*' '{print $0}' | sed 's/^Boot//g' | awk '{print $1}' | tr -d '*')"
+to_delete="$(efibootmgr | grep -P '(UEFI OS|cray)' | awk -F'[^0-9]*' '{print $0}' | sed 's/^Boot//g' | awk '{print $1}' | tr -d '*' || true)"
 if [ "${to_delete}" ]; then
     for item in ${to_delete}; do
         efibootmgr # print before
@@ -213,7 +213,7 @@ fi
 echo 'Disabling the bootloader by removing it'
 rm -rf /metal/recovery/*
 echo 'Deactivating disk boot entries to force netbooting for rebuilding ... '
-to_delete="$(efibootmgr | grep -P '(UEFI OS|cray)' | awk -F'[^0-9]*' '{print $0}' | sed 's/^Boot//g' | awk '{print $1}' | tr -d '*')"
+to_delete="$(efibootmgr | grep -P '(UEFI OS|cray)' | awk -F'[^0-9]*' '{print $0}' | sed 's/^Boot//g' | awk '{print $1}' | tr -d '*' || true)"
 if [ "${to_delete}" ]; then
     for item in ${to_delete}; do
         efibootmgr # print before

--- a/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh
+++ b/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -44,7 +44,7 @@ labels=""
 function usage() {
   echo "CSM ncn worker and storage upgrade script"
   echo
-  echo "Syntax: /usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh [COMMA_SEPARATED_NCN_HOSTNAMES] [-f|--force|--retry|--base-url|--dry-run|--upgrade|--rebuild]"
+  echo "Syntax: /usr/share/doc/csm/upgrade/scripts/upgrade/ncn-upgrade-worker-storage-nodes.sh [COMMA_SEPARATED_NCN_HOSTNAMES] [-f|--force|--no-retry|--base-url|--dry-run|--upgrade|--rebuild]"
   echo "options:"
   echo "--no-retry          Do not automatically retry  (default: false)"
   echo "-f|--force          Remove failed worker or storage rebuild/upgrade workflow and create a new one  (default: ${force})"
@@ -378,15 +378,25 @@ while true; do
     fi
 
     if [[ ${phase} == "Failed" ]]; then
-      echo "WARNING - Workflow in Failed state, Retry ..."
-      retryRebuildWorkflow "$workflow"
-      continue
+      if $retry; then
+        echo "WARNING - Workflow in Failed state, Retry ..."
+        retryRebuildWorkflow "$workflow"
+        continue
+      else
+        echo "ERROR - Workflow ${workflow} is in Failed state"
+        exit 1
+      fi
     fi
 
     if [[ ${phase} == "Error" ]]; then
-      echo "WARNING - Workflow in Error state, Retry ..."
-      retryRebuildWorkflow "$workflow"
-      continue
+      if $retry; then
+        echo "WARNING - Workflow in Error state, Retry ..."
+        retryRebuildWorkflow "$workflow"
+        continue
+      else
+        echo "ERROR - Workflow ${workflow} is in Error state"
+        exit 1
+      fi
     fi
     runningSteps=$(jq -jr ".[] | select(.name==\"${workflow}\") | .status.nodes[] | select(.type==\"Retry\")| select(.phase==\"Running\")  | .name + \"\n  \" " < "${res_file}")
     succeededSteps=$(jq -jr ".[] | select(.name==\"${workflow}\") | .status.nodes[] | select(.type==\"Retry\")| select(.phase==\"Succeeded\")  | .name +\"\n  \" " < "${res_file}")

--- a/upgrade/scripts/upgrade/prerequisites.sh
+++ b/upgrade/scripts/upgrade/prerequisites.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -768,7 +768,7 @@ do_upgrade_csm_chart cray-tftp-pvc sysmgmt.yaml
 
 state_name="UPLOAD_NEW_NCN_IMAGE"
 state_recorded=$(is_state_recorded "${state_name}" "$(hostname)")
-if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" && ${vshasta} == "false" ]]; then
+if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" ]]; then
   echo "====> ${state_name} ..." | tee -a "${LOG_FILE}"
   {
     artdir=${CSM_ARTI_DIR}/images
@@ -794,12 +794,20 @@ if [[ ${state_recorded} == "0" && $(hostname) == "${PRIMARY_NODE}" && ${vshasta}
     if [[ ${k8s_done} == 1 && ${ceph_done} == 1 ]]; then
       echo "Already ran ${NCN_IMAGE_MOD_SCRIPT}, skipping re-run."
     else
-      rm -f "${artdir}/storage-ceph/secure-storage-ceph-${CEPH_VERSION}-${arch}.squashfs" "${artdir}/kubernetes/secure-kubernetes-${KUBERNETES_VERSION}-${arch}.squashfs"
+      # ${artdir} is mounted on top of CephFS. Running mksquashfs against it is very slow. We will copy squashfs files to temporary dir
+      # instead, and run NCN modification script there.
+      tmpdir_kubernetes=$(mktemp -d)
+      tmpdir_storage=$(mktemp -d)
+      cp "${artdir}/kubernetes/kubernetes-${KUBERNETES_VERSION}-${arch}.squashfs" "${tmpdir_kubernetes}/"
+      cp "${artdir}/storage-ceph/storage-ceph-${CEPH_VERSION}-${arch}.squashfs" "${tmpdir_storage}/"
       DEBUG=1 "${NCN_IMAGE_MOD_SCRIPT}" \
         -d /root/.ssh \
-        -k "${artdir}/kubernetes/kubernetes-${KUBERNETES_VERSION}-${arch}.squashfs" \
-        -s "${artdir}/storage-ceph/storage-ceph-${CEPH_VERSION}-${arch}.squashfs" \
+        -k "${tmpdir_kubernetes}/kubernetes-${KUBERNETES_VERSION}-${arch}.squashfs" \
+        -s "${tmpdir_storage}/storage-ceph-${CEPH_VERSION}-${arch}.squashfs" \
         -p
+      mv "${tmpdir_kubernetes}/secure-kubernetes-${KUBERNETES_VERSION}-${arch}.squashfs" "${artdir}/kubernetes/"
+      mv "${tmpdir_storage}/secure-storage-ceph-${CEPH_VERSION}-${arch}.squashfs" "${artdir}/storage-ceph/"
+      rm -Rf "${tmpdir_kubernetes}" "${tmpdir_storage}"
     fi
 
     set -o pipefail

--- a/workflows/ncn/hooks/before-all/install-csi.yaml
+++ b/workflows/ncn/hooks/before-all/install-csi.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -31,6 +31,28 @@ spec:
   scriptContent: |
     #!/bin/sh
     source /srv/cray/scripts/metal/metal-lib.sh
+
+    echo "Sleeping for 60 seconds to let nexus to start after move of singleton pod"
+    sleep 60
+    count=0
+    total=120
+    sleep=5
+    while true; do
+      http_code=$(curl -k -s -S -o /dev/null -w '%{http_code}' https://packages.local/service/rest/v1/status || true)
+      if [ "${http_code}" == "200" ]; then
+        echo "nexus is up"
+        break
+      else
+        if [ "${count}" == "${total}" ]; then
+          echo "nexus is down after ${total} checks, giving up ..."
+          exit 1
+        fi
+        count=$(($count + 1))
+        echo "nexus is down, sleeping for $sleep seconds and retry, attempt $count/$total ..."
+        sleep $sleep
+      fi
+    done
+
     csi_url=$(paginate "https://packages.local/service/rest/v1/components?repository=csm-noos" \
       | jq -r  '.items[] | .assets[] | .downloadUrl' | grep "cray-site-init" | sort -V | tail -1)
     if [[ -z $csi_url ]]; then

--- a/workflows/templates/storage.add-node-to-ceph.yaml
+++ b/workflows/templates/storage.add-node-to-ceph.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -90,6 +90,8 @@ spec:
             templateRef:
               name: ssh-template
               template: shell-script
+            dependencies:
+              - update-ssh-keys
             arguments:
               parameters:
                 - name: dryRun

--- a/workflows/templates/storage.reboot.yaml
+++ b/workflows/templates/storage.reboot.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -46,10 +46,12 @@ spec:
                   value: "{{inputs.parameters.dryRun}}"
                 - name: scriptContent
                   value: |
-                    TOKEN=$(curl -k -s -S -d grant_type=client_credentials \
-                      -d client_id=admin-client \
-                      -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
-                      https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
+                    curl -k -s -d grant_type=client_credentials \
+                        -d client_id=admin-client \
+                        -d client_secret="$(kubectl get secrets admin-client-auth -ojsonpath='{.data.client-secret}' | base64 -d)" \
+                        https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token > /tmp/setup-token.json
+                    export CRAY_CREDENTIALS=/tmp/setup-token.json
+                    TOKEN=$(jq -r '.access_token' /tmp/setup-token.json)
                     TARGET_NCN="{{inputs.parameters.targetNcn}}"
                     TARGET_XNAME=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management" | \
                         jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"$TARGET_NCN\")) | .Xname")
@@ -146,6 +148,8 @@ spec:
                     TARGET_NCN={{inputs.parameters.targetNcn}}
                     TARGET_XNAME=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management" | \
                         jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"$TARGET_NCN\")) | .Xname")
+                    TARGET_MGMT_XNAME=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management" | \
+                      jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"$TARGET_NCN\")) | .Parent")
                     TARGET_NCN_mgmt_host="${TARGET_NCN}-mgmt"
                     export IPMI_USERNAME=$(curl -XGET -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds"| jq -r ".Targets[] | select(.Xname | contains(\"$TARGET_MGMT_XNAME\")) | .Username")
                     export IPMI_PASSWORD=$(curl -XGET -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds"| jq -r ".Targets[] | select(.Xname | contains(\"$TARGET_MGMT_XNAME\")) | .Password")

--- a/workflows/templates/wipe-and-reboot-worker.yaml
+++ b/workflows/templates/wipe-and-reboot-worker.yaml
@@ -49,10 +49,12 @@ spec:
                 value: "{{inputs.parameters.dryRun}}"
               - name: scriptContent
                 value: |
-                  TOKEN=$(curl -k -s -S -d grant_type=client_credentials \
-                    -d client_id=admin-client \
-                    -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
-                    https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
+                  curl -k -s -d grant_type=client_credentials \
+                      -d client_id=admin-client \
+                      -d client_secret="$(kubectl get secrets admin-client-auth -ojsonpath='{.data.client-secret}' | base64 -d)" \
+                      https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token > /tmp/setup-token.json
+                  export CRAY_CREDENTIALS=/tmp/setup-token.json
+                  TOKEN=$(jq -r '.access_token' /tmp/setup-token.json)
                   TARGET_NCN={{inputs.parameters.targetNcn}}
                   TARGET_XNAME=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management" | \
                       jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"$TARGET_NCN\")) | .Xname")
@@ -179,6 +181,8 @@ spec:
                   TARGET_NCN={{inputs.parameters.targetNcn}}
                   TARGET_XNAME=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management" | \
                       jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"$TARGET_NCN\")) | .Xname")
+                  TARGET_MGMT_XNAME=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware?extra_properties.Role=Management" | \
+                      jq -r ".[] | select(.ExtraProperties.Aliases[] | contains(\"$TARGET_NCN\")) | .Parent")
                   TARGET_NCN_mgmt_host="${TARGET_NCN}-mgmt"
                   export IPMI_USERNAME=$(curl -XGET -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds"| jq -r ".Targets[] | select(.Xname | contains(\"$TARGET_MGMT_XNAME\")) | .Username")
                   export IPMI_PASSWORD=$(curl -XGET -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds"| jq -r ".Targets[] | select(.Xname | contains(\"$TARGET_MGMT_XNAME\")) | .Password")


### PR DESCRIPTION
# Description
Backport of enhancements already applied to `release/1.5` via #4577:

* Fix typo in Ceph Troubleshoot HEALTH_ERR
* CASMINST-6692: vShasta upgrade: fix --no-retry switch
* CASMINST-6692: vShasta upgrade: fix UPLOAD_NEW_NCN_IMAGE stage
* CASMINST-6692: vShasta upgrade: install-csi: add wait-for-nexus
* CASMINST-6692: vShasta upgrade: add-node-to-ceph: add missed dependency on ssh-keys
* CASMINST-6692: vShasta upgrade: export CRAY_CREDENTIALS to fix cray bss call
* CASMINST-6692: vShasta upgrade: fix missed TARGET_MGMT_XNAME
* CASMINST-6692: vShasta upgrade: accomodate unexpected efibootmgr output

# Checklist
- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
