### PR TITLE
CASMTRIAGE-6543: auth requirement in API docs

### DIFF
--- a/api/bos.md
+++ b/api/bos.md
@@ -100,6 +100,10 @@ Base URLs:
 
 * <a href="https://cray-bos">https://cray-bos</a>
 
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
+
 <h1 id="boot-orchestration-service-version">version</h1>
 
 ## get__
@@ -116,14 +120,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/ \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/', headers = headers)
@@ -144,6 +150,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -203,8 +210,9 @@ Status Code **200**
 |»» href|string|false|none|none|
 |»» rel|string|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## v1_get
@@ -223,14 +231,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v1 \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v1', headers = headers)
@@ -251,6 +261,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -299,8 +310,9 @@ The versioning system uses [semver](https://semver.org/).
 * versions : Link back to the versions resource|[Version](#schemaversion)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## v1_get_version
@@ -319,14 +331,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/version \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v1/version', headers = headers)
@@ -347,6 +361,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -395,8 +410,9 @@ The versioning system uses [semver](https://semver.org/).
 * versions : Link back to the versions resource|[Version](#schemaversion)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="boot-orchestration-service-healthz">healthz</h1>
@@ -417,14 +433,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/healthz \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v1/healthz', headers = headers)
@@ -445,6 +463,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -483,8 +502,9 @@ Get BOS health details.
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |503|[Service Unavailable](https://tools.ietf.org/html/rfc7231#section-6.6.4)|Service Unavailable|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="boot-orchestration-service-sessiontemplate">sessiontemplate</h1>
@@ -509,7 +529,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 curl -X POST https://api-gw-service-nmn.local/apis/bos/v1/sessiontemplate \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -518,7 +539,8 @@ import requests
 headers = {
   'Content-Type': 'application/json',
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/bos/v1/sessiontemplate', headers = headers)
@@ -541,6 +563,7 @@ func main() {
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -658,8 +681,9 @@ If this parameter is set to a non-empty string, the request will be rejected.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Multi-tenancy is not supported for this BOS v1 request.
 If no tenant was specified, then the request was bad for another reason.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v1_sessiontemplates
@@ -680,7 +704,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/sessiontemplate \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -688,7 +713,8 @@ curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/sessiontemplate \
 import requests
 headers = {
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v1/sessiontemplate', headers = headers)
@@ -710,6 +736,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -821,8 +848,9 @@ If this parameter is set to a non-empty string, the request will be rejected.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Session Template details array|[V2SessionTemplateArray](#schemav2sessiontemplatearray)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Multi-tenancy is not supported for this BOS v1 request.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v1_sessiontemplate
@@ -843,7 +871,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/sessiontemplate/{session_template_id} \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -851,7 +880,8 @@ curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/sessiontemplate/{sessio
 import requests
 headers = {
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v1/sessiontemplate/{session_template_id}', headers = headers)
@@ -873,6 +903,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -986,8 +1017,9 @@ If this parameter is set to a non-empty string, the request will be rejected.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Multi-tenancy is not supported for this BOS v1 request.|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v1_sessiontemplate
@@ -1008,7 +1040,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/bos/v1/sessiontemplate/{session_template_id} \
   -H 'Accept: application/problem+json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1016,7 +1049,8 @@ curl -X DELETE https://api-gw-service-nmn.local/apis/bos/v1/sessiontemplate/{ses
 import requests
 headers = {
   'Accept': 'application/problem+json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/bos/v1/sessiontemplate/{session_template_id}', headers = headers)
@@ -1038,6 +1072,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1091,8 +1126,9 @@ If this parameter is set to a non-empty string, the request will be rejected.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Multi-tenancy is not supported for this BOS v1 request.|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v1_sessiontemplatetemplate
@@ -1111,14 +1147,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/sessiontemplatetemplate \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v1/sessiontemplatetemplate', headers = headers)
@@ -1139,6 +1177,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1238,8 +1277,9 @@ Session Templates.
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Session Template details|[V2SessionTemplate](#schemav2sessiontemplate)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="boot-orchestration-service-session">session</h1>
@@ -1264,7 +1304,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 curl -X POST https://api-gw-service-nmn.local/apis/bos/v1/session \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1273,7 +1314,8 @@ import requests
 headers = {
   'Content-Type': 'application/json',
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/bos/v1/session', headers = headers)
@@ -1296,6 +1338,7 @@ func main() {
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1370,8 +1413,9 @@ If this parameter is set to a non-empty string, the request will be rejected.
 If no tenant was specified, then the request was bad for another reason.|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v1_sessions
@@ -1392,7 +1436,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/session \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1400,7 +1445,8 @@ curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/session \
 import requests
 headers = {
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v1/session', headers = headers)
@@ -1422,6 +1468,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1477,8 +1524,9 @@ Status Code **200**
 |---|---|---|---|---|
 |*anonymous*|[[V1SessionId](#schemav1sessionid)]|false|none|[Unique BOS v1 Session identifier.]|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v1_session
@@ -1499,7 +1547,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id} \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1507,7 +1556,8 @@ curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id} \
 import requests
 headers = {
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}', headers = headers)
@@ -1529,6 +1579,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1588,8 +1639,9 @@ If this parameter is set to a non-empty string, the request will be rejected.
 
 <h3 id="get_v1_session-responseschema">Response Schema</h3>
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v1_session
@@ -1610,7 +1662,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id} \
   -H 'Accept: application/problem+json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1618,7 +1671,8 @@ curl -X DELETE https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}
 import requests
 headers = {
   'Accept': 'application/problem+json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}', headers = headers)
@@ -1640,6 +1694,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1693,8 +1748,9 @@ If this parameter is set to a non-empty string, the request will be rejected.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Multi-tenancy is not supported for this BOS v1 request.|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v1_session_status
@@ -1715,7 +1771,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1723,7 +1780,8 @@ curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/st
 import requests
 headers = {
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status', headers = headers)
@@ -1745,6 +1803,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1810,8 +1869,9 @@ If this parameter is set to a non-empty string, the request will be rejected.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Multi-tenancy is not supported for this BOS v1 request.|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## create_v1_session_status
@@ -1834,7 +1894,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 curl -X POST https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1843,7 +1904,8 @@ import requests
 headers = {
   'Content-Type': 'application/json',
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status', headers = headers)
@@ -1866,6 +1928,7 @@ func main() {
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1957,8 +2020,9 @@ If this parameter is set to a non-empty string, the request will be rejected.
 If no tenant was specified, then the request was bad for another reason.|[ProblemDetails](#schemaproblemdetails)|
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|The resource to be created already exists|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## update_v1_session_status
@@ -1981,7 +2045,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 curl -X PATCH https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1990,7 +2055,8 @@ import requests
 headers = {
   'Content-Type': 'application/json',
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status', headers = headers)
@@ -2013,6 +2079,7 @@ func main() {
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2091,8 +2158,9 @@ If this parameter is set to a non-empty string, the request will be rejected.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Multi-tenancy is not supported for this BOS v1 request.|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v1_session_status
@@ -2113,7 +2181,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status \
   -H 'Accept: application/problem+json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2121,7 +2190,8 @@ curl -X DELETE https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}
 import requests
 headers = {
   'Accept': 'application/problem+json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status', headers = headers)
@@ -2143,6 +2213,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2197,8 +2268,9 @@ If this parameter is set to a non-empty string, the request will be rejected.
 If no tenant was specified, then the request was bad for another reason.|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v1_session_status_by_bootset
@@ -2219,7 +2291,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status/{boot_set_name} \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2227,7 +2300,8 @@ curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/st
 import requests
 headers = {
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status/{boot_set_name}', headers = headers)
@@ -2249,6 +2323,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2344,8 +2419,9 @@ If this parameter is set to a non-empty string, the request will be rejected.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Multi-tenancy is not supported for this BOS v1 request.|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## create_v1_boot_set_status
@@ -2368,7 +2444,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 curl -X POST https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status/{boot_set_name} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2377,7 +2454,8 @@ import requests
 headers = {
   'Content-Type': 'application/json',
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status/{boot_set_name}', headers = headers)
@@ -2400,6 +2478,7 @@ func main() {
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2549,8 +2628,9 @@ If this parameter is set to a non-empty string, the request will be rejected.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Multi-tenancy is not supported for this BOS v1 request.|[ProblemDetails](#schemaproblemdetails)|
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|The resource to be created already exists|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## update_v1_session_status_by_bootset
@@ -2573,7 +2653,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 curl -X PATCH https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status/{boot_set_name} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2582,7 +2663,8 @@ import requests
 headers = {
   'Content-Type': 'application/json',
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status/{boot_set_name}', headers = headers)
@@ -2605,6 +2687,7 @@ func main() {
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2722,8 +2805,9 @@ If this parameter is set to a non-empty string, the request will be rejected.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Multi-tenancy is not supported for this BOS v1 request.|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v1_boot_set_status
@@ -2744,7 +2828,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status/{boot_set_name} \
   -H 'Accept: application/problem+json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2752,7 +2837,8 @@ curl -X DELETE https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}
 import requests
 headers = {
   'Accept': 'application/problem+json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status/{boot_set_name}', headers = headers)
@@ -2774,6 +2860,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2828,8 +2915,9 @@ If this parameter is set to a non-empty string, the request will be rejected.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Multi-tenancy is not supported for this BOS v1 request.
 If no tenant was specified, then the request was bad for another reason.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v1_session_status_by_bootset_and_phase
@@ -2850,7 +2938,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status/{boot_set_name}/{phase_name} \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2858,7 +2947,8 @@ curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/st
 import requests
 headers = {
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status/{boot_set_name}/{phase_name}', headers = headers)
@@ -2880,6 +2970,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2957,8 +3048,9 @@ If this parameter is set to a non-empty string, the request will be rejected.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Multi-tenancy is not supported for this BOS v1 request.|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v1_session_status_by_bootset_and_phase_and_category
@@ -2979,7 +3071,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status/{boot_set_name}/{phase_name}/{category_name} \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2987,7 +3080,8 @@ curl -X GET https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/st
 import requests
 headers = {
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v1/session/{session_id}/status/{boot_set_name}/{phase_name}/{category_name}', headers = headers)
@@ -3009,6 +3103,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3065,8 +3160,9 @@ If this parameter is set to a non-empty string, the request will be rejected.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Multi-tenancy is not supported for this BOS v1 request.|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="boot-orchestration-service-v2">v2</h1>
@@ -3087,14 +3183,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v2 \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v2', headers = headers)
@@ -3115,6 +3213,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3163,8 +3262,9 @@ The versioning system uses [semver](https://semver.org/).
 * versions : Link back to the versions resource|[Version](#schemaversion)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v2_healthz
@@ -3183,14 +3283,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/healthz \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v2/healthz', headers = headers)
@@ -3211,6 +3313,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3249,8 +3352,9 @@ Get BOS health details.
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |503|[Service Unavailable](https://tools.ietf.org/html/rfc7231#section-6.6.4)|Service Unavailable|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v2_sessiontemplates
@@ -3271,7 +3375,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplates \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3279,7 +3384,8 @@ curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplates \
 import requests
 headers = {
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplates', headers = headers)
@@ -3301,6 +3407,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3414,8 +3521,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Session Template details array|[V2SessionTemplateArray](#schemav2sessiontemplatearray)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## validate_v2_sessiontemplate
@@ -3436,7 +3544,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplatesvalid/{session_template_id} \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3444,7 +3553,8 @@ curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplatesvalid/{
 import requests
 headers = {
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplatesvalid/{session_template_id}', headers = headers)
@@ -3466,6 +3576,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3517,8 +3628,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Session Template validity details|[V2SessionTemplateValidation](#schemav2sessiontemplatevalidation)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v2_sessiontemplate
@@ -3539,7 +3651,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplates/{session_template_id} \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3547,7 +3660,8 @@ curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplates/{sessi
 import requests
 headers = {
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplates/{session_template_id}', headers = headers)
@@ -3569,6 +3683,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3684,8 +3799,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Session Template details|[V2SessionTemplate](#schemav2sessiontemplate)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## put_v2_sessiontemplate
@@ -3708,7 +3824,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 curl -X PUT https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplates/{session_template_id} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3717,7 +3834,8 @@ import requests
 headers = {
   'Content-Type': 'application/json',
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.put('https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplates/{session_template_id}', headers = headers)
@@ -3740,6 +3858,7 @@ func main() {
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3916,8 +4035,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Session Template details|[V2SessionTemplate](#schemav2sessiontemplate)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_v2_sessiontemplate
@@ -3940,7 +4060,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 curl -X PATCH https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplates/{session_template_id} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3949,7 +4070,8 @@ import requests
 headers = {
   'Content-Type': 'application/json',
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplates/{session_template_id}', headers = headers)
@@ -3972,6 +4094,7 @@ func main() {
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4149,8 +4272,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v2_sessiontemplate
@@ -4171,7 +4295,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplates/{session_template_id} \
   -H 'Accept: application/problem+json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -4179,7 +4304,8 @@ curl -X DELETE https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplates/{se
 import requests
 headers = {
   'Accept': 'application/problem+json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplates/{session_template_id}', headers = headers)
@@ -4201,6 +4327,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4256,8 +4383,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|The resource was deleted.|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v2_sessiontemplatetemplate
@@ -4276,14 +4404,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplatetemplate \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v2/sessiontemplatetemplate', headers = headers)
@@ -4304,6 +4434,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4403,8 +4534,9 @@ Session Templates.
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Session Template details|[V2SessionTemplate](#schemav2sessiontemplate)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post_v2_session
@@ -4427,7 +4559,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 curl -X POST https://api-gw-service-nmn.local/apis/bos/v2/sessions \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -4436,7 +4569,8 @@ import requests
 headers = {
   'Content-Type': 'application/json',
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/bos/v2/sessions', headers = headers)
@@ -4459,6 +4593,7 @@ func main() {
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4538,8 +4673,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Session details|[V2Session](#schemav2session)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v2_sessions
@@ -4560,7 +4696,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/sessions \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -4568,7 +4705,8 @@ curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/sessions \
 import requests
 headers = {
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v2/sessions', headers = headers)
@@ -4590,6 +4728,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4665,8 +4804,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Session details array|[V2SessionArray](#schemav2sessionarray)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v2_sessions
@@ -4687,7 +4827,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/bos/v2/sessions \
   -H 'Accept: application/problem+json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -4695,7 +4836,8 @@ curl -X DELETE https://api-gw-service-nmn.local/apis/bos/v2/sessions \
 import requests
 headers = {
   'Accept': 'application/problem+json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/bos/v2/sessions', headers = headers)
@@ -4717,6 +4859,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4783,8 +4926,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|The resource was deleted.|None|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v2_session
@@ -4805,7 +4949,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/sessions/{session_id} \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -4813,7 +4958,8 @@ curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/sessions/{session_id} \
 import requests
 headers = {
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v2/sessions/{session_id}', headers = headers)
@@ -4835,6 +4981,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4899,8 +5046,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Session details|[V2Session](#schemav2session)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_v2_session
@@ -4923,7 +5071,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 curl -X PATCH https://api-gw-service-nmn.local/apis/bos/v2/sessions/{session_id} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -4932,7 +5081,8 @@ import requests
 headers = {
   'Content-Type': 'application/json',
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/bos/v2/sessions/{session_id}', headers = headers)
@@ -4955,6 +5105,7 @@ func main() {
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5041,8 +5192,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v2_session
@@ -5063,7 +5215,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/bos/v2/sessions/{session_id} \
   -H 'Accept: application/problem+json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -5071,7 +5224,8 @@ curl -X DELETE https://api-gw-service-nmn.local/apis/bos/v2/sessions/{session_id
 import requests
 headers = {
   'Accept': 'application/problem+json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/bos/v2/sessions/{session_id}', headers = headers)
@@ -5093,6 +5247,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5148,8 +5303,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|The resource was deleted.|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v2_session_status
@@ -5170,7 +5326,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/sessions/{session_id}/status \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -5178,7 +5335,8 @@ curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/sessions/{session_id}/s
 import requests
 headers = {
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v2/sessions/{session_id}/status', headers = headers)
@@ -5200,6 +5358,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5267,8 +5426,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Session status details|[V2SessionExtendedStatus](#schemav2sessionextendedstatus)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## save_v2_session_status
@@ -5289,7 +5449,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/bos/v2/sessions/{session_id}/status \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -5297,7 +5458,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/bos/v2/sessions/{session_id}/
 import requests
 headers = {
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/bos/v2/sessions/{session_id}/status', headers = headers)
@@ -5319,6 +5481,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5383,8 +5546,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Session details|[V2Session](#schemav2session)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v2_components
@@ -5405,7 +5569,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/components \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -5413,7 +5578,8 @@ curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/components \
 import requests
 headers = {
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v2/components', headers = headers)
@@ -5435,6 +5601,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5550,8 +5717,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of Component states|[V2ComponentArray](#schemav2componentarray)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## put_v2_components
@@ -5574,7 +5742,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 curl -X PUT https://api-gw-service-nmn.local/apis/bos/v2/components \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -5583,7 +5752,8 @@ import requests
 headers = {
   'Content-Type': 'application/json',
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.put('https://api-gw-service-nmn.local/apis/bos/v2/components', headers = headers)
@@ -5606,6 +5776,7 @@ func main() {
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5760,8 +5931,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of Component states|[V2ComponentArray](#schemav2componentarray)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_v2_components
@@ -5784,7 +5956,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 curl -X PATCH https://api-gw-service-nmn.local/apis/bos/v2/components \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -5793,7 +5966,8 @@ import requests
 headers = {
   'Content-Type': 'application/json',
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/bos/v2/components', headers = headers)
@@ -5816,6 +5990,7 @@ func main() {
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5975,8 +6150,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v2_component
@@ -5997,7 +6173,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/components/{component_id} \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -6005,7 +6182,8 @@ curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/components/{component_i
 import requests
 headers = {
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v2/components/{component_id}', headers = headers)
@@ -6027,6 +6205,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6127,8 +6306,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## put_v2_component
@@ -6151,7 +6331,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 curl -X PUT https://api-gw-service-nmn.local/apis/bos/v2/components/{component_id} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -6160,7 +6341,8 @@ import requests
 headers = {
   'Content-Type': 'application/json',
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.put('https://api-gw-service-nmn.local/apis/bos/v2/components/{component_id}', headers = headers)
@@ -6183,6 +6365,7 @@ func main() {
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6334,8 +6517,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A single Component state|[V2Component](#schemav2component)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_v2_component
@@ -6358,7 +6542,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 curl -X PATCH https://api-gw-service-nmn.local/apis/bos/v2/components/{component_id} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -6367,7 +6552,8 @@ import requests
 headers = {
   'Content-Type': 'application/json',
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/bos/v2/components/{component_id}', headers = headers)
@@ -6390,6 +6576,7 @@ func main() {
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6543,8 +6730,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|The update was not allowed due to a conflict.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v2_component
@@ -6565,7 +6753,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/bos/v2/components/{component_id} \
   -H 'Accept: application/problem+json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -6573,7 +6762,8 @@ curl -X DELETE https://api-gw-service-nmn.local/apis/bos/v2/components/{componen
 import requests
 headers = {
   'Accept': 'application/problem+json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/bos/v2/components/{component_id}', headers = headers)
@@ -6595,6 +6785,7 @@ func main() {
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6650,8 +6841,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|The resource was deleted.|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post_v2_apply_staged
@@ -6674,7 +6866,8 @@ Cray-Tenant-Name: vcluster-my-tenant1
 curl -X POST https://api-gw-service-nmn.local/apis/bos/v2/applystaged \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
-  -H 'Cray-Tenant-Name: vcluster-my-tenant1'
+  -H 'Cray-Tenant-Name: vcluster-my-tenant1' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -6683,7 +6876,8 @@ import requests
 headers = {
   'Content-Type': 'application/json',
   'Accept': 'application/json',
-  'Cray-Tenant-Name': 'vcluster-my-tenant1'
+  'Cray-Tenant-Name': 'vcluster-my-tenant1',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/bos/v2/applystaged', headers = headers)
@@ -6706,6 +6900,7 @@ func main() {
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
         "Cray-Tenant-Name": []string{"vcluster-my-tenant1"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6778,8 +6973,9 @@ Requests with an empty tenant name, or that omit this parameter, will have no su
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A list of xnames that should have their staged Session applied.|[V2ApplyStagedStatus](#schemav2applystagedstatus)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_v2_options
@@ -6800,7 +6996,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/bos/v2/options \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -6808,7 +7005,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/bos/v2/options \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/bos/v2/options', headers = headers)
@@ -6830,6 +7028,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6900,8 +7099,9 @@ Update one or more of the BOS service options.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of service-wide options|[V2Options](#schemav2options)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_version_v2
@@ -6920,14 +7120,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/version \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v2/version', headers = headers)
@@ -6948,6 +7150,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6996,8 +7199,9 @@ The versioning system uses [semver](https://semver.org/).
 * versions : Link back to the versions resource|[Version](#schemaversion)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="boot-orchestration-service-options">options</h1>
@@ -7018,14 +7222,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/bos/v2/options \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/bos/v2/options', headers = headers)
@@ -7046,6 +7252,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -7091,8 +7298,9 @@ Retrieve the list of BOS service options.
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of service-wide options|[V2Options](#schemav2options)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas

--- a/api/bos.md
+++ b/api/bos.md
@@ -98,8 +98,6 @@ Base URLs:
 
 * <a href="https://api-gw-service-nmn.local/apis/bos">https://api-gw-service-nmn.local/apis/bos</a>
 
-* <a href="https://cray-bos">https://cray-bos</a>
-
 # Authentication
 
 - HTTP Authentication, scheme: bearer 

--- a/api/bss.md
+++ b/api/bss.md
@@ -35,7 +35,11 @@ Verify the boot parameters for the specific host.
 
 Base URLs:
 
-* <a href="http://bootscriptserver:27778/apis/bss">http://bootscriptserver:27778/apis/bss</a>
+* <a href="https://api-gw-service-nmn.local/apis/bss">https://api-gw-service-nmn.local/apis/bss</a>
+
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
 
 <h1 id="boot-script-service-cli_ignore">cli_ignore</h1>
 
@@ -46,26 +50,28 @@ Base URLs:
 > Code samples
 
 ```http
-GET http://bootscriptserver:27778/apis/bss/meta-data HTTP/1.1
-Host: bootscriptserver:27778
+GET https://api-gw-service-nmn.local/apis/bss/meta-data HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://bootscriptserver:27778/apis/bss/meta-data \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/bss/meta-data \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://bootscriptserver:27778/apis/bss/meta-data', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/bss/meta-data', headers = headers)
 
 print(r.json())
 
@@ -83,10 +89,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://bootscriptserver:27778/apis/bss/meta-data", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/bss/meta-data", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -125,8 +132,9 @@ func main() {
 
 <h3 id="meta_data_get-responseschema">Response Schema</h3>
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## user_data_get
@@ -136,26 +144,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://bootscriptserver:27778/apis/bss/user-data HTTP/1.1
-Host: bootscriptserver:27778
+GET https://api-gw-service-nmn.local/apis/bss/user-data HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: text/yaml
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://bootscriptserver:27778/apis/bss/user-data \
-  -H 'Accept: text/yaml'
+curl -X GET https://api-gw-service-nmn.local/apis/bss/user-data \
+  -H 'Accept: text/yaml' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'text/yaml'
+  'Accept': 'text/yaml',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://bootscriptserver:27778/apis/bss/user-data', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/bss/user-data', headers = headers)
 
 print(r.json())
 
@@ -173,10 +183,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"text/yaml"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://bootscriptserver:27778/apis/bss/user-data", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/bss/user-data", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -205,8 +216,9 @@ func main() {
 
 <h3 id="user_data_get-responseschema">Response Schema</h3>
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## phone_home_post
@@ -216,8 +228,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://bootscriptserver:27778/apis/bss/phone-home HTTP/1.1
-Host: bootscriptserver:27778
+POST https://api-gw-service-nmn.local/apis/bss/phone-home HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -225,9 +237,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://bootscriptserver:27778/apis/bss/phone-home \
+curl -X POST https://api-gw-service-nmn.local/apis/bss/phone-home \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -235,10 +248,11 @@ curl -X POST http://bootscriptserver:27778/apis/bss/phone-home \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://bootscriptserver:27778/apis/bss/phone-home', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/bss/phone-home', headers = headers)
 
 print(r.json())
 
@@ -257,10 +271,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://bootscriptserver:27778/apis/bss/phone-home", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/bss/phone-home", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -338,8 +353,9 @@ func main() {
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Either the host, MAC or NID are unknown and there is no Default, or the existing entry does not specify a kernel image for boot.|[Error](#schemaerror)|
 |default|Default|Unexpected error|[Error](#schemaerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="boot-script-service-bootscript">bootscript</h1>
@@ -351,26 +367,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://bootscriptserver:27778/apis/bss/boot/v1/bootscript HTTP/1.1
-Host: bootscriptserver:27778
+GET https://api-gw-service-nmn.local/apis/bss/boot/v1/bootscript HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: text/plain
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://bootscriptserver:27778/apis/bss/boot/v1/bootscript \
-  -H 'Accept: text/plain'
+curl -X GET https://api-gw-service-nmn.local/apis/bss/boot/v1/bootscript \
+  -H 'Accept: text/plain' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'text/plain'
+  'Accept': 'text/plain',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://bootscriptserver:27778/apis/bss/boot/v1/bootscript', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/bss/boot/v1/bootscript', headers = headers)
 
 print(r.json())
 
@@ -388,10 +406,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"text/plain"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://bootscriptserver:27778/apis/bss/boot/v1/bootscript", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/bss/boot/v1/bootscript", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -435,8 +454,9 @@ Retrieve iPXE boot script for the host specified by the MAC parameter. Alternati
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Either the host, MAC, or NID are unknown and there is no Default, or the existing entry does not specify a kernel image for boot.|[Error](#schemaerror)|
 |default|Default|Unexpected error|[Error](#schemaerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="boot-script-service-bootparameters">bootparameters</h1>
@@ -446,8 +466,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters HTTP/1.1
-Host: bootscriptserver:27778
+GET https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -455,9 +475,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X GET http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters \
+curl -X GET https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -465,10 +486,11 @@ curl -X GET http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters', headers = headers)
 
 print(r.json())
 
@@ -487,10 +509,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -620,8 +643,9 @@ Status Code **200**
 |»»» hostname|string|false|none|none|
 |»»» fqdn|string|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__boot_v1_bootparameters
@@ -629,8 +653,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters HTTP/1.1
-Host: bootscriptserver:27778
+POST https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -638,9 +662,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters \
+curl -X POST https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -648,10 +673,11 @@ curl -X POST http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters', headers = headers)
 
 print(r.json())
 
@@ -670,10 +696,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -762,8 +789,9 @@ Special entries for HSM roles like 'Compute', 'Storage' and 'Application' can al
 |---|---|---|---|---|
 |201|BSS-Referral-Token|string||The UUID that will be included in the boot script. A new UUID is generated on each POST and PUT request.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## put__boot_v1_bootparameters
@@ -771,8 +799,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PUT http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters HTTP/1.1
-Host: bootscriptserver:27778
+PUT https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -780,9 +808,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PUT http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters \
+curl -X PUT https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -790,10 +819,11 @@ curl -X PUT http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.put('http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters', headers = headers)
+r = requests.put('https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters', headers = headers)
 
 print(r.json())
 
@@ -812,10 +842,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PUT", "http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters", data)
+    req, err := http.NewRequest("PUT", "https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -904,8 +935,9 @@ Along with the hosts, there must be a kernel image reference in order for the bo
 |---|---|---|---|---|
 |200|BSS-Referral-Token|string||The UUID that will be included in the boot script. A new UUID is generated on each POST and PUT request.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch__boot_v1_bootparameters
@@ -913,8 +945,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters HTTP/1.1
-Host: bootscriptserver:27778
+PATCH https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -922,9 +954,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters \
+curl -X PATCH https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -932,10 +965,11 @@ curl -X PATCH http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters', headers = headers)
 
 print(r.json())
 
@@ -954,10 +988,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1035,8 +1070,9 @@ Update an existing entry with new boot parameters while retaining existing setti
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Cannot find entry for specified host, MAC, or NID|[Error](#schemaerror)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error|[Error](#schemaerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete__boot_v1_bootparameters
@@ -1044,8 +1080,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters HTTP/1.1
-Host: bootscriptserver:27778
+DELETE https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -1053,9 +1089,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X DELETE http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters \
+curl -X DELETE https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1063,10 +1100,11 @@ curl -X DELETE http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters', headers = headers)
 
 print(r.json())
 
@@ -1085,10 +1123,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "http://bootscriptserver:27778/apis/bss/boot/v1/bootparameters", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1166,8 +1205,9 @@ Remove an existing boot parameter settings for one or more hosts, as specified b
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Cannot find specified host, MAC, or NID|[Error](#schemaerror)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error|[Error](#schemaerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="boot-script-service-hosts">hosts</h1>
@@ -1177,26 +1217,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://bootscriptserver:27778/apis/bss/boot/v1/hosts HTTP/1.1
-Host: bootscriptserver:27778
+GET https://api-gw-service-nmn.local/apis/bss/boot/v1/hosts HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://bootscriptserver:27778/apis/bss/boot/v1/hosts \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/bss/boot/v1/hosts \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://bootscriptserver:27778/apis/bss/boot/v1/hosts', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/bss/boot/v1/hosts', headers = headers)
 
 print(r.json())
 
@@ -1214,10 +1256,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://bootscriptserver:27778/apis/bss/boot/v1/hosts", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/bss/boot/v1/hosts", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1278,8 +1321,9 @@ Retrieve list of known hosts obtained from HSM. This list can be filtered by spe
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Return list of hosts and associated attributes known to BSS|[HostInfo](#schemahostinfo)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__boot_v1_hosts
@@ -1287,26 +1331,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://bootscriptserver:27778/apis/bss/boot/v1/hosts HTTP/1.1
-Host: bootscriptserver:27778
+POST https://api-gw-service-nmn.local/apis/bss/boot/v1/hosts HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X POST http://bootscriptserver:27778/apis/bss/boot/v1/hosts \
-  -H 'Accept: application/json'
+curl -X POST https://api-gw-service-nmn.local/apis/bss/boot/v1/hosts \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://bootscriptserver:27778/apis/bss/boot/v1/hosts', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/bss/boot/v1/hosts', headers = headers)
 
 print(r.json())
 
@@ -1324,10 +1370,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://bootscriptserver:27778/apis/bss/boot/v1/hosts", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/bss/boot/v1/hosts", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1365,8 +1412,9 @@ Retrieve the latest host information from HSM.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Error](#schemaerror)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error|[Error](#schemaerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="boot-script-service-dumpstate">dumpstate</h1>
@@ -1376,26 +1424,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://bootscriptserver:27778/apis/bss/boot/v1/dumpstate HTTP/1.1
-Host: bootscriptserver:27778
+GET https://api-gw-service-nmn.local/apis/bss/boot/v1/dumpstate HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://bootscriptserver:27778/apis/bss/boot/v1/dumpstate \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/bss/boot/v1/dumpstate \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://bootscriptserver:27778/apis/bss/boot/v1/dumpstate', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/bss/boot/v1/dumpstate', headers = headers)
 
 print(r.json())
 
@@ -1413,10 +1463,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://bootscriptserver:27778/apis/bss/boot/v1/dumpstate", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/bss/boot/v1/dumpstate", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1507,8 +1558,9 @@ Dump internal state of boot script service for debugging purposes. Return known 
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Error](#schemaerror)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error|[Error](#schemaerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="boot-script-service-endpoint-history">endpoint-history</h1>
@@ -1518,26 +1570,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://bootscriptserver:27778/apis/bss/boot/v1/endpoint-history HTTP/1.1
-Host: bootscriptserver:27778
+GET https://api-gw-service-nmn.local/apis/bss/boot/v1/endpoint-history HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://bootscriptserver:27778/apis/bss/boot/v1/endpoint-history \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/bss/boot/v1/endpoint-history \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://bootscriptserver:27778/apis/bss/boot/v1/endpoint-history', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/bss/boot/v1/endpoint-history', headers = headers)
 
 print(r.json())
 
@@ -1555,10 +1609,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://bootscriptserver:27778/apis/bss/boot/v1/endpoint-history", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/bss/boot/v1/endpoint-history", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1626,8 +1681,9 @@ Status Code **200**
 |endpoint|bootscript|
 |endpoint|user-data|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="boot-script-service-service-status">service-status</h1>
@@ -1637,26 +1693,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://bootscriptserver:27778/apis/bss/boot/v1/service/status HTTP/1.1
-Host: bootscriptserver:27778
+GET https://api-gw-service-nmn.local/apis/bss/boot/v1/service/status HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://bootscriptserver:27778/apis/bss/boot/v1/service/status \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/bss/boot/v1/service/status \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://bootscriptserver:27778/apis/bss/boot/v1/service/status', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/bss/boot/v1/service/status', headers = headers)
 
 print(r.json())
 
@@ -1674,10 +1732,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://bootscriptserver:27778/apis/bss/boot/v1/service/status", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/bss/boot/v1/service/status", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1726,8 +1785,9 @@ Status Code **200**
 |---|---|
 |bss-status|running|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__boot_v1_service_etcd
@@ -1735,26 +1795,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://bootscriptserver:27778/apis/bss/boot/v1/service/etcd HTTP/1.1
-Host: bootscriptserver:27778
+GET https://api-gw-service-nmn.local/apis/bss/boot/v1/service/etcd HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://bootscriptserver:27778/apis/bss/boot/v1/service/etcd \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/bss/boot/v1/service/etcd \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://bootscriptserver:27778/apis/bss/boot/v1/service/etcd', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/bss/boot/v1/service/etcd', headers = headers)
 
 print(r.json())
 
@@ -1772,10 +1834,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://bootscriptserver:27778/apis/bss/boot/v1/service/etcd", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/bss/boot/v1/service/etcd", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1839,8 +1902,9 @@ Status Code **500**
 |---|---|
 |bss-status-etcd|error|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__boot_v1_service_hsm
@@ -1848,26 +1912,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://bootscriptserver:27778/apis/bss/boot/v1/service/hsm HTTP/1.1
-Host: bootscriptserver:27778
+GET https://api-gw-service-nmn.local/apis/bss/boot/v1/service/hsm HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://bootscriptserver:27778/apis/bss/boot/v1/service/hsm \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/bss/boot/v1/service/hsm \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://bootscriptserver:27778/apis/bss/boot/v1/service/hsm', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/bss/boot/v1/service/hsm', headers = headers)
 
 print(r.json())
 
@@ -1885,10 +1951,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://bootscriptserver:27778/apis/bss/boot/v1/service/hsm", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/bss/boot/v1/service/hsm", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1950,8 +2017,9 @@ Status Code **500**
 |---|---|
 |bss-status-hsm|error|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__boot_v1_service_version
@@ -1959,26 +2027,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://bootscriptserver:27778/apis/bss/boot/v1/service/version HTTP/1.1
-Host: bootscriptserver:27778
+GET https://api-gw-service-nmn.local/apis/bss/boot/v1/service/version HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://bootscriptserver:27778/apis/bss/boot/v1/service/version \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/bss/boot/v1/service/version \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://bootscriptserver:27778/apis/bss/boot/v1/service/version', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/bss/boot/v1/service/version', headers = headers)
 
 print(r.json())
 
@@ -1996,10 +2066,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://bootscriptserver:27778/apis/bss/boot/v1/service/version", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/bss/boot/v1/service/version", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2052,8 +2123,9 @@ Status Code **500**
 |---|---|
 |bss-version|error|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__boot_v1_service_status_all
@@ -2061,26 +2133,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://bootscriptserver:27778/apis/bss/boot/v1/service/status/all HTTP/1.1
-Host: bootscriptserver:27778
+GET https://api-gw-service-nmn.local/apis/bss/boot/v1/service/status/all HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://bootscriptserver:27778/apis/bss/boot/v1/service/status/all \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/bss/boot/v1/service/status/all \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://bootscriptserver:27778/apis/bss/boot/v1/service/status/all', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/bss/boot/v1/service/status/all', headers = headers)
 
 print(r.json())
 
@@ -2098,10 +2172,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://bootscriptserver:27778/apis/bss/boot/v1/service/status/all", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/bss/boot/v1/service/status/all", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2178,8 +2253,9 @@ Status Code **500**
 |bss-status-hsm|connected|
 |bss-status-hsm|error|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas

--- a/api/capmc.md
+++ b/api/capmc.md
@@ -63,7 +63,11 @@ This implementation of CAPMC uses Redfish APIs to communicate directly with the 
 
 Base URLs:
 
-* <a href="http://api-gw-service-nmn.local/apis/capmc/capmc/v1">http://api-gw-service-nmn.local/apis/capmc/capmc/v1</a>
+* <a href="https://api-gw-service-nmn.local/apis/capmc/capmc/v1">https://api-gw-service-nmn.local/apis/capmc/capmc/v1</a>
+
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
 
 <h1 id="cray-advanced-platform-monitoring-and-control-capmc--component-control">component control</h1>
 
@@ -72,7 +76,7 @@ Base URLs:
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_xname_status HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_xname_status HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -81,9 +85,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_xname_status \
+curl -X POST https://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_xname_status \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -91,10 +96,11 @@ curl -X POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_xname_statu
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_xname_status', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_xname_status', headers = headers)
 
 print(r.json())
 
@@ -113,10 +119,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_xname_status", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_xname_status", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -220,7 +227,7 @@ Status Code **200**
 
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:
-None
+bearerAuth
 </aside>
 
 ## post__xname_reinit
@@ -228,7 +235,7 @@ None
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_reinit HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_reinit HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -237,9 +244,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_reinit \
+curl -X POST https://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_reinit \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -247,10 +255,11 @@ curl -X POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_reinit \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_reinit', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_reinit', headers = headers)
 
 print(r.json())
 
@@ -269,10 +278,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_reinit", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_reinit", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -365,7 +375,7 @@ Status Code **200**
 
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:
-None
+bearerAuth
 </aside>
 
 ## post__xname_on
@@ -373,7 +383,7 @@ None
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_on HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_on HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -382,9 +392,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_on \
+curl -X POST https://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_on \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -392,10 +403,11 @@ curl -X POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_on \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_on', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_on', headers = headers)
 
 print(r.json())
 
@@ -414,10 +426,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_on", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_on", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -514,7 +527,7 @@ Status Code **200**
 
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:
-None
+bearerAuth
 </aside>
 
 ## post__xname_off
@@ -522,7 +535,7 @@ None
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_off HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_off HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -531,9 +544,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_off \
+curl -X POST https://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_off \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -541,10 +555,11 @@ curl -X POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_off \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_off', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_off', headers = headers)
 
 print(r.json())
 
@@ -563,10 +578,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_off", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/capmc/capmc/v1/xname_off", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -663,7 +679,7 @@ Status Code **200**
 
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:
-None
+bearerAuth
 </aside>
 
 <h1 id="cray-advanced-platform-monitoring-and-control-capmc--power-capping">power capping</h1>
@@ -673,7 +689,7 @@ None
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -682,9 +698,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap \
+curl -X POST https://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -692,10 +709,11 @@ curl -X POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap', headers = headers)
 
 print(r.json())
 
@@ -714,10 +732,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -822,7 +841,7 @@ Status Code **200**
 
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:
-None
+bearerAuth
 </aside>
 
 ## post__get_power_cap_capabilities
@@ -830,7 +849,7 @@ None
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap_capabilities HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap_capabilities HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -839,9 +858,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap_capabilities \
+curl -X POST https://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap_capabilities \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -849,10 +869,11 @@ curl -X POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap_c
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap_capabilities', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap_capabilities', headers = headers)
 
 print(r.json())
 
@@ -871,10 +892,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap_capabilities", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/capmc/capmc/v1/get_power_cap_capabilities", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1003,7 +1025,7 @@ Status Code **200**
 
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:
-None
+bearerAuth
 </aside>
 
 ## post__set_power_cap
@@ -1011,7 +1033,7 @@ None
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/set_power_cap HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/capmc/capmc/v1/set_power_cap HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -1020,9 +1042,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/set_power_cap \
+curl -X POST https://api-gw-service-nmn.local/apis/capmc/capmc/v1/set_power_cap \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1030,10 +1053,11 @@ curl -X POST http://api-gw-service-nmn.local/apis/capmc/capmc/v1/set_power_cap \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/capmc/capmc/v1/set_power_cap', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/capmc/capmc/v1/set_power_cap', headers = headers)
 
 print(r.json())
 
@@ -1052,10 +1076,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/capmc/capmc/v1/set_power_cap", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/capmc/capmc/v1/set_power_cap", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1164,7 +1189,7 @@ Status Code **200**
 
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:
-None
+bearerAuth
 </aside>
 
 <h1 id="cray-advanced-platform-monitoring-and-control-capmc--utilities">utilities</h1>
@@ -1174,7 +1199,7 @@ None
 > Code samples
 
 ```http
-GET http://api-gw-service-nmn.local/apis/capmc/capmc/v1/health HTTP/1.1
+GET https://api-gw-service-nmn.local/apis/capmc/capmc/v1/health HTTP/1.1
 Host: api-gw-service-nmn.local
 Accept: application/json
 
@@ -1182,18 +1207,20 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X GET http://api-gw-service-nmn.local/apis/capmc/capmc/v1/health \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/capmc/capmc/v1/health \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://api-gw-service-nmn.local/apis/capmc/capmc/v1/health', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/capmc/capmc/v1/health', headers = headers)
 
 print(r.json())
 
@@ -1211,10 +1238,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://api-gw-service-nmn.local/apis/capmc/capmc/v1/health", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/capmc/capmc/v1/health", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1268,7 +1296,7 @@ Status Code **200**
 
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:
-None
+bearerAuth
 </aside>
 
 ## get__liveness
@@ -1276,7 +1304,7 @@ None
 > Code samples
 
 ```http
-GET http://api-gw-service-nmn.local/apis/capmc/capmc/v1/liveness HTTP/1.1
+GET https://api-gw-service-nmn.local/apis/capmc/capmc/v1/liveness HTTP/1.1
 Host: api-gw-service-nmn.local
 Accept: application/json
 
@@ -1284,18 +1312,20 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X GET http://api-gw-service-nmn.local/apis/capmc/capmc/v1/liveness \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/capmc/capmc/v1/liveness \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://api-gw-service-nmn.local/apis/capmc/capmc/v1/liveness', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/capmc/capmc/v1/liveness', headers = headers)
 
 print(r.json())
 
@@ -1313,10 +1343,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://api-gw-service-nmn.local/apis/capmc/capmc/v1/liveness", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/capmc/capmc/v1/liveness", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1354,7 +1385,7 @@ This is primarily an endpoint for the automated Kubernetes system.
 
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:
-None
+bearerAuth
 </aside>
 
 ## get__readiness
@@ -1362,7 +1393,7 @@ None
 > Code samples
 
 ```http
-GET http://api-gw-service-nmn.local/apis/capmc/capmc/v1/readiness HTTP/1.1
+GET https://api-gw-service-nmn.local/apis/capmc/capmc/v1/readiness HTTP/1.1
 Host: api-gw-service-nmn.local
 Accept: application/json
 
@@ -1370,18 +1401,20 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X GET http://api-gw-service-nmn.local/apis/capmc/capmc/v1/readiness \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/capmc/capmc/v1/readiness \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://api-gw-service-nmn.local/apis/capmc/capmc/v1/readiness', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/capmc/capmc/v1/readiness', headers = headers)
 
 print(r.json())
 
@@ -1399,10 +1432,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://api-gw-service-nmn.local/apis/capmc/capmc/v1/readiness", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/capmc/capmc/v1/readiness", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1440,7 +1474,7 @@ This is primarily an endpoint for the automated Kubernetes system.
 
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:
-None
+bearerAuth
 </aside>
 
 # Schemas

--- a/api/capmc.md
+++ b/api/capmc.md
@@ -218,8 +218,9 @@ Status Code **200**
 |» ready|[string]|false|none|Optional, list of booted components by xname. Operating system is fully booted and sending heartbeats.|
 |» standby|[string]|false|none|Optional, list of components in standby by xname. Components that were previously booted and but are no longer sending heartbeat.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+None
 </aside>
 
 ## post__xname_reinit
@@ -362,8 +363,9 @@ Status Code **200**
 |»» err_msg|string|true|none|Message indicating any error encountered.|
 |»» xname|string|true|none|Component ID failing power restart attempt.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+None
 </aside>
 
 ## post__xname_on
@@ -510,8 +512,9 @@ Status Code **200**
 |»» err_msg|string|true|none|Message indicating any error encountered.|
 |»» xname|string|true|none|Component ID failing power up attempt.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+None
 </aside>
 
 ## post__xname_off
@@ -658,8 +661,9 @@ Status Code **200**
 |»» e|integer(int32)|true|none|Non-zero status code for failed request.|
 |»» err_msg|string|true|none|Message indicating any error encountered.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+None
 </aside>
 
 <h1 id="cray-advanced-platform-monitoring-and-control-capmc--power-capping">power capping</h1>
@@ -816,8 +820,9 @@ Status Code **200**
 |»»» name|string|true|none|Unique control or status object identifier.|
 |»»» val|integer(int32)|true|none|Control object setting, or zero to indicate control is unconstrained, units are dependent upon control type.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+None
 </aside>
 
 ## post__get_power_cap_capabilities
@@ -996,8 +1001,9 @@ Status Code **200**
 |»»» min|integer(int32)|true|none|Minimum value which may be assigned to the control object, units are dependent upon control type.|
 |»»» max|integer(int32)|true|none|Maximum value which may be assigned to the control object, units are dependent upon control type.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+None
 </aside>
 
 ## post__set_power_cap
@@ -1156,8 +1162,9 @@ Status Code **200**
 |»» e|integer(int32)|true|none|Error status, non-zero indicates operation failed on this node.|
 |»» err_msg|string|true|none|Message indicating any error encountered.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+None
 </aside>
 
 <h1 id="cray-advanced-platform-monitoring-and-control-capmc--utilities">utilities</h1>
@@ -1259,8 +1266,9 @@ Status Code **200**
 |» vault|string|true|none|Description of the connection to the credentials vault.  If there is an error returned when attempting to access the vault that will be included here.|
 |» hsm|string|true|none|Status of the connection to the Hardware State Manager (HSM).  Any error reported by an attempt to access the HSM will be included in this description.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+None
 </aside>
 
 ## get__liveness
@@ -1344,8 +1352,9 @@ This is primarily an endpoint for the automated Kubernetes system.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|[No Content](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5) Network API call success|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|[Method Not Allowed](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.6)|[httpError405_MethodNotAllowed](#schemahttperror405_methodnotallowed)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+None
 </aside>
 
 ## get__readiness
@@ -1429,8 +1438,9 @@ This is primarily an endpoint for the automated Kubernetes system.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|[No Content](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5) Network API call success|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|[Method Not Allowed](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.6)|[httpError405_MethodNotAllowed](#schemahttperror405_methodnotallowed)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+None
 </aside>
 
 # Schemas

--- a/api/cfs.md
+++ b/api/cfs.md
@@ -41,7 +41,9 @@ CFS uses a Git version control server running in the management services infrast
 
 /components - Add, update, retrieve, or delete component information.
 
-/configurations - Add, update, retrieve or delete desired configuration states. (v2 api only)
+/configurations - Add, update, retrieve or delete desired configuration states.
+
+/sources - Add, update, retrieve, or delete playbook source information. (v3 api only)
 ## Workflows
 ### Image Customization
 
@@ -74,6 +76,10 @@ Base URLs:
 
 * <a href="https://api-gw-service-nmn.local/apis/cfs">https://api-gw-service-nmn.local/apis/cfs</a>
 
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
+
 <h1 id="configuration-framework-service-version">version</h1>
 
 ## get_version
@@ -92,14 +98,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/ \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/', headers = headers)
@@ -120,6 +128,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -157,8 +166,9 @@ Return list of versions currently running.
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Version information for the service|[Version](#schemaversion)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_versions
@@ -177,14 +187,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/versions \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/versions', headers = headers)
@@ -205,6 +217,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -242,8 +255,9 @@ Return list of versions currently running.
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Version information for the service|[Version](#schemaversion)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_versions_v2
@@ -262,14 +276,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/v2 \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v2', headers = headers)
@@ -290,6 +306,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -327,8 +344,9 @@ Return list of versions currently running.
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Version information for the service|[Version](#schemaversion)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_versions_v3
@@ -347,14 +365,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/v3 \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v3', headers = headers)
@@ -375,6 +395,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -412,8 +433,9 @@ Return list of versions currently running.
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Version information for the service|[Version](#schemaversion)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="configuration-framework-service-healthz">healthz</h1>
@@ -434,14 +456,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/healthz \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/healthz', headers = headers)
@@ -462,6 +486,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -499,8 +524,9 @@ Get cfs-api health details.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Status information for the service|[Healthz](#schemahealthz)|
 |503|[Service Unavailable](https://tools.ietf.org/html/rfc7231#section-6.6.4)|Status information for the service|[Healthz](#schemahealthz)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="configuration-framework-service-options">options</h1>
@@ -521,14 +547,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/v2/options \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v2/options', headers = headers)
@@ -549,6 +577,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -596,8 +625,9 @@ Retrieve the list of configuration service options.
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of service-wide configuration options|[V2Options](#schemav2options)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_options_v2
@@ -618,7 +648,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v2/options \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -626,7 +657,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v2/options \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/cfs/v2/options', headers = headers)
@@ -648,6 +680,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -722,8 +755,9 @@ Update one or more of the configuration service options.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of service-wide configuration options|[V2Options](#schemav2options)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_options_v3
@@ -742,14 +776,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/v3/options \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v3/options', headers = headers)
@@ -770,6 +806,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -804,6 +841,7 @@ Retrieve the list of configuration service options.
   "default_ansible_config": "cfs-default-ansible-cfg",
   "session_ttl": "24h",
   "additional_inventory_url": "https://api-gw-service-nmn.local/vcs/cray/inventory.git",
+  "additional_inventory_source": "example-source",
   "batcher_max_backoff": 3600,
   "batcher_disable": true,
   "batcher_pending_timeout": 1,
@@ -820,8 +858,9 @@ Retrieve the list of configuration service options.
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of service-wide configuration options|[V3Options](#schemav3options)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_options_v3
@@ -842,7 +881,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v3/options \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -850,7 +890,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v3/options \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/cfs/v3/options', headers = headers)
@@ -872,6 +913,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -903,6 +945,7 @@ Update one or more of the configuration service options.
   "default_ansible_config": "cfs-default-ansible-cfg",
   "session_ttl": "24h",
   "additional_inventory_url": "https://api-gw-service-nmn.local/vcs/cray/inventory.git",
+  "additional_inventory_source": "example-source",
   "batcher_max_backoff": 3600,
   "batcher_disable": true,
   "batcher_pending_timeout": 1,
@@ -934,6 +977,7 @@ Update one or more of the configuration service options.
   "default_ansible_config": "cfs-default-ansible-cfg",
   "session_ttl": "24h",
   "additional_inventory_url": "https://api-gw-service-nmn.local/vcs/cray/inventory.git",
+  "additional_inventory_source": "example-source",
   "batcher_max_backoff": 3600,
   "batcher_disable": true,
   "batcher_pending_timeout": 1,
@@ -951,8 +995,9 @@ Update one or more of the configuration service options.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of service-wide configuration options|[V3Options](#schemav3options)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="configuration-framework-service-sessions">sessions</h1>
@@ -973,14 +1018,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/v2/sessions \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v2/sessions', headers = headers)
@@ -1001,6 +1048,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1111,8 +1159,9 @@ Retrieve all the configuration framework sessions on the system.
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of configuration sessions|[V2SessionArray](#schemav2sessionarray)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## create_session_v2
@@ -1133,7 +1182,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/cfs/v2/sessions \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1141,7 +1191,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/cfs/v2/sessions \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/cfs/v2/sessions', headers = headers)
@@ -1163,6 +1214,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1292,8 +1344,9 @@ Create a new configuration session. A configuration session stages Ansible inven
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|A session with the same name already exists.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_sessions_v2
@@ -1312,14 +1365,16 @@ Accept: application/problem+json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/cfs/v2/sessions \
-  -H 'Accept: application/problem+json'
+  -H 'Accept: application/problem+json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/problem+json'
+  'Accept': 'application/problem+json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/cfs/v2/sessions', headers = headers)
@@ -1340,6 +1395,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1404,8 +1460,9 @@ Delete multiple configuration sessions.  If filters are provided, only sessions 
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|The resource was deleted.|None|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_session_v2
@@ -1424,14 +1481,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/v2/sessions/{session_name} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v2/sessions/{session_name}', headers = headers)
@@ -1452,6 +1511,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1543,8 +1603,9 @@ View details about a specific configuration session. This allows you to track th
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A single configuration session|[V2Session](#schemav2session)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_session_v2
@@ -1563,14 +1624,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v2/sessions/{session_name} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/cfs/v2/sessions/{session_name}', headers = headers)
@@ -1591,6 +1654,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1683,8 +1747,9 @@ Update the status of an existing configuration framework session
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_session_v2
@@ -1703,14 +1768,16 @@ Accept: application/problem+json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/cfs/v2/sessions/{session_name} \
-  -H 'Accept: application/problem+json'
+  -H 'Accept: application/problem+json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/problem+json'
+  'Accept': 'application/problem+json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/cfs/v2/sessions/{session_name}', headers = headers)
@@ -1731,6 +1798,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1777,8 +1845,9 @@ Deleting a configuration session deletes the Kubernetes objects associated with 
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|The resource was deleted.|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_sessions_v3
@@ -1797,14 +1866,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/v3/sessions \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v3/sessions', headers = headers)
@@ -1825,6 +1896,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1947,8 +2019,9 @@ Retrieve all the configuration framework sessions on the system.
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of configuration sessions|[V3SessionDataCollection](#schemav3sessiondatacollection)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## create_session_v3
@@ -1969,7 +2042,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/cfs/v3/sessions \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1977,7 +2051,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/cfs/v3/sessions \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/cfs/v3/sessions', headers = headers)
@@ -1999,6 +2074,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2132,8 +2208,9 @@ Create a new configuration session. A configuration session stages Ansible inven
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|A session with the same name already exists.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_sessions_v3
@@ -2152,14 +2229,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/cfs/v3/sessions \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/cfs/v3/sessions', headers = headers)
@@ -2180,6 +2259,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2297,8 +2377,9 @@ Delete multiple configuration sessions.  If filters are provided, only sessions 
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of configuration sessions|[V3SessionIdCollection](#schemav3sessionidcollection)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_session_v3
@@ -2317,14 +2398,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/v3/sessions/{session_name} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v3/sessions/{session_name}', headers = headers)
@@ -2345,6 +2428,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2439,8 +2523,9 @@ View details about a specific configuration session. This allows you to track th
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A single configuration session|[V3SessionData](#schemav3sessiondata)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_session_v3
@@ -2459,14 +2544,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v3/sessions/{session_name} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/cfs/v3/sessions/{session_name}', headers = headers)
@@ -2487,6 +2574,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2582,8 +2670,9 @@ Update the status of an existing configuration framework session
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_session_v3
@@ -2602,14 +2691,16 @@ Accept: application/problem+json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/cfs/v3/sessions/{session_name} \
-  -H 'Accept: application/problem+json'
+  -H 'Accept: application/problem+json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/problem+json'
+  'Accept': 'application/problem+json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/cfs/v3/sessions/{session_name}', headers = headers)
@@ -2630,6 +2721,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2676,8 +2768,9 @@ Deleting a configuration session deletes the Kubernetes objects associated with 
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|The resource was deleted.|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="configuration-framework-service-components">components</h1>
@@ -2698,14 +2791,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/v2/components \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v2/components', headers = headers)
@@ -2726,6 +2821,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2818,8 +2914,9 @@ Retrieve the full collection of components in the form of a ComponentArray. Full
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of component states|[V2ComponentStateArray](#schemav2componentstatearray)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## put_components_v2
@@ -2840,7 +2937,8 @@ Accept: application/json
 # You can also use wget
 curl -X PUT https://api-gw-service-nmn.local/apis/cfs/v2/components \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2848,7 +2946,8 @@ curl -X PUT https://api-gw-service-nmn.local/apis/cfs/v2/components \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.put('https://api-gw-service-nmn.local/apis/cfs/v2/components', headers = headers)
@@ -2870,6 +2969,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2987,8 +3087,9 @@ Update the state for a collection of components in the cfs database
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of component states|[V2ComponentStateArray](#schemav2componentstatearray)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_components_v2
@@ -3009,7 +3110,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v2/components \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3017,7 +3119,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v2/components \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/cfs/v2/components', headers = headers)
@@ -3039,6 +3142,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3157,8 +3261,9 @@ Update the state for a collection of components in the cfs database
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_component_v2
@@ -3177,14 +3282,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/v2/components/{component_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v2/components/{component_id}', headers = headers)
@@ -3205,6 +3312,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3283,8 +3391,9 @@ Retrieve the configuration and current state of a single component
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## put_component_v2
@@ -3305,7 +3414,8 @@ Accept: application/json
 # You can also use wget
 curl -X PUT https://api-gw-service-nmn.local/apis/cfs/v2/components/{component_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3313,7 +3423,8 @@ curl -X PUT https://api-gw-service-nmn.local/apis/cfs/v2/components/{component_i
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.put('https://api-gw-service-nmn.local/apis/cfs/v2/components/{component_id}', headers = headers)
@@ -3335,6 +3446,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3442,8 +3554,9 @@ Update the state for a given component in the cfs database
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A single component state|[V2ComponentState](#schemav2componentstate)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_component_v2
@@ -3464,7 +3577,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v2/components/{component_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3472,7 +3586,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v2/components/{component
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/cfs/v2/components/{component_id}', headers = headers)
@@ -3494,6 +3609,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3602,8 +3718,9 @@ Update the state for a given component in the cfs database
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_component_v2
@@ -3622,14 +3739,16 @@ Accept: application/problem+json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/cfs/v2/components/{component_id} \
-  -H 'Accept: application/problem+json'
+  -H 'Accept: application/problem+json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/problem+json'
+  'Accept': 'application/problem+json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/cfs/v2/components/{component_id}', headers = headers)
@@ -3650,6 +3769,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3696,8 +3816,9 @@ Delete the given component
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|The resource was deleted.|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_components_v3
@@ -3716,14 +3837,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/v3/components \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v3/components', headers = headers)
@@ -3744,6 +3867,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3850,8 +3974,9 @@ Retrieve the full collection of components in the form of a ComponentArray. Full
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of component states|[V3ComponentDataCollection](#schemav3componentdatacollection)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## put_components_v3
@@ -3872,7 +3997,8 @@ Accept: application/json
 # You can also use wget
 curl -X PUT https://api-gw-service-nmn.local/apis/cfs/v3/components \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3880,7 +4006,8 @@ curl -X PUT https://api-gw-service-nmn.local/apis/cfs/v3/components \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.put('https://api-gw-service-nmn.local/apis/cfs/v3/components', headers = headers)
@@ -3902,6 +4029,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3987,8 +4115,9 @@ Update the state for a collection of components in the cfs database
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of component ids|[V3ComponentIdCollection](#schemav3componentidcollection)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_components_v3
@@ -4009,7 +4138,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v3/components \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -4017,7 +4147,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v3/components \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/cfs/v3/components', headers = headers)
@@ -4039,6 +4170,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4125,8 +4257,9 @@ Update the state for a collection of components in the cfs database
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_component_v3
@@ -4145,14 +4278,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/v3/components/{component_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v3/components/{component_id}', headers = headers)
@@ -4173,6 +4308,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4256,8 +4392,9 @@ Retrieve the configuration and current state of a single component
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## put_component_v3
@@ -4278,7 +4415,8 @@ Accept: application/json
 # You can also use wget
 curl -X PUT https://api-gw-service-nmn.local/apis/cfs/v3/components/{component_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -4286,7 +4424,8 @@ curl -X PUT https://api-gw-service-nmn.local/apis/cfs/v3/components/{component_i
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.put('https://api-gw-service-nmn.local/apis/cfs/v3/components/{component_id}', headers = headers)
@@ -4308,6 +4447,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4421,8 +4561,9 @@ Update the state for a given component in the cfs database
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A single component state|[V3ComponentData](#schemav3componentdata)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_component_v3
@@ -4443,7 +4584,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v3/components/{component_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -4451,7 +4593,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v3/components/{component
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/cfs/v3/components/{component_id}', headers = headers)
@@ -4473,6 +4616,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4587,8 +4731,9 @@ Update the state for a given component in the cfs database
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_component_v3
@@ -4607,14 +4752,16 @@ Accept: application/problem+json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/cfs/v3/components/{component_id} \
-  -H 'Accept: application/problem+json'
+  -H 'Accept: application/problem+json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/problem+json'
+  'Accept': 'application/problem+json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/cfs/v3/components/{component_id}', headers = headers)
@@ -4635,6 +4782,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4681,8 +4829,9 @@ Delete the given component
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|The resource was deleted.|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="configuration-framework-service-configurations">configurations</h1>
@@ -4703,14 +4852,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/v2/configurations \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v2/configurations', headers = headers)
@@ -4731,6 +4882,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4795,8 +4947,9 @@ Retrieve the full collection of configurations in the form of a ConfigurationArr
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of configurations|[V2ConfigurationArray](#schemav2configurationarray)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_configuration_v2
@@ -4815,14 +4968,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/v2/configurations/{configuration_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v2/configurations/{configuration_id}', headers = headers)
@@ -4843,6 +4998,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4905,8 +5061,9 @@ Retrieve the given configuration
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A single configuration|[V2Configuration](#schemav2configuration)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## put_configuration_v2
@@ -4927,7 +5084,8 @@ Accept: application/json
 # You can also use wget
 curl -X PUT https://api-gw-service-nmn.local/apis/cfs/v2/configurations/{configuration_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -4935,7 +5093,8 @@ curl -X PUT https://api-gw-service-nmn.local/apis/cfs/v2/configurations/{configu
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.put('https://api-gw-service-nmn.local/apis/cfs/v2/configurations/{configuration_id}', headers = headers)
@@ -4957,6 +5116,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5046,8 +5206,9 @@ Add a configuration to CFS or replace an existing configuration.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A single configuration|[V2Configuration](#schemav2configuration)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_configuration_v2
@@ -5066,14 +5227,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v2/configurations/{configuration_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/cfs/v2/configurations/{configuration_id}', headers = headers)
@@ -5094,6 +5257,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5156,8 +5320,9 @@ Updates the commits for all layers that specify a branch
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A single configuration|[V2Configuration](#schemav2configuration)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_configuration_v2
@@ -5176,14 +5341,16 @@ Accept: application/problem+json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/cfs/v2/configurations/{configuration_id} \
-  -H 'Accept: application/problem+json'
+  -H 'Accept: application/problem+json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/problem+json'
+  'Accept': 'application/problem+json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/cfs/v2/configurations/{configuration_id}', headers = headers)
@@ -5204,6 +5371,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5251,8 +5419,9 @@ Delete the given configuration. This will fail in any components are using the s
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_configurations_v3
@@ -5271,14 +5440,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/v3/configurations \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v3/configurations', headers = headers)
@@ -5299,6 +5470,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5341,6 +5513,7 @@ Retrieve the full collection of configurations in the form of a ConfigurationArr
         {
           "name": "sample-config",
           "clone_url": "https://api-gw-service-nmn.local/vcs/cray/config-management.git",
+          "source": "string",
           "playbook": "site.yml",
           "commit": "string",
           "branch": "string"
@@ -5349,6 +5522,7 @@ Retrieve the full collection of configurations in the form of a ConfigurationArr
       "additional_inventory": {
         "name": "sample-inventory",
         "clone_url": "https://vcs.domain/vcs/org/inventory.git",
+        "source": "string",
         "commit": "string",
         "branch": "string"
       }
@@ -5368,8 +5542,9 @@ Retrieve the full collection of configurations in the form of a ConfigurationArr
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of configurations|[V3ConfigurationDataCollection](#schemav3configurationdatacollection)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_configuration_v3
@@ -5388,14 +5563,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/cfs/v3/configurations/{configuration_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v3/configurations/{configuration_id}', headers = headers)
@@ -5416,6 +5593,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5454,6 +5632,7 @@ Retrieve the given configuration
     {
       "name": "sample-config",
       "clone_url": "https://api-gw-service-nmn.local/vcs/cray/config-management.git",
+      "source": "string",
       "playbook": "site.yml",
       "commit": "string",
       "branch": "string"
@@ -5462,6 +5641,7 @@ Retrieve the given configuration
   "additional_inventory": {
     "name": "sample-inventory",
     "clone_url": "https://vcs.domain/vcs/org/inventory.git",
+    "source": "string",
     "commit": "string",
     "branch": "string"
   }
@@ -5475,8 +5655,9 @@ Retrieve the given configuration
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A single configuration|[V3ConfigurationData](#schemav3configurationdata)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## put_configuration_v3
@@ -5497,7 +5678,8 @@ Accept: application/json
 # You can also use wget
 curl -X PUT https://api-gw-service-nmn.local/apis/cfs/v3/configurations/{configuration_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -5505,7 +5687,8 @@ curl -X PUT https://api-gw-service-nmn.local/apis/cfs/v3/configurations/{configu
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.put('https://api-gw-service-nmn.local/apis/cfs/v3/configurations/{configuration_id}', headers = headers)
@@ -5527,6 +5710,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5555,6 +5739,7 @@ Add a configuration to CFS or replace an existing configuration.
     {
       "name": "sample-config",
       "clone_url": "https://api-gw-service-nmn.local/vcs/cray/config-management.git",
+      "source": "string",
       "playbook": "site.yml",
       "commit": "string",
       "branch": "string"
@@ -5563,6 +5748,7 @@ Add a configuration to CFS or replace an existing configuration.
   "additional_inventory": {
     "name": "sample-inventory",
     "clone_url": "https://vcs.domain/vcs/org/inventory.git",
+    "source": "string",
     "commit": "string",
     "branch": "string"
   }
@@ -5573,6 +5759,7 @@ Add a configuration to CFS or replace an existing configuration.
 
 |Name|In|Type|Required|Description|
 |---|---|---|---|---|
+|drop_branches|query|boolean|false|Don't store the branches after converting each branch to a commit.|
 |body|body|[V3ConfigurationData](#schemav3configurationdata)|true|A desired configuration state|
 |configuration_id|path|string|true|Name of the target configuration|
 
@@ -5589,6 +5776,7 @@ Add a configuration to CFS or replace an existing configuration.
     {
       "name": "sample-config",
       "clone_url": "https://api-gw-service-nmn.local/vcs/cray/config-management.git",
+      "source": "string",
       "playbook": "site.yml",
       "commit": "string",
       "branch": "string"
@@ -5597,6 +5785,7 @@ Add a configuration to CFS or replace an existing configuration.
   "additional_inventory": {
     "name": "sample-inventory",
     "clone_url": "https://vcs.domain/vcs/org/inventory.git",
+    "source": "string",
     "commit": "string",
     "branch": "string"
   }
@@ -5610,8 +5799,9 @@ Add a configuration to CFS or replace an existing configuration.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A single configuration|[V3ConfigurationData](#schemav3configurationdata)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_configuration_v3
@@ -5630,14 +5820,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v3/configurations/{configuration_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/cfs/v3/configurations/{configuration_id}', headers = headers)
@@ -5658,6 +5850,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5696,6 +5889,7 @@ Updates the commits for all layers that specify a branch
     {
       "name": "sample-config",
       "clone_url": "https://api-gw-service-nmn.local/vcs/cray/config-management.git",
+      "source": "string",
       "playbook": "site.yml",
       "commit": "string",
       "branch": "string"
@@ -5704,6 +5898,7 @@ Updates the commits for all layers that specify a branch
   "additional_inventory": {
     "name": "sample-inventory",
     "clone_url": "https://vcs.domain/vcs/org/inventory.git",
+    "source": "string",
     "commit": "string",
     "branch": "string"
   }
@@ -5717,8 +5912,9 @@ Updates the commits for all layers that specify a branch
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A single configuration|[V3ConfigurationData](#schemav3configurationdata)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_configuration_v3
@@ -5737,14 +5933,16 @@ Accept: application/problem+json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/cfs/v3/configurations/{configuration_id} \
-  -H 'Accept: application/problem+json'
+  -H 'Accept: application/problem+json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/problem+json'
+  'Accept': 'application/problem+json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/cfs/v3/configurations/{configuration_id}', headers = headers)
@@ -5765,6 +5963,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/problem+json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5812,8 +6011,587 @@ Delete the given configuration. This will fail in any components are using the s
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
+</aside>
+
+<h1 id="configuration-framework-service-sources">sources</h1>
+
+## get_sources_v3
+
+<a id="opIdget_sources_v3"></a>
+
+> Code samples
+
+```http
+GET https://api-gw-service-nmn.local/apis/cfs/v3/sources HTTP/1.1
+Host: api-gw-service-nmn.local
+Accept: application/json
+
+```
+
+```shell
+# You can also use wget
+curl -X GET https://api-gw-service-nmn.local/apis/cfs/v3/sources \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+```python
+import requests
+headers = {
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
+}
+
+r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v3/sources', headers = headers)
+
+print(r.json())
+
+```
+
+```go
+package main
+
+import (
+       "bytes"
+       "net/http"
+)
+
+func main() {
+
+    headers := map[string][]string{
+        "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
+    }
+
+    data := bytes.NewBuffer([]byte{jsonReq})
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/cfs/v3/sources", data)
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+
+```
+
+`GET /v3/sources`
+
+*Retrieve a collection of sources*
+
+Retrieve the full collection of sources in the form of a SourceArray.
+
+<h3 id="get_sources_v3-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|limit|query|integer|false|When set, CFS will only return a number of sources up to this limit.  Combined with after_id, this enables paging across results|
+|after_id|query|string|false|When set, CFS will only return the configurations after the source specified.  Combined with limit, this enables paging across results.|
+|in_use|query|boolean|false|Query for only sources that are currently referenced by configurations.|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "components": [
+    {
+      "name": "sample-config",
+      "description": "string",
+      "last_updated": "2019-07-28T03:26:00Z",
+      "clone_url": "string",
+      "credentials": {
+        "authentication_method": "password",
+        "secret_name": "string"
+      },
+      "ca_cert": {
+        "configmap_name": "string",
+        "configmap_namespace": "string"
+      }
+    }
+  ],
+  "next": {
+    "limit": 0,
+    "after_id": "string"
+  }
+}
+```
+
+<h3 id="get_sources_v3-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A collection of sources|[V3SourceDataCollection](#schemav3sourcedatacollection)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
+
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
+</aside>
+
+## post_source_v3
+
+<a id="opIdpost_source_v3"></a>
+
+> Code samples
+
+```http
+POST https://api-gw-service-nmn.local/apis/cfs/v3/sources HTTP/1.1
+Host: api-gw-service-nmn.local
+Content-Type: application/json
+Accept: application/json
+
+```
+
+```shell
+# You can also use wget
+curl -X POST https://api-gw-service-nmn.local/apis/cfs/v3/sources \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+```python
+import requests
+headers = {
+  'Content-Type': 'application/json',
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
+}
+
+r = requests.post('https://api-gw-service-nmn.local/apis/cfs/v3/sources', headers = headers)
+
+print(r.json())
+
+```
+
+```go
+package main
+
+import (
+       "bytes"
+       "net/http"
+)
+
+func main() {
+
+    headers := map[string][]string{
+        "Content-Type": []string{"application/json"},
+        "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
+    }
+
+    data := bytes.NewBuffer([]byte{jsonReq})
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/cfs/v3/sources", data)
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+
+```
+
+`POST /v3/sources`
+
+*Add a single source*
+
+Add a source to CFS
+
+> Body parameter
+
+```json
+{
+  "name": "sample-config",
+  "description": "string",
+  "clone_url": "string",
+  "credentials": {
+    "authentication_method": "password",
+    "username": "string",
+    "password": "string"
+  },
+  "ca_cert": {
+    "configmap_name": "string",
+    "configmap_namespace": "string"
+  }
+}
+```
+
+<h3 id="post_source_v3-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[V3SourceCreateData](#schemav3sourcecreatedata)|true|A source|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "name": "sample-config",
+  "description": "string",
+  "last_updated": "2019-07-28T03:26:00Z",
+  "clone_url": "string",
+  "credentials": {
+    "authentication_method": "password",
+    "secret_name": "string"
+  },
+  "ca_cert": {
+    "configmap_name": "string",
+    "configmap_namespace": "string"
+  }
+}
+```
+
+<h3 id="post_source_v3-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A single source|[V3SourceData](#schemav3sourcedata)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
+|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|A source with the same name already exists|[ProblemDetails](#schemaproblemdetails)|
+
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
+</aside>
+
+## get_source_v3
+
+<a id="opIdget_source_v3"></a>
+
+> Code samples
+
+```http
+GET https://api-gw-service-nmn.local/apis/cfs/v3/sources/{source_id} HTTP/1.1
+Host: api-gw-service-nmn.local
+Accept: application/json
+
+```
+
+```shell
+# You can also use wget
+curl -X GET https://api-gw-service-nmn.local/apis/cfs/v3/sources/{source_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+```python
+import requests
+headers = {
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
+}
+
+r = requests.get('https://api-gw-service-nmn.local/apis/cfs/v3/sources/{source_id}', headers = headers)
+
+print(r.json())
+
+```
+
+```go
+package main
+
+import (
+       "bytes"
+       "net/http"
+)
+
+func main() {
+
+    headers := map[string][]string{
+        "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
+    }
+
+    data := bytes.NewBuffer([]byte{jsonReq})
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/cfs/v3/sources/{source_id}", data)
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+
+```
+
+`GET /v3/sources/{source_id}`
+
+*Retrieve a single source*
+
+Retrieve the given source
+
+<h3 id="get_source_v3-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|source_id|path|string|true|Name of the target source|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "name": "sample-config",
+  "description": "string",
+  "last_updated": "2019-07-28T03:26:00Z",
+  "clone_url": "string",
+  "credentials": {
+    "authentication_method": "password",
+    "secret_name": "string"
+  },
+  "ca_cert": {
+    "configmap_name": "string",
+    "configmap_namespace": "string"
+  }
+}
+```
+
+<h3 id="get_source_v3-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A single source|[V3SourceData](#schemav3sourcedata)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
+
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
+</aside>
+
+## patch_source_v3
+
+<a id="opIdpatch_source_v3"></a>
+
+> Code samples
+
+```http
+PATCH https://api-gw-service-nmn.local/apis/cfs/v3/sources/{source_id} HTTP/1.1
+Host: api-gw-service-nmn.local
+Content-Type: application/json
+Accept: application/json
+
+```
+
+```shell
+# You can also use wget
+curl -X PATCH https://api-gw-service-nmn.local/apis/cfs/v3/sources/{source_id} \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+```python
+import requests
+headers = {
+  'Content-Type': 'application/json',
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
+}
+
+r = requests.patch('https://api-gw-service-nmn.local/apis/cfs/v3/sources/{source_id}', headers = headers)
+
+print(r.json())
+
+```
+
+```go
+package main
+
+import (
+       "bytes"
+       "net/http"
+)
+
+func main() {
+
+    headers := map[string][]string{
+        "Content-Type": []string{"application/json"},
+        "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
+    }
+
+    data := bytes.NewBuffer([]byte{jsonReq})
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/cfs/v3/sources/{source_id}", data)
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+
+```
+
+`PATCH /v3/sources/{source_id}`
+
+*Update the commits for a source*
+
+Updates a CFS source
+
+> Body parameter
+
+```json
+{
+  "description": "string",
+  "clone_url": "string",
+  "credentials": {
+    "authentication_method": "password",
+    "username": "string",
+    "password": "string"
+  },
+  "ca_cert": {
+    "configmap_name": "string",
+    "configmap_namespace": "string"
+  }
+}
+```
+
+<h3 id="patch_source_v3-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[V3SourceUpdateData](#schemav3sourceupdatedata)|true|A source|
+|source_id|path|string|true|Name of the target source|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "name": "sample-config",
+  "description": "string",
+  "last_updated": "2019-07-28T03:26:00Z",
+  "clone_url": "string",
+  "credentials": {
+    "authentication_method": "password",
+    "secret_name": "string"
+  },
+  "ca_cert": {
+    "configmap_name": "string",
+    "configmap_namespace": "string"
+  }
+}
+```
+
+<h3 id="patch_source_v3-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A single source|[V3SourceData](#schemav3sourcedata)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
+
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
+</aside>
+
+## delete_source_v3
+
+<a id="opIddelete_source_v3"></a>
+
+> Code samples
+
+```http
+DELETE https://api-gw-service-nmn.local/apis/cfs/v3/sources/{source_id} HTTP/1.1
+Host: api-gw-service-nmn.local
+Accept: application/problem+json
+
+```
+
+```shell
+# You can also use wget
+curl -X DELETE https://api-gw-service-nmn.local/apis/cfs/v3/sources/{source_id} \
+  -H 'Accept: application/problem+json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+```python
+import requests
+headers = {
+  'Accept': 'application/problem+json',
+  'Authorization': 'Bearer {access-token}'
+}
+
+r = requests.delete('https://api-gw-service-nmn.local/apis/cfs/v3/sources/{source_id}', headers = headers)
+
+print(r.json())
+
+```
+
+```go
+package main
+
+import (
+       "bytes"
+       "net/http"
+)
+
+func main() {
+
+    headers := map[string][]string{
+        "Accept": []string{"application/problem+json"},
+        "Authorization": []string{"Bearer {access-token}"},
+    }
+
+    data := bytes.NewBuffer([]byte{jsonReq})
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/cfs/v3/sources/{source_id}", data)
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+
+```
+
+`DELETE /v3/sources/{source_id}`
+
+*Delete a single source*
+
+Delete the given source. This will fail in any components are using the specified source.
+
+<h3 id="delete_source_v3-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|source_id|path|string|true|Name of the target source|
+
+> Example responses
+
+> 400 Response
+
+```json
+{
+  "type": "about:blank",
+  "title": "string",
+  "status": 400,
+  "instance": "http://example.com",
+  "detail": "string"
+}
+```
+
+<h3 id="delete_source_v3-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|The resource was deleted.|None|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[ProblemDetails](#schemaproblemdetails)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The resource was not found.|[ProblemDetails](#schemaproblemdetails)|
+
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas
@@ -5956,6 +6734,7 @@ Configuration options for the configuration service.
   "default_ansible_config": "cfs-default-ansible-cfg",
   "session_ttl": "24h",
   "additional_inventory_url": "https://api-gw-service-nmn.local/vcs/cray/inventory.git",
+  "additional_inventory_source": "example-source",
   "batcher_max_backoff": 3600,
   "batcher_disable": true,
   "batcher_pending_timeout": 1,
@@ -5981,7 +6760,8 @@ Configuration options for the configuration service.
 |default_playbook|string|false|read-only|[DEPRECATED] The default playbook to be used if not specified in a node's desired state. This option is read-only via the v3 API and remains only for compatibility with the v2 API. This option will be removed from v3 when the v2 API is removed.|
 |default_ansible_config|string|false|none|The Kubernetes ConfigMap which holds the default ansible.cfg for a given CFS session. This ConfigMap must be present in the same Kubernetes namespace as the CFS service.|
 |session_ttl|string|false|none|A time-to-live applied to all completed CFS sessions.  Specified in hours or days. e.g. 3d or 24h.  Set to an empty string to disable.|
-|additional_inventory_url|string|false|none|The git clone URL of a repo with additional inventory files.  All files in the repo will be copied into the hosts directory of CFS.|
+|additional_inventory_url|string|false|none|The git clone URL of a repo with additional inventory files.  All files in the repo will be copied into the hosts directory of CFS. This is mutually exclusive with the additional_inventory_source option and only one can be set.|
+|additional_inventory_source|string|false|none|A CFS source with additional inventory files.  All files in the repo will be copied into the hosts directory of CFS. This is mutually exclusive with the additional_source_url option and only one can be set.|
 |batcher_max_backoff|integer|false|none|The maximum number of seconds that batcher will backoff from session creation if problems are detected.|
 |batcher_disable|boolean|false|none|Disables cfs-batcher's automatic session creation if set to True.|
 |batcher_pending_timeout|integer|false|none|How long cfs-batcher will wait on a pending session before deleting and recreating it (in seconds).|
@@ -6851,6 +7631,7 @@ An inventory reference to include in a set of configurations.
 {
   "name": "sample-inventory",
   "clone_url": "https://vcs.domain/vcs/org/inventory.git",
+  "source": "string",
   "commit": "string",
   "branch": "string"
 }
@@ -6865,6 +7646,7 @@ An inventory reference to include in a set of configurations.
 |---|---|---|---|---|
 |name|string|false|none|The name of the inventory layer.|
 |clone_url|string|true|none|The clone URL of the configuration content repository.|
+|source|string|false|none|A CFS source with directions to the configuration content repository|
 |commit|string|false|none|The commit hash of the configuration repository when the state is set.|
 |branch|string|false|none|The repository branch to use. This will automatically set `commit` to master on the branch<br>when the configuration is added.|
 
@@ -6914,6 +7696,7 @@ A single desired configuration state for a component.
 {
   "name": "sample-config",
   "clone_url": "https://api-gw-service-nmn.local/vcs/cray/config-management.git",
+  "source": "string",
   "playbook": "site.yml",
   "commit": "string",
   "branch": "string"
@@ -6928,7 +7711,8 @@ A single desired configuration state for a component.
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
 |name|string|false|none|The name of the configuration layer.|
-|clone_url|string|true|none|The clone URL of the configuration content repository.|
+|clone_url|string|false|none|The clone URL of the configuration content repository.|
+|source|string|false|none|A CFS source with directions to the configuration content repository|
 |playbook|string|true|none|The Ansible playbook to run.|
 |commit|string|false|none|The commit hash of the configuration repository when the state is set.|
 |branch|string|false|none|The configuration branch to use.  This will automatically set commit to master on the branch<br>when the configuration is added.|
@@ -6995,6 +7779,7 @@ A collection of ConfigurationLayers.
     {
       "name": "sample-config",
       "clone_url": "https://api-gw-service-nmn.local/vcs/cray/config-management.git",
+      "source": "string",
       "playbook": "site.yml",
       "commit": "string",
       "branch": "string"
@@ -7003,6 +7788,7 @@ A collection of ConfigurationLayers.
   "additional_inventory": {
     "name": "sample-inventory",
     "clone_url": "https://vcs.domain/vcs/org/inventory.git",
+    "source": "string",
     "commit": "string",
     "branch": "string"
   }
@@ -7084,6 +7870,7 @@ An array of configurations.
         {
           "name": "sample-config",
           "clone_url": "https://api-gw-service-nmn.local/vcs/cray/config-management.git",
+          "source": "string",
           "playbook": "site.yml",
           "commit": "string",
           "branch": "string"
@@ -7092,6 +7879,7 @@ An array of configurations.
       "additional_inventory": {
         "name": "sample-inventory",
         "clone_url": "https://vcs.domain/vcs/org/inventory.git",
+        "source": "string",
         "commit": "string",
         "branch": "string"
       }
@@ -7766,6 +8554,253 @@ Information for patching multiple components.
 |---|---|---|---|---|
 |patch|[V3ComponentData](#schemav3componentdata)|true|none|The configuration state and desired state for a component.|
 |filters|[V3ComponentsFilter](#schemav3componentsfilter)|true|none|Information for patching multiple components.|
+
+<h2 id="tocS_V3SourceCredentials">V3SourceCredentials</h2>
+<!-- backwards compatibility -->
+<a id="schemav3sourcecredentials"></a>
+<a id="schema_V3SourceCredentials"></a>
+<a id="tocSv3sourcecredentials"></a>
+<a id="tocsv3sourcecredentials"></a>
+
+```json
+{
+  "authentication_method": "password",
+  "secret_name": "string",
+  "username": "string",
+  "password": "string"
+}
+
+```
+
+Information for retrieving the git credentials
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|authentication_method|string|false|none|The git authentication method used.|
+|secret_name|string|false|read-only|The name of the credentials vault secret.|
+|username|string|false|write-only|The username for authenticating to git|
+|password|string|false|write-only|The password for authenticating to git|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|authentication_method|password|
+
+<h2 id="tocS_V3SourceCert">V3SourceCert</h2>
+<!-- backwards compatibility -->
+<a id="schemav3sourcecert"></a>
+<a id="schema_V3SourceCert"></a>
+<a id="tocSv3sourcecert"></a>
+<a id="tocsv3sourcecert"></a>
+
+```json
+{
+  "configmap_name": "string",
+  "configmap_namespace": "string"
+}
+
+```
+
+CA certificate info for retrieving the git credentials
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|configmap_name|string|true|none|The name of the configmap containing a necessary CA cert.|
+|configmap_namespace|string|false|none|The namespace of the CA cert configmap in kubernetes.|
+
+<h2 id="tocS_V3SourceData">V3SourceData</h2>
+<!-- backwards compatibility -->
+<a id="schemav3sourcedata"></a>
+<a id="schema_V3SourceData"></a>
+<a id="tocSv3sourcedata"></a>
+<a id="tocsv3sourcedata"></a>
+
+```json
+{
+  "name": "sample-config",
+  "description": "string",
+  "last_updated": "2019-07-28T03:26:00Z",
+  "clone_url": "string",
+  "credentials": {
+    "authentication_method": "password",
+    "secret_name": "string",
+    "username": "string",
+    "password": "string"
+  },
+  "ca_cert": {
+    "configmap_name": "string",
+    "configmap_namespace": "string"
+  }
+}
+
+```
+
+Information for retrieving git content from a source.
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|name|string|false|none|The name of the configuration.  This field is optional and will default to the clone_url if not specified.|
+|description|string|false|none|A user-defined description. This field is not used by CFS.|
+|last_updated|string(date-time)|false|read-only|The date/time when the state was last updated in RFC 3339 format.|
+|clone_url|string|false|none|The url to access the git content|
+|credentials|[V3SourceCredentials](#schemav3sourcecredentials)|false|none|Information on a secret containing the username and password for accessing the git content|
+|ca_cert|[V3SourceCert](#schemav3sourcecert)|false|none|Information on a configmap containing a CA certificate for authenticating to git|
+
+<h2 id="tocS_V3SourceDataCollection">V3SourceDataCollection</h2>
+<!-- backwards compatibility -->
+<a id="schemav3sourcedatacollection"></a>
+<a id="schema_V3SourceDataCollection"></a>
+<a id="tocSv3sourcedatacollection"></a>
+<a id="tocsv3sourcedatacollection"></a>
+
+```json
+{
+  "components": [
+    {
+      "name": "sample-config",
+      "description": "string",
+      "last_updated": "2019-07-28T03:26:00Z",
+      "clone_url": "string",
+      "credentials": {
+        "authentication_method": "password",
+        "secret_name": "string",
+        "username": "string",
+        "password": "string"
+      },
+      "ca_cert": {
+        "configmap_name": "string",
+        "configmap_namespace": "string"
+      }
+    }
+  ],
+  "next": {
+    "limit": 0,
+    "after_id": "string"
+  }
+}
+
+```
+
+A collection of source data.
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|components|[[V3SourceData](#schemav3sourcedata)]|false|none|[Information for retrieving git content from a source.]|
+|next|[V3NextData](#schemav3nextdata)|false|none|Information for requesting the next page of data|
+
+<h2 id="tocS_V3SourceCreateCredentials">V3SourceCreateCredentials</h2>
+<!-- backwards compatibility -->
+<a id="schemav3sourcecreatecredentials"></a>
+<a id="schema_V3SourceCreateCredentials"></a>
+<a id="tocSv3sourcecreatecredentials"></a>
+<a id="tocsv3sourcecreatecredentials"></a>
+
+```json
+{
+  "authentication_method": "password",
+  "username": "string",
+  "password": "string"
+}
+
+```
+
+Information for retrieving the git credentials
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|authentication_method|string|false|none|The git authentication method used.|
+|username|string|true|write-only|The username for authenticating to git|
+|password|string|true|write-only|The password for authenticating to git|
+
+#### Enumerated Values
+
+|Property|Value|
+|---|---|
+|authentication_method|password|
+
+<h2 id="tocS_V3SourceCreateData">V3SourceCreateData</h2>
+<!-- backwards compatibility -->
+<a id="schemav3sourcecreatedata"></a>
+<a id="schema_V3SourceCreateData"></a>
+<a id="tocSv3sourcecreatedata"></a>
+<a id="tocsv3sourcecreatedata"></a>
+
+```json
+{
+  "name": "sample-config",
+  "description": "string",
+  "clone_url": "string",
+  "credentials": {
+    "authentication_method": "password",
+    "username": "string",
+    "password": "string"
+  },
+  "ca_cert": {
+    "configmap_name": "string",
+    "configmap_namespace": "string"
+  }
+}
+
+```
+
+Information for retrieving git content from a source.
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|name|string|false|none|The name of the configuration.  This field is optional and will default to the clone_url if not specified.|
+|description|string|false|none|A user-defined description. This field is not used by CFS.|
+|clone_url|string|true|none|The url to access the git content|
+|credentials|[V3SourceCreateCredentials](#schemav3sourcecreatecredentials)|true|none|Information on a secret containing the username and password for accessing the git content|
+|ca_cert|[V3SourceCert](#schemav3sourcecert)|false|none|Information on a configmap containing a CA certificate for authenticating to git|
+
+<h2 id="tocS_V3SourceUpdateData">V3SourceUpdateData</h2>
+<!-- backwards compatibility -->
+<a id="schemav3sourceupdatedata"></a>
+<a id="schema_V3SourceUpdateData"></a>
+<a id="tocSv3sourceupdatedata"></a>
+<a id="tocsv3sourceupdatedata"></a>
+
+```json
+{
+  "description": "string",
+  "clone_url": "string",
+  "credentials": {
+    "authentication_method": "password",
+    "secret_name": "string",
+    "username": "string",
+    "password": "string"
+  },
+  "ca_cert": {
+    "configmap_name": "string",
+    "configmap_namespace": "string"
+  }
+}
+
+```
+
+Information for retrieving git content from a source.
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|description|string|false|none|A user-defined description. This field is not used by CFS.|
+|clone_url|string|false|none|The url to access the git content|
+|credentials|[V3SourceCredentials](#schemav3sourcecredentials)|false|none|Information on a secret containing the username and password for accessing the git content|
+|ca_cert|[V3SourceCert](#schemav3sourcecert)|false|none|Information on a configmap containing a CA certificate for authenticating to git|
 
 <h2 id="tocS_ProblemDetails">ProblemDetails</h2>
 <!-- backwards compatibility -->

--- a/api/firmware-action.md
+++ b/api/firmware-action.md
@@ -64,11 +64,7 @@ FAS receives information from the Hardware State Manager (HSM) for each xname.
 
 Base URLs:
 
-* <a href="https://rocket-ncn-w001.us.cray.com/apis/fas/v1">https://rocket-ncn-w001.us.cray.com/apis/fas/v1</a>
-
-* <a href="http://localhost:28800/v1">http://localhost:28800/v1</a>
-
-* <a href="http://localhost:28800">http://localhost:28800</a>
+* <a href="https://api-gw-service-nmn.local/apis/fas/v1">https://api-gw-service-nmn.local/apis/fas/v1</a>
 
 # Authentication
 
@@ -81,15 +77,15 @@ Base URLs:
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/actions HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions \
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/actions \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
@@ -102,7 +98,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/actions', headers = headers)
 
 print(r.json())
 
@@ -124,7 +120,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/actions", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -198,8 +194,8 @@ bearerAuth
 > Code samples
 
 ```http
-POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+POST https://api-gw-service-nmn.local/apis/fas/v1/actions HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -207,7 +203,7 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions \
+curl -X POST https://api-gw-service-nmn.local/apis/fas/v1/actions \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
@@ -222,7 +218,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/fas/v1/actions', headers = headers)
 
 print(r.json())
 
@@ -245,7 +241,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/fas/v1/actions", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -389,15 +385,15 @@ bearerAuth
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID} HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID} \
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID} \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
@@ -410,7 +406,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}', headers = headers)
 
 print(r.json())
 
@@ -432,7 +428,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -658,15 +654,15 @@ bearerAuth
 > Code samples
 
 ```http
-DELETE https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID} HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+DELETE https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/error
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID} \
+curl -X DELETE https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID} \
   -H 'Accept: application/error' \
   -H 'Authorization: Bearer {access-token}'
 
@@ -679,7 +675,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}', headers = headers)
 
 print(r.json())
 
@@ -701,7 +697,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -745,15 +741,15 @@ bearerAuth
 > Code samples
 
 ```http
-DELETE https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/instance HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+DELETE https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/instance HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/instance \
+curl -X DELETE https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/instance \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
@@ -766,7 +762,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/instance', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/instance', headers = headers)
 
 print(r.json())
 
@@ -788,7 +784,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/instance", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/instance", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -842,15 +838,15 @@ bearerAuth
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/status HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/status HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/status \
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/status \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
@@ -863,7 +859,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/status', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/status', headers = headers)
 
 print(r.json())
 
@@ -885,7 +881,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/status", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/status", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -963,15 +959,15 @@ bearerAuth
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/operations HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/operations HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/operations \
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/operations \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
@@ -984,7 +980,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/operations', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/operations', headers = headers)
 
 print(r.json())
 
@@ -1006,7 +1002,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/operations", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/operations", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1412,15 +1408,15 @@ bearerAuth
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/operations/{operationID} HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/operations/{operationID} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/operations/{operationID} \
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/operations/{operationID} \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
@@ -1433,7 +1429,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/operations/{operationID}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/operations/{operationID}', headers = headers)
 
 print(r.json())
 
@@ -1455,7 +1451,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/operations/{operationID}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/actions/{actionID}/operations/{operationID}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1527,15 +1523,15 @@ bearerAuth
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/operations/{operationID} HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/operations/{operationID} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/operations/{operationID} \
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/operations/{operationID} \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
@@ -1548,7 +1544,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/operations/{operationID}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/operations/{operationID}', headers = headers)
 
 print(r.json())
 
@@ -1570,7 +1566,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/operations/{operationID}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/operations/{operationID}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1643,8 +1639,8 @@ bearerAuth
 > Code samples
 
 ```http
-POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+POST https://api-gw-service-nmn.local/apis/fas/v1/images HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -1652,7 +1648,7 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images \
+curl -X POST https://api-gw-service-nmn.local/apis/fas/v1/images \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
@@ -1667,7 +1663,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/fas/v1/images', headers = headers)
 
 print(r.json())
 
@@ -1690,7 +1686,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/fas/v1/images", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1779,15 +1775,15 @@ bearerAuth
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/images HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images \
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/images \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
@@ -1800,7 +1796,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/images', headers = headers)
 
 print(r.json())
 
@@ -1822,7 +1818,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/images", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1896,8 +1892,8 @@ bearerAuth
 > Code samples
 
 ```http
-PUT https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID} HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+PUT https://api-gw-service-nmn.local/apis/fas/v1/images/{imageID} HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/error
 
@@ -1905,7 +1901,7 @@ Accept: application/error
 
 ```shell
 # You can also use wget
-curl -X PUT https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID} \
+curl -X PUT https://api-gw-service-nmn.local/apis/fas/v1/images/{imageID} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/error' \
   -H 'Authorization: Bearer {access-token}'
@@ -1920,7 +1916,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.put('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID}', headers = headers)
+r = requests.put('https://api-gw-service-nmn.local/apis/fas/v1/images/{imageID}', headers = headers)
 
 print(r.json())
 
@@ -1943,7 +1939,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PUT", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID}", data)
+    req, err := http.NewRequest("PUT", "https://api-gw-service-nmn.local/apis/fas/v1/images/{imageID}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2025,15 +2021,15 @@ bearerAuth
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID} HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/images/{imageID} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID} \
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/images/{imageID} \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
@@ -2046,7 +2042,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/images/{imageID}', headers = headers)
 
 print(r.json())
 
@@ -2068,7 +2064,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/images/{imageID}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2147,15 +2143,15 @@ bearerAuth
 > Code samples
 
 ```http
-DELETE https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID} HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+DELETE https://api-gw-service-nmn.local/apis/fas/v1/images/{imageID} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/error
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID} \
+curl -X DELETE https://api-gw-service-nmn.local/apis/fas/v1/images/{imageID} \
   -H 'Accept: application/error' \
   -H 'Authorization: Bearer {access-token}'
 
@@ -2168,7 +2164,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/fas/v1/images/{imageID}', headers = headers)
 
 print(r.json())
 
@@ -2190,7 +2186,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/fas/v1/images/{imageID}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2235,15 +2231,15 @@ bearerAuth
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/service/status HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/service/status HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/service/status \
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/service/status \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
@@ -2256,7 +2252,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/service/status', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/service/status', headers = headers)
 
 print(r.json())
 
@@ -2278,7 +2274,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/service/status", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/service/status", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2323,15 +2319,15 @@ bearerAuth
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/service/status/details HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/service/status/details HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/service/status/details \
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/service/status/details \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
@@ -2344,7 +2340,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/service/status/details', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/service/status/details', headers = headers)
 
 print(r.json())
 
@@ -2366,7 +2362,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/service/status/details", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/service/status/details", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2414,15 +2410,15 @@ bearerAuth
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/service/version HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/service/version HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/service/version \
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/service/version \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
@@ -2435,7 +2431,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/service/version', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/service/version', headers = headers)
 
 print(r.json())
 
@@ -2457,7 +2453,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/service/version", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/service/version", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2504,15 +2500,15 @@ bearerAuth
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/snapshots HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots \
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/snapshots \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
@@ -2525,7 +2521,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/snapshots', headers = headers)
 
 print(r.json())
 
@@ -2547,7 +2543,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/snapshots", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2608,8 +2604,8 @@ bearerAuth
 > Code samples
 
 ```http
-POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+POST https://api-gw-service-nmn.local/apis/fas/v1/snapshots HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -2617,7 +2613,7 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots \
+curl -X POST https://api-gw-service-nmn.local/apis/fas/v1/snapshots \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
@@ -2632,7 +2628,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/fas/v1/snapshots', headers = headers)
 
 print(r.json())
 
@@ -2655,7 +2651,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/fas/v1/snapshots", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2747,15 +2743,15 @@ bearerAuth
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots/{snapshotName} HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/snapshots/{snapshotName} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots/{snapshotName} \
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/snapshots/{snapshotName} \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
@@ -2768,7 +2764,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots/{snapshotName}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/snapshots/{snapshotName}', headers = headers)
 
 print(r.json())
 
@@ -2790,7 +2786,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots/{snapshotName}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/snapshots/{snapshotName}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2899,15 +2895,15 @@ bearerAuth
 > Code samples
 
 ```http
-DELETE https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots/{snapshotName} HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+DELETE https://api-gw-service-nmn.local/apis/fas/v1/snapshots/{snapshotName} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/error
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots/{snapshotName} \
+curl -X DELETE https://api-gw-service-nmn.local/apis/fas/v1/snapshots/{snapshotName} \
   -H 'Accept: application/error' \
   -H 'Authorization: Bearer {access-token}'
 
@@ -2920,7 +2916,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots/{snapshotName}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/fas/v1/snapshots/{snapshotName}', headers = headers)
 
 print(r.json())
 
@@ -2942,7 +2938,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots/{snapshotName}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/fas/v1/snapshots/{snapshotName}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2985,15 +2981,15 @@ bearerAuth
 > Code samples
 
 ```http
-POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots/{snapshotName}/restore?confirm=yes HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+POST https://api-gw-service-nmn.local/apis/fas/v1/snapshots/{snapshotName}/restore?confirm=yes HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots/{snapshotName}/restore?confirm=yes \
+curl -X POST https://api-gw-service-nmn.local/apis/fas/v1/snapshots/{snapshotName}/restore?confirm=yes \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
@@ -3006,7 +3002,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots/{snapshotName}/restore', params={
+r = requests.post('https://api-gw-service-nmn.local/apis/fas/v1/snapshots/{snapshotName}/restore', params={
   'confirm': 'yes'
 }, headers = headers)
 
@@ -3030,7 +3026,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots/{snapshotName}/restore", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/fas/v1/snapshots/{snapshotName}/restore", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3094,8 +3090,8 @@ bearerAuth
 > Code samples
 
 ```http
-POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+POST https://api-gw-service-nmn.local/apis/fas/v1/loader HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/octet-stream
 Accept: application/json
 
@@ -3103,7 +3099,7 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader \
+curl -X POST https://api-gw-service-nmn.local/apis/fas/v1/loader \
   -H 'Content-Type: application/octet-stream' \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
@@ -3118,7 +3114,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/fas/v1/loader', headers = headers)
 
 print(r.json())
 
@@ -3141,7 +3137,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/fas/v1/loader", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3202,15 +3198,15 @@ bearerAuth
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/loader HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader \
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/loader \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
@@ -3223,7 +3219,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/loader', headers = headers)
 
 print(r.json())
 
@@ -3245,7 +3241,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/loader", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3290,15 +3286,15 @@ bearerAuth
 > Code samples
 
 ```http
-GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader/{loaderRunID} HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+GET https://api-gw-service-nmn.local/apis/fas/v1/loader/{loaderRunID} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader/{loaderRunID} \
+curl -X GET https://api-gw-service-nmn.local/apis/fas/v1/loader/{loaderRunID} \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
@@ -3311,7 +3307,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader/{loaderRunID}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/fas/v1/loader/{loaderRunID}', headers = headers)
 
 print(r.json())
 
@@ -3333,7 +3329,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader/{loaderRunID}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/fas/v1/loader/{loaderRunID}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3386,15 +3382,15 @@ bearerAuth
 > Code samples
 
 ```http
-DELETE https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader/{loaderRunID} HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+DELETE https://api-gw-service-nmn.local/apis/fas/v1/loader/{loaderRunID} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/error
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader/{loaderRunID} \
+curl -X DELETE https://api-gw-service-nmn.local/apis/fas/v1/loader/{loaderRunID} \
   -H 'Accept: application/error' \
   -H 'Authorization: Bearer {access-token}'
 
@@ -3407,7 +3403,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader/{loaderRunID}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/fas/v1/loader/{loaderRunID}', headers = headers)
 
 print(r.json())
 
@@ -3429,7 +3425,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader/{loaderRunID}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/fas/v1/loader/{loaderRunID}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3472,15 +3468,15 @@ bearerAuth
 > Code samples
 
 ```http
-POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader/nexus HTTP/1.1
-Host: rocket-ncn-w001.us.cray.com
+POST https://api-gw-service-nmn.local/apis/fas/v1/loader/nexus HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader/nexus \
+curl -X POST https://api-gw-service-nmn.local/apis/fas/v1/loader/nexus \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
@@ -3493,7 +3489,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader/nexus', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/fas/v1/loader/nexus', headers = headers)
 
 print(r.json())
 
@@ -3515,7 +3511,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader/nexus", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/fas/v1/loader/nexus", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3680,7 +3676,7 @@ bearerAuth
 |overrideDryrun|boolean|false|none|none|
 |startTime|string(date-time)|false|none|none|
 |endTime|string(date-time)|false|none|none|
-|state|string|false|none|The state of the action -<br><br><br><br>  *new* - not yet started<br>  *configured* - configured, but not yet started<br>  *blocked* - configured, but cannot run because another action is executing<br>  *running* - started<br>  *completed* - the action has completed all operations<br>  *abortSignaled* - the action has been instructed to STOP all running operations<br>  *aborted* - the action has stopped all operations|
+|state|string|false|none|The state of the action -<br><br><br><br><br>  *new* - not yet started<br>  *configured* - configured, but not yet started<br>  *blocked* - configured, but cannot run because another action is executing<br>  *running* - started<br>  *completed* - the action has completed all operations<br>  *abortSignaled* - the action has been instructed to STOP all running operations<br>  *aborted* - the action has stopped all operations|
 |operationCounts|[OperationCounts](#schemaoperationcounts)|false|none|none|
 |description|string|false|none|none|
 |blockedBy|[string]|false|none|none|
@@ -3946,7 +3942,7 @@ bearerAuth
 |snapshotID|string(uuid)|false|none|none|
 |startTime|string(date-time)|false|none|none|
 |endTime|string(date-time)|false|none|none|
-|state|string|false|none|The state of the action -<br><br><br><br>  *new* - not yet started<br>  *configured* - configured, but not yet started<br>  *blocked* - configured, but cannot run because another action is executing<br>  *running* - started<br>  *completed* - the action has completed all operations<br>  *abortSignaled* - the action has been instructed to STOP all running operations<br>  *aborted* - the action has stopped all operations|
+|state|string|false|none|The state of the action -<br><br><br><br><br>  *new* - not yet started<br>  *configured* - configured, but not yet started<br>  *blocked* - configured, but cannot run because another action is executing<br>  *running* - started<br>  *completed* - the action has completed all operations<br>  *abortSignaled* - the action has been instructed to STOP all running operations<br>  *aborted* - the action has stopped all operations|
 |description|string|false|none|none|
 |operationSummary|[OperationSummary](#schemaoperationsummary)|false|none|none|
 |overrideDryrun|boolean|false|none|none|
@@ -4343,7 +4339,7 @@ bearerAuth
 |snapshotID|string(uuid)|false|none|none|
 |startTime|string(date-time)|false|none|none|
 |endTime|string(date-time)|false|none|none|
-|state|string|false|none|The state of the action -<br><br><br><br>  *new* - not yet started<br>  *configured* - configured, but not yet started<br>  *blocked* - configured, but cannot run because another action is executing<br>  *running* - started<br>  *completed* - the action has completed all operations<br>  *abortSignaled* - the action has been instructed to STOP all running operations<br>  *aborted* - the action has stopped all operations|
+|state|string|false|none|The state of the action -<br><br><br><br><br>  *new* - not yet started<br>  *configured* - configured, but not yet started<br>  *blocked* - configured, but cannot run because another action is executing<br>  *running* - started<br>  *completed* - the action has completed all operations<br>  *abortSignaled* - the action has been instructed to STOP all running operations<br>  *aborted* - the action has stopped all operations|
 |description|string|false|none|none|
 |operationSummary|[OperationDetail](#schemaoperationdetail)|false|none|none|
 |overrideDryrun|boolean|false|none|none|
@@ -4864,7 +4860,7 @@ bearerAuth
 |actionID|string(uuid)|false|none|none|
 |startTime|string(date-time)|false|none|none|
 |endTime|string(date-time)|false|none|none|
-|state|string|false|none|The state of the operation -<br><br><br><br>  *initial* - not yet started<br>  *configured* - configured, but not yet started<br>  *blocked* - cannot run because another operation is blocking this<br>  *inProgress* - operation started - sent update command<br>  *needsVerified* - operation was sent update command, waiting for finish to verify<br>  *verifying* - operation verifying operation<br>  *aborted* - operation was aborted<br>  *noOperation* - operation has nothing to do - already at firmware level<br>  *noSolution* - operation could not find a firmware to flash<br>  *succeeded* - operation completed successfully<br>  *failed* - operation failed|
+|state|string|false|none|The state of the operation -<br><br><br><br><br>  *initial* - not yet started<br>  *configured* - configured, but not yet started<br>  *blocked* - cannot run because another operation is blocking this<br>  *inProgress* - operation started - sent update command<br>  *needsVerified* - operation was sent update command, waiting for finish to verify<br>  *verifying* - operation verifying operation<br>  *aborted* - operation was aborted<br>  *noOperation* - operation has nothing to do - already at firmware level<br>  *noSolution* - operation could not find a firmware to flash<br>  *succeeded* - operation completed successfully<br>  *failed* - operation failed|
 |error|string|false|none|none|
 |xname|string|false|none|none|
 |deviceType|string|false|none|none|
@@ -5506,7 +5502,7 @@ RFC 7807 compliant error payload.  All fields are optional except the 'type' fie
 |actionID|string(uuid)|false|none|none|
 |startTime|string(date-time)|false|none|none|
 |endTime|string(date-time)|false|none|none|
-|state|string|false|none|The state of the action -<br><br><br><br>  *new* - not yet started<br>  *configured* - configured, but not yet started<br>  *blocked* - configured, but cannot run because another action is executing<br>  *running* - started<br>  *completed* - the action has completed all operations<br>  *abortSignaled* - the action has been instructed to STOP all running operations<br>  *aborted* - the action has stopped all operations|
+|state|string|false|none|The state of the action -<br><br><br><br><br>  *new* - not yet started<br>  *configured* - configured, but not yet started<br>  *blocked* - configured, but cannot run because another action is executing<br>  *running* - started<br>  *completed* - the action has completed all operations<br>  *abortSignaled* - the action has been instructed to STOP all running operations<br>  *aborted* - the action has stopped all operations|
 
 #### Enumerated Values
 

--- a/api/firmware-action.md
+++ b/api/firmware-action.md
@@ -70,6 +70,10 @@ Base URLs:
 
 * <a href="http://localhost:28800">http://localhost:28800</a>
 
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
+
 <h1 id="firmware-action-service-actions">actions</h1>
 
 ## get__actions
@@ -86,14 +90,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions', headers = headers)
@@ -114,6 +120,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -181,8 +188,9 @@ end time for completed and in-progress actions.
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[ActionSummarys](#schemaactionsummarys)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__actions
@@ -201,7 +209,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -209,7 +218,8 @@ curl -X POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions', headers = headers)
@@ -231,6 +241,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -368,8 +379,9 @@ commands:
 |201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Created|[ActionID](#schemaactionid)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|action set not found|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__actions_{actionID}
@@ -386,14 +398,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}', headers = headers)
@@ -414,6 +428,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -633,8 +648,9 @@ Retrieve detailed information for a firmware action set specified by actionID.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[Action](#schemaaction)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|action set not found|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete__actions_{actionID}
@@ -651,14 +667,16 @@ Accept: application/error
 ```shell
 # You can also use wget
 curl -X DELETE https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID} \
-  -H 'Accept: application/error'
+  -H 'Accept: application/error' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/error'
+  'Accept': 'application/error',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}', headers = headers)
@@ -679,6 +697,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/error"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -716,8 +735,9 @@ Delete all information about a completed firmware action set.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|cannot delete a running action|[Problem7807](#schemaproblem7807)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|action set not found|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete__actions_{actionID}_instance
@@ -734,14 +754,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/instance \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/instance', headers = headers)
@@ -762,6 +784,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -809,8 +832,9 @@ Abort a running firmware action set. Stops all actions in progress (will not rol
 |202|[Accepted](https://tools.ietf.org/html/rfc7231#section-6.3.3)|Aborting action|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|action set not found|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__actions_{actionID}_status
@@ -827,14 +851,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/status \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/status', headers = headers)
@@ -855,6 +881,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -926,8 +953,9 @@ Retrieve summary information of a firmware action set.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[ActionSummary](#schemaactionsummary)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|action set not found|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__actions_{actionID}_operations
@@ -944,14 +972,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/operations \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/operations', headers = headers)
@@ -972,6 +1002,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1371,8 +1402,9 @@ Retrieve detailed information of a firmware action set.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[ActionDetail](#schemaactiondetail)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|action set not found|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__actions_{actionID}_operations_{operationID}
@@ -1389,14 +1421,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/operations/{operationID} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/actions/{actionID}/operations/{operationID}', headers = headers)
@@ -1417,6 +1451,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1482,8 +1517,9 @@ Retrieve detailed information of a firmware operation.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[Operation](#schemaoperation)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|action set not found|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__operations_{operationID}
@@ -1500,14 +1536,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/operations/{operationID} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/operations/{operationID}', headers = headers)
@@ -1528,6 +1566,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1592,8 +1631,9 @@ Retrieve detailed information of a firmware operation.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[Operation](#schemaoperation)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|operation not found|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="firmware-action-service-images">images</h1>
@@ -1614,7 +1654,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1622,7 +1663,8 @@ curl -X POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images', headers = headers)
@@ -1644,6 +1686,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1726,8 +1769,9 @@ Create a new image record
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request|[Problem7807](#schemaproblem7807)|
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Image Record Already Exists|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__images
@@ -1744,14 +1788,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images', headers = headers)
@@ -1772,6 +1818,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1839,8 +1886,9 @@ Retrieve a list of images that are known to the system.
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[ImageList](#schemaimagelist)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## put__images_{imageID}
@@ -1859,7 +1907,8 @@ Accept: application/error
 # You can also use wget
 curl -X PUT https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/error'
+  -H 'Accept: application/error' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1867,7 +1916,8 @@ curl -X PUT https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/error'
+  'Accept': 'application/error',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.put('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID}', headers = headers)
@@ -1889,6 +1939,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/error"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1964,8 +2015,9 @@ Modify or update an existing image record.
 |201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Created|None|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__images_{imageID}
@@ -1982,14 +2034,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID}', headers = headers)
@@ -2010,6 +2064,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2082,8 +2137,9 @@ Retrieve the image record that is associated with the imageID.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[ImageGet](#schemaimageget)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete__images_{imageID}
@@ -2100,14 +2156,16 @@ Accept: application/error
 ```shell
 # You can also use wget
 curl -X DELETE https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID} \
-  -H 'Accept: application/error'
+  -H 'Accept: application/error' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/error'
+  'Accept': 'application/error',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/images/{imageID}', headers = headers)
@@ -2128,6 +2186,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/error"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2164,8 +2223,9 @@ Deletes an image record from the FAS datastore. Does not delete the actual image
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Successful delete|None|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="firmware-action-service-service">service</h1>
@@ -2184,14 +2244,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/service/status \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/service/status', headers = headers)
@@ -2212,6 +2274,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2250,8 +2313,9 @@ Retrieve the status of the Firmware Action Service.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[ServiceStatus](#schemaservicestatus)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__service_status_details
@@ -2268,14 +2332,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/service/status/details \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/service/status/details', headers = headers)
@@ -2296,6 +2362,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2337,8 +2404,9 @@ Retrieve the status of the Firmware Action Service. HSM, ETCD, Service Status an
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[ServiceStatusDetails](#schemaservicestatusdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__service_version
@@ -2355,14 +2423,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/service/version \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/service/version', headers = headers)
@@ -2383,6 +2453,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2421,8 +2492,9 @@ Retrieve the internal version of FAS.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[ServiceVersion](#schemaserviceversion)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="firmware-action-service-snapshots">snapshots</h1>
@@ -2441,14 +2513,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots', headers = headers)
@@ -2469,6 +2543,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2523,8 +2598,9 @@ Return summary of all stored snapshots
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[SnapshotAll](#schemasnapshotall)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__snapshots
@@ -2543,7 +2619,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2551,7 +2628,8 @@ curl -X POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots', headers = headers)
@@ -2573,6 +2651,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2658,8 +2737,9 @@ Records a snapshot of the firmware versions for every target for every device th
 |---|---|---|---|---|
 |201|Location|string||location of snapshot|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__snapshots_{snapshotName}
@@ -2676,14 +2756,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots/{snapshotName} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots/{snapshotName}', headers = headers)
@@ -2704,6 +2786,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2806,8 +2889,9 @@ Retrieve a snapshot of the system
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[Snapshot](#schemasnapshot)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not found|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete__snapshots_{snapshotName}
@@ -2824,14 +2908,16 @@ Accept: application/error
 ```shell
 # You can also use wget
 curl -X DELETE https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots/{snapshotName} \
-  -H 'Accept: application/error'
+  -H 'Accept: application/error' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/error'
+  'Accept': 'application/error',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots/{snapshotName}', headers = headers)
@@ -2852,6 +2938,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/error"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2888,8 +2975,9 @@ Delete a snapshot of the system. Does not delete any firmware images from S3.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Successful delete|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not found|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__snapshots_{snapshotName}_restore
@@ -2906,14 +2994,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots/{snapshotName}/restore?confirm=yes \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/snapshots/{snapshotName}/restore', params={
@@ -2936,6 +3026,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2991,8 +3082,9 @@ Restore a snapshot by replacing each component (device + target) with the stored
 |---|---|---|---|---|
 |202|Location|string|uuid|actionID of the created firmware action set|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="firmware-action-service-loader">loader</h1>
@@ -3013,7 +3105,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader \
   -H 'Content-Type: application/octet-stream' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3021,7 +3114,8 @@ curl -X POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader \
 import requests
 headers = {
   'Content-Type': 'application/octet-stream',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader', headers = headers)
@@ -3043,6 +3137,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/octet-stream"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3097,8 +3192,9 @@ string
 |429|[Too Many Requests](https://tools.ietf.org/html/rfc6585#section-4)|Loader busy, try again later|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__loader
@@ -3115,14 +3211,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader', headers = headers)
@@ -3143,6 +3241,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3181,8 +3280,9 @@ Return the loader status and list loader runs
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[LoaderStatus](#schemaloaderstatus)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__loader_{loaderRunID}
@@ -3199,14 +3299,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader/{loaderRunID} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader/{loaderRunID}', headers = headers)
@@ -3227,6 +3329,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3273,8 +3376,9 @@ Return the results of a loader run
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[LoaderRunOutput](#schemaloaderrunoutput)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not found|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete__loader_{loaderRunID}
@@ -3291,14 +3395,16 @@ Accept: application/error
 ```shell
 # You can also use wget
 curl -X DELETE https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader/{loaderRunID} \
-  -H 'Accept: application/error'
+  -H 'Accept: application/error' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/error'
+  'Accept': 'application/error',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader/{loaderRunID}', headers = headers)
@@ -3319,6 +3425,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/error"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3355,8 +3462,9 @@ Delete a loader run
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Successful delete|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not found|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__loader_nexus
@@ -3373,14 +3481,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X POST https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader/nexus \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://rocket-ncn-w001.us.cray.com/apis/fas/v1/loader/nexus', headers = headers)
@@ -3401,6 +3511,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3439,8 +3550,9 @@ Have the loader read the firmware library from Nexus and add to S3 and create FA
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[LoaderRunID](#schemaloaderrunid)|
 |429|[Too Many Requests](https://tools.ietf.org/html/rfc6585#section-4)|Loader busy, try again later|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas
@@ -3568,7 +3680,7 @@ This operation does not require authentication
 |overrideDryrun|boolean|false|none|none|
 |startTime|string(date-time)|false|none|none|
 |endTime|string(date-time)|false|none|none|
-|state|string|false|none|The state of the action -<br><br>  *new* - not yet started<br>  *configured* - configured, but not yet started<br>  *blocked* - configured, but cannot run because another action is executing<br>  *running* - started<br>  *completed* - the action has completed all operations<br>  *abortSignaled* - the action has been instructed to STOP all running operations<br>  *aborted* - the action has stopped all operations|
+|state|string|false|none|The state of the action -<br><br><br><br>  *new* - not yet started<br>  *configured* - configured, but not yet started<br>  *blocked* - configured, but cannot run because another action is executing<br>  *running* - started<br>  *completed* - the action has completed all operations<br>  *abortSignaled* - the action has been instructed to STOP all running operations<br>  *aborted* - the action has stopped all operations|
 |operationCounts|[OperationCounts](#schemaoperationcounts)|false|none|none|
 |description|string|false|none|none|
 |blockedBy|[string]|false|none|none|
@@ -3834,7 +3946,7 @@ This operation does not require authentication
 |snapshotID|string(uuid)|false|none|none|
 |startTime|string(date-time)|false|none|none|
 |endTime|string(date-time)|false|none|none|
-|state|string|false|none|The state of the action -<br><br>  *new* - not yet started<br>  *configured* - configured, but not yet started<br>  *blocked* - configured, but cannot run because another action is executing<br>  *running* - started<br>  *completed* - the action has completed all operations<br>  *abortSignaled* - the action has been instructed to STOP all running operations<br>  *aborted* - the action has stopped all operations|
+|state|string|false|none|The state of the action -<br><br><br><br>  *new* - not yet started<br>  *configured* - configured, but not yet started<br>  *blocked* - configured, but cannot run because another action is executing<br>  *running* - started<br>  *completed* - the action has completed all operations<br>  *abortSignaled* - the action has been instructed to STOP all running operations<br>  *aborted* - the action has stopped all operations|
 |description|string|false|none|none|
 |operationSummary|[OperationSummary](#schemaoperationsummary)|false|none|none|
 |overrideDryrun|boolean|false|none|none|
@@ -4231,7 +4343,7 @@ This operation does not require authentication
 |snapshotID|string(uuid)|false|none|none|
 |startTime|string(date-time)|false|none|none|
 |endTime|string(date-time)|false|none|none|
-|state|string|false|none|The state of the action -<br><br>  *new* - not yet started<br>  *configured* - configured, but not yet started<br>  *blocked* - configured, but cannot run because another action is executing<br>  *running* - started<br>  *completed* - the action has completed all operations<br>  *abortSignaled* - the action has been instructed to STOP all running operations<br>  *aborted* - the action has stopped all operations|
+|state|string|false|none|The state of the action -<br><br><br><br>  *new* - not yet started<br>  *configured* - configured, but not yet started<br>  *blocked* - configured, but cannot run because another action is executing<br>  *running* - started<br>  *completed* - the action has completed all operations<br>  *abortSignaled* - the action has been instructed to STOP all running operations<br>  *aborted* - the action has stopped all operations|
 |description|string|false|none|none|
 |operationSummary|[OperationDetail](#schemaoperationdetail)|false|none|none|
 |overrideDryrun|boolean|false|none|none|
@@ -4752,7 +4864,7 @@ This operation does not require authentication
 |actionID|string(uuid)|false|none|none|
 |startTime|string(date-time)|false|none|none|
 |endTime|string(date-time)|false|none|none|
-|state|string|false|none|The state of the operation -<br><br>  *initial* - not yet started<br>  *configured* - configured, but not yet started<br>  *blocked* - cannot run because another operation is blocking this<br>  *inProgress* - operation started - sent update command<br>  *needsVerified* - operation was sent update command, waiting for finish to verify<br>  *verifying* - operation verifying operation<br>  *aborted* - operation was aborted<br>  *noOperation* - operation has nothing to do - already at firmware level<br>  *noSolution* - operation could not find a firmware to flash<br>  *succeeded* - operation completed successfully<br>  *failed* - operation failed|
+|state|string|false|none|The state of the operation -<br><br><br><br>  *initial* - not yet started<br>  *configured* - configured, but not yet started<br>  *blocked* - cannot run because another operation is blocking this<br>  *inProgress* - operation started - sent update command<br>  *needsVerified* - operation was sent update command, waiting for finish to verify<br>  *verifying* - operation verifying operation<br>  *aborted* - operation was aborted<br>  *noOperation* - operation has nothing to do - already at firmware level<br>  *noSolution* - operation could not find a firmware to flash<br>  *succeeded* - operation completed successfully<br>  *failed* - operation failed|
 |error|string|false|none|none|
 |xname|string|false|none|none|
 |deviceType|string|false|none|none|
@@ -5394,7 +5506,7 @@ RFC 7807 compliant error payload.  All fields are optional except the 'type' fie
 |actionID|string(uuid)|false|none|none|
 |startTime|string(date-time)|false|none|none|
 |endTime|string(date-time)|false|none|none|
-|state|string|false|none|The state of the action -<br><br>  *new* - not yet started<br>  *configured* - configured, but not yet started<br>  *blocked* - configured, but cannot run because another action is executing<br>  *running* - started<br>  *completed* - the action has completed all operations<br>  *abortSignaled* - the action has been instructed to STOP all running operations<br>  *aborted* - the action has stopped all operations|
+|state|string|false|none|The state of the action -<br><br><br><br>  *new* - not yet started<br>  *configured* - configured, but not yet started<br>  *blocked* - configured, but cannot run because another action is executing<br>  *running* - started<br>  *completed* - the action has completed all operations<br>  *abortSignaled* - the action has been instructed to STOP all running operations<br>  *aborted* - the action has stopped all operations|
 
 #### Enumerated Values
 

--- a/api/hbtd.md
+++ b/api/hbtd.md
@@ -39,9 +39,11 @@ To change a parameter, perform a PATCH operation with a JSON-formatted payload c
 
 Base URLs:
 
-* <a href="http://cray-hbtd/hmi/v1">http://cray-hbtd/hmi/v1</a>
-
 * <a href="https://api-gw-service-nmn.local/apis/hbtd/hmi/v1">https://api-gw-service-nmn.local/apis/hbtd/hmi/v1</a>
+
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
 
 <h1 id="heartbeat-tracker-service-heartbeat">heartbeat</h1>
 
@@ -52,8 +54,8 @@ Base URLs:
 > Code samples
 
 ```http
-POST http://cray-hbtd/hmi/v1/heartbeat/{xname} HTTP/1.1
-Host: cray-hbtd
+POST https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/heartbeat/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: */*
 
@@ -61,9 +63,10 @@ Accept: */*
 
 ```shell
 # You can also use wget
-curl -X POST http://cray-hbtd/hmi/v1/heartbeat/{xname} \
+curl -X POST https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/heartbeat/{xname} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: */*'
+  -H 'Accept: */*' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -71,10 +74,11 @@ curl -X POST http://cray-hbtd/hmi/v1/heartbeat/{xname} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': '*/*'
+  'Accept': '*/*',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://cray-hbtd/hmi/v1/heartbeat/{xname}', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/heartbeat/{xname}', headers = headers)
 
 print(r.json())
 
@@ -93,10 +97,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"*/*"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://cray-hbtd/hmi/v1/heartbeat/{xname}", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/heartbeat/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -143,8 +148,9 @@ Send a heartbeat message from a managed component like compute node to the heart
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Operation not permitted.  For /heartbeat, only POST operations are allowed.|[Error](#schemaerror)|
 |default|Default|Unexpected error|[Error](#schemaerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## TrackHeartbeat
@@ -154,8 +160,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://cray-hbtd/hmi/v1/heartbeat HTTP/1.1
-Host: cray-hbtd
+POST https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/heartbeat HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: */*
 
@@ -163,9 +169,10 @@ Accept: */*
 
 ```shell
 # You can also use wget
-curl -X POST http://cray-hbtd/hmi/v1/heartbeat \
+curl -X POST https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/heartbeat \
   -H 'Content-Type: application/json' \
-  -H 'Accept: */*'
+  -H 'Accept: */*' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -173,10 +180,11 @@ curl -X POST http://cray-hbtd/hmi/v1/heartbeat \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': '*/*'
+  'Accept': '*/*',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://cray-hbtd/hmi/v1/heartbeat', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/heartbeat', headers = headers)
 
 print(r.json())
 
@@ -195,10 +203,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"*/*"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://cray-hbtd/hmi/v1/heartbeat", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/heartbeat", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -247,8 +256,9 @@ Send a heartbeat message from a managed component like compute node to the heart
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Operation not permitted.  For /heartbeat, only POST operations are allowed.|[Error](#schemaerror)|
 |default|Default|Unexpected error|[Error](#schemaerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="heartbeat-tracker-service-hbstates">hbstates</h1>
@@ -260,8 +270,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST http://cray-hbtd/hmi/v1/hbstates HTTP/1.1
-Host: cray-hbtd
+POST https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/hbstates HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -269,9 +279,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://cray-hbtd/hmi/v1/hbstates \
+curl -X POST https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/hbstates \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -279,10 +290,11 @@ curl -X POST http://cray-hbtd/hmi/v1/hbstates \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://cray-hbtd/hmi/v1/hbstates', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/hbstates', headers = headers)
 
 print(r.json())
 
@@ -301,10 +313,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://cray-hbtd/hmi/v1/hbstates", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/hbstates", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -364,8 +377,9 @@ Sends a list of components to the service in a JSON formatted payload. The servi
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Operation not permitted.  For /hbstates, only POST operations are allowed.|[Error](#schemaerror)|
 |default|Default|Unexpected error|[Error](#schemaerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__hbstate_{xname}
@@ -373,26 +387,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://cray-hbtd/hmi/v1/hbstate/{xname} HTTP/1.1
-Host: cray-hbtd
+GET https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/hbstate/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://cray-hbtd/hmi/v1/hbstate/{xname} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/hbstate/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://cray-hbtd/hmi/v1/hbstate/{xname}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/hbstate/{xname}', headers = headers)
 
 print(r.json())
 
@@ -410,10 +426,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://cray-hbtd/hmi/v1/hbstate/{xname}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/hbstate/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -456,8 +473,9 @@ Query the service for the heartbeat status of a single component.  The service w
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found. Endpoint not available. Check IP routing between managed and management plane. Check that any SMS node services are running on management plane. Check that SMS node API gateway service is running on management plane. Check that SMS node HMI service is running on management plane.|[Error](#schemaerror)|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Operation not permitted.  For /hbstate/{xname}, only GET operations are allowed.|[Error](#schemaerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="heartbeat-tracker-service-params">params</h1>
@@ -467,26 +485,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://cray-hbtd/hmi/v1/params HTTP/1.1
-Host: cray-hbtd
+GET https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/params HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: */*
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://cray-hbtd/hmi/v1/params \
-  -H 'Accept: */*'
+curl -X GET https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/params \
+  -H 'Accept: */*' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': '*/*'
+  'Accept': '*/*',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://cray-hbtd/hmi/v1/params', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/params', headers = headers)
 
 print(r.json())
 
@@ -504,10 +524,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"*/*"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://cray-hbtd/hmi/v1/params", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/params", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -551,8 +572,9 @@ Fetch current heartbeat tracker configurable parameters.
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error.  Unexpected condition encountered when processing the request.|None|
 |default|Default|Unexpected error|[Error](#schemaerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch__params
@@ -560,8 +582,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH http://cray-hbtd/hmi/v1/params HTTP/1.1
-Host: cray-hbtd
+PATCH https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/params HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: */*
 
@@ -569,9 +591,10 @@ Accept: */*
 
 ```shell
 # You can also use wget
-curl -X PATCH http://cray-hbtd/hmi/v1/params \
+curl -X PATCH https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/params \
   -H 'Content-Type: application/json' \
-  -H 'Accept: */*'
+  -H 'Accept: */*' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -579,10 +602,11 @@ curl -X PATCH http://cray-hbtd/hmi/v1/params \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': '*/*'
+  'Accept': '*/*',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('http://cray-hbtd/hmi/v1/params', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/params', headers = headers)
 
 print(r.json())
 
@@ -601,10 +625,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"*/*"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "http://cray-hbtd/hmi/v1/params", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/params", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -672,8 +697,9 @@ Set one or more configurable parameters for the heartbeat tracker service and ha
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error.  Unexpected condition encountered when processing the request.|None|
 |default|Default|Unexpected error|[Error](#schemaerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="heartbeat-tracker-service-health">health</h1>
@@ -683,26 +709,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://cray-hbtd/hmi/v1/health HTTP/1.1
-Host: cray-hbtd
+GET https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/health HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://cray-hbtd/hmi/v1/health \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/health \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://cray-hbtd/hmi/v1/health', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/health', headers = headers)
 
 print(r.json())
 
@@ -720,10 +748,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://cray-hbtd/hmi/v1/health", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/health", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -774,8 +803,9 @@ Status Code **200**
 |» MsgBus|string|true|none|Status of the connection with the message bus.|
 |» HsmStatus|string|true|none|Status of the connection to the Hardware State Manager (HSM).  Any error reported by an attempt to access the HSM will be included here.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__liveness
@@ -783,26 +813,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://cray-hbtd/hmi/v1/liveness HTTP/1.1
-Host: cray-hbtd
+GET https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/liveness HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://cray-hbtd/hmi/v1/liveness \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/liveness \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://cray-hbtd/hmi/v1/liveness', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/liveness', headers = headers)
 
 print(r.json())
 
@@ -820,10 +852,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://cray-hbtd/hmi/v1/liveness", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/liveness", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -862,8 +895,9 @@ This is primarily an endpoint for the automated Kubernetes system.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|[No Content](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5) Network API call success|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Operation Not Permitted.  For /liveness, only GET operations are allowed.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__readiness
@@ -871,26 +905,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://cray-hbtd/hmi/v1/readiness HTTP/1.1
-Host: cray-hbtd
+GET https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/readiness HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://cray-hbtd/hmi/v1/readiness \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/readiness \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://cray-hbtd/hmi/v1/readiness', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/readiness', headers = headers)
 
 print(r.json())
 
@@ -908,10 +944,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://cray-hbtd/hmi/v1/readiness", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/hbtd/hmi/v1/readiness", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -950,8 +987,9 @@ This is primarily an endpoint for the automated Kubernetes system.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|[No Content](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5) Network API call success|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Operation Not Permitted.  For /readiness, only GET operations are allowed.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas

--- a/api/hmnfd.md
+++ b/api/hmnfd.md
@@ -53,8 +53,6 @@ Base URLs:
 
 * <a href="https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2">https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2</a>
 
-* <a href="http://cray-hmnfd/hmi/v2">http://cray-hmnfd/hmi/v2</a>
-
 # Authentication
 
 - HTTP Authentication, scheme: bearer 

--- a/api/hmnfd.md
+++ b/api/hmnfd.md
@@ -55,6 +55,10 @@ Base URLs:
 
 * <a href="http://cray-hmnfd/hmi/v2">http://cray-hmnfd/hmi/v2</a>
 
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
+
 <h1 id="hms-notification-fanout-daemon-subscriptions">subscriptions</h1>
 
 Used for managing State Change Notification subscriptions
@@ -75,14 +79,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/subscriptions \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/subscriptions', headers = headers)
@@ -103,6 +109,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -163,8 +170,9 @@ Retrieve all information on currently held State Change Notification subscriptio
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error.  Unexpected condition encountered when processing the request.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doGetSubscriptionInfoXName
@@ -183,14 +191,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/subscriptions/{xname} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/subscriptions/{xname}', headers = headers)
@@ -211,6 +221,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -278,8 +289,9 @@ Retrieve currently held State Change Notification subscriptions for a component.
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error.  Unexpected condition encountered when processing the request.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doSubscriptionDeleteXName
@@ -298,14 +310,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/subscriptions/{xname}/agents \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/subscriptions/{xname}/agents', headers = headers)
@@ -326,6 +340,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -377,8 +392,9 @@ Delete all state change notification subscriptions for a component.
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error.  Unexpected condition encountered when processing the request.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doSubscriptionPOSTV2
@@ -399,7 +415,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/subscriptions/{xname}/agents/{agent} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -407,7 +424,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/subscriptions/{x
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/subscriptions/{xname}/agents/{agent}', headers = headers)
@@ -429,6 +447,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -503,8 +522,9 @@ Subscribe to state change notifications for a set of components. Once this is do
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error.  Unexpected condition encountered when processing the request.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doSubscriptionPATCHV2
@@ -525,7 +545,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/subscriptions/{xname}/agents/{agent} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -533,7 +554,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/subscriptions/{
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/subscriptions/{xname}/agents/{agent}', headers = headers)
@@ -555,6 +577,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -629,8 +652,9 @@ Modify an existing subscription to state change notifications for a  component a
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error.  Unexpected condition encountered when processing the request.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doSubscriptionDeleteXNameAgentV2
@@ -649,14 +673,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/subscriptions/{xname}/agents/{agent} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/subscriptions/{xname}/agents/{agent}', headers = headers)
@@ -677,6 +703,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -729,8 +756,9 @@ Delete a specific state change notification subscription associated  with a targ
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error.  Unexpected condition encountered when processing the request.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hms-notification-fanout-daemon-scn">scn</h1>
@@ -755,7 +783,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/scn \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -763,7 +792,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/scn \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/scn', headers = headers)
@@ -785,6 +815,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -850,8 +881,9 @@ Send a state change notification for fanout to subscribers. This is the API endp
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error.  Unexpected condition encountered when processing the request.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hms-notification-fanout-daemon-params">params</h1>
@@ -872,14 +904,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/params \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/params', headers = headers)
@@ -900,6 +934,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -950,8 +985,9 @@ Retrieve a JSON-formatted list of current configurable parameters.
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error.  Unexpected condition encountered when processing the request.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doParamsPatch
@@ -972,7 +1008,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/params \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -980,7 +1017,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/params \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/params', headers = headers)
@@ -1002,6 +1040,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1071,8 +1110,9 @@ Change the value of one or more configurable parameters.
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error.  Unexpected condition encountered when processing the request.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hms-notification-fanout-daemon-health">health</h1>
@@ -1091,14 +1131,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/health \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/health', headers = headers)
@@ -1119,6 +1161,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1177,8 +1220,9 @@ Status Code **200**
 |» PruneMap|string|true|none|Status of the list of subscriptions to be pruned.|
 |» WorkerPool|string|true|none|Status of the worker pool servicing the notifications.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__liveness
@@ -1195,14 +1239,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/liveness \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/liveness', headers = headers)
@@ -1223,6 +1269,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1265,8 +1312,9 @@ This is primarily an endpoint for the automated Kubernetes system.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|[No Content](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5) Network API call success|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Operation Not Permitted.  For /liveness, only GET operations are allowed.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__readiness
@@ -1283,14 +1331,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/readiness \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/hmnfd/hmi/v2/readiness', headers = headers)
@@ -1311,6 +1361,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1353,8 +1404,9 @@ This is primarily an endpoint for the automated Kubernetes system.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|[No Content](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5) Network API call success|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Operation Not Permitted.  For /readiness, only GET operations are allowed.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas

--- a/api/ims.md
+++ b/api/ims.md
@@ -106,8 +106,6 @@ Base URLs:
 
 * <a href="https://api-gw-service-nmn.local/apis/ims">https://api-gw-service-nmn.local/apis/ims</a>
 
-* <a href="cray-ims.services.svc.cluster.local">cray-ims.services.svc.cluster.local</a>
-
 License: <a href="http://www.hpe.com/">Hewlett Packard Enterprise Development LP</a>
 
 # Authentication

--- a/api/ims.md
+++ b/api/ims.md
@@ -110,6 +110,10 @@ Base URLs:
 
 License: <a href="http://www.hpe.com/">Hewlett Packard Enterprise Development LP</a>
 
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
+
 <h1 id="image-management-service-images">images</h1>
 
 Interact with image records
@@ -130,14 +134,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/v3/images \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/v3/images', headers = headers)
@@ -158,6 +164,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -227,8 +234,9 @@ Status Code **200**
 |arch|aarch64|
 |arch|x86_64|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post_v3_image
@@ -249,7 +257,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/ims/v3/images \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -257,7 +266,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/ims/v3/images \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/ims/v3/images', headers = headers)
@@ -279,6 +289,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -345,8 +356,9 @@ Create a new ImageRecord and register the new image with IMS.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_all_v3_images
@@ -365,14 +377,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/v3/images \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/v3/images', headers = headers)
@@ -393,6 +407,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -434,8 +449,9 @@ Delete all ImageRecords. Deleted images are soft deleted and added to the /delet
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Image records deleted successfully|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v3_image
@@ -454,14 +470,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/v3/images/{image_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/v3/images/{image_id}', headers = headers)
@@ -482,6 +500,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -533,8 +552,9 @@ Retrieve an image by image_id.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_v3_image
@@ -555,7 +575,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/images/{image_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -563,7 +584,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/images/{image_id} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/ims/v3/images/{image_id}', headers = headers)
@@ -585,6 +607,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -653,8 +676,9 @@ Update an ImageRecord in IMS.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v3_image
@@ -673,14 +697,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/v3/images/{image_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/v3/images/{image_id}', headers = headers)
@@ -701,6 +727,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -749,8 +776,9 @@ Delete an ImageRecord by ID. Deleted images are soft deleted and added to the /d
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_all_v3_deleted_images
@@ -769,14 +797,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/v3/deleted/images \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/v3/deleted/images', headers = headers)
@@ -797,6 +827,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -868,8 +899,9 @@ Status Code **200**
 |arch|aarch64|
 |arch|x86_64|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_all_v3_deleted_images
@@ -888,14 +920,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/v3/deleted/images \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/v3/deleted/images', headers = headers)
@@ -916,6 +950,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -957,8 +992,9 @@ Permanently delete all DeletedImageRecords. Associated artifacts are permanently
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Image records were permanently deleted|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_all_v3_deleted_images
@@ -979,7 +1015,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/deleted/images \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -987,7 +1024,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/deleted/images \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/ims/v3/deleted/images', headers = headers)
@@ -1009,6 +1047,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1068,8 +1107,9 @@ Restore all DeletedImageRecords in IMS.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v3_deleted_image
@@ -1088,14 +1128,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/v3/deleted/images/{deleted_image_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/v3/deleted/images/{deleted_image_id}', headers = headers)
@@ -1116,6 +1158,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1168,8 +1211,9 @@ Retrieve deleted image details by using deleted_image_id.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v3_deleted_image
@@ -1188,14 +1232,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/v3/deleted/images/{deleted_image_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/v3/deleted/images/{deleted_image_id}', headers = headers)
@@ -1216,6 +1262,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1264,8 +1311,9 @@ Permanently delete image record associated with deleted_image_id. Associated art
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_v3_deleted_image
@@ -1286,7 +1334,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/deleted/images/{deleted_image_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1294,7 +1343,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/deleted/images/{delet
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/ims/v3/deleted/images/{deleted_image_id}', headers = headers)
@@ -1316,6 +1366,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1376,8 +1427,9 @@ Restore a DeletedImageRecord in IMS.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_all_v2_images
@@ -1396,14 +1448,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/images \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/images', headers = headers)
@@ -1424,6 +1478,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1493,8 +1548,9 @@ Status Code **200**
 |arch|aarch64|
 |arch|x86_64|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post_v2_image
@@ -1515,7 +1571,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/ims/images \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1523,7 +1580,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/ims/images \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/ims/images', headers = headers)
@@ -1545,6 +1603,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1612,8 +1671,9 @@ Create a new ImageRecord and register the new image with IMS.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_all_v2_images
@@ -1632,14 +1692,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/images \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/images', headers = headers)
@@ -1660,6 +1722,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1707,8 +1770,9 @@ Delete all ImageRecords.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Image records deleted successfully|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v2_image
@@ -1727,14 +1791,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/images/{image_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/images/{image_id}', headers = headers)
@@ -1755,6 +1821,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1806,8 +1873,9 @@ Retrieve an image by image_id.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_v2_image
@@ -1828,7 +1896,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/ims/images/{image_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1836,7 +1905,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/ims/images/{image_id} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/ims/images/{image_id}', headers = headers)
@@ -1858,6 +1928,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1926,8 +1997,9 @@ Update an ImageRecord in IMS.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v2_image
@@ -1946,14 +2018,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/images/{image_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/images/{image_id}', headers = headers)
@@ -1974,6 +2048,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2023,8 +2098,9 @@ Delete an ImageRecord by image_id.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="image-management-service-healthz">healthz</h1>
@@ -2047,14 +2123,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/healthz/ready \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/healthz/ready', headers = headers)
@@ -2075,6 +2153,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2105,8 +2184,9 @@ Readiness probe for IMS. This is used by Kubernetes to determine if IMS is ready
 
 <h3 id="get_healthz_ready-responseschema">Response Schema</h3>
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_healthz_live
@@ -2125,14 +2205,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/healthz/live \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/healthz/live', headers = headers)
@@ -2153,6 +2235,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2183,8 +2266,9 @@ Liveness probe for IMS. This is used by Kubernetes to determine if IMS is respon
 
 <h3 id="get_healthz_live-responseschema">Response Schema</h3>
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="image-management-service-jobs">jobs</h1>
@@ -2207,14 +2291,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/v3/jobs \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/v3/jobs', headers = headers)
@@ -2235,6 +2321,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2360,8 +2447,9 @@ Status Code **200**
 |arch|aarch64|
 |arch|x86_64|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post_v3_job
@@ -2382,7 +2470,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/ims/v3/jobs \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2390,7 +2479,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/ims/v3/jobs \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/ims/v3/jobs', headers = headers)
@@ -2412,6 +2502,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2552,8 +2643,9 @@ depending on request body parameter, job_type.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_all_v3_jobs
@@ -2572,14 +2664,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/v3/jobs \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/v3/jobs', headers = headers)
@@ -2600,6 +2694,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2664,8 +2759,9 @@ Delete all job records.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Job records deleted successfully|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v3_job
@@ -2684,14 +2780,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/v3/jobs/{job_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/v3/jobs/{job_id}', headers = headers)
@@ -2712,6 +2810,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2789,8 +2888,9 @@ Retrieve JobRecord by job_id
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A job record|[JobRecord](#schemajobrecord)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_v3_job
@@ -2811,7 +2911,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/jobs/{job_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2819,7 +2920,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/jobs/{job_id} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/ims/v3/jobs/{job_id}', headers = headers)
@@ -2841,6 +2943,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2931,8 +3034,9 @@ Update a job record. Internal use only. Not for API consumers.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v3_job
@@ -2951,14 +3055,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/v3/jobs/{job_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/v3/jobs/{job_id}', headers = headers)
@@ -2979,6 +3085,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3027,8 +3134,9 @@ Delete a job record by job_id. This also deletes the underlying Kubernetes resou
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_all_v2_jobs
@@ -3047,14 +3155,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/jobs \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/jobs', headers = headers)
@@ -3075,6 +3185,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3200,8 +3311,9 @@ Status Code **200**
 |arch|aarch64|
 |arch|x86_64|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post_v2_job
@@ -3222,7 +3334,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/ims/jobs \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3230,7 +3343,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/ims/jobs \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/ims/jobs', headers = headers)
@@ -3252,6 +3366,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3392,8 +3507,9 @@ depending on request body parameter, job_type.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_all_v2_jobs
@@ -3412,14 +3528,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/jobs \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/jobs', headers = headers)
@@ -3440,6 +3558,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3504,8 +3623,9 @@ Delete all job records.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Job records deleted successfully|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v2_job
@@ -3524,14 +3644,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/jobs/{job_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/jobs/{job_id}', headers = headers)
@@ -3552,6 +3674,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3629,8 +3752,9 @@ Retrieve JobRecord by job_id
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A job record|[JobRecord](#schemajobrecord)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_v2_job
@@ -3651,7 +3775,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/ims/jobs/{job_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3659,7 +3784,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/ims/jobs/{job_id} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/ims/jobs/{job_id}', headers = headers)
@@ -3681,6 +3807,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3771,8 +3898,9 @@ Update a job record. Internal use only. Not for API consumers.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v2_job
@@ -3791,14 +3919,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/jobs/{job_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/jobs/{job_id}', headers = headers)
@@ -3819,6 +3949,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -3867,8 +3998,9 @@ Delete a job record by job_id. This also deletes the underlying Kubernetes resou
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="image-management-service-recipes">recipes</h1>
@@ -3891,14 +4023,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/v3/recipes \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/v3/recipes', headers = headers)
@@ -3919,6 +4053,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4008,8 +4143,9 @@ Status Code **200**
 |arch|aarch64|
 |arch|x86_64|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post_v3_recipes
@@ -4030,7 +4166,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/ims/v3/recipes \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -4038,7 +4175,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/ims/v3/recipes \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/ims/v3/recipes', headers = headers)
@@ -4060,6 +4198,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4145,8 +4284,9 @@ A compressed Kiwi-NG image description is actually stored in the artifact reposi
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_all_v3_recipes
@@ -4165,14 +4305,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/v3/recipes \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/v3/recipes', headers = headers)
@@ -4193,6 +4335,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4234,8 +4377,9 @@ Delete all RecipeRecords. Deleted recipes are soft deleted and added to the /del
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Recipe records deleted successfully|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v3_recipe
@@ -4254,14 +4398,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/v3/recipes/{recipe_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/v3/recipes/{recipe_id}', headers = headers)
@@ -4282,6 +4428,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4341,8 +4488,9 @@ Retrieve a RecipeRecord by ID
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A recipe record|[RecipeRecord](#schemareciperecord)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_v3_recipe
@@ -4363,7 +4511,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/recipes/{recipe_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -4371,7 +4520,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/recipes/{recipe_id} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/ims/v3/recipes/{recipe_id}', headers = headers)
@@ -4393,6 +4543,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4477,8 +4628,9 @@ Update a RecipeRecord in IMS.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v3_recipe
@@ -4497,14 +4649,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/v3/recipes/{recipe_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/v3/recipes/{recipe_id}', headers = headers)
@@ -4525,6 +4679,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4573,8 +4728,9 @@ Delete a RecipeRecord by ID. The deleted recipes are soft deleted and added to t
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_all_v3_deleted_recipes
@@ -4593,14 +4749,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/v3/deleted/recipes \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/v3/deleted/recipes', headers = headers)
@@ -4621,6 +4779,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4703,8 +4862,9 @@ Status Code **200**
 |linux_distribution|sles15|
 |linux_distribution|centos7|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_all_v3_deleted_recipes
@@ -4723,14 +4883,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/v3/deleted/recipes \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/v3/deleted/recipes', headers = headers)
@@ -4751,6 +4913,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4792,8 +4955,9 @@ Permanently delete all DeletedRecipeRecords. Associated artifacts are permanentl
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Recipe records were permanently deleted|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_all_v3_deleted_recipes
@@ -4814,7 +4978,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/deleted/recipes \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -4822,7 +4987,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/deleted/recipes \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/ims/v3/deleted/recipes', headers = headers)
@@ -4844,6 +5010,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -4903,8 +5070,9 @@ Restore all DeletedRecipeRecords in IMS.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v3_deleted_recipe
@@ -4923,14 +5091,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/v3/deleted/recipes/{recipe_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/v3/deleted/recipes/{recipe_id}', headers = headers)
@@ -4951,6 +5121,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5005,8 +5176,9 @@ Retrieve a DeletedRecipeRecord by ID
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A deleted recipe record|[DeletedRecipeRecord](#schemadeletedreciperecord)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v3_deleted_recipe
@@ -5025,14 +5197,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/v3/deleted/recipes/{recipe_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/v3/deleted/recipes/{recipe_id}', headers = headers)
@@ -5053,6 +5227,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5101,8 +5276,9 @@ Permanently delete a DeletedRecipeRecord by ID. Associated artifacts are permane
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_v3_deleted_recipe
@@ -5123,7 +5299,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/deleted/recipes/{recipe_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -5131,7 +5308,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/deleted/recipes/{reci
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/ims/v3/deleted/recipes/{recipe_id}', headers = headers)
@@ -5153,6 +5331,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5213,8 +5392,9 @@ Restore a DeletedRecipeRecord in IMS.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_all_v2_recipes
@@ -5233,14 +5413,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/recipes \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/recipes', headers = headers)
@@ -5261,6 +5443,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5350,8 +5533,9 @@ Status Code **200**
 |arch|aarch64|
 |arch|x86_64|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post_v3_recipe
@@ -5372,7 +5556,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/ims/recipes \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -5380,7 +5565,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/ims/recipes \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/ims/recipes', headers = headers)
@@ -5402,6 +5588,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5487,8 +5674,9 @@ A compressed Kiwi-NG image description is actually stored in the artifact reposi
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_all_v2_recipes
@@ -5507,14 +5695,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/recipes \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/recipes', headers = headers)
@@ -5535,6 +5725,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5582,8 +5773,9 @@ Delete all RecipeRecords.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Recipe records deleted successfully|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v2_recipe
@@ -5602,14 +5794,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/recipes/{recipe_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/recipes/{recipe_id}', headers = headers)
@@ -5630,6 +5824,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5689,8 +5884,9 @@ Retrieve a RecipeRecord by ID
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|A recipe record|[RecipeRecord](#schemareciperecord)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_v2_recipe
@@ -5711,7 +5907,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/ims/recipes/{recipe_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -5719,7 +5916,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/ims/recipes/{recipe_id} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/ims/recipes/{recipe_id}', headers = headers)
@@ -5741,6 +5939,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5825,8 +6024,9 @@ Update a RecipeRecord in IMS.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v2_recipe
@@ -5845,14 +6045,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/recipes/{recipe_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/recipes/{recipe_id}', headers = headers)
@@ -5873,6 +6075,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -5922,8 +6125,9 @@ Delete a recipe by ID.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="image-management-service-public-keys">public keys</h1>
@@ -5946,14 +6150,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/v3/public-keys \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/v3/public-keys', headers = headers)
@@ -5974,6 +6180,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6027,8 +6234,9 @@ Status Code **200**
 |» name|string|true|none|Name of the public key|
 |» public_key|string|true|none|The raw public key|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post_v3_public_key
@@ -6049,7 +6257,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/ims/v3/public-keys \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -6057,7 +6266,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/ims/v3/public-keys \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/ims/v3/public-keys', headers = headers)
@@ -6079,6 +6289,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6135,8 +6346,9 @@ Create a new public SSH key record. Uploaded by administrator to allow them to a
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_all_v3_public_keys
@@ -6155,14 +6367,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/v3/public-keys \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/v3/public-keys', headers = headers)
@@ -6183,6 +6397,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6224,8 +6439,9 @@ Delete all public key-records. Deleted public-keys are soft deleted and added to
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Public key records deleted successfully|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v3_public_key
@@ -6244,14 +6460,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/v3/public-keys/{public_key_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/v3/public-keys/{public_key_id}', headers = headers)
@@ -6272,6 +6490,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6318,8 +6537,9 @@ Retrieve a public key by public_key_id
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v3_public_key
@@ -6338,14 +6558,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/v3/public-keys/{public_key_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/v3/public-keys/{public_key_id}', headers = headers)
@@ -6366,6 +6588,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6414,8 +6637,9 @@ Delete a PublicKeyRecord by ID. Deleted public-keys are soft deleted and added t
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_all_v3_deleted_public_keys
@@ -6434,14 +6658,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/v3/deleted/public-keys \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/v3/deleted/public-keys', headers = headers)
@@ -6462,6 +6688,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6517,8 +6744,9 @@ Status Code **200**
 |» name|string|true|none|Name of the public key|
 |» public_key|string|true|none|The raw public key|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_all_v3_deleted_public_keys
@@ -6537,14 +6765,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/v3/deleted/public-keys \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/v3/deleted/public-keys', headers = headers)
@@ -6565,6 +6795,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6606,8 +6837,9 @@ Permanently delete all public key-records.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|PublicKey records were permanently deleted|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_all_v3_deleted_public_keys
@@ -6628,7 +6860,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/deleted/public-keys \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -6636,7 +6869,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/deleted/public-keys \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/ims/v3/deleted/public-keys', headers = headers)
@@ -6658,6 +6892,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6717,8 +6952,9 @@ Restore all DeletedPublicKeyRecord in IMS.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v3_deleted_public_key
@@ -6737,14 +6973,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/v3/deleted/public-keys/{deleted_public_key_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/v3/deleted/public-keys/{deleted_public_key_id}', headers = headers)
@@ -6765,6 +7003,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6812,8 +7051,9 @@ Retrieve a deleted public key by deleted_public_key_id
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v3_deleted_public_key
@@ -6832,14 +7072,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/v3/deleted/public-keys/{deleted_public_key_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/v3/deleted/public-keys/{deleted_public_key_id}', headers = headers)
@@ -6860,6 +7102,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -6908,8 +7151,9 @@ Permanently delete a DeletedPublicKeyRecord by ID.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch_v3_deleted_public_key
@@ -6930,7 +7174,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/deleted/public-keys/{deleted_public_key_id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -6938,7 +7183,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/ims/v3/deleted/public-keys/{
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/ims/v3/deleted/public-keys/{deleted_public_key_id}', headers = headers)
@@ -6960,6 +7206,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -7020,8 +7267,9 @@ Restore a DeletedPublicKeyRecord in IMS.
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_all_v2_public_keys
@@ -7040,14 +7288,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/public-keys \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/public-keys', headers = headers)
@@ -7068,6 +7318,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -7121,8 +7372,9 @@ Status Code **200**
 |» name|string|true|none|Name of the public key|
 |» public_key|string|true|none|The raw public key|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post_v2_public_key
@@ -7143,7 +7395,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/ims/public-keys \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -7151,7 +7404,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/ims/public-keys \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/ims/public-keys', headers = headers)
@@ -7173,6 +7427,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -7229,8 +7484,9 @@ Create a new public SSH key record. Uploaded by administrator to allow them to a
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Input data was understood, but failed validation. Re-run request with valid input values for the fields indicated in the response.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_all_v2_public_keys
@@ -7249,14 +7505,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/public-keys \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/public-keys', headers = headers)
@@ -7277,6 +7535,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -7318,8 +7577,9 @@ Delete all public key records.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|Public key records deleted successfully|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_v2_public_key
@@ -7338,14 +7598,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/public-keys/{public_key_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/public-keys/{public_key_id}', headers = headers)
@@ -7366,6 +7628,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -7412,8 +7675,9 @@ Retrieve a public key by public_key_id
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_v2_public_key
@@ -7432,14 +7696,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/ims/public-keys/{public_key_id} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/ims/public-keys/{public_key_id}', headers = headers)
@@ -7460,6 +7726,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -7508,8 +7775,9 @@ Delete a public key by public_key_id.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Requested resource does not exist. Re-run request with valid ID.|[ProblemDetails](#schemaproblemdetails)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="image-management-service-version">version</h1>
@@ -7532,14 +7800,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/ims/version \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/ims/version', headers = headers)
@@ -7560,6 +7830,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -7594,8 +7865,9 @@ Retrieve the version of the IMS Service
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|IMS Version|string|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An internal error occurred. Re-running the request may or may not succeed.|[ProblemDetails](#schemaproblemdetails)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas

--- a/api/nls.md
+++ b/api/nls.md
@@ -6,7 +6,11 @@
 
 Base URLs:
 
-* <a href="/apis">/apis</a>
+* <a href="https://api-gw-service-nmn.local/apis">https://api-gw-service-nmn.local/apis</a>
+
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
 
 <h1 id="ncn-lifecycle-service-ncn-lifecycle-events">NCN Lifecycle Events</h1>
 
@@ -15,8 +19,8 @@ Base URLs:
 > Code samples
 
 ```http
-POST /apis/nls/v1/ncns/reboot HTTP/1.1
-
+POST https://api-gw-service-nmn.local/apis/nls/v1/ncns/reboot HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -24,9 +28,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST /apis/nls/v1/ncns/reboot \
+curl -X POST https://api-gw-service-nmn.local/apis/nls/v1/ncns/reboot \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -34,10 +39,11 @@ curl -X POST /apis/nls/v1/ncns/reboot \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('/apis/nls/v1/ncns/reboot', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/nls/v1/ncns/reboot', headers = headers)
 
 print(r.json())
 
@@ -56,10 +62,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "/apis/nls/v1/ncns/reboot", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/nls/v1/ncns/reboot", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -114,8 +121,9 @@ func main() {
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found|[ResponseError](#schemaresponseerror)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error|[ResponseError](#schemaresponseerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__nls_v1_ncns_rebuild
@@ -123,8 +131,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST /apis/nls/v1/ncns/rebuild HTTP/1.1
-
+POST https://api-gw-service-nmn.local/apis/nls/v1/ncns/rebuild HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -132,9 +140,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST /apis/nls/v1/ncns/rebuild \
+curl -X POST https://api-gw-service-nmn.local/apis/nls/v1/ncns/rebuild \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -142,10 +151,11 @@ curl -X POST /apis/nls/v1/ncns/rebuild \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('/apis/nls/v1/ncns/rebuild', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/nls/v1/ncns/rebuild', headers = headers)
 
 print(r.json())
 
@@ -164,10 +174,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "/apis/nls/v1/ncns/rebuild", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/nls/v1/ncns/rebuild", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -229,8 +240,9 @@ func main() {
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found|[ResponseError](#schemaresponseerror)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error|[ResponseError](#schemaresponseerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="ncn-lifecycle-service-workflow-management">Workflow Management</h1>
@@ -240,26 +252,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/nls/v1/workflows HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/nls/v1/workflows HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/nls/v1/workflows \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/nls/v1/workflows \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/nls/v1/workflows', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/nls/v1/workflows', headers = headers)
 
 print(r.json())
 
@@ -277,10 +291,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/nls/v1/workflows", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/nls/v1/workflows", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -334,8 +349,9 @@ Status Code **200**
 |» name|string|false|none|none|
 |» status|object|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete__nls_v1_workflows_{name}
@@ -343,26 +359,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE /apis/nls/v1/workflows/{name} HTTP/1.1
-
+DELETE https://api-gw-service-nmn.local/apis/nls/v1/workflows/{name} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE /apis/nls/v1/workflows/{name} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/nls/v1/workflows/{name} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('/apis/nls/v1/workflows/{name}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/nls/v1/workflows/{name}', headers = headers)
 
 print(r.json())
 
@@ -380,10 +398,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "/apis/nls/v1/workflows/{name}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/nls/v1/workflows/{name}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -422,8 +441,9 @@ func main() {
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found|[ResponseError](#schemaresponseerror)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error|[ResponseError](#schemaresponseerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## put__nls_v1_workflows_{name}_rerun
@@ -431,26 +451,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PUT /apis/nls/v1/workflows/{name}/rerun HTTP/1.1
-
+PUT https://api-gw-service-nmn.local/apis/nls/v1/workflows/{name}/rerun HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X PUT /apis/nls/v1/workflows/{name}/rerun \
-  -H 'Accept: application/json'
+curl -X PUT https://api-gw-service-nmn.local/apis/nls/v1/workflows/{name}/rerun \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.put('/apis/nls/v1/workflows/{name}/rerun', headers = headers)
+r = requests.put('https://api-gw-service-nmn.local/apis/nls/v1/workflows/{name}/rerun', headers = headers)
 
 print(r.json())
 
@@ -468,10 +490,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PUT", "/apis/nls/v1/workflows/{name}/rerun", data)
+    req, err := http.NewRequest("PUT", "https://api-gw-service-nmn.local/apis/nls/v1/workflows/{name}/rerun", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -510,8 +533,9 @@ func main() {
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found|[ResponseError](#schemaresponseerror)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error|[ResponseError](#schemaresponseerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## put__nls_v1_workflows_{name}_retry
@@ -519,8 +543,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PUT /apis/nls/v1/workflows/{name}/retry HTTP/1.1
-
+PUT https://api-gw-service-nmn.local/apis/nls/v1/workflows/{name}/retry HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -528,9 +552,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PUT /apis/nls/v1/workflows/{name}/retry \
+curl -X PUT https://api-gw-service-nmn.local/apis/nls/v1/workflows/{name}/retry \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -538,10 +563,11 @@ curl -X PUT /apis/nls/v1/workflows/{name}/retry \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.put('/apis/nls/v1/workflows/{name}/retry', headers = headers)
+r = requests.put('https://api-gw-service-nmn.local/apis/nls/v1/workflows/{name}/retry', headers = headers)
 
 print(r.json())
 
@@ -560,10 +586,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PUT", "/apis/nls/v1/workflows/{name}/retry", data)
+    req, err := http.NewRequest("PUT", "https://api-gw-service-nmn.local/apis/nls/v1/workflows/{name}/retry", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -612,8 +639,9 @@ func main() {
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found|[ResponseError](#schemaresponseerror)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error|[ResponseError](#schemaresponseerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas

--- a/api/power-control.md
+++ b/api/power-control.md
@@ -38,12 +38,6 @@ Base URLs:
 
 * <a href="https://api-gw-service-nmn.local/apis/power-control/v1">https://api-gw-service-nmn.local/apis/power-control/v1</a>
 
-* <a href="http://cray-power-control/v1">http://cray-power-control/v1</a>
-
-* <a href="https://loki-ncn-m001.us.cray.com/apis/power-control/v1">https://loki-ncn-m001.us.cray.com/apis/power-control/v1</a>
-
-* <a href="http://localhost:26970">http://localhost:26970</a>
-
  License: MIT
 
 # Authentication

--- a/api/power-control.md
+++ b/api/power-control.md
@@ -46,6 +46,10 @@ Base URLs:
 
  License: MIT
 
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
+
 <h1 id="power-control-service-pcs--transitions">transitions</h1>
 
 Endpoints that perform power operations to a set of xnames
@@ -66,7 +70,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/power-control/v1/transitions \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -74,7 +79,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/power-control/v1/transitions 
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/power-control/v1/transitions', headers = headers)
@@ -96,6 +102,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -157,8 +164,9 @@ Request to perform power transitions.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error prevented starting the transition|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__transitions
@@ -175,14 +183,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/power-control/v1/transitions \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/power-control/v1/transitions', headers = headers)
@@ -203,6 +213,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -259,8 +270,9 @@ are automatically deleted.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[transitions_getAll](#schematransitions_getall)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error prevented getting the transitions|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__transitions_{transitionID}
@@ -277,14 +289,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/power-control/v1/transitions/{transitionID} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/power-control/v1/transitions/{transitionID}', headers = headers)
@@ -305,6 +319,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -371,8 +386,9 @@ transitionID.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error prevented getting the transition|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete__transitions_{transitionID}
@@ -389,14 +405,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X DELETE https://api-gw-service-nmn.local/apis/power-control/v1/transitions/{transitionID} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.delete('https://api-gw-service-nmn.local/apis/power-control/v1/transitions/{transitionID}', headers = headers)
@@ -417,6 +435,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -463,8 +482,9 @@ Attempt to abort an in-progress transition by transitionID
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|TransitionID not found|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error prevented abort signaling|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="power-control-service-pcs--power-status">power-status</h1>
@@ -485,14 +505,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/power-control/v1/power-status \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/power-control/v1/power-status', headers = headers)
@@ -513,6 +535,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -581,8 +604,9 @@ Retrieve the power state of the component specified by xname.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="power-control-service-pcs--power-cap">power-cap</h1>
@@ -605,7 +629,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/power-control/v1/power-cap/snapshot \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -613,7 +638,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/power-control/v1/power-cap/sn
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/power-control/v1/power-cap/snapshot', headers = headers)
@@ -635,6 +661,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -690,8 +717,9 @@ Get power cap snapshot for a set of targets.  This operation returns a taskID to
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch__power-cap
@@ -710,7 +738,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH https://api-gw-service-nmn.local/apis/power-control/v1/power-cap \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -718,7 +747,8 @@ curl -X PATCH https://api-gw-service-nmn.local/apis/power-control/v1/power-cap \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('https://api-gw-service-nmn.local/apis/power-control/v1/power-cap', headers = headers)
@@ -740,6 +770,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -803,8 +834,9 @@ Set power cap parameters for a list of targets.  The PATCH payload contains the 
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__power-cap
@@ -821,14 +853,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/power-control/v1/power-cap \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/power-control/v1/power-cap', headers = headers)
@@ -849,6 +883,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -901,8 +936,9 @@ func main() {
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK. The data was successfully retrieved|[power_cap_task_list](#schemapower_cap_task_list)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__power-cap_{taskID}
@@ -919,14 +955,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/power-control/v1/power-cap/{taskID} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/power-control/v1/power-cap/{taskID}', headers = headers)
@@ -947,6 +985,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1023,8 +1062,9 @@ Queries the current status for the specified taskID. Use the taskID returned fro
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|TaskID not found|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="power-control-service-pcs--cli_ignore">cli_ignore</h1>
@@ -1041,14 +1081,18 @@ Host: api-gw-service-nmn.local
 
 ```shell
 # You can also use wget
-curl -X GET https://api-gw-service-nmn.local/apis/power-control/v1/liveness
+curl -X GET https://api-gw-service-nmn.local/apis/power-control/v1/liveness \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
+headers = {
+  'Authorization': 'Bearer {access-token}'
+}
 
-r = requests.get('https://api-gw-service-nmn.local/apis/power-control/v1/liveness')
+r = requests.get('https://api-gw-service-nmn.local/apis/power-control/v1/liveness', headers = headers)
 
 print(r.json())
 
@@ -1063,6 +1107,10 @@ import (
 )
 
 func main() {
+
+    headers := map[string][]string{
+        "Authorization": []string{"Bearer {access-token}"},
+    }
 
     data := bytes.NewBuffer([]byte{jsonReq})
     req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/power-control/v1/liveness", data)
@@ -1088,8 +1136,9 @@ Get liveness status of the service
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|[No Content](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5) Network API call success|None|
 |503|[Service Unavailable](https://tools.ietf.org/html/rfc7231#section-6.6.4)|The service is not taking HTTP requests|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__readiness
@@ -1104,14 +1153,18 @@ Host: api-gw-service-nmn.local
 
 ```shell
 # You can also use wget
-curl -X GET https://api-gw-service-nmn.local/apis/power-control/v1/readiness
+curl -X GET https://api-gw-service-nmn.local/apis/power-control/v1/readiness \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
+headers = {
+  'Authorization': 'Bearer {access-token}'
+}
 
-r = requests.get('https://api-gw-service-nmn.local/apis/power-control/v1/readiness')
+r = requests.get('https://api-gw-service-nmn.local/apis/power-control/v1/readiness', headers = headers)
 
 print(r.json())
 
@@ -1126,6 +1179,10 @@ import (
 )
 
 func main() {
+
+    headers := map[string][]string{
+        "Authorization": []string{"Bearer {access-token}"},
+    }
 
     data := bytes.NewBuffer([]byte{jsonReq})
     req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/power-control/v1/readiness", data)
@@ -1151,8 +1208,9 @@ Get readiness status of the service
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|[No Content](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5) Network API call success|None|
 |503|[Service Unavailable](https://tools.ietf.org/html/rfc7231#section-6.6.4)|The service is not taking HTTP requests|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__health
@@ -1169,14 +1227,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/power-control/v1/health \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/power-control/v1/health', headers = headers)
@@ -1197,6 +1257,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1245,8 +1306,9 @@ This is primarily intended as a diagnostic tool to investigate the functioning o
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|[OK](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.1) Network API call success|[health_rsp](#schemahealth_rsp)|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Operation Not Permitted. For /health, only GET operations are allowed.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas

--- a/api/scsd.md
+++ b/api/scsd.md
@@ -77,6 +77,10 @@ Base URLs:
 
  License: Cray Proprietary
 
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
+
 <h1 id="system-configuration-service-nwp">nwp</h1>
 
 Endpoints that set or get Redfish Network Protocol information
@@ -97,7 +101,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/dumpcfg \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -105,7 +110,8 @@ curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/dumpcfg \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/dumpcfg', headers = headers)
@@ -127,6 +133,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -203,8 +210,9 @@ Get the Redfish Network Protocol data (NTP server, syslog server, SSH key) for a
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Endpoint not found|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Invalid method, only POST is allowed|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__bmc_loadcfg
@@ -223,7 +231,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/loadcfg \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -231,7 +240,8 @@ curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/loadcfg \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/loadcfg', headers = headers)
@@ -253,6 +263,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -329,8 +340,9 @@ The Force field is optional. If present, and set to 'true', the Redfish operatio
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Endpoint not found|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Invalid method, only POST is allowed|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__bmc_cfg_{xname}
@@ -347,14 +359,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET http://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname}', headers = headers)
@@ -375,6 +389,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -433,8 +448,9 @@ Retrieve selected Redfish network protocol data for a single target. You can sel
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Endpoint not found|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Invalid method, only GET,POST is allowed|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__bmc_cfg_{xname}
@@ -453,7 +469,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -461,7 +478,8 @@ curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname}', headers = headers)
@@ -483,6 +501,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -552,8 +571,9 @@ The Force field is optional. If present, and set to 'true', the Redfish operatio
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Endpoint not found|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Invalid method, only GET,POST is allowed|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="system-configuration-service-creds">creds</h1>
@@ -576,7 +596,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/discreetcreds \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -584,7 +605,8 @@ curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/discreetcreds \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/discreetcreds', headers = headers)
@@ -606,6 +628,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -674,8 +697,9 @@ The Force field is optional. If present, and set to 'true', the Redfish operatio
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Endpoint not found|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Invalid method, only POST is allowed|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__bmc_creds_{xname}
@@ -694,7 +718,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds/{xname} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -702,7 +727,8 @@ curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds/{xname} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds/{xname}', headers = headers)
@@ -724,6 +750,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -782,8 +809,9 @@ The Force field is optional. If present, and set to 'true', the Redfish operatio
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Endpoint not found|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Invalid method, only GET,POST is allowed|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__bmc_creds
@@ -800,14 +828,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET http://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds', headers = headers)
@@ -828,6 +858,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -878,8 +909,9 @@ Fetch controller login credentials for a specified targets.  Targets are specifi
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Endpoint not found|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Invalid method, only GET, POST is allowed|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__bmc_globalcreds
@@ -898,7 +930,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/globalcreds \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -906,7 +939,8 @@ curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/globalcreds \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/globalcreds', headers = headers)
@@ -928,6 +962,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -992,8 +1027,9 @@ The Force field is optional. If present, and set to 'true', the Redfish operatio
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Endpoint not found|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Invalid method, only POST is allowed|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="system-configuration-service-bios">bios</h1>
@@ -1014,14 +1050,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET http://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field}', headers = headers)
@@ -1042,6 +1080,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1094,8 +1133,9 @@ Fetch the current BIOS setting for the TPM State.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Xname was not for a bmc.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error including failures communicating with the server.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## patch__bmc_bios_{xname}_{bios_field}
@@ -1114,7 +1154,8 @@ Accept: application/json
 # You can also use wget
 curl -X PATCH http://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1122,7 +1163,8 @@ curl -X PATCH http://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bio
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.patch('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field}', headers = headers)
@@ -1144,6 +1186,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1208,8 +1251,9 @@ Set the TPM State in the BIOS settings.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Xname was not for a bmc.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error including failures communicating with the server.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="system-configuration-service-version">version</h1>
@@ -1230,14 +1274,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET http://api-gw-service-nmn.local/apis/scsd/v1/version \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('http://api-gw-service-nmn.local/apis/scsd/v1/version', headers = headers)
@@ -1258,6 +1304,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1295,8 +1342,9 @@ Retrieve service version information.  Version is returned in vmaj.min.bld forma
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Endpoint not found|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Invalid method, only GET,POST is allowed|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="system-configuration-service-certs">certs</h1>
@@ -1319,7 +1367,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/createcerts \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1327,7 +1376,8 @@ curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/createcerts \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/createcerts', headers = headers)
@@ -1349,6 +1399,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1409,8 +1460,9 @@ Create TLS cert/key pairs for a set of BMC targets.  A TLS cert/key is created p
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Endpoint not found|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Invalid method, only POST or DELETE is allowed|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__bmc_deletecerts
@@ -1429,7 +1481,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/deletecerts \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1437,7 +1490,8 @@ curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/deletecerts \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/deletecerts', headers = headers)
@@ -1459,6 +1513,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1519,8 +1574,9 @@ Delete TLS cert/key information for domain-level TLS certs based on the given ta
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Endpoint not found|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Invalid method, only POST or DELETE is allowed|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__bmc_fetchcerts
@@ -1539,7 +1595,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/fetchcerts \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1547,7 +1604,8 @@ curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/fetchcerts \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/fetchcerts', headers = headers)
@@ -1569,6 +1627,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1633,8 +1692,9 @@ Fetches BMC TLS certs previously created using the /bmc/createcerts endpoint and
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Endpoint not found|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Invalid method, only POST is allowed|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__bmc_setcerts
@@ -1653,7 +1713,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcerts \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1661,7 +1722,8 @@ curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcerts \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcerts', headers = headers)
@@ -1683,6 +1745,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1744,8 +1807,9 @@ Apply TLS cert/key pairs, previously generated using the /bmc/createcerts endpoi
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Endpoint not found|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Invalid method, only POST is allowed|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__bmc_setcert_{xname}
@@ -1760,14 +1824,18 @@ Host: api-gw-service-nmn.local
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcert/{xname}
+curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcert/{xname} \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
+headers = {
+  'Authorization': 'Bearer {access-token}'
+}
 
-r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcert/{xname}')
+r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcert/{xname}', headers = headers)
 
 print(r.json())
 
@@ -1782,6 +1850,10 @@ import (
 )
 
 func main() {
+
+    headers := map[string][]string{
+        "Authorization": []string{"Bearer {access-token}"},
+    }
 
     data := bytes.NewBuffer([]byte{jsonReq})
     req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcert/{xname}", data)
@@ -1816,8 +1888,9 @@ Apply a TLS cert/key pairs previously generated using the /bmc/createcerts endpo
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Endpoint not found|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Invalid method, only POST is allowed|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="system-configuration-service-cli_ignore">cli_ignore</h1>
@@ -1834,14 +1907,18 @@ Host: api-gw-service-nmn.local
 
 ```shell
 # You can also use wget
-curl -X GET http://api-gw-service-nmn.local/apis/scsd/v1/liveness
+curl -X GET http://api-gw-service-nmn.local/apis/scsd/v1/liveness \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
+headers = {
+  'Authorization': 'Bearer {access-token}'
+}
 
-r = requests.get('http://api-gw-service-nmn.local/apis/scsd/v1/liveness')
+r = requests.get('http://api-gw-service-nmn.local/apis/scsd/v1/liveness', headers = headers)
 
 print(r.json())
 
@@ -1856,6 +1933,10 @@ import (
 )
 
 func main() {
+
+    headers := map[string][]string{
+        "Authorization": []string{"Bearer {access-token}"},
+    }
 
     data := bytes.NewBuffer([]byte{jsonReq})
     req, err := http.NewRequest("GET", "http://api-gw-service-nmn.local/apis/scsd/v1/liveness", data)
@@ -1881,8 +1962,9 @@ Get liveness status of the service
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|[No Content](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5) Network API call success|None|
 |503|[Service Unavailable](https://tools.ietf.org/html/rfc7231#section-6.6.4)|The service is not taking HTTP requests|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__readiness
@@ -1897,14 +1979,18 @@ Host: api-gw-service-nmn.local
 
 ```shell
 # You can also use wget
-curl -X GET http://api-gw-service-nmn.local/apis/scsd/v1/readiness
+curl -X GET http://api-gw-service-nmn.local/apis/scsd/v1/readiness \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
+headers = {
+  'Authorization': 'Bearer {access-token}'
+}
 
-r = requests.get('http://api-gw-service-nmn.local/apis/scsd/v1/readiness')
+r = requests.get('http://api-gw-service-nmn.local/apis/scsd/v1/readiness', headers = headers)
 
 print(r.json())
 
@@ -1919,6 +2005,10 @@ import (
 )
 
 func main() {
+
+    headers := map[string][]string{
+        "Authorization": []string{"Bearer {access-token}"},
+    }
 
     data := bytes.NewBuffer([]byte{jsonReq})
     req, err := http.NewRequest("GET", "http://api-gw-service-nmn.local/apis/scsd/v1/readiness", data)
@@ -1944,8 +2034,9 @@ Get readiness status of the service
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|[No Content](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5) Network API call success|None|
 |503|[Service Unavailable](https://tools.ietf.org/html/rfc7231#section-6.6.4)|The service is not taking HTTP requests|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__health
@@ -1962,14 +2053,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET http://api-gw-service-nmn.local/apis/scsd/v1/health \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('http://api-gw-service-nmn.local/apis/scsd/v1/health', headers = headers)
@@ -1990,6 +2083,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2029,8 +2123,9 @@ Get readiness status of the service
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|The service encountered an error when gathering health information|None|
 |503|[Service Unavailable](https://tools.ietf.org/html/rfc7231#section-6.6.4)|The service is not taking HTTP requests|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas

--- a/api/scsd.md
+++ b/api/scsd.md
@@ -71,9 +71,7 @@ Set TPM State in the BIOS settings.
 
 Base URLs:
 
-* <a href="http://api-gw-service-nmn.local/apis/scsd/v1">http://api-gw-service-nmn.local/apis/scsd/v1</a>
-
-* <a href="http://cray-scsd/v1">http://cray-scsd/v1</a>
+* <a href="https://api-gw-service-nmn.local/apis/scsd/v1">https://api-gw-service-nmn.local/apis/scsd/v1</a>
 
  License: Cray Proprietary
 
@@ -90,7 +88,7 @@ Endpoints that set or get Redfish Network Protocol information
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/dumpcfg HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/dumpcfg HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -99,7 +97,7 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/dumpcfg \
+curl -X POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/dumpcfg \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
@@ -114,7 +112,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/dumpcfg', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/dumpcfg', headers = headers)
 
 print(r.json())
 
@@ -137,7 +135,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/dumpcfg", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/dumpcfg", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -220,7 +218,7 @@ bearerAuth
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/loadcfg HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/loadcfg HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -229,7 +227,7 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/loadcfg \
+curl -X POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/loadcfg \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
@@ -244,7 +242,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/loadcfg', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/loadcfg', headers = headers)
 
 print(r.json())
 
@@ -267,7 +265,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/loadcfg", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/loadcfg", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -350,7 +348,7 @@ bearerAuth
 > Code samples
 
 ```http
-GET http://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname} HTTP/1.1
+GET https://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname} HTTP/1.1
 Host: api-gw-service-nmn.local
 Accept: application/json
 
@@ -358,7 +356,7 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X GET http://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname} \
+curl -X GET https://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname} \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
@@ -371,7 +369,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname}', headers = headers)
 
 print(r.json())
 
@@ -393,7 +391,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -458,7 +456,7 @@ bearerAuth
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname} HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname} HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -467,7 +465,7 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname} \
+curl -X POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
@@ -482,7 +480,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname}', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname}', headers = headers)
 
 print(r.json())
 
@@ -505,7 +503,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname}", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/cfg/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -585,7 +583,7 @@ Endpoints that set Redfish access credentials
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/discreetcreds HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/discreetcreds HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -594,7 +592,7 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/discreetcreds \
+curl -X POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/discreetcreds \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
@@ -609,7 +607,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/discreetcreds', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/discreetcreds', headers = headers)
 
 print(r.json())
 
@@ -632,7 +630,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/discreetcreds", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/discreetcreds", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -707,7 +705,7 @@ bearerAuth
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds/{xname} HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds/{xname} HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -716,7 +714,7 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds/{xname} \
+curl -X POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds/{xname} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
@@ -731,7 +729,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds/{xname}', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds/{xname}', headers = headers)
 
 print(r.json())
 
@@ -754,7 +752,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds/{xname}", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -819,7 +817,7 @@ bearerAuth
 > Code samples
 
 ```http
-GET http://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds HTTP/1.1
+GET https://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds HTTP/1.1
 Host: api-gw-service-nmn.local
 Accept: application/json
 
@@ -827,7 +825,7 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X GET http://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds \
+curl -X GET https://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
@@ -840,7 +838,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds', headers = headers)
 
 print(r.json())
 
@@ -862,7 +860,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/creds", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -919,7 +917,7 @@ bearerAuth
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/globalcreds HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/globalcreds HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -928,7 +926,7 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/globalcreds \
+curl -X POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/globalcreds \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
@@ -943,7 +941,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/globalcreds', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/globalcreds', headers = headers)
 
 print(r.json())
 
@@ -966,7 +964,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/globalcreds", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/globalcreds", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1041,7 +1039,7 @@ Endpoints that set or get BIOS information
 > Code samples
 
 ```http
-GET http://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field} HTTP/1.1
+GET https://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field} HTTP/1.1
 Host: api-gw-service-nmn.local
 Accept: application/json
 
@@ -1049,7 +1047,7 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X GET http://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field} \
+curl -X GET https://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field} \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
@@ -1062,7 +1060,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field}', headers = headers)
 
 print(r.json())
 
@@ -1084,7 +1082,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1143,7 +1141,7 @@ bearerAuth
 > Code samples
 
 ```http
-PATCH http://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field} HTTP/1.1
+PATCH https://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field} HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -1152,7 +1150,7 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH http://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field} \
+curl -X PATCH https://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
@@ -1167,7 +1165,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field}', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field}', headers = headers)
 
 print(r.json())
 
@@ -1190,7 +1188,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field}", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/bios/{xname}/{bios_field}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1265,7 +1263,7 @@ Endpoints that perform health and version checks
 > Code samples
 
 ```http
-GET http://api-gw-service-nmn.local/apis/scsd/v1/version HTTP/1.1
+GET https://api-gw-service-nmn.local/apis/scsd/v1/version HTTP/1.1
 Host: api-gw-service-nmn.local
 Accept: application/json
 
@@ -1273,7 +1271,7 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X GET http://api-gw-service-nmn.local/apis/scsd/v1/version \
+curl -X GET https://api-gw-service-nmn.local/apis/scsd/v1/version \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
@@ -1286,7 +1284,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://api-gw-service-nmn.local/apis/scsd/v1/version', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/scsd/v1/version', headers = headers)
 
 print(r.json())
 
@@ -1308,7 +1306,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://api-gw-service-nmn.local/apis/scsd/v1/version", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/scsd/v1/version", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1356,7 +1354,7 @@ Endpoints that create, delete, fetch, and apply TLS certs
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/createcerts HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/createcerts HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -1365,7 +1363,7 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/createcerts \
+curl -X POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/createcerts \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
@@ -1380,7 +1378,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/createcerts', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/createcerts', headers = headers)
 
 print(r.json())
 
@@ -1403,7 +1401,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/createcerts", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/createcerts", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1470,7 +1468,7 @@ bearerAuth
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/deletecerts HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/deletecerts HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -1479,7 +1477,7 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/deletecerts \
+curl -X POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/deletecerts \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
@@ -1494,7 +1492,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/deletecerts', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/deletecerts', headers = headers)
 
 print(r.json())
 
@@ -1517,7 +1515,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/deletecerts", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/deletecerts", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1584,7 +1582,7 @@ bearerAuth
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/fetchcerts HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/fetchcerts HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -1593,7 +1591,7 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/fetchcerts \
+curl -X POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/fetchcerts \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
@@ -1608,7 +1606,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/fetchcerts', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/fetchcerts', headers = headers)
 
 print(r.json())
 
@@ -1631,7 +1629,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/fetchcerts", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/fetchcerts", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1702,7 +1700,7 @@ bearerAuth
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcerts HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcerts HTTP/1.1
 Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
@@ -1711,7 +1709,7 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcerts \
+curl -X POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcerts \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
@@ -1726,7 +1724,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcerts', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcerts', headers = headers)
 
 print(r.json())
 
@@ -1749,7 +1747,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcerts", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcerts", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1817,14 +1815,14 @@ bearerAuth
 > Code samples
 
 ```http
-POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcert/{xname} HTTP/1.1
+POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcert/{xname} HTTP/1.1
 Host: api-gw-service-nmn.local
 
 ```
 
 ```shell
 # You can also use wget
-curl -X POST http://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcert/{xname} \
+curl -X POST https://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcert/{xname} \
   -H 'Authorization: Bearer {access-token}'
 
 ```
@@ -1835,7 +1833,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('http://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcert/{xname}', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcert/{xname}', headers = headers)
 
 print(r.json())
 
@@ -1856,7 +1854,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcert/{xname}", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/scsd/v1/bmc/setcert/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1900,14 +1898,14 @@ bearerAuth
 > Code samples
 
 ```http
-GET http://api-gw-service-nmn.local/apis/scsd/v1/liveness HTTP/1.1
+GET https://api-gw-service-nmn.local/apis/scsd/v1/liveness HTTP/1.1
 Host: api-gw-service-nmn.local
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://api-gw-service-nmn.local/apis/scsd/v1/liveness \
+curl -X GET https://api-gw-service-nmn.local/apis/scsd/v1/liveness \
   -H 'Authorization: Bearer {access-token}'
 
 ```
@@ -1918,7 +1916,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://api-gw-service-nmn.local/apis/scsd/v1/liveness', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/scsd/v1/liveness', headers = headers)
 
 print(r.json())
 
@@ -1939,7 +1937,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://api-gw-service-nmn.local/apis/scsd/v1/liveness", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/scsd/v1/liveness", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1972,14 +1970,14 @@ bearerAuth
 > Code samples
 
 ```http
-GET http://api-gw-service-nmn.local/apis/scsd/v1/readiness HTTP/1.1
+GET https://api-gw-service-nmn.local/apis/scsd/v1/readiness HTTP/1.1
 Host: api-gw-service-nmn.local
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://api-gw-service-nmn.local/apis/scsd/v1/readiness \
+curl -X GET https://api-gw-service-nmn.local/apis/scsd/v1/readiness \
   -H 'Authorization: Bearer {access-token}'
 
 ```
@@ -1990,7 +1988,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://api-gw-service-nmn.local/apis/scsd/v1/readiness', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/scsd/v1/readiness', headers = headers)
 
 print(r.json())
 
@@ -2011,7 +2009,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://api-gw-service-nmn.local/apis/scsd/v1/readiness", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/scsd/v1/readiness", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2044,7 +2042,7 @@ bearerAuth
 > Code samples
 
 ```http
-GET http://api-gw-service-nmn.local/apis/scsd/v1/health HTTP/1.1
+GET https://api-gw-service-nmn.local/apis/scsd/v1/health HTTP/1.1
 Host: api-gw-service-nmn.local
 Accept: application/json
 
@@ -2052,7 +2050,7 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X GET http://api-gw-service-nmn.local/apis/scsd/v1/health \
+curl -X GET https://api-gw-service-nmn.local/apis/scsd/v1/health \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
@@ -2065,7 +2063,7 @@ headers = {
   'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://api-gw-service-nmn.local/apis/scsd/v1/health', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/scsd/v1/health', headers = headers)
 
 print(r.json())
 
@@ -2087,7 +2085,7 @@ func main() {
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://api-gw-service-nmn.local/apis/scsd/v1/health", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/scsd/v1/health", data)
     req.Header = headers
 
     client := &http.Client{}

--- a/api/sls.md
+++ b/api/sls.md
@@ -121,8 +121,6 @@ Base URLs:
 
 * <a href="https://api-gw-service-nmn.local/apis/sls/v1">https://api-gw-service-nmn.local/apis/sls/v1</a>
 
-* <a href="http://cray-sls">http://cray-sls</a>
-
  License: Cray Proprietary
 
 # Authentication

--- a/api/sls.md
+++ b/api/sls.md
@@ -125,6 +125,10 @@ Base URLs:
 
  License: Cray Proprietary
 
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
+
 <h1 id="system-layout-service-hardware">hardware</h1>
 
 Endpoints which request information about hardware
@@ -143,14 +147,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/sls/v1/hardware \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/sls/v1/hardware', headers = headers)
@@ -171,6 +177,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -354,8 +361,9 @@ Status Code **200**
 |NodeType|Management|
 |NodeType|Management|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__hardware
@@ -374,7 +382,8 @@ Accept: application/json
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/sls/v1/hardware \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -382,7 +391,8 @@ curl -X POST https://api-gw-service-nmn.local/apis/sls/v1/hardware \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/sls/v1/hardware', headers = headers)
@@ -404,6 +414,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -476,8 +487,9 @@ Create a new hardware object.
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Conflict. The requested resource already exists|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Unexpected error. See body for details|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__hardware_{xname}
@@ -494,14 +506,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/sls/v1/hardware/{xname} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/sls/v1/hardware/{xname}', headers = headers)
@@ -522,6 +536,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -577,8 +592,9 @@ Retrieve information about the requested xname. All properties are returned as a
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Request successful|[hardware](#schemahardware)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## put__hardware_{xname}
@@ -597,7 +613,8 @@ Accept: application/json
 # You can also use wget
 curl -X PUT https://api-gw-service-nmn.local/apis/sls/v1/hardware/{xname} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -605,7 +622,8 @@ curl -X PUT https://api-gw-service-nmn.local/apis/sls/v1/hardware/{xname} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.put('https://api-gw-service-nmn.local/apis/sls/v1/hardware/{xname}', headers = headers)
@@ -627,6 +645,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -699,8 +718,9 @@ Update a hardware object.  Parent objects will be created, if possible.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. See body for details|None|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Unexpected error. See body for details|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete__hardware_{xname}
@@ -715,14 +735,18 @@ Host: api-gw-service-nmn.local
 
 ```shell
 # You can also use wget
-curl -X DELETE https://api-gw-service-nmn.local/apis/sls/v1/hardware/{xname}
+curl -X DELETE https://api-gw-service-nmn.local/apis/sls/v1/hardware/{xname} \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
+headers = {
+  'Authorization': 'Bearer {access-token}'
+}
 
-r = requests.delete('https://api-gw-service-nmn.local/apis/sls/v1/hardware/{xname}')
+r = requests.delete('https://api-gw-service-nmn.local/apis/sls/v1/hardware/{xname}', headers = headers)
 
 print(r.json())
 
@@ -737,6 +761,10 @@ import (
 )
 
 func main() {
+
+    headers := map[string][]string{
+        "Authorization": []string{"Bearer {access-token}"},
+    }
 
     data := bytes.NewBuffer([]byte{jsonReq})
     req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/sls/v1/hardware/{xname}", data)
@@ -769,8 +797,9 @@ Delete the requested xname from SLS. Note that if you delete a parent object, th
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Xname not found|None|
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Conflict. The xname probably still had children.|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="system-layout-service-search">search</h1>
@@ -791,14 +820,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/sls/v1/search/hardware \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/sls/v1/search/hardware', headers = headers)
@@ -819,6 +850,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1027,8 +1059,9 @@ Status Code **200**
 |NodeType|Management|
 |NodeType|Management|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__search_networks
@@ -1045,14 +1078,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/sls/v1/search/networks \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/sls/v1/search/networks', headers = headers)
@@ -1073,6 +1108,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1190,8 +1226,9 @@ Status Code **200**
 |»»» Comment|string|false|none|none|
 |»» Comment|string|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="system-layout-service-dumpstate">dumpstate</h1>
@@ -1212,14 +1249,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/sls/v1/dumpstate \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/sls/v1/dumpstate', headers = headers)
@@ -1240,6 +1279,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1393,8 +1433,9 @@ Get a dump of current service state. The format of this is implementation-specif
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|State dumped successfully|[slsState](#schemaslsstate)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An error occurred in state dumping.  See body for details|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__loadstate
@@ -1411,14 +1452,16 @@ Content-Type: multipart/form-data
 ```shell
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/sls/v1/loadstate \
-  -H 'Content-Type: multipart/form-data'
+  -H 'Content-Type: multipart/form-data' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Content-Type': 'multipart/form-data'
+  'Content-Type': 'multipart/form-data',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/sls/v1/loadstate', headers = headers)
@@ -1439,6 +1482,7 @@ func main() {
 
     headers := map[string][]string{
         "Content-Type": []string{"multipart/form-data"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1635,8 +1679,9 @@ sls_dump:
 |201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|State loaded successfully|None|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Loading state failed.  See body for error|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="system-layout-service-misc">misc</h1>
@@ -1657,14 +1702,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/sls/v1/health \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/sls/v1/health', headers = headers)
@@ -1685,6 +1732,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1736,8 +1784,9 @@ Status Code **200**
 |» Vault|string|true|none|Status of the Vault.|
 |» DBConnection|string|true|none|Status of the connection with the database.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__liveness
@@ -1754,14 +1803,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/sls/v1/liveness \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/sls/v1/liveness', headers = headers)
@@ -1782,6 +1833,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1824,8 +1876,9 @@ This is primarily an endpoint for the automated Kubernetes system.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|[No Content](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5) Network API call success|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Operation Not Permitted.  For /liveness, only GET operations are allowed.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__readiness
@@ -1842,14 +1895,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/sls/v1/readiness \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/sls/v1/readiness', headers = headers)
@@ -1870,6 +1925,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1912,8 +1968,9 @@ This is primarily an endpoint for the automated Kubernetes system.
 |204|[No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5)|[No Content](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.5) Network API call success|None|
 |405|[Method Not Allowed](https://tools.ietf.org/html/rfc7231#section-6.5.5)|Operation Not Permitted.  For /readiness, only GET operations are allowed.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__version
@@ -1930,14 +1987,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/sls/v1/version \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/sls/v1/version', headers = headers)
@@ -1958,6 +2017,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -1999,8 +2059,9 @@ Retrieve the current version of the SLS mapping. Information returned is a JSON 
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Information retrieved successfully|[versionResponse](#schemaversionresponse)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|An error occurred, see text of response for more information|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="system-layout-service-network">network</h1>
@@ -2019,14 +2080,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/sls/v1/networks \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/sls/v1/networks', headers = headers)
@@ -2047,6 +2110,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2155,8 +2219,9 @@ Status Code **200**
 |»»» Comment|string|false|none|none|
 |»» Comment|string|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__networks
@@ -2173,14 +2238,16 @@ Content-Type: application/json
 ```shell
 # You can also use wget
 curl -X POST https://api-gw-service-nmn.local/apis/sls/v1/networks \
-  -H 'Content-Type: application/json'
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Content-Type': 'application/json'
+  'Content-Type': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.post('https://api-gw-service-nmn.local/apis/sls/v1/networks', headers = headers)
@@ -2201,6 +2268,7 @@ func main() {
 
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2277,8 +2345,9 @@ Create a new network. Must include all fields at the time of upload.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. See body for details|None|
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Network with that name already exists|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__networks_{network}
@@ -2295,14 +2364,16 @@ Accept: application/json
 ```shell
 # You can also use wget
 curl -X GET https://api-gw-service-nmn.local/apis/sls/v1/networks/{network} \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.get('https://api-gw-service-nmn.local/apis/sls/v1/networks/{network}', headers = headers)
@@ -2323,6 +2394,7 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2402,8 +2474,9 @@ Retrieve the specific network.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Request successful|[network](#schemanetwork)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|No network item found with requested name|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## put__networks_{network}
@@ -2422,7 +2495,8 @@ Accept: application/json
 # You can also use wget
 curl -X PUT https://api-gw-service-nmn.local/apis/sls/v1/networks/{network} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2430,7 +2504,8 @@ curl -X PUT https://api-gw-service-nmn.local/apis/sls/v1/networks/{network} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
 r = requests.put('https://api-gw-service-nmn.local/apis/sls/v1/networks/{network}', headers = headers)
@@ -2452,6 +2527,7 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
@@ -2576,8 +2652,9 @@ Update a network object. Parent objects will be created, if possible.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request. See body for details|None|
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Conflict. The requested resource already exists|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete__networks_{network}
@@ -2592,14 +2669,18 @@ Host: api-gw-service-nmn.local
 
 ```shell
 # You can also use wget
-curl -X DELETE https://api-gw-service-nmn.local/apis/sls/v1/networks/{network}
+curl -X DELETE https://api-gw-service-nmn.local/apis/sls/v1/networks/{network} \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
+headers = {
+  'Authorization': 'Bearer {access-token}'
+}
 
-r = requests.delete('https://api-gw-service-nmn.local/apis/sls/v1/networks/{network}')
+r = requests.delete('https://api-gw-service-nmn.local/apis/sls/v1/networks/{network}', headers = headers)
 
 print(r.json())
 
@@ -2614,6 +2695,10 @@ import (
 )
 
 func main() {
+
+    headers := map[string][]string{
+        "Authorization": []string{"Bearer {access-token}"},
+    }
 
     data := bytes.NewBuffer([]byte{jsonReq})
     req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/sls/v1/networks/{network}", data)
@@ -2645,8 +2730,9 @@ Delete the specific network from SLS.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK. Network removed|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Network not found|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas

--- a/api/smd.md
+++ b/api/smd.md
@@ -107,7 +107,11 @@ Generally, nodes transition 'Off' -> 'On' -> 'Ready' when going from 'Off' to bo
 
 Base URLs:
 
-* <a href="https://sms/apis/smd/hsm/v2">https://sms/apis/smd/hsm/v2</a>
+* <a href="https://api-gw-service-nmn.local/apis/smd/hsm/v2">https://api-gw-service-nmn.local/apis/smd/hsm/v2</a>
+
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
 
 <h1 id="hardware-state-manager-api-service-info">Service Info</h1>
 
@@ -120,26 +124,28 @@ Service information APIs for getting information on the HSM service such as read
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/service/ready HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/ready HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/service/ready \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/ready \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/service/ready', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/ready', headers = headers)
 
 print(r.json())
 
@@ -157,10 +163,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/service/ready", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/ready", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -197,8 +204,9 @@ This is primarily an endpoint for the automated Kubernetes system.
 |503|[Service Unavailable](https://tools.ietf.org/html/rfc7231#section-6.6.4)|The service is unhealthy and not ready|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doLivenessGet
@@ -208,26 +216,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/service/liveness HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/liveness HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/service/liveness \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/liveness \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/service/liveness', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/liveness', headers = headers)
 
 print(r.json())
 
@@ -245,10 +255,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/service/liveness", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/liveness", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -288,8 +299,9 @@ This is primarily an endpoint for the automated Kubernetes system.
 |503|[Service Unavailable](https://tools.ietf.org/html/rfc7231#section-6.6.4)|The service is not taking HTTP requests|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doValuesGet
@@ -299,26 +311,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/service/values HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/service/values \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/service/values', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values', headers = headers)
 
 print(r.json())
 
@@ -336,10 +350,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/service/values", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -370,8 +385,9 @@ null
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|An array of parameters and their valid values.|[Values.1.0.0_Values](#schemavalues.1.0.0_values)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doArchValuesGet
@@ -381,26 +397,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/service/values/arch HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/arch HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/service/values/arch \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/arch \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/service/values/arch', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/arch', headers = headers)
 
 print(r.json())
 
@@ -418,10 +436,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/service/values/arch", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/arch", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -456,8 +475,9 @@ Retrieve all valid values for use with the 'arch' (component architecture) param
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|An array of valid values for the 'arch' parameter.|[Values.1.0.0_ArchArray](#schemavalues.1.0.0_archarray)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doClassValuesGet
@@ -467,26 +487,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/service/values/class HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/class HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/service/values/class \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/class \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/service/values/class', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/class', headers = headers)
 
 print(r.json())
 
@@ -504,10 +526,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/service/values/class", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/class", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -542,8 +565,9 @@ Retrieve all valid values for use with the 'class' (hardware class) parameter.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|An array of valid values for the 'class' parameter.|[Values.1.0.0_ClassArray](#schemavalues.1.0.0_classarray)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doFlagValuesGet
@@ -553,26 +577,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/service/values/flag HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/flag HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/service/values/flag \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/flag \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/service/values/flag', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/flag', headers = headers)
 
 print(r.json())
 
@@ -590,10 +616,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/service/values/flag", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/flag", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -628,8 +655,9 @@ Retrieve all valid values for use with the 'flag' (component flag) parameter.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|An array of valid values for the 'flag' parameter.|[Values.1.0.0_FlagArray](#schemavalues.1.0.0_flagarray)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doNetTypeValuesGet
@@ -639,26 +667,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/service/values/nettype HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/nettype HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/service/values/nettype \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/nettype \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/service/values/nettype', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/nettype', headers = headers)
 
 print(r.json())
 
@@ -676,10 +706,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/service/values/nettype", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/nettype", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -714,8 +745,9 @@ Retrieve all valid values for use with the 'nettype' (component network type) pa
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|An array of valid values for the 'nettype' parameter.|[Values.1.0.0_NetTypeArray](#schemavalues.1.0.0_nettypearray)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doRoleValuesGet
@@ -725,26 +757,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/service/values/role HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/role HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/service/values/role \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/role \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/service/values/role', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/role', headers = headers)
 
 print(r.json())
 
@@ -762,10 +796,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/service/values/role", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/role", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -800,8 +835,9 @@ Retrieve all valid values for use with the 'role' (component role) parameter.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|An array of valid values for the 'role' parameter.|[Values.1.0.0_RoleArray](#schemavalues.1.0.0_rolearray)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doSubRoleValuesGet
@@ -811,26 +847,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/service/values/subrole HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/subrole HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/service/values/subrole \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/subrole \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/service/values/subrole', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/subrole', headers = headers)
 
 print(r.json())
 
@@ -848,10 +886,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/service/values/subrole", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/subrole", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -886,8 +925,9 @@ Retrieve all valid values for use with the 'subrole' (component subrole) paramet
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|An array of valid values for the 'subrole' parameter.|[Values.1.0.0_SubRoleArray](#schemavalues.1.0.0_subrolearray)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doStateValuesGet
@@ -897,26 +937,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/service/values/state HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/state HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/service/values/state \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/state \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/service/values/state', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/state', headers = headers)
 
 print(r.json())
 
@@ -934,10 +976,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/service/values/state", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/state", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -972,8 +1015,9 @@ Retrieve all valid values for use with the 'state' (component state) parameter.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|An array of valid values for the 'state' parameter.|[Values.1.0.0_StateArray](#schemavalues.1.0.0_statearray)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doTypeValuesGet
@@ -983,26 +1027,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/service/values/type HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/type HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/service/values/type \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/type \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/service/values/type', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/type', headers = headers)
 
 print(r.json())
 
@@ -1020,10 +1066,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/service/values/type", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/service/values/type", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1058,8 +1105,9 @@ Retrieve all valid values for use with the 'type' (component HMSType) parameter.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|An array of valid values for the 'type' parameter.|[Values.1.0.0_TypeArray](#schemavalues.1.0.0_typearray)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-component">Component</h1>
@@ -1073,26 +1121,28 @@ High-level component information by xname: state, flag, NID, role, etc.
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/State/Components HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/State/Components \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/State/Components', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components', headers = headers)
 
 print(r.json())
 
@@ -1110,10 +1160,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/State/Components", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1269,8 +1320,9 @@ Additional valid values may be added via configuration file. See the results of 
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request such as invalid argument for filter|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doComponentsPost
@@ -1280,8 +1332,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/State/Components HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -1289,9 +1341,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/State/Components \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1299,10 +1352,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/State/Components \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/State/Components', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components', headers = headers)
 
 print(r.json())
 
@@ -1321,10 +1375,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/State/Components", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1392,8 +1447,9 @@ Create/Update a collection of state/components. If the component already exists 
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request such as invalid argument for a component field|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doComponentsDeleteAll
@@ -1403,26 +1459,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/State/Components HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/State/Components \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/State/Components', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components', headers = headers)
 
 print(r.json())
 
@@ -1440,10 +1498,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/State/Components", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1479,8 +1538,9 @@ Delete all entries in the components collection.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Collection is empty|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doComponentGet
@@ -1490,26 +1550,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/State/Components/{xname} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/State/Components/{xname} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/State/Components/{xname}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}', headers = headers)
 
 print(r.json())
 
@@ -1527,10 +1589,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/State/Components/{xname}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1585,8 +1648,9 @@ Retrieve state or components by xname.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doComponentPut
@@ -1596,8 +1660,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PUT https://sms/apis/smd/hsm/v2/State/Components/{xname} HTTP/1.1
-Host: sms
+PUT https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -1605,9 +1669,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PUT https://sms/apis/smd/hsm/v2/State/Components/{xname} \
+curl -X PUT https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1615,10 +1680,11 @@ curl -X PUT https://sms/apis/smd/hsm/v2/State/Components/{xname} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.put('https://sms/apis/smd/hsm/v2/State/Components/{xname}', headers = headers)
+r = requests.put('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}', headers = headers)
 
 print(r.json())
 
@@ -1637,10 +1703,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PUT", "https://sms/apis/smd/hsm/v2/State/Components/{xname}", data)
+    req, err := http.NewRequest("PUT", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1707,8 +1774,9 @@ Create/Update a state/component. If the component already exists it will not be 
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request such as invalid argument for a component field|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doComponentDelete
@@ -1718,26 +1786,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/State/Components/{xname} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/State/Components/{xname} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/State/Components/{xname}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}', headers = headers)
 
 print(r.json())
 
@@ -1755,10 +1825,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/State/Components/{xname}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1800,8 +1871,9 @@ Delete a component by xname.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|XName does Not Exist - no matching ID to delete|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doComponentByNIDGet
@@ -1811,26 +1883,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/State/Components/ByNID/{nid} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/ByNID/{nid} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/State/Components/ByNID/{nid} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/ByNID/{nid} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/State/Components/ByNID/{nid}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/ByNID/{nid}', headers = headers)
 
 print(r.json())
 
@@ -1848,10 +1922,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/State/Components/ByNID/{nid}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/ByNID/{nid}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1906,8 +1981,9 @@ Retrieve a component by NID.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompBulkStateDataPatch
@@ -1917,8 +1993,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkStateData HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkStateData HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -1926,9 +2002,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkStateData \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkStateData \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -1936,10 +2013,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkStateData \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/State/Components/BulkStateData', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkStateData', headers = headers)
 
 print(r.json())
 
@@ -1958,10 +2036,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/State/Components/BulkStateData", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkStateData", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2024,8 +2103,9 @@ Specify a list of xnames to update the State and Flag fields. If the Flag field 
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompStatePatch
@@ -2035,8 +2115,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/StateData HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/StateData HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -2044,9 +2124,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/StateData \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/StateData \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2054,10 +2135,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/StateData \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/State/Components/{xname}/StateData', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/StateData', headers = headers)
 
 print(r.json())
 
@@ -2076,10 +2158,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/State/Components/{xname}/StateData", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/StateData", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2140,8 +2223,9 @@ Update the component's state and flag fields only. If Flag field is omitted, the
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompBulkFlagOnlyPatch
@@ -2151,8 +2235,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkFlagOnly HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkFlagOnly HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -2160,9 +2244,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkFlagOnly \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkFlagOnly \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2170,10 +2255,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkFlagOnly \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/State/Components/BulkFlagOnly', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkFlagOnly', headers = headers)
 
 print(r.json())
 
@@ -2192,10 +2278,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/State/Components/BulkFlagOnly", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkFlagOnly", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2256,8 +2343,9 @@ Specify a list of xnames to update the Flag field and specify the value. The lis
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompFlagOnlyPatch
@@ -2267,8 +2355,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/FlagOnly HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/FlagOnly HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -2276,9 +2364,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/FlagOnly \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/FlagOnly \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2286,10 +2375,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/FlagOnly \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/State/Components/{xname}/FlagOnly', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/FlagOnly', headers = headers)
 
 print(r.json())
 
@@ -2308,10 +2398,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/State/Components/{xname}/FlagOnly", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/FlagOnly", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2370,8 +2461,9 @@ The State is not modified. Only the Flag is updated.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompBulkEnabledPatch
@@ -2381,8 +2473,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkEnabled HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkEnabled HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -2390,9 +2482,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkEnabled \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkEnabled \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2400,10 +2493,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkEnabled \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/State/Components/BulkEnabled', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkEnabled', headers = headers)
 
 print(r.json())
 
@@ -2422,10 +2516,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/State/Components/BulkEnabled", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkEnabled", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2486,8 +2581,9 @@ Update the Enabled field for a list of xnames. Specify a single value for Enable
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompEnabledPatch
@@ -2497,8 +2593,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/Enabled HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/Enabled HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -2506,9 +2602,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/Enabled \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/Enabled \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2516,10 +2613,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/Enabled \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/State/Components/{xname}/Enabled', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/Enabled', headers = headers)
 
 print(r.json())
 
@@ -2538,10 +2636,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/State/Components/{xname}/Enabled", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/Enabled", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2600,8 +2699,9 @@ Update the component's Enabled field only. The State and other fields are not mo
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompBulkSwStatusPatch
@@ -2611,8 +2711,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkSoftwareStatus HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkSoftwareStatus HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -2620,9 +2720,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkSoftwareStatus \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkSoftwareStatus \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2630,10 +2731,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkSoftwareStatus \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/State/Components/BulkSoftwareStatus', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkSoftwareStatus', headers = headers)
 
 print(r.json())
 
@@ -2652,10 +2754,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/State/Components/BulkSoftwareStatus", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkSoftwareStatus", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2716,8 +2819,9 @@ Update the SoftwareStatus field for a list of xnames. Specify a single new value
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompSwStatusPatch
@@ -2727,8 +2831,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/SoftwareStatus HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/SoftwareStatus HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -2736,9 +2840,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/SoftwareStatus \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/SoftwareStatus \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2746,10 +2851,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/SoftwareStatu
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/State/Components/{xname}/SoftwareStatus', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/SoftwareStatus', headers = headers)
 
 print(r.json())
 
@@ -2768,10 +2874,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/State/Components/{xname}/SoftwareStatus", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/SoftwareStatus", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2830,8 +2937,9 @@ Update the component's SoftwareStatus field only. The State and other fields are
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompBulkRolePatch
@@ -2841,8 +2949,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkRole HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkRole HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -2850,9 +2958,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkRole \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkRole \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2860,10 +2969,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkRole \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/State/Components/BulkRole', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkRole', headers = headers)
 
 print(r.json())
 
@@ -2882,10 +2992,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/State/Components/BulkRole", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkRole", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2947,8 +3058,9 @@ Update the Role and SubRole field for a list of xnames. Specify the Role and Sub
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompRolePatch
@@ -2958,8 +3070,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/Role HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/Role HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -2967,9 +3079,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/Role \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/Role \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -2977,10 +3090,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/Role \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/State/Components/{xname}/Role', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/Role', headers = headers)
 
 print(r.json())
 
@@ -2999,10 +3113,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/State/Components/{xname}/Role", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/Role", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3062,8 +3177,9 @@ Update the component's Role and SubRole fields only. Valid only for nodes. The S
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompArrayNIDPatch
@@ -3073,8 +3189,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkNID HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkNID HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -3082,9 +3198,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkNID \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkNID \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3092,10 +3209,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/BulkNID \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/State/Components/BulkNID', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkNID', headers = headers)
 
 print(r.json())
 
@@ -3114,10 +3232,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/State/Components/BulkNID", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/BulkNID", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3180,8 +3299,9 @@ Modify the submitted ComponentArray and update the corresponding NID value for e
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompNIDPatch
@@ -3191,8 +3311,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/NID HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/NID HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -3200,9 +3320,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/NID \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/NID \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3210,10 +3331,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/State/Components/{xname}/NID \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/State/Components/{xname}/NID', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/NID', headers = headers)
 
 print(r.json())
 
@@ -3232,10 +3354,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/State/Components/{xname}/NID", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/{xname}/NID", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3294,8 +3417,9 @@ Update the component's NID field only. Valid only for nodes. State and other fie
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doComponentsQueryPost
@@ -3305,8 +3429,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/State/Components/Query HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/Query HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -3314,9 +3438,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/State/Components/Query \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/Query \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3324,10 +3449,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/State/Components/Query \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/State/Components/Query', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/Query', headers = headers)
 
 print(r.json())
 
@@ -3346,10 +3472,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/State/Components/Query", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/Query", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3463,8 +3590,9 @@ Retrieve the targeted entries in the form of a ComponentArray by providing a pay
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doComponentByNIDQueryPost
@@ -3474,8 +3602,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/State/Components/ByNID/Query HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/ByNID/Query HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -3483,9 +3611,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/State/Components/ByNID/Query \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/ByNID/Query \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3493,10 +3622,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/State/Components/ByNID/Query \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/State/Components/ByNID/Query', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/ByNID/Query', headers = headers)
 
 print(r.json())
 
@@ -3515,10 +3645,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/State/Components/ByNID/Query", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/ByNID/Query", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3592,8 +3723,9 @@ Retrieve the targeted entries in the form of a ComponentArray by providing a pay
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doComponentQueryGet
@@ -3603,26 +3735,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/State/Components/Query/{xname} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/Query/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/State/Components/Query/{xname} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/Query/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/State/Components/Query/{xname}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/Query/{xname}', headers = headers)
 
 print(r.json())
 
@@ -3640,10 +3774,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/State/Components/Query/{xname}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components/Query/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3800,8 +3935,9 @@ Additional valid values may be added via configuration file. See the results of 
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-nodemap">NodeMap</h1>
@@ -3815,26 +3951,28 @@ Given a node xname ID, provide defaults for NID, Role, etc. to be used when the 
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Defaults/NodeMaps HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Defaults/NodeMaps \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Defaults/NodeMaps', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps', headers = headers)
 
 print(r.json())
 
@@ -3852,10 +3990,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Defaults/NodeMaps", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3896,8 +4035,9 @@ Retrieve all Node map entries as a named array, or an empty array if the collect
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doNodeMapPost
@@ -3907,8 +4047,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/Defaults/NodeMaps HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -3916,9 +4056,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/Defaults/NodeMaps \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -3926,10 +4067,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/Defaults/NodeMaps \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/Defaults/NodeMaps', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps', headers = headers)
 
 print(r.json())
 
@@ -3948,10 +4090,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/Defaults/NodeMaps", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -4020,8 +4163,9 @@ Note the following points:
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Conflict. Duplicate resource (NID) would be created.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doNodeMapsDeleteAll
@@ -4031,26 +4175,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Defaults/NodeMaps HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Defaults/NodeMaps \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Defaults/NodeMaps', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps', headers = headers)
 
 print(r.json())
 
@@ -4068,10 +4214,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Defaults/NodeMaps", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -4107,8 +4254,9 @@ Delete all entries in the NodeMaps collection.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Collection is empty|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doNodeMapGet
@@ -4118,26 +4266,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Defaults/NodeMaps/{xname} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Defaults/NodeMaps/{xname} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Defaults/NodeMaps/{xname}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps/{xname}', headers = headers)
 
 print(r.json())
 
@@ -4155,10 +4305,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Defaults/NodeMaps/{xname}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -4202,8 +4353,9 @@ Retrieve NodeMap, i.e. defaults NID/Role/etc. for node located at physical locat
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doNodeMapDelete
@@ -4213,26 +4365,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Defaults/NodeMaps/{xname} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Defaults/NodeMaps/{xname} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Defaults/NodeMaps/{xname}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps/{xname}', headers = headers)
 
 print(r.json())
 
@@ -4250,10 +4404,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Defaults/NodeMaps/{xname}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -4295,8 +4450,9 @@ Delete NodeMap entry for a specific node {xname}.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|XName does Not Exist - no matching ID to delete|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doNodeMapPut
@@ -4306,8 +4462,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PUT https://sms/apis/smd/hsm/v2/Defaults/NodeMaps/{xname} HTTP/1.1
-Host: sms
+PUT https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -4315,9 +4471,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PUT https://sms/apis/smd/hsm/v2/Defaults/NodeMaps/{xname} \
+curl -X PUT https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps/{xname} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -4325,10 +4482,11 @@ curl -X PUT https://sms/apis/smd/hsm/v2/Defaults/NodeMaps/{xname} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.put('https://sms/apis/smd/hsm/v2/Defaults/NodeMaps/{xname}', headers = headers)
+r = requests.put('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps/{xname}', headers = headers)
 
 print(r.json())
 
@@ -4347,10 +4505,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PUT", "https://sms/apis/smd/hsm/v2/Defaults/NodeMaps/{xname}", data)
+    req, err := http.NewRequest("PUT", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Defaults/NodeMaps/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -4408,8 +4567,9 @@ Update or create an entry for an individual node xname using PUT. Note the follo
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Conflict. Duplicate resource (NID) would be created.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-hwinventory">HWInventory</h1>
@@ -4423,26 +4583,28 @@ HWInventoryByLocation collection containing all components matching the query th
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/Hardware/Query/{xname} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/Query/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/Hardware/Query/{xname} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/Query/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/Hardware/Query/{xname}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/Query/{xname}', headers = headers)
 
 print(r.json())
 
@@ -4460,10 +4622,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/Hardware/Query/{xname}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/Query/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -5113,8 +5276,9 @@ Default is NestNodesOnly.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-hwinventorybylocation">HWInventoryByLocation</h1>
@@ -5128,26 +5292,28 @@ Hardware inventory information for the given system location/xname
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/Hardware HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/Hardware \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/Hardware', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware', headers = headers)
 
 print(r.json())
 
@@ -5165,10 +5331,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/Hardware", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -5399,8 +5566,9 @@ Status Code **200**
 |HWInventoryByFRUType|HWInvByFRURouterBMC|
 |HWInventoryByFRUType|HWIncByFRUHSNNIC|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doHWInvByLocationPost
@@ -5410,8 +5578,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/Inventory/Hardware HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -5419,9 +5587,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/Inventory/Hardware \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -5429,10 +5598,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/Inventory/Hardware \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/Inventory/Hardware', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware', headers = headers)
 
 print(r.json())
 
@@ -5451,10 +5621,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/Inventory/Hardware", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -5657,8 +5828,9 @@ Create/Update hardware inventory entries
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doHWInvByLocationDeleteAll
@@ -5668,26 +5840,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/Hardware HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/Hardware \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/Hardware', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware', headers = headers)
 
 print(r.json())
 
@@ -5705,10 +5879,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/Hardware", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -5744,8 +5919,9 @@ Delete all entries in the HWInventoryByLocation collection. Note that this does 
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Collection is empty|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doHWInvByLocationGet
@@ -5755,26 +5931,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/Hardware/{xname} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/Hardware/{xname} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/Hardware/{xname}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/{xname}', headers = headers)
 
 print(r.json())
 
@@ -5792,10 +5970,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/Hardware/{xname}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -6064,8 +6243,9 @@ null
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doHWInvByLocationDelete
@@ -6075,26 +6255,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/Hardware/{xname} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/Hardware/{xname} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/Hardware/{xname}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/{xname}', headers = headers)
 
 print(r.json())
 
@@ -6112,10 +6294,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/Hardware/{xname}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -6157,8 +6340,9 @@ Delete HWInventoryByLocation entry for a specific xname.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|XName does Not Exist - no matching ID to delete|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-hwinventorybyfru">HWInventoryByFRU</h1>
@@ -6172,26 +6356,28 @@ This represents a physical piece of hardware with properties specific to a uniqu
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU', headers = headers)
 
 print(r.json())
 
@@ -6209,10 +6395,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -6391,8 +6578,9 @@ Status Code **200**
 |HWInventoryByFRUType|HWInvByFRURouterBMC|
 |HWInventoryByFRUType|HWIncByFRUHSNNIC|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doHWInvByFRUDeleteAll
@@ -6402,26 +6590,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU', headers = headers)
 
 print(r.json())
 
@@ -6439,10 +6629,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -6478,8 +6669,9 @@ Delete all entries in the HWInventoryByFRU collection. Note that this does not d
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Collection is empty|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doHWInvByFRUGet
@@ -6489,26 +6681,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid}', headers = headers)
 
 print(r.json())
 
@@ -6526,10 +6720,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -6584,8 +6779,9 @@ Retrieve HWInventoryByFRU for a specific fruID.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doHWInvByFRUDelete
@@ -6595,26 +6791,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid}', headers = headers)
 
 print(r.json())
 
@@ -6632,10 +6830,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/{fruid}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -6677,8 +6876,9 @@ Delete an entry in the HWInventoryByFRU collection. Note that this does not dele
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|FRU ID does Not Exist - no matching entry to delete|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-hwinventoryhistory">HWInventoryHistory</h1>
@@ -6692,26 +6892,28 @@ Hardware inventory historical information for the given system location/xname/FR
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/Hardware/History HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/Hardware/History \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/Hardware/History', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History', headers = headers)
 
 print(r.json())
 
@@ -6729,10 +6931,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/Hardware/History", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -6788,8 +6991,9 @@ Retrieve the history entries for all HWInventoryByLocation entries.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doHWInvHistByLocationDeleteAll
@@ -6799,26 +7003,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/Hardware/History HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/Hardware/History \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/Hardware/History', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History', headers = headers)
 
 print(r.json())
 
@@ -6836,10 +7042,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/Hardware/History", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -6875,8 +7082,9 @@ Delete all HWInventory history entries. Note that this also deletes history for 
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Collection is empty|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doHWInvHistByLocationGet
@@ -6886,26 +7094,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/Hardware/History/{xname} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/Hardware/History/{xname} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/Hardware/History/{xname}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History/{xname}', headers = headers)
 
 print(r.json())
 
@@ -6923,10 +7133,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/Hardware/History/{xname}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -6978,8 +7189,9 @@ Retrieve the history entries for a HWInventoryByLocation entry with a specific x
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doHWInvHistByLocationDelete
@@ -6989,26 +7201,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/Hardware/History/{xname} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/Hardware/History/{xname} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/Hardware/History/{xname}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History/{xname}', headers = headers)
 
 print(r.json())
 
@@ -7026,10 +7240,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/Hardware/History/{xname}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Hardware/History/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -7071,8 +7286,9 @@ Delete history for the HWInventoryByLocation entry for a specific xname.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|XName does Not Exist - no matching ID to delete|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doHWInvHistByFRUsGet
@@ -7082,26 +7298,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/History HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/History HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/History \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/History \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/History', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/History', headers = headers)
 
 print(r.json())
 
@@ -7119,10 +7337,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/History", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/History", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -7178,8 +7397,9 @@ Retrieve the history entries for all HWInventoryByFRU entries. Sorted by FRU.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doHWInvHistByFRUGet
@@ -7189,26 +7409,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid}', headers = headers)
 
 print(r.json())
 
@@ -7226,10 +7448,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -7281,8 +7504,9 @@ Retrieve the history entries for the HWInventoryByFRU for a specific fruID.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doHWInvHistByFRUDelete
@@ -7292,26 +7516,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid}', headers = headers)
 
 print(r.json())
 
@@ -7329,10 +7555,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/HardwareByFRU/History/{fruid}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -7374,8 +7601,9 @@ Delete history for an entry in the HWInventoryByFRU collection.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|FRU ID does Not Exist - no matching entry to delete|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-redfishendpoint">RedfishEndpoint</h1>
@@ -7389,26 +7617,28 @@ This is a BMC or other Redfish controller that has a Redfish entry point and Red
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints', headers = headers)
 
 print(r.json())
 
@@ -7426,10 +7656,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -7542,8 +7773,9 @@ Retrieve all Redfish endpoint entries as a named array, optionally filtering it.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doRedfishEndpointsPost
@@ -7553,8 +7785,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -7562,9 +7794,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -7572,10 +7805,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints', headers = headers)
 
 print(r.json())
 
@@ -7594,10 +7828,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -7683,8 +7918,9 @@ Status Code **201**
 |*anonymous*|[[ResourceURI.1.0.0](#schemaresourceuri.1.0.0)]|false|none|[A ResourceURI is like an odata.id, it provides a path to a resource from the API root, such that when a GET is performed, the corresponding object is returned.  It does not imply other odata functionality.]|
 |» ResourceURI|string|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doRedfishEndpointsDeleteAll
@@ -7694,26 +7930,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints', headers = headers)
 
 print(r.json())
 
@@ -7731,10 +7969,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -7770,8 +8009,9 @@ Delete all entries in the RedfishEndpoint collection.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Collection is empty|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doRedfishEndpointGet
@@ -7781,26 +8021,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}', headers = headers)
 
 print(r.json())
 
@@ -7818,10 +8060,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -7882,8 +8125,9 @@ Retrieve RedfishEndpoint, located at physical location {xname}.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doRedfishEndpointDelete
@@ -7893,26 +8137,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}', headers = headers)
 
 print(r.json())
 
@@ -7930,10 +8176,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -7975,8 +8222,9 @@ Delete RedfishEndpoint record for a specific xname.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|XName does Not Exist - no matching ID to delete|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doRedfishEndpointPut
@@ -7986,8 +8234,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PUT https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} HTTP/1.1
-Host: sms
+PUT https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -7995,9 +8243,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PUT https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} \
+curl -X PUT https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -8005,10 +8254,11 @@ curl -X PUT https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.put('https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}', headers = headers)
+r = requests.put('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}', headers = headers)
 
 print(r.json())
 
@@ -8027,10 +8277,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PUT", "https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}", data)
+    req, err := http.NewRequest("PUT", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -8113,8 +8364,9 @@ Create or update RedfishEndpoint record for a specific xname.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|XName does Not Exist - no matching ID to update|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doRedfishEndpointPatch
@@ -8124,8 +8376,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -8133,9 +8385,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -8143,10 +8396,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}', headers = headers)
 
 print(r.json())
 
@@ -8165,10 +8419,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -8251,8 +8506,9 @@ Update (PATCH) RedfishEndpoint record for a specific xname.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|XName does Not Exist - no matching ID to update|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doRedfishEndpointQueryGet
@@ -8262,26 +8518,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/Query/{xname} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/Query/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/Query/{xname} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/Query/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/Query/{xname}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/Query/{xname}', headers = headers)
 
 print(r.json())
 
@@ -8299,10 +8557,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/RedfishEndpoints/Query/{xname}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints/Query/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -8367,8 +8626,9 @@ Given xname and modifiers in query string, retrieve zero or more RedfishEndpoint
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - no matches|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-componentendpoint">ComponentEndpoint</h1>
@@ -8382,26 +8642,28 @@ The Redfish-discovered properties for a component discovered through, and manage
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints', headers = headers)
 
 print(r.json())
 
@@ -8419,10 +8681,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -8578,8 +8841,9 @@ Retrieve the full collection of ComponentEndpoints in the form of a ComponentEnd
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doComponentEndpointsDeleteAll
@@ -8589,26 +8853,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints', headers = headers)
 
 print(r.json())
 
@@ -8626,10 +8892,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -8665,8 +8932,9 @@ Delete all entries in the ComponentEndpoint collection.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Collection is empty|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doComponentEndpointGet
@@ -8676,26 +8944,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname}', headers = headers)
 
 print(r.json())
 
@@ -8713,10 +8983,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -8820,8 +9091,9 @@ Retrieve ComponentEndpoint record for a specific xname.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doComponentEndpointDelete
@@ -8831,26 +9103,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname}', headers = headers)
 
 print(r.json())
 
@@ -8868,10 +9142,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ComponentEndpoints/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -8913,8 +9188,9 @@ Delete ComponentEndpoint for a specific xname.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|XName does Not Exist - no matching ID to delete|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-serviceendpoint">ServiceEndpoint</h1>
@@ -8928,26 +9204,28 @@ The Redfish-discovered properties for a service discovered through, and managed 
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints', headers = headers)
 
 print(r.json())
 
@@ -8965,10 +9243,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -9058,8 +9337,9 @@ Retrieve the full collection of ServiceEndpoints in the form of a ServiceEndpoin
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doServiceEndpointsDeleteAll
@@ -9069,26 +9349,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints', headers = headers)
 
 print(r.json())
 
@@ -9106,10 +9388,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -9145,8 +9428,9 @@ Delete all entries in the ServiceEndpoint collection.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Collection is empty|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doServiceEndpointsGet
@@ -9156,26 +9440,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}', headers = headers)
 
 print(r.json())
 
@@ -9193,10 +9479,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -9287,8 +9574,9 @@ Retrieve all ServiceEndpoint records for the Redfish service.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Service does not exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doServiceEndpointGet
@@ -9298,26 +9586,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname}', headers = headers)
 
 print(r.json())
 
@@ -9335,10 +9625,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -9423,8 +9714,9 @@ Retrieve the ServiceEndpoint for a Redfish service that is managed by xname.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doServiceEndpointDelete
@@ -9434,26 +9726,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname}', headers = headers)
 
 print(r.json())
 
@@ -9471,10 +9765,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/ServiceEndpoints/{service}/RedfishEndpoints/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -9517,8 +9812,9 @@ Delete the {service} ServiceEndpoint managed by {xname}
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - no matching ServiceEndpoint to delete|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-componentethernetinterfaces">ComponentEthernetInterfaces</h1>
@@ -9532,26 +9828,28 @@ The MAC address to IP address relation for components in the system. If the comp
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces', headers = headers)
 
 print(r.json())
 
@@ -9569,10 +9867,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -9690,8 +9989,9 @@ Status Code **200**
 |Type|INVALID|
 |Type|VirtualNode|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompEthInterfacePostV2
@@ -9701,8 +10001,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -9710,9 +10010,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -9720,10 +10021,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces', headers = headers)
 
 print(r.json())
 
@@ -9742,10 +10044,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -9810,8 +10113,9 @@ Create a new component Ethernet interface.
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Conflict. Duplicate component Ethernet interface would be created.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompEthInterfaceDeleteAllV2
@@ -9821,26 +10125,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces', headers = headers)
 
 print(r.json())
 
@@ -9858,10 +10164,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -9897,8 +10204,9 @@ Delete all component Ethernet interface entries.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Collection is empty|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompEthInterfaceGetV2
@@ -9908,26 +10216,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}', headers = headers)
 
 print(r.json())
 
@@ -9945,10 +10255,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -10000,8 +10311,9 @@ Retrieve the component Ethernet interface which was created with the given {ethI
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompEthInterfaceDeleteV2
@@ -10011,26 +10323,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}', headers = headers)
 
 print(r.json())
 
@@ -10048,10 +10362,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -10093,8 +10408,9 @@ Delete the given component Ethernet interface with {ethInterfaceID}.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - No component Ethernet interface with ethInterfaceID.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompEthInterfacePatchV2
@@ -10104,8 +10420,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID} HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID} HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -10113,9 +10429,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID} \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -10123,10 +10440,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInter
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}', headers = headers)
 
 print(r.json())
 
@@ -10145,10 +10463,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -10209,8 +10528,9 @@ To update the IP address, CompID, and/or description of a component Ethernet int
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The component Ethernet interface with this ethInterfaceID does not exist.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompEthInterfaceIPAddressesGetV2
@@ -10220,26 +10540,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses', headers = headers)
 
 print(r.json())
 
@@ -10257,10 +10579,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -10314,8 +10637,9 @@ Status Code **200**
 |» IPAddress|string|true|none|The IP address associated with the MAC address for this component Ethernet interface on for this particular network.|
 |» Network|string|false|none|The network that this IP addresses is associated with.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompEthInterfaceIPAddressesPostV2
@@ -10325,8 +10649,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -10334,9 +10658,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -10344,10 +10669,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterf
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses', headers = headers)
 
 print(r.json())
 
@@ -10366,10 +10692,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -10420,8 +10747,9 @@ Create a new IP address mapping in a component Ethernet interface {ethInterfaceI
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Conflict. Duplicate IP address in component Ethernet interface would be created.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompEthInterfaceIPAddressPatchV2
@@ -10431,8 +10759,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress} HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress} HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -10440,9 +10768,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress} \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -10450,10 +10779,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInter
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress}', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress}', headers = headers)
 
 print(r.json())
 
@@ -10472,10 +10802,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress}", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -10530,8 +10861,9 @@ func main() {
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - No IP address with ipAddress exists on the specified component Ethernet interface.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doCompEthInterfaceIPAddressDeleteV2
@@ -10541,26 +10873,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress}', headers = headers)
 
 print(r.json())
 
@@ -10578,10 +10912,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/EthernetInterfaces/{ethInterfaceID}/IPAddresses/{ipAddress}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -10624,8 +10959,9 @@ Delete the given IP address mapping with {ipAddress} from a component Ethernet i
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - No IP address with ipAddress exists on the specified component Ethernet interface|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-group">Group</h1>
@@ -10639,26 +10975,28 @@ A group is an informal, possibly overlapping division of the system that groups 
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/groups HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/groups \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/groups', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups', headers = headers)
 
 print(r.json())
 
@@ -10676,10 +11014,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/groups", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -10750,8 +11089,9 @@ Status Code **200**
 |» members|[Members.1.0.0](#schemamembers.1.0.0)|false|none|The members are a fully enumerated (i.e. no implied members besides those explicitly provided) representation of the components a partition or group|
 |»» ids|[[XNameRW.1.0.0](#schemaxnamerw.1.0.0)]|false|none|Set of Component XName IDs that represent the membership of the group or partition.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doGroupsPost
@@ -10761,8 +11101,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/groups HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -10770,9 +11110,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/groups \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -10780,10 +11121,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/groups \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/groups', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups', headers = headers)
 
 print(r.json())
 
@@ -10802,10 +11144,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/groups", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -10891,8 +11234,9 @@ Status Code **201**
 |*anonymous*|[[ResourceURI.1.0.0](#schemaresourceuri.1.0.0)]|false|none|[A ResourceURI is like an odata.id, it provides a path to a resource from the API root, such that when a GET is performed, the corresponding object is returned.  It does not imply other odata functionality.]|
 |» ResourceURI|string|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doGroupGet
@@ -10902,26 +11246,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/groups/{group_label} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/groups/{group_label} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/groups/{group_label}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}', headers = headers)
 
 print(r.json())
 
@@ -10939,10 +11285,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/groups/{group_label}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -10998,8 +11345,9 @@ Retrieve the group which was created with the given {group_label}.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doGroupDelete
@@ -11009,26 +11357,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/groups/{group_label} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/groups/{group_label} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/groups/{group_label}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}', headers = headers)
 
 print(r.json())
 
@@ -11046,10 +11396,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/groups/{group_label}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -11091,8 +11442,9 @@ Delete the given group with {group_label}. Any members previously in the group w
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - No group matches label.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doGroupPatch
@@ -11102,8 +11454,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/groups/{group_label} HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label} HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -11111,9 +11463,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/groups/{group_label} \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -11121,10 +11474,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/groups/{group_label} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/groups/{group_label}', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}', headers = headers)
 
 print(r.json())
 
@@ -11143,10 +11497,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/groups/{group_label}", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -11204,8 +11559,9 @@ To update the tags array and/or description, a PATCH operation can be used.  Omi
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The group with this label did not exist.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doGroupLabelsGet
@@ -11215,26 +11571,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/groups/labels HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/labels HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/groups/labels \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/labels \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/groups/labels', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/labels', headers = headers)
 
 print(r.json())
 
@@ -11252,10 +11610,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/groups/labels", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/labels", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -11302,8 +11661,9 @@ Retrieve a string array of all group labels (i.e. group names) that currently ex
 
 <h3 id="dogrouplabelsget-responseschema">Response Schema</h3>
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doGroupMembersGet
@@ -11313,26 +11673,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/groups/{group_label}/members HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}/members HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/groups/{group_label}/members \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}/members \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/groups/{group_label}/members', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}/members', headers = headers)
 
 print(r.json())
 
@@ -11350,10 +11712,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/groups/{group_label}/members", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}/members", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -11400,8 +11763,9 @@ Retrieve members of an existing group {group_label}, optionally filtering the se
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does not exist - No such group {group_label}|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doGroupMembersPost
@@ -11411,8 +11775,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/groups/{group_label}/members HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}/members HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -11420,9 +11784,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/groups/{group_label}/members \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}/members \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -11430,10 +11795,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/groups/{group_label}/members \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/groups/{group_label}/members', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}/members', headers = headers)
 
 print(r.json())
 
@@ -11452,10 +11818,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/groups/{group_label}/members", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}/members", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -11527,8 +11894,9 @@ Status Code **201**
 |*anonymous*|[[ResourceURI.1.0.0](#schemaresourceuri.1.0.0)]|false|none|[A ResourceURI is like an odata.id, it provides a path to a resource from the API root, such that when a GET is performed, the corresponding object is returned.  It does not imply other odata functionality.]|
 |» ResourceURI|string|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doGroupMemberDelete
@@ -11538,26 +11906,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/groups/{group_label}/members/{xname_id} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}/members/{xname_id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/groups/{group_label}/members/{xname_id} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}/members/{xname_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/groups/{group_label}/members/{xname_id}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}/members/{xname_id}', headers = headers)
 
 print(r.json())
 
@@ -11575,10 +11945,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/groups/{group_label}/members/{xname_id}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/{group_label}/members/{xname_id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -11621,8 +11992,9 @@ Delete component {xname_id} from the members of group {group_label}.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - no such member or group.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-partition">Partition</h1>
@@ -11636,26 +12008,28 @@ A partition is a formal, non-overlapping division of the system that forms an ad
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/partitions HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/partitions \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/partitions', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions', headers = headers)
 
 print(r.json())
 
@@ -11673,10 +12047,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/partitions", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -11745,8 +12120,9 @@ Status Code **200**
 |» members|[Members.1.0.0](#schemamembers.1.0.0)|false|none|The members are a fully enumerated (i.e. no implied members besides those explicitly provided) representation of the components a partition or group|
 |»» ids|[[XNameRW.1.0.0](#schemaxnamerw.1.0.0)]|false|none|Set of Component XName IDs that represent the membership of the group or partition.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPartitionsPost
@@ -11756,8 +12132,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/partitions HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -11765,9 +12141,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/partitions \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -11775,10 +12152,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/partitions \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/partitions', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions', headers = headers)
 
 print(r.json())
 
@@ -11797,10 +12175,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/partitions", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -11883,8 +12262,9 @@ Status Code **201**
 |*anonymous*|[[ResourceURI.1.0.0](#schemaresourceuri.1.0.0)]|false|none|[A ResourceURI is like an odata.id, it provides a path to a resource from the API root, such that when a GET is performed, the corresponding object is returned.  It does not imply other odata functionality.]|
 |» ResourceURI|string|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPartitionGet
@@ -11894,26 +12274,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/partitions/{partition_name} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/partitions/{partition_name} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/partitions/{partition_name}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}', headers = headers)
 
 print(r.json())
 
@@ -11931,10 +12313,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/partitions/{partition_name}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -11988,8 +12371,9 @@ Retrieve the partition which was created with the given {partition_name}.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPartitionDelete
@@ -11999,26 +12383,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/partitions/{partition_name} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/partitions/{partition_name} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/partitions/{partition_name}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}', headers = headers)
 
 print(r.json())
 
@@ -12036,10 +12422,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/partitions/{partition_name}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -12081,8 +12468,9 @@ Delete partition {partition_name}. Any members previously in the partition will 
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - No partition matches partition_name.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPartitionPatch
@@ -12092,8 +12480,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/partitions/{partition_name} HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name} HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -12101,9 +12489,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/partitions/{partition_name} \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -12111,10 +12500,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/partitions/{partition_name} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/partitions/{partition_name}', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}', headers = headers)
 
 print(r.json())
 
@@ -12133,10 +12523,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/partitions/{partition_name}", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -12194,8 +12585,9 @@ Update the tags array and/or description by using PATCH. Omitted fields are not 
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|The partition with this partition_name did not exist.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPartitionNamesGet
@@ -12205,26 +12597,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/partitions/names HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/names HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/partitions/names \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/names \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/partitions/names', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/names', headers = headers)
 
 print(r.json())
 
@@ -12242,10 +12636,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/partitions/names", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/names", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -12290,8 +12685,9 @@ Retrieve a string array of all partition names that currently exist in HSM. Thes
 
 <h3 id="dopartitionnamesget-responseschema">Response Schema</h3>
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPartitionMembersGet
@@ -12301,26 +12697,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/partitions/{partition_name}/members HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}/members HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/partitions/{partition_name}/members \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}/members \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/partitions/{partition_name}/members', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}/members', headers = headers)
 
 print(r.json())
 
@@ -12338,10 +12736,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/partitions/{partition_name}/members", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}/members", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -12387,8 +12786,9 @@ Retrieve all members of existing partition {partition_name}, optionally filterin
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does not exist - No such partition {partition_name}|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPartitionMembersPost
@@ -12398,8 +12798,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/partitions/{partition_name}/members HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}/members HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -12407,9 +12807,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/partitions/{partition_name}/members \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}/members \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -12417,10 +12818,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/partitions/{partition_name}/members \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/partitions/{partition_name}/members', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}/members', headers = headers)
 
 print(r.json())
 
@@ -12439,10 +12841,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/partitions/{partition_name}/members", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}/members", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -12514,8 +12917,9 @@ Status Code **201**
 |*anonymous*|[[ResourceURI.1.0.0](#schemaresourceuri.1.0.0)]|false|none|[A ResourceURI is like an odata.id, it provides a path to a resource from the API root, such that when a GET is performed, the corresponding object is returned.  It does not imply other odata functionality.]|
 |» ResourceURI|string|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPartitionMemberDelete
@@ -12525,26 +12929,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/partitions/{partition_name}/members/{xname_id} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}/members/{xname_id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/partitions/{partition_name}/members/{xname_id} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}/members/{xname_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/partitions/{partition_name}/members/{xname_id}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}/members/{xname_id}', headers = headers)
 
 print(r.json())
 
@@ -12562,10 +12968,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/partitions/{partition_name}/members/{xname_id}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/partitions/{partition_name}/members/{xname_id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -12608,8 +13015,9 @@ Delete component {xname_id} from the members of partition {partition_name}.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - no such member or partition.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-membership">Membership</h1>
@@ -12623,26 +13031,28 @@ A membership is a mapping of a component xname to its set of group labels and pa
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/memberships HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/memberships HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/memberships \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/memberships \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/memberships', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/memberships', headers = headers)
 
 print(r.json())
 
@@ -12660,10 +13070,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/memberships", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/memberships", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -12816,8 +13227,9 @@ Status Code **200**
 |» partitionName|string|false|none|The name is a human-readable identifier for the partition and uniquely identifies it.|
 |» groupLabels|[string]|false|none|An array with all group labels the component is associated with The label is the human-readable identifier for a group and uniquely identifies it.|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doMembershipGet
@@ -12827,26 +13239,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/memberships/{xname} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/memberships/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/memberships/{xname} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/memberships/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/memberships/{xname}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/memberships/{xname}', headers = headers)
 
 print(r.json())
 
@@ -12864,10 +13278,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/memberships/{xname}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/memberships/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -12914,8 +13329,9 @@ Display group labels and partition names for a given component xname ID.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found - no such xname.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-discoverystatus">DiscoveryStatus</h1>
@@ -12929,26 +13345,28 @@ Contains status information about the discovery operation for clients to query. 
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/DiscoveryStatus HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/DiscoveryStatus HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/DiscoveryStatus \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/DiscoveryStatus \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/DiscoveryStatus', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/DiscoveryStatus', headers = headers)
 
 print(r.json())
 
@@ -12966,10 +13384,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/DiscoveryStatus", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/DiscoveryStatus", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -13028,8 +13447,9 @@ Status Code **200**
 |Status|InProgress|
 |Status|Complete|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doDiscoveryStatusGet
@@ -13039,26 +13459,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Inventory/DiscoveryStatus/{id} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/DiscoveryStatus/{id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Inventory/DiscoveryStatus/{id} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/DiscoveryStatus/{id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Inventory/DiscoveryStatus/{id}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/DiscoveryStatus/{id}', headers = headers)
 
 print(r.json())
 
@@ -13076,10 +13498,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Inventory/DiscoveryStatus/{id}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/DiscoveryStatus/{id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -13123,8 +13546,9 @@ Retrieve DiscoveryStatus entry with the specific ID.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not found (no such ID)|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-discover">Discover</h1>
@@ -13138,8 +13562,8 @@ Trigger a discovery of system component data by interrogating all, or a subset, 
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/Inventory/Discover HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Discover HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -13147,9 +13571,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/Inventory/Discover \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Discover \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -13157,10 +13582,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/Inventory/Discover \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/Inventory/Discover', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Discover', headers = headers)
 
 print(r.json())
 
@@ -13179,10 +13605,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/Inventory/Discover", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/Discover", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -13256,8 +13683,9 @@ Status Code **200**
 |*anonymous*|[[ResourceURI.1.0.0](#schemaresourceuri.1.0.0)]|false|none|[A ResourceURI is like an odata.id, it provides a path to a resource from the API root, such that when a GET is performed, the corresponding object is returned.  It does not imply other odata functionality.]|
 |» ResourceURI|string|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-scn">SCN</h1>
@@ -13271,8 +13699,8 @@ Manage subscriptions to state change notifications (SCNs) from HSM.
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/Subscriptions/SCN HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -13280,9 +13708,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/Subscriptions/SCN \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -13290,10 +13719,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/Subscriptions/SCN \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/Subscriptions/SCN', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN', headers = headers)
 
 print(r.json())
 
@@ -13312,10 +13742,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/Subscriptions/SCN", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -13394,8 +13825,9 @@ Request a subscription for state change notifications for a set of component sta
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doDeleteSCNSubscriptionsAll
@@ -13405,26 +13837,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Subscriptions/SCN HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Subscriptions/SCN \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Subscriptions/SCN', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN', headers = headers)
 
 print(r.json())
 
@@ -13442,10 +13876,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Subscriptions/SCN", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -13483,8 +13918,9 @@ Delete all subscriptions.
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doGetSCNSubscriptionsAll
@@ -13494,26 +13930,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Subscriptions/SCN HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Subscriptions/SCN \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Subscriptions/SCN', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN', headers = headers)
 
 print(r.json())
 
@@ -13531,10 +13969,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Subscriptions/SCN", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -13587,8 +14026,9 @@ Retrieve all information on currently held state change notification subscriptio
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPutSCNSubscription
@@ -13598,8 +14038,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PUT https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id} HTTP/1.1
-Host: sms
+PUT https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -13607,9 +14047,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PUT https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id} \
+curl -X PUT https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -13617,10 +14058,11 @@ curl -X PUT https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.put('https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id}', headers = headers)
+r = requests.put('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id}', headers = headers)
 
 print(r.json())
 
@@ -13639,10 +14081,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PUT", "https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id}", data)
+    req, err := http.NewRequest("PUT", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -13711,8 +14154,9 @@ Update an existing state change notification subscription in whole. This will ov
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPatchSCNSubscription
@@ -13722,8 +14166,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id} HTTP/1.1
-Host: sms
+PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -13731,9 +14175,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PATCH https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id} \
+curl -X PATCH https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -13741,10 +14186,11 @@ curl -X PATCH https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id}', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id}', headers = headers)
 
 print(r.json())
 
@@ -13763,10 +14209,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id}", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -13834,8 +14281,9 @@ Update a subscription for state change notifications to add or remove triggers.
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal server error. Database error.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doDeleteSCNSubscription
@@ -13845,26 +14293,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id}', headers = headers)
 
 print(r.json())
 
@@ -13882,10 +14332,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -13930,8 +14381,9 @@ Delete a state change notification subscription.
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doGetSCNSubscription
@@ -13941,26 +14393,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id}', headers = headers)
 
 print(r.json())
 
@@ -13978,10 +14432,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/Subscriptions/SCN/{id}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Subscriptions/SCN/{id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -14035,8 +14490,9 @@ Return the information on a currently held state change notification subscriptio
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Database error.|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-locking">Locking</h1>
@@ -14048,8 +14504,8 @@ Manage locks and reservations on components.
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/locks/reservations/remove HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/reservations/remove HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -14057,9 +14513,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/locks/reservations/remove \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/reservations/remove \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -14067,10 +14524,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/locks/reservations/remove \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/locks/reservations/remove', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/reservations/remove', headers = headers)
 
 print(r.json())
 
@@ -14089,10 +14547,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/locks/reservations/remove", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/reservations/remove", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -14197,8 +14656,9 @@ Given a list of components, forcibly deletes any existing reservation. Does not 
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request; something is wrong with the structure received. Will not be used to represent failure to accomplish the operation, that will be returned in the standard payload.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error, could not delete reservations|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__locks_reservations_release
@@ -14206,8 +14666,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/locks/reservations/release HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/reservations/release HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -14215,9 +14675,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/locks/reservations/release \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/reservations/release \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -14225,10 +14686,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/locks/reservations/release \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/locks/reservations/release', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/reservations/release', headers = headers)
 
 print(r.json())
 
@@ -14247,10 +14709,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/locks/reservations/release", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/reservations/release", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -14319,8 +14782,9 @@ Given a list of {xname & reservation key}, releases the associated reservations.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request; something is wrong with the structure received. Will not be used to represent failure to accomplish the operation, that will be returned in the standard payload.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error, could not delete reservations|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__locks_reservations
@@ -14328,8 +14792,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/locks/reservations HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/reservations HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -14337,9 +14801,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/locks/reservations \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/reservations \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -14347,10 +14812,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/locks/reservations \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/locks/reservations', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/reservations', headers = headers)
 
 print(r.json())
 
@@ -14369,10 +14835,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/locks/reservations", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/reservations", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -14474,8 +14941,9 @@ Creates reservations on a set of xnames of infinite duration.  Component must be
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request; something is wrong with the structure received. Will not be used to represent failure to accomplish the operation, that will be returned in the standard payload.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error, could not accept reservations|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__locks_service_reservations_release
@@ -14483,8 +14951,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/locks/service/reservations/release HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations/release HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -14492,9 +14960,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/locks/service/reservations/release \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations/release \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -14502,10 +14971,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/locks/service/reservations/release \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/locks/service/reservations/release', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations/release', headers = headers)
 
 print(r.json())
 
@@ -14524,10 +14994,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/locks/service/reservations/release", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations/release", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -14596,8 +15067,9 @@ Given a list of {xname & reservation key}, releases the associated reservations.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request; something is wrong with the structure received. Will not be used to represent failure to accomplish the operation, that will be returned in the standard payload.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error, could not delete reservations|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__locks_service_reservations
@@ -14605,8 +15077,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/locks/service/reservations HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -14614,9 +15086,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/locks/service/reservations \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -14624,10 +15097,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/locks/service/reservations \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/locks/service/reservations', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations', headers = headers)
 
 print(r.json())
 
@@ -14646,10 +15120,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/locks/service/reservations", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -14753,8 +15228,9 @@ Creates reservations on a set of xnames of finite duration.  Component must be u
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request; something is wrong with the structure received. Will not be used to represent failure to accomplish the operation, that will be returned in the standard payload.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error, could not accept reservations|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__locks_service_reservations_renew
@@ -14762,8 +15238,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/locks/service/reservations/renew HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations/renew HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -14771,9 +15247,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/locks/service/reservations/renew \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations/renew \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -14781,10 +15258,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/locks/service/reservations/renew \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/locks/service/reservations/renew', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations/renew', headers = headers)
 
 print(r.json())
 
@@ -14803,10 +15281,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/locks/service/reservations/renew", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations/renew", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -14876,8 +15355,9 @@ Given a list of {xname & reservation key}, renews the associated reservations.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request; something is wrong with the structure received. Will not be used to represent failure to accomplish the operation, that will be returned in the standard payload.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error, could not delete reservations|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__locks_service_reservations_check
@@ -14885,8 +15365,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/locks/service/reservations/check HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations/check HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -14894,9 +15374,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/locks/service/reservations/check \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations/check \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -14904,10 +15385,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/locks/service/reservations/check \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/locks/service/reservations/check', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations/check', headers = headers)
 
 print(r.json())
 
@@ -14926,10 +15408,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/locks/service/reservations/check", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/service/reservations/check", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -14994,8 +15477,9 @@ Using xname + reservation key check on the validity of reservations.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error, could not check reservations.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__locks_status
@@ -15003,8 +15487,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/locks/status HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/status HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -15012,9 +15496,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/locks/status \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/status \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -15022,10 +15507,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/locks/status \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/locks/status', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/status', headers = headers)
 
 print(r.json())
 
@@ -15044,10 +15530,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/locks/status", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/status", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -15109,8 +15596,9 @@ Using component ID retrieve the status of any lock and/or reservation.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error, could not get lock status.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__locks_status
@@ -15118,26 +15606,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/locks/status HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/status HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/locks/status \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/status \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/locks/status', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/status', headers = headers)
 
 print(r.json())
 
@@ -15155,10 +15645,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/locks/status", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/status", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -15283,8 +15774,9 @@ Additional valid values may be added via configuration file. See the results of 
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error, could not get lock status.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__locks_lock
@@ -15292,8 +15784,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/locks/lock HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/lock HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -15301,9 +15793,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/locks/lock \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/lock \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -15311,10 +15804,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/locks/lock \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/locks/lock', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/lock', headers = headers)
 
 print(r.json())
 
@@ -15333,10 +15827,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/locks/lock", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/lock", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -15441,8 +15936,9 @@ Using a component create a lock.  Cannot be locked if already locked, or if ther
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error, could not lock lock.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__locks_unlock
@@ -15450,8 +15946,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/locks/unlock HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/unlock HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -15459,9 +15955,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/locks/unlock \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/unlock \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -15469,10 +15966,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/locks/unlock \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/locks/unlock', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/unlock', headers = headers)
 
 print(r.json())
 
@@ -15491,10 +15989,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/locks/unlock", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/unlock", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -15599,8 +16098,9 @@ Using a component unlock a lock.  Cannot be unlocked if already unlocked.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error, could not unlock lock.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__locks_repair
@@ -15608,8 +16108,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/locks/repair HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/repair HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -15617,9 +16117,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/locks/repair \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/repair \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -15627,10 +16128,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/locks/repair \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/locks/repair', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/repair', headers = headers)
 
 print(r.json())
 
@@ -15649,10 +16151,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/locks/repair", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/repair", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -15757,8 +16260,9 @@ Repairs the disabled status of an xname allowing new reservations to be created.
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error, could not repair lock.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__locks_disable
@@ -15766,8 +16270,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/locks/disable HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/disable HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -15775,9 +16279,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/locks/disable \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/disable \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -15785,10 +16290,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/locks/disable \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/locks/disable', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/disable', headers = headers)
 
 print(r.json())
 
@@ -15807,10 +16313,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/locks/disable", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/locks/disable", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -15915,8 +16422,9 @@ Disables the ability to create a reservation on components, deletes any existing
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request.|[Problem7807](#schemaproblem7807)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Server error, could not disable lock.|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="hardware-state-manager-api-powermap">PowerMap</h1>
@@ -15930,26 +16438,28 @@ Power mapping of components to the components supplying them power. This may con
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/sysinfo/powermaps HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/sysinfo/powermaps \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/sysinfo/powermaps', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps', headers = headers)
 
 print(r.json())
 
@@ -15967,10 +16477,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/sysinfo/powermaps", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -16010,8 +16521,9 @@ Retrieve all power map entries as a named array, or an empty array if the collec
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPowerMapsPost
@@ -16021,8 +16533,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST https://sms/apis/smd/hsm/v2/sysinfo/powermaps HTTP/1.1
-Host: sms
+POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -16030,9 +16542,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST https://sms/apis/smd/hsm/v2/sysinfo/powermaps \
+curl -X POST https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -16040,10 +16553,11 @@ curl -X POST https://sms/apis/smd/hsm/v2/sysinfo/powermaps \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('https://sms/apis/smd/hsm/v2/sysinfo/powermaps', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps', headers = headers)
 
 print(r.json())
 
@@ -16062,10 +16576,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "https://sms/apis/smd/hsm/v2/sysinfo/powermaps", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -16120,8 +16635,9 @@ Create or update the given set of PowerMaps whose ID fields are each a valid xna
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPowerMapsDeleteAll
@@ -16131,26 +16647,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/sysinfo/powermaps HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/sysinfo/powermaps \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/sysinfo/powermaps', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps', headers = headers)
 
 print(r.json())
 
@@ -16168,10 +16686,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/sysinfo/powermaps", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -16207,8 +16726,9 @@ Delete all entries in the PowerMaps collection.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist - Collection is empty|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPowerMapGet
@@ -16218,26 +16738,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET https://sms/apis/smd/hsm/v2/sysinfo/powermaps/{xname} HTTP/1.1
-Host: sms
+GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET https://sms/apis/smd/hsm/v2/sysinfo/powermaps/{xname} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('https://sms/apis/smd/hsm/v2/sysinfo/powermaps/{xname}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps/{xname}', headers = headers)
 
 print(r.json())
 
@@ -16255,10 +16777,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "https://sms/apis/smd/hsm/v2/sysinfo/powermaps/{xname}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -16303,8 +16826,9 @@ Retrieve PowerMap for a component located at physical location {xname}.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Does Not Exist|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPowerMapDelete
@@ -16314,26 +16838,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE https://sms/apis/smd/hsm/v2/sysinfo/powermaps/{xname} HTTP/1.1
-Host: sms
+DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE https://sms/apis/smd/hsm/v2/sysinfo/powermaps/{xname} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps/{xname} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('https://sms/apis/smd/hsm/v2/sysinfo/powermaps/{xname}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps/{xname}', headers = headers)
 
 print(r.json())
 
@@ -16351,10 +16877,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "https://sms/apis/smd/hsm/v2/sysinfo/powermaps/{xname}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -16396,8 +16923,9 @@ Delete PowerMap entry for a specific component {xname}.
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|XName does Not Exist - no matching ID to delete|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## doPowerMapPut
@@ -16407,8 +16935,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PUT https://sms/apis/smd/hsm/v2/sysinfo/powermaps/{xname} HTTP/1.1
-Host: sms
+PUT https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps/{xname} HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -16416,9 +16944,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X PUT https://sms/apis/smd/hsm/v2/sysinfo/powermaps/{xname} \
+curl -X PUT https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps/{xname} \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -16426,10 +16955,11 @@ curl -X PUT https://sms/apis/smd/hsm/v2/sysinfo/powermaps/{xname} \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.put('https://sms/apis/smd/hsm/v2/sysinfo/powermaps/{xname}', headers = headers)
+r = requests.put('https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps/{xname}', headers = headers)
 
 print(r.json())
 
@@ -16448,10 +16978,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PUT", "https://sms/apis/smd/hsm/v2/sysinfo/powermaps/{xname}", data)
+    req, err := http.NewRequest("PUT", "https://api-gw-service-nmn.local/apis/smd/hsm/v2/sysinfo/powermaps/{xname}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -16505,8 +17036,9 @@ Update or create an entry for an individual component xname using PUT. If the PU
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad Request|[Problem7807](#schemaproblem7807)|
 |default|Default|Unexpected error|[Problem7807](#schemaproblem7807)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas
@@ -18762,7 +19294,7 @@ Either way, the 'Target' field is the parent component, partition or system that
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
 |XName|[XName.1.0.0](#schemaxname.1.0.0)|false|none|Uniquely identifies the component by its physical location (xname). There are formatting rules depending on the matching HMSType.|
-|Format|string|false|none|How results are displayed<br><br>  FullyFlat      All component types listed in their own<br>                 arrays only.  No nesting of any children<br>  Hierarchical   All subcomponents listed as children up to<br>                 top level component (or set of cabinets)<br>  NestNodesOnly  Flat except that node subcomponents are nested<br>                 hierarchically.<br>Default is NestNodesOnly.|
+|Format|string|false|none|How results are displayed<br><br><br><br><br><br>  FullyFlat      All component types listed in their own<br>                 arrays only.  No nesting of any children<br>  Hierarchical   All subcomponents listed as children up to<br>                 top level component (or set of cabinets)<br>  NestNodesOnly  Flat except that node subcomponents are nested<br>                 hierarchically.<br>Default is NestNodesOnly.|
 |Cabinets|[[HWInvByLocCabinet](#schemahwinvbyloccabinet)]|false|read-only|All components with HMS type 'Cabinet' appropriate given Target component/partition and query type.|
 |Chassis|[[HWInvByLocChassis](#schemahwinvbylocchassis)]|false|read-only|All appropriate components with HMS type 'Chassis' given Target component/partition and query type.|
 |ComputeModules|[[HWInvByLocComputeModule](#schemahwinvbyloccomputemodule)]|false|read-only|All appropriate components with HMS type 'ComputeModule' given Target component/partition and query type.|

--- a/api/sts.md
+++ b/api/sts.md
@@ -6,7 +6,11 @@
 
 Base URLs:
 
-* <a href="http://localhost:9090/">http://localhost:9090/</a>
+* <a href="https://api-gw-service-nmn.local/apis/sts">https://api-gw-service-nmn.local/apis/sts</a>
+
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
 
 <h1 id="cray-sts-token-generator-default">Default</h1>
 
@@ -17,26 +21,28 @@ Base URLs:
 > Code samples
 
 ```http
-PUT http://localhost:9090/token HTTP/1.1
-Host: localhost:9090
+PUT https://api-gw-service-nmn.local/apis/sts/token HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X PUT http://localhost:9090/token \
-  -H 'Accept: application/json'
+curl -X PUT https://api-gw-service-nmn.local/apis/sts/token \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.put('http://localhost:9090/token', headers = headers)
+r = requests.put('https://api-gw-service-nmn.local/apis/sts/token', headers = headers)
 
 print(r.json())
 
@@ -54,10 +60,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PUT", "http://localhost:9090/token", data)
+    req, err := http.NewRequest("PUT", "https://api-gw-service-nmn.local/apis/sts/token", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -95,8 +102,9 @@ Generates a STS Token.
 |---|---|---|---|
 |201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|A generated STS Token|[Token](#schematoken)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="cray-sts-token-generator-cli_ignore">cli_ignore</h1>
@@ -108,26 +116,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET http://localhost:9090/healthz HTTP/1.1
-Host: localhost:9090
+GET https://api-gw-service-nmn.local/apis/sts/healthz HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET http://localhost:9090/healthz \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/sts/healthz \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('http://localhost:9090/healthz', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/sts/healthz', headers = headers)
 
 print(r.json())
 
@@ -145,10 +155,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://localhost:9090/healthz", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/sts/healthz", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -188,8 +199,9 @@ Status Code **200**
 |---|---|---|---|---|
 |» Status|string|false|read-only|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas

--- a/api/tapms-operator.md
+++ b/api/tapms-operator.md
@@ -8,7 +8,11 @@ Read-Only APIs to Retrieve Tenant Status
 
 Base URLs:
 
-* <a href="//cray-tapms/apis/tapms/">//cray-tapms/apis/tapms/</a>
+* <a href="https://api-gw-service-nmn.local/apis/tapms/">https://api-gw-service-nmn.local/apis/tapms/</a>
+
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
 
 <h1 id="tapms-tenant-status-api-tenant-and-partition-management-system">Tenant and Partition Management System</h1>
 
@@ -17,26 +21,28 @@ Base URLs:
 > Code samples
 
 ```http
-GET /cray-tapms/apis/tapms/v1alpha3/tenants HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/tapms/v1alpha3/tenants HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /cray-tapms/apis/tapms/v1alpha3/tenants \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/tapms/v1alpha3/tenants \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/cray-tapms/apis/tapms/v1alpha3/tenants', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/tapms/v1alpha3/tenants', headers = headers)
 
 print(r.json())
 
@@ -54,10 +60,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/cray-tapms/apis/tapms/v1alpha3/tenants", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/tapms/v1alpha3/tenants", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -211,8 +218,9 @@ Status Code **200**
 |»» tenantresources|[[TenantResource](#schematenantresource)]|false|none|The desired resources for the Tenant|
 |»» uuid|string(uuid)|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## post__v1alpha3_tenants
@@ -220,8 +228,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST /cray-tapms/apis/tapms/v1alpha3/tenants HTTP/1.1
-
+POST https://api-gw-service-nmn.local/apis/tapms/v1alpha3/tenants HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: application/json
 Accept: application/json
 
@@ -229,9 +237,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST /cray-tapms/apis/tapms/v1alpha3/tenants \
+curl -X POST https://api-gw-service-nmn.local/apis/tapms/v1alpha3/tenants \
   -H 'Content-Type: application/json' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -239,10 +248,11 @@ curl -X POST /cray-tapms/apis/tapms/v1alpha3/tenants \
 import requests
 headers = {
   'Content-Type': 'application/json',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('/cray-tapms/apis/tapms/v1alpha3/tenants', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/tapms/v1alpha3/tenants', headers = headers)
 
 print(r.json())
 
@@ -261,10 +271,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"application/json"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "/cray-tapms/apis/tapms/v1alpha3/tenants", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/tapms/v1alpha3/tenants", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -430,8 +441,9 @@ Status Code **200**
 |»» tenantresources|[[TenantResource](#schematenantresource)]|false|none|The desired resources for the Tenant|
 |»» uuid|string(uuid)|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get__v1alpha3_tenants_{id}
@@ -439,26 +451,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /cray-tapms/apis/tapms/v1alpha3/tenants/{id} HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/tapms/v1alpha3/tenants/{id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /cray-tapms/apis/tapms/v1alpha3/tenants/{id} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/tapms/v1alpha3/tenants/{id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/cray-tapms/apis/tapms/v1alpha3/tenants/{id}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/tapms/v1alpha3/tenants/{id}', headers = headers)
 
 print(r.json())
 
@@ -476,10 +490,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/cray-tapms/apis/tapms/v1alpha3/tenants/{id}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/tapms/v1alpha3/tenants/{id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -597,8 +612,9 @@ func main() {
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found|[ResponseError](#schemaresponseerror)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal Server Error|[ResponseError](#schemaresponseerror)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas

--- a/api/uas-mgr.md
+++ b/api/uas-mgr.md
@@ -288,7 +288,11 @@ list of available choices.
 
 Base URLs:
 
-* <a href="/apis/uas-mgr/v1">/apis/uas-mgr/v1</a>
+* <a href="https://api-gw-service-nmn.local/apis/uas-mgr/v1">https://api-gw-service-nmn.local/apis/uas-mgr/v1</a>
+
+# Authentication
+
+- HTTP Authentication, scheme: bearer 
 
 <h1 id="user-access-service-versions">versions</h1>
 
@@ -299,20 +303,25 @@ Base URLs:
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/ HTTP/1.1
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/ HTTP/1.1
+Host: api-gw-service-nmn.local
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/ \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
+headers = {
+  'Authorization': 'Bearer {access-token}'
+}
 
-r = requests.get('/apis/uas-mgr/v1/')
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/', headers = headers)
 
 print(r.json())
 
@@ -328,8 +337,12 @@ import (
 
 func main() {
 
+    headers := map[string][]string{
+        "Authorization": []string{"Bearer {access-token}"},
+    }
+
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -351,8 +364,9 @@ Return supported UAS API versions.
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Version response|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="user-access-service-uas">uas</h1>
@@ -364,26 +378,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/uas HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/uas HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/uas \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/uas \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/uas-mgr/v1/uas', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/uas', headers = headers)
 
 print(r.json())
 
@@ -401,10 +417,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/uas", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/uas", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -472,8 +489,9 @@ Status Code **200**
 |» uai_host|string|false|none|none|
 |» uai_age|string|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## create_uai
@@ -483,8 +501,8 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST /apis/uas-mgr/v1/uas HTTP/1.1
-
+POST https://api-gw-service-nmn.local/apis/uas-mgr/v1/uas HTTP/1.1
+Host: api-gw-service-nmn.local
 Content-Type: multipart/form-data
 Accept: application/json
 
@@ -492,9 +510,10 @@ Accept: application/json
 
 ```shell
 # You can also use wget
-curl -X POST /apis/uas-mgr/v1/uas \
+curl -X POST https://api-gw-service-nmn.local/apis/uas-mgr/v1/uas \
   -H 'Content-Type: multipart/form-data' \
-  -H 'Accept: application/json'
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
@@ -502,10 +521,11 @@ curl -X POST /apis/uas-mgr/v1/uas \
 import requests
 headers = {
   'Content-Type': 'multipart/form-data',
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('/apis/uas-mgr/v1/uas', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/uas-mgr/v1/uas', headers = headers)
 
 print(r.json())
 
@@ -524,10 +544,11 @@ func main() {
     headers := map[string][]string{
         "Content-Type": []string{"multipart/form-data"},
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "/apis/uas-mgr/v1/uas", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/uas", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -582,8 +603,9 @@ to ports 80, 443, and 8888.
 
 <h3 id="create_uai-responseschema">Response Schema</h3>
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_uai_by_name
@@ -593,25 +615,30 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE /apis/uas-mgr/v1/uas?uai_list=uai-asdfgh098,uai-qwerty123 HTTP/1.1
+DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/uas?uai_list=uai-asdfgh098,uai-qwerty123 HTTP/1.1
+Host: api-gw-service-nmn.local
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE /apis/uas-mgr/v1/uas?uai_list=uai-asdfgh098,uai-qwerty123
+curl -X DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/uas?uai_list=uai-asdfgh098,uai-qwerty123 \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
+headers = {
+  'Authorization': 'Bearer {access-token}'
+}
 
-r = requests.delete('/apis/uas-mgr/v1/uas', params={
+r = requests.delete('https://api-gw-service-nmn.local/apis/uas-mgr/v1/uas', params={
   'uai_list': [
   "uai-asdfgh098",
   "uai-qwerty123"
 ]
-})
+}, headers = headers)
 
 print(r.json())
 
@@ -627,8 +654,12 @@ import (
 
 func main() {
 
+    headers := map[string][]string{
+        "Authorization": []string{"Bearer {access-token}"},
+    }
+
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "/apis/uas-mgr/v1/uas", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/uas", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -658,8 +689,9 @@ associated UAI(s).
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|UAIs deleted|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Failed to delete UAI with {uai_id}|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="user-access-service-images">images</h1>
@@ -671,26 +703,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/images HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/images HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/images \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/images \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/uas-mgr/v1/images', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/images', headers = headers)
 
 print(r.json())
 
@@ -708,10 +742,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/images", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/images", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -747,8 +782,9 @@ List all available UAS images.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|UAS Image List|[Image_list](#schemaimage_list)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|UAS Images not found|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## create_uas_image_admin
@@ -758,26 +794,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST /apis/uas-mgr/v1/admin/config/images?imagename=docker.local%2Fcray%2Fcray-uas-sles15sp1%3Alatest HTTP/1.1
-
+POST https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images?imagename=docker.local%2Fcray%2Fcray-uas-sles15sp1%3Alatest HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X POST /apis/uas-mgr/v1/admin/config/images?imagename=docker.local%2Fcray%2Fcray-uas-sles15sp1%3Alatest \
-  -H 'Accept: application/json'
+curl -X POST https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images?imagename=docker.local%2Fcray%2Fcray-uas-sles15sp1%3Alatest \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('/apis/uas-mgr/v1/admin/config/images', params={
+r = requests.post('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images', params={
   'imagename': 'docker.local/cray/cray-uas-sles15sp1:latest'
 }, headers = headers)
 
@@ -797,10 +835,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "/apis/uas-mgr/v1/admin/config/images", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -843,8 +882,9 @@ upload container image.  Optionally, set default.
 |201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Image added|[Image](#schemaimage)|
 |304|[Not Modified](https://tools.ietf.org/html/rfc7232#section-4.1)|Image not added|string|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_uas_images_admin
@@ -854,26 +894,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/admin/config/images HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/admin/config/images \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/uas-mgr/v1/admin/config/images', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images', headers = headers)
 
 print(r.json())
 
@@ -891,10 +933,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/admin/config/images", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -942,8 +985,9 @@ Status Code **200**
 |» imagename|string|false|none|none|
 |» default|boolean|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_uas_image_admin
@@ -953,26 +997,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/admin/config/images/{image_id} HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images/{image_id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/admin/config/images/{image_id} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images/{image_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/uas-mgr/v1/admin/config/images/{image_id}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images/{image_id}', headers = headers)
 
 print(r.json())
 
@@ -990,10 +1036,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/admin/config/images/{image_id}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images/{image_id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1039,8 +1086,9 @@ configuration.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|UAS Image|[Image](#schemaimage)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|UAS Image {image_id} not found|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## update_uas_image_admin
@@ -1050,26 +1098,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH /apis/uas-mgr/v1/admin/config/images/{image_id} HTTP/1.1
-
+PATCH https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images/{image_id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X PATCH /apis/uas-mgr/v1/admin/config/images/{image_id} \
-  -H 'Accept: application/json'
+curl -X PATCH https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images/{image_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('/apis/uas-mgr/v1/admin/config/images/{image_id}', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images/{image_id}', headers = headers)
 
 print(r.json())
 
@@ -1087,10 +1137,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "/apis/uas-mgr/v1/admin/config/images/{image_id}", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images/{image_id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1141,8 +1192,9 @@ instance.
 |201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Image updated|[Image](#schemaimage)|
 |304|[Not Modified](https://tools.ietf.org/html/rfc7232#section-4.1)|No changes made|[Image](#schemaimage)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_uas_image_admin
@@ -1152,26 +1204,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE /apis/uas-mgr/v1/admin/config/images/{image_id} HTTP/1.1
-
+DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images/{image_id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE /apis/uas-mgr/v1/admin/config/images/{image_id} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images/{image_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('/apis/uas-mgr/v1/admin/config/images/{image_id}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images/{image_id}', headers = headers)
 
 print(r.json())
 
@@ -1189,10 +1243,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "/apis/uas-mgr/v1/admin/config/images/{image_id}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/images/{image_id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1238,8 +1293,9 @@ configuration.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Image removed|[Image](#schemaimage)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Failed to delete image {image_id}|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="user-access-service-mgr-info">mgr-info</h1>
@@ -1251,26 +1307,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/mgr-info HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/mgr-info HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/mgr-info \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/mgr-info \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/uas-mgr/v1/mgr-info', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/mgr-info', headers = headers)
 
 print(r.json())
 
@@ -1288,10 +1346,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/mgr-info", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/mgr-info", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1327,8 +1386,9 @@ Return User Access Service information.
 
 <h3 id="get_uas_mgr_info-responseschema">Response Schema</h3>
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="user-access-service-uais">uais</h1>
@@ -1340,26 +1400,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/uais HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/uais HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/uais \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/uais \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/uas-mgr/v1/uais', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/uais', headers = headers)
 
 print(r.json())
 
@@ -1377,10 +1439,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/uais", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/uais", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1422,8 +1485,9 @@ list UAIs that implements a superset of this functionality under the
 
 <h3 id="get_all_uais-responseschema">Response Schema</h3>
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_all_uais
@@ -1433,20 +1497,25 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE /apis/uas-mgr/v1/uais HTTP/1.1
+DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/uais HTTP/1.1
+Host: api-gw-service-nmn.local
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE /apis/uas-mgr/v1/uais
+curl -X DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/uais \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
+headers = {
+  'Authorization': 'Bearer {access-token}'
+}
 
-r = requests.delete('/apis/uas-mgr/v1/uais')
+r = requests.delete('https://api-gw-service-nmn.local/apis/uas-mgr/v1/uais', headers = headers)
 
 print(r.json())
 
@@ -1462,8 +1531,12 @@ import (
 
 func main() {
 
+    headers := map[string][]string{
+        "Authorization": []string{"Bearer {access-token}"},
+    }
+
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "/apis/uas-mgr/v1/uais", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/uais", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1495,8 +1568,9 @@ of the functionality found here.  This path is deprecated in favor of
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|All UAIs Deleted|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|No UAIs found|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="user-access-service-admin">admin</h1>
@@ -1508,26 +1582,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/admin/uais HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/admin/uais \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/uas-mgr/v1/admin/uais', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais', headers = headers)
 
 print(r.json())
 
@@ -1545,10 +1621,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/admin/uais", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1634,8 +1711,9 @@ Status Code **200**
 |» uai_host|string|false|none|none|
 |» uai_age|string|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## create_uai_admin
@@ -1645,26 +1723,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST /apis/uas-mgr/v1/admin/uais HTTP/1.1
-
+POST https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X POST /apis/uas-mgr/v1/admin/uais \
-  -H 'Accept: application/json'
+curl -X POST https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('/apis/uas-mgr/v1/admin/uais', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais', headers = headers)
 
 print(r.json())
 
@@ -1682,10 +1762,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "/apis/uas-mgr/v1/admin/uais", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1780,8 +1861,9 @@ character.
 |---|---|---|---|
 |201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|UAI Created|[UAI](#schemauai)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_uais_admin
@@ -1791,26 +1873,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE /apis/uas-mgr/v1/admin/uais HTTP/1.1
-
+DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE /apis/uas-mgr/v1/admin/uais \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('/apis/uas-mgr/v1/admin/uais', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais', headers = headers)
 
 print(r.json())
 
@@ -1828,10 +1912,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "/apis/uas-mgr/v1/admin/uais", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -1925,8 +2010,9 @@ Status Code **200**
 |» uai_host|string|false|none|none|
 |» uai_age|string|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_uai_admin
@@ -1936,26 +2022,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/admin/uais/{uai_name} HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais/{uai_name} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/admin/uais/{uai_name} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais/{uai_name} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/uas-mgr/v1/admin/uais/{uai_name}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais/{uai_name}', headers = headers)
 
 print(r.json())
 
@@ -1973,10 +2061,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/admin/uais/{uai_name}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/uais/{uai_name}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2030,8 +2119,9 @@ Retrieve information on the specified UAI.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|UAI Description|[UAI](#schemauai)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|UAI not found|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="user-access-service-config">config</h1>
@@ -2043,20 +2133,25 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE /apis/uas-mgr/v1/admin/config HTTP/1.1
+DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config HTTP/1.1
+Host: api-gw-service-nmn.local
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE /apis/uas-mgr/v1/admin/config
+curl -X DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
+headers = {
+  'Authorization': 'Bearer {access-token}'
+}
 
-r = requests.delete('/apis/uas-mgr/v1/admin/config')
+r = requests.delete('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config', headers = headers)
 
 print(r.json())
 
@@ -2072,8 +2167,12 @@ import (
 
 func main() {
 
+    headers := map[string][]string{
+        "Authorization": []string{"Bearer {access-token}"},
+    }
+
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "/apis/uas-mgr/v1/admin/config", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2100,8 +2199,9 @@ with this request.
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Local configuration reset to defaults|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="user-access-service-volumes">volumes</h1>
@@ -2113,26 +2213,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST /apis/uas-mgr/v1/admin/config/volumes?volumename=my-mount&mount_path=%2Fmnt%2Ftest&volume_description=%7B%20%22config_map%22%3A%20%7B%20%22name%22%3A%20%22my-configmap%22%20%7D%20%7D HTTP/1.1
-
+POST https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes?volumename=my-mount&mount_path=%2Fmnt%2Ftest&volume_description=%7B%20%22config_map%22%3A%20%7B%20%22name%22%3A%20%22my-configmap%22%20%7D%20%7D HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X POST /apis/uas-mgr/v1/admin/config/volumes?volumename=my-mount&mount_path=%2Fmnt%2Ftest&volume_description=%7B%20%22config_map%22%3A%20%7B%20%22name%22%3A%20%22my-configmap%22%20%7D%20%7D \
-  -H 'Accept: application/json'
+curl -X POST https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes?volumename=my-mount&mount_path=%2Fmnt%2Ftest&volume_description=%7B%20%22config_map%22%3A%20%7B%20%22name%22%3A%20%22my-configmap%22%20%7D%20%7D \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('/apis/uas-mgr/v1/admin/config/volumes', params={
+r = requests.post('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes', params={
   'volumename': 'my-mount',  'mount_path': '/mnt/test',  'volume_description': '{ "config_map": { "name": "my-configmap" } }'
 }, headers = headers)
 
@@ -2152,10 +2254,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "/apis/uas-mgr/v1/admin/config/volumes", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2235,8 +2338,9 @@ or
 |304|[Not Modified](https://tools.ietf.org/html/rfc7232#section-4.1)|Volume not added|string|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Invalid type for host, volume not added|string|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_uas_volumes_admin
@@ -2246,26 +2350,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/admin/config/volumes HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/admin/config/volumes \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/uas-mgr/v1/admin/config/volumes', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes', headers = headers)
 
 print(r.json())
 
@@ -2283,10 +2389,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/admin/config/volumes", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2338,8 +2445,9 @@ Status Code **200**
 |» mount_path|string|false|none|none|
 |» volume_description|object|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_uas_volume_admin
@@ -2349,26 +2457,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/admin/config/volumes/{volume_id} HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes/{volume_id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/admin/config/volumes/{volume_id} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes/{volume_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/uas-mgr/v1/admin/config/volumes/{volume_id}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes/{volume_id}', headers = headers)
 
 print(r.json())
 
@@ -2386,10 +2496,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/admin/config/volumes/{volume_id}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes/{volume_id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2436,8 +2547,9 @@ from the configuration.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|UAS Volume|[Volume](#schemavolume)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|UAS Volume {volumename} not found|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## update_uas_volume_admin
@@ -2447,26 +2559,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH /apis/uas-mgr/v1/admin/config/volumes/{volume_id} HTTP/1.1
-
+PATCH https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes/{volume_id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X PATCH /apis/uas-mgr/v1/admin/config/volumes/{volume_id} \
-  -H 'Accept: application/json'
+curl -X PATCH https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes/{volume_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('/apis/uas-mgr/v1/admin/config/volumes/{volume_id}', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes/{volume_id}', headers = headers)
 
 print(r.json())
 
@@ -2484,10 +2598,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "/apis/uas-mgr/v1/admin/config/volumes/{volume_id}", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes/{volume_id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2576,8 +2691,9 @@ or
 |304|[Not Modified](https://tools.ietf.org/html/rfc7232#section-4.1)|No changes made|[Volume](#schemavolume)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Invalid type for host, volume not updated|string|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_uas_volume_admin
@@ -2587,26 +2703,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE /apis/uas-mgr/v1/admin/config/volumes/{volume_id} HTTP/1.1
-
+DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes/{volume_id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE /apis/uas-mgr/v1/admin/config/volumes/{volume_id} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes/{volume_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('/apis/uas-mgr/v1/admin/config/volumes/{volume_id}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes/{volume_id}', headers = headers)
 
 print(r.json())
 
@@ -2624,10 +2742,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "/apis/uas-mgr/v1/admin/config/volumes/{volume_id}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/volumes/{volume_id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2676,8 +2795,9 @@ from the configuration.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Volume removed from list|[Volume](#schemavolume)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Failed to delete volume {volume_id}|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="user-access-service-resources">resources</h1>
@@ -2689,26 +2809,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST /apis/uas-mgr/v1/admin/config/resources HTTP/1.1
-
+POST https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X POST /apis/uas-mgr/v1/admin/config/resources \
-  -H 'Accept: application/json'
+curl -X POST https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('/apis/uas-mgr/v1/admin/config/resources', headers = headers)
+r = requests.post('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources', headers = headers)
 
 print(r.json())
 
@@ -2726,10 +2848,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "/apis/uas-mgr/v1/admin/config/resources", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2795,8 +2918,9 @@ Millicpus and 250 Mibibytes of memory:
 |201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Resource configuration added|[Resource](#schemaresource)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Invalid limit or request specified|string|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_uas_resources_admin
@@ -2806,26 +2930,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/admin/config/resources HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/admin/config/resources \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/uas-mgr/v1/admin/config/resources', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources', headers = headers)
 
 print(r.json())
 
@@ -2843,10 +2969,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/admin/config/resources", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2896,8 +3023,9 @@ Status Code **200**
 |» limit|string|false|none|none|
 |» request|string|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_uas_resource_admin
@@ -2907,26 +3035,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/admin/config/resources/{resource_id} HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources/{resource_id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/admin/config/resources/{resource_id} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources/{resource_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/uas-mgr/v1/admin/config/resources/{resource_id}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources/{resource_id}', headers = headers)
 
 print(r.json())
 
@@ -2944,10 +3074,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/admin/config/resources/{resource_id}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources/{resource_id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -2995,8 +3126,9 @@ config to be retrieved from the configuration.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Resource Limit / Request Configuration Item|[Resource](#schemaresource)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource Configuration {resource_id} not found|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## update_uas_resource_admin
@@ -3006,26 +3138,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH /apis/uas-mgr/v1/admin/config/resources/{resource_id} HTTP/1.1
-
+PATCH https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources/{resource_id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X PATCH /apis/uas-mgr/v1/admin/config/resources/{resource_id} \
-  -H 'Accept: application/json'
+curl -X PATCH https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources/{resource_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('/apis/uas-mgr/v1/admin/config/resources/{resource_id}', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources/{resource_id}', headers = headers)
 
 print(r.json())
 
@@ -3043,10 +3177,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "/apis/uas-mgr/v1/admin/config/resources/{resource_id}", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources/{resource_id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3114,8 +3249,9 @@ Millicpus and 250 Mibibytes of memory:
 |201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|Resource updated|[Resource](#schemaresource)|
 |304|[Not Modified](https://tools.ietf.org/html/rfc7232#section-4.1)|No changes made|[Resource](#schemaresource)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_uas_resource_admin
@@ -3125,26 +3261,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE /apis/uas-mgr/v1/admin/config/resources/{resource_id} HTTP/1.1
-
+DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources/{resource_id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE /apis/uas-mgr/v1/admin/config/resources/{resource_id} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources/{resource_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('/apis/uas-mgr/v1/admin/config/resources/{resource_id}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources/{resource_id}', headers = headers)
 
 print(r.json())
 
@@ -3162,10 +3300,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "/apis/uas-mgr/v1/admin/config/resources/{resource_id}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/resources/{resource_id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3213,8 +3352,9 @@ configuration to be removed from the configuration.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Resource configuration removed|[Resource](#schemaresource)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Failed to delete resource configuration {resource_id}|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 <h1 id="user-access-service-classes">classes</h1>
@@ -3226,26 +3366,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-POST /apis/uas-mgr/v1/admin/config/classes?image_id=af4e59ab-6275-47f9-8f4a-90911eba3f9c HTTP/1.1
-
+POST https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes?image_id=af4e59ab-6275-47f9-8f4a-90911eba3f9c HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X POST /apis/uas-mgr/v1/admin/config/classes?image_id=af4e59ab-6275-47f9-8f4a-90911eba3f9c \
-  -H 'Accept: application/json'
+curl -X POST https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes?image_id=af4e59ab-6275-47f9-8f4a-90911eba3f9c \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.post('/apis/uas-mgr/v1/admin/config/classes', params={
+r = requests.post('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes', params={
   'image_id': 'af4e59ab-6275-47f9-8f4a-90911eba3f9c'
 }, headers = headers)
 
@@ -3265,10 +3407,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "/apis/uas-mgr/v1/admin/config/classes", data)
+    req, err := http.NewRequest("POST", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3478,8 +3621,9 @@ connections.
 |201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|UAI / Broker Class added|[UAIClass](#schemauaiclass)|
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Invalid UAI / Broker Class specified|string|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_uas_classes_admin
@@ -3489,26 +3633,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/admin/config/classes HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/admin/config/classes \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/uas-mgr/v1/admin/config/classes', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes', headers = headers)
 
 print(r.json())
 
@@ -3526,10 +3672,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/admin/config/classes", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3633,8 +3780,9 @@ Status Code **200**
 |»»» mount_path|string|false|none|none|
 |»»» volume_description|object|false|none|none|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## get_uas_class_admin
@@ -3644,26 +3792,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-GET /apis/uas-mgr/v1/admin/config/classes/{class_id} HTTP/1.1
-
+GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes/{class_id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X GET /apis/uas-mgr/v1/admin/config/classes/{class_id} \
-  -H 'Accept: application/json'
+curl -X GET https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes/{class_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.get('/apis/uas-mgr/v1/admin/config/classes/{class_id}', headers = headers)
+r = requests.get('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes/{class_id}', headers = headers)
 
 print(r.json())
 
@@ -3681,10 +3831,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "/apis/uas-mgr/v1/admin/config/classes/{class_id}", data)
+    req, err := http.NewRequest("GET", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes/{class_id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -3762,8 +3913,9 @@ from the configuration.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|UAI / Broker Class|[UAIClass](#schemauaiclass)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|UAI / Broker Class {class_id} not found|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## update_uas_class_admin
@@ -3773,26 +3925,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-PATCH /apis/uas-mgr/v1/admin/config/classes/{class_id} HTTP/1.1
-
+PATCH https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes/{class_id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X PATCH /apis/uas-mgr/v1/admin/config/classes/{class_id} \
-  -H 'Accept: application/json'
+curl -X PATCH https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes/{class_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.patch('/apis/uas-mgr/v1/admin/config/classes/{class_id}', headers = headers)
+r = requests.patch('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes/{class_id}', headers = headers)
 
 print(r.json())
 
@@ -3810,10 +3964,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("PATCH", "/apis/uas-mgr/v1/admin/config/classes/{class_id}", data)
+    req, err := http.NewRequest("PATCH", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes/{class_id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -4021,8 +4176,9 @@ connections.
 |201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|UAI / Broker Class updated|[UAIClass](#schemauaiclass)|
 |304|[Not Modified](https://tools.ietf.org/html/rfc7232#section-4.1)|No changes made|[UAIClass](#schemauaiclass)|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 ## delete_uas_class_admin
@@ -4032,26 +4188,28 @@ This operation does not require authentication
 > Code samples
 
 ```http
-DELETE /apis/uas-mgr/v1/admin/config/classes/{class_id} HTTP/1.1
-
+DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes/{class_id} HTTP/1.1
+Host: api-gw-service-nmn.local
 Accept: application/json
 
 ```
 
 ```shell
 # You can also use wget
-curl -X DELETE /apis/uas-mgr/v1/admin/config/classes/{class_id} \
-  -H 'Accept: application/json'
+curl -X DELETE https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes/{class_id} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```python
 import requests
 headers = {
-  'Accept': 'application/json'
+  'Accept': 'application/json',
+  'Authorization': 'Bearer {access-token}'
 }
 
-r = requests.delete('/apis/uas-mgr/v1/admin/config/classes/{class_id}', headers = headers)
+r = requests.delete('https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes/{class_id}', headers = headers)
 
 print(r.json())
 
@@ -4069,10 +4227,11 @@ func main() {
 
     headers := map[string][]string{
         "Accept": []string{"application/json"},
+        "Authorization": []string{"Bearer {access-token}"},
     }
 
     data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("DELETE", "/apis/uas-mgr/v1/admin/config/classes/{class_id}", data)
+    req, err := http.NewRequest("DELETE", "https://api-gw-service-nmn.local/apis/uas-mgr/v1/admin/config/classes/{class_id}", data)
     req.Header = headers
 
     client := &http.Client{}
@@ -4119,8 +4278,9 @@ removed from the configuration.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Resource configuration removed|[Resource](#schemaresource)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Failed to delete resource configuration {resource_id}|None|
 
-<aside class="success">
-This operation does not require authentication
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+bearerAuth
 </aside>
 
 # Schemas

--- a/gen-api.sh
+++ b/gen-api.sh
@@ -25,20 +25,20 @@
 
 set -e -o pipefail
 function usage() {
-    echo "Generate API docs from swagger file URLs provided in csm manifests."
-    echo ""
-    echo "Usage: $0 <manifest-dir> <dest-dir>"
-    echo ""
-    exit 1
+  echo "Generate API docs from swagger file URLs provided in csm manifests."
+  echo ""
+  echo "Usage: $0 <manifest-dir> <dest-dir>"
+  echo ""
+  exit 1
 }
 
 function error() {
-    echo "${1}"
-    exit 1
+  echo "${1}"
+  exit 1
 }
 
 if [ $# -ne 2 ]; then
-    usage
+  usage
 fi
 
 manifest_dir=$(realpath "${1}")
@@ -47,42 +47,42 @@ tmp_dir=$(mktemp -d)
 mkdir -p "${dest_dir}" "${tmp_dir}"
 
 echo "Preparing yq container ..."
-docker run -u "$(id -u):$(id -g)" --rm --name yq-swagger --entrypoint sh --detach -i -v "${manifest_dir}:/manifests" -v "${tmp_dir}:/swagger" artifactory.algol60.net/docker.io/mikefarah/yq:4 >/dev/null
+docker run -u "$(id -u):$(id -g)" --rm --name yq-swagger --entrypoint sh --detach -i -v "${manifest_dir}:/manifests" -v "${tmp_dir}:/swagger" artifactory.algol60.net/docker.io/mikefarah/yq:4 > /dev/null
 yq="docker exec yq-swagger yq"
 
 echo "Preparing widdershins container ..."
-docker run --rm --name widdershins --entrypoint bash --detach -i -v "${tmp_dir}:/swagger" -v "${dest_dir}:/api" node:16 >/dev/null
+docker run --rm --name widdershins --entrypoint bash --detach -i -v "${tmp_dir}:/swagger" -v "${dest_dir}:/api" node:16 > /dev/null
 docker exec widdershins npm install -g widdershins
 
 trap 'echo "Cleaning up ..."; docker rm -f widdershins >/dev/null; docker rm -f yq-swagger >/dev/null; rm -Rf "${tmp_dir}"' EXIT
 
 find "${manifest_dir}" -name "*.yaml" | while read -r manifest_file; do
-    echo "Parsing ${manifest_file} ..."
-    while read -r swagger_def; do
-        IFS='|' read -r endpoint_name endpoint_url endpoint_version endpoint_title <<< "${swagger_def}"
-        echo ""
-        echo "Downloading from ${endpoint_url} ..."
-        curl -SsL -o "${tmp_dir}/${endpoint_name}.yaml" "${endpoint_url}"
-        if [ -n "${endpoint_title}" ]; then
-            ${yq} e -i ".info.title=\"${endpoint_title}\"" "/swagger/${endpoint_name}.yaml"
-        fi
-        if [ -n "${endpoint_version}" ]; then
-            ${yq} e -i ".info.version=\"${endpoint_version}\"" "/swagger/${endpoint_name}.yaml"
-        fi
-        echo "Producing markdown for ${endpoint_name} out of ${endpoint_url} ..."
-        docker exec widdershins widdershins "/swagger/${endpoint_name}.yaml" -o "/api/${endpoint_name}.md" --omitHeader --language_tabs http shell python go
-    done < <(${yq} e '.spec.charts[].swagger[] | (.name + "|" + .url + "|" + (.version // "") + "|" + (.title // ""))' "/manifests/$(basename "${manifest_file}")")
+  echo "Parsing ${manifest_file} ..."
+  while read -r swagger_def; do
+    IFS='|' read -r endpoint_name endpoint_url endpoint_version endpoint_title <<< "${swagger_def}"
+    echo ""
+    echo "Downloading from ${endpoint_url} ..."
+    curl -SsL -o "${tmp_dir}/${endpoint_name}.yaml" "${endpoint_url}"
+    if [ -n "${endpoint_title}" ]; then
+      ${yq} e -i ".info.title=\"${endpoint_title}\"" "/swagger/${endpoint_name}.yaml"
+    fi
+    if [ -n "${endpoint_version}" ]; then
+      ${yq} e -i ".info.version=\"${endpoint_version}\"" "/swagger/${endpoint_name}.yaml"
+    fi
+    echo "Producing markdown for ${endpoint_name} out of ${endpoint_url} ..."
+    docker exec widdershins widdershins "/swagger/${endpoint_name}.yaml" -o "/api/${endpoint_name}.md" --omitHeader --language_tabs http shell python go
+  done < <(${yq} e '.spec.charts[].swagger[] | (.name + "|" + .url + "|" + (.version // "") + "|" + (.title // ""))' "/manifests/$(basename "${manifest_file}")")
 done
 
 cd "${dest_dir}"
 echo "# REST API Documentation" > README.md
 for file in *.md; do
-    if [ "${file}" != README.md ] && [ "${file}" != index.md ]; then
-        title=$(grep -E '<h1 id=".*">.*</h1>' "${file}" | head -1 | sed -e 's/<h1 id=".*">//' | sed -e 's|</h1>||') || true
-        if [ -z "${title}" ]; then
-            error "ERROR: Could not determine title for service named ${file%.md}"
-        fi
-        echo " * [${title}](./${file})" >> README.md
+  if [ "${file}" != README.md ] && [ "${file}" != index.md ]; then
+    title=$(grep -E '<h1 id=".*">.*</h1>' "${file}" | head -1 | sed -e 's/<h1 id=".*">//' | sed -e 's|</h1>||') || true
+    if [ -z "${title}" ]; then
+      error "ERROR: Could not determine title for service named ${file%.md}"
     fi
+    echo " * [${title}](./${file})" >> README.md
+  fi
 done
 ln -sf ./README.md ./index.md

--- a/gen-api.sh
+++ b/gen-api.sh
@@ -69,6 +69,16 @@ find "${manifest_dir}" -name "*.yaml" | while read -r manifest_file; do
     if [ -n "${endpoint_version}" ]; then
       ${yq} e -i ".info.version=\"${endpoint_version}\"" "/swagger/${endpoint_name}.yaml"
     fi
+    if [ "${endpoint_name}" != bss ] \
+      && [ "${endpoint_name}" != hbtd ] \
+      && [ "${endpoint_name}" != nls ] \
+      && [ "${endpoint_name}" != smd ] \
+      && [ "${endpoint_name}" != sts ] \
+      && [ "${endpoint_name}" != tapms-operator ] \
+      && [ "${endpoint_name}" != uas-mgr ]; then
+      ${yq} e -i '.components.securitySchemes.bearerAuth={"type": "http", "scheme": "bearer"}' "/swagger/${endpoint_name}.yaml"
+      ${yq} e -i '.security=[{"bearerAuth": []}]' "/swagger/${endpoint_name}.yaml"
+    fi
     echo "Producing markdown for ${endpoint_name} out of ${endpoint_url} ..."
     docker exec widdershins widdershins "/swagger/${endpoint_name}.yaml" -o "/api/${endpoint_name}.md" --omitHeader --language_tabs http shell python go
   done < <(${yq} e '.spec.charts[].swagger[] | (.name + "|" + .url + "|" + (.version // "") + "|" + (.title // ""))' "/manifests/$(basename "${manifest_file}")")

--- a/gen-api.sh
+++ b/gen-api.sh
@@ -63,21 +63,29 @@ find "${manifest_dir}" -name "*.yaml" | while read -r manifest_file; do
     echo ""
     echo "Downloading from ${endpoint_url} ..."
     curl -SsL -o "${tmp_dir}/${endpoint_name}.yaml" "${endpoint_url}"
+    openapi_version=$(${yq} e '.openapi // .swagger' "/swagger/${endpoint_name}.yaml")
     if [ -n "${endpoint_title}" ]; then
       ${yq} e -i ".info.title=\"${endpoint_title}\"" "/swagger/${endpoint_name}.yaml"
     fi
     if [ -n "${endpoint_version}" ]; then
       ${yq} e -i ".info.version=\"${endpoint_version}\"" "/swagger/${endpoint_name}.yaml"
     fi
-    if [ "${endpoint_name}" != bss ] \
-      && [ "${endpoint_name}" != hbtd ] \
-      && [ "${endpoint_name}" != nls ] \
-      && [ "${endpoint_name}" != smd ] \
-      && [ "${endpoint_name}" != sts ] \
-      && [ "${endpoint_name}" != tapms-operator ] \
-      && [ "${endpoint_name}" != uas-mgr ]; then
+    if [[ ${openapi_version} == 3.* ]]; then
       ${yq} e -i '.components.securitySchemes.bearerAuth={"type": "http", "scheme": "bearer"}' "/swagger/${endpoint_name}.yaml"
       ${yq} e -i '.security=[{"bearerAuth": []}]' "/swagger/${endpoint_name}.yaml"
+      # Many services have both external (through API Gateway, requires auth) and internal (does not require auth) sample URLs.
+      # Auth requirement can not be scoped to URL, we remove all sample URLs and set one mandatory external URL instead.
+      base_url=$(${yq} e '.servers[] | select(.url == "*/apis/*") | .url | sub(".+/apis/", "/apis/")' "/swagger/${endpoint_name}.yaml" | sort -u | head -1)
+      if [ -z "${base_url}" ]; then
+        base_url="/apis/${endpoint_name}"
+        echo "WARNING: unable to identify sample URL for ${endpoint_name}, guessed as ${base_url}."
+      fi
+      ${yq} e -i ".servers=[{\"url\": \"https://api-gw-service-nmn.local${base_url}\"}]" "/swagger/${endpoint_name}.yaml"
+    elif [[ ${openapi_version} == 2.* ]]; then
+      ${yq} e -i '.securityDefinitions.bearerAuth={"type": "http", "scheme": "bearer"}' "/swagger/${endpoint_name}.yaml"
+      ${yq} e -i '.security=[{"bearerAuth": []}]' "/swagger/${endpoint_name}.yaml"
+      ${yq} e -i '.host="api-gw-service-nmn.local"' "/swagger/${endpoint_name}.yaml"
+      ${yq} e -i '.schemes=["https"]' "/swagger/${endpoint_name}.yaml"
     fi
     echo "Producing markdown for ${endpoint_name} out of ${endpoint_url} ..."
     docker exec widdershins widdershins "/swagger/${endpoint_name}.yaml" -o "/api/${endpoint_name}.md" --omitHeader --language_tabs http shell python go


### PR DESCRIPTION
# Description

REST API docs for various services is generated from Swagger/OpenAPI v3 files. Since services do not implement authentication requirements on their own, Swagger files do not contain such a requirement. However this causes confusion for services being accessed through API Gateway, which imposes authentication requirement.

This PR adds authentication requirement during API generation process, for those services which are only accessed through API gateway. Initial run result which amended generated API docs is also included in this PR.

# Checklist

- [x] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [x] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [x] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
