### PR TITLE
CASMTRIAGE-6542: Updated 'master-host-hook-script.yaml' to remove the…

### DIFF
--- a/workflows/iuf/hooks/master-host-hook-script.yaml
+++ b/workflows/iuf/hooks/master-host-hook-script.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -44,6 +44,8 @@ spec:
                 - name: scriptContent
                   value: >
                     set -e
+
+                    trap 'rm -rf -- "/tmp/${global_params_file}.json"' EXIT
 
                     global_params_file=$(echo $RANDOM | md5sum | head -c 20; echo)
 


### PR DESCRIPTION
… global_params_file to avoid disk space issues

# Description
 Updated "master-host-hook-script.yaml" to remove the global_params_file under /tmp to resolve disk space issues

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [ ] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.
