### PR TITLE
CASMINST-6778: Allow update_tags.sh to work on PIT node after Nexus is populated

### DIFF
--- a/workflows/update_tags.sh
+++ b/workflows/update_tags.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -25,7 +25,9 @@
 # This is necessary since a new docs-csm version could land before or after a CSM update.
 
 set -e
-THIS_REGISTRY_NAME="registry.local"
+DEFAULT_REGISTRY_NAME="registry.local"
+DEFAULT_REGISTRY_REGEX="registry[.]local"
+THIS_REGISTRY_NAME="${DEFAULT_REGISTRY_NAME}"
 THIS_REGISTRY_PROTOCOL="https"
 THIS_PODMAN_TLS=""
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
@@ -61,7 +63,18 @@ function get_list_of_images_to_update() {
 
 function get_latest_tag_for_image() {
   THIS_IMAGE=$1
-  THIS_PREFIX=$([[ $(echo $THIS_IMAGE | grep -e "^${THIS_REGISTRY_NAME}/") ]] && echo "" || echo "${THIS_REGISTRY_NAME}/")
+  # Handle the case where the image already begins with registry.local
+  if [[ ${DEFAULT_REGISTRY_NAME} == "${THIS_REGISTRY_NAME}" ]]; then
+    # If the image is already prefixed with registry.local, we do not need to add it as a prefix
+    THIS_PREFIX=$([[ $(echo $THIS_IMAGE | grep -e "^${THIS_REGISTRY_NAME}/") ]] && echo "" || echo "${THIS_REGISTRY_NAME}/")
+  else
+    # CASMINST-6778
+    # The above code does not work on the PIT node, since the value of THIS_REGISTRY_NAME has changed.
+    # On the PIT node, we always want to use the PIT node prefix, but we still need to strip the registry.local
+    # prefix, if present.
+    THIS_PREFIX="${THIS_REGISTRY_NAME}/"
+    THIS_IMAGE=$(echo "${THIS_IMAGE}" | sed "s#^${DEFAULT_REGISTRY_REGEX}/##")
+  fi
   podman search $THIS_PODMAN_TLS $THIS_PREFIX$THIS_IMAGE --list-tags --format=json | jq -r '
     def opt(f):
       . as $in | try f catch $in;


### PR DESCRIPTION
<!---
    NOTE: This HTML style comment does not show in the PR.


    PULL-REQUESTS ARE LOOKED AT EVERY WORK DAY - WHEN THE MERGE BUTTON IS GREEN THE PR
    MAY BE MERGED.

    If more time is needed for review, please do one of the following:

    - Set the PR to a DRAFT; this allows reviewers to approve or request changes while disabling the merge button.
    - Prefix your PR title with "WIP" to indicate it is a "work in progress"; this is an indicator, it does not disable the merge button

    If neither of those items are present, then a pull-request is seen as a pull-request (e.g. a request to pull new content in) and it may
    be merged by a repository maintainer or CASM release manager at will.

--->
# Description
The `workflows/update_tags.sh` script retags images in Nexus. It gets the list of images by scanning files in the workflows tree. Here is an example of the list it found when run on a CSM 1.4.3 system:

```text
artifactory.algol60.net/csm-docker/stable/cf-gitea-import
artifactory.algol60.net/csm-docker/stable/cf-gitea-update
artifactory.algol60.net/csm-docker/stable/cray-ims-load-artifacts
artifactory.algol60.net/csm-docker/stable/docker.io/alpine/git
artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell
artifactory.algol60.net/csm-docker/stable/iuf
registry.local/artifactory.algol60.net/csm-docker/stable/docker.io/portainer/kubectl-shell
```

The script has code to handle the fact that the last image already has the `registry.local` prefix. However, that code was not written to handle this situation when the script is being run on a PIT node. This PR corrects that. I've tested it on wasp and it works fine. Because of how this PR is written, it will have no impact on how this script runs except on PIT nodes (and only on PIT nodes where Nexus has been populated, since if that's not the case, the script exits out before it gets to this point).

Backports to the other releases which have this script, since they have the same issue:
1.5: https://github.com/Cray-HPE/docs-csm/pull/4652
1.6: https://github.com/Cray-HPE/docs-csm/pull/4653

<!--- 
    NOTE: This HTML style comment does not show in the PR.

    Describe what this change is and what it is for.

    Include any related PRs URLs:

Relates to:
- pr-link-1
- pr-link-N
-->

# Checklist
<!---
    NOTE: This HTML style comment does not show in the PR. 

    An empty check is two brackets with a space in-between, a checked checkbox is two brackets with an x in-between

    unchecked checkbox: [ ]
    checked checkbox: [x]
    invalid checkbox: []
    invalid checkbox: [x ]
    invalid checkbox: [ x]
    invalid checkbox: [ x ]
-->

- [X] If I added any command snippets, the steps they belong to follow the prompt conventions (see [example][1]).
- [X] If I added a new directory, I also updated `.github/CODEOWNERS` with the corresponding team in [Cray-HPE][2].
- [X] My commits or Pull-Request Title contain my JIRA information, or I do not have a JIRA.

<!--- These are Markdown Reference Style URLs, they do not show in the PR --> 
[1]: https://github.com/Cray-HPE/docs-csm/blob/main/introduction/documentation_conventions.md#using-prompts
[2]: https://github.com/Cray-HPE/teams
